### PR TITLE
settings: anchors picker (per-network, per-governance contract version selection)

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -8,4 +8,5 @@ import Foundation
 struct AppDependencies {
     let makeRecoveryPhraseBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
     let makeRelayerPickerFlow: @MainActor () -> RelayerPickerFlow
+    let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
 }

--- a/Sources/OnymIOS/Chain/AnchorSelection.swift
+++ b/Sources/OnymIOS/Chain/AnchorSelection.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Composite key the user picks against — one selection per
+/// (network, governance type) cell. Five governance types × two
+/// networks = ten possible selection cells; most users will have
+/// touched at most a handful explicitly, the rest fall back to
+/// "default to latest".
+struct AnchorSelectionKey: Codable, Equatable, Hashable, Sendable {
+    let network: ContractNetwork
+    let type: GovernanceType
+}
+
+/// The resolved triple a chat carries forever after creation. Reading
+/// `chat.anchor.contractID` + `chat.anchor.network` is the only correct
+/// way to update an *existing* chat's on-chain state — the picker's
+/// current selection is for *new* chats only.
+///
+/// `release` is the human-readable release tag (`"v0.0.2"`) — kept
+/// alongside the resolved contract id for display and audit. If the
+/// user later changes their selection in Settings, this binding does
+/// NOT change; it's pinned at chat-creation time.
+struct AnchorBinding: Codable, Equatable, Hashable, Sendable {
+    let network: ContractNetwork
+    let governanceType: GovernanceType
+    let contractID: String
+    let release: String
+
+    var key: AnchorSelectionKey {
+        AnchorSelectionKey(network: network, type: governanceType)
+    }
+}

