### PR TITLE
ux: random-default + auto-populate from manifest, plus UI tests for relayers and anchors

### DIFF
--- a/Sources/OnymIOS/Chain/RelayerEndpoint.swift
+++ b/Sources/OnymIOS/Chain/RelayerEndpoint.swift
@@ -77,8 +77,48 @@ struct RelayerConfiguration: Codable, Equatable, Hashable, Sendable {
     /// strategy `.primary`, `selectURL` falls back to `endpoints.first`.
     let primaryURL: URL?
     let strategy: RelayerStrategy
+    /// `false` only on cold install before the first `RelayerRepository.refresh()`
+    /// completes. The auto-populate path keys on this — the moment the
+    /// known-relayers list arrives from GitHub, every published entry is
+    /// added to `endpoints` and this flips to `true`. Any subsequent
+    /// mutator (add / remove / setPrimary / setStrategy) also flips it
+    /// to `true` so a user who explicitly clears the list isn't fought
+    /// by another auto-populate on the next refresh.
+    let hasUserInteracted: Bool
 
-    static let empty = RelayerConfiguration(endpoints: [], primaryURL: nil, strategy: .primary)
+    static let empty = RelayerConfiguration(
+        endpoints: [],
+        primaryURL: nil,
+        strategy: .random,
+        hasUserInteracted: false
+    )
+
+    init(
+        endpoints: [RelayerEndpoint],
+        primaryURL: URL?,
+        strategy: RelayerStrategy,
+        hasUserInteracted: Bool = true
+    ) {
+        self.endpoints = endpoints
+        self.primaryURL = primaryURL
+        self.strategy = strategy
+        self.hasUserInteracted = hasUserInteracted
+    }
+
+    /// Backward-compat: PR #20 saves don't carry `hasUserInteracted`.
+    /// Treat absence as "yes, the user already interacted" so we don't
+    /// re-auto-populate over a configuration they already touched.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        endpoints = try c.decode([RelayerEndpoint].self, forKey: .endpoints)
+        primaryURL = try c.decodeIfPresent(URL.self, forKey: .primaryURL)
+        strategy = try c.decode(RelayerStrategy.self, forKey: .strategy)
+        hasUserInteracted = try c.decodeIfPresent(Bool.self, forKey: .hasUserInteracted) ?? true
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case endpoints, primaryURL, strategy, hasUserInteracted
+    }
 
     /// Resolve the URL chain interactors should POST to. Pure — no
     /// side effects, no I/O, deterministic given the RNG. Returns

