### PR TITLE
gitignore: .claude/ (Claude Code per-chunk worktrees + scratch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ vendor/
 *.tmp
 *.swp
 *.swo
+
+# Claude Code per-session worktrees + agent scratch state. Each chunk
+# is developed in its own `.claude/worktrees/<name>/` checkout that
+# gets wiped after its PR merges. Nothing in this directory is build
+# input or the source of truth.
+.claude/


### PR DESCRIPTION
## Summary

One-line `.gitignore` addition: `.claude/`. Each chunk lands in its
own per-session worktree under `.claude/worktrees/<name>/` (created
fresh, wiped clean after the PR merges). Nothing in that directory
is build input or the source of truth — it's purely local agent
state. Listing it as untracked on every `git status` in main was
noise.

## Bonus context: why \`Resources/Localizable.xcstrings\` keeps
showing dirty after Xcode opens the project

It's not a real change — Xcode's String Catalog tooling re-runs
**source extraction** every time the project opens / builds, then
re-saves the catalog with metadata flags reflecting what it found.
The translations stay byte-identical; only the metadata mutates:

| `extractionState` | meaning |
|---|---|
| `extracted_with_value` | Xcode found this exact key as a literal in source |
| `new` | found in source but no translation yet |
| `manual` | hand-added in the catalog editor; never extracted |
| `stale` | catalog has it, but extraction didn't find a literal for it |

Three patterns in our code trip false-positive `stale` flags:

1. **Computed `LocalizedStringKey` properties** —
   ```swift
   private var navigationTitle: LocalizedStringKey {
       switch flow.step {
       case .intro: return "Back up keys"   // extractor sees the literal,
                                            // but it's stored, not passed
                                            // to a recognised localization
                                            // API at this site
       }
   }
   ```
2. **`String(localized:)` with interpolation** —
   ```swift
   String(localized: "Backed up \(date) · BIP-39 English")
   ```
   The interpolation makes the key non-literal. Xcode also auto-extracts a bare `\"%@\"` artifact from the format-string token (visible in the diff).
3. **Three test targets** (`OnymIOS`, `OnymIOSTests`, `OnymIOSUITests`) — extraction runs per-target. A key referenced only from the App target looks "stale" from a tests-target pass.

Plus Xcode 26 dropped writing the `\"version\" : \"1.0\"` field
because it's now implicit. Cosmetic.

**The committed catalog file is the truth.** When you see the
catalog dirty without intentionally editing it:

```sh
git restore Resources/Localizable.xcstrings
```

Don't bother fighting Xcode — the noise is harmless metadata,
discarding it costs nothing.

## Test plan

- [x] `git status` on main now reports clean working tree (after
      restoring the dirty Localizable.xcstrings)
- [x] No build / test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)