### PR TITLE
settings: user-configurable relayer URL (Network section + GitHub Releases discovery)

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -7,4 +7,5 @@ import Foundation
 /// reference themselves.
 struct AppDependencies {
     let makeRecoveryPhraseBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
+    let makeRelayerPickerFlow: @MainActor () -> RelayerPickerFlow
 }

--- a/Sources/OnymIOS/Chain/KnownRelayersFetcher.swift
+++ b/Sources/OnymIOS/Chain/KnownRelayersFetcher.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Network seam that fetches the curated list of known relayers from
+/// the latest GitHub Release of `onymchat/onym-relayer`. The repo
+/// owner attaches a `relayers.json` asset to each release; the URL
+/// `releases/latest/download/<asset>` is a public GitHub redirect
+/// that always points at the latest release's asset, so we don't
+/// need the GitHub API (and don't burn rate limit).
+protocol KnownRelayersFetcher: Sendable {
+    /// Fetch and parse the latest `relayers.json`. Throws on network
+    /// failure, non-2xx response, or malformed JSON. Callers are
+    /// expected to fall back to the cached list on throw.
+    func fetchLatest() async throws -> [RelayerEndpoint]
+}
+
+/// Production `KnownRelayersFetcher`. Pure `URLSession` — no third-
+/// party HTTP client. Tests inject a fake `URLSession` via
+/// `URLProtocol` to drive the response without hitting the network.
+struct GitHubReleasesKnownRelayersFetcher: KnownRelayersFetcher {
+    /// GitHub redirect that always resolves to the latest release's
+    /// `relayers.json` asset. See
+    /// https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases
+    static let defaultURL = URL(string: "https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json")!
+
+    let url: URL
+    let session: URLSession
+    let decoder: JSONDecoder
+
+    init(
+        url: URL = defaultURL,
+        session: URLSession = .shared,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.url = url
+        self.session = session
+        self.decoder = decoder
+    }
+
+    func fetchLatest() async throws -> [RelayerEndpoint] {
+        let (data, response) = try await session.data(from: url)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(statusCode) else {
+            throw KnownRelayersFetchError.badStatus(statusCode)
+        }
+        let document: KnownRelayersDocument
+        do {
+            document = try decoder.decode(KnownRelayersDocument.self, from: data)
+        } catch {
+            throw KnownRelayersFetchError.malformedDocument(error)
+        }
+        return document.relayers
+    }
+}
+
+enum KnownRelayersFetchError: Error, Sendable {
+    case badStatus(Int)
+    case malformedDocument(Error)
+}

--- a/Sources/OnymIOS/Chain/RelayerEndpoint.swift
+++ b/Sources/OnymIOS/Chain/RelayerEndpoint.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// One entry in the known-relayers list published at
+/// `https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json`.
+/// Pure value type — no behaviour, just the wire shape.
+struct RelayerEndpoint: Codable, Equatable, Hashable, Identifiable, Sendable {
+    /// Display name shown in the picker.
+    let name: String
+    /// Base URL of the relayer (no trailing slash).
+    let url: URL
+    /// `"testnet"` / `"public"` (Stellar mainnet) / freeform string. Drives
+    /// the badge in the picker so a user doesn't accidentally pick mainnet
+    /// when they meant testnet.
+    let network: String
+
+    /// Stable id for SwiftUI list diffing — URL is the natural unique key.
+    var id: URL { url }
+}
+
+/// Top-level shape of the JSON asset attached to the latest release of
+/// onym-relayer. The `version` field is for forward-compat: when we
+/// change the wire shape we bump it and the parser can route on it.
+struct KnownRelayersDocument: Codable, Equatable, Sendable {
+    let version: Int
+    let relayers: [RelayerEndpoint]
+}
+
+/// Persisted user choice. `.known(endpoint)` means the user picked one
+/// of the entries from the published list; `.custom(url)` means they
+/// typed in their own (e.g. a localhost relayer for development, or
+/// a private deployment not in the public list).
+enum RelayerSelection: Codable, Equatable, Hashable, Sendable {
+    case known(RelayerEndpoint)
+    case custom(URL)
+
+    /// The URL chain interactors actually POST to, regardless of source.
+    var url: URL {
+        switch self {
+        case .known(let endpoint): return endpoint.url
+        case .custom(let url): return url
+        }
+    }
+}

