### PR TITLE
architecture: align code with diagram (close OnymSDK + repository leaks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Solid boxes exist today; dashed boxes are planned.
                                                      ▼              │
                                           ┌──────────────────────────────────┐
                                           │ Interactors (@Observable)        │
-                                          │ stateless orchestration ·        │
-                                          │ no I/O · no persistence          │
+                                          │ owns flow state · no domain      │
+                                          │ state · UI-affordance I/O via    │
+                                          │ small local seams                │
                                           │ RecoveryPhraseBackupFlow         │
                                           │ ╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶     │
                                           │ ╎ planned: ChatFlow · InviteFlow ╎│
@@ -77,7 +78,10 @@ Solid boxes exist today; dashed boxes are planned.
                                           ║ Common · Anarchy · OneOnOne ·      ║
                                           ║ Tyranny — Plonk · Poseidon · BLS · ║
                                           ║ BIP340 Nostr signing               ║
-                                          ║ called ONLY from inside repositories ║
+                                          ║ imported only from the Identity    ║
+                                          ║ layer (repositories + their own    ║
+                                          ║ signer providers like              ║
+                                          ║ OnymNostrSignerProvider)           ║
                                           ╚════════════════════════════════════╝
 ```
 
@@ -89,9 +93,9 @@ review where it isn't.
 
 | Layer | May call | Forbidden |
 |---|---|---|
-| **View** | its own interactor (intents in, snapshots out) | repository directly · `OnymSDK` · Keychain · transport · `URLSession` · another interactor |
-| **Interactor** | repositories (commands + snapshots) | `OnymSDK` · Keychain · transport · disk · network · another interactor's internals |
-| **Repository** | persistence seam · transport seam · `OnymSDK` | another repository's internals · views · interactors |
+| **View** | its own interactor (intents in, snapshots out) · child-interactor factory closures from `AppDependencies` | repository directly · `OnymSDK` · Keychain · transport · `URLSession` · another interactor's internals |
+| **Interactor** | repositories (commands + snapshots) · its own small UI-affordance seams (clipboard, biometric prompt, haptics) | `OnymSDK` · Keychain · transport · disk · network · persistence I/O · another interactor's internals |
+| **Repository** | persistence seam · transport seam · `OnymSDK` (directly or via a repository-owned adapter like `OnymNostrSignerProvider`) | another repository's internals · views · interactors |
 | **Persistence / Transport seam** | the one concrete backend it implements | repositories · `OnymSDK` · the other seam |
 | **OnymSDK** | itself | everything above |
 
@@ -121,17 +125,25 @@ Two extra invariants that cut across the layers:
   `KeychainStore` reference — swapping in a SQLite-backed or in-memory
   store for a different deployment / test environment is a constructor
   change, not a rewrite.
-- **Interactors are stateless.** The reference impl puts orchestration
-  on `AppState`, a single `@Observable` god-object. We split
-  orchestration per-flow (`RecoveryPhraseBackupFlow` today, `ChatFlow`
-  / `InviteFlow` later); each owns its own state machine and *only*
-  its state machine. Repository state stays in the repository.
-- **Views never close over a repository.** SwiftUI views observe an
-  interactor's snapshot and dispatch intents; the interactor is the
-  only thing that holds a reference to a repository. A view written
-  against this layering can be redesigned (or A/B-tested, or skinned
-  for a different surface like a Watch complication) without changing
-  anything below it.
+- **Interactors own flow state, not domain state.** The reference impl
+  puts orchestration on `AppState`, a single `@Observable` god-object
+  that mixes per-screen flow state with cross-cutting domain state. We
+  split orchestration per-flow (`RecoveryPhraseBackupFlow` today,
+  `ChatFlow` / `InviteFlow` later); each owns its own state machine and
+  *only* its state machine — no shared mutable bag. Domain state stays
+  in the repository.
+- **Views never hold a repository reference.** `OnymIOSApp` constructs
+  `AppDependencies` once with factory closures that capture the
+  repositories. Views receive only the closures (`makeBackupFlow: () ->
+  RecoveryPhraseBackupFlow`) and call them when they need a fresh
+  interactor. The compiler can't accidentally dot-access a repository
+  from a view because views never see the type.
+- **`OnymSDK` is callable only from the Identity layer.** The
+  `Transport/Nostr/` seam imports zero `OnymSDK` symbols — it asks an
+  injected `NostrEphemeralSignerProvider` for a fresh signer per
+  outgoing event. The provider implementation
+  (`OnymNostrSignerProvider`) lives in `Identity/` next to
+  `IdentityRepository`, the only other place that imports `OnymSDK`.
 
 ### Why `IdentityRepository` is the root
 

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// App-wide composition root. Constructed exactly once by `OnymIOSApp`
+/// and threaded down to views via `RootView`. Each member is a factory
+/// closure that captures the repositories / I/O affordances it needs —
+/// views receive only these factories so they never hold a repository
+/// reference themselves.
+struct AppDependencies {
+    let makeRecoveryPhraseBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
+}

--- a/Sources/OnymIOS/Identity/OnymNostrSigner.swift
+++ b/Sources/OnymIOS/Identity/OnymNostrSigner.swift
@@ -1,0 +1,51 @@
+import Foundation
+import OnymSDK
+import Security
+
+/// `NostrSigner` backed by a 32-byte secp256k1 secret. Uses
+/// `OnymSDK.Common` for the underlying BIP340 operations. Lives in the
+/// Identity layer (alongside the only other `OnymSDK` consumer,
+/// `IdentityRepository`) so the Transport seam never imports `OnymSDK`.
+struct OnymNostrSigner: NostrSigner {
+    let secretKey: Data
+
+    init(secretKey: Data) throws {
+        guard secretKey.count == 32 else {
+            throw NostrSignerError.invalidSecretKeyLength(actual: secretKey.count)
+        }
+        self.secretKey = secretKey
+    }
+
+    func publicKey() throws -> Data {
+        try Common.nostrDerivePublicKey(secretKey: secretKey)
+    }
+
+    func signEventID(_ eventID: Data) throws -> Data {
+        guard eventID.count == 32 else {
+            throw NostrSignerError.invalidEventIDLength(actual: eventID.count)
+        }
+        return try Common.nostrSignEventId(secretKey: secretKey, eventId: eventID)
+    }
+
+    /// Per-event ephemeral signer backed by a fresh CSPRNG-derived
+    /// secret. Construction-time convenience used by the production
+    /// signer provider and by tests; production callers in the Transport
+    /// layer go through `NostrEphemeralSignerProvider` instead.
+    static func ephemeral() throws -> OnymNostrSigner {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, 32, &bytes)
+        guard status == errSecSuccess else {
+            throw NostrSignerError.csprngFailed(status: Int(status))
+        }
+        return try OnymNostrSigner(secretKey: Data(bytes))
+    }
+}
+
+/// Production `NostrEphemeralSignerProvider`. Stateless; owns no
+/// secret material itself — every call returns a fresh `OnymNostrSigner`
+/// with its own freshly-randomised secret. Safe to share.
+struct OnymNostrSignerProvider: NostrEphemeralSignerProvider {
+    func makeEphemeralSigner() throws -> any NostrSigner {
+        try OnymNostrSigner.ephemeral()
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -2,29 +2,39 @@ import SwiftUI
 
 @main
 struct OnymIOSApp: App {
-    private let repository: IdentityRepository
-    private let authenticator: BiometricAuthenticator
+    private let dependencies: AppDependencies
 
     init() {
         let args = ProcessInfo.processInfo.arguments
+        let repository: IdentityRepository
+        let authenticator: BiometricAuthenticator
         #if DEBUG
         if let testMode = Self.resolveTestMode(args: args) {
-            self.repository = testMode.repository
-            self.authenticator = testMode.authenticator
-            return
+            repository = testMode.repository
+            authenticator = testMode.authenticator
+        } else {
+            repository = IdentityRepository.shared
+            authenticator = LAContextAuthenticator()
         }
-        #endif
-        self.repository = IdentityRepository.shared
-        self.authenticator = LAContextAuthenticator()
+        #else
+        repository = IdentityRepository.shared
+        authenticator = LAContextAuthenticator()
         _ = args  // silence unused warning in Release
+        #endif
+
+        self.dependencies = AppDependencies(
+            makeRecoveryPhraseBackupFlow: { @MainActor in
+                RecoveryPhraseBackupFlow(
+                    repository: repository,
+                    authenticator: authenticator
+                )
+            }
+        )
     }
 
     var body: some Scene {
         WindowGroup {
-            RootView(
-                repository: repository,
-                authenticator: authenticator
-            )
+            RootView(dependencies: dependencies)
         }
     }
 }

--- a/Sources/OnymIOS/Recovery/RecoveryPhraseBackupView.swift
+++ b/Sources/OnymIOS/Recovery/RecoveryPhraseBackupView.swift
@@ -10,11 +10,8 @@ struct RecoveryPhraseBackupView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var obscured = false
 
-    init(repository: IdentityRepository, authenticator: BiometricAuthenticator) {
-        _flow = State(initialValue: RecoveryPhraseBackupFlow(
-            repository: repository,
-            authenticator: authenticator
-        ))
+    init(flow: RecoveryPhraseBackupFlow) {
+        _flow = State(initialValue: flow)
     }
 
     var body: some View {

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -15,8 +15,7 @@ struct RootView: View {
         case search
     }
 
-    let repository: IdentityRepository
-    let authenticator: BiometricAuthenticator
+    let dependencies: AppDependencies
 
     @State private var selectedTab: RootTab = .settings
 
@@ -24,10 +23,7 @@ struct RootView: View {
         TabView(selection: $selectedTab) {
             Tab("Settings", systemImage: "gearshape", value: .settings) {
                 NavigationStack {
-                    SettingsView(
-                        repository: repository,
-                        authenticator: authenticator
-                    )
+                    SettingsView(makeBackupFlow: dependencies.makeRecoveryPhraseBackupFlow)
                 }
             }
 

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -5,8 +5,7 @@ import SwiftUI
 /// presents `RecoveryPhraseBackupView` as a sheet. More sections land
 /// as the app grows (preferences, advanced, about).
 struct SettingsView: View {
-    let repository: IdentityRepository
-    let authenticator: BiometricAuthenticator
+    let makeBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
 
     @State private var showRecoveryPhrase = false
 
@@ -31,10 +30,7 @@ struct SettingsView: View {
         }
         .navigationTitle("Settings")
         .sheet(isPresented: $showRecoveryPhrase) {
-            RecoveryPhraseBackupView(
-                repository: repository,
-                authenticator: authenticator
-            )
+            RecoveryPhraseBackupView(flow: makeBackupFlow())
         }
     }
 

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -13,9 +13,11 @@ final class NostrInboxTransport: InboxTransport {
     private static let inboxTagPrefix = "sep-inbox:"
 
     private let state: State
+    private let signerProvider: any NostrEphemeralSignerProvider
 
-    init() {
+    init(signerProvider: any NostrEphemeralSignerProvider) {
         self.state = State()
+        self.signerProvider = signerProvider
     }
 
     func connect(to endpoints: [TransportEndpoint]) async {
@@ -28,7 +30,7 @@ final class NostrInboxTransport: InboxTransport {
 
     @discardableResult
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
-        let signer = try OnymNostrSigner.ephemeral()
+        let signer = try signerProvider.makeEphemeralSigner()
         let event = try Self.buildSendEvent(payload: payload, inbox: inbox, signer: signer)
         let accepted = try await state.send(event: event)
         return PublishReceipt(messageID: event.id, acceptedBy: accepted)

--- a/Sources/OnymIOS/Transport/Nostr/NostrMessageTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrMessageTransport.swift
@@ -15,9 +15,11 @@ final class NostrMessageTransport: MessageTransport {
     private static let sinceSlack: TimeInterval = 60
 
     private let state: State
+    private let signerProvider: any NostrEphemeralSignerProvider
 
-    init() {
+    init(signerProvider: any NostrEphemeralSignerProvider) {
         self.state = State()
+        self.signerProvider = signerProvider
     }
 
     func connect(to endpoints: [TransportEndpoint]) async {
@@ -30,7 +32,7 @@ final class NostrMessageTransport: MessageTransport {
 
     @discardableResult
     func publish(_ payload: Data, to topic: TransportTopic) async throws -> PublishReceipt {
-        let signer = try OnymNostrSigner.ephemeral()
+        let signer = try signerProvider.makeEphemeralSigner()
         let event = try Self.buildPublishEvent(payload: payload, topic: topic, signer: signer)
         let accepted = try await state.publish(event: event)
         return PublishReceipt(messageID: event.id, acceptedBy: accepted)

--- a/Sources/OnymIOS/Transport/Nostr/NostrSigner.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrSigner.swift
@@ -1,49 +1,20 @@
 import Foundation
-import OnymSDK
-import Security
 
 /// BIP340 secp256k1 Schnorr signer over a Nostr event id. The transport
-/// layer never sees the secret key — it only asks for the x-only public
-/// key (32 bytes) and a signature (64 bytes) for a given event id.
+/// layer holds these but never constructs them — it asks a
+/// `NostrEphemeralSignerProvider` for a fresh one per outgoing event so
+/// `OnymSDK` stays out of this layer entirely.
 protocol NostrSigner: Sendable {
     func publicKey() throws -> Data
     func signEventID(_ eventID: Data) throws -> Data
 }
 
-/// `NostrSigner` backed by a 32-byte secp256k1 secret. The signer uses
-/// `OnymSDK.Common` for the underlying BIP340 operations.
-struct OnymNostrSigner: NostrSigner {
-    let secretKey: Data
-
-    init(secretKey: Data) throws {
-        guard secretKey.count == 32 else {
-            throw NostrSignerError.invalidSecretKeyLength(actual: secretKey.count)
-        }
-        self.secretKey = secretKey
-    }
-
-    func publicKey() throws -> Data {
-        try Common.nostrDerivePublicKey(secretKey: secretKey)
-    }
-
-    func signEventID(_ eventID: Data) throws -> Data {
-        guard eventID.count == 32 else {
-            throw NostrSignerError.invalidEventIDLength(actual: eventID.count)
-        }
-        return try Common.nostrSignEventId(secretKey: secretKey, eventId: eventID)
-    }
-
-    /// Per-event ephemeral signer backed by a fresh CSPRNG-derived secret.
-    /// Used for metadata-hiding kinds (44114 / 34113) so the outer event
-    /// `pubkey` can't be used to cluster co-membership.
-    static func ephemeral() throws -> OnymNostrSigner {
-        var bytes = [UInt8](repeating: 0, count: 32)
-        let status = SecRandomCopyBytes(kSecRandomDefault, 32, &bytes)
-        guard status == errSecSuccess else {
-            throw NostrSignerError.csprngFailed(status: Int(status))
-        }
-        return try OnymNostrSigner(secretKey: Data(bytes))
-    }
+/// Source of fresh per-event signers for metadata-hiding outbound events
+/// (kinds 44114 / 34113). Implemented by a repository-layer adapter that
+/// owns the `OnymSDK` call site and the CSPRNG; injected into Nostr
+/// transports at construction time.
+protocol NostrEphemeralSignerProvider: Sendable {
+    func makeEphemeralSigner() throws -> any NostrSigner
 }
 
 enum NostrSignerError: Error, Sendable {


### PR DESCRIPTION
## Summary

Audit (https://github.com/onymchat/onym-ios/pull/14 follow-up) found four places the code didn't honour the architecture diagram. Two of them are real leaks the code can fix; two are wording problems where the code is correct and the diagram was over-claiming. This PR addresses all four.

| # | Violation | Fix |
|---|---|---|
| 1 | Views threaded `IdentityRepository` down through `RootView` → `SettingsView` → `RecoveryPhraseBackupView` for plumbing. | **Code:** introduce `AppDependencies` with factory closures; views now hold only `makeBackupFlow: () -> RecoveryPhraseBackupFlow`. No view in the codebase sees `IdentityRepository` as a type. |
| 2 | Diagram said "interactors are stateless" — `RecoveryPhraseBackupFlow` owns a substantial state machine. | **Wording:** "owns flow state, not domain state." |
| 3 | Diagram said "interactors do no I/O" — flow does `UIPasteboard` + `LAContext` calls (through small seams it owns). | **Wording:** "owns small local UI-affordance seams (clipboard, biometric prompt)." |
| 4 | `Transport/Nostr/NostrSigner.swift` imported `OnymSDK` and called `Common.nostrDerivePublicKey` / `nostrSignEventId` directly. | **Code:** strip OnymSDK out of `Transport/` entirely; the seam now exposes only `NostrSigner` + `NostrEphemeralSignerProvider` protocols. The OnymSDK-backed impl + factory move to `Identity/OnymNostrSigner.swift` next to `IdentityRepository` (the only other OnymSDK consumer). Transports take the provider via constructor injection. |

## Commits

1. `transport: route OnymSDK ephemeral signer through a provider injected from Identity` — closes #4.
2. `ui: lift dependency wiring to @main; views hold flow factories not repositories` — closes #1.
3. `docs: refine architecture wording to match what the code actually does` — closes #2 + #3 + reflects the new shape from commits 1 + 2.

## Test plan

- [x] `xcodebuild build` (production) clean, no warnings on touched files.
- [x] `xcodebuild test -only-testing:OnymIOSTests` — 68/68 unit tests pass in 0.96s.
- [x] `xcodebuild test -only-testing:OnymIOSUITests` — 4/4 UI tests pass in 88s (the dependency-wiring change exercises the actual app launch path).

## Out of scope

- The two stretch items the audit raised but don't reflect leaks: ChatRepository / ChatFlow / SQLite persistence still live in the "planned" boxes of the diagram; this PR doesn't add them.
- The transport seam still has no production caller. `MessageTransport` / `InboxTransport` ship but no `ChatRepository` consumes them yet — the wiring lands when chat does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)