--- a/Sources/OnymIOS/Chain/AnchorSelectionStore.swift
+++ b/Sources/OnymIOS/Chain/AnchorSelectionStore.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Persistence seam for both the user's per-(network, type)
+/// version selections and the cached `ContractsManifest`. Same
+/// shape as `RelayerSelectionStore` from PR #18.
+///
+/// Selections are stored as a JSON-encoded `[AnchorSelectionKey:
+/// String]` dictionary. UserDefaults can't natively persist a
+/// `[Hashable: ...]` map, so we serialise to a single `Data` blob.
+protocol AnchorSelectionStore: Sendable {
+    func loadSelections() -> [AnchorSelectionKey: String]
+    func saveSelections(_ selections: [AnchorSelectionKey: String])
+
+    func loadCachedManifest() -> ContractsManifest?
+    func saveCachedManifest(_ manifest: ContractsManifest)
+}
+
+/// Production `AnchorSelectionStore`. UserDefaults-backed (no secret
+/// material). Suite-name injectable for per-test isolation.
+struct UserDefaultsAnchorSelectionStore: AnchorSelectionStore, @unchecked Sendable {
+    private static let selectionsKey = "chat.onym.ios.anchors.selections"
+    private static let manifestKey = "chat.onym.ios.anchors.cachedManifest"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func loadSelections() -> [AnchorSelectionKey: String] {
+        guard let data = defaults.data(forKey: Self.selectionsKey),
+              let entries = try? JSONDecoder().decode([SelectionEntry].self, from: data)
+        else { return [:] }
+        var result: [AnchorSelectionKey: String] = [:]
+        for entry in entries {
+            result[entry.key] = entry.releaseTag
+        }
+        return result
+    }
+
+    func saveSelections(_ selections: [AnchorSelectionKey: String]) {
+        let entries = selections.map { SelectionEntry(key: $0.key, releaseTag: $0.value) }
+        if let data = try? JSONEncoder().encode(entries) {
+            defaults.set(data, forKey: Self.selectionsKey)
+        } else {
+            defaults.removeObject(forKey: Self.selectionsKey)
+        }
+    }
+
+    func loadCachedManifest() -> ContractsManifest? {
+        guard let data = defaults.data(forKey: Self.manifestKey),
+              let manifest = try? JSONDecoder.iso8601().decode(ContractsManifest.self, from: data)
+        else { return nil }
+        return manifest
+    }
+
+    func saveCachedManifest(_ manifest: ContractsManifest) {
+        guard let data = try? JSONEncoder.iso8601().encode(manifest) else { return }
+        defaults.set(data, forKey: Self.manifestKey)
+    }
+}
+
+/// Round-trip wrapper so we can serialise the dictionary as a JSON
+/// array (dictionaries with non-String keys aren't natively
+/// `Codable`-friendly to JSON).
+private struct SelectionEntry: Codable {
+    let key: AnchorSelectionKey
+    let releaseTag: String
+}
+
+extension JSONDecoder {
+    /// Decoder configured for ISO-8601 dates (the wire format the
+    /// GitHub Releases API and the manifest both use).
+    static func iso8601() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+extension JSONEncoder {
+    static func iso8601() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}

--- a/Sources/OnymIOS/Chain/ContractEntry.swift
+++ b/Sources/OnymIOS/Chain/ContractEntry.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Stellar network the contract is deployed on. `public` is Stellar's
+/// own name for what most users call "mainnet" — kept for parity with
+/// the Stellar passphrase strings.
+enum ContractNetwork: String, Codable, CaseIterable, Hashable, Sendable {
+    case testnet
+    case `public`
+
+    /// User-facing label.
+    var displayName: String {
+        switch self {
+        case .testnet: return "Testnet"
+        case .public: return "Mainnet"
+        }
+    }
+}
+
+/// Governance type — pinned to the five known SEP contract families.
+/// The on-wire `type` string carries the wire name (`oneonone`, etc.);
+/// the manifest decoder silently drops entries with unknown values so
+/// a future governance type doesn't crash an older client.
+enum GovernanceType: String, Codable, CaseIterable, Hashable, Sendable {
+    case anarchy
+    case democracy
+    case oligarchy
+    case oneonone
+    case tyranny
+
+    /// User-facing label.
+    var displayName: String {
+        switch self {
+        case .anarchy: return "Anarchy"
+        case .democracy: return "Democracy"
+        case .oligarchy: return "Oligarchy"
+        case .oneonone: return "One-on-one"
+        case .tyranny: return "Tyranny"
+        }
+    }
+}
+
+/// One contract deployment — a (network, type, contract id) triple.
+struct ContractEntry: Codable, Equatable, Hashable, Sendable {
+    let network: ContractNetwork
+    let type: GovernanceType
+    let id: String
+}
+
+/// One release of `onymchat/onym-contracts` — a tag + publish date +
+/// the set of contracts deployed in it.
+struct ContractRelease: Codable, Equatable, Hashable, Sendable {
+    let release: String       // e.g. "v0.0.2"
+    let publishedAt: Date
+    let contracts: [ContractEntry]
+}
+
+/// Wire shape of the `contracts-manifest.json` asset attached to the
+/// latest release. `releases[]` is the union of all historical
+/// releases — newest-first. Regenerated and re-attached on every new
+/// release (CI step in the contracts repo).
+struct ContractsManifest: Codable, Equatable, Sendable {
+    let version: Int
+    let releases: [ContractRelease]
+
+    static let empty = ContractsManifest(version: 0, releases: [])
+}

--- a/Sources/OnymIOS/Chain/ContractsManifestFetcher.swift
+++ b/Sources/OnymIOS/Chain/ContractsManifestFetcher.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Network seam: fetches the curated `contracts-manifest.json` asset
+/// from the latest release of `onymchat/onym-contracts`. Same redirect
+/// pattern as `KnownRelayersFetcher` from PR #18 — the URL
+/// `releases/latest/download/<asset>` is a public GitHub redirect that
+/// always points at the latest release, no GitHub API rate limit.
+///
+/// Unknown enum values (a future `network` or `type` an older client
+/// doesn't know about) are silently dropped at parse time so the rest
+/// of the manifest stays usable.
+protocol ContractsManifestFetcher: Sendable {
+    func fetchLatest() async throws -> ContractsManifest
+}
+
+/// Production `ContractsManifestFetcher`. Pure `URLSession` — no
+/// third-party HTTP client. Tests inject a fake `URLSession` via
+/// `StubURLProtocol` to drive the response without hitting the network.
+struct GitHubReleasesContractsManifestFetcher: ContractsManifestFetcher {
+    /// GitHub redirect that always resolves to the latest release's
+    /// `contracts-manifest.json` asset.
+    static let defaultURL = URL(string: "https://github.com/onymchat/onym-contracts/releases/latest/download/contracts-manifest.json")!
+
+    let url: URL
+    let session: URLSession
+
+    init(url: URL = defaultURL, session: URLSession = .shared) {
+        self.url = url
+        self.session = session
+    }
+
+    func fetchLatest() async throws -> ContractsManifest {
+        let (data, response) = try await session.data(from: url)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(statusCode) else {
+            throw ContractsManifestFetchError.badStatus(statusCode)
+        }
+        return try Self.decodeFiltering(data)
+    }
+
+    /// Decode the manifest, dropping any `ContractEntry` whose
+    /// `network` or `type` doesn't match a known enum value. Visible
+    /// at `internal` access so the same filtering can be tested
+    /// without going through the URL pipeline.
+    static func decodeFiltering(_ data: Data) throws -> ContractsManifest {
+        let raw: RawManifest
+        do {
+            raw = try JSONDecoder.iso8601().decode(RawManifest.self, from: data)
+        } catch {
+            throw ContractsManifestFetchError.malformedDocument(error)
+        }
+        let releases = raw.releases.map { rawRelease -> ContractRelease in
+            let contracts = rawRelease.contracts.compactMap { rawEntry -> ContractEntry? in
+                guard let network = ContractNetwork(rawValue: rawEntry.network),
+                      let type = GovernanceType(rawValue: rawEntry.type)
+                else { return nil }
+                return ContractEntry(network: network, type: type, id: rawEntry.id)
+            }
+            return ContractRelease(
+                release: rawRelease.release,
+                publishedAt: rawRelease.publishedAt,
+                contracts: contracts
+            )
+        }
+        return ContractsManifest(version: raw.version, releases: releases)
+    }
+}
+
+/// Stringly-typed mirror of the wire format. Decoded first, then
+/// projected onto the typed `ContractsManifest` while filtering
+/// unknown `network` / `type` values. The two-step shape keeps the
+/// public types strict while the wire format stays forward-compatible.
+private struct RawManifest: Decodable {
+    let version: Int
+    let releases: [RawRelease]
+
+    struct RawRelease: Decodable {
+        let release: String
+        let publishedAt: Date
+        let contracts: [RawEntry]
+    }
+
+    struct RawEntry: Decodable {
+        let network: String
+        let type: String
+        let id: String
+    }
+}
+
+enum ContractsManifestFetchError: Error, Sendable {
+    case badStatus(Int)
+    case malformedDocument(Error)
+}

--- a/Sources/OnymIOS/Chain/ContractsRepository.swift
+++ b/Sources/OnymIOS/Chain/ContractsRepository.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+/// Snapshot the picker view subscribes to. Combines the cached
+/// manifest with the user's selections — the picker reads both.
+///
+/// The resolution rules (binding / available-releases / anchored
+/// network membership) live on this value type so SwiftUI render
+/// paths can call them synchronously without round-tripping the
+/// repository actor on every cell.
+struct ContractsState: Equatable, Sendable {
+    let manifest: ContractsManifest
+    let selections: [AnchorSelectionKey: String]
+
+    static let empty = ContractsState(manifest: .empty, selections: [:])
+
+    /// Resolve `key` to a concrete `AnchorBinding` per:
+    /// 1. Explicit selection wins.
+    /// 2. Default to latest release with an entry for this key.
+    /// 3. Otherwise nil ("no contracts yet").
+    func binding(for key: AnchorSelectionKey) -> AnchorBinding? {
+        if let selectedTag = selections[key],
+           let release = manifest.releases.first(where: { $0.release == selectedTag }),
+           let entry = release.contracts.first(where: { $0.network == key.network && $0.type == key.type })
+        {
+            return AnchorBinding(
+                network: entry.network,
+                governanceType: entry.type,
+                contractID: entry.id,
+                release: release.release
+            )
+        }
+        for release in manifest.releases {
+            if let entry = release.contracts.first(where: { $0.network == key.network && $0.type == key.type }) {
+                return AnchorBinding(
+                    network: entry.network,
+                    governanceType: entry.type,
+                    contractID: entry.id,
+                    release: release.release
+                )
+            }
+        }
+        return nil
+    }
+
+    /// Releases that have a contract for `key`, in the manifest's
+    /// newest-first order.
+    func availableReleases(for key: AnchorSelectionKey) -> [ContractRelease] {
+        manifest.releases.filter { release in
+            release.contracts.contains { $0.network == key.network && $0.type == key.type }
+        }
+    }
+
+    /// True when at least one release has at least one contract on
+    /// `network`. Used to gray out the Mainnet row until contracts
+    /// ship there.
+    func hasAnyContracts(network: ContractNetwork) -> Bool {
+        manifest.releases.contains { release in
+            release.contracts.contains { $0.network == network }
+        }
+    }
+}
+
+/// Owns the contracts manifest + the user's per-(network, type)
+/// selections + the resolution rules that turn a selection key into
+/// a concrete `AnchorBinding`. Mirrors `RelayerRepository` shape.
+///
+/// **Resolution rules** (load-bearing — repeated in the README and
+/// the cross-platform Android prompt so iOS / Android stay aligned):
+///
+/// 1. If the user has an explicit selection for `key` AND the
+///    manifest has a release with that tag AND that release has a
+///    contract for this `(network, type)` → use it.
+/// 2. Otherwise default to the **latest** release that has a
+///    contract for `(network, type)` (manifest is sorted newest-first).
+/// 3. Otherwise return nil — the UI shows "No contracts yet" and
+///    chain interactors get back `nil` from `binding(for:)`.
+actor ContractsRepository {
+    private let fetcher: any ContractsManifestFetcher
+    private let store: any AnchorSelectionStore
+
+    private var cached: ContractsState
+    private var continuations: [UUID: AsyncStream<ContractsState>.Continuation] = [:]
+    private var startTask: Task<Void, Never>?
+
+    init(fetcher: any ContractsManifestFetcher, store: any AnchorSelectionStore) {
+        self.fetcher = fetcher
+        self.store = store
+        self.cached = ContractsState(
+            manifest: store.loadCachedManifest() ?? .empty,
+            selections: store.loadSelections()
+        )
+    }
+
+    /// Trigger a background fetch of the latest manifest. Idempotent.
+    /// Failures fall through silently — the cached manifest (if any)
+    /// remains the source of truth.
+    func start() {
+        guard startTask == nil else { return }
+        startTask = Task { [weak self] in
+            await self?.refreshSilently()
+        }
+    }
+
+    /// Force a refresh and surface any error to the caller (so a
+    /// future pull-to-refresh UI can show progress / error state).
+    func refresh() async throws {
+        var manifest = try await fetcher.fetchLatest()
+        manifest = Self.sortedNewestFirst(manifest)
+        store.saveCachedManifest(manifest)
+        cached = ContractsState(manifest: manifest, selections: cached.selections)
+        publish()
+    }
+
+    // MARK: - Selection mutations
+
+    /// User explicitly picked `releaseTag` for the (network, type)
+    /// in `key`. Subsequent `binding(for: key)` calls return that
+    /// release's contract.
+    func select(key: AnchorSelectionKey, releaseTag: String) {
+        var selections = cached.selections
+        selections[key] = releaseTag
+        store.saveSelections(selections)
+        cached = ContractsState(manifest: cached.manifest, selections: selections)
+        publish()
+    }
+
+    /// Drop the explicit selection for `key`. After this,
+    /// `binding(for: key)` falls back to the default-to-latest rule.
+    func clearSelection(key: AnchorSelectionKey) {
+        var selections = cached.selections
+        selections.removeValue(forKey: key)
+        store.saveSelections(selections)
+        cached = ContractsState(manifest: cached.manifest, selections: selections)
+        publish()
+    }
+
+    // MARK: - Read
+
+    func currentState() -> ContractsState { cached }
+
+    /// Convenience: resolve `key` to a concrete `AnchorBinding` per
+    /// the rules on `ContractsState`. Async because it crosses the
+    /// actor; SwiftUI render paths should hold a `ContractsState`
+    /// snapshot directly and call `state.binding(for:)` synchronously.
+    func binding(for key: AnchorSelectionKey) -> AnchorBinding? {
+        cached.binding(for: key)
+    }
+
+    /// Convenience: see `ContractsState.availableReleases(for:)`.
+    func availableReleases(for key: AnchorSelectionKey) -> [ContractRelease] {
+        cached.availableReleases(for: key)
+    }
+
+    // MARK: - AsyncStream
+
+    nonisolated var snapshots: AsyncStream<ContractsState> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<ContractsState>.Continuation
+    ) {
+        continuations[id] = continuation
+        continuation.yield(cached)
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func publish() {
+        for continuation in continuations.values {
+            continuation.yield(cached)
+        }
+    }
+
+    private func refreshSilently() async {
+        do {
+            try await refresh()
+        } catch {
+            // Cached manifest (if any) remains valid; nothing to do.
+        }
+    }
+
+    /// Manifest's `releases[]` is sorted newest-first so default-to-
+    /// latest is just `releases.first { has-entry-for-key }`. The
+    /// upstream JSON should already be sorted, but defensive sort here
+    /// removes a load-bearing wire-format invariant.
+    private static func sortedNewestFirst(_ manifest: ContractsManifest) -> ContractsManifest {
+        let sorted = manifest.releases.sorted { $0.publishedAt > $1.publishedAt }
+        return ContractsManifest(version: manifest.version, releases: sorted)
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct OnymIOSApp: App {
     private let dependencies: AppDependencies
     private let relayerRepository: RelayerRepository
+    private let contractsRepository: ContractsRepository
 
     init() {
         let args = ProcessInfo.processInfo.arguments
@@ -29,6 +30,12 @@ struct OnymIOSApp: App {
         )
         self.relayerRepository = relayerRepository
 
+        let contractsRepository = ContractsRepository(
+            fetcher: GitHubReleasesContractsManifestFetcher(),
+            store: UserDefaultsAnchorSelectionStore()
+        )
+        self.contractsRepository = contractsRepository
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -38,6 +45,9 @@ struct OnymIOSApp: App {
             },
             makeRelayerPickerFlow: { @MainActor in
                 RelayerPickerFlow(repository: relayerRepository)
+            },
+            makeAnchorsPickerFlow: { @MainActor in
+                AnchorsPickerFlow(repository: contractsRepository)
             }
         )
     }
@@ -46,10 +56,12 @@ struct OnymIOSApp: App {
         WindowGroup {
             RootView(dependencies: dependencies)
                 .task {
-                    // Kick off the GitHub Releases fetch as soon as the
-                    // app is on screen. Failures are silent; the user
-                    // can always enter a custom URL.
+                    // Kick off both GitHub Releases fetches as soon as the
+                    // app is on screen. Failures are silent; the user can
+                    // still enter a custom relayer URL / pick an older
+                    // contract from whatever was cached on the previous run.
                     await relayerRepository.start()
+                    await contractsRepository.start()
                 }
         }
     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -25,7 +25,8 @@ struct RootView: View {
                 NavigationStack {
                     SettingsView(
                         makeBackupFlow: dependencies.makeRecoveryPhraseBackupFlow,
-                        makeRelayerPickerFlow: dependencies.makeRelayerPickerFlow
+                        makeRelayerPickerFlow: dependencies.makeRelayerPickerFlow,
+                        makeAnchorsPickerFlow: dependencies.makeAnchorsPickerFlow
                     )
                 }
             }

--- a/Sources/OnymIOS/Settings/AnchorsPickerFlow.swift
+++ b/Sources/OnymIOS/Settings/AnchorsPickerFlow.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Stateless interactor for the anchors drill-down. Drains
+/// `ContractsRepository` snapshots into `state.snapshot`; intents
+/// dispatch to the repository for selection mutations. The picker
+/// view reads from `state` and calls the intent methods on tap;
+/// navigation itself is owned by SwiftUI's `NavigationStack` (this
+/// flow only knows about the data shape, not the navigation path).
+@MainActor
+@Observable
+final class AnchorsPickerFlow {
+    private(set) var state: ContractsState = .empty
+
+    private let repository: ContractsRepository
+    private var snapshotTask: Task<Void, Never>?
+
+    init(repository: ContractsRepository) {
+        self.repository = repository
+    }
+
+    /// Begin draining repository snapshots. Idempotent.
+    func start() {
+        guard snapshotTask == nil else { return }
+        snapshotTask = Task { [weak self] in
+            guard let self else { return }
+            for await snapshot in self.repository.snapshots {
+                self.state = snapshot
+            }
+        }
+    }
+
+    func stop() {
+        snapshotTask?.cancel()
+        snapshotTask = nil
+    }
+
+    // MARK: - Read helpers (used by the picker views, all sync)
+
+    /// Resolve `(network, type)` to its `AnchorBinding`. Pure read
+    /// over `state` — safe to call from a SwiftUI cell.
+    func binding(for key: AnchorSelectionKey) -> AnchorBinding? {
+        state.binding(for: key)
+    }
+
+    /// Releases that have a contract for `key`, newest-first.
+    func availableReleases(for key: AnchorSelectionKey) -> [ContractRelease] {
+        state.availableReleases(for: key)
+    }
+
+    /// True when the user has explicitly picked a release for `key`
+    /// (vs. falling back to default-to-latest). Drives the
+    /// "(latest)" / "(selected)" subtitle on each row.
+    func hasExplicitSelection(for key: AnchorSelectionKey) -> Bool {
+        state.selections[key] != nil
+    }
+
+    /// True when at least one release has a contract on `network`.
+    /// The Network row uses this to render Mainnet as disabled until
+    /// contracts ship there.
+    func hasAnyContracts(network: ContractNetwork) -> Bool {
+        state.hasAnyContracts(network: network)
+    }
+
+    // MARK: - Intents
+
+    func tappedVersion(key: AnchorSelectionKey, releaseTag: String) {
+        Task { await repository.select(key: key, releaseTag: releaseTag) }
+    }
+
+    func tappedResetToDefault(key: AnchorSelectionKey) {
+        Task { await repository.clearSelection(key: key) }
+    }
+}

--- a/Sources/OnymIOS/Settings/AnchorsView.swift
+++ b/Sources/OnymIOS/Settings/AnchorsView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+/// Root of the Anchors drill-down — Testnet / Mainnet rows. Pushes to
+/// `AnchorsNetworkView` for the picked network. Mainnet is disabled
+/// while no manifest entries exist for it.
+struct AnchorsView: View {
+    @State private var flow: AnchorsPickerFlow
+
+    init(flow: AnchorsPickerFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                ForEach(ContractNetwork.allCases, id: \.self) { network in
+                    networkRow(network)
+                }
+            } footer: {
+                Text("Choose the contract version used to anchor on-chain group state. Selection per (network, governance type) pins to new chats; existing chats keep the contract they were created with.")
+            }
+        }
+        .navigationTitle("Anchors")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { flow.start() }
+    }
+
+    @ViewBuilder
+    private func networkRow(_ network: ContractNetwork) -> some View {
+        let hasContracts = flow.hasAnyContracts(network: network)
+        if hasContracts {
+            NavigationLink {
+                AnchorsNetworkView(flow: flow, network: network)
+            } label: {
+                HStack {
+                    Text(network.displayName)
+                        .foregroundStyle(.primary)
+                    Spacer()
+                }
+            }
+            .accessibilityIdentifier("anchors.network.\(network.rawValue)")
+        } else {
+            HStack {
+                Text(network.displayName)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("No contracts yet")
+                    .font(.footnote)
+                    .foregroundStyle(.tertiary)
+            }
+            .accessibilityIdentifier("anchors.network.\(network.rawValue).disabled")
+        }
+    }
+}
+
+/// Second-level drill-down: lists the five governance types for the
+/// chosen network. Each row shows the currently resolved release tag
+/// + "(latest)" or "(selected)" subtitle.
+struct AnchorsNetworkView: View {
+    let flow: AnchorsPickerFlow
+    let network: ContractNetwork
+
+    var body: some View {
+        Form {
+            Section {
+                ForEach(GovernanceType.allCases, id: \.self) { type in
+                    governanceRow(type)
+                }
+            }
+        }
+        .navigationTitle(network.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private func governanceRow(_ type: GovernanceType) -> some View {
+        let key = AnchorSelectionKey(network: network, type: type)
+        let binding = flow.binding(for: key)
+        let isExplicit = flow.hasExplicitSelection(for: key)
+
+        if let binding {
+            NavigationLink {
+                AnchorsVersionView(flow: flow, key: key)
+            } label: {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(type.displayName)
+                            .foregroundStyle(.primary)
+                        Text(binding.release + " " + (isExplicit ? "(selected)" : "(latest)"))
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+            }
+            .accessibilityIdentifier("anchors.type.\(type.rawValue)")
+        } else {
+            HStack {
+                Text(type.displayName)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("No contract")
+                    .font(.footnote)
+                    .foregroundStyle(.tertiary)
+            }
+            .accessibilityIdentifier("anchors.type.\(type.rawValue).disabled")
+        }
+    }
+}
+
+/// Leaf drill-down: lists all releases that have a contract for the
+/// (network, type) being picked, newest-first. Tap to select; pop back
+/// is automatic. A "Reset to default" row at the bottom clears the
+/// explicit selection so the default-to-latest rule kicks in.
+struct AnchorsVersionView: View {
+    let flow: AnchorsPickerFlow
+    let key: AnchorSelectionKey
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Form {
+            Section {
+                let releases = flow.availableReleases(for: key)
+                let selectedTag = flow.binding(for: key)?.release
+                ForEach(releases, id: \.release) { release in
+                    versionRow(release: release, isSelected: release.release == selectedTag)
+                }
+            }
+
+            if flow.hasExplicitSelection(for: key) {
+                Section {
+                    Button("Reset to Default (latest)") {
+                        flow.tappedResetToDefault(key: key)
+                        dismiss()
+                    }
+                    .accessibilityIdentifier("anchors.version.reset")
+                }
+            }
+        }
+        .navigationTitle("\(key.network.displayName) · \(key.type.displayName)")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private func versionRow(release: ContractRelease, isSelected: Bool) -> some View {
+        Button {
+            flow.tappedVersion(key: key, releaseTag: release.release)
+            dismiss()
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(release.release)
+                        .font(.body.monospaced())
+                        .foregroundStyle(.primary)
+                    Text(release.publishedAt.formatted(date: .abbreviated, time: .omitted))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("anchors.version.\(release.release)")
+    }
+}

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct SettingsView: View {
     let makeBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
     let makeRelayerPickerFlow: @MainActor () -> RelayerPickerFlow
+    let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
 
     @State private var showRecoveryPhrase = false
 
@@ -39,10 +40,20 @@ struct SettingsView: View {
                     )
                 }
                 .accessibilityIdentifier("settings.relayer_row")
+
+                NavigationLink {
+                    AnchorsView(flow: makeAnchorsPickerFlow())
+                } label: {
+                    row(
+                        icon: SettingsIconBox(systemImage: "link", background: .indigo),
+                        title: "Anchors"
+                    )
+                }
+                .accessibilityIdentifier("settings.anchors_row")
             } header: {
                 Text("Network")
             } footer: {
-                Text("Choose the relayer used to anchor on-chain group state. Pick one from the published list or enter a custom URL.")
+                Text("Choose the relayer that submits transactions and which contract version anchors new chats. Existing chats keep the contract they were created with.")
             }
         }
         .navigationTitle("Settings")

--- a/Tests/OnymIOSTests/AnchorSelectionStoreTests.swift
+++ b/Tests/OnymIOSTests/AnchorSelectionStoreTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import OnymIOS
+
+/// UserDefaults round-trip with per-test suite isolation. Mirrors
+/// `RelayerSelectionStoreTests` from PR #18.
+final class AnchorSelectionStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var store: UserDefaultsAnchorSelectionStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "chat.onym.ios.anchors.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = UserDefaultsAnchorSelectionStore(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        store = nil
+        super.tearDown()
+    }
+
+    // MARK: - selections
+
+    func test_loadSelections_returnsEmptyWhenNothingPersisted() {
+        XCTAssertTrue(store.loadSelections().isEmpty)
+    }
+
+    func test_saveSelections_thenLoadSelections_roundtripsMap() {
+        let key1 = AnchorSelectionKey(network: .testnet, type: .anarchy)
+        let key2 = AnchorSelectionKey(network: .public, type: .oneonone)
+        let original: [AnchorSelectionKey: String] = [key1: "v0.0.2", key2: "v1.0.0"]
+        store.saveSelections(original)
+        XCTAssertEqual(store.loadSelections(), original)
+    }
+
+    func test_saveSelections_overwrites() {
+        let key = AnchorSelectionKey(network: .testnet, type: .anarchy)
+        store.saveSelections([key: "v0.0.1"])
+        store.saveSelections([key: "v0.0.2"])
+        XCTAssertEqual(store.loadSelections(), [key: "v0.0.2"])
+    }
+
+    func test_saveSelectionsEmpty_clearsPersistedSelections() {
+        store.saveSelections([
+            AnchorSelectionKey(network: .testnet, type: .anarchy): "v0.0.1"
+        ])
+        store.saveSelections([:])
+        XCTAssertTrue(store.loadSelections().isEmpty)
+    }
+
+    // MARK: - cached manifest
+
+    func test_loadCachedManifest_returnsNilWhenNothingPersisted() {
+        XCTAssertNil(store.loadCachedManifest())
+    }
+
+    func test_saveCachedManifest_thenLoad_roundtripsManifest() {
+        let manifest = ContractsManifest(version: 1, releases: [
+            ContractRelease(
+                release: "v0.0.2",
+                publishedAt: Date(timeIntervalSince1970: 1_730_000_000),
+                contracts: [
+                    ContractEntry(network: .testnet, type: .anarchy, id: "CDWYYK...RO2UMV"),
+                ]
+            )
+        ])
+        store.saveCachedManifest(manifest)
+        XCTAssertEqual(store.loadCachedManifest(), manifest)
+    }
+}

--- a/Tests/OnymIOSTests/AnchorsPickerFlowTests.swift
+++ b/Tests/OnymIOSTests/AnchorsPickerFlowTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import OnymIOS
+
+/// Picker flow against a real `ContractsRepository` backed by the
+/// in-memory fakes. Asserts the read-helper rules (default-to-latest
+/// vs explicit-selection rendering, mainnet-disabled gating) and the
+/// intent → repository → snapshot pipeline.
+@MainActor
+final class AnchorsPickerFlowTests: XCTestCase {
+
+    private static let v002 = ContractRelease(
+        release: "v0.0.2",
+        publishedAt: Date(timeIntervalSince1970: 1_700_000_002),
+        contracts: [
+            ContractEntry(network: .testnet, type: .anarchy, id: "CDWYYK..."),
+        ]
+    )
+    private static let v001 = ContractRelease(
+        release: "v0.0.1",
+        publishedAt: Date(timeIntervalSince1970: 1_700_000_001),
+        contracts: [
+            ContractEntry(network: .testnet, type: .anarchy, id: "CDSIJT..."),
+        ]
+    )
+    private static let manifest = ContractsManifest(version: 1, releases: [v002, v001])
+
+    private let testnetAnarchy = AnchorSelectionKey(network: .testnet, type: .anarchy)
+    private let mainnetAnarchy = AnchorSelectionKey(network: .public, type: .anarchy)
+
+    private func makeFlow(
+        store: InMemoryAnchorSelectionStore? = nil
+    ) -> (AnchorsPickerFlow, ContractsRepository) {
+        let resolvedStore = store ?? InMemoryAnchorSelectionStore(manifest: Self.manifest)
+        let fetcher = FakeContractsManifestFetcher(mode: .succeeds(.empty))
+        let repo = ContractsRepository(fetcher: fetcher, store: resolvedStore)
+        let flow = AnchorsPickerFlow(repository: repo)
+        return (flow, repo)
+    }
+
+    // MARK: - read helpers
+
+    func test_binding_returnsLatestWhenNoExplicitSelection() async throws {
+        let (flow, _) = makeFlow()
+        flow.start()
+        defer { flow.stop() }
+        try await waitForState(flow: flow) { !$0.manifest.releases.isEmpty }
+        XCTAssertEqual(flow.binding(for: testnetAnarchy)?.release, "v0.0.2")
+    }
+
+    func test_binding_returnsExplicitSelectionWhenSet() async throws {
+        let store = InMemoryAnchorSelectionStore(
+            selections: [testnetAnarchy: "v0.0.1"],
+            manifest: Self.manifest
+        )
+        let (flow, _) = makeFlow(store: store)
+        flow.start()
+        defer { flow.stop() }
+        try await waitForState(flow: flow) { $0.selections[self.testnetAnarchy] == "v0.0.1" }
+        XCTAssertEqual(flow.binding(for: testnetAnarchy)?.release, "v0.0.1")
+    }
+
+    func test_hasExplicitSelection_reflectsStore() async throws {
+        let store = InMemoryAnchorSelectionStore(
+            selections: [testnetAnarchy: "v0.0.1"],
+            manifest: Self.manifest
+        )
+        let (flow, _) = makeFlow(store: store)
+        flow.start()
+        defer { flow.stop() }
+        try await waitForState(flow: flow) { !$0.selections.isEmpty }
+        XCTAssertTrue(flow.hasExplicitSelection(for: testnetAnarchy))
+        XCTAssertFalse(flow.hasExplicitSelection(
+            for: AnchorSelectionKey(network: .testnet, type: .democracy)
+        ))
+    }
+
+    func test_hasAnyContracts_trueForTestnet_falseForMainnet() async throws {
+        let (flow, _) = makeFlow()
+        flow.start()
+        defer { flow.stop() }
+        try await waitForState(flow: flow) { !$0.manifest.releases.isEmpty }
+        XCTAssertTrue(flow.hasAnyContracts(network: .testnet))
+        XCTAssertFalse(flow.hasAnyContracts(network: .public),
+                       "manifest only has testnet contracts → mainnet row stays disabled")
+    }
+
+    func test_availableReleases_newestFirst() async throws {
+        let (flow, _) = makeFlow()
+        flow.start()
+        defer { flow.stop() }
+        try await waitForState(flow: flow) { !$0.manifest.releases.isEmpty }
+        let releases = flow.availableReleases(for: testnetAnarchy)
+        XCTAssertEqual(releases.map(\.release), ["v0.0.2", "v0.0.1"])
+    }
+
+    // MARK: - intents
+
+    func test_tappedVersion_persistsViaRepository() async throws {
+        let store = InMemoryAnchorSelectionStore(manifest: Self.manifest)
+        let (flow, _) = makeFlow(store: store)
+        flow.start()
+        defer { flow.stop() }
+
+        flow.tappedVersion(key: testnetAnarchy, releaseTag: "v0.0.1")
+        try await waitFor { store.loadSelections()[self.testnetAnarchy] == "v0.0.1" }
+        XCTAssertEqual(flow.binding(for: testnetAnarchy)?.release, "v0.0.1")
+    }
+
+    func test_tappedResetToDefault_clearsExplicitAndFallsBackToLatest() async throws {
+        let store = InMemoryAnchorSelectionStore(
+            selections: [testnetAnarchy: "v0.0.1"],
+            manifest: Self.manifest
+        )
+        let (flow, _) = makeFlow(store: store)
+        flow.start()
+        defer { flow.stop() }
+        try await waitForState(flow: flow) { $0.selections[self.testnetAnarchy] == "v0.0.1" }
+
+        flow.tappedResetToDefault(key: testnetAnarchy)
+        try await waitFor { store.loadSelections()[self.testnetAnarchy] == nil }
+        XCTAssertEqual(flow.binding(for: testnetAnarchy)?.release, "v0.0.2",
+                       "after reset → default-to-latest")
+    }
+
+    // MARK: - helpers
+
+    private func waitForState(
+        flow: AnchorsPickerFlow,
+        timeoutMs: Int = 1000,
+        _ predicate: @escaping @MainActor (ContractsState) -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMs) / 1000)
+        while !predicate(flow.state) {
+            if Date() > deadline {
+                XCTFail("waitForState timed out after \(timeoutMs)ms")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+
+    private func waitFor(
+        timeoutMs: Int = 1000,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMs) / 1000)
+        while !condition() {
+            if Date() > deadline {
+                XCTFail("waitFor timed out after \(timeoutMs)ms")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}

--- a/Tests/OnymIOSTests/ContractsManifestDecodingTests.swift
+++ b/Tests/OnymIOSTests/ContractsManifestDecodingTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import OnymIOS
+
+/// Pin the wire format + the unknown-enum-dropping behaviour of the
+/// manifest decoder. A future contracts release that adds (e.g.) a
+/// "monarchy" governance type or a "futurenet" network must not crash
+/// older clients — the decoder silently drops those entries while
+/// keeping the rest of the manifest usable.
+final class ContractsManifestDecodingTests: XCTestCase {
+
+    // MARK: - happy path
+
+    func test_decodeFiltering_parsesValidManifest() throws {
+        let manifest = try GitHubReleasesContractsManifestFetcher.decodeFiltering(Data(Self.fixtureJSON.utf8))
+        XCTAssertEqual(manifest.version, 1)
+        XCTAssertEqual(manifest.releases.count, 2)
+
+        let v002 = try XCTUnwrap(manifest.releases.first { $0.release == "v0.0.2" })
+        XCTAssertEqual(v002.contracts.count, 5)
+        XCTAssertEqual(v002.contracts.first?.network, .testnet)
+        XCTAssertEqual(v002.contracts.first?.type, .anarchy)
+        XCTAssertEqual(v002.contracts.first?.id, "CDWYYK...RO2UMV")
+    }
+
+    // MARK: - unknown-enum dropping
+
+    func test_decodeFiltering_dropsUnknownNetwork() throws {
+        let json = """
+        {
+          "version": 1,
+          "releases": [{
+            "release": "v0.0.3",
+            "publishedAt": "2026-06-01T00:00:00Z",
+            "contracts": [
+              { "network": "futurenet", "type": "anarchy", "id": "FUTURE..." },
+              { "network": "testnet",   "type": "anarchy", "id": "KEEP..." }
+            ]
+          }]
+        }
+        """
+        let manifest = try GitHubReleasesContractsManifestFetcher.decodeFiltering(Data(json.utf8))
+        XCTAssertEqual(manifest.releases[0].contracts.count, 1, "futurenet entry must be silently dropped")
+        XCTAssertEqual(manifest.releases[0].contracts[0].id, "KEEP...")
+    }
+
+    func test_decodeFiltering_dropsUnknownGovernanceType() throws {
+        let json = """
+        {
+          "version": 1,
+          "releases": [{
+            "release": "v0.0.3",
+            "publishedAt": "2026-06-01T00:00:00Z",
+            "contracts": [
+              { "network": "testnet", "type": "monarchy", "id": "MONARCH..." },
+              { "network": "testnet", "type": "anarchy",  "id": "KEEP..." }
+            ]
+          }]
+        }
+        """
+        let manifest = try GitHubReleasesContractsManifestFetcher.decodeFiltering(Data(json.utf8))
+        XCTAssertEqual(manifest.releases[0].contracts.count, 1, "monarchy entry must be silently dropped")
+    }
+
+    // MARK: - error paths
+
+    func test_decodeFiltering_throwsOnMalformedJSON() {
+        XCTAssertThrowsError(
+            try GitHubReleasesContractsManifestFetcher.decodeFiltering(Data("not json".utf8))
+        ) { error in
+            guard case ContractsManifestFetchError.malformedDocument = error else {
+                return XCTFail("expected malformedDocument, got \(error)")
+            }
+        }
+    }
+
+    func test_decodeFiltering_throwsOnMissingVersionField() {
+        let json = #"{"releases": []}"#
+        XCTAssertThrowsError(
+            try GitHubReleasesContractsManifestFetcher.decodeFiltering(Data(json.utf8))
+        )
+    }
+
+    // MARK: - default URL
+
+    func test_defaultURL_pointsAtGitHubReleasesLatestDownload() {
+        XCTAssertEqual(
+            GitHubReleasesContractsManifestFetcher.defaultURL.absoluteString,
+            "https://github.com/onymchat/onym-contracts/releases/latest/download/contracts-manifest.json",
+            "Renaming this URL silently breaks the prepopulation flow on every install"
+        )
+    }
+
+    // MARK: - Fixture
+
+    private static let fixtureJSON = """
+    {
+      "version": 1,
+      "releases": [
+        {
+          "release": "v0.0.2",
+          "publishedAt": "2026-05-01T15:29:00Z",
+          "contracts": [
+            { "network": "testnet", "type": "anarchy",   "id": "CDWYYK...RO2UMV" },
+            { "network": "testnet", "type": "democracy", "id": "CBEBQM...ZPHIAC" },
+            { "network": "testnet", "type": "oligarchy", "id": "CBHY24...J46COU" },
+            { "network": "testnet", "type": "oneonone",  "id": "CAHXGZ...FO6OEB" },
+            { "network": "testnet", "type": "tyranny",   "id": "CC6Y2F...45CFO3" }
+          ]
+        },
+        {
+          "release": "v0.0.1",
+          "publishedAt": "2026-05-01T11:43:00Z",
+          "contracts": [
+            { "network": "testnet", "type": "anarchy",   "id": "CDSIJT...3RQ5B5" },
+            { "network": "testnet", "type": "democracy", "id": "CBYHYJ...PGGYIX" },
+            { "network": "testnet", "type": "oligarchy", "id": "CDCX2K...FEKM5W" },
+            { "network": "testnet", "type": "oneonone",  "id": "CBTXK4...MQYJI3" },
+            { "network": "testnet", "type": "tyranny",   "id": "CD2RTY...KCL447" }
+          ]
+        }
+      ]
+    }
+    """
+}

--- a/Tests/OnymIOSTests/ContractsManifestFetcherTests.swift
+++ b/Tests/OnymIOSTests/ContractsManifestFetcherTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import OnymIOS
+
+/// Hits the production fetcher with `StubURLProtocol` (the reusable
+/// scaffolding from PR #18) in front. Pins the network behaviour:
+/// 200 → parse, non-2xx → throw badStatus, malformed body →
+/// throw malformedDocument. Wire-format details are pinned in
+/// `ContractsManifestDecodingTests`.
+final class ContractsManifestFetcherTests: XCTestCase {
+    private var session: URLSession!
+    private let fixtureURL = URL(string: "https://test.example/contracts-manifest.json")!
+
+    override func setUp() {
+        super.setUp()
+        session = StubURLProtocol.makeSession()
+    }
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        session = nil
+        super.tearDown()
+    }
+
+    func test_fetchLatest_parsesValidDocument() async throws {
+        StubURLProtocol.set { request in
+            XCTAssertEqual(request.url, self.fixtureURL)
+            let body = """
+            {
+              "version": 1,
+              "releases": [{
+                "release": "v0.0.1",
+                "publishedAt": "2026-05-01T11:43:00Z",
+                "contracts": [
+                  { "network": "testnet", "type": "anarchy", "id": "CDSIJT...3RQ5B5" }
+                ]
+              }]
+            }
+            """
+            return (Data(body.utf8), HTTPURLResponse(url: self.fixtureURL, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesContractsManifestFetcher(url: fixtureURL, session: session)
+        let manifest = try await fetcher.fetchLatest()
+        XCTAssertEqual(manifest.releases.count, 1)
+        XCTAssertEqual(manifest.releases[0].contracts[0].id, "CDSIJT...3RQ5B5")
+    }
+
+    func test_fetchLatest_throwsOn404() async {
+        StubURLProtocol.set { _ in
+            (Data(), HTTPURLResponse(url: self.fixtureURL, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesContractsManifestFetcher(url: fixtureURL, session: session)
+        do {
+            _ = try await fetcher.fetchLatest()
+            XCTFail("expected throw")
+        } catch let ContractsManifestFetchError.badStatus(code) {
+            XCTAssertEqual(code, 404)
+        } catch {
+            XCTFail("expected badStatus(404), got \(error)")
+        }
+    }
+
+    func test_fetchLatest_throwsOnMalformedJSON() async {
+        StubURLProtocol.set { _ in
+            (Data("not json".utf8), HTTPURLResponse(url: self.fixtureURL, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesContractsManifestFetcher(url: fixtureURL, session: session)
+        do {
+            _ = try await fetcher.fetchLatest()
+            XCTFail("expected throw")
+        } catch ContractsManifestFetchError.malformedDocument { /* expected */ }
+        catch { XCTFail("expected malformedDocument, got \(error)") }
+    }
+}

--- a/Tests/OnymIOSTests/ContractsRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ContractsRepositoryTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+@testable import OnymIOS
+
+/// Repository against the in-memory fakes — focused on the binding
+/// resolution rules (the part chains will read forever) plus the
+/// reactive surface, selection persistence, and silent-on-error
+/// background start.
+final class ContractsRepositoryTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private static let v002 = ContractRelease(
+        release: "v0.0.2",
+        publishedAt: Date(timeIntervalSince1970: 1_700_000_002),  // newer
+        contracts: [
+            ContractEntry(network: .testnet, type: .anarchy,   id: "CDWYYK..."),
+            ContractEntry(network: .testnet, type: .democracy, id: "CBEBQM..."),
+        ]
+    )
+    private static let v001 = ContractRelease(
+        release: "v0.0.1",
+        publishedAt: Date(timeIntervalSince1970: 1_700_000_001),  // older
+        contracts: [
+            ContractEntry(network: .testnet, type: .anarchy,   id: "CDSIJT..."),
+            ContractEntry(network: .testnet, type: .democracy, id: "CBYHYJ..."),
+        ]
+    )
+    /// Manifest with two testnet anarchy releases (v0.0.2 newest).
+    private static let twoReleaseManifest = ContractsManifest(version: 1, releases: [v002, v001])
+
+    private let testnetAnarchy = AnchorSelectionKey(network: .testnet, type: .anarchy)
+    private let testnetTyranny = AnchorSelectionKey(network: .testnet, type: .tyranny)  // never published
+    private let mainnetAnarchy = AnchorSelectionKey(network: .public, type: .anarchy)   // never published
+
+    // MARK: - construction
+
+    func test_init_loadsCachedManifestAndSelectionsFromStore() async {
+        let store = InMemoryAnchorSelectionStore(
+            selections: [testnetAnarchy: "v0.0.1"],
+            manifest: Self.twoReleaseManifest
+        )
+        let fetcher = FakeContractsManifestFetcher(mode: .succeeds(.empty))
+        let repo = ContractsRepository(fetcher: fetcher, store: store)
+
+        let state = await repo.currentState()
+        XCTAssertEqual(state.manifest, Self.twoReleaseManifest)
+        XCTAssertEqual(state.selections[testnetAnarchy], "v0.0.1")
+    }
+
+    // MARK: - binding resolution rules (load-bearing)
+
+    func test_binding_explicitSelection_wins() async {
+        let store = InMemoryAnchorSelectionStore(
+            selections: [testnetAnarchy: "v0.0.1"],
+            manifest: Self.twoReleaseManifest
+        )
+        let repo = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(.empty)),
+            store: store
+        )
+        let binding = await repo.binding(for: testnetAnarchy)
+        XCTAssertEqual(binding?.release, "v0.0.1")
+        XCTAssertEqual(binding?.contractID, "CDSIJT...")
+    }
+
+    func test_binding_noExplicit_defaultsToLatestRelease() async {
+        let store = InMemoryAnchorSelectionStore(
+            selections: [:],
+            manifest: Self.twoReleaseManifest
+        )
+        let repo = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(.empty)),
+            store: store
+        )
+        let binding = await repo.binding(for: testnetAnarchy)
+        XCTAssertEqual(binding?.release, "v0.0.2", "default-to-latest must pick the newest publishedAt")
+        XCTAssertEqual(binding?.contractID, "CDWYYK...")
+    }
+
+    func test_binding_noContractForKey_returnsNil() async {
+        let store = InMemoryAnchorSelectionStore(manifest: Self.twoReleaseManifest)
+        let repo = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(.empty)),
+            store: store
+        )
+        let tyranny = await repo.binding(for: testnetTyranny)
+        let mainnet = await repo.binding(for: mainnetAnarchy)
+        XCTAssertNil(tyranny, "no published contract for tyranny on testnet → nil")
+        XCTAssertNil(mainnet, "no published contract on mainnet at all → nil")
+    }
+
+    func test_binding_explicitSelectionForReleaseWithoutContractForKey_fallsBackToLatest() async {
+        // User picked v0.0.2 for tyranny but neither release has a
+        // tyranny contract — fall back to latest release that DOES
+        // have one. Here that's still nil since neither does.
+        let store = InMemoryAnchorSelectionStore(
+            selections: [testnetTyranny: "v0.0.2"],
+            manifest: Self.twoReleaseManifest
+        )
+        let repo = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(.empty)),
+            store: store
+        )
+        let result = await repo.binding(for: testnetTyranny)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - mutators
+
+    func test_select_persistsAndPushesSnapshot() async {
+        let store = InMemoryAnchorSelectionStore(manifest: Self.twoReleaseManifest)
+        let repo = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(.empty)),
+            store: store
+        )
+        await repo.select(key: testnetAnarchy, releaseTag: "v0.0.1")
+        XCTAssertEqual(store.loadSelections()[testnetAnarchy], "v0.0.1")
+        let state = await repo.currentState()
+        XCTAssertEqual(state.selections[testnetAnarchy], "v0.0.1")
+    }
+
+    func test_clearSelection_removesAndFallsBackToLatest() async {
+        let store = InMemoryAnchorSelectionStore(
+            selections: [testnetAnarchy: "v0.0.1"],
+            manifest: Self.twoReleaseManifest
+        )
+        let repo = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(.empty)),
+            store: store
+        )
+        await repo.clearSelection(key: testnetAnarchy)
+        XCTAssertNil(store.loadSelections()[testnetAnarchy])
+        let binding = await repo.binding(for: testnetAnarchy)
+        XCTAssertEqual(binding?.release, "v0.0.2", "after clear → default-to-latest")
+    }
+
+    // MARK: - refresh + start
+
+    func test_refresh_persistsAndPushesNewManifest() async throws {
+        let store = InMemoryAnchorSelectionStore()
+        let fetcher = FakeContractsManifestFetcher(mode: .succeeds(Self.twoReleaseManifest))
+        let repo = ContractsRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+        XCTAssertEqual(store.loadCachedManifest(), Self.twoReleaseManifest)
+        let state = await repo.currentState()
+        XCTAssertEqual(state.manifest, Self.twoReleaseManifest)
+    }
+
+    func test_refresh_throwsAndLeavesCachedManifestIntact() async {
+        let cached = Self.twoReleaseManifest
+        let store = InMemoryAnchorSelectionStore(manifest: cached)
+        let fetcher = FakeContractsManifestFetcher(mode: .failing(URLError(.notConnectedToInternet)))
+        let repo = ContractsRepository(fetcher: fetcher, store: store)
+
+        do { try await repo.refresh(); XCTFail("expected throw") } catch { /* expected */ }
+
+        let state = await repo.currentState()
+        XCTAssertEqual(state.manifest, cached, "fetch failure must not erase cached manifest")
+    }
+
+    func test_start_isIdempotent_doesNotDoubleFetch() async throws {
+        let store = InMemoryAnchorSelectionStore()
+        let fetcher = FakeContractsManifestFetcher(mode: .succeeds(Self.twoReleaseManifest))
+        let repo = ContractsRepository(fetcher: fetcher, store: store)
+
+        await repo.start()
+        await repo.start()
+        await repo.start()
+
+        // Wait for the first fetch to land.
+        try await waitForManifest(repo: repo, timeoutMs: 1000)
+        XCTAssertEqual(fetcher.fetchCallCount, 1, "start() must be idempotent")
+    }
+
+    func test_start_swallowsFetchFailures() async {
+        let store = InMemoryAnchorSelectionStore()
+        let fetcher = FakeContractsManifestFetcher(mode: .failing(URLError(.timedOut)))
+        let repo = ContractsRepository(fetcher: fetcher, store: store)
+
+        await repo.start()  // must not throw or trap
+        try? await Task.sleep(for: .milliseconds(50))
+        let state = await repo.currentState()
+        XCTAssertTrue(state.manifest.releases.isEmpty)
+    }
+
+    // MARK: - snapshots
+
+    func test_snapshots_emitsCurrentValueOnSubscribe() async throws {
+        let store = InMemoryAnchorSelectionStore(manifest: Self.twoReleaseManifest)
+        let repo = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(.empty)),
+            store: store
+        )
+        var iterator = repo.snapshots.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first?.manifest, Self.twoReleaseManifest)
+    }
+
+    func test_snapshots_emitsAfterSelect() async throws {
+        let store = InMemoryAnchorSelectionStore(manifest: Self.twoReleaseManifest)
+        let repo = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(.empty)),
+            store: store
+        )
+        var iterator = repo.snapshots.makeAsyncIterator()
+        _ = await iterator.next()  // initial
+
+        await repo.select(key: testnetAnarchy, releaseTag: "v0.0.1")
+        let next = await iterator.next()
+        XCTAssertEqual(next?.selections[testnetAnarchy], "v0.0.1")
+    }
+
+    // MARK: - helpers
+
+    private func waitForManifest(
+        repo: ContractsRepository,
+        timeoutMs: Int
+    ) async throws {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMs) / 1000)
+        while await repo.currentState().manifest.releases.isEmpty {
+            if Date() > deadline {
+                XCTFail("timed out waiting for non-empty manifest")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}

--- a/Tests/OnymIOSTests/Support/FakeContractsManifestFetcher.swift
+++ b/Tests/OnymIOSTests/Support/FakeContractsManifestFetcher.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import OnymIOS
+
+/// `ContractsManifestFetcher` test double. Three modes mirror the
+/// `FakeKnownRelayersFetcher` pattern from PR #18 so tests look the
+/// same regardless of which seam they're driving.
+final class FakeContractsManifestFetcher: ContractsManifestFetcher, @unchecked Sendable {
+    enum Mode {
+        case succeeds(ContractsManifest)
+        case failing(Error)
+        case scripted([Result<ContractsManifest, Error>])
+    }
+
+    private let lock = NSLock()
+    private var mode: Mode
+    private(set) var fetchCallCount: Int = 0
+    private var scriptIndex: Int = 0
+
+    init(mode: Mode) {
+        self.mode = mode
+    }
+
+    func setMode(_ newMode: Mode) {
+        lock.withLock {
+            self.mode = newMode
+            self.scriptIndex = 0
+        }
+    }
+
+    func fetchLatest() async throws -> ContractsManifest {
+        try lock.withLock {
+            fetchCallCount += 1
+            switch mode {
+            case .succeeds(let manifest):
+                return manifest
+            case .failing(let error):
+                throw error
+            case .scripted(let results):
+                precondition(scriptIndex < results.count,
+                             "FakeContractsManifestFetcher: scripted ran out of results at call #\(scriptIndex + 1)")
+                let result = results[scriptIndex]
+                scriptIndex += 1
+                return try result.get()
+            }
+        }
+    }
+}

--- a/Tests/OnymIOSTests/Support/InMemoryAnchorSelectionStore.swift
+++ b/Tests/OnymIOSTests/Support/InMemoryAnchorSelectionStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+@testable import OnymIOS
+
+/// `AnchorSelectionStore` impl backed by plain in-memory state. Used
+/// by repository tests that don't care about UserDefaults plumbing —
+/// same role as `InMemoryRelayerSelectionStore` from PR #18.
+final class InMemoryAnchorSelectionStore: AnchorSelectionStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var selections: [AnchorSelectionKey: String]
+    private var manifest: ContractsManifest?
+
+    init(
+        selections: [AnchorSelectionKey: String] = [:],
+        manifest: ContractsManifest? = nil
+    ) {
+        self.selections = selections
+        self.manifest = manifest
+    }
+
+    func loadSelections() -> [AnchorSelectionKey: String] {
+        lock.withLock { selections }
+    }
+
+    func saveSelections(_ selections: [AnchorSelectionKey: String]) {
+        lock.withLock { self.selections = selections }
+    }
+
+    func loadCachedManifest() -> ContractsManifest? {
+        lock.withLock { manifest }
+    }
+
+    func saveCachedManifest(_ manifest: ContractsManifest) {
+        lock.withLock { self.manifest = manifest }
+    }
+}


