### PR TITLE
UI test infra + 4 end-to-end cases for the recovery-phrase flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Keychain.
 ├── scripts/
 │   └── lint-secrets.py                      ← static check: no off-repo secret reads
 ├── Sources/OnymIOS/
-│   ├── OnymIOSApp.swift                     ← @main, holds repo + authenticator
+│   ├── OnymIOSApp.swift                     ← @main, repo + authenticator + test wiring
+│   ├── RootView.swift                       ← TabView shell (Settings + Search role)
 │   ├── Identity/
 │   │   ├── Identity.swift                   ← Sendable value type the views see
 │   │   ├── IdentityRepository.swift         ← actor + AsyncStream snapshots
@@ -68,14 +69,28 @@ Keychain.
 │   │   ├── IdentityError.swift              ← single error type
 │   │   ├── Bip39.swift                      ← BIP39 wordlist + PBKDF2 + HKDF
 │   │   └── StellarStrKey.swift              ← Ed25519 → G... account ID encoder
-│   └── Recovery/
-│       ├── RecoveryPhraseBackupView.swift   ← root view + Intro/Reveal/Verify/Done
-│       ├── RecoveryPhraseBackupFlow.swift   ← @Observable @MainActor view-model
-│       └── BiometricAuthenticator.swift     ← protocol + LAContext impl
-├── Tests/OnymIOSTests/
+│   ├── Recovery/
+│   │   ├── RecoveryPhraseBackupView.swift   ← root view + Intro/Reveal/Verify/Done
+│   │   ├── RecoveryPhraseBackupFlow.swift   ← @Observable @MainActor view-model
+│   │   └── BiometricAuthenticator.swift     ← protocol + LAContext + DEBUG-only mock
+│   ├── Settings/
+│   │   └── SettingsView.swift               ← Form → Backup row → sheet
+│   └── Search/
+│       └── SearchView.swift                 ← placeholder for the .search role tab
+├── Tests/OnymIOSTests/                      ← unit / integration (XCTest, in-process)
 │   ├── SmokeTests.swift                     ← OnymSDK wiring sanity check
 │   ├── IdentityRepositoryTests.swift        ← real-Keychain integration tests
 │   └── RecoveryPhraseBackupFlowTests.swift  ← flow with real repo + fake auth
