### PR TITLE
group: foundation port (PR-A of Create Group)

### DIFF
--- a/Sources/OnymIOS/Chain/SEPContractClient.swift
+++ b/Sources/OnymIOS/Chain/SEPContractClient.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Generic envelope wrapping a contract-function invocation. Mirrors
+/// `swift-mls`'s `SEPContractInvocation` so the relayer wire format stays
+/// in sync — the relayer reads `contract_id`, `function`, and `payload`
+/// out of the JSON top-level. Stellar Soroban SDK is intentionally not
+/// pulled in: relayers handle tx assembly + signing, this client just
+/// posts the function call.
+struct SEPContractInvocation<Payload: Encodable & Sendable>: Encodable, Sendable {
+    let contractID: String
+    let function: String
+    let payload: Payload
+
+    enum CodingKeys: String, CodingKey {
+        case contractID = "contract_id"
+        case function
+        case payload
+    }
+}
+
+/// Seam for the network leg. Tests inject a fake; production uses
+/// `URLSessionSEPContractTransport` constructed from a `RelayerEndpoint`
+/// resolved via `RelayerSelectionStrategy`.
+protocol SEPContractTransport: Sendable {
+    func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ invocation: SEPContractInvocation<Payload>,
+        responseType: Response.Type
+    ) async throws -> Response
+}
+
+struct URLSessionSEPContractTransport: SEPContractTransport {
+    let endpoint: URL
+    let session: URLSession
+    let encoder: JSONEncoder
+    let decoder: JSONDecoder
+
+    init(
+        endpoint: URL,
+        session: URLSession = .shared,
+        encoder: JSONEncoder = JSONEncoder(),
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.endpoint = endpoint
+        self.session = session
+        self.encoder = encoder
+        self.decoder = decoder
+    }
+
+    func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ invocation: SEPContractInvocation<Payload>,
+        responseType: Response.Type
+    ) async throws -> Response {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try encoder.encode(invocation)
+
+        let (data, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? "<non-UTF8 body>"
+            throw SEPError.invalidResponse(statusCode: statusCode, body: body)
+        }
+        do {
+            return try decoder.decode(Response.self, from: data)
+        } catch {
+            throw SEPError.decodeFailure(String(describing: error))
+        }
+    }
+}
+
+/// Pins a `(contractID, transport)` pair and exposes the four contract
+/// entrypoints PR-A needs: `create_group_v2` (Anarchy / 1v1 / Democracy /
+/// Tyranny), `update_commitment` (Tyranny member-add later), `get_state`
+/// (post-create read-back). Per-type Oligarchy creation lives outside
+/// PR-A scope.
+struct SEPContractClient: Sendable {
+    let contractID: String
+    let transport: any SEPContractTransport
+
+    init(contractID: String, transport: any SEPContractTransport) {
+        self.contractID = contractID
+        self.transport = transport
+    }
+
+    func createGroupV2(_ request: SEPCreateGroupV2Request) async throws -> SEPSubmissionResponse {
+        try await invoke("create_group_v2", payload: request, responseType: SEPSubmissionResponse.self)
+    }
+
+    func updateCommitment(_ request: SEPUpdateCommitmentRequest) async throws -> SEPSubmissionResponse {
+        try await invoke("update_commitment", payload: request, responseType: SEPSubmissionResponse.self)
+    }
+
+    func getState(groupID: Data) async throws -> SEPCommitmentEntry {
+        try await invoke(
+            "get_state",
+            payload: SEPGetStateRequest(groupID: groupID),
+            responseType: SEPCommitmentEntry.self
+        )
+    }
+
+    private func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ function: String,
+        payload: Payload,
+        responseType: Response.Type
+    ) async throws -> Response {
+        try await transport.invoke(
+            SEPContractInvocation(contractID: contractID, function: function, payload: payload),
+            responseType: responseType
+        )
+    }
+}

