### PR TITLE
fix: relayer list spinner spins forever on cold install

### DIFF
--- a/Sources/OnymIOS/Chain/RelayerEndpoint.swift
+++ b/Sources/OnymIOS/Chain/RelayerEndpoint.swift
@@ -3,22 +3,24 @@ import Foundation
 /// One entry in the known-relayers list published at
 /// `https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json`.
 /// Pure value type — no behaviour, just the wire shape. Custom user-
-/// added entries also use this type, with `network = "custom"`.
+/// added entries also use this type, with `networks = ["custom"]`.
 struct RelayerEndpoint: Codable, Equatable, Hashable, Identifiable, Sendable {
     /// Display name. For known entries, comes from the published list.
     /// For custom entries, defaults to the URL's host.
     let name: String
     /// Base URL of the relayer (no trailing slash).
     let url: URL
-    /// `"testnet"` / `"public"` (Stellar mainnet) / `"custom"`. Drives
-    /// the badge in the picker so a user doesn't accidentally treat a
-    /// mainnet relayer as testnet (or vice versa).
-    let network: String
+    /// One or more of `"testnet"` / `"public"` (Stellar mainnet) /
+    /// `"custom"`. The published manifest may list multiple networks
+    /// per relayer (a single deployment can serve both testnet and
+    /// mainnet). Drives the network badges in the picker so a user
+    /// doesn't accidentally treat a mainnet relayer as testnet.
+    let networks: [String]
 
     /// Stable id for SwiftUI list diffing — URL is the natural unique key.
     var id: URL { url }
 
-    /// Sentinel for the `network` field of user-typed entries.
+    /// Sentinel for `networks` of user-typed entries.
     static let customNetwork = "custom"
 
     /// Convenience for synthesising an endpoint from a custom URL the
@@ -28,8 +30,45 @@ struct RelayerEndpoint: Codable, Equatable, Hashable, Identifiable, Sendable {
         RelayerEndpoint(
             name: url.host() ?? url.absoluteString,
             url: url,
-            network: customNetwork
+            networks: [customNetwork]
         )
+    }
+
+    // MARK: - Codable
+
+    /// Backward-compat decoder: accepts the new `networks: [String]`
+    /// shape AND the legacy `network: String` shape (PR #20 / #22
+    /// saved configurations + the early relayers.json wire format).
+    /// Encoder always emits the new shape.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        name = try c.decode(String.self, forKey: .name)
+        url = try c.decode(URL.self, forKey: .url)
+        if let plural = try c.decodeIfPresent([String].self, forKey: .networks) {
+            networks = plural
+        } else if let singular = try c.decodeIfPresent(String.self, forKey: .legacyNetwork) {
+            networks = [singular]
+        } else {
+            networks = []
+        }
+    }
+
+    init(name: String, url: URL, networks: [String]) {
+        self.name = name
+        self.url = url
+        self.networks = networks
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(name, forKey: .name)
+        try c.encode(url, forKey: .url)
+        try c.encode(networks, forKey: .networks)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, url, networks
+        case legacyNetwork = "network"
     }
 }
 

--- a/Sources/OnymIOS/Chain/RelayerRepository.swift
+++ b/Sources/OnymIOS/Chain/RelayerRepository.swift
@@ -1,14 +1,36 @@
 import Foundation
 
-/// Combined snapshot consumed by the picker view. Three halves change
-/// independently — refreshing the GitHub list is async; configuration
-/// changes are synchronous user actions — but views always want them
-/// in one go.
+/// Outcome of the most recent attempt to fetch the published
+/// relayers list. Lets the picker show the right copy:
+/// - `.idle`: never attempted (cold launch before `start()`).
+/// - `.fetching`: in flight — show the spinner.
+/// - `.success`: got an answer (possibly an empty list — UI shows
+///   "No published relayers yet" rather than spinning forever).
+/// - `.failed(message)`: GitHub unreachable, asset 404, JSON broken,
+///   etc. UI shows the message + a retry affordance instead of
+///   spinning indefinitely.
+enum RelayerFetchStatus: Equatable, Sendable {
+    case idle
+    case fetching
+    case success
+    case failed(message: String)
+}
+
+/// Combined snapshot consumed by the picker view. The three halves
+/// change independently — the configuration is mutated synchronously
+/// by user intents, the known list is the result of an async GitHub
+/// fetch, the fetch status reflects the in-flight / failed state of
+/// that fetch — but views always want them in one go.
 struct RelayerState: Equatable, Sendable {
     let configuration: RelayerConfiguration
     let knownList: [RelayerEndpoint]
+    let fetchStatus: RelayerFetchStatus
 
-    static let empty = RelayerState(configuration: .empty, knownList: [])
+    static let empty = RelayerState(
+        configuration: .empty,
+        knownList: [],
+        fetchStatus: .idle
+    )
 }
 
 /// Owns the user's relayer configuration (multiple endpoints, primary