### PR DESCRIPTION
## Summary

A new "Anchors" row in Settings → Network with a 3-level drill-down: **Network** (Testnet | Mainnet) → **Governance type** (anarchy | democracy | oligarchy | oneonone | tyranny) → **Version** (release tags from `onymchat/onym-contracts`). Selection per (network, type) is exactly one. The repository resolves to a concrete `AnchorBinding` (network + type + contractID + release) that future chat-creation code reads when anchoring a brand-new chat.

Same shape as PR #18 (relayer config) — chain seam + repository + picker UI + reusable test fakes — different domain.

## Wire format you need to publish

Single asset `contracts-manifest.json` attached to the **latest** release of `onymchat/onym-contracts`. Fetched via `https://github.com/onymchat/onym-contracts/releases/latest/download/contracts-manifest.json` (no GitHub API rate limit). Pinned in `ContractsManifestDecodingTests.test_defaultURL_pointsAtGitHubReleasesLatestDownload` against silent renames.

```json
{
  "version": 1,
  "releases": [
    {
      "release": "v0.0.2",
      "publishedAt": "2026-05-01T15:29:00Z",
      "contracts": [
        { "network": "testnet", "type": "anarchy",   "id": "CDWYYK...RO2UMV" },
        { "network": "testnet", "type": "democracy", "id": "CBEBQM...ZPHIAC" },
        { "network": "testnet", "type": "oligarchy", "id": "CBHY24...J46COU" },
        { "network": "testnet", "type": "oneonone",  "id": "CAHXGZ...FO6OEB" },
        { "network": "testnet", "type": "tyranny",   "id": "CC6Y2F...45CFO3" }
      ]
    },
    { "release": "v0.0.1", "publishedAt": "2026-05-01T11:43:00Z", "contracts": [...] }
  ]
}
```