--- a/Sources/OnymIOS/Chain/RelayerRepository.swift
+++ b/Sources/OnymIOS/Chain/RelayerRepository.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Combined snapshot consumed by the picker view. Two halves change
+/// independently — refreshing the GitHub list is async; selection is
+/// a synchronous user action — but views always want both in one go.
+struct RelayerState: Equatable, Sendable {
+    let selection: RelayerSelection?
+    let knownList: [RelayerEndpoint]
+
+    static let empty = RelayerState(selection: nil, knownList: [])
+}
+
+/// Owns the user's relayer choice + the cached known-relayers list.
+/// Mirrors `IdentityRepository` / `IncomingInvitationsRepository`
+/// shape: `actor` with snapshot replay on subscribe + a fresh push
+/// after every successful mutation.
+///
+/// Lifecycle:
+/// 1. `OnymIOSApp.init` constructs the repository with the prod
+///    fetcher + UserDefaults store.
+/// 2. App `.task { await repo.start() }` triggers a background fetch
+///    of the latest `relayers.json`. While it's in flight, the UI
+///    sees whatever was cached on disk from the last successful run.
+/// 3. User taps Settings → Network → Relayer; the picker view reads
+///    `snapshots`, dispatches `select` / `selectCustom` intents.
+/// 4. Future chain interactors read `snapshot.selection?.url` to
+///    decide where to POST.
+actor RelayerRepository {
+    private let fetcher: any KnownRelayersFetcher
+    private let store: any RelayerSelectionStore
+
+    private var cached: RelayerState
+    private var continuations: [UUID: AsyncStream<RelayerState>.Continuation] = [:]
+    private var startTask: Task<Void, Never>?
+
+    init(fetcher: any KnownRelayersFetcher, store: any RelayerSelectionStore) {
+        self.fetcher = fetcher
+        self.store = store
+        self.cached = RelayerState(
+            selection: store.loadSelection(),
+            knownList: store.loadCachedKnownList()
+        )
+    }
+
+    /// Trigger a background refresh of the known-relayers list.
+    /// Idempotent — a second call while the first is in flight is a
+    /// no-op. Failures fall through silently; the cached list (if
+    /// any) remains the source of truth, and the user can always
+    /// enter a custom URL.
+    func start() {
+        guard startTask == nil else { return }
+        startTask = Task { [weak self] in
+            await self?.refreshFromNetwork()
+        }
+    }
+
+    /// Force a fresh fetch (user-initiated pull-to-refresh, eventually).
+    /// Awaits completion so callers can show progress UI. Failures
+    /// throw so the UI can surface them.
+    func refresh() async throws {
+        let list = try await fetcher.fetchLatest()
+        store.saveCachedKnownList(list)
+        cached = RelayerState(selection: cached.selection, knownList: list)
+        publish()
+    }
+
+    /// User picked one of the published relayers from the list.
+    func select(_ endpoint: RelayerEndpoint) {
+        let selection = RelayerSelection.known(endpoint)
+        store.saveSelection(selection)
+        cached = RelayerState(selection: selection, knownList: cached.knownList)
+        publish()
+    }
+
+    /// User typed a custom URL (private deployment, localhost, etc.).
+    func selectCustom(url: URL) {
+        let selection = RelayerSelection.custom(url)
+        store.saveSelection(selection)
+        cached = RelayerState(selection: selection, knownList: cached.knownList)
+        publish()
+    }
+
+    /// User cleared the selection (e.g. signing out of a deployment).
+    func clearSelection() {
+        store.saveSelection(nil)
+        cached = RelayerState(selection: nil, knownList: cached.knownList)
+        publish()
+    }
+
+    /// Snapshot the current state without subscribing to future ones.
+    func currentState() -> RelayerState { cached }
+
+    nonisolated var snapshots: AsyncStream<RelayerState> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<RelayerState>.Continuation
+    ) {
+        continuations[id] = continuation
+        continuation.yield(cached)
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func publish() {
+        for continuation in continuations.values {
+            continuation.yield(cached)
+        }
+    }
+
+    /// Internal-use refresh; swallows errors so background `start()`
+    /// can't leak an exception. Public callers go through `refresh()`.
+    private func refreshFromNetwork() async {
+        do {
+            try await refresh()
+        } catch {
+            // Cached list (if any) remains valid; nothing to do.
+        }
+    }
+}