--- a/Sources/OnymIOS/Chain/SEPContractTypes.swift
+++ b/Sources/OnymIOS/Chain/SEPContractTypes.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Mirrors `stellar-mls/swift-mls`'s `SEPGroupType` plus the post-v0.0.3
+/// `tyranny` case that swift-mls hasn't been bumped for yet. Persisted as
+/// the `group_type` u32 in the contract's `CommitmentEntryV2`.
+enum SEPGroupType: UInt32, Codable, CaseIterable, Sendable {
+    case anarchy = 0
+    case oneOnOne = 1
+    case democracy = 2
+    case oligarchy = 3
+    case tyranny = 4
+}
+
+/// Tier sizing for a Merkle tree commitment. Values pinned to match the
+/// VK ceremonies.
+enum SEPTier: Int, Codable, CaseIterable, Sendable {
+    case small = 0
+    case medium = 1
+    case large = 2
+
+    var maxMembers: Int {
+        switch self {
+        case .small: return 32
+        case .medium: return 256
+        case .large: return 2048
+        }
+    }
+
+    var depth: Int {
+        switch self {
+        case .small: return 5
+        case .medium: return 8
+        case .large: return 11
+        }
+    }
+}
+
+/// Public-input bundle accompanying a Groth16 / PLONK proof: the new
+/// commitment + the epoch number it lives at.
+struct SEPPublicInputs: Codable, Equatable, Sendable {
+    let commitment: Data
+    let epoch: UInt64
+}
+
+/// Public-input bundle for the UpdateCircuit (#59 fix). The contract
+/// rederives `cNew` from the proof itself, so the relayer no longer
+/// trusts a client-supplied "new commitment". JSON keys use snake_case
+/// to match the relayer payload schema.
+struct SEPUpdatePublicInputs: Codable, Equatable, Sendable {
+    let cOld: Data
+    let epochOld: UInt64
+    let cNew: Data
+
+    enum CodingKeys: String, CodingKey {
+        case cOld = "c_old"
+        case epochOld = "epoch_old"
+        case cNew = "c_new"
+    }
+}
+
+/// Payload for `create_group_v2`. Used by Anarchy, 1v1, Democracy, AND
+/// Tyranny (the latter not yet listed in swift-mls). Oligarchy uses its
+/// own dedicated `SEPCreateOligarchyGroupRequest` because it seeds an
+/// extra admin root.
+struct SEPCreateGroupV2Request: Codable, Equatable, Sendable {
+    let caller: String
+    let groupID: Data
+    let commitment: Data
+    let tier: UInt32
+    let groupType: SEPGroupType
+    let memberCount: UInt32
+    let proof: Data
+    let publicInputs: SEPPublicInputs
+
+    enum CodingKeys: String, CodingKey {
+        case caller
+        case groupID = "group_id"
+        case commitment
+        case tier
+        case groupType = "group_type"
+        case memberCount = "member_count"
+        case proof
+        case publicInputs = "public_inputs"
+    }
+}
+
+/// Payload for `update_commitment` (member-add / member-remove).
+struct SEPUpdateCommitmentRequest: Codable, Equatable, Sendable {
+    let groupID: Data
+    let proof: Data
+    let publicInputs: SEPUpdatePublicInputs
+
+    enum CodingKeys: String, CodingKey {
+        case groupID = "group_id"
+        case proof
+        case publicInputs = "public_inputs"
+    }
+}
+
+/// Payload for `get_state` / `get_state_v2` / `get_admin_root`.
+struct SEPGetStateRequest: Codable, Equatable, Sendable {
+    let groupID: Data
+
+    enum CodingKeys: String, CodingKey {
+        case groupID = "group_id"
+    }
+}
+
+/// On-chain state returned by `get_state`. V1 entries (no group_type
+/// metadata).
+struct SEPCommitmentEntry: Codable, Equatable, Sendable {
+    let commitment: Data
+    let epoch: UInt64
+    let timestamp: UInt64
+    let tier: UInt32
+    let active: Bool
+}
+
+/// Relayer's response to a contract-invocation POST. `accepted` reflects
+/// the contract's verification result; `transactionHash` is set when a
+/// Soroban tx was actually submitted.
+struct SEPSubmissionResponse: Codable, Equatable, Sendable {
+    let accepted: Bool
+    let transactionHash: String?
+    let message: String?
+}
+
+enum SEPError: Error, LocalizedError, Equatable, Sendable {
+    case invalidResponse(statusCode: Int, body: String)
+    case decodeFailure(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidResponse(statusCode, body):
+            return "HTTP \(statusCode): \(body)"
+        case let .decodeFailure(message):
+            return "Decode failure: \(message)"
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// In-memory snapshot of a chat group as the iOS app understands it.
+/// PR-A holds this purely as a value type — `GroupRepository` and the
+/// SwiftData @Model land in PR-B.
+///
+/// Trimmed compared to `stellar-mls/clients/ios/StellarChat/Models/ChatGroup`:
+/// the chat-message / avatar / push fields are out of scope until the
+/// chat screen ships. `groupSecret` stays in the type because it's
+/// seeded into the invitation envelope at create time and the receiver
+/// needs it to derive message-keys later.
+struct ChatGroup: Identifiable, Equatable, Sendable {
+    /// Hex-encoded 32-byte group ID.
+    let id: String
+    let name: String
+    /// 32-byte shared secret. Used for `topicTag` derivation and message
+    /// key HKDF — both still TBD on iOS, but the value must be sealed
+    /// into the invitation now so receivers can rebuild the same key.
+    let groupSecret: Data
+    let createdAt: Date
+
+    var members: [GovernanceMember]
+    var epoch: UInt64
+    var salt: Data
+    /// Latest verified Poseidon commitment. `nil` until the first
+    /// `recomputeCommitment` call (or until on-chain state is read back).
+    var commitment: Data?
+    var tier: SEPTier
+    var groupType: SEPGroupType
+    /// Hex (lowercase, 96 chars) BLS pubkey of the single Tyranny admin.
+    /// `nil` for `.anarchy` / `.oneOnOne` (no privileged member).
+    var adminPubkeyHex: String?
+    /// Flips to `true` once the relayer's `create_group_v2` returns
+    /// `accepted = true`. Persisted-but-not-anchored groups can be
+    /// retried.
+    var isPublishedOnChain: Bool
+
+    /// Group ID as the raw 32-byte payload (parsed back from `id`).
+    /// Used directly when building chain payloads + invitations.
+    var groupIDData: Data {
+        ChatGroup.bytes(fromHex: id)
+    }
+
+    static func bytes(fromHex hex: String) -> Data {
+        var data = Data(capacity: hex.count / 2)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2, limitedBy: hex.endIndex) ?? hex.endIndex
+            if let byte = UInt8(hex[index..<next], radix: 16) {
+                data.append(byte)
+            }
+            index = next
+        }
+        return data
+    }
+}

--- a/Sources/OnymIOS/Group/GovernanceMember.swift
+++ b/Sources/OnymIOS/Group/GovernanceMember.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// One member-leaf entry in a group's roster. The two byte arrays are
+/// derived from the same 32-byte BLS Fr secret:
+///
+/// - `publicKeyCompressed` — 48 bytes, arkworks-compressed G1Affine
+///   (`[sk] · G`). Used for Merkle-tree leaf ordering (lex sort) and as
+///   the stable on-the-wire identifier of a member across epochs.
+/// - `leafHash` — 32 bytes, `Poseidon(sk_fr)`. The actual scalar that
+///   lands in the Poseidon Merkle tree the contract verifies against.
+///
+/// Mirrors `SEPGroupMemberLeaf` from `swift-mls`.
+struct GovernanceMember: Codable, Equatable, Sendable {
+    let publicKeyCompressed: Data
+    let leafHash: Data
+}