`releases[]` is the union of all historical releases — newest-first. Regenerated and re-attached to the latest release on every new release (CI step in the contracts repo). Backfill v0.0.1 + v0.0.2 by attaching this asset to v0.0.2.

## What lands

```
Sources/OnymIOS/
├── Chain/
│   ├── ContractEntry.swift                  ← ContractEntry + ContractRelease + ContractsManifest + ContractNetwork + GovernanceType
│   ├── AnchorSelection.swift                ← AnchorSelectionKey (network+type) + AnchorBinding (the resolved triple chats carry)
│   ├── AnchorSelectionStore.swift           ← UserDefaults persistence seam
│   ├── ContractsManifestFetcher.swift       ← URLSession → manifest URL; ISO-8601 dates; unknown-enum filtering at decode boundary
│   └── ContractsRepository.swift            ← actor + AsyncStream<ContractsState>; resolution rules live on ContractsState as pure functions
└── Settings/
    ├── AnchorsPickerFlow.swift              ← stateless interactor; sync read helpers backed by ContractsState
    ├── AnchorsView.swift                    ← 3-screen NavigationStack drill-down
    └── SettingsView.swift (modified)        ← +Anchors row inside the existing Network section

Tests/OnymIOSTests/
├── Support/
│   ├── InMemoryAnchorSelectionStore.swift   ← reusable fake (dictionary-backed)
│   └── FakeContractsManifestFetcher.swift   ← reusable fake (.succeeds / .failing / .scripted modes)
├── ContractsManifestDecodingTests.swift     ← 6 cases (wire-format pin + unknown-enum dropping)
├── AnchorSelectionStoreTests.swift          ← 6 cases (UserDefaults round-trip, per-test suite isolation)
├── ContractsManifestFetcherTests.swift      ← 3 cases (StubURLProtocol-driven, reusing PR #18's scaffolding)
├── ContractsRepositoryTests.swift           ← 12 cases (binding resolution rules + reactive surface)
└── AnchorsPickerFlowTests.swift             ← 8 cases (intents + read helpers + Mainnet gating)
```

