### PR TITLE
decryption: incoming Nostr invitations (X25519 ECDH + AES-GCM, stateless interactor + tests)

### DIFF
--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -18,7 +18,7 @@ import OnymSDK
 /// PBKDF2, HKDF, and FFI calls into OnymSDK all run on the actor — never on
 /// the main thread by construction. Views interact via `await` from a
 /// `Task` (typically a SwiftUI `.task`).
-actor IdentityRepository {
+actor IdentityRepository: InvitationEnvelopeDecrypting {
     static let shared = IdentityRepository()
 
     private let keychain: KeychainStore
@@ -88,6 +88,68 @@ actor IdentityRepository {
             continuation.onTermination = { _ in
                 Task { await self.unsubscribe(id: id) }
             }
+        }
+    }
+
+    // MARK: - Invitation decryption
+
+    /// Decode an inbox-transport-delivered invitation envelope and open
+    /// it with the X25519 private key derived from the persisted nostr
+    /// secret. The private key is recomputed on every call (single
+    /// HKDF) and discarded — secret material never escapes this actor.
+    func decryptInvitation(envelopeBytes: Data) throws -> Data {
+        let envelope: SealedEnvelope
+        do {
+            envelope = try JSONDecoder().decode(SealedEnvelope.self, from: envelopeBytes)
+        } catch {
+            throw InvitationDecryptError.malformedEnvelope
+        }
+        guard envelope.scheme == "x25519-aes-256-gcm-v1" else {
+            throw InvitationDecryptError.unsupportedScheme(envelope.scheme)
+        }
+        guard let ephPubData = envelope.ephemeralPublicKey else {
+            throw InvitationDecryptError.missingEphemeralKey
+        }
+        guard let nonceData = envelope.nonce, let tag = envelope.authenticationTag else {
+            throw InvitationDecryptError.missingNonceOrTag
+        }
+
+        // M-5 / N-1: verify Ed25519 signature on the ephemeral pubkey if
+        // present. Prevents a relay from substituting its own ephemeral
+        // key (which would let it decrypt the invitation in flight).
+        if let sigData = envelope.ephemeralKeySignature,
+           let senderPubData = envelope.senderEd25519PublicKey {
+            do {
+                let verifyingKey = try Curve25519.Signing.PublicKey(rawRepresentation: senderPubData)
+                guard verifyingKey.isValidSignature(sigData, for: ephPubData) else {
+                    throw InvitationDecryptError.signatureVerificationFailed
+                }
+            } catch let error as InvitationDecryptError {
+                throw error
+            } catch {
+                throw InvitationDecryptError.signatureVerificationFailed
+            }
+        }
+
+        guard let snapshot = try keychain.load() else {
+            throw InvitationDecryptError.identityNotLoaded
+        }
+        let privateKey = try Self.inboxKeyAgreementPrivateKey(fromNostrSecret: snapshot.nostrSecretKey)
+
+        do {
+            let ephPub = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: ephPubData)
+            let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: ephPub)
+            let key = sharedSecret.hkdfDerivedSymmetricKey(
+                using: SHA256.self,
+                salt: Data("sep-invitation-v1".utf8),
+                sharedInfo: Data("aes-256-gcm".utf8),
+                outputByteCount: 32
+            )
+            let nonce = try AES.GCM.Nonce(data: nonceData)
+            let box = try AES.GCM.SealedBox(nonce: nonce, ciphertext: envelope.ciphertext, tag: tag)
+            return try AES.GCM.open(box, using: key)
+        } catch {
+            throw InvitationDecryptError.decryptionFailed
         }
     }
 
@@ -189,6 +251,16 @@ actor IdentityRepository {
     /// HKDF-SHA256(nostrSecret, salt="chat.onym.ios", info="x25519-key-agreement-v1", 32B).
     /// **MUST** match `KeyManager.deriveKeyAgreementKey` in stellar-mls.
     private static func inboxPublicKey(fromNostrSecret nostrSecret: Data) -> Data {
+        let privateKey = (try? inboxKeyAgreementPrivateKey(fromNostrSecret: nostrSecret))!
+        return Data(privateKey.publicKey.rawRepresentation)
+    }
+
+    /// Sibling of `inboxPublicKey` that returns the X25519 *private* key
+    /// instead of just the public half. Used internally by
+    /// `decryptInvitation`. The private key never leaves this actor.
+    private static func inboxKeyAgreementPrivateKey(
+        fromNostrSecret nostrSecret: Data
+    ) throws -> Curve25519.KeyAgreement.PrivateKey {
         let derived = HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: nostrSecret),
             salt: Data("chat.onym.ios".utf8),
@@ -196,8 +268,7 @@ actor IdentityRepository {
             outputByteCount: 32
         )
         let seed = derived.withUnsafeBytes { Data($0) }
-        let privateKey = try! Curve25519.KeyAgreement.PrivateKey(rawRepresentation: seed)
-        return Data(privateKey.publicKey.rawRepresentation)
+        return try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: seed)
     }
 
     /// First 8 bytes of `SHA-256("sep-inbox-v1" || inboxPublicKey)`, hex-encoded

