### PR TITLE
App icon + launch screen: lift Assets.xcassets from stellar-mls

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Onym</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string>LaunchBackground</string>
+		<key>UIImageName</key>
+		<string>LaunchLogo</string>
+	</dict>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Sources/OnymIOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Sources/OnymIOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/OnymIOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Sources/OnymIOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "images" : [
+    {
+      "filename" : "Icon-1024.png",
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/OnymIOS/Assets.xcassets/AppIcon.appiconset/Icon-1024.png
+++ b/Sources/OnymIOS/Assets.xcassets/AppIcon.appiconset/Icon-1024.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:229db30b93f20b7e270a75c7e2f7251d40dc893be4953cff7d77e84e005a56cd
+size 85869

--- a/Sources/OnymIOS/Assets.xcassets/Contents.json
+++ b/Sources/OnymIOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/OnymIOS/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/Sources/OnymIOS/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/OnymIOS/Assets.xcassets/LaunchLogo.imageset/Contents.json
+++ b/Sources/OnymIOS/Assets.xcassets/LaunchLogo.imageset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "images" : [
+    {
+      "filename" : "LaunchLogo.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "filename" : "LaunchLogo@2x.png",
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "filename" : "LaunchLogo@3x.png",
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/OnymIOS/Assets.xcassets/LaunchLogo.imageset/LaunchLogo.png
+++ b/Sources/OnymIOS/Assets.xcassets/LaunchLogo.imageset/LaunchLogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62d33a4b81ccc7971281d2487dc0c0749be8570a8c4cf4fbdca1597fe16c1141
+size 14931

--- a/Sources/OnymIOS/Assets.xcassets/LaunchLogo.imageset/LaunchLogo@2x.png
+++ b/Sources/OnymIOS/Assets.xcassets/LaunchLogo.imageset/LaunchLogo@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d017366ffb8b0406c24d592ec8b1d6093095f3510cee37056725bffe68c2be
+size 37240

--- a/Sources/OnymIOS/Assets.xcassets/LaunchLogo.imageset/LaunchLogo@3x.png
+++ b/Sources/OnymIOS/Assets.xcassets/LaunchLogo.imageset/LaunchLogo@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6323ad2926dccc9b44393e34ccadb054ef82cbbcc640a8d3d62176a5be6556c4
+size 72002

--- a/project.yml
+++ b/project.yml
@@ -26,26 +26,46 @@ targets:
       - Resources
     dependencies:
       - package: OnymSDK
+    # Hand-written Info.plist via xcodegen's `info:` block. We tried
+    # the GENERATE_INFOPLIST_FILE + INFOPLIST_KEY_* approach first but
+    # `INFOPLIST_KEY_UILaunchScreen_BackgroundColor` / `_ImageName` are
+    # silently ignored by Xcode's auto-generator — the launch dict came
+    # out empty, so the asset-catalog launch image never rendered.
+    # Migrating to a real Info.plist gives full control over the
+    # UILaunchScreen sub-keys (UIColorName + UIImageName) which point
+    # at `LaunchBackground` and `LaunchLogo` from
+    # `Sources/OnymIOS/Assets.xcassets`. Same shape as stellar-mls.
+    info:
+      path: Info.plist
+      properties:
+        CFBundleDisplayName: Onym
+        UIApplicationSceneManifest:
+          UIApplicationSupportsMultipleScenes: true
+          UISceneConfigurations: {}
+        UIApplicationSupportsIndirectInputEvents: true
+        UILaunchScreen:
+          UIColorName: LaunchBackground
+          UIImageName: LaunchLogo
+        UISupportedInterfaceOrientations~iphone:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios
-        INFOPLIST_KEY_CFBundleDisplayName: Onym
         MARKETING_VERSION: "0.0.1"
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: "5.0"
-        GENERATE_INFOPLIST_FILE: YES
-        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
-        INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
-        # Without a UILaunchScreen entry, iOS treats the app as a legacy
-        # iPhone-4-era binary and letterboxes it on every modern device
-        # (visible as huge black bars above and below the app's content).
-        # Setting this YES makes xcodegen emit an empty `UILaunchScreen`
-        # dict in Info.plist — opt-in to native dimensions, no real
-        # launch storyboard required since the SwiftUI scene takes over
-        # immediately on launch.
-        INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        # Asset catalog name for the AppIcon set. `AppIcon` is the
+        # default — explicit so renaming the .appiconset folder fails
+        # loud at build time instead of silently producing an unbranded
+        # icon.
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         TARGETED_DEVICE_FAMILY: "1,2"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}


### PR DESCRIPTION
## What it does

Copies the asset catalog verbatim from
`stellar-mls/clients/ios/StellarChat/StellarChat/Assets.xcassets`
into `Sources/OnymIOS/Assets.xcassets`:

- `AppIcon.appiconset/` — 1024×1024 source PNG (Onym mark)
- `LaunchLogo.imageset/` — 1x / 2x / 3x raster PNGs of the mark
- `LaunchBackground.colorset/` — white in both light + dark
- `AccentColor.colorset/` — default (system blue)

Same brand as `stellar-mls/StellarChat` — both ship under
`chat.onym.ios`, the logo and chrome should be identical.

## Why a real Info.plist now

PR #7 fixed the legacy-letterbox by setting
`INFOPLIST_KEY_UILaunchScreen_Generation: YES`, which makes Xcode
synthesise an empty `UILaunchScreen {}` dict. That gets us native
dimensions but a boring white screen on launch with no logo.

To point the launch dict at `LaunchBackground` + `LaunchLogo` from
the asset catalog, the dict's sub-keys (`UIColorName`,
`UIImageName`) must be filled in. Tried
`INFOPLIST_KEY_UILaunchScreen_BackgroundColor` /
`_ImageName` first — Xcode silently ignores these; the dict stayed
empty. So this PR migrates the OnymIOS target to xcodegen's
`info:` block (real, generated `Info.plist` at the worktree root)
which lets us specify the launch dict's full contents.

All previous `INFOPLIST_KEY_*` settings move into `info.properties`:

```yaml
info:
  path: Info.plist
  properties:
    CFBundleDisplayName: Onym
    UIApplicationSceneManifest:
      UIApplicationSupportsMultipleScenes: true
      UISceneConfigurations: {}
    UIApplicationSupportsIndirectInputEvents: true
    UILaunchScreen:
      UIColorName: LaunchBackground
      UIImageName: LaunchLogo
    UISupportedInterfaceOrientations~iphone: [...]
    UISupportedInterfaceOrientations~ipad:   [...]
```

Also: `ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon` is set
explicitly. It's the default — explicit means renaming the
appiconset directory fails loud at build time instead of silently
producing an unbranded icon.

## Verification

Built + installed on iPhone 17 Pro simulator. Captured the launch
screen via `xcrun simctl io booted screenshot` immediately after
launch — shows the Onym broken-circle mark centered on a white
background, exactly matching stellar-mls.

`plutil -p` on the rebuilt Info.plist confirms:

```
UILaunchScreen => {
  UIColorName => LaunchBackground
  UIImageName => LaunchLogo
}
```

Bundle has rasterized icon variants for both iPhone and iPad:

```
AppIcon60x60@2x.png        (iPhone primary)
AppIcon76x76@2x~ipad.png   (iPad primary)
```

## Test plan

- [x] `xcodebuild build` clean
- [x] All 24 existing unit tests pass green
- [x] `python3 scripts/lint-secrets.py` clean
- [x] Visual: launch screen captured with Onym mark on white
- [ ] Visual: home-screen icon — verify on real device after merge,
      since simulator home-screen icon caching can be stubborn

🤖 Generated with [Claude Code](https://claude.com/claude-code)