## Per-chat binding (the load-bearing invariant)

When `ChatGroup` lands (separate future PR), it carries:

```swift
struct ChatGroup {
    // ...
    let anchor: AnchorBinding       // pinned at chat-creation time
}
```

Two write paths future code must respect:

- **Create chat**: read `contractsRepository.binding(for: key)` → store as `chat.anchor`. Settings changes after this never mutate the chat.
- **Update chat**: read `chat.anchor.contractID` + `chat.anchor.network` directly. The chat is the source of truth for "which contract do I update" — current settings only seed new chats.

This PR ships `AnchorBinding` as a public value type so the future Chat PR can pick it up without redefining.

## Resolution rules (load-bearing — also in the Android prompt for cross-platform parity)

`ContractsState.binding(for: key)`:

1. If the user has an explicit selection for `key` AND the manifest has a release with that tag AND that release has a contract for this `(network, type)` → use it.
2. Otherwise default to the **latest** release that has a contract for `(network, type)` (manifest is sorted newest-first).
3. Otherwise return `nil` — UI shows "No contracts yet" / disabled, chain interactors get back `nil` from `binding(for:)`.

## Architecture compliance

| Layer | What this PR adds | Touches |
|---|---|---|
| **Persistence seam** | `AnchorSelectionStore` (UserDefaults — no secret material) | Foundation only |
| **Network seam** | `ContractsManifestFetcher` | URLSession + JSONDecoder only |
| **Repository** | `ContractsRepository` (actor) | both seams + AsyncStream |
| **Interactor** | `AnchorsPickerFlow` | the repository only |
| **View** | `AnchorsView` (+ network/version sub-views) | the interactor only |
| **OnymSDK** | nothing | nothing |