--- a/Sources/OnymIOS/Group/GroupCommitmentBuilder.swift
+++ b/Sources/OnymIOS/Group/GroupCommitmentBuilder.swift
@@ -1,0 +1,81 @@
+import CryptoKit
+import Foundation
+import OnymSDK
+
+/// Thin wrapper around `OnymSDK.Common` that speaks `GovernanceMember`
+/// rather than raw byte buffers. Mirrors `SEPCommitmentBuilder` in
+/// `swift-mls` so cross-platform behaviour (and test vectors) stays
+/// aligned.
+///
+/// All FFI calls run synchronously — the heavy work is hashing, not
+/// proving, so they're fine on the actor that owns the group state.
+enum GroupCommitmentBuilder {
+
+    /// Fresh 32-byte salt for a brand-new group. Random bytes; the
+    /// circuit interprets them little-endian-mod-r in-circuit.
+    static func generateSalt() -> Data {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        for i in bytes.indices {
+            bytes[i] = UInt8.random(in: UInt8.min...UInt8.max)
+        }
+        return Data(bytes)
+    }
+
+    /// Deterministic salt rotation for member-add events.
+    /// `SHA256(previousSalt || memberKey)` — both sides of a
+    /// `SEPMemberJoined` derive the same salt and therefore the same
+    /// epoch's encryption key, so observers don't fork.
+    static func deriveSalt(previousSalt: Data, memberKey: Data) -> Data {
+        var hasher = SHA256()
+        hasher.update(data: previousSalt)
+        hasher.update(data: memberKey)
+        return Data(hasher.finalize())
+    }
+
+    /// 32-byte Poseidon leaf hash for a single member's BLS Fr secret.
+    static func computeLeafHash(secretKey: Data) throws -> Data {
+        try Common.leafHash(secretKey: secretKey)
+    }
+
+    /// 48-byte arkworks-compressed G1 BLS public key for a 32-byte
+    /// secret. Used to compute the stable `publicKeyCompressed` on
+    /// `GovernanceMember`.
+    static func computePublicKey(secretKey: Data) throws -> Data {
+        try Common.publicKey(secretKey: secretKey)
+    }
+
+    /// Sort `members` lex by `publicKeyCompressed`, pack the
+    /// `leafHash` bytes, pad to `2^depth` with `Fr::ZERO`, and ask
+    /// OnymSDK for the Poseidon Merkle root.
+    ///
+    /// The lex sort matches SEP-XXXX §2.1 — both peers MUST sort
+    /// identically before computing roots, otherwise commitments
+    /// diverge.
+    static func computeMerkleRoot(
+        members: [GovernanceMember],
+        tier: SEPTier
+    ) throws -> Data {
+        let sorted = members.sorted { lhs, rhs in
+            lhs.publicKeyCompressed.lexicographicallyPrecedes(rhs.publicKeyCompressed)
+        }
+        var packed = Data(capacity: sorted.count * 32)
+        for member in sorted {
+            packed.append(member.leafHash)
+        }
+        return try Common.merkleRoot(leafHashes: packed, depth: tier.depth)
+    }
+
+    /// `Poseidon(Poseidon(root, Fr(epoch)), salt_fr)`. The plonk-era
+    /// commitment shape used by every sep-* contract.
+    static func computePoseidonCommitment(
+        poseidonRoot: Data,
+        epoch: UInt64,
+        salt: Data
+    ) throws -> Data {
+        try Common.poseidonCommitment(
+            poseidonRoot: poseidonRoot,
+            epoch: epoch,
+            salt: salt
+        )
+    }
+}

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -18,7 +18,7 @@ import OnymSDK
 /// PBKDF2, HKDF, and FFI calls into OnymSDK all run on the actor — never on
 /// the main thread by construction. Views interact via `await` from a
 /// `Task` (typically a SwiftUI `.task`).
