### PR TITLE
transport: unit tests for Nostr framing + signer

### DIFF
--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -29,20 +29,30 @@ final class NostrInboxTransport: InboxTransport {
     @discardableResult
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         let signer = try OnymNostrSigner.ephemeral()
+        let event = try Self.buildSendEvent(payload: payload, inbox: inbox, signer: signer)
+        let accepted = try await state.send(event: event)
+        return PublishReceipt(messageID: event.id, acceptedBy: accepted)
+    }
+
+    /// Pure event-builder for the send path. Exposed at `internal` access
+    /// so tests can verify the inbox tag set without standing up a relay.
+    static func buildSendEvent(
+        payload: Data,
+        inbox: TransportInboxID,
+        signer: NostrSigner
+    ) throws -> NostrEvent {
         let tags: [[String]] = [
-            ["d", Self.inboxTagPrefix + inbox.rawValue],
+            ["d", inboxTagPrefix + inbox.rawValue],
             ["t", inbox.rawValue],
             ["sep_inbox", inbox.rawValue],
             ["sep_version", "1"],
         ]
-        let event = try NostrEvent.build(
-            kind: Self.primaryKind,
+        return try NostrEvent.build(
+            kind: primaryKind,
             tags: tags,
             content: payload.base64EncodedString(),
             signer: signer
         )
-        let accepted = try await state.send(event: event)
-        return PublishReceipt(messageID: event.id, acceptedBy: accepted)
     }
 
     func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
@@ -60,7 +70,11 @@ final class NostrInboxTransport: InboxTransport {
         await state.unsubscribe(inbox: inbox)
     }
 
-    fileprivate static func subscriptionFilters(inbox: String) -> [[String: Any]] {
+    /// Three filter shapes the subscriber installs on each relay:
+    /// the primary `#d` (parameterised-replaceable) plus a `#t`
+    /// fallback on the same kind, plus the legacy kind 24113 path
+    /// during migration. Internal so tests can assert the shape.
+    static func subscriptionFilters(inbox: String) -> [[String: Any]] {
         [
             [
                 "kinds": [primaryKind],

--- a/Sources/OnymIOS/Transport/Nostr/NostrMessageTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrMessageTransport.swift
@@ -31,14 +31,25 @@ final class NostrMessageTransport: MessageTransport {
     @discardableResult
     func publish(_ payload: Data, to topic: TransportTopic) async throws -> PublishReceipt {
         let signer = try OnymNostrSigner.ephemeral()
-        let event = try NostrEvent.build(
-            kind: Self.primaryKind,
+        let event = try Self.buildPublishEvent(payload: payload, topic: topic, signer: signer)
+        let accepted = try await state.publish(event: event)
+        return PublishReceipt(messageID: event.id, acceptedBy: accepted)
+    }
+
+    /// Pure event-builder for the publish path. Exposed at `internal`
+    /// access so tests can verify Nostr framing (kind, topic tag, base64
+    /// payload, valid id) without standing up a relay.
+    static func buildPublishEvent(
+        payload: Data,
+        topic: TransportTopic,
+        signer: NostrSigner
+    ) throws -> NostrEvent {
+        try NostrEvent.build(
+            kind: primaryKind,
             tags: [["t", topic.rawValue]],
             content: payload.base64EncodedString(),
             signer: signer
         )
-        let accepted = try await state.publish(event: event)
-        return PublishReceipt(messageID: event.id, acceptedBy: accepted)
     }
 
     func subscribe(topic: TransportTopic, since: Date?) -> AsyncStream<InboundMessage> {

--- a/Tests/OnymIOSTests/NostrEventTests.swift
+++ b/Tests/OnymIOSTests/NostrEventTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+@testable import OnymIOS
+
+/// Tests for the NIP-01 wire format and the integrity check that
+/// `NostrRelayConnection` runs on every inbound event. These are the
+/// only invariants that protect us from relay-side tampering, so the
+/// coverage is deliberately blunt: build → mutate one byte → verify
+/// fails.
+final class NostrEventTests: XCTestCase {
+    private var signer: OnymNostrSigner!
+
+    override func setUp() {
+        super.setUp()
+        // Deterministic 32-byte secret so generated event ids are stable
+        // across runs — makes failures easier to debug than a random key.
+        let secret = Data(repeating: 0xAB, count: 32)
+        signer = try! OnymNostrSigner(secretKey: secret)
+    }
+
+    // MARK: - build
+
+    func test_build_producesValidEventID() throws {
+        let event = try NostrEvent.build(
+            kind: 44114,
+            tags: [["t", "topic-x"]],
+            content: "hello",
+            signer: signer
+        )
+        XCTAssertTrue(event.verifyEventID(), "freshly built event must verify")
+    }
+
+    func test_build_appendsMillisecondTag() throws {
+        let event = try NostrEvent.build(
+            kind: 44114,
+            tags: [["t", "topic-x"]],
+            content: "hello",
+            signer: signer
+        )
+        let msTag = event.tags.first { $0.first == "ms" }
+        XCTAssertNotNil(msTag, "build() must append [\"ms\", ...]")
+        XCTAssertEqual(msTag?.count, 2)
+        let ms = Int64(msTag?[1] ?? "")
+        XCTAssertNotNil(ms)
+        // Within 5s of "now" — sanity, not exact equality.
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        XCTAssertLessThan(abs((ms ?? 0) - nowMs), 5_000)
+    }
+
+    func test_build_signatureIs64Bytes() throws {
+        let event = try NostrEvent.build(
+            kind: 44114,
+            tags: [],
+            content: "x",
+            signer: signer
+        )
+        XCTAssertEqual(event.sig.count, 128, "BIP340 sig is 64 bytes = 128 hex chars")
+    }
+
+    func test_build_pubkeyMatchesSigner() throws {
+        let event = try NostrEvent.build(
+            kind: 44114,
+            tags: [],
+            content: "x",
+            signer: signer
+        )
+        let expectedPubkeyHex = try signer.publicKey().map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(event.pubkey, expectedPubkeyHex)
+    }
+
+    func test_build_preservesCallerProvidedTags() throws {
+        let userTags: [[String]] = [["t", "topic-x"], ["sep_version", "1"]]
+        let event = try NostrEvent.build(
+            kind: 34113,
+            tags: userTags,
+            content: "x",
+            signer: signer
+        )
+        // Caller tags appear first, then the appended ms tag.
+        XCTAssertEqual(Array(event.tags.prefix(userTags.count)), userTags)
+    }
+
+    // MARK: - verifyEventID tampering
+
+    func test_verifyEventID_rejectsTamperedContent() throws {
+        let event = try NostrEvent.build(kind: 44114, tags: [], content: "hello", signer: signer)
+        let tampered = NostrEvent(
+            id: event.id, pubkey: event.pubkey, createdAt: event.createdAt,
+            kind: event.kind, tags: event.tags,
+            content: "goodbye", sig: event.sig
+        )
+        XCTAssertFalse(tampered.verifyEventID())
+    }
+
+    func test_verifyEventID_rejectsTamperedTags() throws {
+        let event = try NostrEvent.build(kind: 44114, tags: [["t", "a"]], content: "x", signer: signer)
+        let tampered = NostrEvent(
+            id: event.id, pubkey: event.pubkey, createdAt: event.createdAt,
+            kind: event.kind,
+            tags: [["t", "b"]] + event.tags.dropFirst(),
+            content: event.content, sig: event.sig
+        )
+        XCTAssertFalse(tampered.verifyEventID())
+    }
+
+    func test_verifyEventID_rejectsTamperedKind() throws {
+        let event = try NostrEvent.build(kind: 44114, tags: [], content: "x", signer: signer)
+        let tampered = NostrEvent(
+            id: event.id, pubkey: event.pubkey, createdAt: event.createdAt,
+            kind: 1, tags: event.tags,
+            content: event.content, sig: event.sig
+        )
+        XCTAssertFalse(tampered.verifyEventID())
+    }
+
+    // MARK: - displayMilliseconds
+
+    func test_displayMilliseconds_readsMsTag() {
+        let event = NostrEvent(
+            id: "00", pubkey: "00", createdAt: 1_700_000_000,
+            kind: 44114, tags: [["ms", "1700000000123"]],
+            content: "", sig: ""
+        )
+        XCTAssertEqual(event.displayMilliseconds, 1_700_000_000_123)
+    }
+
+    func test_displayMilliseconds_fallsBackToCreatedAt() {
+        let event = NostrEvent(
+            id: "00", pubkey: "00", createdAt: 1_700_000_000,
+            kind: 44114, tags: [],
+            content: "", sig: ""
+        )
+        XCTAssertEqual(event.displayMilliseconds, 1_700_000_000_000)
+    }
+
+    func test_displayMilliseconds_ignoresMalformedMsTag() {
+        let event = NostrEvent(
+            id: "00", pubkey: "00", createdAt: 1_700_000_000,
+            kind: 44114, tags: [["ms", "not-a-number"]],
+            content: "", sig: ""
+        )
+        XCTAssertEqual(event.displayMilliseconds, 1_700_000_000_000)
+    }
+
+    func test_displayMilliseconds_ignoresNegativeMs() {
+        let event = NostrEvent(
+            id: "00", pubkey: "00", createdAt: 1_700_000_000,
+            kind: 44114, tags: [["ms", "-1"]],
+            content: "", sig: ""
+        )
+        XCTAssertEqual(event.displayMilliseconds, 1_700_000_000_000)
+    }
+
+    // MARK: - Codable
+
+    func test_codable_usesCreatedAtFieldName() throws {
+        let event = NostrEvent(
+            id: "deadbeef", pubkey: "abc", createdAt: 42,
+            kind: 1, tags: [["t", "x"]], content: "hi", sig: "sig"
+        )
+        let json = try JSONEncoder().encode(event)
+        let dict = try JSONSerialization.jsonObject(with: json) as? [String: Any]
+        XCTAssertNotNil(dict?["created_at"], "wire field is `created_at`, not `createdAt`")
+        XCTAssertNil(dict?["createdAt"])
+    }
+
+    func test_codable_roundtrip() throws {
+        let original = NostrEvent(
+            id: "deadbeef", pubkey: "abc", createdAt: 42,
+            kind: 1, tags: [["t", "x"], ["ms", "42000"]], content: "hi", sig: "sig"
+        )
+        let json = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(NostrEvent.self, from: json)
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.createdAt, original.createdAt)
+        XCTAssertEqual(decoded.tags, original.tags)
+        XCTAssertEqual(decoded.content, original.content)
+    }
+}

--- a/Tests/OnymIOSTests/NostrInboxTransportTests.swift
+++ b/Tests/OnymIOSTests/NostrInboxTransportTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import OnymIOS
+
+/// Covers the pure event-building and filter-shape paths of the inbox
+/// adapter. Connection-bearing paths await an integration test layer.
+final class NostrInboxTransportTests: XCTestCase {
+    private var signer: OnymNostrSigner!
+
+    override func setUp() {
+        super.setUp()
+        signer = try! OnymNostrSigner(secretKey: Data(repeating: 0xEF, count: 32))
+    }
+
+    // MARK: - buildSendEvent
+
+    func test_buildSendEvent_usesKind34113() throws {
+        let event = try NostrInboxTransport.buildSendEvent(
+            payload: Data(),
+            inbox: TransportInboxID(rawValue: "abc123"),
+            signer: signer
+        )
+        XCTAssertEqual(event.kind, 34113)
+    }
+
+    func test_buildSendEvent_emitsExpectedTagSet() throws {
+        let event = try NostrInboxTransport.buildSendEvent(
+            payload: Data(),
+            inbox: TransportInboxID(rawValue: "abc123"),
+            signer: signer
+        )
+        // Strip the appended ms tag — its value is non-deterministic.
+        let userTags = event.tags.filter { $0.first != "ms" }
+        XCTAssertEqual(userTags, [
+            ["d", "sep-inbox:abc123"],
+            ["t", "abc123"],
+            ["sep_inbox", "abc123"],
+            ["sep_version", "1"],
+        ])
+    }
+
+    func test_buildSendEvent_dTagPrefixIsLoadBearing() throws {
+        // A relay using the parameterised-replaceable `d` tag for routing
+        // would key on the literal string — drift on the prefix would
+        // silently break delivery.
+        let event = try NostrInboxTransport.buildSendEvent(
+            payload: Data(),
+            inbox: TransportInboxID(rawValue: "id-1"),
+            signer: signer
+        )
+        let dTag = event.tags.first { $0.first == "d" }
+        XCTAssertEqual(dTag?[1], "sep-inbox:id-1")
+    }
+
+    func test_buildSendEvent_payloadRoundtripsViaBase64() throws {
+        let payload = Data("invitation-blob".utf8)
+        let event = try NostrInboxTransport.buildSendEvent(
+            payload: payload,
+            inbox: TransportInboxID(rawValue: "x"),
+            signer: signer
+        )
+        XCTAssertEqual(Data(base64Encoded: event.content), payload)
+    }
+
+    func test_buildSendEvent_eventIDIsValid() throws {
+        let event = try NostrInboxTransport.buildSendEvent(
+            payload: Data("x".utf8),
+            inbox: TransportInboxID(rawValue: "x"),
+            signer: signer
+        )
+        XCTAssertTrue(event.verifyEventID())
+    }
+
+    // MARK: - subscriptionFilters
+
+    func test_subscriptionFilters_returnsThreeShapes() {
+        let filters = NostrInboxTransport.subscriptionFilters(inbox: "id-1")
+        XCTAssertEqual(filters.count, 3,
+                       "primary #d + secondary #t + legacy kind = 3 filters")
+    }
+
+    func test_subscriptionFilters_primaryUsesDTagWithPrefix() {
+        let filters = NostrInboxTransport.subscriptionFilters(inbox: "id-1")
+        let kinds = filters[0]["kinds"] as? [Int]
+        let dValues = filters[0]["#d"] as? [String]
+        XCTAssertEqual(kinds, [34113])
+        XCTAssertEqual(dValues, ["sep-inbox:id-1"])
+    }
+
+    func test_subscriptionFilters_secondaryUsesTTagOnPrimaryKind() {
+        let filters = NostrInboxTransport.subscriptionFilters(inbox: "id-1")
+        let kinds = filters[1]["kinds"] as? [Int]
+        let tValues = filters[1]["#t"] as? [String]
+        XCTAssertEqual(kinds, [34113])
+        XCTAssertEqual(tValues, ["id-1"])
+    }
+
+    func test_subscriptionFilters_legacyUsesTTagOnLegacyKind() {
+        let filters = NostrInboxTransport.subscriptionFilters(inbox: "id-1")
+        let kinds = filters[2]["kinds"] as? [Int]
+        let tValues = filters[2]["#t"] as? [String]
+        XCTAssertEqual(kinds, [24113])
+        XCTAssertEqual(tValues, ["id-1"])
+    }
+}

--- a/Tests/OnymIOSTests/NostrMessageTransportTests.swift
+++ b/Tests/OnymIOSTests/NostrMessageTransportTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import OnymIOS
+
+/// Covers the pure event-building path of the broadcast adapter. The
+/// connection / publish / subscribe paths require a real or fake
+/// WebSocket server and are deferred to integration tests.
+final class NostrMessageTransportTests: XCTestCase {
+    private var signer: OnymNostrSigner!
+
+    override func setUp() {
+        super.setUp()
+        signer = try! OnymNostrSigner(secretKey: Data(repeating: 0xCD, count: 32))
+    }
+
+    func test_buildPublishEvent_usesKind44114() throws {
+        let event = try NostrMessageTransport.buildPublishEvent(
+            payload: Data("hello".utf8),
+            topic: TransportTopic(rawValue: "topic-a"),
+            signer: signer
+        )
+        XCTAssertEqual(event.kind, 44114)
+    }
+
+    func test_buildPublishEvent_emitsTopicTag() throws {
+        let event = try NostrMessageTransport.buildPublishEvent(
+            payload: Data(),
+            topic: TransportTopic(rawValue: "topic-a"),
+            signer: signer
+        )
+        let tTags = event.tags.filter { $0.first == "t" }
+        XCTAssertEqual(tTags, [["t", "topic-a"]],
+                       "publish must emit exactly one [t, topic] tag")
+    }
+
+    func test_buildPublishEvent_appendsMsTag() throws {
+        let event = try NostrMessageTransport.buildPublishEvent(
+            payload: Data(),
+            topic: TransportTopic(rawValue: "x"),
+            signer: signer
+        )
+        XCTAssertNotNil(event.tags.first { $0.first == "ms" })
+    }
+
+    func test_buildPublishEvent_payloadRoundtripsViaBase64() throws {
+        let payload = Data((0..<256).map { UInt8($0) })
+        let event = try NostrMessageTransport.buildPublishEvent(
+            payload: payload,
+            topic: TransportTopic(rawValue: "x"),
+            signer: signer
+        )
+        let decoded = Data(base64Encoded: event.content)
+        XCTAssertEqual(decoded, payload)
+    }
+
+    func test_buildPublishEvent_emptyPayloadProducesEmptyBase64() throws {
+        let event = try NostrMessageTransport.buildPublishEvent(
+            payload: Data(),
+            topic: TransportTopic(rawValue: "x"),
+            signer: signer
+        )
+        XCTAssertEqual(event.content, "")
+    }
+
+    func test_buildPublishEvent_eventIDIsValid() throws {
+        let event = try NostrMessageTransport.buildPublishEvent(
+            payload: Data("hello".utf8),
+            topic: TransportTopic(rawValue: "topic-a"),
+            signer: signer
+        )
+        XCTAssertTrue(event.verifyEventID())
+    }
+
+    func test_buildPublishEvent_distinctEphemeralSignersProduceDifferentPubkeys() throws {
+        let signerA = try OnymNostrSigner.ephemeral()
+        let signerB = try OnymNostrSigner.ephemeral()
+        let topic = TransportTopic(rawValue: "x")
+        let eventA = try NostrMessageTransport.buildPublishEvent(payload: Data(), topic: topic, signer: signerA)
+        let eventB = try NostrMessageTransport.buildPublishEvent(payload: Data(), topic: topic, signer: signerB)
+        XCTAssertNotEqual(eventA.pubkey, eventB.pubkey,
+                          "ephemeral signing is the metadata-hiding property — pubkeys must differ")
+    }
+}

--- a/Tests/OnymIOSTests/OnymNostrSignerTests.swift
+++ b/Tests/OnymIOSTests/OnymNostrSignerTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+import OnymSDK
+@testable import OnymIOS
+
+/// Hits OnymSDK's BIP340 / secp256k1 FFI through `OnymNostrSigner` —
+/// no mocks. The roundtrip uses `Common.nostrVerifyEventSignature` so
+/// a regression in either signing or verification surfaces here.
+final class OnymNostrSignerTests: XCTestCase {
+
+    // MARK: - constructor
+
+    func test_init_acceptsValid32ByteSecret() throws {
+        let secret = Data(repeating: 0x01, count: 32)
+        XCTAssertNoThrow(try OnymNostrSigner(secretKey: secret))
+    }
+
+    func test_init_rejectsShortSecret() {
+        let secret = Data(repeating: 0x01, count: 31)
+        XCTAssertThrowsError(try OnymNostrSigner(secretKey: secret)) { error in
+            guard case NostrSignerError.invalidSecretKeyLength(let actual) = error else {
+                return XCTFail("expected invalidSecretKeyLength, got \(error)")
+            }
+            XCTAssertEqual(actual, 31)
+        }
+    }
+
+    func test_init_rejectsLongSecret() {
+        let secret = Data(repeating: 0x01, count: 33)
+        XCTAssertThrowsError(try OnymNostrSigner(secretKey: secret))
+    }
+
+    func test_init_rejectsEmptySecret() {
+        XCTAssertThrowsError(try OnymNostrSigner(secretKey: Data()))
+    }
+
+    // MARK: - publicKey
+
+    func test_publicKey_is32Bytes() throws {
+        let signer = try OnymNostrSigner(secretKey: Data(repeating: 0x42, count: 32))
+        let pub = try signer.publicKey()
+        XCTAssertEqual(pub.count, 32, "BIP340 x-only pubkey is 32 bytes")
+    }
+
+    func test_publicKey_isDeterministic() throws {
+        let secret = Data(repeating: 0x42, count: 32)
+        let signerA = try OnymNostrSigner(secretKey: secret)
+        let signerB = try OnymNostrSigner(secretKey: secret)
+        let pubA = try signerA.publicKey()
+        let pubB = try signerB.publicKey()
+        XCTAssertEqual(pubA, pubB)
+    }
+
+    // MARK: - signEventID
+
+    func test_signEventID_rejectsShortEventID() throws {
+        let signer = try OnymNostrSigner(secretKey: Data(repeating: 0x01, count: 32))
+        XCTAssertThrowsError(try signer.signEventID(Data(repeating: 0xAA, count: 31))) { error in
+            guard case NostrSignerError.invalidEventIDLength(let actual) = error else {
+                return XCTFail("expected invalidEventIDLength, got \(error)")
+            }
+            XCTAssertEqual(actual, 31)
+        }
+    }
+
+    func test_signEventID_returns64Bytes() throws {
+        let signer = try OnymNostrSigner(secretKey: Data(repeating: 0x01, count: 32))
+        let eventID = Data(repeating: 0xAA, count: 32)
+        let sig = try signer.signEventID(eventID)
+        XCTAssertEqual(sig.count, 64, "BIP340 schnorr sig is 64 bytes")
+    }
+
+    func test_signEventID_verifiesAgainstOnymSDK() throws {
+        let signer = try OnymNostrSigner(secretKey: Data(repeating: 0x01, count: 32))
+        let pub = try signer.publicKey()
+        let eventID = Data(repeating: 0xAA, count: 32)
+        let sig = try signer.signEventID(eventID)
+        XCTAssertNoThrow(
+            try Common.nostrVerifyEventSignature(publicKey: pub, eventId: eventID, signature: sig),
+            "OnymSDK must verify a signature its own signer just produced"
+        )
+    }
+
+    func test_signEventID_verificationFailsForWrongMessage() throws {
+        let signer = try OnymNostrSigner(secretKey: Data(repeating: 0x01, count: 32))
+        let pub = try signer.publicKey()
+        let signedID = Data(repeating: 0xAA, count: 32)
+        let otherID = Data(repeating: 0xBB, count: 32)
+        let sig = try signer.signEventID(signedID)
+        XCTAssertThrowsError(
+            try Common.nostrVerifyEventSignature(publicKey: pub, eventId: otherID, signature: sig)
+        )
+    }
+
+    // MARK: - ephemeral
+
+    func test_ephemeral_producesDistinctKeysPerCall() throws {
+        let a = try OnymNostrSigner.ephemeral()
+        let b = try OnymNostrSigner.ephemeral()
+        XCTAssertNotEqual(a.secretKey, b.secretKey)
+        XCTAssertNotEqual(try a.publicKey(), try b.publicKey())
+    }
+
+    func test_ephemeral_secretIs32Bytes() throws {
+        let signer = try OnymNostrSigner.ephemeral()
+        XCTAssertEqual(signer.secretKey.count, 32)
+    }
+
+    func test_ephemeral_canSignAndVerify() throws {
+        let signer = try OnymNostrSigner.ephemeral()
+        let pub = try signer.publicKey()
+        let eventID = Data(repeating: 0x55, count: 32)
+        let sig = try signer.signEventID(eventID)
+        XCTAssertNoThrow(
+            try Common.nostrVerifyEventSignature(publicKey: pub, eventId: eventID, signature: sig)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #12. Pins the Nostr transport's wire-format invariants with 43 unit tests:

- **NostrEvent** (14 tests) — `build` produces a verifying NIP-01 id, appends the `["ms", ...]` ordering tag, signs with the supplied signer's pubkey, preserves caller tags. `verifyEventID` rejects tampered content / tags / kind. `displayMilliseconds` reads the ms tag and falls back to `createdAt * 1000` for legacy / malformed / negative values. Codable shape uses the `created_at` wire field.
- **OnymNostrSigner** (13 tests) — length validation on secret + event id, deterministic 32-byte pubkey, BIP340 signature is 64 bytes, sign/verify roundtrip via `OnymSDK.Common.nostrVerifyEventSignature`, verification fails for the wrong message, `ephemeral()` produces distinct keys per call (the metadata-hiding property).
- **NostrMessageTransport** (7 tests) — `buildPublishEvent` emits kind 44114, exactly one `["t", topic]` tag, base64-roundtripping payload (including empty), valid event id, distinct ephemeral pubkeys for distinct signers.
- **NostrInboxTransport** (9 tests) — `buildSendEvent` emits kind 34113 with the full tag set (`d` with `sep-inbox:` prefix + `t` + `sep_inbox` + `sep_version`), valid event id. `subscriptionFilters` returns the three expected shapes (primary `#d` on 34113, secondary `#t` on 34113, legacy `#t` on 24113).

## Refactor enabling the tests

`NostrMessageTransport.publish` and `NostrInboxTransport.send` extracted the pure event-building into `static buildPublishEvent` / `buildSendEvent` (`internal` access). `NostrInboxTransport.subscriptionFilters` promoted from `fileprivate` to `internal`. No behaviour change.

## Out of scope

Connection-bearing publish/subscribe paths (`NostrRelayConnection`, `NostrMessageTransport.subscribe`, `NostrInboxTransport.subscribe`) require a real or fake WebSocket relay and belong in an integration test layer.

## Test plan

- [x] `xcodebuild test -only-testing:NostrEventTests/OnymNostrSignerTests/NostrMessageTransportTests/NostrInboxTransportTests` on iPhone 17 Pro simulator: 43/43 pass in 0.029s.
- [x] Full `OnymIOSTests` suite still green (no regressions in IdentityRepository / RecoveryPhraseBackupFlow / Smoke tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)