## Lifecycle

1. `OnymIOSApp.init` constructs `ContractsRepository` once (prod fetcher + UserDefaults store).
2. WindowGroup `.task` calls `repo.start()` alongside the relayer fetch — both manifest fetches in flight before the user opens Settings.
3. Failures silent: cached manifest from previous successful run remains usable.
4. User opens Settings → Network → Anchors → drill down → pick.
5. Selection persists; future chain interactors read `repo.binding(for: key)`.

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests` — 187/187 pass in 1.48s on iPhone 17 Pro simulator (35 new + 152 pre-existing).
- [x] Production target builds clean, no warnings on touched files.
- [ ] Manual smoke: open Settings → Network → Anchors → Testnet → Anarchy → see "v0.0.2 (latest)" once you've published the manifest.

## Out of scope (intentionally — keeps the slice tight)

- **`ChatGroup` itself.** Ships `AnchorBinding` as the public value type chats will carry; the actual `ChatGroup` lands with a future chat-creation PR.
- **The chain client.** The relayer HTTP client (the `SEPContractClient` port) is the next PR; this one just delivers the contract-version selection mechanism that client will read from.
- **Mainnet — no contracts published yet.** Mainnet row stays disabled until a mainnet contract lands in a future release, at which point it lights up automatically.
- **Localization.** Section / button labels are English-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)