-actor IdentityRepository: InvitationEnvelopeDecrypting {
+actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealing {
     static let shared = IdentityRepository()
 
     private let keychain: KeychainStore
@@ -153,6 +153,82 @@ actor IdentityRepository: InvitationEnvelopeDecrypting {
         }
     }
 
+    // MARK: - Invitation sealing
+
+    /// Sender-side mirror of `decryptInvitation`. Generates a fresh
+    /// per-envelope X25519 keypair, derives an AES-GCM key from the
+    /// ECDH shared secret with the recipient's inbox pubkey, encrypts
+    /// the payload, signs the ephemeral pubkey with the device's
+    /// Ed25519 identity key (M-5), and returns the JSON-serialised
+    /// `SealedEnvelope`. Secret material never escapes this actor —
+    /// only the resulting bytes do.
+    func sealInvitation(
+        payload: Data,
+        to recipientInboxPublicKey: Data
+    ) async throws -> Data {
+        let recipientPubkey: Curve25519.KeyAgreement.PublicKey
+        do {
+            recipientPubkey = try Curve25519.KeyAgreement.PublicKey(
+                rawRepresentation: recipientInboxPublicKey
+            )
+        } catch {
+            throw InvitationSealError.invalidRecipientPublicKey
+        }
+
+        guard let snapshot = try keychain.load() else {
+            throw InvitationSealError.identityNotLoaded
+        }
+        let signingKey = try Self.stellarSigningPrivateKey(fromNostrSecret: snapshot.nostrSecretKey)
+
+        let ephemeral = Curve25519.KeyAgreement.PrivateKey()
+        let sharedSecret: SharedSecret
+        do {
+            sharedSecret = try ephemeral.sharedSecretFromKeyAgreement(with: recipientPubkey)
+        } catch {
+            throw InvitationSealError.encryptionFailed
+        }
+        let key = sharedSecret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data("sep-invitation-v1".utf8),
+            sharedInfo: Data("aes-256-gcm".utf8),
+            outputByteCount: 32
+        )
+
+        let nonce = AES.GCM.Nonce()
+        let sealed: AES.GCM.SealedBox
+        do {
+            sealed = try AES.GCM.seal(payload, using: key, nonce: nonce)
+        } catch {
+            throw InvitationSealError.encryptionFailed
+        }
+
+        let ephPubData = Data(ephemeral.publicKey.rawRepresentation)
+        let ephSig: Data
+        do {
+            ephSig = try signingKey.signature(for: ephPubData)
+        } catch {
+            throw InvitationSealError.signingFailed
+        }
+        let senderPubData = Data(signingKey.publicKey.rawRepresentation)
+
+        let envelope = SealedEnvelope(
+            version: 1,
+            scheme: "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey: ephPubData,
+            ephemeralKeySignature: ephSig,
+            senderEd25519PublicKey: senderPubData,
+            nonce: Data(nonce),
+            ciphertext: Data(sealed.ciphertext),
+            authenticationTag: Data(sealed.tag)
+        )
+
+        do {
+            return try JSONEncoder().encode(envelope)
+        } catch {
+            throw InvitationSealError.encodingFailed
+        }
+    }
+
     // MARK: - Private
 
     private func subscribe(
@@ -237,6 +313,17 @@ actor IdentityRepository: InvitationEnvelopeDecrypting {
     /// **MUST** match `KeyManager.deriveStellarKey` in stellar-mls — a recovery
     /// phrase generated there must produce the same `G...` account ID here.
     private static func stellarPublicKey(fromNostrSecret nostrSecret: Data) -> Data {
+        let privateKey = (try? stellarSigningPrivateKey(fromNostrSecret: nostrSecret))!
+        return Data(privateKey.publicKey.rawRepresentation)
+    }
+
+    /// Sibling of `stellarPublicKey` that returns the Ed25519
+    /// *private* key. Used by `sealInvitation` for the M-5 attestation
+    /// signature on per-envelope ephemeral pubkeys. Never leaves this
+    /// actor.
+    private static func stellarSigningPrivateKey(
+        fromNostrSecret nostrSecret: Data
+    ) throws -> Curve25519.Signing.PrivateKey {
         let derived = HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: nostrSecret),
             salt: Data("chat.onym.ios".utf8),
@@ -244,8 +331,7 @@ actor IdentityRepository: InvitationEnvelopeDecrypting {
             outputByteCount: 32
         )
         let seed = derived.withUnsafeBytes { Data($0) }
-        let privateKey = try! Curve25519.Signing.PrivateKey(rawRepresentation: seed)
-        return Data(privateKey.publicKey.rawRepresentation)
+        return try Curve25519.Signing.PrivateKey(rawRepresentation: seed)
     }
 
     /// HKDF-SHA256(nostrSecret, salt="chat.onym.ios", info="x25519-key-agreement-v1", 32B).

--- a/Sources/OnymIOS/Identity/InvitationEnvelopeSealing.swift
+++ b/Sources/OnymIOS/Identity/InvitationEnvelopeSealing.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Sender-side mirror of `InvitationEnvelopeDecrypting`. The chain
+/// interactor that creates a group depends on this seam to wrap each
+/// invitee's bootstrap payload in an X25519+AES-GCM-sealed
+/// `SealedEnvelope` JSON blob — without ever holding the device's
+/// long-term identity keys directly.
+///
+/// Only the producer of this protocol (i.e. `IdentityRepository`)
+/// holds the Ed25519 signing key used to attest the per-envelope
+/// ephemeral X25519 pubkey (M-5). The interactor only sees the
+/// resulting bytes.
+protocol InvitationEnvelopeSealing: Sendable {
+    /// Seal `payload` for a single recipient. Generates a fresh
+    /// per-envelope X25519 keypair, derives the AES-GCM key via
+    /// HKDF-SHA256 over the ECDH shared secret with
+    /// `recipientInboxPublicKey` (32-byte raw X25519 pubkey), encrypts
+    /// the payload with a random nonce, signs the ephemeral pubkey
+    /// with the sender's Ed25519 identity key (M-5), and returns the
+    /// JSON-encoded `SealedEnvelope` bytes ready to drop on
+    /// `InboxTransport.send(...)`.
+    ///
+    /// Throws on: missing identity, malformed recipient pubkey,
+    /// signing failure, encryption failure.
+    func sealInvitation(
+        payload: Data,
+        to recipientInboxPublicKey: Data
+    ) async throws -> Data
+}
+
+enum InvitationSealError: Error, Equatable, Sendable {
+    case identityNotLoaded
+    case invalidRecipientPublicKey
+    case signingFailed
+    case encryptionFailed
+    case encodingFailed
+}

--- a/Tests/OnymIOSTests/ChatGroupTests.swift
+++ b/Tests/OnymIOSTests/ChatGroupTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import OnymIOS
+
+final class ChatGroupTests: XCTestCase {
+
+    func test_groupIDData_roundtripsThroughHex() {
+        let raw = Data(repeating: 0xAB, count: 32)
+        let hex = raw.map { String(format: "%02x", $0) }.joined()
+        let group = makeGroup(id: hex)
+        XCTAssertEqual(group.groupIDData, raw)
+        XCTAssertEqual(group.groupIDData.count, 32)
+    }
+
+    func test_groupIDData_handlesShortHex() {
+        let group = makeGroup(id: "abcd")
+        XCTAssertEqual(group.groupIDData, Data([0xAB, 0xCD]))
+    }
+
+    func test_groupIDData_isLowercaseInsensitive() {
+        let group = makeGroup(id: "AbCd")
+        XCTAssertEqual(group.groupIDData, Data([0xAB, 0xCD]))
+    }
+
+    private func makeGroup(id: String) -> ChatGroup {
+        ChatGroup(
+            id: id,
+            name: "test",
+            groupSecret: Data(repeating: 0, count: 32),
+            createdAt: Date(timeIntervalSince1970: 0),
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: nil,
+            isPublishedOnChain: false
+        )
+    }
+}

--- a/Tests/OnymIOSTests/GroupCommitmentBuilderTests.swift
+++ b/Tests/OnymIOSTests/GroupCommitmentBuilderTests.swift
@@ -1,0 +1,102 @@
+import CryptoKit
+import XCTest
+@testable import OnymIOS
+
+/// Unit tests for `GroupCommitmentBuilder`. The pure-Swift helpers
+/// (salt generation + derivation) are exercised directly; the FFI-
+/// backed leaf / merkle / commitment helpers go through `OnymSDK` and
+/// just verify they round-trip and produce stable byte counts — the
+/// underlying cryptography is the SDK's responsibility, not this
+/// wrapper's.
+final class GroupCommitmentBuilderTests: XCTestCase {
+
+    func test_generateSalt_returns32RandomBytes() {
+        let a = GroupCommitmentBuilder.generateSalt()
+        let b = GroupCommitmentBuilder.generateSalt()
+        XCTAssertEqual(a.count, 32)
+        XCTAssertEqual(b.count, 32)
+        XCTAssertNotEqual(a, b, "two consecutive calls must produce different salts")
+    }
+
+    func test_deriveSalt_isDeterministic_andMatchesSHA256() {
+        let prev = Data(repeating: 0xAA, count: 32)
+        let memberKey = Data(repeating: 0xBB, count: 48)
+
+        let derived1 = GroupCommitmentBuilder.deriveSalt(previousSalt: prev, memberKey: memberKey)
+        let derived2 = GroupCommitmentBuilder.deriveSalt(previousSalt: prev, memberKey: memberKey)
+        XCTAssertEqual(derived1, derived2, "deterministic for the same inputs")
+
+        var hasher = CryptoKit.SHA256()
+        hasher.update(data: prev)
+        hasher.update(data: memberKey)
+        XCTAssertEqual(derived1, Data(hasher.finalize()))
+    }
+
+    func test_deriveSalt_differentInputsDiverge() {
+        let prev = Data(repeating: 0xAA, count: 32)
+        let m1 = Data(repeating: 0x01, count: 48)
+        let m2 = Data(repeating: 0x02, count: 48)
+        XCTAssertNotEqual(
+            GroupCommitmentBuilder.deriveSalt(previousSalt: prev, memberKey: m1),
+            GroupCommitmentBuilder.deriveSalt(previousSalt: prev, memberKey: m2)
+        )
+    }
+
+    func test_computePublicKeyAndLeafHash_returnExpectedSizes() throws {
+        let secret = Data(repeating: 0x42, count: 32)
+        let pub = try GroupCommitmentBuilder.computePublicKey(secretKey: secret)
+        let leaf = try GroupCommitmentBuilder.computeLeafHash(secretKey: secret)
+        XCTAssertEqual(pub.count, 48, "compressed BLS12-381 G1 is 48 bytes")
+        XCTAssertEqual(leaf.count, 32, "Poseidon Fr leaf is 32 bytes")
+    }
+
+    func test_computeMerkleRoot_isOrderInvariant() throws {
+        // Lex-sort behaviour: building the same roster in two orders
+        // must produce the same Poseidon root.
+        let a = try memberFromSecret(Data(repeating: 0x10, count: 32))
+        let b = try memberFromSecret(Data(repeating: 0x20, count: 32))
+        let c = try memberFromSecret(Data(repeating: 0x30, count: 32))
+
+        let root1 = try GroupCommitmentBuilder.computeMerkleRoot(
+            members: [a, b, c],
+            tier: .small
+        )
+        let root2 = try GroupCommitmentBuilder.computeMerkleRoot(
+            members: [c, a, b],
+            tier: .small
+        )
+        XCTAssertEqual(root1, root2)
+        XCTAssertEqual(root1.count, 32)
+    }
+
+    func test_computePoseidonCommitment_changesWithEpoch() throws {
+        let member = try memberFromSecret(Data(repeating: 0x42, count: 32))
+        let root = try GroupCommitmentBuilder.computeMerkleRoot(
+            members: [member],
+            tier: .small
+        )
+        let salt = Data(repeating: 0x77, count: 32)
+
+        let c0 = try GroupCommitmentBuilder.computePoseidonCommitment(
+            poseidonRoot: root,
+            epoch: 0,
+            salt: salt
+        )
+        let c1 = try GroupCommitmentBuilder.computePoseidonCommitment(
+            poseidonRoot: root,
+            epoch: 1,
+            salt: salt
+        )
+        XCTAssertEqual(c0.count, 32)
+        XCTAssertNotEqual(c0, c1, "epoch participates in the commitment")
+    }
+
+    // MARK: - Helpers
+
+    private func memberFromSecret(_ secret: Data) throws -> GovernanceMember {
+        GovernanceMember(
+            publicKeyCompressed: try GroupCommitmentBuilder.computePublicKey(secretKey: secret),
+            leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: secret)
+        )
+    }
+}

