### PR TITLE
CI: split release tests into unit-tests + ui-tests jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,8 @@ jobs:
           target_commitish: ${{ github.sha }}
           body_path: release_notes.md
 
-  test:
+  unit-tests:
+    name: Unit tests (OnymIOSTests)
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +102,7 @@ jobs:
           echo "Using simulator: $NAME"
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
-      - name: xcodebuild test
+      - name: xcodebuild test (unit)
         # NOTE: do NOT pass CODE_SIGNING_ALLOWED=NO — without the synthesised
         # `application-identifier` entitlement, every Keychain call in the
         # IdentityRepository tests fails with errSecMissingEntitlement (-34018).
@@ -110,11 +111,86 @@ jobs:
             -project OnymIOS.xcodeproj \
             -scheme OnymIOS \
             -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }},OS=latest" \
-            -derivedDataPath /tmp/onym-ios-release-test
+            -derivedDataPath /tmp/onym-ios-release-unit \
+            -resultBundlePath /tmp/onym-ios-unit.xcresult \
+            -only-testing:OnymIOSTests
+
+      - name: Upload unit test xcresult on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-tests-xcresult
+          path: /tmp/onym-ios-unit.xcresult
+          retention-days: 7
+
+  ui-tests:
+    name: UI tests (OnymIOSUITests)
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.app
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: ./generate-xcodeproj.sh
+
+      - name: Pick + pre-boot iOS Simulator destination
+        id: sim
+        run: |
+          # UI tests benefit from a warm simulator — `xcodebuild test` will
+          # auto-boot if needed but the cold-boot adds ~10s and can race the
+          # first test's first interaction. Pre-boot here so the runner is
+          # ready before xcodebuild even looks at it.
+          UDID=$(xcrun simctl list devices available --json \
+            | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; \
+                         devs=[dev for runtime,ds in d.items() \
+                                if 'iOS' in runtime \
+                                for dev in ds if 'iPhone' in dev['name']]; \
+                         print(devs[-1]['udid'] if devs else '', end='')")
+          NAME=$(xcrun simctl list devices available --json \
+            | python3 -c "import json,sys,os; d=json.load(sys.stdin)['devices']; \
+                         devs=[dev for runtime,ds in d.items() \
+                                if 'iOS' in runtime \
+                                for dev in ds if 'iPhone' in dev['name']]; \
+                         print(devs[-1]['name'] if devs else '', end='')")
+          if [ -z "$UDID" ]; then
+            echo "No iPhone simulator device available on runner" >&2
+            xcrun simctl list devices available >&2
+            exit 1
+          fi
+          xcrun simctl boot "$UDID" 2>/dev/null || true   # idempotent
+          xcrun simctl bootstatus "$UDID" -b
+          echo "Using simulator: $NAME ($UDID)"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: xcodebuild test (UI)
+        # Same Keychain-entitlement note as the unit job — keep CODE_SIGNING
+        # at the default so XCUIApplication can use the test-isolated
+        # keychain service from the App's --ui-testing branch.
+        run: |
+          xcodebuild test \
+            -project OnymIOS.xcodeproj \
+            -scheme OnymIOS \
+            -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }},OS=latest" \
+            -derivedDataPath /tmp/onym-ios-release-ui \
+            -resultBundlePath /tmp/onym-ios-ui.xcresult \
+            -only-testing:OnymIOSUITests
+
+      - name: Upload UI test xcresult on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-tests-xcresult
+          path: /tmp/onym-ios-ui.xcresult
+          retention-days: 7
 
   build:
     runs-on: [self-hosted, macOS, ARM64]
-    needs: [lint, create-release, test]
+    needs: [lint, create-release, unit-tests, ui-tests]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -498,15 +498,37 @@ script and naming the reason in the PR.
    secret reads. Hard fail.
 2. **Create release** (ubuntu) — generates notes from `git log
    <prev-tag>..HEAD` and opens an empty GitHub Release at the tag.
-3. **Test** (self-hosted macOS ARM64) — `xcodebuild test` against an
-   iPhone simulator.
-4. **Build** (self-hosted macOS ARM64; needs all three above) —
+3. **Unit tests** (self-hosted macOS ARM64) — `xcodebuild test` with
+   `-only-testing:OnymIOSTests`. Fast (~10–20 s on a warm runner).
+4. **UI tests** (self-hosted macOS ARM64) — `xcodebuild test` with
+   `-only-testing:OnymIOSUITests`. Pre-boots the iPhone simulator so
+   the suite doesn't race the cold-boot. Slower (~90 s).
+5. **Build** (self-hosted macOS ARM64; needs **all four** above) —
    `bundle exec fastlane ios release` runs match (adhoc, readonly,
    git storage) → gym → produces a signed `OnymIOS-<version>.ipa`,
    which is uploaded to the release as an asset.
 