--- a/Sources/OnymIOS/Identity/InvitationEnvelopeDecrypting.swift
+++ b/Sources/OnymIOS/Identity/InvitationEnvelopeDecrypting.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Narrow seam the inbox-side interactor depends on instead of the
+/// whole `IdentityRepository`. Lets test fakes substitute a canned
+/// decrypter without standing up a real identity, and keeps the
+/// secret-material rule honest: only the producer of this protocol
+/// (i.e. `IdentityRepository`) ever holds the X25519 private key.
+protocol InvitationEnvelopeDecrypting: Sendable {
+    /// Decode `envelopeBytes` (a JSON-serialised `SealedEnvelope`) and
+    /// open the AES-GCM ciphertext using the X25519 private key derived
+    /// from the on-device identity. Returns the plaintext bytes.
+    ///
+    /// Throws on: malformed JSON, wrong scheme, missing identity,
+    /// invalid signature on the ephemeral key (when present), or
+    /// AES-GCM tag mismatch.
+    func decryptInvitation(envelopeBytes: Data) async throws -> Data
+}
+
+enum InvitationDecryptError: Error, Equatable, Sendable {
+    case identityNotLoaded
+    case malformedEnvelope
+    case unsupportedScheme(String)
+    case missingEphemeralKey
+    case missingNonceOrTag
+    case signatureVerificationFailed
+    case decryptionFailed
+}

--- a/Sources/OnymIOS/Identity/SealedEnvelope.swift
+++ b/Sources/OnymIOS/Identity/SealedEnvelope.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Wire format for an X25519+AES-GCM-sealed payload received over the
+/// Nostr inbox transport. Senders construct one of these per invitation,
+/// encode as JSON, and ship the bytes via the inbox transport. The
+/// receiver decodes here, then `IdentityRepository.decryptInvitation`
+/// runs the X25519 ECDH + HKDF + AES-GCM open against its X25519
+/// private key.
+///
+/// Field names match the stellar-mls reference impl exactly so a
+/// stellar-mls sender's invitation decodes here and vice versa.
+///
+/// Internal to the Identity layer — outside callers pass raw envelope
+/// bytes to `IdentityRepository.decryptInvitation(envelopeBytes:)` and
+/// receive plaintext bytes back. This struct never crosses that boundary.
+struct SealedEnvelope: Codable, Equatable, Sendable {
+    /// Format version; bump when changing wire shape in a non-additive way.
+    let version: Int
+    /// Cipher discriminator. Currently only `"x25519-aes-256-gcm-v1"` is
+    /// accepted by `decryptInvitation` — the legacy `"aes-256-gcm-v1"`
+    /// (group-key broadcast) format is rejected here since this code
+    /// path is invitation-only.
+    let scheme: String
+    /// Sender's per-invitation X25519 ephemeral public key. Recipient
+    /// runs ECDH against their long-term X25519 private key to derive
+    /// the AES key.
+    let ephemeralPublicKey: Data?
+    /// Ed25519 signature over `ephemeralPublicKey` by the sender's
+    /// identity key (M-5 in the stellar-mls codebase). Prevents MITM
+    /// substitution of the ephemeral X25519 key. Verified at decrypt
+    /// time when present; absent envelopes accept without verification.
+    let ephemeralKeySignature: Data?
+    /// Sender's Ed25519 public key embedded in the envelope so the
+    /// recipient can verify `ephemeralKeySignature` without out-of-band
+    /// key exchange (N-1).
+    let senderEd25519PublicKey: Data?
+    /// AES-GCM 12-byte nonce.
+    let nonce: Data?
+    /// AES-GCM ciphertext.
+    let ciphertext: Data
+    /// AES-GCM 16-byte authentication tag.
+    let authenticationTag: Data?
+
+    enum CodingKeys: String, CodingKey {
+        case version, scheme
+        case ephemeralPublicKey = "ephemeral_public_key"
+        case ephemeralKeySignature = "ephemeral_key_signature"
+        case senderEd25519PublicKey = "sender_ed25519_public_key"
+        case nonce, ciphertext
+        case authenticationTag = "authentication_tag"
+    }
+}