--- a/Sources/OnymIOS/Chain/RelayerRepository.swift
+++ b/Sources/OnymIOS/Chain/RelayerRepository.swift
@@ -59,10 +59,32 @@ actor RelayerRepository {
     /// Force a fresh fetch (user-initiated pull-to-refresh, eventually).
     /// Awaits completion so callers can show progress UI. Failures
     /// throw so the UI can surface them.
+    ///
+    /// First-launch auto-populate: if the user has never touched the
+    /// configuration AND the fetched list is non-empty, every published
+    /// relayer is auto-added to `endpoints`, the strategy is set to
+    /// `.random`, and `hasUserInteracted` flips to `true`. The flag is
+    /// sticky — subsequent fetches never re-auto-populate, so a user
+    /// who explicitly clears the list isn't fought by the next refresh.
     func refresh() async throws {
         let list = try await fetcher.fetchLatest()
         store.saveCachedKnownList(list)
-        cached = RelayerState(configuration: cached.configuration, knownList: list)
+
+        let current = cached.configuration
+        let updatedConfig: RelayerConfiguration
+        if !current.hasUserInteracted && !list.isEmpty {
+            updatedConfig = RelayerConfiguration(
+                endpoints: list,
+                primaryURL: nil,
+                strategy: .random,
+                hasUserInteracted: true
+            )
+            store.saveConfiguration(updatedConfig)
+        } else {
+            updatedConfig = current
+        }
+
+        cached = RelayerState(configuration: updatedConfig, knownList: list)
         publish()
     }
 

--- a/Sources/OnymIOS/Chain/UITestFakes.swift
+++ b/Sources/OnymIOS/Chain/UITestFakes.swift
@@ -1,0 +1,117 @@
+#if DEBUG
+import Foundation
+
+/// App-side fakes used by `OnymIOSApp` when launched with the
+/// `--ui-testing` argument. They live in production sources (not the
+/// test target) because `OnymIOSApp.init` constructs them directly,
+/// but the entire file is gated by `#if DEBUG` so none of it ships
+/// to Release.
+///
+/// Distinct from the more-elaborate fakes under
+/// `Tests/OnymIOSTests/Support/` (which power unit tests via
+/// `@testable import OnymIOS` and have scripted/failing modes). Here
+/// we just want deterministic fixtures the UI tests can assert
+/// against — no scripting, no error injection.
+
+// MARK: - Relayer
+
+/// Returns a fixed pair of known relayers regardless of input. Tests
+/// can assert on these names / URLs deterministically.
+struct UITestKnownRelayersFetcher: KnownRelayersFetcher {
+    static let testnet = RelayerEndpoint(
+        name: "UITest Testnet Relayer",
+        url: URL(string: "https://uitest-testnet-relayer.example")!,
+        network: "testnet"
+    )
+    static let publicNet = RelayerEndpoint(
+        name: "UITest Mainnet Relayer",
+        url: URL(string: "https://uitest-mainnet-relayer.example")!,
+        network: "public"
+    )
+
+    func fetchLatest() async throws -> [RelayerEndpoint] {
+        [Self.testnet, Self.publicNet]
+    }
+}
+
+/// In-memory `RelayerSelectionStore` so each UI test launch starts
+/// with no persisted configuration (the auto-populate path then
+/// hydrates from the `UITestKnownRelayersFetcher` above).
+final class UITestRelayerSelectionStore: RelayerSelectionStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var configuration: RelayerConfiguration = .empty
+    private var cachedList: [RelayerEndpoint] = []
+
+    func loadConfiguration() -> RelayerConfiguration {
+        lock.withLock { configuration }
+    }
+
+    func saveConfiguration(_ configuration: RelayerConfiguration) {
+        lock.withLock { self.configuration = configuration }
+    }
+
+    func loadCachedKnownList() -> [RelayerEndpoint] {
+        lock.withLock { cachedList }
+    }
+
+    func saveCachedKnownList(_ list: [RelayerEndpoint]) {
+        lock.withLock { cachedList = list }
+    }
+}
+
+// MARK: - Contracts
+
+/// Returns a fixed two-release manifest. v0.0.2 is newer (default-to-
+/// latest picks it) and includes all five governance types on testnet
+/// only. v0.0.1 is older and has a subset. Mainnet stays empty so the
+/// "No contracts yet" branch can be exercised.
+struct UITestContractsManifestFetcher: ContractsManifestFetcher {
+    func fetchLatest() async throws -> ContractsManifest {
+        let v002 = ContractRelease(
+            release: "v0.0.2",
+            publishedAt: Date(timeIntervalSince1970: 1_700_000_002),
+            contracts: [
+                ContractEntry(network: .testnet, type: .anarchy,   id: "CDWYYK"),
+                ContractEntry(network: .testnet, type: .democracy, id: "CBEBQM"),
+                ContractEntry(network: .testnet, type: .oligarchy, id: "CBHY24"),
+                ContractEntry(network: .testnet, type: .oneonone,  id: "CAHXGZ"),
+                ContractEntry(network: .testnet, type: .tyranny,   id: "CC6Y2F"),
+            ]
+        )
+        let v001 = ContractRelease(
+            release: "v0.0.1",
+            publishedAt: Date(timeIntervalSince1970: 1_700_000_001),
+            contracts: [
+                ContractEntry(network: .testnet, type: .anarchy,   id: "CDSIJT"),
+                ContractEntry(network: .testnet, type: .democracy, id: "CBYHYJ"),
+            ]
+        )
+        return ContractsManifest(version: 1, releases: [v002, v001])
+    }
+}
+
+/// In-memory `AnchorSelectionStore` so each UI test launch starts
+/// with no persisted selections.
+final class UITestAnchorSelectionStore: AnchorSelectionStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var selections: [AnchorSelectionKey: String] = [:]
+    private var manifest: ContractsManifest?
+
+    func loadSelections() -> [AnchorSelectionKey: String] {
+        lock.withLock { selections }
+    }
+
+    func saveSelections(_ selections: [AnchorSelectionKey: String]) {
+        lock.withLock { self.selections = selections }
+    }
+
+    func loadCachedManifest() -> ContractsManifest? {
+        lock.withLock { manifest }
+    }
+
+    func saveCachedManifest(_ manifest: ContractsManifest) {
+        lock.withLock { self.manifest = manifest }
+    }
+}
+
+#endif

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -24,16 +24,39 @@ struct OnymIOSApp: App {
         _ = args  // silence unused warning in Release
         #endif
 
-        let relayerRepository = RelayerRepository(
+        let relayerRepository: RelayerRepository
+        let contractsRepository: ContractsRepository
+        #if DEBUG
+        if args.contains("--ui-testing") {
+            relayerRepository = RelayerRepository(
+                fetcher: UITestKnownRelayersFetcher(),
+                store: UITestRelayerSelectionStore()
+            )
+            contractsRepository = ContractsRepository(
+                fetcher: UITestContractsManifestFetcher(),
+                store: UITestAnchorSelectionStore()
+            )
+        } else {
+            relayerRepository = RelayerRepository(
+                fetcher: GitHubReleasesKnownRelayersFetcher(),
+                store: UserDefaultsRelayerSelectionStore()
+            )
+            contractsRepository = ContractsRepository(
+                fetcher: GitHubReleasesContractsManifestFetcher(),
+                store: UserDefaultsAnchorSelectionStore()
+            )
+        }
+        #else
+        relayerRepository = RelayerRepository(
             fetcher: GitHubReleasesKnownRelayersFetcher(),
             store: UserDefaultsRelayerSelectionStore()
         )
-        self.relayerRepository = relayerRepository
-
-        let contractsRepository = ContractsRepository(
+        contractsRepository = ContractsRepository(
             fetcher: GitHubReleasesContractsManifestFetcher(),
             store: UserDefaultsAnchorSelectionStore()
         )
+        #endif
+        self.relayerRepository = relayerRepository
         self.contractsRepository = contractsRepository
 
         self.dependencies = AppDependencies(

--- a/Sources/OnymIOS/Settings/AnchorsView.swift
+++ b/Sources/OnymIOS/Settings/AnchorsView.swift
@@ -167,6 +167,11 @@ struct AnchorsVersionView: View {
                         .foregroundStyle(Color.accentColor)
                 }
             }
+            // Make the entire row hit-testable. Without this the
+            // `Spacer()` between the labels and the checkmark eats
+            // taps under `.buttonStyle(.plain)` and the action never
+            // fires (caught by UI tests in PR #22).
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("anchors.version.\(release.release)")

--- a/Sources/OnymIOS/Settings/RelayerSettingsView.swift
+++ b/Sources/OnymIOS/Settings/RelayerSettingsView.swift
@@ -107,6 +107,11 @@ struct RelayerSettingsView: View {
             Spacer()
             networkBadge(endpoint.network)
         }
+        // `.contain` keeps the inner star Button individually
+        // accessible (otherwise SwiftUI flattens the HStack into a
+        // single accessibility element that absorbs the inner Button's
+        // identifier — caught the hard way by UI tests in PR #22).
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("relayer.configured.\(endpoint.url.absoluteString)")
     }
 

--- a/Tests/OnymIOSTests/RelayerConfigurationTests.swift
+++ b/Tests/OnymIOSTests/RelayerConfigurationTests.swift
@@ -124,10 +124,46 @@ final class RelayerConfigurationTests: XCTestCase {
         let config = RelayerConfiguration(
             endpoints: [a, b, c],
             primaryURL: b.url,
-            strategy: .random
+            strategy: .random,
+            hasUserInteracted: true
         )
         let json = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(RelayerConfiguration.self, from: json)
         XCTAssertEqual(decoded, config)
+    }
+
+    // MARK: - defaults
+
+    func test_empty_strategy_isRandom() {
+        XCTAssertEqual(RelayerConfiguration.empty.strategy, .random,
+                       "default strategy is .random so a freshly-installed user gets load-balanced across the auto-populated relayer list out of the box")
+    }
+
+    func test_empty_hasUserInteracted_isFalse() {
+        XCTAssertFalse(RelayerConfiguration.empty.hasUserInteracted,
+                       ".empty represents a never-touched configuration so the auto-populate path can detect it")
+    }
+
+    // MARK: - backward compat
+
+    func test_codable_decodesPR20WireShape_treatsMissingFlagAsInteracted() throws {
+        // PR #20's wire format had no `hasUserInteracted` field. Existing
+        // users with a saved configuration must NOT be treated as
+        // never-interacted on app launch — that would let the auto-populate
+        // path overwrite their custom URLs / explicit selections.
+        let pr20JSON = """
+        {
+            "endpoints": [
+                { "name": "Existing", "url": "https://existing.example", "network": "testnet" }
+            ],
+            "primaryURL": "https://existing.example",
+            "strategy": "primary"
+        }
+        """
+        let decoded = try JSONDecoder().decode(RelayerConfiguration.self, from: Data(pr20JSON.utf8))
+        XCTAssertTrue(decoded.hasUserInteracted,
+                      "absent flag must default to true so existing users aren't reset")
+        XCTAssertEqual(decoded.endpoints.count, 1)
+        XCTAssertEqual(decoded.strategy, .primary)
     }
 }

--- a/Tests/OnymIOSTests/RelayerRepositoryTests.swift
+++ b/Tests/OnymIOSTests/RelayerRepositoryTests.swift
@@ -225,6 +225,103 @@ final class RelayerRepositoryTests: XCTestCase {
         XCTAssertEqual(knownList, [])
     }
 
+    // MARK: - first-launch auto-populate
+
+    func test_refresh_onEmptyConfig_autoPopulatesAndSwitchesToRandom() async throws {
+        let store = InMemoryRelayerSelectionStore()  // .empty config; hasUserInteracted = false
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([a, b, c]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+
+        let state = await repo.currentState()
+        XCTAssertEqual(state.configuration.endpoints, [a, b, c],
+                       "auto-populate must add every fetched endpoint to the configured list")
+        XCTAssertEqual(state.configuration.strategy, .random,
+                       "auto-populate must set strategy to .random")
+        XCTAssertNil(state.configuration.primaryURL,
+                     "auto-populate doesn't pre-pick a primary; .random doesn't need one")
+        XCTAssertTrue(state.configuration.hasUserInteracted,
+                      "auto-populate flips the flag so the next refresh doesn't re-populate")
+        XCTAssertEqual(store.loadConfiguration().endpoints, [a, b, c],
+                       "auto-populated configuration is persisted")
+    }
+
+    func test_refresh_onAlreadyInteractedConfig_doesNotAutoPopulate() async throws {
+        let store = InMemoryRelayerSelectionStore(
+            configuration: RelayerConfiguration(
+                endpoints: [a],
+                primaryURL: a.url,
+                strategy: .primary,
+                hasUserInteracted: true
+            )
+        )
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([a, b, c]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+
+        let state = await repo.currentState()
+        XCTAssertEqual(state.configuration.endpoints, [a],
+                       "subsequent refresh must NOT clobber an already-touched configuration")
+        XCTAssertEqual(state.configuration.strategy, .primary)
+        XCTAssertEqual(state.configuration.primaryURL, a.url)
+    }
+
+    func test_refresh_onEmptyConfig_emptyFetchedList_leavesEverythingEmpty() async throws {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+
+        let state = await repo.currentState()
+        XCTAssertTrue(state.configuration.endpoints.isEmpty)
+        XCTAssertFalse(state.configuration.hasUserInteracted,
+                       "no fetched relayers means no auto-populate; flag stays false so a later non-empty fetch can still populate")
+    }
+
+    func test_refresh_userClearedThenRefresh_doesNotRepopulate() async throws {
+        // User clears all entries (configuration is empty + interacted).
+        // A subsequent refresh must NOT re-add the relayers the user
+        // explicitly removed.
+        let store = InMemoryRelayerSelectionStore(
+            configuration: RelayerConfiguration(
+                endpoints: [],
+                primaryURL: nil,
+                strategy: .random,
+                hasUserInteracted: true
+            )
+        )
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([a, b]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+
+        let state = await repo.currentState()
+        XCTAssertTrue(state.configuration.endpoints.isEmpty,
+                      "user explicitly cleared the list; refresh must respect that")
+        XCTAssertEqual(state.knownList, [a, b],
+                       "the known-list cache still updates so the picker can offer them via Add From Published List")
+    }
+
+    func test_addEndpoint_promotesHasUserInteracted() async {
+        let store = InMemoryRelayerSelectionStore()  // .empty / not interacted
+        let repo = makeRepo(store: store)
+
+        await repo.addEndpoint(a)
+        XCTAssertTrue(store.loadConfiguration().hasUserInteracted,
+                      "any mutator must promote hasUserInteracted so a later refresh doesn't clobber the user's adds")
+    }
+
+    func test_setStrategy_promotesHasUserInteracted() async {
+        let store = InMemoryRelayerSelectionStore()
+        let repo = makeRepo(store: store)
+
+        await repo.setStrategy(.primary)
+        XCTAssertTrue(store.loadConfiguration().hasUserInteracted)
+    }
+
     // MARK: - helpers
 
     private func makeRepo(

--- a/Tests/OnymIOSUITests/AnchorsUITests.swift
+++ b/Tests/OnymIOSUITests/AnchorsUITests.swift
@@ -1,0 +1,82 @@
+import XCTest
+
+/// End-to-end UI tests for Settings → Anchors. The UITest fake
+/// (`UITestContractsManifestFetcher`) ships a 2-release fixture with
+/// testnet contracts only, so the Mainnet row always renders disabled
+/// and Testnet drilling-down works for every governance type.
+final class AnchorsUITests: XCTestCase {
+
+    func test_drilldown_pickVersion_thenResetToDefault() throws {
+        let app = AppLauncher.launchFresh()
+        let settings = SettingsScreen(app: app)
+        XCTAssertTrue(settings.waitForReady())
+        settings.tapAnchors()
+
+        let root = AnchorsRootScreen(app: app)
+        XCTAssertTrue(root.waitForReady())
+        root.tapNetwork("testnet")
+
+        let network = AnchorsNetworkScreen(app: app)
+        XCTAssertTrue(network.waitForReady())
+        network.tapType("anarchy")
+
+        let version = AnchorsVersionScreen(app: app)
+        XCTAssertTrue(version.waitForReady())
+
+        // Initially no explicit selection → Reset button hidden.
+        XCTAssertFalse(version.resetButton.exists,
+                       "Reset must not appear before the user picks a version")
+
+        // Pick the older release explicitly (default-to-latest would
+        // otherwise resolve to v0.0.2). The button auto-pops back via
+        // dismiss(), but if the dismiss races with the test we'd
+        // assert state on the popped network screen instead — handle
+        // both by waiting on whichever appears first.
+        version.tapVersion("v0.0.1")
+
+        // After the tap, the explicit selection lands. Reset becomes
+        // visible if we're still on the version screen; otherwise we
+        // popped back to the network screen and need to drill in
+        // again to see Reset.
+        let onVersionScreen = version.resetButton.waitForExistence(timeout: 2)
+        if !onVersionScreen {
+            XCTAssertTrue(network.waitForReady(),
+                          "expected to be back on network screen if dismiss popped")
+            network.tapType("anarchy")
+            XCTAssertTrue(version.waitForReady())
+            XCTAssertTrue(version.resetButton.waitForExistence(timeout: 3),
+                          "Reset to Default must show after the user has an explicit selection")
+        }
+
+        // Tap Reset — clears the explicit selection. Reset itself
+        // should disappear (its section is gated on
+        // `hasExplicitSelection`).
+        version.tapReset()
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(
+            predicate: predicate,
+            object: version.resetButton
+        )
+        // If dismiss fires after Reset, the button disappears because
+        // we left the screen — either way exists==false eventually.
+        XCTAssertEqual(.completed, XCTWaiter.wait(for: [expectation], timeout: 3),
+                       "Reset to Default must hide once the explicit selection is cleared")
+    }
+
+    func test_mainnet_isDisabled_whenNoContractsPublished() throws {
+        let app = AppLauncher.launchFresh()
+        let settings = SettingsScreen(app: app)
+        XCTAssertTrue(settings.waitForReady())
+        settings.tapAnchors()
+
+        let root = AnchorsRootScreen(app: app)
+        XCTAssertTrue(root.waitForReady())
+
+        // Mainnet renders as a disabled row (no NavigationLink) because
+        // the UITest fixture publishes testnet contracts only.
+        XCTAssertTrue(root.disabledNetworkRow("public").waitForExistence(timeout: 3),
+                      "Mainnet must render disabled when no manifest entries exist for it")
+        // The active row still works.
+        XCTAssertTrue(root.networkRow("testnet").exists)
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/AnchorsNetworkScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/AnchorsNetworkScreen.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+/// Page object for Anchors → \<Network\> — the second-level drill-
+/// down listing the five governance types for the chosen network.
+struct AnchorsNetworkScreen {
+    let app: XCUIApplication
+
+    /// Governance-type row when contracts are available (NavigationLink).
+    func typeRow(_ raw: String) -> XCUIElement {
+        firstMatching("anchors.type.\(raw)")
+    }
+
+    /// Governance-type row when no contract exists (plain text).
+    func disabledTypeRow(_ raw: String) -> XCUIElement {
+        firstMatching("anchors.type.\(raw).disabled")
+    }
+
+    func waitForReady(timeout: TimeInterval = 5) -> Bool {
+        typeRow("anarchy").waitForExistence(timeout: timeout)
+    }
+
+    func tapType(_ raw: String) {
+        let row = typeRow(raw)
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "expected an enabled type row for \(raw)")
+        row.tap()
+    }
+
+    private func firstMatching(_ identifier: String) -> XCUIElement {
+        for query in [app.buttons, app.cells, app.otherElements, app.staticTexts] {
+            let element = query[identifier]
+            if element.exists { return element }
+        }
+        return app.buttons[identifier]
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/AnchorsRootScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/AnchorsRootScreen.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+/// Page object for the Settings → Anchors root screen. Two rows
+/// (Testnet / Mainnet); Mainnet renders as text-only when no manifest
+/// entries exist for it. The UITest fixture has testnet contracts
+/// only, so Mainnet is always disabled.
+struct AnchorsRootScreen {
+    let app: XCUIApplication
+
+    /// Network row when contracts ARE published for it (NavigationLink).
+    func networkRow(_ raw: String) -> XCUIElement {
+        firstMatching("anchors.network.\(raw)")
+    }
+
+    /// Network row when NO contracts are published for it (plain text,
+    /// not tappable).
+    func disabledNetworkRow(_ raw: String) -> XCUIElement {
+        firstMatching("anchors.network.\(raw).disabled")
+    }
+
+    func waitForReady(timeout: TimeInterval = 5) -> Bool {
+        networkRow("testnet").waitForExistence(timeout: timeout)
+    }
+
+    func tapNetwork(_ raw: String) {
+        let row = networkRow(raw)
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "expected an enabled network row for \(raw)")
+        row.tap()
+    }
+
+    private func firstMatching(_ identifier: String) -> XCUIElement {
+        for query in [app.buttons, app.cells, app.otherElements, app.staticTexts] {
+            let element = query[identifier]
+            if element.exists { return element }
+        }
+        return app.buttons[identifier]
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/AnchorsVersionScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/AnchorsVersionScreen.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+/// Page object for Anchors → \<Network\> → \<Type\> — the leaf
+/// drill-down listing all releases that have a contract for the
+/// (network, type) being picked, newest-first. Tap a row to select;
+/// pop back is automatic. "Reset to Default" appears only when the
+/// user has an explicit selection.
+struct AnchorsVersionScreen {
+    let app: XCUIApplication
+
+    func versionRow(_ release: String) -> XCUIElement {
+        firstMatching("anchors.version.\(release)")
+    }
+
+    var resetButton: XCUIElement {
+        app.buttons["anchors.version.reset"]
+    }
+
+    func waitForReady(timeout: TimeInterval = 5) -> Bool {
+        // Wait for at least the v0.0.2 row (the UITest fixture's newest
+        // release; always present for the .testnet × .anarchy pair the
+        // happy-path test exercises).
+        versionRow("v0.0.2").waitForExistence(timeout: timeout)
+    }
+
+    func tapVersion(_ release: String) {
+        let row = versionRow(release)
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "expected a version row for \(release)")
+        row.tap()
+    }
+
+    func tapReset() {
+        XCTAssertTrue(resetButton.waitForExistence(timeout: 5),
+                      "Reset to Default button never appeared (only shown when user has an explicit selection)")
+        resetButton.tap()
+    }
+
+    private func firstMatching(_ identifier: String) -> XCUIElement {
+        for query in [app.buttons, app.cells, app.otherElements] {
+            let element = query[identifier]
+            if element.exists { return element }
+        }
+        return app.buttons[identifier]
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/RelayerSettingsScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/RelayerSettingsScreen.swift
@@ -1,0 +1,82 @@
+import XCTest
+
+/// Page object for the Settings → Relayer screen. Tests configure the
+/// relayer list (auto-populated from the UITest fake fetcher on first
+/// launch), pick a primary, switch strategy, etc.
+struct RelayerSettingsScreen {
+    let app: XCUIApplication
+
+    /// SwiftUI's segmented `Picker` doesn't expose its `accessibilityIdentifier`
+    /// as a queryable container — only the segment buttons are
+    /// individually addressable, by their localised display name. Tests
+    /// pass the en label they want; under a non-en locale, swap to a
+    /// localised lookup.
+    func strategySegment(label: String) -> XCUIElement {
+        app.buttons[label]
+    }
+
+    var primarySegment: XCUIElement { strategySegment(label: "Primary") }
+    var randomSegment: XCUIElement { strategySegment(label: "Random") }
+
+    /// Configured-list row identifier is `relayer.configured.<URL>`.
+    /// SwiftUI's accessibility flattening promoted this row to a
+    /// Button (with the inner star's label "Favorite"), so query the
+    /// buttons collection.
+    func configuredRow(url: String) -> XCUIElement {
+        firstMatching("relayer.configured.\(url)")
+    }
+
+    /// Per-row star button id. Tap to mark that row primary. Reachable
+    /// because `.accessibilityElement(children: .contain)` on the row
+    /// keeps inner elements individually queryable.
+    func primaryStar(url: String) -> XCUIElement {
+        app.buttons["relayer.configured.primary.\(url)"]
+    }
+
+    /// "Add from Published List" row id.
+    func addKnownRow(url: String) -> XCUIElement {
+        firstMatching("relayer.add.known.\(url)")
+    }
+
+    var customField: XCUIElement {
+        app.textFields["relayer.add.custom.field"]
+    }
+
+    var customAddButton: XCUIElement {
+        app.buttons["relayer.add.custom.button"]
+    }
+
+    /// Wait for the screen to be ready by waiting on a known segment.
+    func waitForReady(timeout: TimeInterval = 5) -> Bool {
+        randomSegment.waitForExistence(timeout: timeout)
+    }
+
+    /// Tap the segment with the given label.
+    func tapStrategy(label: String) {
+        let segment = strategySegment(label: label)
+        XCTAssertTrue(segment.waitForExistence(timeout: 5),
+                      "strategy segment '\(label)' never appeared")
+        segment.tap()
+    }
+
+    /// Swipe left on the row at `url` to reveal the system Delete
+    /// affordance, then tap it.
+    func swipeToDelete(url: String) {
+        let row = configuredRow(url: url)
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "expected a configured row for \(url) before swiping")
+        row.swipeLeft()
+        let deleteButton = app.buttons["Delete"]
+        XCTAssertTrue(deleteButton.waitForExistence(timeout: 3),
+                      "system Delete button never appeared after swipe")
+        deleteButton.tap()
+    }
+
+    private func firstMatching(_ identifier: String) -> XCUIElement {
+        for query in [app.buttons, app.cells, app.otherElements] {
+            let element = query[identifier]
+            if element.exists { return element }
+        }
+        return app.buttons[identifier]
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/SettingsScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/SettingsScreen.swift
@@ -8,6 +8,16 @@ struct SettingsScreen {
         app.buttons["settings.backup_recovery_phrase_row"]
     }
 
+    /// Network → Relayer NavigationLink. Lives behind a chevron row.
+    var relayerRow: XCUIElement {
+        firstMatching("settings.relayer_row")
+    }
+
+    /// Network → Anchors NavigationLink.
+    var anchorsRow: XCUIElement {
+        firstMatching("settings.anchors_row")
+    }
+
     @discardableResult
     func waitForReady(timeout: TimeInterval = 5) -> Bool {
         backupRow.waitForExistence(timeout: timeout)
@@ -17,5 +27,30 @@ struct SettingsScreen {
         XCTAssertTrue(backupRow.waitForExistence(timeout: 5),
                       "settings backup row never appeared")
         backupRow.tap()
+    }
+
+    func tapRelayer() {
+        XCTAssertTrue(relayerRow.waitForExistence(timeout: 5),
+                      "settings relayer row never appeared")
+        relayerRow.tap()
+    }
+
+    func tapAnchors() {
+        XCTAssertTrue(anchorsRow.waitForExistence(timeout: 5),
+                      "settings anchors row never appeared")
+        anchorsRow.tap()
+    }
+
+    /// SwiftUI's NavigationLink renders as different XCUIElement types
+    /// depending on iOS version + form context. Try a few likely
+    /// queries and return the first that exists.
+    private func firstMatching(_ identifier: String) -> XCUIElement {
+        for query in [app.buttons, app.cells, app.otherElements] {
+            let element = query[identifier]
+            if element.exists { return element }
+        }
+        // Fall through with a button query so the eventual
+        // waitForExistence assertion fires with a useful name.
+        return app.buttons[identifier]
     }
 }

--- a/Tests/OnymIOSUITests/RelayerSettingsUITests.swift
+++ b/Tests/OnymIOSUITests/RelayerSettingsUITests.swift
@@ -1,0 +1,114 @@
+import XCTest
+
+/// End-to-end UI tests for Settings → Relayer. The app's UITest mode
+/// (`--ui-testing`) swaps in `UITestKnownRelayersFetcher` +
+/// `UITestRelayerSelectionStore` so each launch starts from a clean
+/// in-memory state and the GitHub fetch is replaced by a deterministic
+/// fixture (the two `UITestKnownRelayersFetcher` constants).
+///
+/// Critically the auto-populate behaviour means the configured list is
+/// pre-seeded on first launch — every test starts with both fixture
+/// relayers already in `Configured` and strategy = Random.
+final class RelayerSettingsUITests: XCTestCase {
+
+    // Fixture URLs — duplicated from `UITestKnownRelayersFetcher` so
+    // a rename forces a test fix here too (treat the IDs as cross-
+    // bundle contract).
+    private let testnetURL = "https://uitest-testnet-relayer.example"
+    private let publicURL = "https://uitest-mainnet-relayer.example"
+
+    // MARK: - first launch
+
+    func test_firstLaunch_configuredListAutoPopulatedFromManifest() throws {
+        let app = AppLauncher.launchFresh()
+        let settings = SettingsScreen(app: app)
+        XCTAssertTrue(settings.waitForReady())
+        settings.tapRelayer()
+
+        let relayer = RelayerSettingsScreen(app: app)
+        XCTAssertTrue(relayer.waitForReady())
+
+        XCTAssertTrue(relayer.configuredRow(url: testnetURL).waitForExistence(timeout: 5),
+                      "first launch should auto-populate the testnet fixture")
+        XCTAssertTrue(relayer.configuredRow(url: publicURL).exists,
+                      "first launch should auto-populate the mainnet fixture too")
+    }
+
+    func test_firstLaunch_strategyDefaultsToRandom() throws {
+        let app = AppLauncher.launchFresh()
+        let settings = SettingsScreen(app: app)
+        XCTAssertTrue(settings.waitForReady())
+        settings.tapRelayer()
+
+        let relayer = RelayerSettingsScreen(app: app)
+        XCTAssertTrue(relayer.waitForReady())
+
+        // Random segment is selected by default.
+        XCTAssertTrue(relayer.randomSegment.isSelected,
+                      "Random strategy must be selected by default after first-launch auto-populate")
+    }
+
+    // MARK: - mutators
+
+    func test_setPrimary_thenSwitchToPrimary_persistsViaUI() throws {
+        let app = AppLauncher.launchFresh()
+        let settings = SettingsScreen(app: app)
+        XCTAssertTrue(settings.waitForReady())
+        settings.tapRelayer()
+
+        let relayer = RelayerSettingsScreen(app: app)
+        XCTAssertTrue(relayer.waitForReady())
+
+        // Mark the testnet fixture as primary.
+        let star = relayer.primaryStar(url: testnetURL)
+        XCTAssertTrue(star.waitForExistence(timeout: 5))
+        star.tap()
+
+        // Switch to Primary strategy via the segmented control.
+        relayer.tapStrategy(label: "Primary")
+
+        // Primary segment is now the selected one.
+        XCTAssertTrue(relayer.primarySegment.isSelected)
+    }
+
+    func test_swipeToDelete_removesRowFromConfigured() throws {
+        let app = AppLauncher.launchFresh()
+        let settings = SettingsScreen(app: app)
+        XCTAssertTrue(settings.waitForReady())
+        settings.tapRelayer()
+
+        let relayer = RelayerSettingsScreen(app: app)
+        XCTAssertTrue(relayer.waitForReady())
+
+        XCTAssertTrue(relayer.configuredRow(url: publicURL).waitForExistence(timeout: 5))
+        relayer.swipeToDelete(url: publicURL)
+
+        // The row should disappear within a beat.
+        let deletedRow = relayer.configuredRow(url: publicURL)
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: deletedRow)
+        XCTAssertEqual(.completed, XCTWaiter.wait(for: [expectation], timeout: 3))
+    }
+
+    func test_addCustomURL_appearsInConfigured() throws {
+        let app = AppLauncher.launchFresh()
+        let settings = SettingsScreen(app: app)
+        XCTAssertTrue(settings.waitForReady())
+        settings.tapRelayer()
+
+        let relayer = RelayerSettingsScreen(app: app)
+        XCTAssertTrue(relayer.waitForReady())
+
+        let customURL = "https://my-custom-relayer.dev"
+
+        XCTAssertTrue(relayer.customField.waitForExistence(timeout: 5))
+        relayer.customField.tap()
+        relayer.customField.typeText(customURL)
+        relayer.customAddButton.tap()
+
+        // Field cleared, new row visible.
+        let added = relayer.configuredRow(url: customURL)
+        XCTAssertTrue(added.waitForExistence(timeout: 5),
+                      "custom URL should appear in Configured after Add")
+    }
+}


### PR DESCRIPTION
## Summary

Two related landings in one PR:

1. **Random strategy is the new default + the configured-relayer list auto-populates from the GitHub manifest on first launch.** PR #20 left brand-new installs with an empty list — user had to manually add every relayer before any chain interactor had a URL to POST to. Now: every published relayer is auto-added on first manifest fetch, strategy defaults to `.random`, user can still delete entries / switch strategy / add custom URLs. Sticky `hasUserInteracted` flag means a user who explicitly clears the list isn't re-populated by the next refresh.

2. **End-to-end UI tests for both Settings → Relayer and Settings → Anchors flows.** Test mode swaps in deterministic in-memory fakes when `--ui-testing` is set; tests assert via stable accessibility identifiers.

## Behaviour change details

| Field | PR #20 | This PR |
|---|---|---|
| `RelayerConfiguration.empty.strategy` | `.primary` | `.random` |
| `RelayerConfiguration.empty.hasUserInteracted` | (not present) | `false` |
| First-launch UX | empty list, must add manually | full list pre-seeded from manifest |
| Refresh after user cleared list | re-populated 😕 | stays empty (sticky flag) |
| Codable backward compat | n/a | absent flag → `true` (PR #20 saves treated as already-interacted) |

Resolution rules in `selectURL` unchanged — `.random` already worked from PR #20. The change is purely in the *default state*.

## Architecture compliance

| Layer | What this PR adds | Touches |
|---|---|---|
| **Chain seam** | `hasUserInteracted` field; auto-populate path in `RelayerRepository.refresh` | persistence seam (now stores the flag) |
| **OnymIOSApp** | `--ui-testing` swaps fakes for relayer + contracts repos under `#if DEBUG` | `Sources/OnymIOS/Chain/UITestFakes.swift` |
| **Views** | Two accessibility fixes (`.contentShape(Rectangle())` on version row HStack; `.accessibilityElement(children: .contain)` on configured row) | nothing else |
| **OnymSDK** | nothing | nothing |

UI fakes live in `Sources/OnymIOS/Chain/UITestFakes.swift` under `#if DEBUG` so they don't ship to Release. Distinct from the unit-test fakes in `Tests/OnymIOSTests/Support/` (which have scripted/failing modes for fine-grained unit testing) — these are simpler deterministic fixtures.

## Two view fixes load-bearing for XCUITest visibility

Both caught by the new UI tests on the first run:

1. **`RelayerSettingsView` configured row** — without `.accessibilityElement(children: .contain)`, SwiftUI flattens the HStack into a single Button that absorbs the inner star button's identifier (`relayer.configured.primary.<url>`). Test couldn't tap the star to mark primary. The contain modifier keeps the row addressable AND the inner star addressable.
2. **`AnchorsView` version row** — under `.buttonStyle(.plain)`, the Spacer between the labels and the checkmark eats taps in the row HStack. The Button's action never fires from XCUITest's synthesised tap. `.contentShape(Rectangle())` makes the whole row hit-testable.

Both fixes are surface-only (don't affect anything below the view layer) and pinned by the new UI tests.

## What lands

```
Sources/OnymIOS/
├── Chain/
│   ├── RelayerEndpoint.swift (modified)        ← +hasUserInteracted; .empty default flips to .random
│   ├── RelayerRepository.swift (modified)      ← refresh() auto-populates on first-launch
│   └── UITestFakes.swift                        ← NEW (#if DEBUG); deterministic in-memory fakes
├── OnymIOSApp.swift (modified)                  ← --ui-testing swaps relayer + contracts repos to fakes
└── Settings/
    ├── AnchorsView.swift (modified)             ← .contentShape(Rectangle()) on version row
    └── RelayerSettingsView.swift (modified)     ← .accessibilityElement(children: .contain) on configured row

Tests/OnymIOSTests/
├── RelayerConfigurationTests.swift (modified)   ← +new defaults + PR #20 codable backward compat
└── RelayerRepositoryTests.swift (modified)      ← +auto-populate, +mutator-promotion, +user-cleared cases

Tests/OnymIOSUITests/
├── PageObjects/
│   ├── SettingsScreen.swift (modified)          ← +relayerRow, +anchorsRow taps
│   ├── RelayerSettingsScreen.swift              ← NEW
│   ├── AnchorsRootScreen.swift                  ← NEW
│   ├── AnchorsNetworkScreen.swift               ← NEW
│   └── AnchorsVersionScreen.swift               ← NEW
├── RelayerSettingsUITests.swift                 ← NEW (5 cases)
└── AnchorsUITests.swift                         ← NEW (2 cases)
```

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests` — 225/225 unit tests pass in 1.52s on iPhone 17 Pro simulator (216 + 9 new).
- [x] `xcodebuild test -only-testing:OnymIOSUITests` — 11/11 UI tests pass on iPhone 17 Pro simulator (4 pre-existing recovery-phrase + 5 new relayer + 2 new anchors).

## Out of scope (intentionally)

- **Re-populating after a manifest schema bump.** A future contracts/relayers release format change isn't auto-detected; users would re-fetch the cached list, but the auto-populate gate stays sticky. If we ever need to force-repopulate (e.g. a security advisory), a separate "reset to defaults" affordance can land then.
- **Localising the strategy footer for the random-default state.** The footers from PR #21 are still accurate for both strategies.
- **Reordering the configured list.** Same as PR #20 — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)