--- a/Tests/OnymIOSTests/IdentityRepositorySealInvitationTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositorySealInvitationTests.swift
@@ -1,0 +1,152 @@
+import CryptoKit
+import XCTest
+@testable import OnymIOS
+
+/// Sender side of the invitation envelope. Mirrors
+/// `IdentityRepositoryInvitationDecryptTests` but exercises the new
+/// `sealInvitation` method — sealed bytes round-trip through
+/// `decryptInvitation` on a *different* `IdentityRepository` (the
+/// recipient) and the M-5 ephemeral-pubkey signature must verify
+/// against the sender's identity key.
+final class IdentityRepositorySealInvitationTests: XCTestCase {
+    private var senderKeychain: KeychainStore!
+    private var sender: IdentityRepository!
+    private var recipientKeychain: KeychainStore!
+    private var recipient: IdentityRepository!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        senderKeychain = KeychainStore(
+            service: "chat.onym.ios.identity.tests.sender.\(UUID().uuidString)",
+            account: "current"
+        )
+        sender = IdentityRepository(keychain: senderKeychain)
+        _ = try await sender.restore(
+            mnemonic: "legal winner thank year wave sausage worth useful legal winner thank yellow"
+        )
+
+        recipientKeychain = KeychainStore(
+            service: "chat.onym.ios.identity.tests.recipient.\(UUID().uuidString)",
+            account: "current"
+        )
+        recipient = IdentityRepository(keychain: recipientKeychain)
+        _ = try await recipient.restore(
+            mnemonic: "letter advice cage absurd amount doctor acoustic avoid letter advice cage above"
+        )
+    }
+
+    override func tearDown() async throws {
+        try? senderKeychain.wipe()
+        try? recipientKeychain.wipe()
+        senderKeychain = nil
+        sender = nil
+        recipientKeychain = nil
+        recipient = nil
+        try await super.tearDown()
+    }
+
+    func test_sealInvitation_roundtripsThroughDecrypt() async throws {
+        let recipientIdentity = try await XCTUnwrapAsync(await recipient.currentIdentity())
+        let plaintext = Data("hello, invitee".utf8)
+
+        let sealed = try await sender.sealInvitation(
+            payload: plaintext,
+            to: recipientIdentity.inboxPublicKey
+        )
+        let decrypted = try await recipient.decryptInvitation(envelopeBytes: sealed)
+        XCTAssertEqual(decrypted, plaintext)
+    }
+
+    func test_sealInvitation_signatureVerifiesAgainstSenderIdentity() async throws {
+        let recipientIdentity = try await XCTUnwrapAsync(await recipient.currentIdentity())
+        let senderIdentity = try await XCTUnwrapAsync(await sender.currentIdentity())
+
+        let sealed = try await sender.sealInvitation(
+            payload: Data("attested".utf8),
+            to: recipientIdentity.inboxPublicKey
+        )
+        let envelope = try JSONDecoder().decode(SealedEnvelope.self, from: sealed)
+
+        let senderPub = try XCTUnwrap(envelope.senderEd25519PublicKey)
+        XCTAssertEqual(
+            senderPub,
+            senderIdentity.stellarPublicKey,
+            "sender Ed25519 pubkey embedded in envelope must match the sender's identity"
+        )
+        let sig = try XCTUnwrap(envelope.ephemeralKeySignature)
+        let ephPub = try XCTUnwrap(envelope.ephemeralPublicKey)
+        let verifyingKey = try Curve25519.Signing.PublicKey(rawRepresentation: senderPub)
+        XCTAssertTrue(verifyingKey.isValidSignature(sig, for: ephPub))
+    }
+
+    func test_sealInvitation_freshEphemeralPerCall() async throws {
+        let recipientIdentity = try await XCTUnwrapAsync(await recipient.currentIdentity())
+
+        let firstBytes = try await sender.sealInvitation(
+            payload: Data("a".utf8),
+            to: recipientIdentity.inboxPublicKey
+        )
+        let secondBytes = try await sender.sealInvitation(
+            payload: Data("a".utf8),
+            to: recipientIdentity.inboxPublicKey
+        )
+        let first = try JSONDecoder().decode(SealedEnvelope.self, from: firstBytes)
+        let second = try JSONDecoder().decode(SealedEnvelope.self, from: secondBytes)
+        XCTAssertNotEqual(
+            first.ephemeralPublicKey,
+            second.ephemeralPublicKey,
+            "each seal must mint a fresh per-envelope X25519 keypair"
+        )
+        XCTAssertNotEqual(first.ciphertext, second.ciphertext, "different nonce → different ciphertext")
+    }
+
+    func test_sealInvitation_rejectsInvalidRecipientPublicKey() async throws {
+        let badPub = Data(repeating: 0, count: 16)  // X25519 expects 32B
+        await assertThrows(
+            try await sender.sealInvitation(payload: Data("x".utf8), to: badPub),
+            InvitationSealError.invalidRecipientPublicKey
+        )
+    }
+
+    func test_sealInvitation_throwsIdentityNotLoaded_afterWipe() async throws {
+        let recipientIdentity = try await XCTUnwrapAsync(await recipient.currentIdentity())
+        try await sender.wipe()
+        await assertThrows(
+            try await sender.sealInvitation(
+                payload: Data("x".utf8),
+                to: recipientIdentity.inboxPublicKey
+            ),
+            InvitationSealError.identityNotLoaded
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrows<T: Sendable>(
+        _ expression: @autoclosure () async throws -> T,
+        _ expected: InvitationSealError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("expected to throw \(expected), got success", file: file, line: line)
+        } catch let error as InvitationSealError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("expected \(expected), got \(error)", file: file, line: line)
+        }
+    }
+
+    private func XCTUnwrapAsync<T>(
+        _ value: T?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> T {
+        guard let value else {
+            XCTFail("unexpected nil", file: file, line: line)
+            throw XCTSkip("nil")
+        }
+        return value
+    }
+}

