### PR TITLE
group: Tyranny proof generator + group repository (PR-B of Create Group)

### DIFF
--- a/Sources/OnymIOS/Chain/GroupProofGenerator.swift
+++ b/Sources/OnymIOS/Chain/GroupProofGenerator.swift
@@ -1,0 +1,118 @@
+import Foundation
+import OnymSDK
+
+/// Output of `GroupProofGenerator.proveCreate`. The relayer / contract
+/// expect:
+/// - `proof` — 1568 bytes, the `Common.parsePlonkProof`-trimmed form of
+///   the raw 1601-byte SDK output (strips the four `len()` u64
+///   prefixes + the trailing `plookup_proof: None` byte).
+/// - `publicInputs` — the `(commitment, epoch)` pair the
+///   `SEPCreateGroupV2Request` carries. For create the SDK's
+///   per-type-specific PI bundle (`commitment || Fr(0) || …`) is sliced
+///   to its first 32 bytes for the commitment; epoch is always 0 for
+///   create.
+struct GroupCreateProof: Equatable, Sendable {
+    let proof: Data
+    let publicInputs: SEPPublicInputs
+}
+
+/// PR-B's chain seam for proof generation. Switches on `groupType` so
+/// that PR-C's interactor doesn't need to import OnymSDK directly. Only
+/// `.tyranny` is wired in this slice — the other governance types
+/// throw `notYetSupported`, which the UI surfaces as a clear "TBD"
+/// message rather than a silent fallback.
+protocol GroupProofGenerator: Sendable {
+    func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof
+}
+
+/// Inputs for a create-group proof. The caller (PR-C interactor) is
+/// responsible for:
+/// - lex-sorting `members` by `publicKeyCompressed` before computing
+///   `adminIndex` (the SDK reuses the same sort to validate
+///   `memberLeafHashes[adminIndex] == leafHash(adminBlsSecretKey)`),
+/// - generating a fresh 32-byte salt via `GroupCommitmentBuilder.generateSalt`,
+/// - choosing the tier based on the expected member count.
+struct GroupProofCreateInput: Sendable {
+    let groupType: SEPGroupType
+    let tier: SEPTier
+    /// Lex-sorted by `publicKeyCompressed`. The packed `leafHash`es
+    /// land in the prover in this order.
+    let members: [GovernanceMember]
+    /// 32 bytes BE — the sender's own BLS Fr scalar.
+    let adminBlsSecretKey: Data
+    /// Position of the admin in `members` (after the lex sort).
+    let adminIndex: Int
+    /// 32-byte raw group ID — used directly as the `group_id_fr`
+    /// per-group binding scalar in the Tyranny circuit.
+    let groupID: Data
+    /// 32 bytes; LE-mod-r in-circuit.
+    let salt: Data
+}
+
+enum GroupProofGeneratorError: Error, Equatable, Sendable {
+    case notYetSupported(SEPGroupType)
+    case adminIndexOutOfRange(index: Int, count: Int)
+    case sdkFailure(String)
+}
+
+struct OnymGroupProofGenerator: GroupProofGenerator {
+
+    init() {}
+
+    func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
+        switch input.groupType {
+        case .tyranny:
+            return try proveTyrannyCreate(input)
+        case .anarchy, .oneOnOne, .democracy, .oligarchy:
+            // PR-B ships Tyranny only — see `project_create_group_plan`
+            // memory note. The other types stay stubbed until their own
+            // slice; wiring them here without a UI to drive them just
+            // accumulates dead code.
+            throw GroupProofGeneratorError.notYetSupported(input.groupType)
+        }
+    }
+
+    private func proveTyrannyCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
+        guard input.adminIndex >= 0, input.adminIndex < input.members.count else {
+            throw GroupProofGeneratorError.adminIndexOutOfRange(
+                index: input.adminIndex,
+                count: input.members.count
+            )
+        }
+        var packedLeaves = Data(capacity: input.members.count * 32)
+        for member in input.members {
+            packedLeaves.append(member.leafHash)
+        }
+
+        let result: Tyranny.CreateProof
+        do {
+            result = try Tyranny.proveCreate(
+                depth: input.tier.depth,
+                memberLeafHashes: packedLeaves,
+                adminSecretKey: input.adminBlsSecretKey,
+                adminIndex: input.adminIndex,
+                groupIdFr: input.groupID,
+                salt: input.salt
+            )
+        } catch {
+            throw GroupProofGeneratorError.sdkFailure(String(describing: error))
+        }
+
+        let parsed: Data
+        do {
+            parsed = try Common.parsePlonkProof(result.proof)
+        } catch {
+            throw GroupProofGeneratorError.sdkFailure(String(describing: error))
+        }
+
+        // PI bundle layout (Tyranny.CreateProof):
+        //   commitment(32) || Fr(0)(32) || admin_pubkey_commitment(32) || group_id_fr(32)
+        // Only the first 32 bytes (commitment) cross the wire; the rest
+        // are bound by the proof itself.
+        let commitment = result.publicInputs.prefix(32)
+        return GroupCreateProof(
+            proof: parsed,
+            publicInputs: SEPPublicInputs(commitment: Data(commitment), epoch: 0)
+        )
+    }
+}

