### PR TITLE
group: Create Group UI flow + interactor wiring (PR-C of Create Group)

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -9,4 +9,5 @@ struct AppDependencies {
     let makeRecoveryPhraseBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
     let makeRelayerSettingsFlow: @MainActor () -> RelayerSettingsFlow
     let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
+    let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
 }

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -1,0 +1,264 @@
+import Foundation
+import Observation
+
+/// The five routes the design's flow walks through. Each screen
+/// renders based on `flow.route`; transitions are driven by
+/// view-side intents (next, back, addInvitee, submit, etc).
+enum CreateGroupRoute: Equatable, Sendable {
+    case step1            // name + accent + governance
+    case step2            // review invitees + create
+    case inviteByKey      // paste 64-char inbox key
+    case creating         // progress steps
+    case success          // hero + members + done
+}
+
+/// One pasted-and-validated invitee. The 32-byte X25519 key is what
+/// the interactor needs; the hex-prefix label is what the UI
+/// renders (full hex is too long for a row).
+struct OnymInvitee: Equatable, Identifiable, Sendable {
+    let id: UUID
+    let inboxPublicKey: Data  // 32 bytes
+    /// Cached hex prefix for display ("a4f9b2…51"). Computed once at
+    /// add time so the SwiftUI list doesn't re-derive on every row.
+    let displayLabel: String
+}
+
+/// `@Observable @MainActor` driver for the five screens. Owns the
+/// form state, drives navigation, and runs the interactor pipeline.
+/// SwiftUI views read fields directly and call intent methods on tap.
+@MainActor
+@Observable
+final class CreateGroupFlow {
+    // MARK: - Form state
+
+    var name: String = ""
+    var accent: OnymAccent = .blue
+    /// Always `.tyranny` in PR-C — the picker disables the others.
+    var governance: OnymUIGovernance = .tyranny
+    var invitees: [OnymInvitee] = []
+
+    /// Bound to the InviteByKey screen's TextField.
+    var inviteeInput: String = ""
+    /// Inline error shown under the InviteByKey TextField. Cleared on
+    /// every keystroke.
+    var inviteeError: String?
+
+    // MARK: - Navigation + pipeline
+
+    var route: CreateGroupRoute = .step1
+    var progress: CreateGroupProgress?
+    /// Set when the interactor throws. Surface as a banner / inline
+    /// error in the Creating / Step1 / Step2 screens.
+    var error: CreateGroupError?
+    /// Populated when the pipeline finishes — drives Success screen
+    /// content (name + member count come from here, not `self.name`,
+    /// in case the user edits after submit).
+    var createdGroup: ChatGroup?
+
+    /// Tapped Cancel/Close from any screen — host (sheet presenter)
+    /// dismisses.
+    var onClose: @MainActor () -> Void = {}
+
+    private let interactor: CreateGroupInteractor
+
+    init(interactor: CreateGroupInteractor) {
+        self.interactor = interactor
+    }
+
+    // MARK: - Step 1 → Step 2
+
+    /// True when the name is non-empty and a valid governance type
+    /// is selected. Disables the Step1 "Next" button.
+    var canAdvanceToStep2: Bool {
+        !trimmedName.isEmpty && governance.isAvailable
+    }
+
+    func tappedNext() {
+        guard canAdvanceToStep2 else { return }
+        route = .step2
+    }
+
+    // MARK: - Step 2
+
+    func tappedInviteByKey() {
+        inviteeInput = ""
+        inviteeError = nil
+        route = .inviteByKey
+    }
+
+    func tappedBackFromStep2() {
+        route = .step1
+    }
+
+    func removeInvitee(at index: Int) {
+        guard invitees.indices.contains(index) else { return }
+        invitees.remove(at: index)
+    }
+
+    /// Label for the primary "Create" CTA. Mirrors the design
+    /// (`Create empty group` / `Create with N people`).
+    var createCTALabel: String {
+        if invitees.isEmpty { return "Create empty group" }
+        let n = invitees.count
+        return "Create with \(n) \(n == 1 ? "person" : "people")"
+    }
+
+    // MARK: - InviteByKey
+
+    func tappedAddInvitee() {
+        let cleaned = inviteeInput.replacingOccurrences(
+            of: "\\s+",
+            with: "",
+            options: .regularExpression
+        )
+        guard !cleaned.isEmpty else {
+            inviteeError = "Paste an inbox key to continue."
+            return
+        }
+        guard cleaned.count == 64 else {
+            inviteeError = "Inbox keys are 64 characters. You pasted \(cleaned.count)."
+            return
+        }
+        guard let raw = Data(hex: cleaned), raw.count == 32 else {
+            inviteeError = "That doesn\u{2019}t look like a valid inbox key."
+            return
+        }
+        let prefix = cleaned.prefix(6)
+        let suffix = cleaned.suffix(4)
+        let invitee = OnymInvitee(
+            id: UUID(),
+            inboxPublicKey: raw,
+            displayLabel: "\(prefix)\u{2026}\(suffix)"
+        )
+        invitees.append(invitee)
+        inviteeInput = ""
+        inviteeError = nil
+        route = .step2
+    }
+
+    func tappedCancelInviteByKey() {
+        route = .step2
+    }
+
+    /// Live char count for the InviteByKey field — matches the
+    /// design's `(43/64)` chip.
+    var inviteeInputCleanedLength: Int {
+        inviteeInput.replacingOccurrences(of: "\\s+", with: "", options: .regularExpression).count
+    }
+
+    var inviteeInputIsValid: Bool {
+        let cleaned = inviteeInput.replacingOccurrences(
+            of: "\\s+",
+            with: "",
+            options: .regularExpression
+        )
+        return cleaned.count == 64 && Data(hex: cleaned)?.count == 32
+    }
+
+    // MARK: - Submit
+
+    func tappedCreate() {
+        Task { await submit() }
+    }
+
+    /// Run the interactor pipeline. Updates `progress` from each
+    /// `CreateGroupProgress` event the interactor reports, then
+    /// transitions to `.success` on completion or sets `error` on
+    /// failure. Public for tests; production code dispatches via
+    /// `tappedCreate`.
+    func submit() async {
+        guard governance.isAvailable else {
+            error = .noContractBinding(governance.sepGroupType.governanceType)
+            return
+        }
+        error = nil
+        progress = .validating
+        route = .creating
+
+        do {
+            let invitees = self.invitees.map(\.inboxPublicKey)
+            let group = try await interactor.create(
+                name: name,
+                invitees: invitees,
+                onProgress: { [weak self] p in
+                    Task { @MainActor in self?.progress = p }
+                }
+            )
+            createdGroup = group
+            progress = nil
+            route = .success
+        } catch let err as CreateGroupError {
+            error = err
+            progress = nil
+            // Stay on .creating to show the error banner; the user
+            // can dismiss back to step2/step1 from there.
+        } catch {
+            self.error = .sdkFailure(String(describing: error))
+            progress = nil
+        }
+    }
+
+    // MARK: - Success / reset
+
+    func tappedDone() {
+        reset()
+        onClose()
+    }
+
+    func tappedDismissError() {
+        error = nil
+        route = .step2
+    }
+
+    private func reset() {
+        name = ""
+        accent = .blue
+        governance = .tyranny
+        invitees = []
+        inviteeInput = ""
+        inviteeError = nil
+        progress = nil
+        error = nil
+        createdGroup = nil
+        route = .step1
+    }
+
+    // MARK: - Helpers
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - SEPGroupType ↔ GovernanceType bridge
+
+private extension SEPGroupType {
+    /// Bridges to the GovernanceType used by `CreateGroupError.noContractBinding`.
+    var governanceType: GovernanceType {
+        switch self {
+        case .anarchy: .anarchy
+        case .oneOnOne: .oneonone
+        case .democracy: .democracy
+        case .oligarchy: .oligarchy
+        case .tyranny: .tyranny
+        }
+    }
+}
+
+// MARK: - Hex decoding
+
+private extension Data {
+    init?(hex: String) {
+        let cleaned = hex.lowercased()
+        guard cleaned.count.isMultiple(of: 2) else { return nil }
+        var data = Data(capacity: cleaned.count / 2)
+        var index = cleaned.startIndex
+        while index < cleaned.endIndex {
+            let next = cleaned.index(index, offsetBy: 2)
+            guard let byte = UInt8(cleaned[index..<next], radix: 16) else { return nil }
+            data.append(byte)
+            index = next
+        }
+        self = data
+    }
+}

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -1,0 +1,328 @@
+import CryptoKit
+import Foundation
+import Security
+
+/// Stateless orchestration for the create-group flow. Holds dependencies
+/// only — every call to `create` is independent. The view-model
+/// (`CreateGroupFlow`) owns the form state and progress; this type only
+/// knows how to drive a single end-to-end run.
+///
+/// ## Pipeline
+///
+/// 1. Validate name + invitees (caller already parsed hex → 32-byte
+///    X25519 pubkeys).
+/// 2. Resolve relayer URL (`RelayerRepository.selectURL`) +
+///    contract binding (`ContractsRepository.binding(for: testnet/tyranny)`).
+/// 3. Generate fresh `groupID` + `groupSecret` + `salt` (32 random
+///    bytes each).
+/// 4. Build the creator's `GovernanceMember` from the device's BLS
+///    secret (single-member roster at creation; future invitees join
+///    later via `update_commitment`).
+/// 5. Generate the Tyranny PLONK proof via `GroupProofGenerator`.
+/// 6. POST `create_group_v2` to the relayer; require
+///    `accepted == true`.
+/// 7. Insert the group locally via `GroupRepository.insert` then
+///    `markPublished` so a subscriber sees `isPublishedOnChain = true`
+///    immediately.
+/// 8. For each invitee: encode + seal the `GroupInvitationPayload`,
+///    send via `InboxTransport.send`, require `acceptedBy >= 1`. The
+///    group is already saved on disk at this point — invitation
+///    failures throw `CreateGroupError.invitationSendFailed` but
+///    leave the group durable so a future "retry invites" UI can
+///    pick it up.
+struct CreateGroupInteractor: Sendable {
+    let identity: IdentityRepository
+    let relayers: RelayerRepository
+    let contracts: ContractsRepository
+    let groups: GroupRepository
+    let proofGenerator: any GroupProofGenerator
+    let inboxTransport: any InboxTransport
+    /// Builds a `SEPContractTransport` from the relayer URL chosen
+    /// per-call. Injected so tests can swap in a fake without
+    /// touching `URLSession`.
+    let makeContractTransport: @Sendable (URL) -> any SEPContractTransport
+
+    init(
+        identity: IdentityRepository,
+        relayers: RelayerRepository,
+        contracts: ContractsRepository,
+        groups: GroupRepository,
+        proofGenerator: any GroupProofGenerator = OnymGroupProofGenerator(),
+        inboxTransport: any InboxTransport,
+        makeContractTransport: @escaping @Sendable (URL) -> any SEPContractTransport = { url in
+            URLSessionSEPContractTransport(endpoint: url)
+        }
+    ) {
+        self.identity = identity
+        self.relayers = relayers
+        self.contracts = contracts
+        self.groups = groups
+        self.proofGenerator = proofGenerator
+        self.inboxTransport = inboxTransport
+        self.makeContractTransport = makeContractTransport
+    }
+
+    /// Run the full pipeline. `onProgress` is called on the actor's
+    /// executor — pass `{ progress in Task { @MainActor in … } }` if
+    /// you need to update SwiftUI state from it.
+    func create(
+        name: String,
+        invitees: [Data],
+        onProgress: @Sendable (CreateGroupProgress) -> Void = { _ in }
+    ) async throws -> ChatGroup {
+        // 1. Validate
+        onProgress(.validating)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw CreateGroupError.invalidName
+        }
+        for (index, key) in invitees.enumerated() {
+            guard key.count == 32 else {
+                throw CreateGroupError.invalidInviteeKey(index: index)
+            }
+        }
+
+        // 2. Resolve relayer + contract
+        guard let relayerURL = await relayers.selectURL() else {
+            throw CreateGroupError.noActiveRelayer
+        }
+        let key = AnchorSelectionKey(network: .testnet, type: .tyranny)
+        guard let binding = await contracts.binding(for: key) else {
+            throw CreateGroupError.noContractBinding(.tyranny)
+        }
+
+        // 3. Group params
+        let groupID = Self.randomBytes(32)
+        let groupSecret = Self.randomBytes(32)
+        let salt = GroupCommitmentBuilder.generateSalt()
+        let tier: SEPTier = .small
+
+        // 4. Creator member (BLS pubkey + Poseidon leaf hash).
+        let blsSecret: Data
+        do {
+            blsSecret = try await identity.blsSecretKey()
+        } catch {
+            throw CreateGroupError.missingIdentity
+        }
+        guard let identitySnapshot = await identity.currentIdentity() else {
+            throw CreateGroupError.missingIdentity
+        }
+        let creatorMember: GovernanceMember
+        do {
+            creatorMember = GovernanceMember(
+                publicKeyCompressed: identitySnapshot.blsPublicKey,
+                leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: blsSecret)
+            )
+        } catch {
+            throw CreateGroupError.sdkFailure(String(describing: error))
+        }
+        let members = [creatorMember]  // already sorted (single-element list)
+
+        // 5. Generate proof
+        onProgress(.proving)
+        let input = GroupProofCreateInput(
+            groupType: .tyranny,
+            tier: tier,
+            members: members,
+            adminBlsSecretKey: blsSecret,
+            adminIndex: 0,
+            groupID: groupID,
+            salt: salt
+        )
+        let proof: GroupCreateProof
+        do {
+            proof = try proofGenerator.proveCreate(input)
+        } catch let err as GroupProofGeneratorError {
+            throw CreateGroupError.proofGenerationFailed(err)
+        } catch {
+            throw CreateGroupError.sdkFailure(String(describing: error))
+        }
+
+        // 6. Anchor on chain
+        onProgress(.anchoring)
+        let transport = makeContractTransport(relayerURL)
+        let client = SEPContractClient(contractID: binding.contractID, transport: transport)
+        let request = SEPCreateGroupV2Request(
+            caller: identitySnapshot.stellarAccountID,
+            groupID: groupID,
+            commitment: proof.publicInputs.commitment,
+            tier: UInt32(tier.rawValue),
+            groupType: .tyranny,
+            memberCount: UInt32(members.count),
+            proof: proof.proof,
+            publicInputs: proof.publicInputs
+        )
+        let response: SEPSubmissionResponse
+        do {
+            response = try await client.createGroupV2(request)
+        } catch {
+            throw CreateGroupError.anchorTransport(String(describing: error))
+        }
+        guard response.accepted else {
+            throw CreateGroupError.anchorRejected(message: response.message)
+        }
+
+        // 7. Save locally
+        let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+        let adminPubkeyHex = identitySnapshot.blsPublicKey
+            .map { String(format: "%02x", $0) }.joined()
+        let group = ChatGroup(
+            id: groupIDHex,
+            name: trimmedName,
+            groupSecret: groupSecret,
+            createdAt: Date(),
+            members: members,
+            epoch: 0,
+            salt: salt,
+            commitment: proof.publicInputs.commitment,
+            tier: tier,
+            groupType: .tyranny,
+            adminPubkeyHex: adminPubkeyHex,
+            isPublishedOnChain: false
+        )
+        _ = await groups.insert(group)
+        await groups.markPublished(id: group.id, commitment: proof.publicInputs.commitment)
+
+        // 8. Send invitations
+        if !invitees.isEmpty {
+            onProgress(.sendingInvitations(total: invitees.count))
+            let payload = GroupInvitationPayload(
+                version: 1,
+                groupID: groupID,
+                groupSecret: groupSecret,
+                name: trimmedName,
+                members: members,
+                epoch: 0,
+                salt: salt,
+                commitment: proof.publicInputs.commitment,
+                tierRaw: tier.rawValue,
+                groupTypeRaw: SEPGroupType.tyranny.rawValue,
+                adminPubkeyHex: adminPubkeyHex
+            )
+            let payloadBytes: Data
+            do {
+                payloadBytes = try JSONEncoder().encode(payload)
+            } catch {
+                throw CreateGroupError.invitationEncodingFailed
+            }
+            for (index, inboxKey) in invitees.enumerated() {
+                let sealed: Data
+                do {
+                    sealed = try await identity.sealInvitation(
+                        payload: payloadBytes,
+                        to: inboxKey
+                    )
+                } catch {
+                    throw CreateGroupError.invitationSendFailed(
+                        index: index,
+                        reason: String(describing: error)
+                    )
+                }
+                let inboxTag = Self.inboxTag(from: inboxKey)
+                let receipt: PublishReceipt
+                do {
+                    receipt = try await inboxTransport.send(
+                        sealed,
+                        to: TransportInboxID(rawValue: inboxTag)
+                    )
+                } catch {
+                    throw CreateGroupError.invitationSendFailed(
+                        index: index,
+                        reason: String(describing: error)
+                    )
+                }
+                guard receipt.acceptedBy >= 1 else {
+                    throw CreateGroupError.invitationSendFailed(
+                        index: index,
+                        reason: "no relay accepted the invitation"
+                    )
+                }
+            }
+        }
+
+        // The flag was already flipped via `markPublished`; reload our
+        // in-memory snapshot to mirror the on-disk state.
+        return await groups.snapshots.first(where: { $0.contains { $0.id == group.id } })?
+            .first { $0.id == group.id }
+            ?? group
+    }
+
+    // MARK: - Helpers
+
+    /// Same derivation as `IdentityRepository.inboxTag(from:)` —
+    /// duplicated here because the repo's helper is private and we
+    /// only need the formula, not the keychain lookup.
+    private static func inboxTag(from inboxPublicKey: Data) -> String {
+        var hasher = SHA256()
+        hasher.update(data: Data("sep-inbox-v1".utf8))
+        hasher.update(data: inboxPublicKey)
+        let hash = hasher.finalize()
+        return hash.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func randomBytes(_ count: Int) -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        _ = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        return Data(bytes)
+    }
+}
+
+enum CreateGroupProgress: Equatable, Sendable {
+    case validating
+    case proving
+    case anchoring
+    case sendingInvitations(total: Int)
+}
+
+enum CreateGroupError: Error, Equatable, Sendable {
+    case invalidName
+    case invalidInviteeKey(index: Int)
+    case missingIdentity
+    case noActiveRelayer
+    case noContractBinding(GovernanceType)
+    case proofGenerationFailed(GroupProofGeneratorError)
+    case anchorTransport(String)
+    case anchorRejected(message: String?)
+    case invitationEncodingFailed
+    case invitationSendFailed(index: Int, reason: String)
+    case sdkFailure(String)
+}
+
+extension CreateGroupError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidName: return "Group name cannot be empty"
+        case let .invalidInviteeKey(index):
+            return "Invitee #\(index + 1) is not a 32-byte X25519 public key"
+        case .missingIdentity: return "No identity is loaded — bootstrap or restore first"
+        case .noActiveRelayer: return "No relayer is configured"
+        case let .noContractBinding(type):
+            return "No \(type.rawValue) contract is published yet — pick one in Settings → Anchors"
+        case let .proofGenerationFailed(err):
+            return err.localizedDescription
+        case let .anchorTransport(message):
+            return "Couldn't reach the relayer: \(message)"
+        case let .anchorRejected(message):
+            return "Relayer rejected the create: \(message ?? "(no message)")"
+        case .invitationEncodingFailed:
+            return "Couldn't encode the invitation payload"
+        case let .invitationSendFailed(index, reason):
+            return "Invitation #\(index + 1) failed: \(reason)"
+        case let .sdkFailure(message):
+            return "SDK failure: \(message)"
+        }
+    }
+}
+
+extension GroupProofGeneratorError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .notYetSupported(type):
+            return "\(type) is not supported yet — only Tyranny ships in this release"
+        case let .adminIndexOutOfRange(index, count):
+            return "Admin index \(index) is out of range for \(count) members"
+        case let .sdkFailure(message):
+            return "Proof generation failed: \(message)"
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -1,0 +1,1208 @@
+import SwiftUI
+
+/// Top-level view for the Create Group flow. Pixel-port of the
+/// Claude Designed reference (`onym-ios/project/Onym Create Group.html`)
+/// adapted to PR-C scope:
+///
+/// - Tyranny is the only selectable governance type. The 1-on-1 and
+///   Anarchy cards stay in the picker but are dimmed with a "Soon"
+///   pill — they ship in a follow-up slice.
+/// - The "Add People" screen replaces the design's Contacts list with
+///   a paste-only invitee list (Contacts framework is out of scope).
+/// - The "Invite by Inbox Key" screen drops the Scan QR button (no
+///   camera entitlement in the MVP).
+/// - The Creating screen wires its step list to real
+///   `CreateGroupProgress` events from the interactor.
+/// - The Success screen replaces "Open" + "Invite more" with a single
+///   "Done" CTA — there's no chat screen yet, and member-add via
+///   `update_commitment` is out of scope.
+///
+/// Hosted as a `.fullScreenCover` from Settings (see
+/// `SettingsView.tappedCreateGroup`).
+struct CreateGroupView: View {
+    @State var flow: CreateGroupFlow
+
+    init(flow: CreateGroupFlow) {
+        _flow = State(wrappedValue: flow)
+    }
+
+    var body: some View {
+        ZStack {
+            OnymTokens.bg.ignoresSafeArea()
+            currentScreen
+                .id(flow.route)
+                .transition(.opacity)
+        }
+        .preferredColorScheme(.dark)
+        .animation(.easeInOut(duration: 0.18), value: flow.route)
+    }
+
+    @ViewBuilder
+    private var currentScreen: some View {
+        switch flow.route {
+        case .step1: CreateGroupStep1View(flow: flow)
+        case .step2: CreateGroupStep2View(flow: flow)
+        case .inviteByKey: CreateGroupInviteByKeyView(flow: flow)
+        case .creating: CreateGroupCreatingView(flow: flow)
+        case .success: CreateGroupSuccessView(flow: flow)
+        }
+    }
+}
+
+// MARK: - Shared bits
+
+/// Centered title block used at the top of every screen
+/// (title-only nav per the design — back/cancel live in the footer).
+private struct OnymNavTitle: View {
+    let title: String
+    let subtitle: String?
+
+    var body: some View {
+        VStack(spacing: 1) {
+            Text(title)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(OnymTokens.text3)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
+    }
+}
+
+private struct OnymSectionLabel: View {
+    let text: String
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: 11, weight: .semibold))
+            .tracking(0.88)
+            .foregroundStyle(OnymTokens.text3)
+            .padding(.horizontal, 4)
+            .padding(.top, 22)
+            .padding(.bottom, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// Primary footer button (52pt tall, full-width, accent fill).
+private struct OnymPrimaryButton: View {
+    let title: String
+    var enabled: Bool = true
+    var accent: Color
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 16, weight: .bold))
+                .tracking(-0.16)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .foregroundStyle(enabled ? OnymTokens.onAccent : OnymTokens.text3)
+                .background(enabled ? accent : OnymTokens.surface3)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .shadow(color: enabled ? accent.opacity(0.30) : .clear, radius: 12, y: 8)
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+    }
+}
+
+/// Quiet text-only button shown under the primary CTA (Cancel / Back).
+private struct OnymQuietButton: View {
+    let title: String
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 14.5, weight: .semibold))
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+                .foregroundStyle(OnymTokens.text2)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Step 1: name + accent + governance
+
+private struct CreateGroupStep1View: View {
+    @Bindable var flow: CreateGroupFlow
+
+    var body: some View {
+        VStack(spacing: 0) {
+            OnymNavTitle(title: "New Group", subtitle: "Step 1 of 2")
+            ScrollView {
+                VStack(spacing: 0) {
+                    avatar
+                    nameField
+                    nameFootnote
+                    OnymSectionLabel(text: "Accent color")
+                    accentRow
+                    OnymSectionLabel(text: "How it\u{2019}s run")
+                    governancePicker
+                    selectedExplanation
+                    encryptedFooterCard
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 16)
+            }
+            footer
+        }
+    }
+
+    private var accentColor: Color { flow.accent.color }
+
+    private var avatar: some View {
+        ZStack(alignment: .bottomTrailing) {
+            OnymGroupAvatar(size: 92, accent: accentColor)
+            ZStack {
+                Circle()
+                    .fill(accentColor)
+                    .frame(width: 28, height: 28)
+                    .overlay(
+                        Circle().stroke(OnymTokens.bg, lineWidth: 2)
+                    )
+                Image(systemName: "camera.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.black)
+            }
+            .offset(x: 4, y: 4)
+        }
+        .padding(.top, 10)
+        .padding(.bottom, 18)
+    }
+
+    private var nameField: some View {
+        HStack {
+            TextField("", text: $flow.name, prompt: Text("Group name").foregroundColor(OnymTokens.text3))
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(OnymTokens.text)
+                .tint(accentColor)
+                .textInputAutocapitalization(.sentences)
+                .autocorrectionDisabled()
+                .onChange(of: flow.name) { _, new in
+                    if new.count > 32 { flow.name = String(new.prefix(32)) }
+                }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14).stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var nameFootnote: some View {
+        Text("Visible to members. You can change this anytime.")
+            .font(.system(size: 11.5))
+            .foregroundStyle(OnymTokens.text3)
+            .padding(.horizontal, 4)
+            .padding(.top, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var accentRow: some View {
+        HStack(spacing: 12) {
+            ForEach(OnymAccent.allCases) { a in
+                Button {
+                    flow.accent = a
+                } label: {
+                    ZStack {
+                        Circle().fill(a.color)
+                        if flow.accent == a {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundStyle(.white)
+                        }
+                    }
+                    .frame(width: 34, height: 34)
+                    .scaleEffect(flow.accent == a ? 1.05 : 1)
+                    .overlay(
+                        Circle()
+                            .stroke(a.color, lineWidth: flow.accent == a ? 2 : 0)
+                            .padding(-3)
+                    )
+                    .overlay(
+                        Circle()
+                            .stroke(OnymTokens.bg, lineWidth: flow.accent == a ? 2 : 0)
+                            .padding(-1)
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private var governancePicker: some View {
+        HStack(spacing: 10) {
+            ForEach(OnymUIGovernance.allCases) { g in
+                governanceCard(g)
+            }
+        }
+    }
+
+    private func governanceCard(_ g: OnymUIGovernance) -> some View {
+        let selected = flow.governance == g && g.isAvailable
+        let available = g.isAvailable
+        return Button {
+            guard available else { return }
+            flow.governance = g
+        } label: {
+            governanceCardLabel(g, selected: selected, available: available)
+        }
+        .buttonStyle(.plain)
+        .disabled(!available)
+    }
+
+    private func governanceCardLabel(
+        _ g: OnymUIGovernance,
+        selected: Bool,
+        available: Bool
+    ) -> some View {
+        let labelColor: Color = selected
+            ? accentColor
+            : (available ? OnymTokens.text : OnymTokens.text2)
+        let bgTint: Color = selected ? accentColor.opacity(0.18) : .clear
+        let strokeColor: Color = selected ? accentColor : OnymTokens.hairline
+        let strokeWidth: CGFloat = selected ? 1.5 : 1
+        let shadowColor: Color = selected ? accentColor.opacity(0.14) : .clear
+
+        return VStack(spacing: 8) {
+            governanceCardIconBlock(g, selected: selected, available: available)
+            Text(g.label)
+                .font(.system(size: 13, weight: .semibold))
+                .tracking(-0.13)
+                .foregroundStyle(labelColor)
+            Text(g.sub)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(OnymTokens.text2)
+                .padding(.top, -4)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 14)
+        .padding(.bottom, 12)
+        .padding(.horizontal, 10)
+        .background(bgTint)
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(strokeColor, lineWidth: strokeWidth)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .shadow(color: shadowColor, radius: 4)
+        .opacity(available ? 1 : 0.55)
+    }
+
+    private func governanceCardIconBlock(
+        _ g: OnymUIGovernance,
+        selected: Bool,
+        available: Bool
+    ) -> some View {
+        ZStack(alignment: .topTrailing) {
+            OnymGovIcon(
+                type: g,
+                accent: selected ? accentColor : OnymTokens.text,
+                size: 42,
+                dimmed: !selected || !available
+            )
+            .frame(maxWidth: .infinity, alignment: .center)
+
+            if !available {
+                Text("Soon")
+                    .font(.system(size: 9, weight: .semibold))
+                    .tracking(0.5)
+                    .foregroundStyle(OnymTokens.text3)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(OnymTokens.surface3)
+                    .clipShape(Capsule())
+                    .offset(x: 6, y: -4)
+            }
+
+            if selected {
+                ZStack {
+                    Circle().fill(accentColor)
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.black)
+                }
+                .frame(width: 18, height: 18)
+                .offset(x: 6, y: -4)
+            }
+        }
+    }
+
+    private var selectedExplanation: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Capsule()
+                .fill(accentColor.opacity(0.85))
+                .frame(width: 6)
+            VStack(alignment: .leading, spacing: 0) {
+                (
+                    Text("\(flow.governance.sub). ")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(OnymTokens.text)
+                    + Text(flow.governance.tooltip)
+                        .font(.system(size: 13))
+                        .foregroundColor(OnymTokens.text2)
+                )
+                .lineSpacing(1.5)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(accentColor.opacity(0.08))
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(accentColor.opacity(0.22), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.top, 12)
+    }
+
+    private var encryptedFooterCard: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(OnymTokens.text2)
+            (
+                Text("End-to-end encrypted").foregroundColor(OnymTokens.text)
+                + Text(" \u{00B7} published on Stellar so anyone can verify it\u{2019}s real.")
+                    .foregroundColor(OnymTokens.text2)
+            )
+            .font(.system(size: 12.5))
+            .lineSpacing(1.4)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(OnymTokens.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14).stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.top, 18)
+    }
+
+    private var footer: some View {
+        VStack(spacing: 4) {
+            OnymPrimaryButton(
+                title: flow.canAdvanceToStep2 ? "Next \u{00B7} Add people" : "Name your group to continue",
+                enabled: flow.canAdvanceToStep2,
+                accent: accentColor,
+                action: flow.tappedNext
+            )
+            OnymQuietButton(title: "Cancel", action: flow.onClose)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 22)
+        .background(OnymTokens.bg)
+        .overlay(Rectangle().fill(OnymTokens.hairline).frame(height: 1), alignment: .top)
+    }
+}
+
+// MARK: - Step 2: review invitees + create
+
+private struct CreateGroupStep2View: View {
+    @Bindable var flow: CreateGroupFlow
+
+    var body: some View {
+        VStack(spacing: 0) {
+            OnymNavTitle(title: "Add People", subtitle: "Step 2 of 2")
+            ScrollView {
+                VStack(spacing: 0) {
+                    typeBanner
+                        .padding(.top, 4)
+                    if flow.invitees.isEmpty {
+                        emptyState
+                    } else {
+                        inviteesList
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 16)
+            }
+            footer
+        }
+    }
+
+    private var accentColor: Color { flow.accent.color }
+
+    private var typeBanner: some View {
+        HStack(spacing: 10) {
+            OnymGovIcon(type: flow.governance, accent: accentColor, size: 28)
+            (
+                Text("\(flow.governance.label). ")
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundColor(OnymTokens.text)
+                + Text("You\u{2019}ll be the only admin.")
+                    .font(.system(size: 12.5))
+                    .foregroundColor(OnymTokens.text2)
+            )
+            .lineSpacing(1.35)
+            Spacer(minLength: 0)
+            Text("\(flow.invitees.count)")
+                .font(.system(size: 11.5, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(OnymTokens.surface3)
+                .clipShape(Capsule())
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(accentColor.opacity(0.10))
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(accentColor.opacity(0.20), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "person.crop.circle.badge.plus")
+                .font(.system(size: 36, weight: .light))
+                .foregroundStyle(OnymTokens.text3)
+                .padding(.top, 28)
+            Text("No invitees yet")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text("Use \u{201C}Invite by inbox key\u{201D} below to add someone.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(OnymTokens.text2)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 20)
+    }
+
+    private var inviteesList: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(flow.invitees.enumerated()), id: \.element.id) { index, invitee in
+                inviteeRow(invitee, index: index)
+                if index < flow.invitees.count - 1 {
+                    Rectangle().fill(OnymTokens.hairline).frame(height: 1)
+                }
+            }
+        }
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14).stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.top, 14)
+    }
+
+    private func inviteeRow(_ invitee: OnymInvitee, index: Int) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle().fill(OnymTokens.surface3)
+                Image(systemName: "key.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(accentColor)
+            }
+            .frame(width: 40, height: 40)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Inbox \(invitee.displayLabel)")
+                    .font(.system(size: 14.5, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("Direct inbox key")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .lineLimit(1)
+            .truncationMode(.middle)
+
+            Spacer(minLength: 0)
+
+            Button {
+                flow.removeInvitee(at: index)
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 18))
+                    .foregroundStyle(OnymTokens.text3)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private var footer: some View {
+        VStack(spacing: 10) {
+            Button(action: flow.tappedInviteByKey) {
+                HStack(spacing: 12) {
+                    ZStack {
+                        Circle().fill(accentColor.opacity(0.22))
+                        Image(systemName: "key.fill")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(accentColor)
+                    }
+                    .frame(width: 30, height: 30)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Invite by inbox key")
+                            .font(.system(size: 13.5, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text)
+                        Text("Paste a 64-char key")
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(OnymTokens.text2)
+                    }
+                    Spacer(minLength: 0)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text3)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(OnymTokens.surface2)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12).stroke(OnymTokens.hairlineStrong, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .buttonStyle(.plain)
+
+            OnymPrimaryButton(
+                title: flow.createCTALabel,
+                enabled: true,
+                accent: accentColor,
+                action: flow.tappedCreate
+            )
+
+            OnymQuietButton(title: "Back", action: flow.tappedBackFromStep2)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 22)
+        .background(OnymTokens.bg)
+        .overlay(Rectangle().fill(OnymTokens.hairline).frame(height: 1), alignment: .top)
+    }
+}
+
+// MARK: - Invite by inbox key
+
+private struct CreateGroupInviteByKeyView: View {
+    @Bindable var flow: CreateGroupFlow
+    @FocusState private var fieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            OnymNavTitle(
+                title: "Invite by Inbox Key",
+                subtitle: "For \(flow.name.isEmpty ? "group" : flow.name)"
+            )
+            ScrollView {
+                VStack(spacing: 0) {
+                    explanation
+                    keyInput
+                    if let err = flow.inviteeError {
+                        errorPill(err)
+                    }
+                    pasteButton
+                    helper
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 12)
+            }
+            footer
+        }
+        .onAppear { fieldFocused = true }
+    }
+
+    private var accentColor: Color { flow.accent.color }
+
+    private var explanation: some View {
+        (
+            Text("Ask for their ").foregroundColor(OnymTokens.text2)
+            + Text("inbox key").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
+            + Text(" \u{2014} they can find it in ").foregroundColor(OnymTokens.text2)
+            + Text("Settings \u{2192} Advanced").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
+            + Text(", or share a QR code from there.").foregroundColor(OnymTokens.text2)
+        )
+        .font(.system(size: 13))
+        .lineSpacing(1.5)
+        .padding(.horizontal, 4)
+        .padding(.top, 4)
+        .padding(.bottom, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var keyInput: some View {
+        let cleanedLength = flow.inviteeInputCleanedLength
+        let isValid = flow.inviteeInputIsValid
+        let tooLong = cleanedLength > 64
+        let borderColor: Color = {
+            if flow.inviteeError != nil { return OnymTokens.red }
+            if isValid { return accentColor.opacity(0.5) }
+            return OnymTokens.hairline
+        }()
+
+        return VStack(alignment: .leading, spacing: 8) {
+            TextField(
+                "",
+                text: $flow.inviteeInput,
+                prompt: Text("Paste 64-char inbox key").foregroundColor(OnymTokens.text3),
+                axis: .vertical
+            )
+            .lineLimit(3, reservesSpace: true)
+            .font(.system(size: 14, design: .monospaced))
+            .foregroundStyle(OnymTokens.text)
+            .tint(accentColor)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .focused($fieldFocused)
+            .onChange(of: flow.inviteeInput) { _, _ in
+                flow.inviteeError = nil
+            }
+
+            Rectangle().fill(OnymTokens.hairline).frame(height: 1)
+
+            HStack {
+                Text("\(cleanedLength)/64")
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(tooLong ? OnymTokens.red : (isValid ? accentColor : OnymTokens.text3))
+                Spacer()
+                if cleanedLength > 0 {
+                    Button {
+                        flow.inviteeInput = ""
+                        flow.inviteeError = nil
+                    } label: {
+                        Text("Clear")
+                            .font(.system(size: 12))
+                            .foregroundStyle(OnymTokens.text2)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14).stroke(borderColor, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func errorPill(_ message: String) -> some View {
+        Text(message)
+            .font(.system(size: 12.5))
+            .foregroundStyle(OnymTokens.red)
+            .lineSpacing(1.4)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(OnymTokens.red.opacity(0.10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12).stroke(OnymTokens.red.opacity(0.30), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.top, 10)
+    }
+
+    private var pasteButton: some View {
+        Button {
+            #if canImport(UIKit)
+            if let pasted = UIPasteboard.general.string {
+                flow.inviteeInput = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
+                flow.inviteeError = nil
+            }
+            #endif
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "doc.on.clipboard")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Paste from clipboard")
+                    .font(.system(size: 14.5, weight: .semibold))
+            }
+            .frame(maxWidth: .infinity, minHeight: 46)
+            .foregroundStyle(accentColor)
+            .background(OnymTokens.surface2)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14).stroke(OnymTokens.hairlineStrong, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 12)
+    }
+
+    private var helper: some View {
+        HStack(alignment: .top, spacing: 10) {
+            ZStack {
+                Circle().fill(OnymTokens.surface3)
+                Text("i")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .frame(width: 18, height: 18)
+            .padding(.top, 1)
+
+            (
+                Text("Don\u{2019}t have their key? ").foregroundColor(OnymTokens.text)
+                + Text("Create the group, then share the invite link \u{2014} they can join later without sharing any keys.").foregroundColor(OnymTokens.text2)
+            )
+            .font(.system(size: 12))
+            .lineSpacing(1.5)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(OnymTokens.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14).stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.top, 16)
+    }
+
+    private var footer: some View {
+        VStack(spacing: 6) {
+            OnymPrimaryButton(
+                title: flow.inviteeInputIsValid
+                    ? "Add to group"
+                    : (flow.inviteeInputCleanedLength == 0 ? "Paste a key to continue" : "Key incomplete"),
+                enabled: flow.inviteeInputIsValid,
+                accent: accentColor,
+                action: flow.tappedAddInvitee
+            )
+            OnymQuietButton(title: "Cancel", action: flow.tappedCancelInviteByKey)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 22)
+        .background(OnymTokens.bg)
+        .overlay(Rectangle().fill(OnymTokens.hairline).frame(height: 1), alignment: .top)
+    }
+}
+
+// MARK: - Creating (progress)
+
+private struct CreateGroupCreatingView: View {
+    @Bindable var flow: CreateGroupFlow
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("Creating \(flow.name.isEmpty ? "Group" : flow.name)")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+                .frame(maxWidth: .infinity)
+                .padding(.top, 20)
+
+            OnymGroupAvatar(
+                size: 92,
+                accent: flow.accent.color,
+                ringPulse: true,
+                spinning: true,
+                brand: true
+            )
+            .padding(.top, 24)
+            .padding(.bottom, 22)
+
+            stepsCard
+
+            if let error = flow.error {
+                errorBanner(error)
+                    .padding(.top, 12)
+            } else {
+                Text("This usually takes a few seconds. It\u{2019}s safe to close this \u{2014} we\u{2019}ll finish in the background.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text3)
+                    .lineSpacing(1.45)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 14)
+                    .padding(.horizontal, 8)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private var stepsCard: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(steps.enumerated()), id: \.offset) { i, step in
+                if i > 0 {
+                    Rectangle().fill(OnymTokens.hairline).frame(height: 1)
+                }
+                stepRow(step, status: status(for: i))
+            }
+        }
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14).stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func stepRow(_ step: CreateGroupCreatingStep, status: StepStatus) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                switch status {
+                case .done:
+                    Circle().fill(OnymTokens.green)
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(.black)
+                case .active:
+                    Circle()
+                        .stroke(flow.accent.color, lineWidth: 2)
+                        .opacity(0.25)
+                    Circle()
+                        .trim(from: 0, to: 0.3)
+                        .stroke(flow.accent.color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                        .rotationEffect(.degrees(activeRotation))
+                        .onAppear {
+                            withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+                                activeRotation = 360
+                            }
+                        }
+                case .pending:
+                    Circle().stroke(OnymTokens.hairlineStrong, lineWidth: 2)
+                }
+            }
+            .frame(width: 22, height: 22)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(step.label)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text(step.sub)
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .lineLimit(1)
+            .truncationMode(.tail)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
+        .opacity(status == .pending ? 0.5 : 1)
+    }
+
+    @State private var activeRotation: Double = 0
+
+    private func errorBanner(_ error: CreateGroupError) -> some View {
+        VStack(spacing: 12) {
+            Text(error.localizedDescription)
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.red)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 14)
+            Button {
+                flow.tappedDismissError()
+            } label: {
+                Text("Try again")
+                    .font(.system(size: 14.5, weight: .semibold))
+                    .foregroundStyle(flow.accent.color)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 8)
+                    .background(OnymTokens.surface2)
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(14)
+        .background(OnymTokens.red.opacity(0.10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14).stroke(OnymTokens.red.opacity(0.30), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    // MARK: - Step plan
+
+    private var steps: [CreateGroupCreatingStep] {
+        var rows: [CreateGroupCreatingStep] = [
+            .init(label: "Setting up encrypted group", sub: "Generating keys on your device"),
+            .init(label: "Setting up your admin keys", sub: "You\u{2019}ll be the only admin"),
+        ]
+        for invitee in flow.invitees {
+            rows.append(.init(
+                label: "Sending invitation to \(invitee.displayLabel)",
+                sub: "Encrypted, end-to-end"
+            ))
+        }
+        rows.append(.init(label: "Anchoring on Stellar", sub: "So anyone can verify this group is real"))
+        return rows
+    }
+
+    private func status(for index: Int) -> StepStatus {
+        guard let progress = flow.progress else {
+            // No progress means either pre-flight (validating, but we
+            // shouldn't be here without progress) OR completed —
+            // every step done.
+            return flow.error == nil ? .done : .pending
+        }
+        let activeIndex = currentStepIndex(progress)
+        if index < activeIndex { return .done }
+        if index == activeIndex { return .active }
+        return .pending
+    }
+
+    /// Map `CreateGroupProgress` to which row in the steps array is
+    /// currently spinning. Validating + Proving share row 0/1; the
+    /// real ~3.5s of work is the Tyranny prove call so step 1
+    /// dominates wall-clock.
+    private func currentStepIndex(_ progress: CreateGroupProgress) -> Int {
+        switch progress {
+        case .validating: return 0
+        case .proving: return 1
+        case .anchoring:
+            // Anchoring is the last step (after invitations).
+            return 2 + flow.invitees.count
+        case .sendingInvitations:
+            // First invitee row is index 2.
+            return 2
+        }
+    }
+
+    private enum StepStatus { case done, active, pending }
+}
+
+private struct CreateGroupCreatingStep {
+    let label: String
+    let sub: String
+}
+
+// MARK: - Success
+
+private struct CreateGroupSuccessView: View {
+    @Bindable var flow: CreateGroupFlow
+
+    var body: some View {
+        VStack(spacing: 0) {
+            topBar
+            ScrollView {
+                VStack(spacing: 0) {
+                    hero
+                    membersCard
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 24)
+            }
+            footer
+        }
+    }
+
+    private var accentColor: Color { flow.accent.color }
+    private var groupName: String {
+        flow.createdGroup?.name ?? (flow.name.isEmpty ? "Group" : flow.name)
+    }
+
+    private var topBar: some View {
+        HStack {
+            Spacer().frame(width: 60)
+            Spacer()
+            Text("\(groupName) is live")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Spacer()
+            Spacer().frame(width: 60)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 6)
+        .padding(.bottom, 8)
+    }
+
+    private var hero: some View {
+        VStack(spacing: 0) {
+            ZStack(alignment: .bottomTrailing) {
+                OnymGroupAvatar(size: 96, accent: accentColor)
+                ZStack {
+                    Circle().fill(OnymTokens.green)
+                        .overlay(Circle().stroke(OnymTokens.bg, lineWidth: 2))
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(.black)
+                }
+                .frame(width: 28, height: 28)
+                .offset(x: 4, y: 4)
+            }
+            .padding(.top, 14)
+
+            Text(groupName)
+                .font(.system(size: 22, weight: .bold))
+                .tracking(-0.22)
+                .foregroundStyle(OnymTokens.text)
+                .padding(.top, 14)
+
+            HStack(spacing: 6) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("End-to-end encrypted")
+                    .font(.system(size: 12.5))
+            }
+            .foregroundStyle(OnymTokens.text2)
+            .padding(.top, 4)
+
+            // Type chip
+            HStack(spacing: 8) {
+                OnymGovIcon(type: flow.governance, accent: accentColor, size: 20)
+                (
+                    Text("\(flow.governance.label) \u{00B7} ").foregroundColor(OnymTokens.text).font(.system(size: 12.5, weight: .semibold))
+                    + Text(typeChipSummary).foregroundColor(OnymTokens.text2).font(.system(size: 12.5))
+                )
+            }
+            .padding(.leading, 8)
+            .padding(.trailing, 12)
+            .padding(.vertical, 6)
+            .background(accentColor.opacity(0.18))
+            .background(OnymTokens.surface2)
+            .overlay(
+                Capsule().stroke(accentColor.opacity(0.30), lineWidth: 1)
+            )
+            .clipShape(Capsule())
+            .padding(.top, 12)
+
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("Published on-chain")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(OnymTokens.green)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(OnymTokens.green.opacity(0.12))
+            .clipShape(Capsule())
+            .padding(.top, 12)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 18)
+    }
+
+    private var typeChipSummary: String {
+        let n = flow.invitees.count
+        return "You\u{2019}re the only admin. \(n) member\(n == 1 ? "" : "s") added."
+    }
+
+    private var membersCard: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Members")
+                        .font(.system(size: 13.5, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text)
+                    Text("\(flow.invitees.count + 1) \(flow.invitees.count == 0 ? "person" : "people") so far")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(OnymTokens.text2)
+                }
+                Spacer()
+                Text("You \u{00B7} admin")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(accentColor)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(accentColor.opacity(0.18))
+                    .background(OnymTokens.surface3)
+                    .clipShape(Capsule())
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .overlay(Rectangle().fill(OnymTokens.hairline).frame(height: 1), alignment: .bottom)
+
+            // You row
+            memberRow(
+                badge: "ME",
+                badgeColor: accentColor,
+                name: "You",
+                sub: "Admin \u{00B7} created this group",
+                trailing: "Admin"
+            )
+
+            // Invitee rows
+            ForEach(Array(flow.invitees.enumerated()), id: \.element.id) { index, invitee in
+                Rectangle().fill(OnymTokens.hairline).frame(height: 1)
+                memberRow(
+                    badge: "I\(index + 1)",
+                    badgeColor: OnymTokens.surface3,
+                    name: "Inbox \(invitee.displayLabel)",
+                    sub: "Invited",
+                    trailing: nil
+                )
+            }
+        }
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 18).stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+    }
+
+    private func memberRow(
+        badge: String,
+        badgeColor: Color,
+        name: String,
+        sub: String,
+        trailing: String?
+    ) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle().fill(badgeColor)
+                Text(badge)
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+            .frame(width: 36, height: 36)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(name)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text(sub)
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .lineLimit(1)
+
+            Spacer(minLength: 0)
+
+            if let trailing {
+                Text(trailing)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(accentColor)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(accentColor.opacity(0.18))
+                    .clipShape(Capsule())
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private var footer: some View {
+        VStack(spacing: 10) {
+            OnymPrimaryButton(
+                title: "Done",
+                enabled: true,
+                accent: accentColor,
+                action: flow.tappedDone
+            )
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 22)
+        .background(OnymTokens.bg)
+        .overlay(Rectangle().fill(OnymTokens.hairline).frame(height: 1), alignment: .top)
+    }
+}

--- a/Sources/OnymIOS/Group/GroupInvitationPayload.swift
+++ b/Sources/OnymIOS/Group/GroupInvitationPayload.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Plaintext payload that gets sealed (X25519 + AES-GCM via
+/// `IdentityRepository.sealInvitation`) and dropped on
+/// `InboxTransport.send` for each invitee. Mirrors stellar-mls's
+/// `InviteCode` shape so an Android / Apple receiver decoding the
+/// payload sees the same fields.
+///
+/// Versioned for forward compatibility — `version = 1` is the only
+/// shape the receiver has to handle today; later versions can add
+/// fields with non-failing `decodeIfPresent` decoders.
+struct GroupInvitationPayload: Codable, Equatable, Sendable {
+    let version: Int
+    let groupID: Data
+    let groupSecret: Data
+    let name: String
+    /// Lex-sorted by `publicKeyCompressed` — the receiver MUST be
+    /// able to recompute the same Poseidon root, which requires the
+    /// same canonical order.
+    let members: [GovernanceMember]
+    let epoch: UInt64
+    let salt: Data
+    /// Latest verified Poseidon commitment. `nil` only for offline
+    /// invitations not yet anchored on chain — current creator flow
+    /// always anchors first, so this is always set in practice.
+    let commitment: Data?
+    let tierRaw: Int
+    let groupTypeRaw: UInt32
+    /// Lowercase hex (96 chars) BLS pubkey of the Tyranny admin.
+    /// `nil` for `.anarchy` / `.oneOnOne`.
+    let adminPubkeyHex: String?
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case groupID = "group_id"
+        case groupSecret = "group_secret"
+        case name
+        case members
+        case epoch
+        case salt
+        case commitment
+        case tierRaw = "tier_raw"
+        case groupTypeRaw = "group_type_raw"
+        case adminPubkeyHex = "admin_pubkey_hex"
+    }
+}

--- a/Sources/OnymIOS/Group/OnymBrand.swift
+++ b/Sources/OnymIOS/Group/OnymBrand.swift
@@ -1,0 +1,328 @@
+import SwiftUI
+
+// MARK: - Tokens
+
+/// Dark-theme design tokens for the Create Group flow. Mirrors the
+/// tokens in the Claude Designed reference (`THEMES.dark` in
+/// `app.jsx`). Light theme will land later — PR-C ships dark only.
+enum OnymTokens {
+    static let bg = Color(red: 0, green: 0, blue: 0)
+    static let surface = Color(red: 0x0E / 255, green: 0x0E / 255, blue: 0x10 / 255)
+    static let surface2 = Color(red: 0x17 / 255, green: 0x17 / 255, blue: 0x1A / 255)
+    static let surface3 = Color(red: 0x1F / 255, green: 0x1F / 255, blue: 0x23 / 255)
+    static let text = Color(red: 0xF2 / 255, green: 0xF2 / 255, blue: 0xF4 / 255)
+    static let text2 = Color(red: 0xF2 / 255, green: 0xF2 / 255, blue: 0xF4 / 255).opacity(0.62)
+    static let text3 = Color(red: 0xF2 / 255, green: 0xF2 / 255, blue: 0xF4 / 255).opacity(0.40)
+    static let hairline = Color.white.opacity(0.07)
+    static let hairlineStrong = Color.white.opacity(0.12)
+    static let green = Color(red: 0x34 / 255, green: 0xC7 / 255, blue: 0x59 / 255)
+    static let red = Color(red: 0xFF / 255, green: 0x45 / 255, blue: 0x3A / 255)
+    /// Reads on accent fills.
+    static let onAccent = Color.black
+}
+
+// MARK: - Accent palette
+
+enum OnymAccent: String, CaseIterable, Identifiable, Sendable {
+    case orange, blue, green, purple, pink, yellow
+
+    var id: String { rawValue }
+
+    var color: Color {
+        switch self {
+        case .orange: Color(red: 0xFF / 255, green: 0x7A / 255, blue: 0x45 / 255)
+        case .blue:   Color(red: 0x3F / 255, green: 0xA8 / 255, blue: 0xFF / 255)
+        case .green:  Color(red: 0x3D / 255, green: 0xD6 / 255, blue: 0x6E / 255)
+        case .purple: Color(red: 0xB2 / 255, green: 0x78 / 255, blue: 0xFF / 255)
+        case .pink:   Color(red: 0xFF / 255, green: 0x4D / 255, blue: 0x6D / 255)
+        case .yellow: Color(red: 0xFF / 255, green: 0xC9 / 255, blue: 0x3C / 255)
+        }
+    }
+}
+
+// MARK: - OnymMark — broken-ring brand logo
+
+/// The Onym brand mark: a broken/segmented ring with two narrow radial
+/// gaps. The gaps suggest privacy/anonymity — the identity is whole
+/// but never fully closed.
+///
+/// Implemented as a `Circle().stroke` with a dash pattern of
+/// `[46, 4, 46, 4]` (% of circumference), then a `rotationEffect` to
+/// align the gaps near 1:30 and 7:30 o'clock. Matches the SVG
+/// reference in `app.jsx` (`OnymMark` component, dasharray `46 4 46 4`,
+/// dashoffset `-25`).
+struct OnymMark: View {
+    var size: CGFloat = 32
+    var color: Color = OnymTokens.text
+    var strokeRatio: CGFloat = 0.16
+    var spinning: Bool = false
+    var fillOpacity: Double = 0.92
+
+    @State private var rotation: Double = -90  // -90° lands the dash pattern's first gap near 1:30
+
+    var body: some View {
+        let stroke = size * strokeRatio
+        let radius = (size - stroke) / 2
+        let circumference = 2 * .pi * radius
+        let arc = circumference * 0.46
+        let gap = circumference * 0.04
+
+        Circle()
+            .stroke(
+                color,
+                style: StrokeStyle(
+                    lineWidth: stroke,
+                    lineCap: .butt,
+                    dash: [arc, gap, arc, gap]
+                )
+            )
+            .opacity(fillOpacity)
+            .frame(width: size - stroke, height: size - stroke)
+            .padding(stroke / 2)
+            .rotationEffect(.degrees(rotation))
+            .onAppear {
+                guard spinning else { return }
+                withAnimation(.linear(duration: 4.2).repeatForever(autoreverses: false)) {
+                    rotation += 360
+                }
+            }
+    }
+}
+
+// MARK: - Governance type (UI-side)
+
+/// UI-side mirror of the design's three governance cards. Maps to
+/// `SEPGroupType` for the actual chain call. PR-C only enables
+/// `.tyranny` — the other two render with a "Soon" label and aren't
+/// selectable.
+enum OnymUIGovernance: String, CaseIterable, Identifiable, Sendable {
+    case tyranny
+    case oneOnOne = "dialog"
+    case anarchy
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .tyranny: "Tyranny"
+        case .oneOnOne: "1\u{2011}on\u{2011}1"  // non-breaking hyphens
+        case .anarchy: "Anarchy"
+        }
+    }
+
+    var sub: String {
+        switch self {
+        case .tyranny: "Single admin"
+        case .oneOnOne: "Dialog"
+        case .anarchy: "Open control"
+        }
+    }
+
+    var oneLine: String {
+        switch self {
+        case .tyranny: "You control membership and settings."
+        case .oneOnOne: "A private two-person conversation."
+        case .anarchy: "Every member has the same control."
+        }
+    }
+
+    var tooltip: String {
+        switch self {
+        case .tyranny: "Only the admin can manage this group."
+        case .oneOnOne: "Exactly two people. No one else can join."
+        case .anarchy: "Anyone can add, remove, or change settings."
+        }
+    }
+
+    /// Per-PR-C scope: only Tyranny is wired to the chain layer.
+    var isAvailable: Bool { self == .tyranny }
+
+    var sepGroupType: SEPGroupType {
+        switch self {
+        case .tyranny: .tyranny
+        case .oneOnOne: .oneOnOne
+        case .anarchy: .anarchy
+        }
+    }
+}
+
+// MARK: - Governance icons
+
+/// Small badge icons that go on each governance card. Three distinct
+/// silhouettes: crown (admin), facing bubbles (dialog), nodes-in-ring
+/// (anarchy). Implemented with SwiftUI `Path`/`Shape` rather than
+/// SF symbols because the design uses custom artwork.
+struct OnymGovIcon: View {
+    let type: OnymUIGovernance
+    let accent: Color
+    var size: CGFloat = 44
+    var dimmed: Bool = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(strokeColor, lineWidth: 1.4 * size / 44)
+                .opacity(0.5)
+            Circle()
+                .fill(strokeColor.opacity(0.14))
+                .padding(size * 6 / 44)
+
+            switch type {
+            case .tyranny: tyrannyMark
+            case .oneOnOne: dialogMark
+            case .anarchy: anarchyMark
+            }
+        }
+        .frame(width: size, height: size)
+    }
+
+    private var strokeColor: Color { dimmed ? OnymTokens.text3 : accent }
+
+    private var tyrannyMark: some View {
+        // Crown: filled chevron-y polygon + bar + dot, all in `accent`.
+        ZStack {
+            Path { path in
+                let s = size
+                path.move(to: CGPoint(x: s * 13/44, y: s * 24/44))
+                path.addLine(to: CGPoint(x: s * 15/44, y: s * 17/44))
+                path.addLine(to: CGPoint(x: s * 19/44, y: s * 21/44))
+                path.addLine(to: CGPoint(x: s * 22/44, y: s * 15/44))
+                path.addLine(to: CGPoint(x: s * 25/44, y: s * 21/44))
+                path.addLine(to: CGPoint(x: s * 29/44, y: s * 17/44))
+                path.addLine(to: CGPoint(x: s * 31/44, y: s * 24/44))
+                path.closeSubpath()
+            }
+            .fill(strokeColor)
+
+            RoundedRectangle(cornerRadius: 0.8 * size / 44)
+                .fill(strokeColor)
+                .frame(width: 18 * size / 44, height: 3 * size / 44)
+                .position(x: 22 * size / 44, y: 27 * size / 44)
+
+            Circle()
+                .fill(dimmed ? OnymTokens.text3 : Color.white)
+                .frame(width: 2.4 * size / 44, height: 2.4 * size / 44)
+                .position(x: 22 * size / 44, y: 20 * size / 44)
+        }
+    }
+
+    private var dialogMark: some View {
+        ZStack {
+            // Left bubble (filled accent)
+            Path { path in
+                let s = size
+                path.move(to: CGPoint(x: s * 9/44, y: s * 17/44))
+                path.addQuadCurve(to: CGPoint(x: s * 12/44, y: s * 14/44), control: CGPoint(x: s * 9/44, y: s * 14/44))
+                path.addLine(to: CGPoint(x: s * 19/44, y: s * 14/44))
+                path.addQuadCurve(to: CGPoint(x: s * 22/44, y: s * 17/44), control: CGPoint(x: s * 22/44, y: s * 14/44))
+                path.addLine(to: CGPoint(x: s * 22/44, y: s * 20/44))
+                path.addQuadCurve(to: CGPoint(x: s * 19/44, y: s * 23/44), control: CGPoint(x: s * 22/44, y: s * 23/44))
+                path.addLine(to: CGPoint(x: s * 16/44, y: s * 23/44))
+                path.addLine(to: CGPoint(x: s * 13/44, y: s * 26/44))
+                path.addLine(to: CGPoint(x: s * 13/44, y: s * 23/44))
+                path.addLine(to: CGPoint(x: s * 12/44, y: s * 23/44))
+                path.addQuadCurve(to: CGPoint(x: s * 9/44, y: s * 20/44), control: CGPoint(x: s * 9/44, y: s * 23/44))
+                path.closeSubpath()
+            }
+            .fill(strokeColor)
+
+            // Right bubble (translucent accent)
+            Path { path in
+                let s = size
+                path.move(to: CGPoint(x: s * 35/44, y: s * 22/44))
+                path.addQuadCurve(to: CGPoint(x: s * 32/44, y: s * 19/44), control: CGPoint(x: s * 35/44, y: s * 19/44))
+                path.addLine(to: CGPoint(x: s * 25/44, y: s * 19/44))
+                path.addQuadCurve(to: CGPoint(x: s * 22/44, y: s * 22/44), control: CGPoint(x: s * 22/44, y: s * 19/44))
+                path.addLine(to: CGPoint(x: s * 22/44, y: s * 25/44))
+                path.addQuadCurve(to: CGPoint(x: s * 25/44, y: s * 28/44), control: CGPoint(x: s * 22/44, y: s * 28/44))
+                path.addLine(to: CGPoint(x: s * 28/44, y: s * 28/44))
+                path.addLine(to: CGPoint(x: s * 31/44, y: s * 31/44))
+                path.addLine(to: CGPoint(x: s * 31/44, y: s * 28/44))
+                path.addLine(to: CGPoint(x: s * 32/44, y: s * 28/44))
+                path.addQuadCurve(to: CGPoint(x: s * 35/44, y: s * 25/44), control: CGPoint(x: s * 35/44, y: s * 28/44))
+                path.closeSubpath()
+            }
+            .fill(strokeColor.opacity(0.55))
+        }
+    }
+
+    private var anarchyMark: some View {
+        // Five nodes in a ring with light edges between every pair.
+        let count = 5
+        let nodes: [CGPoint] = (0..<count).map { i in
+            let a = (Double(i) / Double(count)) * .pi * 2 - .pi / 2
+            return CGPoint(
+                x: 22 * size / 44 + cos(a) * 10 * size / 44,
+                y: 22 * size / 44 + sin(a) * 10 * size / 44
+            )
+        }
+        return ZStack {
+            // Edges
+            Path { path in
+                for i in 0..<count {
+                    for j in (i + 1)..<count {
+                        path.move(to: nodes[i])
+                        path.addLine(to: nodes[j])
+                    }
+                }
+            }
+            .stroke(strokeColor.opacity(0.45), lineWidth: 0.9 * size / 44)
+
+            // Nodes
+            ForEach(0..<count, id: \.self) { i in
+                Circle()
+                    .fill(strokeColor)
+                    .frame(width: 5.2 * size / 44, height: 5.2 * size / 44)
+                    .position(nodes[i])
+            }
+        }
+    }
+}
+
+// MARK: - Group avatar (Onym mark as upload placeholder)
+
+/// Avatar slot. In this prototype the user never uploads an image, so
+/// the slot always shows the brand mark — same behaviour as the
+/// design's `GroupAvatar` after the `forceInitials` refactor.
+struct OnymGroupAvatar: View {
+    var size: CGFloat = 96
+    var accent: Color = OnymAccent.blue.color
+    var ringPulse: Bool = false
+    var spinning: Bool = false
+    /// When `true` the mark renders in the accent colour rather than
+    /// the neutral text colour — used on the Creating screen.
+    var brand: Bool = false
+
+    var body: some View {
+        ZStack {
+            if ringPulse {
+                Circle()
+                    .stroke(accent, lineWidth: 1.5)
+                    .padding(-8)
+                    .modifier(PulseModifier())
+            }
+            OnymMark(
+                size: size,
+                color: brand ? accent : OnymTokens.text,
+                spinning: spinning,
+                fillOpacity: brand ? 1.0 : 0.92
+            )
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+private struct PulseModifier: ViewModifier {
+    @State private var animating = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(animating ? 0.55 : 0.35)
+            .scaleEffect(animating ? 1.06 : 1.0)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 2.4).repeatForever(autoreverses: true)) {
+                    animating = true
+                }
+            }
+    }
+}

--- a/Sources/OnymIOS/Identity/IdentityError.swift
+++ b/Sources/OnymIOS/Identity/IdentityError.swift
@@ -6,6 +6,7 @@ enum IdentityError: Error, Equatable {
     case keychainDelete(OSStatus)
     case storedSnapshotInvalid(reason: String)
     case invalidMnemonic
+    case identityNotLoaded
     case sdkFailure(String)
 }
 
@@ -22,6 +23,8 @@ extension IdentityError: LocalizedError {
             return "Stored identity is invalid: \(reason)"
         case .invalidMnemonic:
             return "Invalid recovery phrase"
+        case .identityNotLoaded:
+            return "No identity is loaded — bootstrap or restore first"
         case let .sdkFailure(message):
             return "OnymSDK call failed: \(message)"
         }

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -79,6 +79,18 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// wiped. Reading this does not trigger a Keychain load.
     func currentIdentity() -> Identity? { current }
 
+    /// One-shot accessor for the device's 32-byte BLS Fr scalar. Used
+    /// by the chain layer (`OnymGroupProofGenerator`) to call
+    /// `Tyranny.proveCreate` etc. Loads from the Keychain on every
+    /// call (no in-memory cache); callers MUST NOT retain the
+    /// returned bytes beyond the immediate proof-generation hop.
+    func blsSecretKey() throws -> Data {
+        guard let snapshot = try keychain.load() else {
+            throw IdentityError.identityNotLoaded
+        }
+        return snapshot.blsSecretKey
+    }
+
     /// Stream of identity snapshots — current value on subscribe, then one
     /// new value per successful mutation.
     nonisolated var snapshots: AsyncStream<Identity?> {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -5,6 +5,7 @@ struct OnymIOSApp: App {
     private let dependencies: AppDependencies
     private let relayerRepository: RelayerRepository
     private let contractsRepository: ContractsRepository
+    private let groupRepository: GroupRepository
 
     init() {
         let args = ProcessInfo.processInfo.arguments
@@ -59,6 +60,24 @@ struct OnymIOSApp: App {
         self.relayerRepository = relayerRepository
         self.contractsRepository = contractsRepository
 
+        // Group repository — falls back to in-memory if the on-disk
+        // store can't open (rare; FileProtection / sandbox issues).
+        // Failure here is non-fatal for the create-group flow, just
+        // means newly-created groups don't survive a relaunch.
+        let groupRepository: GroupRepository
+        if let store = try? SwiftDataGroupStore() {
+            groupRepository = GroupRepository(store: store)
+        } else {
+            groupRepository = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        }
+        self.groupRepository = groupRepository
+
+        // Inbox transport for invitation send. Connects on first use
+        // via `RootView.task`.
+        let inboxTransport = NostrInboxTransport(
+            signerProvider: OnymNostrSignerProvider()
+        )
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -71,6 +90,15 @@ struct OnymIOSApp: App {
             },
             makeAnchorsPickerFlow: { @MainActor in
                 AnchorsPickerFlow(repository: contractsRepository)
+            },
+            makeCreateGroupFlow: { @MainActor in
+                CreateGroupFlow(interactor: CreateGroupInteractor(
+                    identity: repository,
+                    relayers: relayerRepository,
+                    contracts: contractsRepository,
+                    groups: groupRepository,
+                    inboxTransport: inboxTransport
+                ))
             }
         )
     }
@@ -85,6 +113,8 @@ struct OnymIOSApp: App {
                     // contract from whatever was cached on the previous run.
                     await relayerRepository.start()
                     await contractsRepository.start()
+                    // Replay groups for the in-memory snapshot stream.
+                    await groupRepository.reload()
                 }
         }
     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -26,7 +26,8 @@ struct RootView: View {
                     SettingsView(
                         makeBackupFlow: dependencies.makeRecoveryPhraseBackupFlow,
                         makeRelayerSettingsFlow: dependencies.makeRelayerSettingsFlow,
-                        makeAnchorsPickerFlow: dependencies.makeAnchorsPickerFlow
+                        makeAnchorsPickerFlow: dependencies.makeAnchorsPickerFlow,
+                        makeCreateGroupFlow: dependencies.makeCreateGroupFlow
                     )
                 }
             }

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -8,11 +8,30 @@ struct SettingsView: View {
     let makeBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
     let makeRelayerSettingsFlow: @MainActor () -> RelayerSettingsFlow
     let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
+    let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
 
     @State private var showRecoveryPhrase = false
+    @State private var showCreateGroup = false
 
     var body: some View {
         Form {
+            Section {
+                Button {
+                    showCreateGroup = true
+                } label: {
+                    row(
+                        icon: SettingsIconBox(systemImage: "person.3.fill", background: .green),
+                        title: "Create Group"
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("settings.create_group_row")
+            } header: {
+                Text("Groups")
+            } footer: {
+                Text("Create an end-to-end encrypted group anchored on Stellar testnet. Only Tyranny is available right now.")
+            }
+
             Section {
                 Button {
                     showRecoveryPhrase = true
@@ -60,6 +79,12 @@ struct SettingsView: View {
         .sheet(isPresented: $showRecoveryPhrase) {
             RecoveryPhraseBackupView(flow: makeBackupFlow())
         }
+        .fullScreenCover(isPresented: $showCreateGroup) {
+            CreateGroupViewHost(
+                makeFlow: makeCreateGroupFlow,
+                onClose: { showCreateGroup = false }
+            )
+        }
     }
 
     @ViewBuilder
@@ -72,6 +97,34 @@ struct SettingsView: View {
             Image(systemName: "chevron.right")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+/// Host view that constructs the `CreateGroupFlow` exactly once on
+/// first render and wires its `onClose` callback to the parent's
+/// dismiss state. Inlining this construction inside `.fullScreenCover`
+/// would re-make the flow on every state mutation.
+private struct CreateGroupViewHost: View {
+    let makeFlow: @MainActor () -> CreateGroupFlow
+    let onClose: () -> Void
+
+    @State private var flow: CreateGroupFlow?
+
+    var body: some View {
+        Group {
+            if let flow {
+                CreateGroupView(flow: flow)
+            } else {
+                Color.black.ignoresSafeArea()
+            }
+        }
+        .onAppear {
+            if flow == nil {
+                let f = makeFlow()
+                f.onClose = onClose
+                flow = f
+            }
         }
     }
 }

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -1,0 +1,227 @@
+import XCTest
+@testable import OnymIOS
+
+/// View-model tests for `CreateGroupFlow`. The interactor is real but
+/// uses the same in-memory environment as `CreateGroupInteractorTests`,
+/// so these tests verify the flow's intent dispatch + form validation
+/// rather than the pipeline mechanics.
+@MainActor
+final class CreateGroupFlowTests: XCTestCase {
+
+    // MARK: - Step1 → Step2
+
+    func test_canAdvanceToStep2_requiresNonEmptyNameAndAvailableGovernance() async throws {
+        let flow = await makeFlow()
+        XCTAssertFalse(flow.canAdvanceToStep2, "empty name blocks advance")
+        flow.name = "  "
+        XCTAssertFalse(flow.canAdvanceToStep2, "whitespace-only name blocks advance")
+        flow.name = "Friends"
+        XCTAssertTrue(flow.canAdvanceToStep2)
+    }
+
+    func test_unavailableGovernance_blocksAdvance() async throws {
+        let flow = await makeFlow()
+        flow.name = "Friends"
+        flow.governance = .anarchy   // not yet supported
+        XCTAssertFalse(flow.canAdvanceToStep2)
+    }
+
+    func test_tappedNext_advancesToStep2() async throws {
+        let flow = await makeFlow()
+        flow.name = "Friends"
+        flow.tappedNext()
+        XCTAssertEqual(flow.route, .step2)
+    }
+
+    func test_tappedNext_isNoOpWhenInvalid() async throws {
+        let flow = await makeFlow()
+        flow.tappedNext()  // empty name
+        XCTAssertEqual(flow.route, .step1)
+    }
+
+    // MARK: - InviteByKey
+
+    func test_addInvitee_validHex_appendsAndReturnsToStep2() async throws {
+        let flow = await makeFlow()
+        flow.route = .inviteByKey
+        flow.inviteeInput = String(repeating: "ab", count: 32)  // 64 chars
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.invitees.count, 1)
+        XCTAssertEqual(flow.invitees[0].inboxPublicKey, Data(repeating: 0xAB, count: 32))
+        XCTAssertEqual(flow.route, .step2)
+        XCTAssertNil(flow.inviteeError)
+        XCTAssertEqual(flow.inviteeInput, "")
+    }
+
+    func test_addInvitee_emptyInput_setsError_doesNotAppend() async throws {
+        let flow = await makeFlow()
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.invitees.count, 0)
+        XCTAssertNotNil(flow.inviteeError)
+        XCTAssertTrue(flow.inviteeError?.contains("Paste") ?? false)
+    }
+
+    func test_addInvitee_wrongLength_setsError() async throws {
+        let flow = await makeFlow()
+        flow.inviteeInput = "abc"
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.invitees.count, 0)
+        XCTAssertTrue(flow.inviteeError?.contains("64") ?? false)
+    }
+
+    func test_addInvitee_nonHex_setsError() async throws {
+        let flow = await makeFlow()
+        flow.inviteeInput = String(repeating: "z", count: 64)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.invitees.count, 0)
+        XCTAssertNotNil(flow.inviteeError)
+    }
+
+    func test_addInvitee_stripsWhitespace() async throws {
+        let flow = await makeFlow()
+        // Hex with embedded whitespace — should be cleaned before length check.
+        let raw = String(repeating: "ab", count: 32)
+        let withSpaces = raw.enumerated().map { i, c in
+            i % 8 == 0 ? " \(c)" : "\(c)"
+        }.joined()
+        flow.inviteeInput = withSpaces
+        XCTAssertEqual(flow.inviteeInputCleanedLength, 64)
+        XCTAssertTrue(flow.inviteeInputIsValid)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.invitees.count, 1)
+    }
+
+    func test_removeInvitee_removesByIndex() async throws {
+        let flow = await makeFlow()
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        flow.inviteeInput = String(repeating: "bb", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.invitees.count, 2)
+        flow.removeInvitee(at: 0)
+        XCTAssertEqual(flow.invitees.count, 1)
+        XCTAssertEqual(flow.invitees[0].inboxPublicKey, Data(repeating: 0xBB, count: 32))
+    }
+
+    // MARK: - Routing
+
+    func test_tappedInviteByKey_clearsInputAndNavigates() async throws {
+        let flow = await makeFlow()
+        flow.inviteeInput = "leftover"
+        flow.inviteeError = "stale"
+        flow.tappedInviteByKey()
+        XCTAssertEqual(flow.route, .inviteByKey)
+        XCTAssertEqual(flow.inviteeInput, "")
+        XCTAssertNil(flow.inviteeError)
+    }
+
+    func test_createCTALabel_reflectsInviteeCount() async throws {
+        let flow = await makeFlow()
+        XCTAssertEqual(flow.createCTALabel, "Create empty group")
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.createCTALabel, "Create with 1 person")
+        flow.inviteeInput = String(repeating: "bb", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.createCTALabel, "Create with 2 people")
+    }
+
+    // MARK: - onClose
+
+    func test_tappedDone_resetsAndCallsOnClose() async throws {
+        let flow = await makeFlow()
+        var closedCount = 0
+        flow.onClose = { closedCount += 1 }
+        flow.name = "stale"
+        flow.invitees = [
+            OnymInvitee(id: UUID(), inboxPublicKey: Data(repeating: 0, count: 32), displayLabel: "x")
+        ]
+        flow.route = .success
+        flow.tappedDone()
+        XCTAssertEqual(closedCount, 1)
+        XCTAssertEqual(flow.route, .step1)
+        XCTAssertEqual(flow.name, "")
+        XCTAssertTrue(flow.invitees.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeFlow() async -> CreateGroupFlow {
+        let env = await CreateGroupFlowTestEnv.make()
+        return CreateGroupFlow(interactor: env.interactor)
+    }
+}
+
+@MainActor
+private final class CreateGroupFlowTestEnv {
+    let interactor: CreateGroupInteractor
+    private let keychain: KeychainStore
+
+    static func make() async -> CreateGroupFlowTestEnv {
+        let keychain = KeychainStore(
+            service: "chat.onym.ios.identity.tests.flow.\(UUID().uuidString)",
+            account: "current"
+        )
+        let identity = IdentityRepository(keychain: keychain)
+        _ = try? await identity.restore(
+            mnemonic: "legal winner thank year wave sausage worth useful legal winner thank yellow"
+        )
+        let relayers = RelayerRepository(
+            fetcher: FakeKnownRelayersFetcher(mode: .succeeds([])),
+            store: InMemoryRelayerSelectionStore()
+        )
+        let manifest = ContractsManifest(
+            version: 1,
+            releases: [ContractRelease(
+                release: "v0.0.3",
+                publishedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                contracts: [ContractEntry(network: .testnet, type: .tyranny, id: "CTYRANNYTEST")]
+            )]
+        )
+        let contracts = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(manifest)),
+            store: InMemoryAnchorSelectionStore()
+        )
+        try? await contracts.refresh()
+
+        // Tests in this file only touch flow state — the interactor is
+        // never invoked, so an unconfigured contract transport is fine.
+        let interactor = CreateGroupInteractor(
+            identity: identity,
+            relayers: relayers,
+            contracts: contracts,
+            groups: GroupRepository(store: SwiftDataGroupStore.inMemory()),
+            inboxTransport: FlowTestInboxTransport(),
+            makeContractTransport: { _ in FlowTestContractTransport() }
+        )
+        return CreateGroupFlowTestEnv(interactor: interactor, keychain: keychain)
+    }
+
+    private init(interactor: CreateGroupInteractor, keychain: KeychainStore) {
+        self.interactor = interactor
+        self.keychain = keychain
+    }
+
+    deinit { try? keychain.wipe() }
+}
+
+private struct FlowTestInboxTransport: InboxTransport {
+    func connect(to endpoints: [TransportEndpoint]) async {}
+    func disconnect() async {}
+    func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
+        PublishReceipt(messageID: "x", acceptedBy: 1)
+    }
+    func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> { AsyncStream { _ in } }
+    func unsubscribe(inbox: TransportInboxID) async {}
+}
+
+private struct FlowTestContractTransport: SEPContractTransport {
+    func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ invocation: SEPContractInvocation<Payload>,
+        responseType: Response.Type
+    ) async throws -> Response {
+        let stub = SEPSubmissionResponse(accepted: true, transactionHash: nil, message: nil)
+        let data = try JSONEncoder().encode(stub)
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+}

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -1,0 +1,385 @@
+import Foundation
+import XCTest
+@testable import OnymIOS
+
+/// End-to-end tests for the `CreateGroupInteractor` pipeline. Real
+/// `IdentityRepository` (Keychain-isolated per test), real
+/// `RelayerRepository` + `ContractsRepository` seeded with in-memory
+/// fakes, real `SwiftDataGroupStore.inMemory()`. Proof generation and
+/// chain transport are stubbed so the suite finishes in <1s — the full
+/// real-proof path is exercised by `GroupProofGeneratorTests`
+/// already.
+@MainActor
+final class CreateGroupInteractorTests: XCTestCase {
+
+    // MARK: - Happy path
+
+    func test_create_withNoInvitees_savesGroupAndAnchorsOnChain() async throws {
+        let env = await makeTestEnv()
+        let interactor = env.makeInteractor()
+
+        let group = try await interactor.create(name: "My Group", invitees: [])
+
+        XCTAssertEqual(group.name, "My Group")
+        XCTAssertTrue(group.isPublishedOnChain)
+        XCTAssertEqual(group.groupType, .tyranny)
+        XCTAssertEqual(group.tier, .small)
+        XCTAssertEqual(group.epoch, 0)
+        XCTAssertEqual(group.members.count, 1, "creator-only roster at create")
+
+        // Group landed in the repository.
+        let stored = await env.groups.snapshots.first { _ in true }
+        XCTAssertEqual(stored?.first?.id, group.id)
+
+        // No invitations sent.
+        let sends = await env.inboxTransport.sends
+        XCTAssertTrue(sends.isEmpty)
+
+        // Chain anchor was POSTed exactly once.
+        let invocations = env.contractTransport.invocations
+        XCTAssertEqual(invocations.count, 1)
+        XCTAssertEqual(invocations.first?.function, "create_group_v2")
+    }
+
+    func test_create_withTwoInvitees_sendsOneInvitationPerInvitee() async throws {
+        let env = await makeTestEnv()
+        let interactor = env.makeInteractor()
+
+        // Two valid 32-byte X25519 raw pubkeys (random bytes — IdentityRepository.sealInvitation
+        // doesn't actually require valid curve points; CryptoKit only checks length).
+        let invitee1 = Data(repeating: 0xAA, count: 32)
+        let invitee2 = Data(repeating: 0xBB, count: 32)
+
+        let group = try await interactor.create(
+            name: "Friends",
+            invitees: [invitee1, invitee2]
+        )
+
+        XCTAssertTrue(group.isPublishedOnChain)
+        let sends = await env.inboxTransport.sends
+        XCTAssertEqual(sends.count, 2, "one invitation per invitee")
+        XCTAssertEqual(Set(sends.map(\.inbox.rawValue)).count, 2,
+                       "each invitee gets a distinct inbox tag")
+    }
+
+    // MARK: - Validation
+
+    func test_create_emptyName_throwsInvalidName() async throws {
+        let env = await makeTestEnv()
+        await assertThrows(
+            try await env.makeInteractor().create(name: "   ", invitees: []),
+            CreateGroupError.invalidName
+        )
+    }
+
+    func test_create_inviteeWrongLength_throwsInvalidInviteeKey() async throws {
+        let env = await makeTestEnv()
+        await assertThrows(
+            try await env.makeInteractor().create(
+                name: "G",
+                invitees: [Data(repeating: 0x01, count: 16)]  // 16 ≠ 32
+            ),
+            CreateGroupError.invalidInviteeKey(index: 0)
+        )
+    }
+
+    // MARK: - Resolution failures
+
+    func test_create_noActiveRelayer_throws() async throws {
+        let env = await makeTestEnv(addRelayer: false)
+        await assertThrows(
+            try await env.makeInteractor().create(name: "G", invitees: []),
+            CreateGroupError.noActiveRelayer
+        )
+    }
+
+    func test_create_noContractBinding_throws() async throws {
+        let env = await makeTestEnv(includeTyrannyContract: false)
+        await assertThrows(
+            try await env.makeInteractor().create(name: "G", invitees: []),
+            CreateGroupError.noContractBinding(.tyranny)
+        )
+    }
+
+    // MARK: - Chain failures
+
+    func test_create_anchorTransportError_throws() async throws {
+        let env = await makeTestEnv()
+        env.contractTransport.behavior = .throws(SEPError.invalidResponse(statusCode: 502, body: "bad gateway"))
+        do {
+            _ = try await env.makeInteractor().create(name: "G", invitees: [])
+            XCTFail("expected anchorTransport error")
+        } catch CreateGroupError.anchorTransport(let msg) {
+            XCTAssertTrue(msg.contains("502"), "error message should mention status code")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_create_anchorRejected_throws() async throws {
+        let env = await makeTestEnv()
+        env.contractTransport.behavior = .response(SEPSubmissionResponse(
+            accepted: false,
+            transactionHash: nil,
+            message: "duplicate group ID"
+        ))
+        await assertThrows(
+            try await env.makeInteractor().create(name: "G", invitees: []),
+            CreateGroupError.anchorRejected(message: "duplicate group ID")
+        )
+    }
+
+    func test_create_invitationSendNotAccepted_throws() async throws {
+        let env = await makeTestEnv()
+        await env.inboxTransport.setReceiptAcceptedBy(0)
+
+        do {
+            _ = try await env.makeInteractor().create(
+                name: "G",
+                invitees: [Data(repeating: 0xAA, count: 32)]
+            )
+            XCTFail("expected invitationSendFailed")
+        } catch CreateGroupError.invitationSendFailed(let index, _) {
+            XCTAssertEqual(index, 0)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrows<T: Sendable>(
+        _ expression: @autoclosure () async throws -> T,
+        _ expected: CreateGroupError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("expected to throw \(expected), got success", file: file, line: line)
+        } catch let error as CreateGroupError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("expected \(expected), got \(error)", file: file, line: line)
+        }
+    }
+
+    private func makeTestEnv(
+        addRelayer: Bool = true,
+        includeTyrannyContract: Bool = true
+    ) async -> CreateGroupTestEnv {
+        let env = await CreateGroupTestEnv.make(
+            addRelayer: addRelayer,
+            includeTyrannyContract: includeTyrannyContract
+        )
+        return env
+    }
+}
+
+// MARK: - Test environment
+
+/// Holds every dependency `CreateGroupInteractor` needs, pre-seeded
+/// for the happy path. Each test can mutate `contractTransport.behavior`
+/// or the inbox transport's receipt count to exercise specific
+/// failures without rebuilding the whole graph.
+@MainActor
+private final class CreateGroupTestEnv {
+    let identity: IdentityRepository
+    let relayers: RelayerRepository
+    let contracts: ContractsRepository
+    let groups: GroupRepository
+    let inboxTransport: ConfigurableInboxTransport
+    let contractTransport: ConfigurableContractTransport
+    let proofGenerator: StubGroupProofGenerator
+    private let keychain: KeychainStore
+
+    static func make(addRelayer: Bool, includeTyrannyContract: Bool) async -> CreateGroupTestEnv {
+        let keychain = KeychainStore(
+            service: "chat.onym.ios.identity.tests.create-group.\(UUID().uuidString)",
+            account: "current"
+        )
+        let identity = IdentityRepository(keychain: keychain)
+        // Use a real BIP39 vector so we get real BLS keys + StrKey AccountID.
+        _ = try? await identity.restore(
+            mnemonic: "legal winner thank year wave sausage worth useful legal winner thank yellow"
+        )
+
+        let relayerStore = InMemoryRelayerSelectionStore()
+        let relayers = RelayerRepository(
+            fetcher: FakeKnownRelayersFetcher(mode: .succeeds([])),
+            store: relayerStore
+        )
+        if addRelayer {
+            _ = await relayers.addEndpoint(RelayerEndpoint(
+                name: "test",
+                url: URL(string: "https://relayer.test.example")!,
+                networks: ["testnet"]
+            ))
+            await relayers.setStrategy(.primary)
+            await relayers.setPrimary(url: URL(string: "https://relayer.test.example")!)
+        }
+
+        let contractEntries: [ContractEntry] = includeTyrannyContract
+            ? [ContractEntry(network: .testnet, type: .tyranny, id: "CTYRANNYTEST00000000000000000000000000000000000000000000")]
+            : []
+        let manifest = ContractsManifest(
+            version: 1,
+            releases: [
+                ContractRelease(
+                    release: "v0.0.3",
+                    publishedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    contracts: contractEntries
+                )
+            ]
+        )
+        let contractsStore = InMemoryAnchorSelectionStore()
+        let contracts = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(manifest)),
+            store: contractsStore
+        )
+        try? await contracts.refresh()
+
+        return CreateGroupTestEnv(
+            identity: identity,
+            relayers: relayers,
+            contracts: contracts,
+            groups: GroupRepository(store: SwiftDataGroupStore.inMemory()),
+            inboxTransport: ConfigurableInboxTransport(),
+            contractTransport: ConfigurableContractTransport(),
+            proofGenerator: StubGroupProofGenerator(),
+            keychain: keychain
+        )
+    }
+
+    private init(
+        identity: IdentityRepository,
+        relayers: RelayerRepository,
+        contracts: ContractsRepository,
+        groups: GroupRepository,
+        inboxTransport: ConfigurableInboxTransport,
+        contractTransport: ConfigurableContractTransport,
+        proofGenerator: StubGroupProofGenerator,
+        keychain: KeychainStore
+    ) {
+        self.identity = identity
+        self.relayers = relayers
+        self.contracts = contracts
+        self.groups = groups
+        self.inboxTransport = inboxTransport
+        self.contractTransport = contractTransport
+        self.proofGenerator = proofGenerator
+        self.keychain = keychain
+    }
+
+    deinit { try? keychain.wipe() }
+
+    func makeInteractor() -> CreateGroupInteractor {
+        CreateGroupInteractor(
+            identity: identity,
+            relayers: relayers,
+            contracts: contracts,
+            groups: groups,
+            proofGenerator: proofGenerator,
+            inboxTransport: inboxTransport,
+            makeContractTransport: { [contractTransport] _ in contractTransport }
+        )
+    }
+}
+
+// MARK: - Stubs
+
+/// Returns a deterministic 1568-byte "proof" without actually proving.
+/// Skips the ~3.5s real prover so the test suite stays fast.
+private struct StubGroupProofGenerator: GroupProofGenerator {
+    func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
+        guard input.groupType == .tyranny else {
+            throw GroupProofGeneratorError.notYetSupported(input.groupType)
+        }
+        return GroupCreateProof(
+            proof: Data(repeating: 0xAB, count: 1568),
+            publicInputs: SEPPublicInputs(
+                commitment: Data(repeating: 0xCD, count: 32),
+                epoch: 0
+            )
+        )
+    }
+}
+
+/// Recording inbox transport with a configurable acceptedBy count.
+/// Different from the existing `FakeInboxTransport` (which forces
+/// acceptedBy=1) so we can exercise the "no relay accepted" path.
+private actor ConfigurableInboxTransport: InboxTransport {
+    struct Send: Sendable {
+        let payload: Data
+        let inbox: TransportInboxID
+    }
+
+    private(set) var sends: [Send] = []
+    private var receiptAcceptedBy: Int = 1
+
+    func setReceiptAcceptedBy(_ count: Int) { receiptAcceptedBy = count }
+
+    func connect(to endpoints: [TransportEndpoint]) async {}
+    func disconnect() async {}
+
+    func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
+        sends.append(Send(payload: payload, inbox: inbox))
+        return PublishReceipt(messageID: "fake-\(UUID().uuidString)", acceptedBy: receiptAcceptedBy)
+    }
+
+    nonisolated func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
+        AsyncStream { _ in }
+    }
+
+    func unsubscribe(inbox: TransportInboxID) async {}
+}
+
+/// Recording contract transport. `behavior` controls whether the next
+/// invocation throws or returns a canned response.
+private final class ConfigurableContractTransport: SEPContractTransport, @unchecked Sendable {
+    enum Behavior: Sendable {
+        case response(SEPSubmissionResponse)
+        case `throws`(Error)
+    }
+
+    struct Invocation: @unchecked Sendable {
+        let function: String
+        let payload: Data
+    }
+
+    private let lock = NSLock()
+    private var _behavior: Behavior = .response(SEPSubmissionResponse(
+        accepted: true,
+        transactionHash: "0xstub",
+        message: nil
+    ))
+    private var _invocations: [Invocation] = []
+
+    var behavior: Behavior {
+        get { lock.withLock { _behavior } }
+        set { lock.withLock { _behavior = newValue } }
+    }
+
+    var invocations: [Invocation] {
+        lock.withLock { _invocations }
+    }
+
+    func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ invocation: SEPContractInvocation<Payload>,
+        responseType: Response.Type
+    ) async throws -> Response {
+        let encoded = try JSONEncoder().encode(invocation)
+        let body = (try? JSONSerialization.jsonObject(with: encoded)) as? [String: Any]
+        let function = (body?["function"] as? String) ?? "?"
+        lock.withLock {
+            _invocations.append(Invocation(function: function, payload: encoded))
+        }
+        switch behavior {
+        case .response(let stub):
+            let data = try JSONEncoder().encode(stub)
+            return try JSONDecoder().decode(Response.self, from: data)
+        case .throws(let error):
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR-C of the 4-PR Create Group slice. Builds on PR-A (#24, foundation
types + sealer) and PR-B (#25, proof generator + repository). This PR
wires them into the user-facing flow:

UI → `CreateGroupFlow` → `CreateGroupInteractor` → `Tyranny.proveCreate` →
relayer `createGroupV2` → `GroupRepository.insert` + `markPublished` →
seal+send invitation per invitee (`acceptedBy >= 1`).

The 4 PRs:
- PR-A (#24, **merged**): foundation port.
- PR-B (#25, **merged**): Tyranny proof generator + group repository.
- **PR-C (this one)**: Create Group UI + invitation send.
- PR-D: real-testnet E2E test gated on `ONYM_INTEGRATION=1`.

## What's in PR-C

| Layer | File | What it does |
|---|---|---|
| Identity | `IdentityRepository.swift` | `+blsSecretKey()` one-shot accessor (callers must not retain). Mirrors stellar-mls's KeyManager surface. `+IdentityError.identityNotLoaded`. |
| Group | `GroupInvitationPayload.swift` | Codable invite envelope mirroring stellar-mls's `InviteCode` shape (`groupID`, `groupSecret`, `name`, `members`, `epoch`, `salt`, `commitment`, `tierRaw`, `groupTypeRaw`, `adminPubkeyHex`). Sealed via `IdentityRepository.sealInvitation`, sent via `InboxTransport.send`. |
| Group | `CreateGroupInteractor.swift` | Stateless orchestration. Validate → resolve relayer + tyranny binding → fresh group params → BLS leaf → `proveCreate` → POST `createGroupV2` → `groups.insert` + `markPublished` → for each invitee: seal + send (`acceptedBy >= 1`). Throws on hard failures; group lands locally even when invitation legs fail. |
| Group | `CreateGroupFlow.swift` | `@Observable @MainActor` view-model. Form state + 5-route enum (step1 / step2 / inviteByKey / creating / success) + intent methods. Live hex validation (64 chars → 32 bytes; whitespace stripped). |
| Group | `OnymBrand.swift` | Pixel-port of the design's brand kit: broken-ring `OnymMark` logo, 6-color accent palette, `OnymGovIcon` (crown/bubbles/nodes), `OnymGroupAvatar` with pulsing-ring + spinning variants. |
| Group | `CreateGroupView.swift` | Five SwiftUI screens (Step1 / Step2 / InviteByKey / Creating / Success) wired via `flow.route`. Sticky-footer layout. Pixel-port of the design adapted to PR-C scope. |
| App | `AppDependencies.swift`, `OnymIOSApp.swift` | `makeCreateGroupFlow` factory. One `GroupRepository` constructed at app boot (falls back to in-memory if on-disk store can't open). `NostrInboxTransport` wired for invitation send. |
| Settings | `SettingsView.swift` | New "Groups" section at the top with "Create Group" row → presents `CreateGroupView` via `.fullScreenCover`. |

## Design adaptations from the Claude Designed reference

The design covers Tyranny / 1-on-1 / Anarchy. PR-C ships only the
Tyranny path:

- **Governance picker** keeps all 3 cards (matches design) but 1-on-1
  and Anarchy show a "Soon" pill and aren't selectable.
- **Step 2 "Add People"** drops the Contacts list (no `CNContactStore`
  per scope) — invitees come exclusively from the Invite by Inbox Key
  screen.
- **InviteByKey** drops the "Scan QR" button (no camera entitlement
  in MVP).
- **Creating** wires the steps card to real `CreateGroupProgress`
  events from the interactor (no faked timing).
- **Success** drops the QR + "Open" button (no chat screen yet) —
  ships with just a "Done" CTA.

## Settled scope (don't re-litigate)

1. **Tyranny first.** Other governance types throw `.notYetSupported`.
2. **Paste-only invitee picker.** No Contacts framework, no QR scanner.
3. **Wait for at-least-one OK** before declaring success — both the
   chain anchor and each invitation send must return acceptedBy >= 1.

## Test plan

22/22 unit tests pass on iPhone 17 Pro / iOS 26 simulator.

**Interactor (9):**
- [x] Happy path with 0 invitees — group anchored + saved
- [x] Happy path with 2 invitees — one inbox.send per invitee
- [x] Empty name → `.invalidName`
- [x] Wrong-size invitee key → `.invalidInviteeKey`
- [x] No active relayer → `.noActiveRelayer`
- [x] No tyranny contract binding → `.noContractBinding(.tyranny)`
- [x] Relayer non-2xx → `.anchorTransport` with status code
- [x] `accepted=false` → `.anchorRejected(message:)`
- [x] Invitation `acceptedBy=0` → `.invitationSendFailed(index:)`

**Flow view-model (13):**
- [x] `canAdvanceToStep2` requires non-empty name + available governance
- [x] Unavailable governance blocks advance
- [x] `tappedNext` advances + is no-op when invalid
- [x] Add invitee: valid hex / empty / wrong length / non-hex / strips whitespace
- [x] Remove invitee by index
- [x] `tappedInviteByKey` clears input + navigates
- [x] `createCTALabel` reflects invitee count ("Create empty group" / "1 person" / "N people")
- [x] `tappedDone` resets state + calls `onClose`

A UI smoke test was prototyped but failed in the iOS 26 simulator due
to a `.fullScreenCover`-vs-XCUITest timing quirk that doesn't manifest
in the live app. Removed for now — UI verified manually.

## Architecture compliance

Mirrors PR #15's touch-surface table.

- `CreateGroupInteractor` (interactor) holds `IdentityRepository`,
  `RelayerRepository`, `ContractsRepository`, `GroupRepository`,
  `GroupProofGenerator`, `InboxTransport` references. Never imports
  `OnymSDK` or `URLSession` directly.
- `CreateGroupFlow` (view-model) holds the interactor only.
- `CreateGroupView` (view) holds the flow only.
- `GroupInvitationPayload` is a pure value type.
- `OnymBrand` imports SwiftUI only.

## Out of scope (defers to PR-D)

- Real-testnet E2E test against the deployed relayer — that's PR-D.
- Anarchy / 1-on-1 / Democracy / Oligarchy governance types.
- Chat screen / message list — explicitly skipped.
- Member-add via `update_commitment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)