--- a/Tests/OnymIOSTests/SEPContractClientTests.swift
+++ b/Tests/OnymIOSTests/SEPContractClientTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import OnymIOS
+
+/// Pure-Swift unit tests for `SEPContractClient` — no real HTTP. A
+/// `RecordingTransport` captures the encoded invocation and returns a
+/// canned response, so we verify both the wire shape (snake_case keys,
+/// envelope structure) and the client's response decoding without
+/// touching `URLSession`.
+final class SEPContractClientTests: XCTestCase {
+    private let testContractID = "CONTRACTID000000000000000000000000000000000000000000000000"
+
+    func test_createGroupV2_sendsSnakeCasePayload() async throws {
+        let recorder = RecordingTransport(
+            response: SEPSubmissionResponse(
+                accepted: true,
+                transactionHash: "abc123",
+                message: nil
+            )
+        )
+        let client = SEPContractClient(contractID: testContractID, transport: recorder)
+
+        let request = SEPCreateGroupV2Request(
+            caller: "GBABCDEF",
+            groupID: Data(repeating: 0xAB, count: 32),
+            commitment: Data(repeating: 0xCD, count: 32),
+            tier: UInt32(SEPTier.small.rawValue),
+            groupType: .tyranny,
+            memberCount: 1,
+            proof: Data(repeating: 0xEE, count: 64),
+            publicInputs: SEPPublicInputs(
+                commitment: Data(repeating: 0xCD, count: 32),
+                epoch: 0
+            )
+        )
+        let response = try await client.createGroupV2(request)
+
+        XCTAssertTrue(response.accepted)
+        XCTAssertEqual(response.transactionHash, "abc123")
+
+        let json = try XCTUnwrap(recorder.lastJSON())
+        XCTAssertEqual(json["function"] as? String, "create_group_v2")
+        XCTAssertEqual(json["contract_id"] as? String, testContractID)
+        let payload = try XCTUnwrap(json["payload"] as? [String: Any])
+        XCTAssertEqual(payload["caller"] as? String, "GBABCDEF")
+        XCTAssertEqual((payload["group_type"] as? NSNumber)?.uint32Value, SEPGroupType.tyranny.rawValue)
+        XCTAssertEqual((payload["member_count"] as? NSNumber)?.uint32Value, 1)
+        XCTAssertNotNil(payload["group_id"])  // Data → base64 string in JSON
+        XCTAssertNotNil(payload["public_inputs"])
+    }
+
+    func test_updateCommitment_routesToUpdateFunction() async throws {
+        let recorder = RecordingTransport(
+            response: SEPSubmissionResponse(accepted: true, transactionHash: nil, message: nil)
+        )
+        let client = SEPContractClient(contractID: testContractID, transport: recorder)
+
+        let request = SEPUpdateCommitmentRequest(
+            groupID: Data(repeating: 0x01, count: 32),
+            proof: Data(repeating: 0x02, count: 32),
+            publicInputs: SEPUpdatePublicInputs(
+                cOld: Data(repeating: 0x03, count: 32),
+                epochOld: 1,
+                cNew: Data(repeating: 0x04, count: 32)
+            )
+        )
+        _ = try await client.updateCommitment(request)
+
+        let json = try XCTUnwrap(recorder.lastJSON())
+        XCTAssertEqual(json["function"] as? String, "update_commitment")
+        let payload = try XCTUnwrap(json["payload"] as? [String: Any])
+        let publicInputs = try XCTUnwrap(payload["public_inputs"] as? [String: Any])
+        XCTAssertNotNil(publicInputs["c_old"])
+        XCTAssertNotNil(publicInputs["c_new"])
+        XCTAssertEqual((publicInputs["epoch_old"] as? NSNumber)?.uint64Value, 1)
+    }
+
+    func test_getState_sendsGroupIdInGetStateEnvelope() async throws {
+        let entry = SEPCommitmentEntry(
+            commitment: Data(repeating: 0x09, count: 32),
+            epoch: 7,
+            timestamp: 1_700_000_000,
+            tier: 0,
+            active: true
+        )
+        let recorder = RecordingTransport(response: entry)
+        let client = SEPContractClient(contractID: testContractID, transport: recorder)
+
+        let result = try await client.getState(groupID: Data(repeating: 0x55, count: 32))
+        XCTAssertEqual(result, entry)
+
+        let json = try XCTUnwrap(recorder.lastJSON())
+        XCTAssertEqual(json["function"] as? String, "get_state")
+        let payload = try XCTUnwrap(json["payload"] as? [String: Any])
+        XCTAssertNotNil(payload["group_id"])
+    }
+
+    func test_urlSessionTransport_throwsOnNon2xx() async throws {
+        let url = URL(string: "https://example.invalid/contract")!
+        StubURLProtocol.set(handler: { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "text/plain"]
+            )!
+            return (Data("boom".utf8), response)
+        })
+        defer { StubURLProtocol.reset() }
+        let session = StubURLProtocol.makeSession()
+        let transport = URLSessionSEPContractTransport(endpoint: url, session: session)
+        let client = SEPContractClient(contractID: testContractID, transport: transport)
+
+        do {
+            _ = try await client.getState(groupID: Data(repeating: 0, count: 32))
+            XCTFail("expected SEPError.invalidResponse")
+        } catch let SEPError.invalidResponse(statusCode, body) {
+            XCTAssertEqual(statusCode, 500)
+            XCTAssertEqual(body, "boom")
+        }
+    }
+
+    func test_urlSessionTransport_decodes2xxResponse() async throws {
+        let url = URL(string: "https://example.invalid/contract")!
+        let stub = SEPSubmissionResponse(
+            accepted: true,
+            transactionHash: "deadbeef",
+            message: "ok"
+        )
+        let body = try JSONEncoder().encode(stub)
+        StubURLProtocol.set(handler: { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Content-Type"),
+                "application/json"
+            )
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (body, response)
+        })
+        defer { StubURLProtocol.reset() }
+        let session = StubURLProtocol.makeSession()
+        let transport = URLSessionSEPContractTransport(endpoint: url, session: session)
+        let client = SEPContractClient(contractID: testContractID, transport: transport)
+
+        let request = SEPCreateGroupV2Request(
+            caller: "GBABCDEF",
+            groupID: Data(repeating: 0, count: 32),
+            commitment: Data(repeating: 0, count: 32),
+            tier: 0,
+            groupType: .tyranny,
+            memberCount: 1,
+            proof: Data(),
+            publicInputs: SEPPublicInputs(commitment: Data(repeating: 0, count: 32), epoch: 0)
+        )
+        let response = try await client.createGroupV2(request)
+        XCTAssertEqual(response, stub)
+    }
+}
+
+// MARK: - Recording transport
+
+private final class RecordingTransport<Stub: Encodable & Sendable>: SEPContractTransport, @unchecked Sendable {
+    private let stub: Stub
+    private let lock = NSLock()
+    private var lastBody: Data?
+
+    init(response: Stub) {
+        self.stub = response
+    }
+
+    func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ invocation: SEPContractInvocation<Payload>,
+        responseType: Response.Type
+    ) async throws -> Response {
+        let encoded = try JSONEncoder().encode(invocation)
+        lock.withLock { lastBody = encoded }
+        let stubData = try JSONEncoder().encode(stub)
+        return try JSONDecoder().decode(Response.self, from: stubData)
+    }
+
+    func lastJSON() -> [String: Any]? {
+        guard let data = lock.withLock({ lastBody }) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+}


