### PR TITLE
Fix letterbox: opt in to UILaunchScreen so iOS uses native dimensions

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -36,7 +36,14 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
-        INFOPLIST_KEY_UILaunchScreen_Generation: NO
+        # Without a UILaunchScreen entry, iOS treats the app as a legacy
+        # iPhone-4-era binary and letterboxes it on every modern device
+        # (visible as huge black bars above and below the app's content).
+        # Setting this YES makes xcodegen emit an empty `UILaunchScreen`
+        # dict in Info.plist — opt-in to native dimensions, no real
+        # launch storyboard required since the SwiftUI scene takes over
+        # immediately on launch.
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         TARGETED_DEVICE_FAMILY: "1,2"


### PR DESCRIPTION
## What was wrong

App rendered letterboxed inside huge black bars on every modern
device — Dynamic Island clipped, content compressed, fake "borders"
above the status area and below the tab bar.

## Root cause

Chunk 1 set `INFOPLIST_KEY_UILaunchScreen_Generation: NO`, copied
from the stellar-mls reference impl. But stellar-mls also has a
**hand-written** `Info.plist` carrying a `UILaunchScreen` dict —
which this repo doesn't have, because onym-ios uses
`GENERATE_INFOPLIST_FILE: YES` so xcodegen synthesises Info.plist
entirely from `INFOPLIST_KEY_*` settings. With `_Generation: NO`,
xcodegen omitted the key entirely.

iOS sees no `UILaunchScreen` → treats the binary as a legacy
iPhone-4-era app → clamps the window to the legacy display rect →
fat black bars.

## Fix

Flip to `INFOPLIST_KEY_UILaunchScreen_Generation: YES`. That makes
xcodegen emit an empty `UILaunchScreen {}` dict, which is the
documented opt-in for native-resolution rendering. No real launch
storyboard needed because the SwiftUI scene takes over immediately
on launch.

One line of project.yml + a comment block explaining the trap so
the next dev doesn't undo it.

```diff
-        INFOPLIST_KEY_UILaunchScreen_Generation: NO
+        # Without a UILaunchScreen entry, iOS treats the app as a legacy
+        # iPhone-4-era binary and letterboxes it on every modern device
+        # (visible as huge black bars above and below the app's content).
+        # Setting this YES makes xcodegen emit an empty `UILaunchScreen`
+        # dict in Info.plist — opt-in to native dimensions, no real
+        # launch storyboard required since the SwiftUI scene takes over
+        # immediately on launch.
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
```

## Verification

`plutil -p` on the rebuilt Info.plist confirms `UILaunchScreen` dict
is now present:

```
"UILaunchScreen" => {
}
```

Installed on iPhone 17 Pro simulator, screenshot confirms:

- Dynamic Island visible at the top (no longer clipped)
- "Settings" large title flush to safe-area top (not pushed mid-screen)
- Form content fills down to the floating tab bar
- No letterbox black bars anywhere

Same Settings tab + magnifying-glass Search role tab from PR #6 —
just no longer letterboxed.

## Test plan

- [x] `xcodebuild build` clean
- [x] All 24 existing tests still pass
- [x] `python3 scripts/lint-secrets.py` clean
- [x] Visual: full-screen render confirmed via screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)