--- a/Sources/OnymIOS/Group/GroupRepository.swift
+++ b/Sources/OnymIOS/Group/GroupRepository.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Owns the `GroupStore` and exposes a reactive snapshots stream.
+/// Mirrors `IncomingInvitationsRepository`: every successful mutation
+/// is followed by a fresh snapshot pushed to all subscribers; the
+/// current list is replayed on every new subscribe.
+///
+/// This is the only thing in the codebase that holds a `GroupStore`
+/// reference. PR-C's `CreateGroupInteractor` calls `insert` /
+/// `markPublished` / `delete` and observes `snapshots`; views observe
+/// via the interactor.
+actor GroupRepository {
+    private let store: any GroupStore
+    private var cached: [ChatGroup] = []
+    private var continuations: [UUID: AsyncStream<[ChatGroup]>.Continuation] = [:]
+
+    init(store: any GroupStore) {
+        self.store = store
+    }
+
+    /// Idempotent on `group.id` (delegates to
+    /// `GroupStore.insertOrUpdate`). Any subsequent insert with the
+    /// same id overwrites the row in place — the chain-anchor flow
+    /// uses this to flip `isPublishedOnChain` and bump the
+    /// commitment.
+    @discardableResult
+    func insert(_ group: ChatGroup) async -> Bool {
+        let inserted = await store.insertOrUpdate(group)
+        await refreshFromStore()
+        return inserted
+    }
+
+    /// Mark a group as anchored on chain. The commitment, when
+    /// supplied, replaces whatever was held in memory (the relayer's
+    /// `get_state` is the source of truth post-anchor).
+    func markPublished(id: String, commitment: Data?) async {
+        await store.markPublished(id: id, commitment: commitment)
+        await refreshFromStore()
+    }
+
+    func delete(id: String) async {
+        await store.delete(id: id)
+        await refreshFromStore()
+    }
+
+    /// Force a refresh from the backing store. Used at app launch and
+    /// by tests; mutators call it themselves.
+    func reload() async {
+        await refreshFromStore()
+    }
+
+    nonisolated var snapshots: AsyncStream<[ChatGroup]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<[ChatGroup]>.Continuation
+    ) async {
+        if cached.isEmpty {
+            await refreshFromStore()
+        }
+        continuations[id] = continuation
+        continuation.yield(cached)
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func refreshFromStore() async {
+        cached = await store.list()
+        for continuation in continuations.values {
+            continuation.yield(cached)
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/GroupStore.swift
+++ b/Sources/OnymIOS/Group/GroupStore.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Persistence seam for chat groups. Async surface mirrors
+/// `InvitationStore` (PR #16) so a concrete impl can serialise writes
+/// on its own queue without forcing callers onto a specific actor.
+///
+/// `ChatGroup` itself is the domain shape; the store is responsible
+/// for AES-GCM-wrapping the sensitive columns at the boundary.
+protocol GroupStore: Sendable {
+    func list() async -> [ChatGroup]
+
+    /// Idempotent on `ChatGroup.id`: if the row exists, sensitive +
+    /// mutable fields are overwritten in place (so a chain-anchor
+    /// retry can flip `isPublishedOnChain` and bump the commitment
+    /// without losing the original `createdAt`). Returns `true` on
+    /// insert, `false` on update.
+    @discardableResult
+    func insertOrUpdate(_ group: ChatGroup) async -> Bool
+
+    /// Convenience for the post-anchor flow: flip
+    /// `isPublishedOnChain` to true and update the commitment to
+    /// whatever the relayer's `get_state` returned. No-op if the row
+    /// is missing.
+    func markPublished(id: String, commitment: Data?) async
+
+    func delete(id: String) async
+}

--- a/Sources/OnymIOS/Group/PersistedGroup.swift
+++ b/Sources/OnymIOS/Group/PersistedGroup.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SwiftData
+
+/// SwiftData row for one chat group on disk. Splits the schema into
+/// plain (queryable, non-identifying) and AES-GCM-encrypted (sensitive)
+/// columns — same pattern as `PersistedInvitation` (PR #16).
+///
+/// Plain:
+/// - `id` — 64-char hex of the 32-byte group ID. Already public on-chain
+///   (the contract stores it as the entry key), so encrypting locally
+///   would buy nothing while breaking dedup lookups.
+/// - `createdAt`, `epoch`, `tierRaw`, `groupTypeRaw`,
+///   `isPublishedOnChain` — small enums / counts; not user-identifying.
+///
+/// Encrypted (`StorageEncryption.encrypt`):
+/// - `name` — user-supplied; can leak intent.
+/// - `groupSecret` — drives all message-key derivation.
+/// - `membersJSON` — the lex-sorted roster (BLS pubkeys + leaf hashes).
+/// - `salt`, `commitment`, `adminPubkeyHex`.
+///
+/// Decryption boundary lives in `SwiftDataGroupStore`, not here —
+/// `PersistedGroup` is intentionally dumb storage so the @Model macro
+/// doesn't have to reason about CryptoKit types.
+@Model
+final class PersistedGroup {
+    @Attribute(.unique) var id: String
+    var createdAt: Date
+    var epoch: Int64
+    var tierRaw: Int
+    var groupTypeRaw: Int
+    var isPublishedOnChain: Bool
+
+    var encryptedName: Data
+    var encryptedGroupSecret: Data
+    var encryptedMembersJSON: Data
+    var encryptedSalt: Data
+    var encryptedCommitment: Data?
+    var encryptedAdminPubkeyHex: Data?
+
+    init(
+        id: String,
+        createdAt: Date,
+        epoch: Int64,
+        tierRaw: Int,
+        groupTypeRaw: Int,
+        isPublishedOnChain: Bool,
+        encryptedName: Data,
+        encryptedGroupSecret: Data,
+        encryptedMembersJSON: Data,
+        encryptedSalt: Data,
+        encryptedCommitment: Data?,
+        encryptedAdminPubkeyHex: Data?
+    ) {
+        self.id = id
+        self.createdAt = createdAt
+        self.epoch = epoch
+        self.tierRaw = tierRaw
+        self.groupTypeRaw = groupTypeRaw
+        self.isPublishedOnChain = isPublishedOnChain
+        self.encryptedName = encryptedName
+        self.encryptedGroupSecret = encryptedGroupSecret
+        self.encryptedMembersJSON = encryptedMembersJSON
+        self.encryptedSalt = encryptedSalt
+        self.encryptedCommitment = encryptedCommitment
+        self.encryptedAdminPubkeyHex = encryptedAdminPubkeyHex
+    }
+}

--- a/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
+++ b/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
@@ -1,0 +1,158 @@
+import Foundation
+import SwiftData
+
+/// SwiftData-backed `GroupStore`. Owns one `ModelContainer` for the
+/// group schema; each call hops to this actor's executor so concurrent
+/// saves don't fight over `ModelContext`. Same shape as
+/// `SwiftDataInvitationStore`.
+actor SwiftDataGroupStore: GroupStore {
+    private let container: ModelContainer
+    private let context: ModelContext
+
+    /// Production initializer — on-disk SQLite under
+    /// `Application Support/OnymIOS/Groups.store`, with
+    /// `FileProtectionType.complete` on the directory.
+    init() throws {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        )[0]
+        let storeDir = appSupport.appendingPathComponent("OnymIOS", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: storeDir,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        let url = storeDir.appendingPathComponent("Groups.store")
+        let schema = Schema([PersistedGroup.self])
+        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        self.container = container
+        self.context = ModelContext(container)
+    }
+
+    /// In-memory factory for tests.
+    static func inMemory() -> SwiftDataGroupStore {
+        let schema = Schema([PersistedGroup.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: [config])
+        return SwiftDataGroupStore(container: container)
+    }
+
+    private init(container: ModelContainer) {
+        self.container = container
+        self.context = ModelContext(container)
+    }
+
+    // MARK: - GroupStore
+
+    func list() -> [ChatGroup] {
+        let descriptor = FetchDescriptor<PersistedGroup>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        guard let rows = try? context.fetch(descriptor) else { return [] }
+        return rows.compactMap(Self.decode)
+    }
+
+    @discardableResult
+    func insertOrUpdate(_ group: ChatGroup) -> Bool {
+        guard let encoded = try? Self.encode(group) else { return false }
+
+        let id = group.id
+        let descriptor = FetchDescriptor<PersistedGroup>(
+            predicate: #Predicate { $0.id == id }
+        )
+        if let existing = try? context.fetch(descriptor).first {
+            existing.epoch = encoded.epoch
+            existing.tierRaw = encoded.tierRaw
+            existing.groupTypeRaw = encoded.groupTypeRaw
+            existing.isPublishedOnChain = encoded.isPublishedOnChain
+            existing.encryptedName = encoded.encryptedName
+            existing.encryptedGroupSecret = encoded.encryptedGroupSecret
+            existing.encryptedMembersJSON = encoded.encryptedMembersJSON
+            existing.encryptedSalt = encoded.encryptedSalt
+            existing.encryptedCommitment = encoded.encryptedCommitment
+            existing.encryptedAdminPubkeyHex = encoded.encryptedAdminPubkeyHex
+            try? context.save()
+            return false
+        }
+
+        context.insert(encoded)
+        try? context.save()
+        return true
+    }
+
+    func markPublished(id: String, commitment: Data?) {
+        let descriptor = FetchDescriptor<PersistedGroup>(
+            predicate: #Predicate { $0.id == id }
+        )
+        guard let row = try? context.fetch(descriptor).first else { return }
+        row.isPublishedOnChain = true
+        if let commitment {
+            row.encryptedCommitment = (try? StorageEncryption.encrypt(commitment))
+                ?? row.encryptedCommitment
+        }
+        try? context.save()
+    }
+
+    func delete(id: String) {
+        let descriptor = FetchDescriptor<PersistedGroup>(
+            predicate: #Predicate { $0.id == id }
+        )
+        if let rows = try? context.fetch(descriptor) {
+            for row in rows { context.delete(row) }
+        }
+        try? context.save()
+    }
+
+    // MARK: - Mapping
+
+    private static func encode(_ group: ChatGroup) throws -> PersistedGroup {
+        let membersJSON = try JSONEncoder().encode(group.members)
+        return PersistedGroup(
+            id: group.id,
+            createdAt: group.createdAt,
+            epoch: Int64(bitPattern: group.epoch),
+            tierRaw: group.tier.rawValue,
+            groupTypeRaw: Int(group.groupType.rawValue),
+            isPublishedOnChain: group.isPublishedOnChain,
+            encryptedName: try StorageEncryption.encrypt(group.name),
+            encryptedGroupSecret: try StorageEncryption.encrypt(group.groupSecret),
+            encryptedMembersJSON: try StorageEncryption.encrypt(membersJSON),
+            encryptedSalt: try StorageEncryption.encrypt(group.salt),
+            encryptedCommitment: try group.commitment.map(StorageEncryption.encrypt),
+            encryptedAdminPubkeyHex: try group.adminPubkeyHex.map(StorageEncryption.encrypt)
+        )
+    }
+
+    private static func decode(_ row: PersistedGroup) -> ChatGroup? {
+        guard
+            let name = try? StorageEncryption.decryptString(row.encryptedName),
+            let groupSecret = try? StorageEncryption.decrypt(row.encryptedGroupSecret),
+            let membersJSON = try? StorageEncryption.decrypt(row.encryptedMembersJSON),
+            let members = try? JSONDecoder().decode([GovernanceMember].self, from: membersJSON),
+            let salt = try? StorageEncryption.decrypt(row.encryptedSalt),
+            let tier = SEPTier(rawValue: row.tierRaw),
+            let groupType = SEPGroupType(rawValue: UInt32(row.groupTypeRaw))
+        else {
+            return nil
+        }
+        let commitment = row.encryptedCommitment.flatMap { try? StorageEncryption.decrypt($0) }
+        let adminPubkeyHex = row.encryptedAdminPubkeyHex.flatMap {
+            try? StorageEncryption.decryptString($0)
+        }
+        return ChatGroup(
+            id: row.id,
+            name: name,
+            groupSecret: groupSecret,
+            createdAt: row.createdAt,
+            members: members,
+            epoch: UInt64(bitPattern: row.epoch),
+            salt: salt,
+            commitment: commitment,
+            tier: tier,
+            groupType: groupType,
+            adminPubkeyHex: adminPubkeyHex,
+            isPublishedOnChain: row.isPublishedOnChain
+        )
+    }
+}

--- a/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
+++ b/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+import OnymSDK
+@testable import OnymIOS
+
+/// Real proof generation against the OnymSDK Tyranny circuit. The tier
+/// is `.small` (depth 5) — fastest to prove (~1s on the simulator) but
+/// still goes through the full circuit so the byte sizes asserted here
+/// would catch any drift in `Tyranny.CreateProof.publicInputs` layout.
+final class GroupProofGeneratorTests: XCTestCase {
+
+    func test_proveCreate_tyranny_returnsParsedProofAndCommitment() throws {
+        let secrets = (1...3).map(fr)
+        let members = try secrets.map { sk in
+            GovernanceMember(
+                publicKeyCompressed: try Common.publicKey(secretKey: sk),
+                leafHash: try Common.leafHash(secretKey: sk)
+            )
+        }
+        let sorted = members.sorted { lhs, rhs in
+            lhs.publicKeyCompressed.lexicographicallyPrecedes(rhs.publicKeyCompressed)
+        }
+        let adminSecret = secrets[0]
+        let adminLeaf = try Common.leafHash(secretKey: adminSecret)
+        let adminIndex = sorted.firstIndex(where: { $0.leafHash == adminLeaf })!
+
+        let input = GroupProofCreateInput(
+            groupType: .tyranny,
+            tier: .small,
+            members: sorted,
+            adminBlsSecretKey: adminSecret,
+            adminIndex: adminIndex,
+            groupID: fr(0x7777),
+            salt: Data(repeating: 0xEE, count: 32)
+        )
+
+        let result = try OnymGroupProofGenerator().proveCreate(input)
+        XCTAssertEqual(result.proof.count, 1568, "Common.parsePlonkProof trims the 1601-byte raw output")
+        XCTAssertEqual(result.publicInputs.commitment.count, 32)
+        XCTAssertEqual(result.publicInputs.epoch, 0, "create-group is always epoch 0")
+    }
+
+    func test_proveCreate_anarchy_throwsNotYetSupported() {
+        let input = stubInput(groupType: .anarchy)
+        XCTAssertThrowsError(try OnymGroupProofGenerator().proveCreate(input)) { error in
+            XCTAssertEqual(
+                error as? GroupProofGeneratorError,
+                .notYetSupported(.anarchy)
+            )
+        }
+    }
+
+    func test_proveCreate_oneOnOne_throwsNotYetSupported() {
+        let input = stubInput(groupType: .oneOnOne)
+        XCTAssertThrowsError(try OnymGroupProofGenerator().proveCreate(input)) { error in
+            XCTAssertEqual(
+                error as? GroupProofGeneratorError,
+                .notYetSupported(.oneOnOne)
+            )
+        }
+    }
+
+    func test_proveCreate_adminIndexOutOfRange_throws() {
+        let input = GroupProofCreateInput(
+            groupType: .tyranny,
+            tier: .small,
+            members: [
+                GovernanceMember(
+                    publicKeyCompressed: Data(repeating: 0xAA, count: 48),
+                    leafHash: Data(repeating: 0xBB, count: 32)
+                )
+            ],
+            adminBlsSecretKey: Data(repeating: 0x01, count: 32),
+            adminIndex: 5,
+            groupID: Data(repeating: 0, count: 32),
+            salt: Data(repeating: 0, count: 32)
+        )
+        XCTAssertThrowsError(try OnymGroupProofGenerator().proveCreate(input)) { error in
+            XCTAssertEqual(
+                error as? GroupProofGeneratorError,
+                .adminIndexOutOfRange(index: 5, count: 1)
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func stubInput(groupType: SEPGroupType) -> GroupProofCreateInput {
+        GroupProofCreateInput(
+            groupType: groupType,
+            tier: .small,
+            members: [],
+            adminBlsSecretKey: Data(repeating: 0x01, count: 32),
+            adminIndex: 0,
+            groupID: Data(repeating: 0, count: 32),
+            salt: Data(repeating: 0, count: 32)
+        )
+    }
+
+    /// 32-byte BE encoding of a small u64 — copied from the OnymSDK
+    /// test helpers, can't import them here.
+    private func fr(_ value: UInt64) -> Data {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        for i in 0..<8 {
+            bytes[31 - i] = UInt8((value >> (i * 8)) & 0xFF)
+        }
+        return Data(bytes)
+    }
+}

--- a/Tests/OnymIOSTests/GroupRepositoryTests.swift
+++ b/Tests/OnymIOSTests/GroupRepositoryTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import OnymIOS
+
+/// Reactive-surface tests for `GroupRepository`. Backed by an in-memory
+/// `GroupStore` fake so the SwiftData layer doesn't pull in the
+/// Keychain-dependent `StorageEncryption` here — that's covered by
+/// `SwiftDataGroupStoreTests`. Mirrors `IncomingInvitationsRepositoryTests`.
+final class GroupRepositoryTests: XCTestCase {
+
+    func test_snapshots_replaysCurrentOnSubscribe() async throws {
+        let store = InMemoryGroupStore()
+        let group = makeGroup(id: "aa".repeated(32), name: "Family")
+        await store.preload([group])
+        let repo = GroupRepository(store: store)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first?.count, 1)
+        XCTAssertEqual(first?.first?.id, group.id)
+    }
+
+    func test_insert_broadcastsNewSnapshot() async throws {
+        let store = InMemoryGroupStore()
+        let repo = GroupRepository(store: store)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        _ = await iterator.next()  // initial empty snapshot
+
+        let group = makeGroup(id: "bb".repeated(32), name: "Friends")
+        let inserted = await repo.insert(group)
+        XCTAssertTrue(inserted)
+
+        let next = await iterator.next()
+        XCTAssertEqual(next?.count, 1)
+        XCTAssertEqual(next?.first?.name, "Friends")
+    }
+
+    func test_markPublished_broadcastsUpdatedSnapshot() async throws {
+        let store = InMemoryGroupStore()
+        let group = makeGroup(id: "cc".repeated(32), name: "G")
+        await store.preload([group])
+        let repo = GroupRepository(store: store)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        _ = await iterator.next()
+
+        let onchainCommitment = Data(repeating: 0x42, count: 32)
+        await repo.markPublished(id: group.id, commitment: onchainCommitment)
+
+        let next = await iterator.next()
+        XCTAssertEqual(next?.first?.isPublishedOnChain, true)
+        XCTAssertEqual(next?.first?.commitment, onchainCommitment)
+    }
+
+    func test_delete_emptiesSnapshot() async throws {
+        let store = InMemoryGroupStore()
+        let group = makeGroup(id: "dd".repeated(32), name: "G")
+        await store.preload([group])
+        let repo = GroupRepository(store: store)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        _ = await iterator.next()
+
+        await repo.delete(id: group.id)
+        let next = await iterator.next()
+        XCTAssertEqual(next?.count, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeGroup(id: String, name: String) -> ChatGroup {
+        ChatGroup(
+            id: id,
+            name: name,
+            groupSecret: Data(repeating: 0x33, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x44, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: nil,
+            isPublishedOnChain: false
+        )
+    }
+}
+
+/// Reusable in-memory fake; lives next to the test that uses it
+/// because PR-B has only one consumer. Promote to `Tests/Support/`
+/// when PR-C's interactor tests grow a second one.
+private actor InMemoryGroupStore: GroupStore {
+    private var rows: [String: ChatGroup] = [:]
+
+    func preload(_ groups: [ChatGroup]) {
+        for group in groups { rows[group.id] = group }
+    }
+
+    func list() -> [ChatGroup] {
+        rows.values.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    @discardableResult
+    func insertOrUpdate(_ group: ChatGroup) -> Bool {
+        let isNew = rows[group.id] == nil
+        rows[group.id] = group
+        return isNew
+    }
+
+    func markPublished(id: String, commitment: Data?) {
+        guard var existing = rows[id] else { return }
+        existing.isPublishedOnChain = true
+        if let commitment {
+            existing.commitment = commitment
+        }
+        rows[id] = existing
+    }
+
+    func delete(id: String) {
+        rows.removeValue(forKey: id)
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import OnymIOS
+
+/// Round-trip tests for `SwiftDataGroupStore`. Uses
+/// `SwiftDataGroupStore.inMemory()` so the on-disk store under
+/// Application Support isn't touched. Encrypted columns go through
+/// the real `StorageEncryption` (the storage root key lives in the
+/// shared Keychain — same dependency every other persistence test in
+/// this target has).
+final class SwiftDataGroupStoreTests: XCTestCase {
+
+    private var store: SwiftDataGroupStore!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        store = SwiftDataGroupStore.inMemory()
+    }
+
+    override func tearDown() async throws {
+        store = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Round-trip
+
+    func test_insertOrUpdate_thenList_roundtripsAllFields() async {
+        let group = makeGroup(
+            id: "aa".repeated(32),
+            name: "Family",
+            adminPubkeyHex: "ee".repeated(48)
+        )
+        let inserted = await store.insertOrUpdate(group)
+        XCTAssertTrue(inserted)
+
+        let listed = await store.list()
+        XCTAssertEqual(listed.count, 1)
+        let first = listed[0]
+        XCTAssertEqual(first.id, group.id)
+        XCTAssertEqual(first.name, "Family")
+        XCTAssertEqual(first.groupSecret, group.groupSecret)
+        XCTAssertEqual(first.salt, group.salt)
+        XCTAssertEqual(first.commitment, group.commitment)
+        XCTAssertEqual(first.tier, .small)
+        XCTAssertEqual(first.groupType, .tyranny)
+        XCTAssertEqual(first.adminPubkeyHex, "ee".repeated(48))
+        XCTAssertEqual(first.epoch, group.epoch)
+        XCTAssertFalse(first.isPublishedOnChain)
+        XCTAssertEqual(first.members.count, group.members.count)
+        XCTAssertEqual(first.members.first?.publicKeyCompressed,
+                       group.members.first?.publicKeyCompressed)
+    }
+
+    // MARK: - Idempotence
+
+    func test_insertOrUpdate_secondCallUpdatesInPlace() async {
+        let original = makeGroup(id: "bb".repeated(32), name: "Old name")
+        _ = await store.insertOrUpdate(original)
+
+        var updated = original
+        updated.epoch = 7
+        updated.commitment = Data(repeating: 0x99, count: 32)
+        let inserted = await store.insertOrUpdate(updated)
+        XCTAssertFalse(inserted, "second insertOrUpdate on the same id is an update")
+
+        let listed = await store.list()
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed[0].epoch, 7)
+        XCTAssertEqual(listed[0].commitment, Data(repeating: 0x99, count: 32))
+    }
+
+    // MARK: - markPublished
+
+    func test_markPublished_flipsFlagAndStoresCommitment() async {
+        let group = makeGroup(id: "cc".repeated(32), name: "G")
+        _ = await store.insertOrUpdate(group)
+
+        let onchainCommitment = Data(repeating: 0x42, count: 32)
+        await store.markPublished(id: group.id, commitment: onchainCommitment)
+
+        let listed = await store.list()
+        XCTAssertTrue(listed[0].isPublishedOnChain)
+        XCTAssertEqual(listed[0].commitment, onchainCommitment)
+    }
+
+    func test_markPublished_unknownIdIsNoOp() async {
+        await store.markPublished(id: "ff".repeated(32), commitment: nil)
+        let listed = await store.list()
+        XCTAssertTrue(listed.isEmpty)
+    }
+
+    // MARK: - delete
+
+    func test_delete_removesRow() async {
+        let group = makeGroup(id: "dd".repeated(32), name: "G")
+        _ = await store.insertOrUpdate(group)
+        let beforeDelete = await store.list()
+        XCTAssertEqual(beforeDelete.count, 1)
+
+        await store.delete(id: group.id)
+        let afterDelete = await store.list()
+        XCTAssertTrue(afterDelete.isEmpty)
+    }
+
+    // MARK: - sort
+
+    func test_list_sortsByCreatedAtDescending() async {
+        let older = makeGroup(
+            id: "01".repeated(32),
+            name: "older",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let newer = makeGroup(
+            id: "02".repeated(32),
+            name: "newer",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_500)
+        )
+        _ = await store.insertOrUpdate(older)
+        _ = await store.insertOrUpdate(newer)
+
+        let listed = await store.list()
+        XCTAssertEqual(listed.map(\.id), [newer.id, older.id])
+    }
+
+    // MARK: - Helpers
+
+    private func makeGroup(
+        id: String,
+        name: String,
+        adminPubkeyHex: String? = nil,
+        createdAt: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    ) -> ChatGroup {
+        let member = GovernanceMember(
+            publicKeyCompressed: Data(repeating: 0x11, count: 48),
+            leafHash: Data(repeating: 0x22, count: 32)
+        )
+        return ChatGroup(
+            id: id,
+            name: name,
+            groupSecret: Data(repeating: 0x33, count: 32),
+            createdAt: createdAt,
+            members: [member],
+            epoch: 0,
+            salt: Data(repeating: 0x44, count: 32),
+            commitment: Data(repeating: 0x55, count: 32),
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: adminPubkeyHex,
+            isPublishedOnChain: false
+        )
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}


### PR DESCRIPTION
## Summary

PR-B of the 4-PR Create Group slice. Builds on PR-A (#24, merged):
foundation types are in place; this PR adds the chain seam that turns
a roster into a PLONK proof, plus the SwiftData persistence + reactive
repository for groups. Still no UI — that lands in PR-C.

The 4 PRs:
- PR-A (#24, **merged**): foundation port — sealer protocol, contract
  client, ChatGroup/GovernanceMember/GroupCommitmentBuilder.
- **PR-B (this one)**: Tyranny proof generator + group repository.
- PR-C: Create Group UI + invitation send (paste-only invitee picker).
- PR-D: real-testnet E2E test gated on `ONYM_INTEGRATION=1`.

## What's in PR-B

| Layer | File | What it does |
|---|---|---|
| Chain | `GroupProofGenerator.swift` | Protocol + `OnymGroupProofGenerator`. `.tyranny` calls `Tyranny.proveCreate`, parses the raw 1601-byte plonk proof down to the 1568-byte wire form via `Common.parsePlonkProof`, slices the first 32 bytes of the SDK PI bundle as the on-wire commitment, pins `epoch = 0` for create. Anarchy / OneOnOne / Democracy / Oligarchy throw `.notYetSupported`. |
| Group | `PersistedGroup.swift` | SwiftData `@Model`. Plain columns: `id` (hex, on-chain anyway), `createdAt`, `epoch`, `tierRaw`, `groupTypeRaw`, `isPublishedOnChain`. AES-GCM-encrypted: `name`, `groupSecret`, `membersJSON`, `salt`, `commitment`, `adminPubkeyHex`. Same StorageEncryption pattern as `PersistedInvitation` (#16). |
| Group | `GroupStore.swift`, `SwiftDataGroupStore.swift` | Actor mirror of `SwiftDataInvitationStore`. `insertOrUpdate` is idempotent on `id` so the post-anchor flow can flip `isPublishedOnChain` + bump `commitment` in place; `markPublished` + `delete` + sorted-by-`createdAt` list. Encrypt/decrypt at the boundary; `@Model` stays dumb. |
| Group | `GroupRepository.swift` | Actor mirror of `IncomingInvitationsRepository`. `snapshots: AsyncStream<[ChatGroup]>` replays current on subscribe; mutators rebroadcast. Only thing in the codebase that holds a `GroupStore` reference. |

## Tyranny only — by design

Per the settled scope, only `.tyranny` is wired in this PR. The other
governance types throw `GroupProofGeneratorError.notYetSupported(type)`
which PR-C surfaces as a clear "TBD" message. Anarchy / 1v1 ship as a
separate slice once Tyranny is end-to-end green on testnet.

## Test plan

14 tests pass on iPhone 17 Pro / iOS 26 simulator.

- [x] Real `Tyranny.proveCreate` at depth 5 returns 1568-byte parsed proof + 32-byte commitment + epoch 0 (~3.5s; full-circuit prove + parse)
- [x] `.anarchy` / `.oneOnOne` throw `.notYetSupported(type)`
- [x] `adminIndex` out-of-range throws before hitting the SDK
- [x] SwiftData encrypted columns roundtrip — name, groupSecret, members, salt, commitment, adminPubkeyHex all decrypt to the original values
- [x] `insertOrUpdate` is idempotent on `id`; second call updates in place (epoch + commitment bumped)
- [x] `markPublished` flips `isPublishedOnChain` + replaces commitment; unknown id is no-op
- [x] `list()` sorts by `createdAt` descending
- [x] Repository `snapshots` replays current on subscribe
- [x] `insert` / `markPublished` / `delete` each broadcast a fresh snapshot

## Architecture compliance

Mirrors PR #15's touch-surface table.

- `GroupProofGenerator` (chain seam) imports `OnymSDK` only.
- `GroupRepository` (repository) holds `GroupStore` only; never imports OnymSDK or URLSession.
- `SwiftDataGroupStore` (persistence) imports `SwiftData` + `StorageEncryption` only.

## Out of scope (defers to PR-C)

- Wiring into `AppDependencies` / `OnymIOSApp.init`.
- The `CreateGroupInteractor` that orchestrates `proveCreate` →
  `SEPContractClient.createGroupV2` → `GroupRepository.insert` →
  `markPublished` → invitation send.
- All UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)