+├── Tests/OnymIOSUITests/                    ← XCUITest, drives the live app
+│   ├── RecoveryPhraseBackupUITests.swift    ← end-to-end flow coverage
+│   ├── PageObjects/                         ← per-screen wrappers
+│   │   ├── SettingsScreen.swift
+│   │   ├── IntroScreen.swift
+│   │   ├── RevealScreen.swift
+│   │   ├── VerifyScreen.swift
+│   │   └── DoneScreen.swift
+│   └── Support/
+│       └── AppLauncher.swift                ← fresh-launch helper with test args
 └── README.md
 ```
 
@@ -299,6 +314,91 @@ auto-clear, wrong-pick retry, in-flight advance idempotency). Real
 `IdentityRepository` per test (unique Keychain service for
 isolation), seeded with a known mnemonic via `restore(mnemonic:)` so
 the recovery phrase is deterministic.
+
+## UI tests
+
+`Tests/OnymIOSUITests/` is a separate `bundle.ui-testing` target (its
+own process, distinct from the in-process `OnymIOSTests` unit
+bundle). Tests boot the real app via `XCUIApplication`, drive it
+through the live SwiftUI views, and assert against the
+accessibility tree.
+
+### App-side test hooks
+
+`OnymIOSApp.init` reads three launch arguments under `#if DEBUG` so
+each test starts from a clean, deterministic state. Production
+Release builds compile this code path out — there's no way for a
+shipped binary to take the test-mode branch.
+
+| arg                  | effect                                                                                |
+|----------------------|---------------------------------------------------------------------------------------|
+| `--ui-testing`       | Required gate. Without it the App ignores the other two args.                         |
+| `--reset-keychain`   | Wipes the test-isolated keychain item before bootstrap.                               |
+| `--mock-biometric`   | Swaps `LAContextAuthenticator` for `AlwaysAcceptAuthenticator` (DEBUG-only struct).   |
+
+UI tests use a separate Keychain service
+(`chat.onym.ios.identity.uitests`) that is never touched by
+production builds, so even a developer running tests on their own
+device cannot disturb their real identity.
+
+### Page-object pattern
+
+Each screen has a `XYZScreen` struct in `PageObjects/` exposing the
+elements and high-level actions tests need:
+
+```swift
+let app = AppLauncher.launchFresh(language: "en")
+let settings = SettingsScreen(app: app)
+settings.tapBackupRecoveryPhrase()
+
+let intro = IntroScreen(app: app)
+intro.tapContinue()                           // waits for isReady internally
+
+let reveal = RevealScreen(app: app)
+reveal.tapReveal()
+let phrase = reveal.capturedPhrase()          // reads positions 1…12
+
+let verify = VerifyScreen(app: app)
+let position = verify.waitForRound()
+verify.pick(word: phrase[position - 1])
+```
+
+Selectors are stable accessibility identifiers
+(`reveal.word.<position>`, `verify.option.<word>`,
+`settings.backup_recovery_phrase_row`, etc.) — never label text,
+which would break the moment we localize a string or copy-edit a
+button.
+
+### How verify works without knowing the phrase
+
+The flow generates 3 random rounds, each picking a random word
+position and 4 random distractors. Tests can't predict which word
+is correct without reading the phrase off the Reveal screen first
+— so each test that exercises Verify reads the phrase via
+`reveal.capturedPhrase()`, then on each Verify round looks up the
+word at the requested position.
+
+### Wiring & runtime
+
+The `OnymIOS` scheme runs both `OnymIOSTests` and `OnymIOSUITests`
+on `xcodebuild test` (no `-only-testing` flag needed). Defaults:
+
+```sh
+xcodebuild test \
+  -project OnymIOS.xcodeproj \
+  -scheme OnymIOS \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -derivedDataPath /tmp/onym-ios-build
+```
+
+Wall-clock on iPhone 17 Pro simulator: ~89s for the full UI suite
+(4 cases × ~22s/each, dominated by the simulator launch). Unit
+tests still complete in ~1s. Run only the UI suite with
+`-only-testing:OnymIOSUITests`.
+
+The release pipeline (`.github/workflows/release.yml`) runs both
+suites in its `test` job — same `xcodebuild test` invocation, same
+`OnymIOS` scheme. UI tests are part of the release gate.
 
 ## Localization
 

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -2,8 +2,22 @@ import SwiftUI
 
 @main
 struct OnymIOSApp: App {
-    private let repository = IdentityRepository.shared
-    private let authenticator: BiometricAuthenticator = LAContextAuthenticator()
+    private let repository: IdentityRepository
+    private let authenticator: BiometricAuthenticator
+
+    init() {
+        let args = ProcessInfo.processInfo.arguments
+        #if DEBUG
+        if let testMode = Self.resolveTestMode(args: args) {
+            self.repository = testMode.repository
+            self.authenticator = testMode.authenticator
+            return
+        }
+        #endif
+        self.repository = IdentityRepository.shared
+        self.authenticator = LAContextAuthenticator()
+        _ = args  // silence unused warning in Release
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -14,3 +28,39 @@ struct OnymIOSApp: App {
         }
     }
 }
