### PR TITLE
Localization: String Catalog (en + ru) for the recovery-phrase flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Keychain.
 .
 ├── project.yml                              ← xcodegen source of truth
 ├── generate-xcodeproj.sh                    ← regenerates OnymIOS.xcodeproj
+├── Resources/
+│   └── Localizable.xcstrings                ← single-file String Catalog (en + ru)
 ├── Gemfile                                  ← fastlane gem
 ├── fastlane/
 │   ├── Fastfile                             ← `release` lane: match adhoc + gym
@@ -297,6 +299,63 @@ auto-clear, wrong-pick retry, in-flight advance idempotency). Real
 `IdentityRepository` per test (unique Keychain service for
 isolation), seeded with a known mnemonic via `restore(mnemonic:)` so
 the recovery phrase is deterministic.
+
+## Localization
+
+Strings live in a single Xcode 15+ **String Catalog** at
+`Resources/Localizable.xcstrings` (sourceLanguage `en`). Currently
+shipped languages:
+
+- `en` — English (development language, source of truth)
+- `ru` — Russian (full coverage)
+
+The catalog is one JSON file holding every locale, so a translator
+gets exactly one artifact to work with — no `.strings` per language,
+no merge conflicts when two PRs touch different locales. Xcode
+compiles each entry into per-locale `.strings` (or `.stringsdict`
+for plural variants) inside the app bundle at build time.
+
+**How to use a string in code:**
+
+```swift
+// Inside SwiftUI — automatic; the LocalizedStringKey initializer picks
+// up the catalog entry by key.
+Text("Back up keys")
+Button("I've written it down") { ... }
+.navigationTitle("Recovery phrase")     // returns LocalizedStringKey
+
+// Outside SwiftUI (passing to LAContext, a String? property, etc.) —
+// explicit String(localized:):
+let reason = String(localized: "Authenticate to reveal your recovery phrase")
+let footer = String(localized: "Backed up \(date) · BIP-39 English")
+```
+
+Xcode auto-extracts string literals passed to `Text`,
+`LocalizedStringKey`, `String(localized:)`, etc. from source on every
+build and adds them to the catalog with a `new` state. Translators
+then provide the localized value in the Xcode editor (or by hand-
+editing the JSON).
+
+**Plurals (Russian-style):** `Localizable.xcstrings` supports CLDR
+plural variations natively (`one` / `few` / `many` / `other` etc.).
+The "Write down these %lld words" entry has `one`/`few`/`other`
+forms in Russian so 1 word → "слово", 2-4 → "слова", 5+/12/24 →
+"слов". English needs only `one`/`other`.
+
+**Adding a new language:**
+
+1. Open `Resources/Localizable.xcstrings` in Xcode.
+2. Click `+` in the language sidebar, pick the new locale.
+3. Translate each entry (Xcode shows source-language value as the
+   reference; mark each unit `state: translated` when done).
+4. Re-run `./generate-xcodeproj.sh` only if `project.yml` changed
+   (it doesn't for new languages).
+
+**Catching missing translations** — Xcode shows untranslated entries
+as a warning in the catalog editor. CI doesn't currently fail on
+missing translations; if/when we want that gate, run a script that
+parses the catalog JSON and asserts every entry has a `translated`
+state for every shipped language.
 
 ## Static checks
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,0 +1,484 @@
+{
+  "sourceLanguage" : "en",
+  "version" : "1.0",
+  "strings" : {
+    "Anyone with it can read your chats" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anyone with it can read your chats"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Любой обладатель сможет читать ваши чаты"
+          }
+        }
+      }
+    },
+    "Authenticate to reveal your recovery phrase" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to reveal your recovery phrase"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подтвердите личность, чтобы увидеть фразу восстановления"
+          }
+        }
+      }
+    },
+    "Authentication Failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication Failed"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось аутентифицироваться"
+          }
+        }
+      }
+    },
+    "Back up keys" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back up keys"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Резервная копия ключей"
+          }
+        }
+      }
+    },
+    "Backed up %@ · BIP-39 English" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backed up %@ · BIP-39 English"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Резервное копирование: %@ · BIP-39 (англ.)"
+          }
+        }
+      }
+    },
+    "Backup verified" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup verified"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Резервная копия подтверждена"
+          }
+        }
+      }
+    },
+    "Before you start" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Before you start"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перед началом"
+          }
+        }
+      }
+    },
+    "Cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмена"
+          }
+        }
+      }
+    },
+    "Continue with Face ID" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue with Face ID"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить с Face ID"
+          }
+        }
+      }
+    },
+    "Copied" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скопировано"
+          }
+        }
+      }
+    },
+    "Copy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Копировать"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
+        }
+      }
+    },
+    "I've written it down" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I've written it down"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Я записал(а)"
+          }
+        }
+      }
+    },
+    "Never share or photograph" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Never share or photograph"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Никому не показывайте и не фотографируйте"
+          }
+        }
+      }
+    },
+    "Not the right word. Check your phrase and try again." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not the right word. Check your phrase and try again."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это не то слово. Проверьте фразу и повторите попытку."
+          }
+        }
+      }
+    },
+    "OK" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ОК"
+          }
+        }
+      }
+    },
+    "Recovery phrase" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovery phrase"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фраза восстановления"
+          }
+        }
+      }
+    },
+    "Recovery phrase copied. It will be cleared from clipboard in 60 seconds. Store it securely now." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovery phrase copied. It will be cleared from clipboard in 60 seconds. Store it securely now."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фраза восстановления скопирована. Через 60 секунд она будет удалена из буфера обмена. Сохраните её сейчас в надёжном месте."
+          }
+        }
+      }
+    },
+    "Recovery phrase unavailable. Your identity may not be BIP39-backed." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovery phrase unavailable. Your identity may not be BIP39-backed."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фраза восстановления недоступна. Возможно, ваша личность не привязана к BIP-39."
+          }
+        }
+      }
+    },
+    "Select word number" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select word number"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите слово номер"
+          }
+        }
+      }
+    },
+    "Store offline (paper or metal)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Store offline (paper or metal)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Храните офлайн (бумага или металл)"
+          }
+        }
+      }
+    },
+    "Tap to reveal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to reveal"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажмите, чтобы показать"
+          }
+        }
+      }
+    },
+    "The phrase is generated on-device and never sent off the device." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The phrase is generated on-device and never sent off the device."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фраза создаётся на устройстве и никогда его не покидает."
+          }
+        }
+      }
+    },
+    "Try Again" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторить"
+          }
+        }
+      }
+    },
+    "Verify" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verify"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка"
+          }
+        }
+      }
+    },
+    "Write down these %lld words in order. You'll confirm three of them on the next screen." : {
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Write down this %lld word in order. You'll confirm three of them on the next screen."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Write down these %lld words in order. You'll confirm three of them on the next screen."
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Запишите %lld слово по порядку. На следующем экране нужно будет подтвердить три из них."
+                }
+              },
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Запишите %lld слова по порядку. На следующем экране нужно будет подтвердить три из них."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Запишите %lld слов по порядку. На следующем экране нужно будет подтвердить три из них."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Your identity, in 12 words" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your identity, in 12 words"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваша личность в 12 словах"
+          }
+        }
+      }
+    },
+    "Your recovery phrase is confirmed. Store it somewhere safe — you'll only need it if you lose this device." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your recovery phrase is confirmed. Store it somewhere safe — you'll only need it if you lose this device."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваша фраза восстановления подтверждена. Храните её в безопасном месте — она понадобится только при потере устройства."
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/OnymIOS/Recovery/RecoveryPhraseBackupFlow.swift
+++ b/Sources/OnymIOS/Recovery/RecoveryPhraseBackupFlow.swift
@@ -170,7 +170,7 @@ final class RecoveryPhraseBackupFlow {
     func authenticate() async {
         do {
             try await authenticator.authenticate(
-                reason: "Authenticate to reveal your recovery phrase"
+                reason: String(localized: "Authenticate to reveal your recovery phrase")
             )
         } catch {
             let message = (error as? LocalizedError)?.errorDescription
@@ -184,7 +184,7 @@ final class RecoveryPhraseBackupFlow {
         // (Face ID / passcode)-gated authenticator above.
         guard let phrase = currentIdentity?.recoveryPhrase else {
             step = .authFailed(
-                reason: "Recovery phrase unavailable. Your identity may not be BIP39-backed."
+                reason: String(localized: "Recovery phrase unavailable. Your identity may not be BIP39-backed.")
             )
             return
         }

--- a/Sources/OnymIOS/Recovery/RecoveryPhraseBackupView.swift
+++ b/Sources/OnymIOS/Recovery/RecoveryPhraseBackupView.swift
@@ -75,7 +75,7 @@ struct RecoveryPhraseBackupView: View {
         }
     }
 
-    private var navigationTitle: String {
+    private var navigationTitle: LocalizedStringKey {
         switch flow.step {
         case .intro, .authFailed: return "Back up keys"
         case .reveal: return "Recovery phrase"
@@ -546,7 +546,8 @@ private struct DoneScreen: View {
     private var footer: String {
         let df = DateFormatter()
         df.dateStyle = .medium
-        return "Backed up \(df.string(from: Date())) · BIP-39 English"
+        let date = df.string(from: Date())
+        return String(localized: "Backed up \(date) · BIP-39 English")
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -5,6 +5,7 @@ options:
     iOS: "26.0"
   xcodeVersion: "26.0"
   generateEmptyDirectories: true
+  developmentLanguage: en
 
 # OnymSDK is consumed via SwiftPM. The released tag pins a
 # .binaryTarget pointing at OnymFFI.xcframework attached to the
@@ -22,6 +23,7 @@ targets:
     platform: iOS
     sources:
       - Sources/OnymIOS
+      - Resources
     dependencies:
       - package: OnymSDK
     settings:


### PR DESCRIPTION
**Stacked on #4** — targets `recovery/backup-flow`. When #4 merges
to main, retarget this PR to main; the diff will rebase cleanly.

## Summary

Adds Apple's modern Xcode 15+ **String Catalog** as the localization
mechanism for the iOS app. English (source) and Russian as the first
two shipped languages. Every user-facing string in the recovery-phrase
backup flow translated to Russian, including the Russian-style
plural-aware "Запишите %lld слово / слова / слов" form.

## Why String Catalog (`.xcstrings`)

| Approach | Verdict |
|---|---|
| `.strings` per locale (legacy) | One file per language, hand-managed, easy to drift |
| `.xcstrings` (Xcode 15+) | **Picked.** One file, all locales, native plurals, auto-extracts from source |
| SwiftGen | Adds a build-time codegen dependency for marginal benefit on iOS 17+ |
| swift-localized-string-resource | Same as String Catalog under the hood |

App targets iOS 26 — `.xcstrings` is the obvious default.

## What landed

- **`Resources/Localizable.xcstrings`** — 27 entries covering intro,
  reveal, verify, done, alert, and authentication screens. English +
  Russian fully translated. The "Write down these %lld words" entry
  has CLDR plural variants (`one`/`other` for English; `one`/`few`/
  `other` for Russian).
- **`project.yml`** — new `Resources` source path on the OnymIOS
  target + `developmentLanguage: en`. xcodegen wires the `.xcstrings`
  into Copy Bundle Resources automatically.
- **`RecoveryPhraseBackupView.navigationTitle`** — returns
  `LocalizedStringKey` instead of `String` so SwiftUI's
  auto-localizing `.navigationTitle(_ titleKey:)` overload kicks in.
- **`RecoveryPhraseBackupView.footer`** — wraps the date suffix in
  `String(localized: "Backed up \(date) · BIP-39 English")` so the
  catalog can interpolate the date positionally.
- **`RecoveryPhraseBackupFlow.authenticate()`** — LAContext reason
  and the no-identity error message now use `String(localized:)`.

Everything else (`Text("...")`, `Button("...") { }`, `Label("...",
systemImage:)`, `.alert("...", ...)`) was already auto-localizing
because those initializers take `LocalizedStringKey` — adding the
keys to the catalog was sufficient.

## Build verification

`xcodebuild build` produces, inside `OnymIOS.app`:

```
en.lproj/Localizable.strings        ← 26 simple strings
ru.lproj/Localizable.strings        ← 26 Russian translations
ru.lproj/Localizable.stringsdict    ← plural variants for "Write down these %lld words"
```

Inspected via `plutil -p`:

```
"Back up keys" => "Резервная копия ключей"
"Recovery phrase" => "Фраза восстановления"
"Verify" => "Проверка"
"Continue with Face ID" => "Продолжить с Face ID"
"I've written it down" => "Я записал(а)"
... (22 more)
```

Plural dict (Russian):

```
"one" => "Запишите %lld слово по порядку. ..."
"few" => "Запишите %lld слова по порядку. ..."
"other" => "Запишите %lld слов по порядку. ..."
```

So a 12-word phrase (BIP39 default) renders as "Запишите 12 слов",
24-word (BIP39 256-bit) as "Запишите 24 слова" — both grammatically
correct.

## Test plan

- [x] All 24 existing tests pass green (`xcodebuild test`):
  - 13 `RecoveryPhraseBackupFlowTests`
  - 11 `IdentityRepositoryTests`
  - 1 `SmokeTests`
  - Tests are locale-agnostic — they assert on flow.step transitions
    and explicit error strings the test owns.
- [x] Bundle inspection confirms `en.lproj/Localizable.strings`,
  `ru.lproj/Localizable.strings`, and `ru.lproj/Localizable.stringsdict`
  all present with correct contents.
- [x] `python3 scripts/lint-secrets.py` clean — the localization
  changes don't add any new secret-read sites.

To verify the Russian build manually:

```sh
xcrun simctl boot 'iPhone 17 Pro'
xcrun simctl install booted /tmp/onym-ios-i18n-build/Build/Products/Debug-iphonesimulator/OnymIOS.app
xcrun simctl launch booted chat.onym.ios -AppleLanguages '(ru)' -AppleLocale ru_RU
```

## How to add another language

1. Open `Resources/Localizable.xcstrings` in Xcode.
2. Click `+` in the language sidebar; pick the new locale.
3. Translate each entry; mark each `state: translated` when done.
4. Rebuild — no `project.yml` change needed for new languages.

## Out of scope (future)

- More languages.
- CI gate for missing translations (parse the catalog, assert every
  entry has `state: translated` for every shipped language).
- Localized OnymSDK error strings — currently surfaced via
  `LocalizedError.errorDescription` which is in English. Localize
  when those errors become user-visible (today only LAError surfaces,
  which Apple already translates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)