### PR DESCRIPTION
## Summary

PR-A of the 4-PR Create Group slice. Pure foundation: protocol seams +
URLSession contract client + value types + 19 passing unit tests. Zero
behavior change at the app level — nothing wires these in yet.

The 4 PRs:
- **PR-A (this one)**: foundation port — sealer protocol, contract
  client, ChatGroup/GovernanceMember/GroupCommitmentBuilder.
- PR-B: Tyranny proof generator (`Tyranny.proveCreate`) + group
  repository (SwiftData @Model with field-level encryption per #16).
- PR-C: Create Group UI + invitation send (paste-only invitee picker).
- PR-D: real-testnet E2E test gated on `ONYM_INTEGRATION=1`.

## What's in PR-A

| Layer | File | What it does |
|---|---|---|
| Identity | `InvitationEnvelopeSealing.swift` | Sender-side mirror of the existing decryption protocol. |
| Identity | `IdentityRepository.swift` | `+sealInvitation(payload:to:)` — fresh per-envelope X25519 keypair, AES-GCM-256 seal, M-5 Ed25519 attestation on the ephemeral pubkey. Secrets stay inside the actor. |
| Chain | `SEPContractTypes.swift` | Codable payloads (`SEPCreateGroupV2Request`, `SEPUpdateCommitmentRequest`, `SEPGetStateRequest`, `SEPSubmissionResponse`, …) with snake_case JSON keys. `SEPGroupType` extends swift-mls's enum with `.tyranny = 4`. |
| Chain | `SEPContractClient.swift` | URLSession-only port of swift-mls's `SEPContractClient` — no Stellar Soroban SDK, the relayer handles tx assembly. `SEPContractTransport` seam for tests. |
| Group | `ChatGroup.swift`, `GovernanceMember.swift` | Trimmed value types (no chat/avatar/push fields yet). |
| Group | `GroupCommitmentBuilder.swift` | OnymSDK.Common wrapper — Poseidon leaf hash + lex-sorted merkle root + 2-level commitment. Mirrors `SEPCommitmentBuilder` in swift-mls. |

## Settled scope (don't re-litigate)

- **Tyranny first.** Anarchy / OneOnOne stub in PR-B with a clear "not
  yet supported" error.
- **Paste-only invitee picker.** No QR scanner, no Contacts framework
  in the MVP.
- **Wait for at-least-one relay OK** before flipping the flow to
  `.success` (both chain anchor + invitation send).

## Test plan

- [x] 19 new unit tests pass on iPhone 17 Pro / iOS 26 simulator
- [x] Roundtrip seal → decrypt across two `IdentityRepository` instances
- [x] M-5 signature verifies against sender's stellarPublicKey
- [x] Fresh ephemeral keypair per `sealInvitation` call
- [x] `create_group_v2` payload uses snake_case keys (`group_id`, `group_type`, `member_count`, `public_inputs`)
- [x] `URLSessionSEPContractTransport` throws `SEPError.invalidResponse` on non-2xx
- [x] Lex-invariant merkle root regardless of insertion order
- [x] `deriveSalt` deterministic and matches SHA256(prev || memberKey)

## Cross-platform

Android catch-up prompt covering all 4 PRs lives at
`~/Desktop/android-create-group.md` — same scope decisions, mappings
called out (OkHttp + kotlinx.serialization for the relayer client,
Room for group persistence, BouncyCastle X25519 for the seal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)