@@ -39,7 +61,8 @@ actor RelayerRepository {
         self.store = store
         self.cached = RelayerState(
             configuration: store.loadConfiguration(),
-            knownList: store.loadCachedKnownList()
+            knownList: store.loadCachedKnownList(),
+            fetchStatus: .idle
         )
     }
 
@@ -67,7 +90,28 @@ actor RelayerRepository {
     /// sticky — subsequent fetches never re-auto-populate, so a user
     /// who explicitly clears the list isn't fought by the next refresh.
     func refresh() async throws {
-        let list = try await fetcher.fetchLatest()
+        // Mark in-flight so the picker stops showing whatever stale
+        // status it had and renders the spinner.
+        cached = RelayerState(
+            configuration: cached.configuration,
+            knownList: cached.knownList,
+            fetchStatus: .fetching
+        )
+        publish()
+
+        let list: [RelayerEndpoint]
+        do {
+            list = try await fetcher.fetchLatest()
+        } catch {
+            cached = RelayerState(
+                configuration: cached.configuration,
+                knownList: cached.knownList,
+                fetchStatus: .failed(message: Self.message(for: error))
+            )
+            publish()
+            throw error
+        }
+
         store.saveCachedKnownList(list)
 
         let current = cached.configuration
@@ -84,8 +128,28 @@ actor RelayerRepository {
             updatedConfig = current
         }
 
-        cached = RelayerState(configuration: updatedConfig, knownList: list)
+        cached = RelayerState(
+            configuration: updatedConfig,
+            knownList: list,
+            fetchStatus: .success
+        )
         publish()
+    }
+
+    /// Map any thrown fetch error to a user-facing one-liner. Keeps
+    /// the picker copy short — the chain layer's diagnostic detail
+    /// doesn't belong in the UI.
+    private static func message(for error: Error) -> String {
+        switch error {
+        case KnownRelayersFetchError.badStatus(let code):
+            return String(localized: "Couldn't reach the published list (status \(code)).")
+        case KnownRelayersFetchError.malformedDocument:
+            return String(localized: "Published list is in an unexpected format.")
+        case is URLError:
+            return String(localized: "Couldn't reach the published list.")
+        default:
+            return String(localized: "Couldn't reach the published list.")
+        }
     }
 
     // MARK: - Configuration mutations
@@ -189,7 +253,11 @@ actor RelayerRepository {
 
     private func applyConfiguration(_ configuration: RelayerConfiguration) {
         store.saveConfiguration(configuration)
-        cached = RelayerState(configuration: configuration, knownList: cached.knownList)
+        cached = RelayerState(
+            configuration: configuration,
+            knownList: cached.knownList,
+            fetchStatus: cached.fetchStatus
+        )
         publish()
     }
 

--- a/Sources/OnymIOS/Chain/UITestFakes.swift
+++ b/Sources/OnymIOS/Chain/UITestFakes.swift
@@ -21,12 +21,12 @@ struct UITestKnownRelayersFetcher: KnownRelayersFetcher {
     static let testnet = RelayerEndpoint(
         name: "UITest Testnet Relayer",
         url: URL(string: "https://uitest-testnet-relayer.example")!,
-        network: "testnet"
+        networks: ["testnet"]
     )
     static let publicNet = RelayerEndpoint(
         name: "UITest Mainnet Relayer",
         url: URL(string: "https://uitest-mainnet-relayer.example")!,
-        network: "public"
+        networks: ["public"]
     )
 
     func fetchLatest() async throws -> [RelayerEndpoint] {

--- a/Sources/OnymIOS/Settings/RelayerSettingsFlow.swift
+++ b/Sources/OnymIOS/Settings/RelayerSettingsFlow.swift
@@ -84,6 +84,13 @@ final class RelayerSettingsFlow {
         Task { await repository.setStrategy(strategy) }
     }
 
+    /// Retry button on a `.failed` fetch state. Kicks off another
+    /// fetch; the repository sets `.fetching` immediately and the
+    /// view re-renders accordingly.
+    func tappedRetryFetch() {
+        Task { try? await repository.refresh() }
+    }
+
     // MARK: - Read helpers
 
     /// Configured endpoints that aren't already in the user's list —

--- a/Sources/OnymIOS/Settings/RelayerSettingsView.swift
+++ b/Sources/OnymIOS/Settings/RelayerSettingsView.swift
@@ -105,7 +105,7 @@ struct RelayerSettingsView: View {
                     .truncationMode(.middle)
             }
             Spacer()
-            networkBadge(endpoint.network)
+            networkBadges(endpoint.networks)
         }
         // `.contain` keeps the inner star Button individually
         // accessible (otherwise SwiftUI flattens the HStack into a
@@ -119,46 +119,99 @@ struct RelayerSettingsView: View {
 
     @ViewBuilder
     private var addFromKnownSection: some View {
-        let unconfigured = flow.unconfiguredKnownList
         Section {
-            if flow.state.snapshot.knownList.isEmpty {
-                HStack {
-                    ProgressView()
-                    Text("Fetching list…").foregroundStyle(.secondary)
-                }
-            } else if unconfigured.isEmpty {
-                Text("All published relayers added.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(unconfigured) { endpoint in
-                    Button {
-                        flow.tappedAddKnown(endpoint)
-                    } label: {
-                        HStack(spacing: 12) {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(endpoint.name)
-                                    .foregroundStyle(.primary)
-                                Text(endpoint.url.absoluteString)
-                                    .font(.caption.monospaced())
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                            }
-                            Spacer()
-                            networkBadge(endpoint.network)
-                            Image(systemName: "plus.circle.fill")
-                                .foregroundStyle(Color.accentColor)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("relayer.add.known.\(endpoint.url.absoluteString)")
-                }
-            }
+            knownSectionContent
         } header: {
             Text("Add from Published List")
         } footer: {
             Text("Published by the onym-relayer project. Tap to add.")
+        }
+    }
+
+    /// Status-aware content for the published-list section. Gates on
+    /// `fetchStatus` (NOT `knownList.isEmpty`) so a failed fetch shows
+    /// an actionable error + retry instead of spinning forever, and a
+    /// successful fetch with an empty list shows that explicitly.
+    @ViewBuilder
+    private var knownSectionContent: some View {
+        let snapshot = flow.state.snapshot
+        let unconfigured = flow.unconfiguredKnownList
+        switch snapshot.fetchStatus {
+        case .idle:
+            // Background fetch hasn't been kicked off yet (or app
+            // launched without `.task { repo.start() }`).
+            HStack {
+                ProgressView()
+                Text("Fetching list…").foregroundStyle(.secondary)
+            }
+            .accessibilityIdentifier("relayer.add.known.fetching")
+
+        case .fetching:
+            // In flight; show the spinner unless we already have a
+            // cached list to display from a previous successful run.
+            if snapshot.knownList.isEmpty {
+                HStack {
+                    ProgressView()
+                    Text("Fetching list…").foregroundStyle(.secondary)
+                }
+                .accessibilityIdentifier("relayer.add.known.fetching")
+            } else {
+                knownEndpointsList(unconfigured: unconfigured)
+            }
+
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 8) {
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                Button("Try Again") {
+                    flow.tappedRetryFetch()
+                }
+                .accessibilityIdentifier("relayer.add.known.retry")
+            }
+
+        case .success:
+            if snapshot.knownList.isEmpty {
+                Text("No published relayers yet.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("relayer.add.known.empty")
+            } else if unconfigured.isEmpty {
+                Text("All published relayers added.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("relayer.add.known.all_added")
+            } else {
+                knownEndpointsList(unconfigured: unconfigured)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func knownEndpointsList(unconfigured: [RelayerEndpoint]) -> some View {
+        ForEach(unconfigured) { endpoint in
+            Button {
+                flow.tappedAddKnown(endpoint)
+            } label: {
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(endpoint.name)
+                            .foregroundStyle(.primary)
+                        Text(endpoint.url.absoluteString)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer()
+                    networkBadges(endpoint.networks)
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(Color.accentColor)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("relayer.add.known.\(endpoint.url.absoluteString)")
         }
     }
 
@@ -195,13 +248,21 @@ struct RelayerSettingsView: View {
 
     // MARK: - Atoms
 
-    private func networkBadge(_ network: String) -> some View {
-        Text(network.uppercased())
-            .font(.caption2.weight(.semibold))
-            .foregroundStyle(badgeForeground(for: network))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(badgeForeground(for: network).opacity(0.15), in: Capsule())
+    /// Render one badge per network the relayer serves. The published
+    /// manifest may list multiple networks per endpoint (a single
+    /// deployment can serve testnet + mainnet); custom user entries
+    /// have a single `"custom"` badge.
+    private func networkBadges(_ networks: [String]) -> some View {
+        HStack(spacing: 4) {
+            ForEach(networks, id: \.self) { network in
+                Text(network.uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(badgeForeground(for: network))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(badgeForeground(for: network).opacity(0.15), in: Capsule())
+            }
+        }
     }
 
     private func badgeForeground(for network: String) -> Color {

--- a/Tests/OnymIOSTests/KnownRelayersFetcherTests.swift
+++ b/Tests/OnymIOSTests/KnownRelayersFetcherTests.swift
@@ -43,8 +43,8 @@ final class KnownRelayersFetcherTests: XCTestCase {
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list[0].name, "Onym Testnet")
         XCTAssertEqual(list[0].url, URL(string: "https://relayer-testnet.onym.chat"))
-        XCTAssertEqual(list[0].network, "testnet")
-        XCTAssertEqual(list[1].network, "public")
+        XCTAssertEqual(list[0].networks, ["testnet"])
+        XCTAssertEqual(list[1].networks, ["public"])
     }
 
     func test_fetchLatest_acceptsEmptyRelayersArray() async throws {

--- a/Tests/OnymIOSTests/RelayerConfigurationTests.swift
+++ b/Tests/OnymIOSTests/RelayerConfigurationTests.swift
@@ -5,9 +5,9 @@ import XCTest
 /// chain interactors will call per request. No actor, no I/O, just
 /// the strategy + primary fallback rules.
 final class RelayerConfigurationTests: XCTestCase {
-    private let a = RelayerEndpoint(name: "A", url: URL(string: "https://a.example")!, network: "testnet")
-    private let b = RelayerEndpoint(name: "B", url: URL(string: "https://b.example")!, network: "testnet")
-    private let c = RelayerEndpoint(name: "C", url: URL(string: "https://c.example")!, network: "public")
+    private let a = RelayerEndpoint(name: "A", url: URL(string: "https://a.example")!, networks: ["testnet"])
+    private let b = RelayerEndpoint(name: "B", url: URL(string: "https://b.example")!, networks: ["testnet"])
+    private let c = RelayerEndpoint(name: "C", url: URL(string: "https://c.example")!, networks: ["public"])
 
     // MARK: - empty
 

--- a/Tests/OnymIOSTests/RelayerEndpointSchemaTests.swift
+++ b/Tests/OnymIOSTests/RelayerEndpointSchemaTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import OnymIOS
+
+/// Pin the wire-format compat between the iOS app and the published
+/// `relayers.json` (and any saves from earlier app versions). The
+/// publisher uses `networks: [String]` so a single deployment can
+/// serve multiple Stellar networks; PR #20 / #22 saves used the old
+/// singular `network: String` shape. The decoder must accept both.
+final class RelayerEndpointSchemaTests: XCTestCase {
+
+    // MARK: - new shape
+
+    func test_decode_pluralNetworksArray_succeeds() throws {
+        let json = """
+        {
+            "name": "Onym Official",
+            "url": "https://relayer.onym.chat",
+            "networks": ["testnet", "public"]
+        }
+        """
+        let decoded = try JSONDecoder().decode(RelayerEndpoint.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.name, "Onym Official")
+        XCTAssertEqual(decoded.url, URL(string: "https://relayer.onym.chat"))
+        XCTAssertEqual(decoded.networks, ["testnet", "public"])
+    }
+
+    func test_decode_pluralNetworks_emptyArray_succeeds() throws {
+        let json = """
+        { "name": "X", "url": "https://x.com", "networks": [] }
+        """
+        let decoded = try JSONDecoder().decode(RelayerEndpoint.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.networks, [])
+    }
+
+    // MARK: - legacy shape (PR #20 / #22 saved configs)
+
+    func test_decode_legacySingularNetwork_promotesToOneElementArray() throws {
+        // PR #20 / #22 wire shape — `network: String`. Decoder
+        // promotes to `["X"]` so the in-memory model is uniform.
+        let json = """
+        {
+            "name": "Existing",
+            "url": "https://existing.example",
+            "network": "testnet"
+        }
+        """
+        let decoded = try JSONDecoder().decode(RelayerEndpoint.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.networks, ["testnet"])
+    }
+
+    func test_decode_legacySingularNetwork_customSentinel_promotesToOneElementArray() throws {
+        // Custom user-typed entries from PR #20 / #22 used `network: "custom"`.
+        let json = """
+        {
+            "name": "my-relayer.dev",
+            "url": "https://my-relayer.dev",
+            "network": "custom"
+        }
+        """
+        let decoded = try JSONDecoder().decode(RelayerEndpoint.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.networks, [RelayerEndpoint.customNetwork])
+    }
+
+    // MARK: - encoder
+
+    func test_encode_alwaysEmitsPluralShape() throws {
+        let endpoint = RelayerEndpoint(
+            name: "X",
+            url: URL(string: "https://x.com")!,
+            networks: ["testnet"]
+        )
+        let json = try JSONEncoder().encode(endpoint)
+        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: json) as? [String: Any])
+        XCTAssertNotNil(dict["networks"], "encoder must emit `networks` array")
+        XCTAssertNil(dict["network"], "encoder must NOT emit the legacy singular `network`")
+    }
+
+    func test_roundtrip_throughEncoderAndDecoder() throws {
+        let original = RelayerEndpoint(
+            name: "Onym Official",
+            url: URL(string: "https://relayer.onym.chat")!,
+            networks: ["testnet", "public"]
+        )
+        let json = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(RelayerEndpoint.self, from: json)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - factory
+
+    func test_customFactory_marksNetworkAsCustom() {
+        let endpoint = RelayerEndpoint.custom(url: URL(string: "https://x.com")!)
+        XCTAssertEqual(endpoint.networks, [RelayerEndpoint.customNetwork])
+        XCTAssertEqual(endpoint.name, "x.com",
+                       "custom endpoint name defaults to the URL host")
+    }
+
+    // MARK: - manifest decoding (current published shape)
+
+    func test_decode_publishedManifestShape_succeeds() throws {
+        // Snapshot of what
+        // https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json
+        // is currently serving. Pin so the iOS app stays
+        // schema-compatible with future publisher releases.
+        let json = """
+        {
+            "version": 1,
+            "relayers": [
+                {
+                    "name": "Onym Official",
+                    "url": "https://relayer.onym.chat",
+                    "networks": ["testnet", "public"]
+                }
+            ]
+        }
+        """
+        let document = try JSONDecoder().decode(KnownRelayersDocument.self, from: Data(json.utf8))
+        XCTAssertEqual(document.version, 1)
+        XCTAssertEqual(document.relayers.count, 1)
+        XCTAssertEqual(document.relayers[0].networks, ["testnet", "public"])
+    }
+}

--- a/Tests/OnymIOSTests/RelayerRepositoryTests.swift
+++ b/Tests/OnymIOSTests/RelayerRepositoryTests.swift
@@ -13,9 +13,9 @@ import XCTest
 /// - background `start()` is idempotent (no double fetch) and silent
 ///   on error.
 final class RelayerRepositoryTests: XCTestCase {
-    private let a = RelayerEndpoint(name: "A", url: URL(string: "https://a.example")!, network: "testnet")
-    private let b = RelayerEndpoint(name: "B", url: URL(string: "https://b.example")!, network: "testnet")
-    private let c = RelayerEndpoint(name: "C", url: URL(string: "https://c.example")!, network: "public")
+    private let a = RelayerEndpoint(name: "A", url: URL(string: "https://a.example")!, networks: ["testnet"])
+    private let b = RelayerEndpoint(name: "B", url: URL(string: "https://b.example")!, networks: ["testnet"])
+    private let c = RelayerEndpoint(name: "C", url: URL(string: "https://c.example")!, networks: ["public"])
 
     // MARK: - construction
 
@@ -48,7 +48,7 @@ final class RelayerRepositoryTests: XCTestCase {
         let repo = makeRepo(store: store)
 
         await repo.addEndpoint(a)
-        let renamed = RelayerEndpoint(name: "A renamed", url: a.url, network: a.network)
+        let renamed = RelayerEndpoint(name: "A renamed", url: a.url, networks: a.networks)
         let inserted = await repo.addEndpoint(renamed)
 
         XCTAssertFalse(inserted)
@@ -320,6 +320,78 @@ final class RelayerRepositoryTests: XCTestCase {
 
         await repo.setStrategy(.primary)
         XCTAssertTrue(store.loadConfiguration().hasUserInteracted)
+    }
+
+    // MARK: - fetch status
+
+    func test_initialState_fetchStatusIsIdle() async {
+        let repo = makeRepo()
+        let state = await repo.currentState()
+        XCTAssertEqual(state.fetchStatus, .idle)
+    }
+
+    func test_refresh_success_setsFetchStatusToSuccess() async throws {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([a]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+
+        let status = await repo.currentState().fetchStatus
+        XCTAssertEqual(status, .success)
+    }
+
+    func test_refresh_success_emptyList_stillSetsSuccess() async throws {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+
+        let status = await repo.currentState().fetchStatus
+        XCTAssertEqual(status, .success,
+                       "empty fetched list is still a SUCCESS — UI shows 'No published relayers yet' rather than spinning")
+    }
+
+    func test_refresh_failure_setsFetchStatusToFailed_andRethrows() async {
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(
+            mode: .failing(KnownRelayersFetchError.badStatus(404))
+        )
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        do {
+            try await repo.refresh()
+            XCTFail("expected refresh to rethrow on fetcher failure")
+        } catch {
+            // expected
+        }
+
+        let status = await repo.currentState().fetchStatus
+        if case .failed(let message) = status {
+            XCTAssertFalse(message.isEmpty,
+                           "failed status must carry a non-empty user-facing message")
+        } else {
+            XCTFail("expected .failed, got \(status)")
+        }
+    }
+
+    func test_refresh_failure_leavesCachedKnownListIntact() async {
+        let cached = [a, b]
+        let store = InMemoryRelayerSelectionStore(cachedList: cached)
+        let fetcher = FakeKnownRelayersFetcher(
+            mode: .failing(URLError(.notConnectedToInternet))
+        )
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try? await repo.refresh()
+
+        let state = await repo.currentState()
+        XCTAssertEqual(state.knownList, cached,
+                       "fetch failure must not erase the cached list (UI still shows what it had)")
+        if case .failed = state.fetchStatus {} else {
+            XCTFail("expected .failed status after a fetch error")
+        }
     }
 
     // MARK: - helpers

--- a/Tests/OnymIOSTests/RelayerSelectionStoreTests.swift
+++ b/Tests/OnymIOSTests/RelayerSelectionStoreTests.swift
@@ -41,7 +41,7 @@ final class RelayerSelectionStoreTests: XCTestCase {
         let endpoint = RelayerEndpoint(
             name: "Test",
             url: URL(string: "https://relayer-test.example")!,
-            network: "testnet"
+            networks: ["testnet"]
         )
         let config = RelayerConfiguration(
             endpoints: [endpoint],
@@ -53,8 +53,8 @@ final class RelayerSelectionStoreTests: XCTestCase {
     }
 
     func test_saveConfiguration_overwrites() {
-        let a = RelayerEndpoint(name: "A", url: URL(string: "https://a.example")!, network: "testnet")
-        let b = RelayerEndpoint(name: "B", url: URL(string: "https://b.example")!, network: "public")
+        let a = RelayerEndpoint(name: "A", url: URL(string: "https://a.example")!, networks: ["testnet"])
+        let b = RelayerEndpoint(name: "B", url: URL(string: "https://b.example")!, networks: ["public"])
         store.saveConfiguration(RelayerConfiguration(endpoints: [a], primaryURL: a.url, strategy: .primary))
         store.saveConfiguration(RelayerConfiguration(endpoints: [a, b], primaryURL: b.url, strategy: .random))
 
@@ -72,8 +72,8 @@ final class RelayerSelectionStoreTests: XCTestCase {
 
     func test_saveCachedKnownList_thenLoad_roundtripsList() {
         let list = [
-            RelayerEndpoint(name: "A", url: URL(string: "https://a.com")!, network: "testnet"),
-            RelayerEndpoint(name: "B", url: URL(string: "https://b.com")!, network: "public"),
+            RelayerEndpoint(name: "A", url: URL(string: "https://a.com")!, networks: ["testnet"]),
+            RelayerEndpoint(name: "B", url: URL(string: "https://b.com")!, networks: ["public"]),
         ]
         store.saveCachedKnownList(list)
         XCTAssertEqual(store.loadCachedKnownList(), list)
@@ -87,7 +87,7 @@ final class RelayerSelectionStoreTests: XCTestCase {
         let endpoint = RelayerEndpoint(
             name: "Legacy",
             url: URL(string: "https://legacy.example")!,
-            network: "testnet"
+            networks: ["testnet"]
         )
         let legacyJSON = #"{ "known": { "name": "Legacy", "url": "https://legacy.example", "network": "testnet" } }"#
         defaults.set(Data(legacyJSON.utf8), forKey: "chat.onym.ios.relayer.selection")
@@ -106,7 +106,7 @@ final class RelayerSelectionStoreTests: XCTestCase {
         let migrated = store.loadConfiguration()
         XCTAssertEqual(migrated.endpoints.count, 1)
         XCTAssertEqual(migrated.endpoints.first?.url, URL(string: "https://custom.example"))
-        XCTAssertEqual(migrated.endpoints.first?.network, RelayerEndpoint.customNetwork)
+        XCTAssertEqual(migrated.endpoints.first?.networks, [RelayerEndpoint.customNetwork])
         XCTAssertEqual(migrated.primaryURL, URL(string: "https://custom.example"))
         XCTAssertEqual(migrated.strategy, .primary)
     }

--- a/Tests/OnymIOSTests/RelayerSettingsFlowTests.swift
+++ b/Tests/OnymIOSTests/RelayerSettingsFlowTests.swift
@@ -12,7 +12,7 @@ final class RelayerSettingsFlowTests: XCTestCase {
     private let testEndpoint = RelayerEndpoint(
         name: "Test",
         url: URL(string: "https://relayer-test.example")!,
-        network: "testnet"
+        networks: ["testnet"]
     )
 
     private func makeFlow(
@@ -60,7 +60,7 @@ final class RelayerSettingsFlowTests: XCTestCase {
         try await waitFor { !store.loadConfiguration().endpoints.isEmpty }
         let endpoint = store.loadConfiguration().endpoints.first
         XCTAssertEqual(endpoint?.url, URL(string: "https://my-relayer.dev"))
-        XCTAssertEqual(endpoint?.network, RelayerEndpoint.customNetwork)
+        XCTAssertEqual(endpoint?.networks, [RelayerEndpoint.customNetwork])
         XCTAssertEqual(endpoint?.name, "my-relayer.dev",
                        "custom endpoint name defaults to the URL host")
         XCTAssertEqual(flow.state.customDraft, "",
@@ -119,7 +119,7 @@ final class RelayerSettingsFlowTests: XCTestCase {
     }
 
     func test_tappedSetPrimary_marksViaRepository() async throws {
-        let other = RelayerEndpoint(name: "Other", url: URL(string: "https://other.example")!, network: "testnet")
+        let other = RelayerEndpoint(name: "Other", url: URL(string: "https://other.example")!, networks: ["testnet"])
         let store = InMemoryRelayerSelectionStore(
             configuration: RelayerConfiguration(endpoints: [testEndpoint, other], primaryURL: testEndpoint.url, strategy: .primary)
         )
@@ -148,7 +148,7 @@ final class RelayerSettingsFlowTests: XCTestCase {
     func test_unconfiguredKnownList_hidesAlreadyConfiguredURLs() async throws {
         let known = [
             testEndpoint,
-            RelayerEndpoint(name: "Other", url: URL(string: "https://other.example")!, network: "public")
+            RelayerEndpoint(name: "Other", url: URL(string: "https://other.example")!, networks: ["public"])
         ]
         let store = InMemoryRelayerSelectionStore(
             configuration: RelayerConfiguration(endpoints: [testEndpoint], primaryURL: nil, strategy: .primary),


### PR DESCRIPTION
## Summary

Fresh install hits Settings → Relayer, "Fetching list…" spinner runs forever. Two bugs combined:

1. **Wire format mismatch.** Published `relayers.json` uses `"networks": ["testnet", "public"]` (a single deployment can serve multiple Stellar networks); iOS expected `"network": "testnet"` (singular). JSON decode threw `malformedDocument` on every fetch.
2. **Silent failure swallowed in the UI.** `refreshFromNetwork` swallowed any thrown error; the picker section gated the spinner on `knownList.isEmpty` (true forever after a failed fetch). Spinner spun forever instead of surfacing the failure.

After this PR: schema decoder accepts both shapes (so PR #20/#22 saves keep loading on upgrade), the picker gates on an explicit `RelayerFetchStatus` enum (`.idle / .fetching / .success / .failed(message)`), and the UI shows actionable copy + a "Try Again" button on failure / "No published relayers yet" on a successful-but-empty fetch.

## What lands

```
Sources/OnymIOS/
├── Chain/
│   ├── RelayerEndpoint.swift (modified)         ← network: String → networks: [String]; backward-compat decoder
│   ├── RelayerRepository.swift (modified)       ← +RelayerFetchStatus enum on RelayerState; refresh updates it
│   └── UITestFakes.swift (modified)             ← fixtures use `networks: ["..."]`
└── Settings/
    ├── RelayerSettingsFlow.swift (modified)     ← +tappedRetryFetch intent
    └── RelayerSettingsView.swift (modified)     ← knownSectionContent gates on fetchStatus; multi-network badges

Tests/OnymIOSTests/
├── RelayerEndpointSchemaTests.swift             ← NEW (8 cases) — pins wire format both directions
├── RelayerRepositoryTests.swift (modified)      ← +5 cases for fetch-status semantics
├── RelayerConfigurationTests.swift (modified)   ← updated for `networks: [...]`
├── RelayerSelectionStoreTests.swift (modified)  ← updated for `networks: [...]`
├── RelayerSettingsFlowTests.swift (modified)    ← updated for `networks: [...]`
├── RelayerRepositoryTests.swift (modified)      ← updated fixture constructors
└── KnownRelayersFetcherTests.swift (modified)   ← assertions now check `networks`
```

## Wire format we now accept (both shapes)

```json
// New shape (current published format and forward-going saves)
{ "name": "Onym Official", "url": "https://relayer.onym.chat", "networks": ["testnet", "public"] }

// Legacy shape (PR #20 / #22 saved configs — decoded backward-compatibly)
{ "name": "Onym Official", "url": "https://relayer.onym.chat", "network": "testnet" }
```

Encoder always emits the plural shape. The decoder reads the plural array if present, otherwise promotes the singular `network` to a `[String]` of one element. Pinned by `RelayerEndpointSchemaTests`.

## Fetch status semantics

| State | UI |
|---|---|
| `.idle` | "Fetching list…" spinner (background fetch hasn't kicked off yet) |
| `.fetching` (cached list empty) | "Fetching list…" spinner |
| `.fetching` (cached list non-empty) | the cached list (with stale-warning badge possible later) |
| `.success` (non-empty) | the published list |
| `.success` (empty) | "No published relayers yet." |
| `.failed(message)` | the localized error message + "Try Again" button |

Mapped error messages (all localized via `String(localized:)`):
- `KnownRelayersFetchError.badStatus(code)` → "Couldn't reach the published list (status N)."
- `KnownRelayersFetchError.malformedDocument` → "Published list is in an unexpected format."
- `URLError` (network failure) / default → "Couldn't reach the published list."

## Architecture compliance

No layer changes — the fix tightens the chain seam's contract and updates the UI to surface the new state. Touch-surface table from PR #15 unchanged.

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests` — 238/238 unit tests pass in 1.49s on iPhone 17 Pro simulator (225 + 13 new).
- [x] `xcodebuild test -only-testing:OnymIOSUITests` — 11/11 UI tests pass on iPhone 17 Pro simulator.
- [x] Manual fresh-install smoke: launch the app, navigate Settings → Relayer, see the published Onym Official relayer auto-populated in Configured (the published `relayers.json` has 1 entry); strategy is Random; the "Add from Published List" section shows "All published relayers added." (no longer spins forever).

## Out of scope

- **Same fix for the contracts manifest**. `ContractsRepository.refresh()` has the same swallow-on-error pattern. Could surface the same bug if the contracts manifest is unreachable. Not biting yet because the contracts manifest schema is correct and reachable — but a follow-up PR could mirror the `FetchStatus` plumbing for `ContractsState` so the anchors picker isn't vulnerable to the same failure mode.
- **Stale indicator after a successful refresh later fails**. Currently the cached list is shown silently if a subsequent refresh fails after a prior success. Could add a small "stale" badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)