+
+#if DEBUG
+extension OnymIOSApp {
+    /// Resolves UI-test launch arguments into the dependencies the App
+    /// should use. Returns `nil` when not under UI test, in which case the
+    /// production wiring runs.
+    ///
+    /// Recognised args (only honoured when `--ui-testing` is also present):
+    ///   `--reset-keychain`    Wipes the test-isolated keychain on launch
+    ///                         so each test starts from a clean slate.
+    ///   `--mock-biometric`    Swaps in `AlwaysAcceptAuthenticator` so the
+    ///                         flow doesn't block on a real Face ID prompt
+    ///                         (the simulator can't pass one).
+    ///
+    /// All UI-test runs use a separate Keychain service
+    /// (`chat.onym.ios.identity.uitests`) so they never touch the user's
+    /// real identity even on a developer machine.
+    fileprivate static func resolveTestMode(
+        args: [String]
+    ) -> (repository: IdentityRepository, authenticator: BiometricAuthenticator)? {
+        guard args.contains("--ui-testing") else { return nil }
+        let keychain = KeychainStore(
+            service: "chat.onym.ios.identity.uitests",
+            account: "current"
+        )
+        if args.contains("--reset-keychain") {
+            try? keychain.wipe()
+        }
+        let repo = IdentityRepository(keychain: keychain)
+        let auth: BiometricAuthenticator = args.contains("--mock-biometric")
+            ? AlwaysAcceptAuthenticator()
+            : LAContextAuthenticator()
+        return (repo, auth)
+    }
+}
+#endif

--- a/Sources/OnymIOS/Recovery/BiometricAuthenticator.swift
+++ b/Sources/OnymIOS/Recovery/BiometricAuthenticator.swift
@@ -30,6 +30,16 @@ struct LAContextAuthenticator: BiometricAuthenticator {
     }
 }
 
+#if DEBUG
+/// `BiometricAuthenticator` impl that always succeeds without prompting.
+/// Compiled out of Release builds so production never has a code path that
+/// silently bypasses biometric auth. Wired in by `OnymIOSApp.init` only
+/// when launched under XCUITest with the `--mock-biometric` argument.
+struct AlwaysAcceptAuthenticator: BiometricAuthenticator {
+    func authenticate(reason: String) async throws {}
+}
+#endif
+
 private extension LAContext {
     func evaluatePolicyAsync(_ policy: LAPolicy, localizedReason: String) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in

--- a/Sources/OnymIOS/Recovery/RecoveryPhraseBackupView.swift
+++ b/Sources/OnymIOS/Recovery/RecoveryPhraseBackupView.swift
@@ -150,6 +150,7 @@ private struct IntroScreen: View {
                 .opacity(isReady ? 1 : 0.5)
                 .padding(.horizontal, 16)
                 .padding(.top, 22)
+                .accessibilityIdentifier("intro.continue_button")
             }
             .padding(.bottom, 28)
         }
@@ -264,6 +265,7 @@ private struct RevealScreen: View {
                     }
                     .disabled(!revealed)
                     .opacity(revealed ? 1 : 0.4)
+                    .accessibilityIdentifier("reveal.copy_button")
                 }
                 .padding(.horizontal, 16)
 
@@ -279,6 +281,7 @@ private struct RevealScreen: View {
                 .opacity(revealed ? 1 : 0.5)
                 .padding(.horizontal, 16)
                 .padding(.top, 14)
+                .accessibilityIdentifier("reveal.continue_button")
 
                 Text("The phrase is generated on-device and never sent off the device.")
                     .font(.footnote)
@@ -312,6 +315,7 @@ private struct RevealScreen: View {
                             .monospacedDigit()
                         Text(word)
                             .font(.callout.weight(.medium))
+                            .accessibilityIdentifier("reveal.word.\(index + 1)")
                         Spacer(minLength: 0)
                     }
                     .padding(.horizontal, 10)
@@ -343,6 +347,7 @@ private struct RevealScreen: View {
                     }
                 }
                 .contentShape(Rectangle())
+                .accessibilityIdentifier("reveal.tap_button")
             }
         }
         .frame(maxWidth: .infinity)
@@ -377,6 +382,7 @@ private struct VerifyScreen: View {
                         .font(.system(size: 64, weight: .bold))
                         .foregroundStyle(Color.accentColor)
                         .monospacedDigit()
+                        .accessibilityIdentifier("verify.position")
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 20)
@@ -408,6 +414,7 @@ private struct VerifyScreen: View {
                         .frame(maxWidth: .infinity)
                         .padding(.horizontal, 32)
                         .padding(.top, 18)
+                        .accessibilityIdentifier("verify.error_message")
                 }
             }
             .padding(.bottom, 28)