-Lint, create-release, and test run in parallel; build only starts
-when all three succeed. If lint fails the IPA never builds.
+```
+   workflow_dispatch -f tag=vX.Y.Z
+        │
+        ├─► lint           (ubuntu)              ─┐
+        ├─► create-release (ubuntu)              ─┤
+        ├─► unit-tests     (self-hosted macOS)   ─┤  all four
+        └─► ui-tests       (self-hosted macOS)   ─┘  must succeed
+                                                       │
+                                                       ▼
+                                                  build (self-hosted)
+                                                  fastlane match adhoc + gym
+                                                       │
+                                                       ▼
+                                                  upload IPA to GH Release
+```
+
+All four gate jobs run in parallel; build only starts when every
+one succeeds. If any test job fails its `.xcresult` bundle is
+uploaded as a build artifact (named `unit-tests-xcresult` /
+`ui-tests-xcresult`, retained 7 days) so the failure can be
+inspected without re-running the workflow.
 
 The structure was lifted from
 `stellar-mls/.github/workflows/release.yml` — minus TestFlight


### PR DESCRIPTION
## Summary

Splits the release pipeline's `test` job into two named, scoped
jobs (`unit-tests` and `ui-tests`) so each kind of test failure
surfaces independently in GitHub's job summary.

## Why now

The previous `test` job ran `xcodebuild test` against the OnymIOS
scheme without a target filter. After PR #8 the scheme picked up
`OnymIOSUITests`, so UI tests were technically already running on
every release dispatch — just invisibly, mixed into one job named
"test". A UI-only failure showed up as "test failed" with no signal
about whether unit or UI was broken until you opened the logs.

## New shape

```
workflow_dispatch -f tag=vX.Y.Z
      │
      ├─► lint           (ubuntu)              ─┐
      ├─► create-release (ubuntu)              ─┤
      ├─► unit-tests     (self-hosted macOS)   ─┤  all four
      └─► ui-tests       (self-hosted macOS)   ─┘  must succeed
                                                     │
                                                     ▼
                                                build (self-hosted)
                                                fastlane match adhoc + gym
                                                     │
                                                     ▼
                                                upload IPA to GH Release
```

| job | targets | wall (typical) |
|---|---|---|
| `unit-tests` | `OnymIOSTests` | ~10–20 s |
| `ui-tests`   | `OnymIOSUITests` | ~90 s |

`build` now waits on `[lint, create-release, unit-tests, ui-tests]`.
Any one failing prevents the IPA from being produced.

## What's actually changed

- **`unit-tests` job** — the old `test` job, narrowed to
  `-only-testing:OnymIOSTests`.
- **`ui-tests` job** — new sibling, `-only-testing:OnymIOSUITests`.
  Pre-boots the iPhone simulator (`simctl boot` + `simctl
  bootstatus -b`) before `xcodebuild test` runs. Cold-boot inside
  xcodebuild adds ~10 s and can race the first XCUIApplication
  interaction; pre-warming is the standard mitigation.
- **`-resultBundlePath`** on both jobs, with `actions/upload-artifact`
  capturing `.xcresult` bundles on failure (7-day retention). Failed
  tests can be inspected via `xcrun xcresulttool` without re-running
  the workflow.
- **`build.needs`** updated to all four upstream jobs.

## Test plan

- [x] `python3 scripts/lint-secrets.py` clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses
- [ ] First post-merge release dispatch — verify both jobs run and
      surface as separate entries in the run summary

Repro for triggering after merge:

```sh
gh workflow run Release -f tag=v0.0.2
gh run watch
```

## Out of scope (future)

- Move unit-tests to `macos-latest` (GitHub-hosted) for true
  parallelism — the self-hosted macOS runner serializes everything
  it picks up. Worth it once unit-tests grows past 5–10 s.
- A separate PR-time `ci.yml` workflow (today only release dispatch
  triggers tests). Useful when contributors land — flag for a
  future chunk.
- Snapshot / pixel-diff tests in the UI suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)