--- a/Sources/OnymIOS/Chain/RelayerSelectionStore.swift
+++ b/Sources/OnymIOS/Chain/RelayerSelectionStore.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Persistence seam for the user's selected relayer + the cached
+/// known-relayers list. UserDefaults-backed — the URL isn't secret
+/// (it's a public service endpoint) and Keychain access for a non-
+/// secret would be an over-rotation.
+///
+/// Two seams in one protocol because they share the same backing
+/// store and lifecycle (both are app-level config, not domain data).
+protocol RelayerSelectionStore: Sendable {
+    func loadSelection() -> RelayerSelection?
+    func saveSelection(_ selection: RelayerSelection?)
+
+    func loadCachedKnownList() -> [RelayerEndpoint]
+    func saveCachedKnownList(_ list: [RelayerEndpoint])
+}
+
+/// Production `RelayerSelectionStore`. Keys are scoped under
+/// `chat.onym.ios.relayer.*` so other UserDefaults consumers can't
+/// collide. Suite name is injectable so each test gets its own
+/// isolated suite (mirrors the per-test Keychain service pattern in
+/// `IdentityRepositoryTests`).
+///
+/// `@unchecked Sendable` because `UserDefaults` is documented as
+/// thread-safe (its set / remove / data(forKey:) APIs serialise
+/// internally) but isn't formally `Sendable` in the standard library.
+struct UserDefaultsRelayerSelectionStore: RelayerSelectionStore, @unchecked Sendable {
+    private static let selectionKey = "chat.onym.ios.relayer.selection"
+    private static let cachedListKey = "chat.onym.ios.relayer.cachedKnownList"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func loadSelection() -> RelayerSelection? {
+        guard let data = defaults.data(forKey: Self.selectionKey) else { return nil }
+        return try? JSONDecoder().decode(RelayerSelection.self, from: data)
+    }
+
+    func saveSelection(_ selection: RelayerSelection?) {
+        if let selection, let data = try? JSONEncoder().encode(selection) {
+            defaults.set(data, forKey: Self.selectionKey)
+        } else {
+            defaults.removeObject(forKey: Self.selectionKey)
+        }
+    }
+
+    func loadCachedKnownList() -> [RelayerEndpoint] {
+        guard let data = defaults.data(forKey: Self.cachedListKey),
+              let list = try? JSONDecoder().decode([RelayerEndpoint].self, from: data)
+        else { return [] }
+        return list
+    }
+
+    func saveCachedKnownList(_ list: [RelayerEndpoint]) {
+        guard let data = try? JSONEncoder().encode(list) else { return }
+        defaults.set(data, forKey: Self.cachedListKey)
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct OnymIOSApp: App {
     private let dependencies: AppDependencies
+    private let relayerRepository: RelayerRepository
 
     init() {
         let args = ProcessInfo.processInfo.arguments
@@ -22,12 +23,21 @@ struct OnymIOSApp: App {
         _ = args  // silence unused warning in Release
         #endif
 
+        let relayerRepository = RelayerRepository(
+            fetcher: GitHubReleasesKnownRelayersFetcher(),
+            store: UserDefaultsRelayerSelectionStore()
+        )
+        self.relayerRepository = relayerRepository
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
                     repository: repository,
                     authenticator: authenticator
                 )
+            },
+            makeRelayerPickerFlow: { @MainActor in
+                RelayerPickerFlow(repository: relayerRepository)
             }
         )
     }
@@ -35,6 +45,12 @@ struct OnymIOSApp: App {
     var body: some Scene {
         WindowGroup {
             RootView(dependencies: dependencies)
+                .task {
+                    // Kick off the GitHub Releases fetch as soon as the
+                    // app is on screen. Failures are silent; the user
+                    // can always enter a custom URL.
+                    await relayerRepository.start()
+                }
         }
     }
 }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -23,7 +23,10 @@ struct RootView: View {
         TabView(selection: $selectedTab) {
             Tab("Settings", systemImage: "gearshape", value: .settings) {
                 NavigationStack {
-                    SettingsView(makeBackupFlow: dependencies.makeRecoveryPhraseBackupFlow)
+                    SettingsView(
+                        makeBackupFlow: dependencies.makeRecoveryPhraseBackupFlow,
+                        makeRelayerPickerFlow: dependencies.makeRelayerPickerFlow
+                    )
                 }
             }
 

--- a/Sources/OnymIOS/Settings/RelayerPickerFlow.swift
+++ b/Sources/OnymIOS/Settings/RelayerPickerFlow.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Stateless interactor for the relayer picker. Owns the per-screen
+/// state machine (current snapshot, custom-URL draft text, validation
+/// state) and dispatches commands to the repository. The view reads
+/// `state` and emits intents; the repository owns persistence.
+@MainActor
+@Observable
+final class RelayerPickerFlow {
+    /// Combined snapshot from the repository plus the custom-URL
+    /// draft the user is currently typing. The draft is local-only
+    /// until they tap Save — the repository never sees half-typed
+    /// URLs.
+    struct State: Equatable {
+        var snapshot: RelayerState
+        var customDraft: String
+        var customDraftError: String?
+    }
+
+    private(set) var state: State
+
+    private let repository: RelayerRepository
+    private var snapshotTask: Task<Void, Never>?
+
+    init(repository: RelayerRepository) {
+        self.repository = repository
+        self.state = State(snapshot: .empty, customDraft: "", customDraftError: nil)
+    }
+
+    /// Begin draining repository snapshots. Idempotent — safe to call
+    /// from `.task` on every appear.
+    func start() {
+        guard snapshotTask == nil else { return }
+        snapshotTask = Task { [weak self] in
+            guard let self else { return }
+            for await snapshot in self.repository.snapshots {
+                self.state.snapshot = snapshot
+                // If the user already had a known selection, prefill
+                // the custom draft empty (don't disturb it if they're
+                // mid-type).
+                if case .custom(let url) = snapshot.selection, self.state.customDraft.isEmpty {
+                    self.state.customDraft = url.absoluteString
+                }
+            }
+        }
+    }
+
+    func stop() {
+        snapshotTask?.cancel()
+        snapshotTask = nil
+    }
+
+    // MARK: - Intents
+
+    func tappedKnownRelayer(_ endpoint: RelayerEndpoint) {
+        Task { await repository.select(endpoint) }
+    }
+
+    func customDraftChanged(_ text: String) {
+        state.customDraft = text
+        state.customDraftError = nil
+    }
+
+    func tappedSaveCustom() {
+        let trimmed = state.customDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = Self.validate(trimmed) else {
+            state.customDraftError = String(localized: "Enter a valid https:// URL")
+            return
+        }
+        Task { await repository.selectCustom(url: url) }
+    }
+
+    func tappedClearSelection() {
+        Task { await repository.clearSelection() }
+    }
+
+    /// Return the active URL (selected or nil) — used by chain
+    /// interactor wiring once it lands.
+    var activeURL: URL? {
+        state.snapshot.selection?.url
+    }
+
+    // MARK: - Private
+
+    /// Permissive URL validation: must parse, must have an http or
+    /// https scheme, must have a host. Does not normalise; relayer
+    /// will canonicalise if needed.
+    static func validate(_ raw: String) -> URL? {
+        guard let url = URL(string: raw),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              let host = url.host(), !host.isEmpty
+        else { return nil }
+        return url
+    }
+}

--- a/Sources/OnymIOS/Settings/RelayerPickerView.swift
+++ b/Sources/OnymIOS/Settings/RelayerPickerView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// Picker for the relayer the app uses to anchor on-chain state.
+/// Two sections:
+///   - "Known relayers" — from the latest GitHub Releases asset of
+///     onymchat/onym-relayer. Tap a row to select.
+///   - "Custom" — text field for a private deployment / localhost.
+///     Tap Save to commit; clears the known-list selection.
+struct RelayerPickerView: View {
+    @State private var flow: RelayerPickerFlow
+
+    init(flow: RelayerPickerFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                if flow.state.snapshot.knownList.isEmpty {
+                    HStack {
+                        ProgressView()
+                        Text("Fetching list…")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ForEach(flow.state.snapshot.knownList) { endpoint in
+                        Button {
+                            flow.tappedKnownRelayer(endpoint)
+                        } label: {
+                            knownRow(endpoint)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("relayer.known.\(endpoint.url.absoluteString)")
+                    }
+                }
+            } header: {
+                Text("Known Relayers")
+            } footer: {
+                Text("Published by the onym-relayer project. Tap to select.")
+            }
+
+            Section {
+                TextField("https://relayer.example.com", text: Binding(
+                    get: { flow.state.customDraft },
+                    set: { flow.customDraftChanged($0) }
+                ))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .accessibilityIdentifier("relayer.custom.field")
+
+                if let error = flow.state.customDraftError {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+
+                Button("Save Custom URL") {
+                    flow.tappedSaveCustom()
+                }
+                .accessibilityIdentifier("relayer.custom.save")
+            } header: {
+                Text("Custom")
+            } footer: {
+                Text("Use a private deployment, localhost, or any relayer not in the published list.")
+            }
+
+            if flow.state.snapshot.selection != nil {
+                Section {
+                    Button("Clear Selection", role: .destructive) {
+                        flow.tappedClearSelection()
+                    }
+                    .accessibilityIdentifier("relayer.clear")
+                }
+            }
+        }
+        .navigationTitle("Relayer")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { flow.start() }
+    }
+
+    @ViewBuilder
+    private func knownRow(_ endpoint: RelayerEndpoint) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(endpoint.name)
+                    .foregroundStyle(.primary)
+                Text(endpoint.url.absoluteString)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            networkBadge(endpoint.network)
+            if isSelected(endpoint) {
+                Image(systemName: "checkmark")
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
+    }
+
+    private func networkBadge(_ network: String) -> some View {
+        Text(network.uppercased())
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(network == "public" ? Color.red : Color.green)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                (network == "public" ? Color.red : Color.green).opacity(0.15),
+                in: Capsule()
+            )
+    }
+
+    private func isSelected(_ endpoint: RelayerEndpoint) -> Bool {
+        if case .known(let selected) = flow.state.snapshot.selection {
+            return selected == endpoint
+        }
+        return false
+    }
+}

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// as the app grows (preferences, advanced, about).
 struct SettingsView: View {
     let makeBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
+    let makeRelayerPickerFlow: @MainActor () -> RelayerPickerFlow
 
     @State private var showRecoveryPhrase = false
 
@@ -26,6 +27,22 @@ struct SettingsView: View {
                 Text("Security")
             } footer: {
                 Text("View your 12-word recovery phrase. You will need it to restore your identity on a new device.")
+            }
+
+            Section {
+                NavigationLink {
+                    RelayerPickerView(flow: makeRelayerPickerFlow())
+                } label: {
+                    row(
+                        icon: SettingsIconBox(systemImage: "antenna.radiowaves.left.and.right", background: .blue),
+                        title: "Relayer"
+                    )
+                }
+                .accessibilityIdentifier("settings.relayer_row")
+            } header: {
+                Text("Network")
+            } footer: {
+                Text("Choose the relayer used to anchor on-chain group state. Pick one from the published list or enter a custom URL.")
             }
         }
         .navigationTitle("Settings")

--- a/Tests/OnymIOSTests/KnownRelayersFetcherTests.swift
+++ b/Tests/OnymIOSTests/KnownRelayersFetcherTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import OnymIOS
+
+/// Hits the production `URLSession`-backed fetcher with `StubURLProtocol`
+/// in front so we can pin the wire format (the `relayers.json` shape we
+/// promise to publish) and the error-path behaviour (cache fallback
+/// happens at the repository layer; the fetcher itself just throws on
+/// any failure).
+final class KnownRelayersFetcherTests: XCTestCase {
+    private var session: URLSession!
+    private let fixtureURL = URL(string: "https://test.example/relayers.json")!
+
+    override func setUp() {
+        super.setUp()
+        session = StubURLProtocol.makeSession()
+    }
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        session = nil
+        super.tearDown()
+    }
+
+    // MARK: - happy path
+
+    func test_fetchLatest_parsesValidDocument() async throws {
+        StubURLProtocol.set { request in
+            XCTAssertEqual(request.url, self.fixtureURL)
+            let body = """
+            {
+                "version": 1,
+                "relayers": [
+                    { "name": "Onym Testnet", "url": "https://relayer-testnet.onym.chat", "network": "testnet" },
+                    { "name": "Onym Mainnet", "url": "https://relayer.onym.chat", "network": "public" }
+                ]
+            }
+            """
+            return (Data(body.utf8), HTTPURLResponse(url: self.fixtureURL, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesKnownRelayersFetcher(url: fixtureURL, session: session)
+
+        let list = try await fetcher.fetchLatest()
+        XCTAssertEqual(list.count, 2)
+        XCTAssertEqual(list[0].name, "Onym Testnet")
+        XCTAssertEqual(list[0].url, URL(string: "https://relayer-testnet.onym.chat"))
+        XCTAssertEqual(list[0].network, "testnet")
+        XCTAssertEqual(list[1].network, "public")
+    }
+
+    func test_fetchLatest_acceptsEmptyRelayersArray() async throws {
+        // Bootstrap state — release exists but no relayers published yet.
+        StubURLProtocol.set { _ in
+            let body = #"{ "version": 1, "relayers": [] }"#
+            return (Data(body.utf8), HTTPURLResponse(url: self.fixtureURL, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesKnownRelayersFetcher(url: fixtureURL, session: session)
+        let list = try await fetcher.fetchLatest()
+        XCTAssertEqual(list, [])
+    }
+
+    // MARK: - error paths
+
+    func test_fetchLatest_throwsOn404() async {
+        StubURLProtocol.set { _ in
+            (Data(), HTTPURLResponse(url: self.fixtureURL, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesKnownRelayersFetcher(url: fixtureURL, session: session)
+        do {
+            _ = try await fetcher.fetchLatest()
+            XCTFail("expected throw")
+        } catch let KnownRelayersFetchError.badStatus(code) {
+            XCTAssertEqual(code, 404)
+        } catch {
+            XCTFail("expected badStatus(404), got \(error)")
+        }
+    }
+
+    func test_fetchLatest_throwsOn500() async {
+        StubURLProtocol.set { _ in
+            (Data(), HTTPURLResponse(url: self.fixtureURL, statusCode: 500, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesKnownRelayersFetcher(url: fixtureURL, session: session)
+        do {
+            _ = try await fetcher.fetchLatest()
+            XCTFail("expected throw")
+        } catch KnownRelayersFetchError.badStatus { /* ok */ }
+        catch { XCTFail("expected badStatus, got \(error)") }
+    }
+
+    func test_fetchLatest_throwsOnMalformedJSON() async {
+        StubURLProtocol.set { _ in
+            let body = "not even json"
+            return (Data(body.utf8), HTTPURLResponse(url: self.fixtureURL, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesKnownRelayersFetcher(url: fixtureURL, session: session)
+        do {
+            _ = try await fetcher.fetchLatest()
+            XCTFail("expected throw")
+        } catch KnownRelayersFetchError.malformedDocument { /* ok */ }
+        catch { XCTFail("expected malformedDocument, got \(error)") }
+    }
+
+    func test_fetchLatest_throwsOnMissingRelayersField() async {
+        StubURLProtocol.set { _ in
+            // valid JSON but wrong shape
+            let body = #"{ "version": 1, "something_else": [] }"#
+            return (Data(body.utf8), HTTPURLResponse(url: self.fixtureURL, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesKnownRelayersFetcher(url: fixtureURL, session: session)
+        do {
+            _ = try await fetcher.fetchLatest()
+            XCTFail("expected throw")
+        } catch KnownRelayersFetchError.malformedDocument { /* ok */ }
+        catch { XCTFail("expected malformedDocument, got \(error)") }
+    }
+
+    // MARK: - default URL
+
+    func test_defaultURL_pointsAtGitHubReleasesLatestDownload() {
+        XCTAssertEqual(
+            GitHubReleasesKnownRelayersFetcher.defaultURL.absoluteString,
+            "https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json",
+            "Renaming this URL silently breaks the prepopulation flow on every install"
+        )
+    }
+}

--- a/Tests/OnymIOSTests/RelayerPickerFlowTests.swift
+++ b/Tests/OnymIOSTests/RelayerPickerFlowTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import OnymIOS
+
+/// Picker flow against a real `RelayerRepository` backed by the
+/// in-memory store + fake fetcher. Asserts the intent → repository
+/// → snapshot → state pipeline plus the local-only custom-URL draft
+/// + validation.
+@MainActor
+final class RelayerPickerFlowTests: XCTestCase {
+    private let testEndpoint = RelayerEndpoint(
+        name: "Test",
+        url: URL(string: "https://relayer-test.example")!,
+        network: "testnet"
+    )
+
+    private func makeFlow(
+        store: InMemoryRelayerSelectionStore = InMemoryRelayerSelectionStore(),
+        fetcherMode: FakeKnownRelayersFetcher.Mode = .succeeds([])
+    ) -> (RelayerPickerFlow, RelayerRepository, InMemoryRelayerSelectionStore) {
+        let fetcher = FakeKnownRelayersFetcher(mode: fetcherMode)
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+        let flow = RelayerPickerFlow(repository: repo)
+        return (flow, repo, store)
+    }
+
+    // MARK: - intents
+
+    func test_tappedKnownRelayer_persistsViaRepository() async throws {
+        let (flow, _, store) = makeFlow()
+        flow.start()
+        defer { flow.stop() }
+
+        flow.tappedKnownRelayer(testEndpoint)
+        try await waitFor { store.loadSelection() != nil }
+        XCTAssertEqual(store.loadSelection(), .known(testEndpoint))
+    }
+
+    func test_tappedClearSelection_clearsViaRepository() async throws {
+        let store = InMemoryRelayerSelectionStore(selection: .known(testEndpoint))
+        let (flow, _, _) = makeFlow(store: store)
+        flow.start()
+        defer { flow.stop() }
+
+        flow.tappedClearSelection()
+        try await waitFor { store.loadSelection() == nil }
+        XCTAssertNil(store.loadSelection())
+    }
+
+    // MARK: - custom URL draft
+
+    func test_customDraftChanged_updatesStateAndClearsError() {
+        let (flow, _, _) = makeFlow()
+        // Drive an error onto the state via the public API (empty
+        // save fails validation), then assert that the next
+        // customDraftChanged clears it.
+        flow.tappedSaveCustom()
+        XCTAssertNotNil(flow.state.customDraftError, "precondition: error must be set")
+
+        flow.customDraftChanged("https://x.com")
+        XCTAssertEqual(flow.state.customDraft, "https://x.com")
+        XCTAssertNil(flow.state.customDraftError)
+    }
+
+    func test_tappedSaveCustom_validURL_persistsViaRepository() async throws {
+        let (flow, _, store) = makeFlow()
+        flow.start()
+        defer { flow.stop() }
+
+        flow.customDraftChanged("https://my-relayer.dev")
+        flow.tappedSaveCustom()
+        try await waitFor { store.loadSelection() != nil }
+        XCTAssertEqual(store.loadSelection(), .custom(URL(string: "https://my-relayer.dev")!))
+        XCTAssertNil(flow.state.customDraftError)
+    }
+
+    func test_tappedSaveCustom_emptyDraft_setsError() {
+        let (flow, _, store) = makeFlow()
+        flow.customDraftChanged("")
+        flow.tappedSaveCustom()
+        XCTAssertNotNil(flow.state.customDraftError)
+        XCTAssertNil(store.loadSelection())
+    }
+
+    func test_tappedSaveCustom_garbageDraft_setsError() {
+        let (flow, _, store) = makeFlow()
+        flow.customDraftChanged("not-a-url at all")
+        flow.tappedSaveCustom()
+        XCTAssertNotNil(flow.state.customDraftError)
+        XCTAssertNil(store.loadSelection())
+    }
+
+    func test_tappedSaveCustom_ftpScheme_setsError() {
+        // Reject non-http(s) schemes — the relayer is HTTP.
+        let (flow, _, store) = makeFlow()
+        flow.customDraftChanged("ftp://relayer.example.com")
+        flow.tappedSaveCustom()
+        XCTAssertNotNil(flow.state.customDraftError)
+        XCTAssertNil(store.loadSelection())
+    }
+
+    func test_tappedSaveCustom_trimsWhitespace() async throws {
+        let (flow, _, store) = makeFlow()
+        flow.start()
+        defer { flow.stop() }
+
+        flow.customDraftChanged("   https://relayer.example.com  \n")
+        flow.tappedSaveCustom()
+        try await waitFor { store.loadSelection() != nil }
+        XCTAssertEqual(
+            store.loadSelection(),
+            .custom(URL(string: "https://relayer.example.com")!)
+        )
+    }
+
+    // MARK: - URL validation
+
+    func test_validate_acceptsHTTPS() {
+        XCTAssertNotNil(RelayerPickerFlow.validate("https://relayer.example.com"))
+    }
+
+    func test_validate_acceptsHTTPForLocalhost() {
+        XCTAssertNotNil(RelayerPickerFlow.validate("http://localhost:8080"))
+    }
+
+    func test_validate_rejectsEmpty() {
+        XCTAssertNil(RelayerPickerFlow.validate(""))
+    }
+
+    func test_validate_rejectsMissingScheme() {
+        XCTAssertNil(RelayerPickerFlow.validate("relayer.example.com"))
+    }
+
+    func test_validate_rejectsMissingHost() {
+        XCTAssertNil(RelayerPickerFlow.validate("https://"))
+    }
+
+    // MARK: - snapshot prefill
+
+    func test_start_prefillsCustomDraftFromExistingCustomSelection() async throws {
+        let url = URL(string: "https://existing-custom.dev")!
+        let store = InMemoryRelayerSelectionStore(selection: .custom(url))
+        let (flow, _, _) = makeFlow(store: store)
+        flow.start()
+        defer { flow.stop() }
+
+        try await waitFor { flow.state.customDraft == url.absoluteString }
+        XCTAssertEqual(flow.state.customDraft, url.absoluteString)
+    }
+
+    // MARK: - helpers
+
+    private func waitFor(
+        timeoutMs: Int = 1000,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMs) / 1000)
+        while !condition() {
+            if Date() > deadline {
+                XCTFail("waitFor timed out after \(timeoutMs)ms")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}

--- a/Tests/OnymIOSTests/RelayerRepositoryTests.swift
+++ b/Tests/OnymIOSTests/RelayerRepositoryTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+@testable import OnymIOS
+
+/// Repository against the in-memory fakes — fast, focused on:
+/// - the snapshot replay-on-subscribe contract
+/// - selection persistence (delegates to store; this just verifies
+///   the wire-up and the snapshot push)
+/// - background `start()` populates the cached known list from the
+///   fetcher and pushes a snapshot
+/// - `start()` is idempotent — second call is a no-op while the
+///   first is in flight (no double-fetch)
+/// - `refresh()` surfaces errors to the caller (UI can show
+///   progress / error states)
+final class RelayerRepositoryTests: XCTestCase {
+    private let testEndpoint = RelayerEndpoint(
+        name: "Test",
+        url: URL(string: "https://relayer-test.example")!,
+        network: "testnet"
+    )
+
+    // MARK: - construction
+
+    func test_init_loadsCachedSelectionAndKnownListFromStore() async {
+        let store = InMemoryRelayerSelectionStore(
+            selection: .known(testEndpoint),
+            cachedList: [testEndpoint]
+        )
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        let state = await repo.currentState()
+        XCTAssertEqual(state.selection, .known(testEndpoint))
+        XCTAssertEqual(state.knownList, [testEndpoint])
+    }
+
+    // MARK: - select / selectCustom / clearSelection
+
+    func test_select_persistsAndPushesSnapshot() async {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        await repo.select(testEndpoint)
+
+        XCTAssertEqual(store.loadSelection(), .known(testEndpoint))
+        let state = await repo.currentState()
+        XCTAssertEqual(state.selection, .known(testEndpoint))
+    }
+
+    func test_selectCustom_persistsAndPushesSnapshot() async {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+        let customURL = URL(string: "https://my-relayer.dev")!
+
+        await repo.selectCustom(url: customURL)
+
+        XCTAssertEqual(store.loadSelection(), .custom(customURL))
+        let state = await repo.currentState()
+        XCTAssertEqual(state.selection, .custom(customURL))
+    }
+
+    func test_clearSelection_removesPersistedAndPushesNilSnapshot() async {
+        let store = InMemoryRelayerSelectionStore(selection: .known(testEndpoint))
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        await repo.clearSelection()
+
+        XCTAssertNil(store.loadSelection())
+        let state = await repo.currentState()
+        XCTAssertNil(state.selection)
+    }
+
+    // MARK: - refresh
+
+    func test_refresh_persistsAndPushesNewKnownList() async throws {
+        let store = InMemoryRelayerSelectionStore()
+        let fetched = [testEndpoint]
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds(fetched))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+
+        XCTAssertEqual(store.loadCachedKnownList(), fetched)
+        let state = await repo.currentState()
+        XCTAssertEqual(state.knownList, fetched)
+    }
+
+    func test_refresh_throwsAndLeavesCachedListIntact() async {
+        let cached = [testEndpoint]
+        let store = InMemoryRelayerSelectionStore(cachedList: cached)
+        let fetcher = FakeKnownRelayersFetcher(mode: .failing(URLError(.notConnectedToInternet)))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        do {
+            try await repo.refresh()
+            XCTFail("expected throw")
+        } catch {
+            // expected
+        }
+
+        let state = await repo.currentState()
+        XCTAssertEqual(state.knownList, cached, "fetch failure must not erase the cached list")
+    }
+
+    // MARK: - start
+
+    func test_start_kicksOffBackgroundRefresh() async throws {
+        let store = InMemoryRelayerSelectionStore()
+        let fetched = [testEndpoint]
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds(fetched))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        await repo.start()
+        // start() returns immediately; await the first non-empty snapshot.
+        let observed = try await waitForNonEmptyKnownList(repo: repo, timeoutMs: 1000)
+        XCTAssertEqual(observed, fetched)
+    }
+
+    func test_start_swallowsFetchFailures() async {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .failing(URLError(.timedOut)))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        // Should not throw or trap — failures during background start
+        // are silent so app launch never crashes on a transient
+        // network problem.
+        await repo.start()
+
+        // Wait one scheduler tick so the start task can finish.
+        try? await Task.sleep(for: .milliseconds(50))
+        let state = await repo.currentState()
+        XCTAssertEqual(state.knownList, [], "fetch failed; no cache; list stays empty")
+    }
+
+    func test_start_isIdempotent_doesNotDoubleFetch() async throws {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([testEndpoint]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        await repo.start()
+        await repo.start()
+        await repo.start()
+
+        // Wait until at least the first fetch has completed.
+        _ = try await waitForNonEmptyKnownList(repo: repo, timeoutMs: 1000)
+        XCTAssertEqual(fetcher.fetchCallCount, 1, "start() must be idempotent")
+    }
+
+    // MARK: - snapshots
+
+    func test_snapshots_emitsCurrentValueOnSubscribe() async throws {
+        let store = InMemoryRelayerSelectionStore(
+            selection: .known(testEndpoint),
+            cachedList: [testEndpoint]
+        )
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first?.selection, .known(testEndpoint))
+        XCTAssertEqual(first?.knownList, [testEndpoint])
+    }
+
+    func test_snapshots_emitsAfterSelectMutation() async throws {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        _ = await iterator.next()  // initial empty
+
+        await repo.select(testEndpoint)
+
+        let next = await iterator.next()
+        XCTAssertEqual(next?.selection, .known(testEndpoint))
+    }
+
+    // MARK: - helpers
+
+    private func waitForNonEmptyKnownList(
+        repo: RelayerRepository,
+        timeoutMs: Int
+    ) async throws -> [RelayerEndpoint] {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMs) / 1000)
+        while true {
+            let state = await repo.currentState()
+            if !state.knownList.isEmpty { return state.knownList }
+            if Date() > deadline {
+                XCTFail("timed out waiting for non-empty knownList")
+                return []
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}

--- a/Tests/OnymIOSTests/RelayerSelectionStoreTests.swift
+++ b/Tests/OnymIOSTests/RelayerSelectionStoreTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import OnymIOS
+
+/// Round-trip the persistence seam against real UserDefaults. Each
+/// test gets its own suite so runs don't collide with each other or
+/// the production `.standard` defaults — same isolation pattern as
+/// the per-test Keychain service in `IdentityRepositoryTests`.
+final class RelayerSelectionStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var store: UserDefaultsRelayerSelectionStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "chat.onym.ios.relayer.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = UserDefaultsRelayerSelectionStore(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        store = nil
+        super.tearDown()
+    }
+
+    // MARK: - selection
+
+    func test_loadSelection_returnsNilWhenNothingPersisted() {
+        XCTAssertNil(store.loadSelection())
+    }
+
+    func test_saveSelection_thenLoadSelection_roundtripsKnown() {
+        let endpoint = RelayerEndpoint(
+            name: "Test",
+            url: URL(string: "https://relayer.example.com")!,
+            network: "testnet"
+        )
+        store.saveSelection(.known(endpoint))
+        XCTAssertEqual(store.loadSelection(), .known(endpoint))
+    }
+
+    func test_saveSelection_thenLoadSelection_roundtripsCustom() {
+        let url = URL(string: "https://my-private-relayer.dev")!
+        store.saveSelection(.custom(url))
+        XCTAssertEqual(store.loadSelection(), .custom(url))
+    }
+
+    func test_saveSelectionNil_clearsPersistedSelection() {
+        store.saveSelection(.custom(URL(string: "https://x.com")!))
+        store.saveSelection(nil)
+        XCTAssertNil(store.loadSelection())
+    }
+
+    // MARK: - cached known list
+
+    func test_loadCachedKnownList_returnsEmptyWhenNothingPersisted() {
+        XCTAssertEqual(store.loadCachedKnownList(), [])
+    }
+
+    func test_saveCachedKnownList_thenLoad_roundtripsList() {
+        let list = [
+            RelayerEndpoint(name: "A", url: URL(string: "https://a.com")!, network: "testnet"),
+            RelayerEndpoint(name: "B", url: URL(string: "https://b.com")!, network: "public"),
+        ]
+        store.saveCachedKnownList(list)
+        XCTAssertEqual(store.loadCachedKnownList(), list)
+    }
+
+    func test_saveCachedKnownList_overwrites() {
+        store.saveCachedKnownList([
+            RelayerEndpoint(name: "A", url: URL(string: "https://a.com")!, network: "testnet")
+        ])
+        store.saveCachedKnownList([
+            RelayerEndpoint(name: "B", url: URL(string: "https://b.com")!, network: "public")
+        ])
+        XCTAssertEqual(store.loadCachedKnownList().map(\.name), ["B"])
+    }
+}

--- a/Tests/OnymIOSTests/Support/FakeKnownRelayersFetcher.swift
+++ b/Tests/OnymIOSTests/Support/FakeKnownRelayersFetcher.swift
@@ -1,0 +1,54 @@
+import Foundation
+@testable import OnymIOS
+
+/// `KnownRelayersFetcher` test double. Three modes:
+///
+/// - `.succeeds(list)` — every call returns the given list.
+/// - `.failing(error)` — every call throws.
+/// - `.scripted([result])` — return one result per call, in order;
+///   asserts on a fourth call (caught by `precondition`).
+///
+/// Tracks `fetchCallCount` so tests can assert how many fetches
+/// happened (e.g. `start()` is idempotent — second call shouldn't
+/// re-fetch while the first is still in flight).
+final class FakeKnownRelayersFetcher: KnownRelayersFetcher, @unchecked Sendable {
+    enum Mode {
+        case succeeds([RelayerEndpoint])
+        case failing(Error)
+        case scripted([Result<[RelayerEndpoint], Error>])
+    }
+
+    private let lock = NSLock()
+    private var mode: Mode
+    private(set) var fetchCallCount: Int = 0
+    private var scriptIndex: Int = 0
+
+    init(mode: Mode) {
+        self.mode = mode
+    }
+
+    func setMode(_ newMode: Mode) {
+        lock.withLock {
+            self.mode = newMode
+            self.scriptIndex = 0
+        }
+    }
+
+    func fetchLatest() async throws -> [RelayerEndpoint] {
+        try lock.withLock {
+            fetchCallCount += 1
+            switch mode {
+            case .succeeds(let list):
+                return list
+            case .failing(let error):
+                throw error
+            case .scripted(let results):
+                precondition(scriptIndex < results.count,
+                             "FakeKnownRelayersFetcher: scripted ran out of results at call #\(scriptIndex + 1)")
+                let result = results[scriptIndex]
+                scriptIndex += 1
+                return try result.get()
+            }
+        }
+    }
+}

--- a/Tests/OnymIOSTests/Support/InMemoryRelayerSelectionStore.swift
+++ b/Tests/OnymIOSTests/Support/InMemoryRelayerSelectionStore.swift
@@ -1,0 +1,33 @@
+import Foundation
+@testable import OnymIOS
+
+/// `RelayerSelectionStore` impl backed by a plain dictionary. Used by
+/// any test that needs a `RelayerRepository` but doesn't care about
+/// the UserDefaults plumbing — same role as `InMemoryInvitationStore`
+/// from PR #16.
+final class InMemoryRelayerSelectionStore: RelayerSelectionStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var selection: RelayerSelection?
+    private var cachedList: [RelayerEndpoint] = []
+
+    init(selection: RelayerSelection? = nil, cachedList: [RelayerEndpoint] = []) {
+        self.selection = selection
+        self.cachedList = cachedList
+    }
+
+    func loadSelection() -> RelayerSelection? {
+        lock.withLock { selection }
+    }
+
+    func saveSelection(_ selection: RelayerSelection?) {
+        lock.withLock { self.selection = selection }
+    }
+
+    func loadCachedKnownList() -> [RelayerEndpoint] {
+        lock.withLock { cachedList }
+    }
+
+    func saveCachedKnownList(_ list: [RelayerEndpoint]) {
+        lock.withLock { cachedList = list }
+    }
+}

--- a/Tests/OnymIOSTests/Support/StubURLProtocol.swift
+++ b/Tests/OnymIOSTests/Support/StubURLProtocol.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// `URLProtocol` subclass that intercepts every request issued by a
+/// `URLSession` configured with it. Tests register a per-URL handler
+/// that returns the bytes / status / headers a fake server would
+/// emit. Standard pattern for testing `URLSession`-based code without
+/// any third-party HTTP mocking library.
+///
+/// Usage:
+/// ```swift
+/// let session = StubURLProtocol.makeSession()
+/// StubURLProtocol.set(handler: { request in
+///     (Data("hello".utf8), HTTPURLResponse(...))
+/// })
+/// defer { StubURLProtocol.reset() }
+/// // ... use session
+/// ```
+final class StubURLProtocol: URLProtocol, @unchecked Sendable {
+    typealias Handler = @Sendable (URLRequest) throws -> (Data, HTTPURLResponse)
+
+    nonisolated(unsafe) private static var handler: Handler?
+    private static let lock = NSLock()
+
+    static func set(handler: @escaping Handler) {
+        lock.withLock { Self.handler = handler }
+    }
+
+    static func reset() {
+        lock.withLock { Self.handler = nil }
+    }
+
+    /// Build a `URLSession` configured to route every request through
+    /// `StubURLProtocol`. Each test should make its own session so
+    /// configuration changes don't leak.
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.lock.withLock({ Self.handler }) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Summary

First piece of the on-chain anchoring path: a user-facing **Network** section in Settings that lets the user pick a relayer URL. The published list of relayers is **discovered at runtime** from the latest GitHub Release of `onymchat/onym-relayer` — when you publish a new release with a `relayers.json` asset, every install picks it up automatically (no app update needed).

This unblocks the chain interactor work (CreateGroupInteractor / JoinGroupInteractor) — they read `RelayerRepository.snapshot.selection?.url` to decide where to POST.

## What lands

```
Sources/OnymIOS/
├── Chain/
│   ├── RelayerEndpoint.swift                ← value type + KnownRelayersDocument + RelayerSelection enum
│   ├── RelayerSelectionStore.swift          ← UserDefaults persistence seam
│   ├── KnownRelayersFetcher.swift           ← URLSession + GitHub Releases redirect URL
│   └── RelayerRepository.swift              ← actor + AsyncStream<RelayerState>
└── Settings/
    ├── RelayerPickerFlow.swift              ← stateless interactor; URL validation
    ├── RelayerPickerView.swift              ← Form: known list + custom URL field
    └── SettingsView.swift (modified)        ← +Network section row

Tests/OnymIOSTests/
├── Support/
│   ├── InMemoryRelayerSelectionStore.swift  ← reusable fake (dictionary-backed)
│   ├── FakeKnownRelayersFetcher.swift       ← reusable fake (.succeeds / .failing / .scripted)
│   └── StubURLProtocol.swift                ← reusable URLSession-interception scaffolding
├── RelayerSelectionStoreTests.swift         ← 7 cases (real UserDefaults, per-test suite isolation)
├── KnownRelayersFetcherTests.swift          ← 7 cases (StubURLProtocol-driven wire-format pin)
├── RelayerRepositoryTests.swift             ← 11 cases (against in-memory fakes)
└── RelayerPickerFlowTests.swift             ← 14 cases (intents, validation, draft prefill)
```

## Wire format we're committing to

The asset attached to each `onym-relayer` release must be `relayers.json` with this shape:

```json
{
  "version": 1,
  "relayers": [
    { "name": "Onym Official Testnet", "url": "https://relayer-testnet.onym.chat", "network": "testnet" },
    { "name": "Onym Official Mainnet", "url": "https://relayer.onym.chat",         "network": "public" }
  ]
}
```

Fetched from the GitHub redirect URL `https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json` — public, no GitHub API rate limit, always points at the latest release's asset. `KnownRelayersFetcherTests.test_defaultURL_pointsAtGitHubReleasesLatestDownload` pins this string against silent renames.

## Architecture compliance

| Layer | What this PR adds | Touches |
|---|---|---|
| **Persistence seam** | `RelayerSelectionStore` (UserDefaults — URL isn't secret) | `Foundation` only |
| **Network seam** | `KnownRelayersFetcher` | `URLSession` + `JSONDecoder` only |
| **Repository** | `RelayerRepository` (actor) | both seams + AsyncStream |
| **Interactor** | `RelayerPickerFlow` | the repository + a String→URL validator |
| **View** | `RelayerPickerView` | the interactor only |
| **OnymSDK** | nothing | nothing |

Picker view never holds the repository; `AppDependencies.makeRelayerPickerFlow` is the closure factory it receives (per the AppDependencies pattern from PR #15).

## Lifecycle

1. `OnymIOSApp.init` constructs `RelayerRepository` once (prod fetcher + UserDefaults store).
2. The `WindowGroup`'s `.task` calls `repo.start()` — kicks off the GitHub Releases fetch in the background. App launch never blocks on the network; failures are silent.
3. While the fetch is in flight, the picker shows whatever was cached on disk from the last successful run.
4. User opens Settings → Network → Relayer; picks a known relayer or types a custom URL.
5. Selection persists; future chain interactors read `repo.currentState().selection?.url`.

## URL validation rules

`RelayerPickerFlow.validate`: must parse, must use `http` or `https` (so `localhost` for dev works), must have a host. Whitespace trimmed before validation. Rejects empty, garbage, `ftp://`, missing scheme, missing host.

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests` — 152/152 pass in 1.43s on iPhone 17 Pro simulator (39 new + 113 pre-existing).
- [x] Production target builds clean, no warnings on touched files.
- [ ] Manual smoke: open the app, navigate Settings → Network → Relayer, see "Fetching list…" briefly then the published entries (will be empty until the first `relayers.json` asset is published — at which point the picker auto-populates without a new app release).

## Out of scope (intentionally — keeps the slice tight)

- **The chain client itself.** This PR delivers the URL config; the next PR ports `SEPContractClient` from stellar-mls and binds it to `repo.currentState().selection?.url`.
- **TLS pinning.** Stellar-mls's `SEPCertificatePinningDelegate` pins the relayer's TLS pubkey. Defer to when production wiring lands; the test path doesn't need it.
- **Localization.** Network section header / footer / button labels are English-only for now. Add to `Localizable.xcstrings` when other settings strings get translated.
- **Pull-to-refresh in the picker.** `RelayerRepository.refresh()` exists for this; UI hookup is a 5-minute follow-up if the user demand surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)