@@ -450,6 +457,7 @@ private struct VerifyOption: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("verify.option.\(word)")
     }
 
     private var background: Color {
@@ -513,6 +521,7 @@ private struct DoneScreen: View {
             Text("Backup verified")
                 .font(.title.weight(.bold))
                 .padding(.bottom, 10)
+                .accessibilityIdentifier("done.title")
             Text("Your recovery phrase is confirmed. Store it somewhere safe — you'll only need it if you lose this device.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -529,6 +538,7 @@ private struct DoneScreen: View {
                     .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .padding(.horizontal, 16)
+            .accessibilityIdentifier("done.button")
 
             Spacer()
 

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -22,6 +22,7 @@ struct SettingsView: View {
                     )
                 }
                 .buttonStyle(.plain)
+                .accessibilityIdentifier("settings.backup_recovery_phrase_row")
             } header: {
                 Text("Security")
             } footer: {

--- a/Tests/OnymIOSUITests/PageObjects/DoneScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/DoneScreen.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+/// Page object for the recovery-flow Done screen.
+struct DoneScreen {
+    let app: XCUIApplication
+
+    var title: XCUIElement      { app.staticTexts["done.title"] }
+    var doneButton: XCUIElement { app.buttons["done.button"] }
+
+    func waitForDisplayed(timeout: TimeInterval = 5) -> Bool {
+        title.waitForExistence(timeout: timeout)
+    }
+
+    func tapDone() {
+        XCTAssertTrue(doneButton.isHittable, "done button not hittable")
+        doneButton.tap()
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/IntroScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/IntroScreen.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+/// Page object for the recovery-flow Intro screen.
+struct IntroScreen {
+    let app: XCUIApplication
+
+    var continueButton: XCUIElement {
+        app.buttons["intro.continue_button"]
+    }
+
+    /// Waits for the Continue button to exist AND become hittable. The
+    /// button is rendered immediately but disabled until the
+    /// `IdentityRepository.bootstrap()` call inside the flow's `start()`
+    /// resolves and hands `flow.isReady = true` back to the view.
+    func waitForReady(timeout: TimeInterval = 8) -> Bool {
+        guard continueButton.waitForExistence(timeout: timeout) else { return false }
+        let predicate = NSPredicate(format: "isHittable == true")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: continueButton)
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    func tapContinue() {
+        XCTAssertTrue(waitForReady(), "intro continue button never became hittable")
+        continueButton.tap()
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/RevealScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/RevealScreen.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+/// Page object for the recovery-flow Reveal screen.
+///
+/// Each of the 12 phrase words has its own accessibility identifier
+/// (`reveal.word.<1-based-position>`) so the UI test can reconstruct the
+/// full mnemonic after tapping reveal — and then look up which word lives
+/// at each position when verifying.
+struct RevealScreen {
+    let app: XCUIApplication
+
+    var tapToRevealButton: XCUIElement { app.buttons["reveal.tap_button"] }
+    var continueButton: XCUIElement   { app.buttons["reveal.continue_button"] }
+    var copyButton: XCUIElement       { app.buttons["reveal.copy_button"] }
+
+    func waitForUnrevealed(timeout: TimeInterval = 5) -> Bool {
+        tapToRevealButton.waitForExistence(timeout: timeout)
+    }
+
+    func tapReveal() {
+        XCTAssertTrue(waitForUnrevealed(), "reveal screen never showed `Tap to reveal`")
+        tapToRevealButton.tap()
+    }
+
+    /// Reads positions 1…12 off the Reveal grid. Call only after `tapReveal()`.
+    func capturedPhrase() -> [String] {
+        var words: [String] = []
+        for position in 1...12 {
+            let element = app.staticTexts["reveal.word.\(position)"]
+            XCTAssertTrue(element.waitForExistence(timeout: 2),
+                          "reveal.word.\(position) never appeared")
+            words.append(element.label)
+        }
+        return words
+    }
+
+    func tapContinue() {
+        XCTAssertTrue(continueButton.isHittable,
+                      "reveal continue button not hittable (did you forget to tap reveal first?)")
+        continueButton.tap()
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/SettingsScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/SettingsScreen.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+/// Page object for the Settings tab — the app's root screen.
+struct SettingsScreen {
+    let app: XCUIApplication
+
+    var backupRow: XCUIElement {
+        app.buttons["settings.backup_recovery_phrase_row"]
+    }
+
+    @discardableResult
+    func waitForReady(timeout: TimeInterval = 5) -> Bool {
+        backupRow.waitForExistence(timeout: timeout)
+    }
+
+    func tapBackupRecoveryPhrase() {
+        XCTAssertTrue(backupRow.waitForExistence(timeout: 5),
+                      "settings backup row never appeared")
+        backupRow.tap()
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/VerifyScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/VerifyScreen.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+/// Page object for the recovery-flow Verify screen.
+///
+/// The flow generates 3 random rounds, each asking for a specific 1-based
+/// position and rendering 4 candidate words (1 correct + 3 distractors).
+/// The current position is exposed via the `verify.position` static text;
+/// each option button's identifier embeds the displayed word
+/// (`verify.option.<word>`).
+struct VerifyScreen {
+    let app: XCUIApplication
+
+    var positionLabel: XCUIElement { app.staticTexts["verify.position"] }
+    var errorMessage: XCUIElement  { app.staticTexts["verify.error_message"] }
+
+    /// Returns the 1-based word position the current round is asking for.
+    /// Waits for the round's UI to settle.
+    func waitForRound(timeout: TimeInterval = 5) -> Int {
+        XCTAssertTrue(positionLabel.waitForExistence(timeout: timeout),
+                      "verify position label never appeared")
+        guard let position = Int(positionLabel.label) else {
+            XCTFail("verify.position label is not an integer: \(positionLabel.label)")
+            return 0
+        }
+        return position
+    }
+
+    /// Returns true if a verify option button for `word` is currently visible.
+    func hasOption(_ word: String) -> Bool {
+        app.buttons["verify.option.\(word)"].exists
+    }
+
+    /// Picks the option labeled `word`. Asserts the option exists.
+    func pick(word: String) {
+        let option = app.buttons["verify.option.\(word)"]
+        XCTAssertTrue(option.waitForExistence(timeout: 2),
+                      "no verify option for word `\(word)`")
+        option.tap()
+    }
+
+    /// Picks any visible option whose word is **not** `correctWord`.
+    /// Used by the wrong-pick test, which doesn't care which wrong option
+    /// gets chosen — just that one of them is.
+    func pickAnyWrongOption(correctWord: String) {
+        let allOptions = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'verify.option.'")
+        )
+        let count = allOptions.count
+        XCTAssertGreaterThan(count, 0, "no verify option buttons visible")
+        for i in 0..<count {
+            let option = allOptions.element(boundBy: i)
+            let id = option.identifier
+            if id != "verify.option.\(correctWord)" {
+                option.tap()
+                return
+            }
+        }
+        XCTFail("every visible option matched the correct word `\(correctWord)`")
+    }
+}

--- a/Tests/OnymIOSUITests/RecoveryPhraseBackupUITests.swift
+++ b/Tests/OnymIOSUITests/RecoveryPhraseBackupUITests.swift
@@ -1,0 +1,139 @@
+import XCTest
+
+/// End-to-end coverage of the recovery-phrase backup flow, driven through
+/// the live SwiftUI views via `XCUIApplication`. Every case launches a
+/// fresh app instance so prior state never leaks across tests; XCTest
+/// runs UI cases serially per-target by default, so no extra annotation
+/// is needed to keep them off each other's toes.
+///
+/// The app under test reads three launch arguments (gated to `#if DEBUG`
+/// in `OnymIOSApp`) so each case starts from a clean slate:
+///   `--ui-testing`      flips the App into test wiring
+///   `--reset-keychain`  wipes the test-isolated identity item
+///   `--mock-biometric`  swaps in `AlwaysAcceptAuthenticator`
+///
+/// See `Support/AppLauncher.swift` and the page objects in `PageObjects/`
+/// for the underlying mechanics.
+///
+/// Note: written in XCTest rather than Swift Testing because the
+/// `Testing` module isn't wired into UI-test bundles by default in
+/// Xcode 26. Unit tests in `OnymIOSTests` can still adopt Swift Testing
+/// when its UI-bundle support lands.
+final class RecoveryPhraseBackupUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    // MARK: - Happy path
+
+    func test_happyPath_endToEnd() {
+        let app = AppLauncher.launchFresh(language: "en")
+        defer { app.terminate() }
+
+        let settings = SettingsScreen(app: app)
+        settings.tapBackupRecoveryPhrase()
+
+        let intro = IntroScreen(app: app)
+        intro.tapContinue()
+
+        let reveal = RevealScreen(app: app)
+        reveal.tapReveal()
+        let phrase = reveal.capturedPhrase()
+        XCTAssertEqual(phrase.count, 12)
+        for word in phrase {
+            XCTAssertFalse(word.isEmpty)
+        }
+        reveal.tapContinue()
+
+        let verify = VerifyScreen(app: app)
+        for round in 0..<3 {
+            let position = verify.waitForRound()
+            XCTAssertTrue((1...12).contains(position),
+                          "round \(round): position \(position) out of 1…12")
+            let correctWord = phrase[position - 1]
+            verify.pick(word: correctWord)
+        }
+
+        let done = DoneScreen(app: app)
+        XCTAssertTrue(done.waitForDisplayed(),
+                      "Done screen never appeared after three correct picks")
+    }
+
+    // MARK: - Wrong word
+
+    func test_wrongWordPicked_keepsRound_andShowsError() {
+        let app = AppLauncher.launchFresh(language: "en")
+        defer { app.terminate() }
+
+        SettingsScreen(app: app).tapBackupRecoveryPhrase()
+        IntroScreen(app: app).tapContinue()
+
+        let reveal = RevealScreen(app: app)
+        reveal.tapReveal()
+        let phrase = reveal.capturedPhrase()
+        reveal.tapContinue()
+
+        let verify = VerifyScreen(app: app)
+        let position = verify.waitForRound()
+        let correctWord = phrase[position - 1]
+        verify.pickAnyWrongOption(correctWord: correctWord)
+
+        XCTAssertTrue(verify.errorMessage.waitForExistence(timeout: 2),
+                      "verify error message never appeared after wrong pick")
+        XCTAssertEqual(verify.waitForRound(), position,
+                       "round changed after wrong pick — should have stayed put")
+    }
+
+    // MARK: - Russian locale
+
+    func test_russianLocale_rendersRussianStrings() {
+        let app = AppLauncher.launchFresh(language: "ru")
+        defer { app.terminate() }
+
+        XCTAssertTrue(
+            app.staticTexts["Настройки"].waitForExistence(timeout: 6),
+            "Russian Settings nav title never appeared"
+        )
+        XCTAssertTrue(
+            app.staticTexts["Резервная копия фразы восстановления"]
+                .waitForExistence(timeout: 3),
+            "Russian Backup row title never appeared"
+        )
+
+        SettingsScreen(app: app).tapBackupRecoveryPhrase()
+
+        XCTAssertTrue(
+            app.staticTexts["Ваша личность в 12 словах"]
+                .waitForExistence(timeout: 3),
+            "Russian intro hero title never appeared"
+        )
+    }
+
+    // MARK: - Fresh launch
+
+    func test_freshLaunch_generates12WordPhrase() {
+        let app = AppLauncher.launchFresh(language: "en")
+        defer { app.terminate() }
+
+        SettingsScreen(app: app).tapBackupRecoveryPhrase()
+        IntroScreen(app: app).tapContinue()
+
+        let reveal = RevealScreen(app: app)
+        reveal.tapReveal()
+        let phrase = reveal.capturedPhrase()
+
+        XCTAssertEqual(phrase.count, 12)
+        XCTAssertGreaterThanOrEqual(
+            Set(phrase).count, 6,
+            "12-word phrase had \(Set(phrase).count) unique words — suspicious for a fresh BIP-39 seed"
+        )
+        for word in phrase {
+            XCTAssertTrue(
+                word.allSatisfy { $0.isLetter && $0.isLowercase },
+                "phrase word `\(word)` is not all-lowercase letters"
+            )
+        }
+    }
+}

--- a/Tests/OnymIOSUITests/Support/AppLauncher.swift
+++ b/Tests/OnymIOSUITests/Support/AppLauncher.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+/// Boots `OnymIOS` with a fresh test-isolated keychain + a mock biometric
+/// authenticator so the UI test never blocks on a Face ID prompt and never
+/// inherits state from a previous test.
+///
+/// Launch arguments honoured by the app under `#if DEBUG`:
+///   `--ui-testing`      Required to flip the App into test wiring.
+///   `--reset-keychain`  Wipe the test-isolated `chat.onym.ios.identity.uitests`
+///                       keychain item before bootstrap.
+///   `--mock-biometric`  Swap `LAContextAuthenticator` for a stub that returns
+///                       success immediately without prompting.
+///
+/// `language` flips Apple's `-AppleLanguages` / `-AppleLocale` user-defaults
+/// so the same test can exercise localized strings.
+enum AppLauncher {
+    static func launchFresh(language: String = "en") -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "--ui-testing",
+            "--reset-keychain",
+            "--mock-biometric",
+            "-AppleLanguages", "(\(language))",
+            "-AppleLocale", localeIdentifier(for: language),
+        ]
+        app.launch()
+        return app
+    }
+
+    private static func localeIdentifier(for language: String) -> String {
+        switch language {
+        case "ru": return "ru_RU"
+        default:   return "en_US"
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -68,12 +68,29 @@ targets:
       - target: OnymIOS
       - package: OnymSDK
 
+  OnymIOSUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - Tests/OnymIOSUITests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios.uitests
+        SWIFT_VERSION: "5.0"
+        GENERATE_INFOPLIST_FILE: YES
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
+        TEST_TARGET_NAME: OnymIOS
+    dependencies:
+      - target: OnymIOS
+
 schemes:
   OnymIOS:
     build:
       targets:
         OnymIOS: all
         OnymIOSTests: [test]
+        OnymIOSUITests: [test]
     run:
       config: Debug
       environmentVariables:
@@ -82,6 +99,7 @@ schemes:
       config: Debug
       targets:
         - OnymIOSTests
+        - OnymIOSUITests
     profile:
       config: Release
     analyze:


### PR DESCRIPTION
## Summary

Adds an `OnymIOSUITests` target driven by XCUITest, with the
infrastructure to keep UI tests deterministic and four end-to-end
cases covering the recovery-phrase backup flow.

## App-side test hooks (gated to `#if DEBUG`)

`OnymIOSApp.init` reads three launch arguments. Production Release
builds compile this code path out — there's no way for a shipped
binary to take the test branch.

| arg                 | effect                                                                                |
|---------------------|---------------------------------------------------------------------------------------|
| `--ui-testing`      | Required gate. Without it the App ignores the other two args.                         |
| `--reset-keychain`  | Wipes the test-isolated keychain item before bootstrap.                               |
| `--mock-biometric`  | Swaps `LAContextAuthenticator` for `AlwaysAcceptAuthenticator` (DEBUG-only struct).   |

UI tests use a separate Keychain service
(`chat.onym.ios.identity.uitests`) that production builds never
touch — even a developer running tests on their device cannot
disturb their real identity.

## Page-object pattern

Each screen has a `XYZScreen` struct in `Tests/OnymIOSUITests/PageObjects/`
exposing the elements and high-level actions tests need:

```swift
let app = AppLauncher.launchFresh(language: "en")
let settings = SettingsScreen(app: app)
settings.tapBackupRecoveryPhrase()

let intro = IntroScreen(app: app)
intro.tapContinue()                           // waits for isReady internally

let reveal = RevealScreen(app: app)
reveal.tapReveal()
let phrase = reveal.capturedPhrase()          // reads positions 1…12

let verify = VerifyScreen(app: app)
let position = verify.waitForRound()
verify.pick(word: phrase[position - 1])
```

Selectors are stable accessibility identifiers
(`reveal.word.<position>`, `verify.option.<word>`,
`settings.backup_recovery_phrase_row`, etc.) — never label text,
which would break the moment we localize a string or copy-edit a
button.

## How verify works without knowing the phrase

The flow generates 3 random rounds, each picking a random word
position and 4 random distractors. Tests can't predict which word
is correct without reading the phrase off the Reveal screen first
— so each test that exercises Verify reads the phrase via
`reveal.capturedPhrase()`, then on each Verify round looks up the
word at the requested position.

## 4 cases

| case                                              | what it covers                                                                          | wall  |
|---------------------------------------------------|-----------------------------------------------------------------------------------------|-------|
| `test_happyPath_endToEnd`                         | Settings → Backup → Continue → Reveal → capture phrase → Continue → pick correct ×3 → Done | ~31s |
| `test_wrongWordPicked_keepsRound_andShowsError`   | Pick a wrong distractor; verify inline error appears AND round didn't advance           | ~26s |
| `test_russianLocale_rendersRussianStrings`        | Launch with `-AppleLanguages "(ru)"`; confirm Russian copy renders                      | ~8s  |
| `test_freshLaunch_generates12WordPhrase`          | `--reset-keychain` produces fresh BIP-39 identity (12 lowercase words, ≥6 unique)       | ~24s |

Total: **~89s wall** on iPhone 17 Pro simulator. Unit tests
(`OnymIOSTests`) still ~1s. Both run together on `xcodebuild test`
under the `OnymIOS` scheme — no `-only-testing` flag needed.

## XCTest, not Swift Testing — for now

UI cases are written as `XCTestCase` subclasses, not `@Test` /
`#expect`, because the `Testing` module isn't wired into UI-test
bundles by default in Xcode 26 (resolves with
`unable to resolve module dependency: '_Testing_Unavailable'`).
Unit tests under `OnymIOSTests` can still adopt Swift Testing if
desired; the page-object pattern translates cleanly when the
UI-bundle gap closes.

## project.yml

- New `OnymIOSUITests` target with `bundle.ui-testing`, depends on
  `OnymIOS`
- `OnymIOS` scheme's `build.targets` and `test.targets` updated to
  include `OnymIOSUITests`

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSUITests` — all 4 cases
      pass green, ~89s wall
- [x] `xcodebuild test -only-testing:OnymIOSTests` — all 24 unit
      tests still pass green
- [x] `xcodebuild test` — full suite passes green
- [x] `python3 scripts/lint-secrets.py` — clean (no new secret-read
      sites; the page objects observe accessibility values, not the
      private fields)

Repro:

```sh
./generate-xcodeproj.sh
xcodebuild test \
  -project OnymIOS.xcodeproj \
  -scheme OnymIOS \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -derivedDataPath /tmp/onym-ios-build
```

## What's NOT in this PR (future)

- Snapshot / pixel-diff testing
- Localized assertions for additional languages (only Russian today;
  a future locale just adds more `app.staticTexts["…"]` checks or
  a parameterized helper)
- UI tests for the Settings tab itself beyond the Backup row entry
  (more rows arrive as Settings grows)
- Switch to Swift Testing for UI tests once Xcode wires `Testing`
  into UI-test bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)