--- a/Sources/OnymIOS/Inbox/DecryptedInvitation.swift
+++ b/Sources/OnymIOS/Inbox/DecryptedInvitation.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// User-facing parsed shape of a received invitation. Decoded from the
+/// JSON plaintext that comes out of `IdentityRepository.decryptInvitation`.
+///
+/// This is a deliberate **subset** of the stellar-mls `BootstrapPayload`
+/// wire format — only the fields a recipient needs to display the
+/// invitation in a list. `Codable` ignores unknown JSON fields by
+/// default, so a future PR can add `members` / `groupSecret` /
+/// `relayHints` / `salt` (everything needed to actually join the group)
+/// without breaking decode of older payloads or requiring a wire format
+/// change. Senders writing the full stellar-mls payload decode here
+/// fine.
+struct DecryptedInvitation: Codable, Equatable, Sendable {
+    /// Group identifier — 32 bytes on the wire (binary), shown as hex
+    /// when surfacing to UI.
+    let groupID: Data
+    /// Display name of the group at invite time.
+    let name: String
+    /// Group epoch when the invitation was issued.
+    let epoch: UInt64
+    /// Sender's stable Nostr pubkey (BIP340 x-only, 32-byte hex). Note:
+    /// the *event* pubkey on the kind 34113 envelope is ephemeral
+    /// per-event and meaningless for sender identity — this field
+    /// (carried inside the encrypted payload) is what to show.
+    let senderNostrPubkey: String
+}

--- a/Sources/OnymIOS/Inbox/InvitationDecryptor.swift
+++ b/Sources/OnymIOS/Inbox/InvitationDecryptor.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Stateless interactor: takes a persisted `IncomingInvitation` (opaque
+/// ciphertext) and turns it into a parsed `DecryptedInvitation`. Two
+/// steps: the envelope-decrypter seam unwraps the X25519 layer, then
+/// `JSONDecoder` parses the payload.
+///
+/// Depends on the narrow `InvitationEnvelopeDecrypting` seam, not the
+/// whole `IdentityRepository`. Tests substitute a fake decrypter and
+/// drive specific plaintext bytes; the real wiring binds it to
+/// `IdentityRepository`.
+struct InvitationDecryptor: Sendable {
+    let envelopeDecrypter: any InvitationEnvelopeDecrypting
+
+    /// Decrypt and parse one invitation. Throws the underlying
+    /// `InvitationDecryptError` on envelope-layer failures, or a
+    /// `DecodingError` if the plaintext isn't a `DecryptedInvitation`.
+    func decrypt(_ invitation: IncomingInvitation) async throws -> DecryptedInvitation {
+        let plaintext = try await envelopeDecrypter.decryptInvitation(envelopeBytes: invitation.payload)
+        return try JSONDecoder().decode(DecryptedInvitation.self, from: plaintext)
+    }
+}

--- a/Tests/OnymIOSTests/IdentityRepositoryInvitationDecryptTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryInvitationDecryptTests.swift
@@ -1,0 +1,236 @@
+import CryptoKit
+import XCTest
+@testable import OnymIOS
+
+/// Real X25519 + AES-GCM round-trip against `IdentityRepository`. Uses
+/// an isolated Keychain service per test (same pattern as
+/// `IdentityRepositoryTests`) so runs don't collide with each other or
+/// with the production identity item.
+///
+/// `TestInvitationEncryptor` is the sender side — replicates
+/// stellar-mls's `GroupCrypto.encryptInvitation` formula in test code
+/// so we can produce real ciphertext without porting the encrypt path
+/// to production (no app code sends invitations yet).
+final class IdentityRepositoryInvitationDecryptTests: XCTestCase {
+    private var keychain: KeychainStore!
+    private var repository: IdentityRepository!
+
+    /// BIP39 vector that gives a richer mnemonic than `abandon × 11 +
+    /// about` — same one `RecoveryPhraseBackupFlowTests` uses.
+    private let testMnemonic = "legal winner thank year wave sausage worth useful legal winner thank yellow"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        keychain = KeychainStore(
+            service: "chat.onym.ios.identity.tests.\(UUID().uuidString)",
+            account: "current"
+        )
+        repository = IdentityRepository(keychain: keychain)
+        _ = try await repository.restore(mnemonic: testMnemonic)
+    }
+
+    override func tearDown() async throws {
+        try? keychain.wipe()
+        keychain = nil
+        repository = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Happy path
+
+    func test_decryptInvitation_roundtripsSealedPayload() async throws {
+        let identity = try await XCTUnwrapAsync(await repository.currentIdentity())
+        let plaintext = Data("hello, invitee".utf8)
+
+        let envelope = try TestInvitationEncryptor.envelopeBytes(
+            plaintext: plaintext,
+            recipientX25519PublicKey: identity.inboxPublicKey
+        )
+
+        let decrypted = try await repository.decryptInvitation(envelopeBytes: envelope)
+        XCTAssertEqual(decrypted, plaintext)
+    }
+
+    func test_decryptInvitation_acceptsValidSenderSignature() async throws {
+        let identity = try await XCTUnwrapAsync(await repository.currentIdentity())
+        let senderSigningKey = Curve25519.Signing.PrivateKey()
+
+        let envelope = try TestInvitationEncryptor.envelopeBytes(
+            plaintext: Data("signed".utf8),
+            recipientX25519PublicKey: identity.inboxPublicKey,
+            senderSigningKey: senderSigningKey
+        )
+
+        let decrypted = try await repository.decryptInvitation(envelopeBytes: envelope)
+        XCTAssertEqual(decrypted, Data("signed".utf8))
+    }
+
+    // MARK: - Error paths
+
+    func test_decryptInvitation_rejectsMalformedJSON() async {
+        await assertThrows(
+            try await repository.decryptInvitation(envelopeBytes: Data("not json".utf8)),
+            InvitationDecryptError.malformedEnvelope
+        )
+    }
+
+    func test_decryptInvitation_rejectsUnsupportedScheme() async throws {
+        let envelope = SealedEnvelope(
+            version: 1,
+            scheme: "aes-256-gcm-v1",  // legacy group-broadcast scheme, not invitation
+            ephemeralPublicKey: Data(repeating: 0, count: 32),
+            ephemeralKeySignature: nil,
+            senderEd25519PublicKey: nil,
+            nonce: Data(repeating: 0, count: 12),
+            ciphertext: Data(),
+            authenticationTag: Data(repeating: 0, count: 16)
+        )
+        let bytes = try JSONEncoder().encode(envelope)
+        await assertThrows(
+            try await repository.decryptInvitation(envelopeBytes: bytes),
+            InvitationDecryptError.unsupportedScheme("aes-256-gcm-v1")
+        )
+    }
+
+    func test_decryptInvitation_rejectsMissingEphemeralKey() async throws {
+        let envelope = SealedEnvelope(
+            version: 1,
+            scheme: "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey: nil,
+            ephemeralKeySignature: nil,
+            senderEd25519PublicKey: nil,
+            nonce: Data(repeating: 0, count: 12),
+            ciphertext: Data(),
+            authenticationTag: Data(repeating: 0, count: 16)
+        )
+        let bytes = try JSONEncoder().encode(envelope)
+        await assertThrows(
+            try await repository.decryptInvitation(envelopeBytes: bytes),
+            InvitationDecryptError.missingEphemeralKey
+        )
+    }
+
+    func test_decryptInvitation_rejectsTamperedSignature() async throws {
+        let identity = try await XCTUnwrapAsync(await repository.currentIdentity())
+        let senderSigningKey = Curve25519.Signing.PrivateKey()
+
+        var envelope = try TestInvitationEncryptor.sealedEnvelope(
+            plaintext: Data("payload".utf8),
+            recipientX25519PublicKey: identity.inboxPublicKey,
+            senderSigningKey: senderSigningKey
+        )
+        // Flip a bit in the signature. `Data(...)` copies into a fresh
+        // contiguous buffer so subscript [0] is safe (CryptoKit Data
+        // outputs are slices with non-zero startIndex otherwise).
+        var tamperedSig = Data(envelope.ephemeralKeySignature!)
+        tamperedSig[0] ^= 0x01
+        envelope = SealedEnvelope(
+            version: envelope.version,
+            scheme: envelope.scheme,
+            ephemeralPublicKey: envelope.ephemeralPublicKey,
+            ephemeralKeySignature: tamperedSig,
+            senderEd25519PublicKey: envelope.senderEd25519PublicKey,
+            nonce: envelope.nonce,
+            ciphertext: envelope.ciphertext,
+            authenticationTag: envelope.authenticationTag
+        )
+        let bytes = try JSONEncoder().encode(envelope)
+
+        await assertThrows(
+            try await repository.decryptInvitation(envelopeBytes: bytes),
+            InvitationDecryptError.signatureVerificationFailed
+        )
+    }
+
+    func test_decryptInvitation_rejectsTamperedCiphertext() async throws {
+        let identity = try await XCTUnwrapAsync(await repository.currentIdentity())
+        var envelope = try TestInvitationEncryptor.sealedEnvelope(
+            plaintext: Data("payload".utf8),
+            recipientX25519PublicKey: identity.inboxPublicKey
+        )
+        // CryptoKit returns ciphertext as a slice into the SealedBox's
+        // backing buffer; subscripting at [0] reads outside the slice
+        // and crashes. `Data(...)` copies into a fresh contiguous buffer.
+        var tamperedCiphertext = Data(envelope.ciphertext)
+        tamperedCiphertext[0] ^= 0x01
+        envelope = SealedEnvelope(
+            version: envelope.version,
+            scheme: envelope.scheme,
+            ephemeralPublicKey: envelope.ephemeralPublicKey,
+            ephemeralKeySignature: envelope.ephemeralKeySignature,
+            senderEd25519PublicKey: envelope.senderEd25519PublicKey,
+            nonce: envelope.nonce,
+            ciphertext: tamperedCiphertext,
+            authenticationTag: envelope.authenticationTag
+        )
+        let bytes = try JSONEncoder().encode(envelope)
+
+        await assertThrows(
+            try await repository.decryptInvitation(envelopeBytes: bytes),
+            InvitationDecryptError.decryptionFailed
+        )
+    }
+
+    func test_decryptInvitation_rejectsWrongRecipient() async throws {
+        // Encrypt to a *different* recipient — the on-device X25519
+        // private key won't match the ephemeral ECDH partner, so AES
+        // tag verification fails.
+        let strangerKey = Curve25519.KeyAgreement.PrivateKey()
+        let strangerPubData = Data(strangerKey.publicKey.rawRepresentation)
+
+        let envelope = try TestInvitationEncryptor.envelopeBytes(
+            plaintext: Data("not for us".utf8),
+            recipientX25519PublicKey: strangerPubData
+        )
+
+        await assertThrows(
+            try await repository.decryptInvitation(envelopeBytes: envelope),
+            InvitationDecryptError.decryptionFailed
+        )
+    }
+
+    func test_decryptInvitation_throwsIdentityNotLoaded_afterWipe() async throws {
+        try await repository.wipe()
+
+        let strangerKey = Curve25519.KeyAgreement.PrivateKey()
+        let envelope = try TestInvitationEncryptor.envelopeBytes(
+            plaintext: Data("payload".utf8),
+            recipientX25519PublicKey: Data(strangerKey.publicKey.rawRepresentation)
+        )
+
+        await assertThrows(
+            try await repository.decryptInvitation(envelopeBytes: envelope),
+            InvitationDecryptError.identityNotLoaded
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrows<T: Sendable>(
+        _ expression: @autoclosure () async throws -> T,
+        _ expected: InvitationDecryptError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("expected to throw \(expected), got success", file: file, line: line)
+        } catch let error as InvitationDecryptError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("expected \(expected), got \(error)", file: file, line: line)
+        }
+    }
+
+    private func XCTUnwrapAsync<T>(
+        _ value: T?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> T {
+        guard let value else {
+            XCTFail("unexpected nil", file: file, line: line)
+            throw XCTSkip("nil")
+        }
+        return value
+    }
+}

--- a/Tests/OnymIOSTests/InvitationDecryptorTests.swift
+++ b/Tests/OnymIOSTests/InvitationDecryptorTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import OnymIOS
+
+/// Interactor tests against `FakeInvitationEnvelopeDecrypter` — fast,
+/// no real crypto. Asserts the pump shape: takes an `IncomingInvitation`,
+/// hands its payload to the decrypter, JSON-decodes the result. Real
+/// X25519 round-trip is in `IdentityRepositoryInvitationDecryptTests`.
+final class InvitationDecryptorTests: XCTestCase {
+
+    // MARK: - Happy path
+
+    func test_decrypt_passesPayloadToDecrypterAndReturnsParsed() async throws {
+        let plaintext = try Self.encodeInvitation(name: "Onym Launch", senderHex: "deadbeef")
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+        let interactor = InvitationDecryptor(envelopeDecrypter: decrypter)
+
+        let invitation = Self.makeInvitation(id: "evt-1", payload: Data("envelope-bytes".utf8))
+        let decrypted = try await interactor.decrypt(invitation)
+
+        XCTAssertEqual(decrypted.name, "Onym Launch")
+        XCTAssertEqual(decrypted.senderNostrPubkey, "deadbeef")
+        let calls = await decrypter.decryptCalls
+        XCTAssertEqual(calls, [Data("envelope-bytes".utf8)],
+                       "interactor must hand the persisted ciphertext bytes to the decrypter unchanged")
+    }
+
+    func test_decrypt_drivesMultipleInvitationsIndependently() async throws {
+        let p1 = try Self.encodeInvitation(name: "Group A", senderHex: "aaaa")
+        let p2 = try Self.encodeInvitation(name: "Group B", senderHex: "bbbb")
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .scripted([
+            Data("env-1".utf8): p1,
+            Data("env-2".utf8): p2,
+        ]))
+        let interactor = InvitationDecryptor(envelopeDecrypter: decrypter)
+
+        let d1 = try await interactor.decrypt(Self.makeInvitation(id: "1", payload: Data("env-1".utf8)))
+        let d2 = try await interactor.decrypt(Self.makeInvitation(id: "2", payload: Data("env-2".utf8)))
+
+        XCTAssertEqual(d1.name, "Group A")
+        XCTAssertEqual(d2.name, "Group B")
+    }
+
+    // MARK: - Error paths
+
+    func test_decrypt_propagatesDecrypterError() async {
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .failing(.signatureVerificationFailed))
+        let interactor = InvitationDecryptor(envelopeDecrypter: decrypter)
+        let invitation = Self.makeInvitation(id: "evt-1", payload: Data())
+
+        do {
+            _ = try await interactor.decrypt(invitation)
+            XCTFail("expected throw")
+        } catch let error as InvitationDecryptError {
+            XCTAssertEqual(error, .signatureVerificationFailed,
+                           "envelope-layer errors must surface to the caller verbatim")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_decrypt_throwsDecodingError_onMalformedPlaintext() async {
+        // Decrypter returns "decryption succeeded" but the plaintext
+        // isn't a `DecryptedInvitation` — JSON decode should throw.
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(Data("not the right shape".utf8)))
+        let interactor = InvitationDecryptor(envelopeDecrypter: decrypter)
+        let invitation = Self.makeInvitation(id: "evt-1", payload: Data())
+
+        do {
+            _ = try await interactor.decrypt(invitation)
+            XCTFail("expected throw")
+        } catch is DecodingError {
+            // expected
+        } catch {
+            XCTFail("expected DecodingError, got \(error)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static func makeInvitation(
+        id: String,
+        payload: Data,
+        receivedAt: Date = Date(),
+        status: IncomingInvitationStatus = .pending
+    ) -> IncomingInvitation {
+        IncomingInvitation(id: id, payload: payload, receivedAt: receivedAt, status: status)
+    }
+
+    private static func encodeInvitation(
+        name: String,
+        senderHex: String,
+        groupID: Data = Data((0..<32).map { _ in UInt8.random(in: 0...255) }),
+        epoch: UInt64 = 1
+    ) throws -> Data {
+        let invitation = DecryptedInvitation(
+            groupID: groupID,
+            name: name,
+            epoch: epoch,
+            senderNostrPubkey: senderHex
+        )
+        return try JSONEncoder().encode(invitation)
+    }
+}

--- a/Tests/OnymIOSTests/SealedEnvelopeTests.swift
+++ b/Tests/OnymIOSTests/SealedEnvelopeTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import OnymIOS
+
+/// Pin the SealedEnvelope wire format. Cross-platform interop with the
+/// stellar-mls reference impl rides on these JSON field names — a
+/// silent rename here would break a stellar-mls sender's invitations.
+final class SealedEnvelopeTests: XCTestCase {
+
+    // MARK: - JSON field names (cross-platform contract)
+
+    func test_jsonEncoding_usesSnakeCaseFieldNames() throws {
+        let envelope = SealedEnvelope(
+            version: 1,
+            scheme: "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey: Data([0x01]),
+            ephemeralKeySignature: Data([0x02]),
+            senderEd25519PublicKey: Data([0x03]),
+            nonce: Data([0x04]),
+            ciphertext: Data([0x05]),
+            authenticationTag: Data([0x06])
+        )
+        let json = try JSONEncoder().encode(envelope)
+        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: json) as? [String: Any])
+
+        XCTAssertNotNil(dict["ephemeral_public_key"], "renaming this breaks stellar-mls interop")
+        XCTAssertNotNil(dict["ephemeral_key_signature"])
+        XCTAssertNotNil(dict["sender_ed25519_public_key"])
+        XCTAssertNotNil(dict["authentication_tag"])
+        // Camel-case keys must NOT appear.
+        XCTAssertNil(dict["ephemeralPublicKey"])
+        XCTAssertNil(dict["ephemeralKeySignature"])
+        XCTAssertNil(dict["senderEd25519PublicKey"])
+        XCTAssertNil(dict["authenticationTag"])
+    }
+
+    // MARK: - Roundtrip
+
+    func test_roundtripsThroughJSONCoder() throws {
+        let original = SealedEnvelope(
+            version: 1,
+            scheme: "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey: Data((0..<32).map { UInt8($0) }),
+            ephemeralKeySignature: Data((0..<64).map { UInt8($0) }),
+            senderEd25519PublicKey: Data((0..<32).map { UInt8($0 ^ 0x55) }),
+            nonce: Data((0..<12).map { UInt8($0) }),
+            ciphertext: Data("hello".utf8),
+            authenticationTag: Data((0..<16).map { UInt8($0) })
+        )
+        let json = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SealedEnvelope.self, from: json)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_decodesEnvelopeWithMissingOptionalFields() throws {
+        // Older stellar-mls senders may omit the M-5 signature fields.
+        let json = """
+        {
+            "version": 1,
+            "scheme": "x25519-aes-256-gcm-v1",
+            "ephemeral_public_key": "AQ==",
+            "nonce": "AAECAwQFBgcICQoL",
+            "ciphertext": "aGVsbG8=",
+            "authentication_tag": "AAECAwQFBgcICQoLDA0ODw=="
+        }
+        """
+        let decoded = try JSONDecoder().decode(SealedEnvelope.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.version, 1)
+        XCTAssertEqual(decoded.scheme, "x25519-aes-256-gcm-v1")
+        XCTAssertNotNil(decoded.ephemeralPublicKey)
+        XCTAssertNil(decoded.ephemeralKeySignature)
+        XCTAssertNil(decoded.senderEd25519PublicKey)
+    }
+}

--- a/Tests/OnymIOSTests/Support/FakeInvitationEnvelopeDecrypter.swift
+++ b/Tests/OnymIOSTests/Support/FakeInvitationEnvelopeDecrypter.swift
@@ -1,0 +1,44 @@
+import Foundation
+@testable import OnymIOS
+
+/// `InvitationEnvelopeDecrypting` test double. Two modes:
+///
+/// - `.fixed(plaintext)` — every call returns the same plaintext bytes,
+///   useful for asserting the interactor's pump shape without caring
+///   about the envelope contents.
+/// - `.scripted(byEnvelope: [Data: Data])` — match input bytes to a
+///   specific plaintext, so a single test can drive multiple distinct
+///   invitations through the interactor and assert each maps correctly.
+/// - `.failing(error)` — every call throws, for error-path coverage.
+///
+/// Tracks every received envelope in `decryptCalls` so tests can assert
+/// what the interactor actually fed to the decrypter.
+actor FakeInvitationEnvelopeDecrypter: InvitationEnvelopeDecrypting {
+    enum Mode: Sendable {
+        case fixed(Data)
+        case scripted([Data: Data])
+        case failing(InvitationDecryptError)
+    }
+
+    private let mode: Mode
+    private(set) var decryptCalls: [Data] = []
+
+    init(mode: Mode) {
+        self.mode = mode
+    }
+
+    func decryptInvitation(envelopeBytes: Data) throws -> Data {
+        decryptCalls.append(envelopeBytes)
+        switch mode {
+        case .fixed(let plaintext):
+            return plaintext
+        case .scripted(let table):
+            guard let plaintext = table[envelopeBytes] else {
+                throw InvitationDecryptError.malformedEnvelope
+            }
+            return plaintext
+        case .failing(let error):
+            throw error
+        }
+    }
+}

--- a/Tests/OnymIOSTests/Support/TestInvitationEncryptor.swift
+++ b/Tests/OnymIOSTests/Support/TestInvitationEncryptor.swift
@@ -1,0 +1,75 @@
+import CryptoKit
+import Foundation
+@testable import OnymIOS
+
+/// Test-only helper that produces real `SealedEnvelope` ciphertext so
+/// `IdentityRepositoryInvitationDecryptTests` can do an end-to-end
+/// round-trip without porting the sender-side `encryptInvitation` to
+/// production code (no app code needs to *send* invitations yet).
+///
+/// Mirrors the stellar-mls `GroupCrypto.encryptInvitation` formula
+/// exactly: ephemeral X25519 keypair, ECDH against the recipient's
+/// X25519 public key, HKDF with the same salt+info as the production
+/// decrypter, AES-GCM seal. Optional Ed25519 signature over the
+/// ephemeral pubkey when `senderSigningKey` is provided (for M-5
+/// signature-verification tests).
+enum TestInvitationEncryptor {
+    /// Build a `SealedEnvelope` and JSON-encode it to the byte form a
+    /// real inbox-transport message would carry.
+    static func envelopeBytes(
+        plaintext: Data,
+        recipientX25519PublicKey: Data,
+        senderSigningKey: Curve25519.Signing.PrivateKey? = nil
+    ) throws -> Data {
+        let envelope = try sealedEnvelope(
+            plaintext: plaintext,
+            recipientX25519PublicKey: recipientX25519PublicKey,
+            senderSigningKey: senderSigningKey
+        )
+        return try JSONEncoder().encode(envelope)
+    }
+
+    static func sealedEnvelope(
+        plaintext: Data,
+        recipientX25519PublicKey: Data,
+        senderSigningKey: Curve25519.Signing.PrivateKey? = nil
+    ) throws -> SealedEnvelope {
+        let ephemeral = Curve25519.KeyAgreement.PrivateKey()
+        let recipientPubkey = try Curve25519.KeyAgreement.PublicKey(
+            rawRepresentation: recipientX25519PublicKey
+        )
+
+        let sharedSecret = try ephemeral.sharedSecretFromKeyAgreement(with: recipientPubkey)
+        let key = sharedSecret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data("sep-invitation-v1".utf8),
+            sharedInfo: Data("aes-256-gcm".utf8),
+            outputByteCount: 32
+        )
+
+        let nonce = AES.GCM.Nonce()
+        let sealed = try AES.GCM.seal(plaintext, using: key, nonce: nonce)
+
+        let ephPubData = Data(ephemeral.publicKey.rawRepresentation)
+        let ephKeySignature: Data?
+        let senderPubData: Data?
+        if let signingKey = senderSigningKey {
+            ephKeySignature = try signingKey.signature(for: ephPubData)
+            senderPubData = Data(signingKey.publicKey.rawRepresentation)
+        } else {
+            ephKeySignature = nil
+            senderPubData = nil
+        }
+
+        return SealedEnvelope(
+            version: 1,
+            scheme: "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey: ephPubData,
+            ephemeralKeySignature: ephKeySignature,
+            senderEd25519PublicKey: senderPubData,
+            nonce: Data(nonce),
+            ciphertext: sealed.ciphertext,
+            authenticationTag: sealed.tag
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Decryption layer for the invitations that PR #16 persists. Adds a narrow `InvitationEnvelopeDecrypting` seam (one method, returns plaintext bytes) that the inbox-side interactor depends on — the production implementation lives on `IdentityRepository` so secret material never escapes the actor; tests substitute a fake decrypter. Carries the X25519 ECDH + HKDF + AES-GCM open and (when the envelope provides one) verifies the M-5 Ed25519 signature on the ephemeral pubkey to prevent MITM substitution.

## What lands

```
Sources/OnymIOS/
├── Identity/
│   ├── SealedEnvelope.swift                        ← NIP-XX wire-format struct (snake_case JSON)
│   ├── InvitationEnvelopeDecrypting.swift          ← narrow protocol + InvitationDecryptError enum
│   └── IdentityRepository.swift (modified)         ← +decryptInvitation(envelopeBytes:) + private X25519 key helper
└── Inbox/
    ├── DecryptedInvitation.swift                   ← Codable subset of stellar-mls BootstrapPayload
    └── InvitationDecryptor.swift                   ← stateless interactor: envelope→plaintext→DecryptedInvitation

Tests/OnymIOSTests/
├── Support/
│   ├── FakeInvitationEnvelopeDecrypter.swift       ← reusable: .fixed / .scripted / .failing modes
│   └── TestInvitationEncryptor.swift               ← test-only sender-side helper (encryptInvitation parity)
├── SealedEnvelopeTests.swift                       ← 3 cases (cross-platform JSON contract)
├── IdentityRepositoryInvitationDecryptTests.swift  ← 8 cases (real X25519 round-trip + 6 error paths)
└── InvitationDecryptorTests.swift                  ← 5 cases (pump shape + error propagation)
```

## Architecture compliance

Per the touch-surface table in the architecture section:

| Layer | What this PR adds | Touches |
|---|---|---|
| **Seam protocol** | `InvitationEnvelopeDecrypting` | `Foundation` only; defined in Identity layer |
| **Repository** | `IdentityRepository.decryptInvitation` | Keychain (snapshot load) + CryptoKit only — no transport, no OnymSDK |
| **Interactor** | `InvitationDecryptor` | the seam protocol + `JSONDecoder` — no other repository, no OnymSDK |
| **OnymSDK** | nothing | nothing |

Secret material (X25519 private key) is recomputed inside the actor on every call from the persisted nostr secret and discarded — never assigned to a stored property, never crosses the actor boundary. `InvitationDecryptor` only ever sees plaintext bytes the seam gives it.

## Test pattern continuation

PR #16 introduced reusable seam fakes (`FakeInboxTransport`, `InMemoryInvitationStore`) for the upstream/downstream sides of the persistence pump. This PR adds two more pieces of scaffolding for any future "interactor that needs invitation decryption" test:

- **`FakeInvitationEnvelopeDecrypter`** — three modes covering happy-path pump tests (`.fixed`), per-input scripted decoding (`.scripted`), and error propagation (`.failing`).
- **`TestInvitationEncryptor`** — replicates stellar-mls's `encryptInvitation` formula in test code so round-trip tests can produce real X25519+AES-GCM ciphertext without polluting production with sender-side code (no app code sends invitations yet — that's a future capability). Will move to production when send-invitation lands.

The same shape that landed in PR #16 — narrow seam protocols at every layer, fakes for fast tests, a real-crypto integration test for the security-critical path — drops in cleanly.

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests` — 113/113 pass in 1.18s on iPhone 17 Pro simulator (16 new + 97 pre-existing).
- [x] Production target builds clean, no warnings on touched files.

### Crash bug fixed during development

Two of the AES tampering tests crashed the simulator (`SIGTRAP` in `Data._Representation.subscript.getter`). Root cause: `AES.GCM.SealedBox.ciphertext` and `Curve25519.Signing.PrivateKey.signature(for:)` return `Data` slices into a backing buffer with non-zero `startIndex`; subscripting at `[0]` reads outside the slice. Fixed by copying via `Data(...)` first to force a contiguous buffer at index 0.

## Out of scope (intentionally — keeps the slice tight)

- **App wiring.** `OnymIOSApp` doesn't consume `InvitationDecryptor` yet — capability ships tested; wire-up belongs with the next slice.
- **The full BootstrapPayload.** `DecryptedInvitation` is a 4-field subset; `members` / `groupSecret` / `relayHints` / `salt` / `commitment` / `senderTransportBundle` etc. land when a UI needs them or a flow needs to actually join the group. Codable's ignore-unknown semantics means adding fields is non-breaking.
- **Sender side.** `encryptInvitation` / `BootstrapPayload.from(group:)` aren't ported. We only consume incoming invitations today; sender-side moves to production when the app gains create-group + invite-contact capability.
- **UI.** No view consumes `DecryptedInvitation` yet. The `InviteFlow` shown as "planned" in the architecture diagram lands when there's a screen for received invitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)