### PR TITLE
group: relayer wire format + UX fixes (PR-C follow-up)

### DIFF
--- a/Sources/OnymIOS/Chain/GroupProofGenerator.swift
+++ b/Sources/OnymIOS/Chain/GroupProofGenerator.swift
@@ -1,19 +1,31 @@
 import Foundation
 import OnymSDK
 
-/// Output of `GroupProofGenerator.proveCreate`. The relayer / contract
-/// expect:
-/// - `proof` — 1568 bytes, the `Common.parsePlonkProof`-trimmed form of
-///   the raw 1601-byte SDK output (strips the four `len()` u64
-///   prefixes + the trailing `plookup_proof: None` byte).
-/// - `publicInputs` — the `(commitment, epoch)` pair the
-///   `SEPCreateGroupV2Request` carries. For create the SDK's
-///   per-type-specific PI bundle (`commitment || Fr(0) || …`) is sliced
-///   to its first 32 bytes for the commitment; epoch is always 0 for
-///   create.
+/// Output of `GroupProofGenerator.proveCreate`. The relayer expects:
+/// - `proof` — the **raw 1601-byte PLONK proof** (the relayer's
+///   `decode_wire_bytes(_, _, Some(1601))` rejects anything else; the
+///   `parsePlonkProof` trim happens on the contract side, not on the
+///   wire).
+/// - `publicInputs` — the SDK's full per-type PI bundle, split into
+///   32-byte chunks. Tyranny create returns 4 chunks
+///   (`commitment || Fr(0) || admin_pubkey_commitment || group_id_fr`)
+///   which the relayer forwards as the contract's `Vec<BytesN<32>>`
+///   public-inputs argument.
+/// - `commitment` and `adminPubkeyCommitment` are convenience
+///   accessors so callers don't have to re-slice the bundle.
 struct GroupCreateProof: Equatable, Sendable {
     let proof: Data
-    let publicInputs: SEPPublicInputs
+    let publicInputs: [Data]
+
+    /// First 32 bytes of the PI bundle — the new commitment the
+    /// contract will store.
+    var commitment: Data { publicInputs[0] }
+
+    /// Bytes 64..96 of the PI bundle (Tyranny only) — the Poseidon
+    /// commitment to the admin's BLS pubkey, surfaced separately
+    /// because the relayer needs it both as a top-level CLI arg and
+    /// as `publicInputs[2]`.
+    var adminPubkeyCommitment: Data { publicInputs[2] }
 }
 
 /// PR-B's chain seam for proof generation. Switches on `groupType` so
@@ -98,21 +110,21 @@ struct OnymGroupProofGenerator: GroupProofGenerator {
             throw GroupProofGeneratorError.sdkFailure(String(describing: error))
         }
 
-        let parsed: Data
-        do {
-            parsed = try Common.parsePlonkProof(result.proof)
-        } catch {
-            throw GroupProofGeneratorError.sdkFailure(String(describing: error))
-        }
-
-        // PI bundle layout (Tyranny.CreateProof):
+        // SDK returns the raw 1601-byte proof. Don't `parsePlonkProof`
+        // — the relayer rejects the trimmed form.
+        // PI bundle layout (`Tyranny.CreateProof.publicInputs`, 128 B):
         //   commitment(32) || Fr(0)(32) || admin_pubkey_commitment(32) || group_id_fr(32)
-        // Only the first 32 bytes (commitment) cross the wire; the rest
-        // are bound by the proof itself.
-        let commitment = result.publicInputs.prefix(32)
-        return GroupCreateProof(
-            proof: parsed,
-            publicInputs: SEPPublicInputs(commitment: Data(commitment), epoch: 0)
-        )
+        // Each 32-byte chunk maps to one `BytesN<32>` in the contract's
+        // `Vec<BytesN<32>>` public-inputs argument.
+        let bundle = result.publicInputs
+        guard bundle.count == 128 else {
+            throw GroupProofGeneratorError.sdkFailure(
+                "expected 128-byte PI bundle, got \(bundle.count)"
+            )
+        }
+        let chunks: [Data] = stride(from: 0, to: bundle.count, by: 32).map { offset in
+            Data(bundle[offset..<(offset + 32)])
+        }
+        return GroupCreateProof(proof: result.proof, publicInputs: chunks)
     }
 }

--- a/Sources/OnymIOS/Chain/NetworkPreference.swift
+++ b/Sources/OnymIOS/Chain/NetworkPreference.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// User's selected Stellar network for new groups. Defaults to
+/// `.testnet` because the v0.0.3 contracts only ship there today;
+/// `.mainnet` is reachable via the Settings → Network toggle once
+/// real contracts land on it.
+enum AppNetwork: String, Codable, CaseIterable, Sendable {
+    case testnet
+    case mainnet
+
+    /// Bridges to `ContractNetwork` (used by `AnchorSelectionKey` for
+    /// the contracts manifest). The wire spelling is `public` for
+    /// mainnet — see `SEPNetwork`.
+    var contractNetwork: ContractNetwork {
+        switch self {
+        case .testnet: .testnet
+        case .mainnet: .public
+        }
+    }
+
+    var sepNetwork: SEPNetwork {
+        switch self {
+        case .testnet: .testnet
+        case .mainnet: .publicNet
+        }
+    }
+}
+
+/// Read-only seam over whichever store backs the user's preference.
+/// `CreateGroupInteractor` depends on this rather than UserDefaults so
+/// tests can swap it without touching `@AppStorage`.
+protocol NetworkPreferenceProviding: Sendable {
+    func current() -> AppNetwork
+}
+
+/// Production impl — backed by `UserDefaults` under the same key the
+/// Settings `Toggle` reads via `@AppStorage("onym.useMainnet")`.
+struct UserDefaultsNetworkPreference: NetworkPreferenceProviding, @unchecked Sendable {
+    static let storageKey = "onym.useMainnet"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func current() -> AppNetwork {
+        defaults.bool(forKey: Self.storageKey) ? .mainnet : .testnet
+    }
+}
+
+/// Test fake — returns whatever was passed in.
+struct StaticNetworkPreference: NetworkPreferenceProviding {
+    let value: AppNetwork
+    func current() -> AppNetwork { value }
+}

--- a/Sources/OnymIOS/Chain/SEPContractClient.swift
+++ b/Sources/OnymIOS/Chain/SEPContractClient.swift
@@ -1,26 +1,11 @@
 import Foundation
 
-/// Generic envelope wrapping a contract-function invocation. Mirrors
-/// `swift-mls`'s `SEPContractInvocation` so the relayer wire format stays
-/// in sync — the relayer reads `contract_id`, `function`, and `payload`
-/// out of the JSON top-level. Stellar Soroban SDK is intentionally not
-/// pulled in: relayers handle tx assembly + signing, this client just
-/// posts the function call.
-struct SEPContractInvocation<Payload: Encodable & Sendable>: Encodable, Sendable {
-    let contractID: String
-    let function: String
-    let payload: Payload
-
-    enum CodingKeys: String, CodingKey {
-        case contractID = "contract_id"
-        case function
-        case payload
-    }
-}
-
 /// Seam for the network leg. Tests inject a fake; production uses
 /// `URLSessionSEPContractTransport` constructed from a `RelayerEndpoint`
-/// resolved via `RelayerSelectionStrategy`.
+/// resolved by `RelayerRepository.selectURL`.
+///
+/// The `SEPContractInvocation` envelope itself lives in
+/// `SEPContractTypes.swift` so the wire-format types stay together.
 protocol SEPContractTransport: Sendable {
     func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
         _ invocation: SEPContractInvocation<Payload>,
@@ -69,32 +54,41 @@ struct URLSessionSEPContractTransport: SEPContractTransport {
     }
 }
 
-/// Pins a `(contractID, transport)` pair and exposes the four contract
-/// entrypoints PR-A needs: `create_group_v2` (Anarchy / 1v1 / Democracy /
-/// Tyranny), `update_commitment` (Tyranny member-add later), `get_state`
-/// (post-create read-back). Per-type Oligarchy creation lives outside
-/// PR-A scope.
+/// Pins a `(contractID, contractType, network, transport)` tuple and
+/// exposes the per-function entrypoints PR-C needs:
+/// `create_group` (Tyranny only at this slice), `update_commitment`,
+/// `get_commitment`. Top-level fields are stamped onto every
+/// invocation so the relayer can route + allowlist-check.
 struct SEPContractClient: Sendable {
     let contractID: String
+    let contractType: SEPGroupType
+    let network: SEPNetwork
     let transport: any SEPContractTransport
 
-    init(contractID: String, transport: any SEPContractTransport) {
+    init(
+        contractID: String,
+        contractType: SEPGroupType,
+        network: SEPNetwork,
+        transport: any SEPContractTransport
+    ) {
         self.contractID = contractID
+        self.contractType = contractType
+        self.network = network
         self.transport = transport
     }
 
-    func createGroupV2(_ request: SEPCreateGroupV2Request) async throws -> SEPSubmissionResponse {
-        try await invoke("create_group_v2", payload: request, responseType: SEPSubmissionResponse.self)
+    func createGroupTyranny(_ payload: TyrannyCreateGroupPayload) async throws -> SEPSubmissionResponse {
+        try await invoke("create_group", payload: payload, responseType: SEPSubmissionResponse.self)
     }
 
-    func updateCommitment(_ request: SEPUpdateCommitmentRequest) async throws -> SEPSubmissionResponse {
-        try await invoke("update_commitment", payload: request, responseType: SEPSubmissionResponse.self)
+    func updateCommitmentTyranny(_ payload: TyrannyUpdateCommitmentPayload) async throws -> SEPSubmissionResponse {
+        try await invoke("update_commitment", payload: payload, responseType: SEPSubmissionResponse.self)
     }
 
-    func getState(groupID: Data) async throws -> SEPCommitmentEntry {
+    func getCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
         try await invoke(
-            "get_state",
-            payload: SEPGetStateRequest(groupID: groupID),
+            "get_commitment",
+            payload: GetCommitmentPayload(groupID: groupID),
             responseType: SEPCommitmentEntry.self
         )
     }
@@ -105,7 +99,13 @@ struct SEPContractClient: Sendable {
         responseType: Response.Type
     ) async throws -> Response {
         try await transport.invoke(
-            SEPContractInvocation(contractID: contractID, function: function, payload: payload),
+            SEPContractInvocation(
+                contractID: contractID,
+                contractType: contractType,
+                network: network,
+                function: function,
+                payload: payload
+            ),
             responseType: responseType
         )
     }

--- a/Sources/OnymIOS/Chain/SEPContractTypes.swift
+++ b/Sources/OnymIOS/Chain/SEPContractTypes.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-/// Mirrors `stellar-mls/swift-mls`'s `SEPGroupType` plus the post-v0.0.3
-/// `tyranny` case that swift-mls hasn't been bumped for yet. Persisted as
-/// the `group_type` u32 in the contract's `CommitmentEntryV2`.
-enum SEPGroupType: UInt32, Codable, CaseIterable, Sendable {
-    case anarchy = 0
-    case oneOnOne = 1
-    case democracy = 2
-    case oligarchy = 3
-    case tyranny = 4
+/// On-chain governance flavour. The relayer (`onym-relayer/src/config.rs`,
+/// `enum ContractType`) accepts the lowercase string spelling on the
+/// wire — these `rawValue`s are pinned to match.
+enum SEPGroupType: String, Codable, CaseIterable, Sendable {
+    case anarchy
+    case oneOnOne = "oneonone"
+    case democracy
+    case oligarchy
+    case tyranny
 }
 
 /// Tier sizing for a Merkle tree commitment. Values pinned to match the
-/// VK ceremonies.
+/// VK ceremonies. Wire-encoded as the raw `Int` for `--tier`.
 enum SEPTier: Int, Codable, CaseIterable, Sendable {
     case small = 0
     case medium = 1
@@ -35,70 +35,101 @@ enum SEPTier: Int, Codable, CaseIterable, Sendable {
     }
 }
 
-/// Public-input bundle accompanying a Groth16 / PLONK proof: the new
-/// commitment + the epoch number it lives at.
-struct SEPPublicInputs: Codable, Equatable, Sendable {
-    let commitment: Data
-    let epoch: UInt64
+/// Stellar network the relayer should target. Wire-encoded as the
+/// lowercase label (`testnet` or `public`) — `mainnet` is also accepted
+/// by the relayer as an alias for `public` but we always send `public`.
+enum SEPNetwork: String, Codable, CaseIterable, Sendable {
+    case testnet
+    case publicNet = "public"
 }
 
-/// Public-input bundle for the UpdateCircuit (#59 fix). The contract
-/// rederives `cNew` from the proof itself, so the relayer no longer
-/// trusts a client-supplied "new commitment". JSON keys use snake_case
-/// to match the relayer payload schema.
-struct SEPUpdatePublicInputs: Codable, Equatable, Sendable {
-    let cOld: Data
-    let epochOld: UInt64
-    let cNew: Data
+/// Generic envelope the relayer expects on `POST /`. Top-level shape
+/// (mirrors `RelayerRequest` in `onym-relayer/src/handler.rs`):
+///
+/// ```json
+/// {
+///   "contractID":   "C…",
+///   "contractType": "tyranny",
+///   "network":      "testnet",
+///   "function":     "create_group",
+///   "payload":      { …function-specific… }
+/// }
+/// ```
+///
+/// Payloads are typed per function (e.g. `TyrannyCreateGroupPayload`)
+/// and JSON-encoded with their own `CodingKeys`. JSONEncoder default
+/// `Data` strategy is base64 — the relayer accepts both base64 and hex
+/// (`decode_wire_bytes`), so byte fields round-trip without needing a
+/// custom encoder.
+struct SEPContractInvocation<Payload: Encodable & Sendable>: Encodable, Sendable {
+    let contractID: String
+    let contractType: SEPGroupType
+    let network: SEPNetwork
+    let function: String
+    let payload: Payload
 
     enum CodingKeys: String, CodingKey {
-        case cOld = "c_old"
-        case epochOld = "epoch_old"
-        case cNew = "c_new"
+        case contractID
+        case contractType
+        case network
+        case function
+        case payload
     }
 }
 
-/// Payload for `create_group_v2`. Used by Anarchy, 1v1, Democracy, AND
-/// Tyranny (the latter not yet listed in swift-mls). Oligarchy uses its
-/// own dedicated `SEPCreateOligarchyGroupRequest` because it seeds an
-/// extra admin root.
-struct SEPCreateGroupV2Request: Codable, Equatable, Sendable {
-    let caller: String
+/// `create_group` payload for the Tyranny contract. Differs from the
+/// Anarchy / 1-on-1 / Democracy shape — Tyranny needs the Poseidon
+/// `admin_pubkey_commitment` (32 B) as a separate CLI arg AND in the
+/// 4-element public-inputs vector that the contract verifies.
+///
+/// The PI vector is sent as 4 `Data` elements (each 32 bytes,
+/// JSON-encoded as base64 strings):
+/// `[commitment, fr_zero (= 32 zero bytes), admin_pubkey_commitment, group_id_fr]`
+/// — i.e. the SDK's 128-byte `Tyranny.CreateProof.publicInputs`
+/// bundle split into 4 chunks. Relayer handler:
+/// `build_public_inputs_from_object` → `ContractType::Tyranny` arm.
+struct TyrannyCreateGroupPayload: Encodable, Equatable, Sendable {
     let groupID: Data
     let commitment: Data
-    let tier: UInt32
-    let groupType: SEPGroupType
-    let memberCount: UInt32
+    let tier: Int
+    let adminPubkeyCommitment: Data
+    /// 1601-byte raw PLONK proof — relayer's `decode_wire_bytes(_, _, Some(1601))`
+    /// rejects anything else.
     let proof: Data
-    let publicInputs: SEPPublicInputs
+    /// 4 elements × 32 bytes — see comment above.
+    let publicInputs: [Data]
 
     enum CodingKeys: String, CodingKey {
-        case caller
         case groupID = "group_id"
         case commitment
         case tier
-        case groupType = "group_type"
-        case memberCount = "member_count"
+        case adminPubkeyCommitment = "admin_pubkey_commitment"
         case proof
-        case publicInputs = "public_inputs"
+        case publicInputs
     }
 }
 
-/// Payload for `update_commitment` (member-add / member-remove).
-struct SEPUpdateCommitmentRequest: Codable, Equatable, Sendable {
+/// `update_commitment` payload — Tyranny variant. Same 4-element PI
+/// shape as create, but the SDK's `Tyranny.UpdateProof.publicInputs`
+/// is 160 bytes = 5 chunks (`c_old || epoch_old || c_new ||
+/// admin_pubkey_commitment || group_id_fr`). Not used in PR-C; lives
+/// here so the chain seam is complete.
+struct TyrannyUpdateCommitmentPayload: Encodable, Equatable, Sendable {
     let groupID: Data
     let proof: Data
-    let publicInputs: SEPUpdatePublicInputs
+    let publicInputs: [Data]
 
     enum CodingKeys: String, CodingKey {
         case groupID = "group_id"
         case proof
-        case publicInputs = "public_inputs"
+        case publicInputs
     }
 }
 
-/// Payload for `get_state` / `get_state_v2` / `get_admin_root`.
-struct SEPGetStateRequest: Codable, Equatable, Sendable {
+/// Payload for `get_commitment`. The relayer's response is a JSON
+/// object containing `commitment`, `epoch`, `timestamp`, `tier`,
+/// `active` — captured by `SEPCommitmentEntry`.
+struct GetCommitmentPayload: Encodable, Equatable, Sendable {
     let groupID: Data
 
     enum CodingKeys: String, CodingKey {
@@ -106,8 +137,7 @@ struct SEPGetStateRequest: Codable, Equatable, Sendable {
     }
 }
 
-/// On-chain state returned by `get_state`. V1 entries (no group_type
-/// metadata).
+/// On-chain state returned by `get_commitment`.
 struct SEPCommitmentEntry: Codable, Equatable, Sendable {
     let commitment: Data
     let epoch: UInt64
@@ -116,9 +146,9 @@ struct SEPCommitmentEntry: Codable, Equatable, Sendable {
     let active: Bool
 }
 
-/// Relayer's response to a contract-invocation POST. `accepted` reflects
-/// the contract's verification result; `transactionHash` is set when a
-/// Soroban tx was actually submitted.
+/// Relayer's response to a contract-invocation POST. Mirrors
+/// `RelayerResponse` in `onym-relayer/src/handler.rs` — top-level
+/// camelCase with optional `transactionHash` and `message`.
 struct SEPSubmissionResponse: Codable, Equatable, Sendable {
     let accepted: Bool
     let transactionHash: String?

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -31,11 +31,24 @@ struct OnymInvitee: Equatable, Identifiable, Sendable {
 final class CreateGroupFlow {
     // MARK: - Form state
 
-    var name: String = ""
+    var name: String
     var accent: OnymAccent = .blue
     /// Always `.tyranny` in PR-C — the picker disables the others.
     var governance: OnymUIGovernance = .tyranny
     var invitees: [OnymInvitee] = []
+
+    /// Friendly placeholder generated on init / reset (e.g. "Maple
+    /// Garden"). The TextField pre-fills with this so the user can
+    /// hit Create immediately without typing — first focus on the
+    /// field clears it (see `tappedNameFieldFocused`). Submit also
+    /// falls back to this if the user emptied the field and didn't
+    /// retype.
+    private(set) var generatedName: String
+
+    /// Goes true on the first focus event of the name field. Used to
+    /// distinguish "user accepted the placeholder" from "user wants
+    /// to type their own".
+    private var nameFieldHasBeenFocused = false
 
     /// Bound to the InviteByKey screen's TextField.
     var inviteeInput: String = ""
@@ -63,14 +76,35 @@ final class CreateGroupFlow {
 
     init(interactor: CreateGroupInteractor) {
         self.interactor = interactor
+        let generated = Self.generatePlaceholderName()
+        self.generatedName = generated
+        self.name = generated
+    }
+
+    /// Called by the Step1 view when the name TextField gets focus.
+    /// On the *first* focus we clear the field so the user can type a
+    /// fresh name without manually deleting the placeholder. After
+    /// that, focus is a no-op — the user is in charge of the field.
+    func tappedNameFieldFocused() {
+        guard !nameFieldHasBeenFocused else { return }
+        nameFieldHasBeenFocused = true
+        if name == generatedName {
+            name = ""
+        }
     }
 
     // MARK: - Step 1 → Step 2
 
-    /// True when the name is non-empty and a valid governance type
-    /// is selected. Disables the Step1 "Next" button.
-    var canAdvanceToStep2: Bool {
-        !trimmedName.isEmpty && governance.isAvailable
+    /// True when a valid governance type is selected. The name can
+    /// be empty — submit falls back to `generatedName`. The Step1
+    /// "Next" button is enabled whenever governance is available.
+    var canAdvanceToStep2: Bool { governance.isAvailable }
+
+    /// What to send to the interactor: the user's typed name if
+    /// non-empty, else the placeholder we generated for them.
+    var effectiveName: String {
+        let trimmed = trimmedName
+        return trimmed.isEmpty ? generatedName : trimmed
     }
 
     func tappedNext() {
@@ -178,7 +212,7 @@ final class CreateGroupFlow {
         do {
             let invitees = self.invitees.map(\.inboxPublicKey)
             let group = try await interactor.create(
-                name: name,
+                name: effectiveName,
                 invitees: invitees,
                 onProgress: { [weak self] p in
                     Task { @MainActor in self?.progress = p }
@@ -210,8 +244,21 @@ final class CreateGroupFlow {
         route = .step2
     }
 
+    /// User chose to cancel out of the flow from the error state on
+    /// the Creating screen. The group may already be saved on disk
+    /// (we save before sending invitations) — leaving it intact is
+    /// fine, a future "retry invites" UI can pick it up. Just close
+    /// the modal and reset.
+    func tappedCancelFromError() {
+        reset()
+        onClose()
+    }
+
     private func reset() {
-        name = ""
+        let generated = Self.generatePlaceholderName()
+        generatedName = generated
+        name = generated
+        nameFieldHasBeenFocused = false
         accent = .blue
         governance = .tyranny
         invitees = []
@@ -221,6 +268,27 @@ final class CreateGroupFlow {
         error = nil
         createdGroup = nil
         route = .step1
+    }
+
+    /// Build a "Adjective Noun" label like "Maple Garden". Random
+    /// pick from a small lexicon picked for being warm + neutral.
+    /// Pure function so it's deterministic given the system RNG;
+    /// tests that need a stable name can override `generatedName`
+    /// directly after init.
+    static func generatePlaceholderName() -> String {
+        let adjectives = [
+            "Maple", "Quiet", "Sunny", "Brave", "Crimson",
+            "Velvet", "Northern", "Golden", "Ember", "Wild",
+            "Distant", "Tidal", "Silver", "Twilight", "Amber",
+        ]
+        let nouns = [
+            "Garden", "Forest", "Harbor", "Meadow", "Atlas",
+            "River", "Cottage", "Lantern", "Compass", "Orchard",
+            "Mountain", "Lighthouse", "Plateau", "Valley", "Bay",
+        ]
+        let a = adjectives.randomElement() ?? "Quiet"
+        let n = nouns.randomElement() ?? "Forest"
+        return "\(a) \(n)"
     }
 
     // MARK: - Helpers

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -35,6 +35,7 @@ struct CreateGroupInteractor: Sendable {
     let relayers: RelayerRepository
     let contracts: ContractsRepository
     let groups: GroupRepository
+    let networkPreference: any NetworkPreferenceProviding
     let proofGenerator: any GroupProofGenerator
     let inboxTransport: any InboxTransport
     /// Builds a `SEPContractTransport` from the relayer URL chosen
@@ -47,6 +48,7 @@ struct CreateGroupInteractor: Sendable {
         relayers: RelayerRepository,
         contracts: ContractsRepository,
         groups: GroupRepository,
+        networkPreference: any NetworkPreferenceProviding = UserDefaultsNetworkPreference(),
         proofGenerator: any GroupProofGenerator = OnymGroupProofGenerator(),
         inboxTransport: any InboxTransport,
         makeContractTransport: @escaping @Sendable (URL) -> any SEPContractTransport = { url in
@@ -57,6 +59,7 @@ struct CreateGroupInteractor: Sendable {
         self.relayers = relayers
         self.contracts = contracts
         self.groups = groups
+        self.networkPreference = networkPreference
         self.proofGenerator = proofGenerator
         self.inboxTransport = inboxTransport
         self.makeContractTransport = makeContractTransport
@@ -82,11 +85,12 @@ struct CreateGroupInteractor: Sendable {
             }
         }
 
-        // 2. Resolve relayer + contract
+        // 2. Resolve relayer + contract for the user's preferred network.
         guard let relayerURL = await relayers.selectURL() else {
             throw CreateGroupError.noActiveRelayer
         }
-        let key = AnchorSelectionKey(network: .testnet, type: .tyranny)
+        let activeNetwork = networkPreference.current()
+        let key = AnchorSelectionKey(network: activeNetwork.contractNetwork, type: .tyranny)
         guard let binding = await contracts.binding(for: key) else {
             throw CreateGroupError.noContractBinding(.tyranny)
         }
@@ -141,20 +145,23 @@ struct CreateGroupInteractor: Sendable {
         // 6. Anchor on chain
         onProgress(.anchoring)
         let transport = makeContractTransport(relayerURL)
-        let client = SEPContractClient(contractID: binding.contractID, transport: transport)
-        let request = SEPCreateGroupV2Request(
-            caller: identitySnapshot.stellarAccountID,
+        let client = SEPContractClient(
+            contractID: binding.contractID,
+            contractType: .tyranny,
+            network: activeNetwork.sepNetwork,
+            transport: transport
+        )
+        let payload = TyrannyCreateGroupPayload(
             groupID: groupID,
-            commitment: proof.publicInputs.commitment,
-            tier: UInt32(tier.rawValue),
-            groupType: .tyranny,
-            memberCount: UInt32(members.count),
+            commitment: proof.commitment,
+            tier: tier.rawValue,
+            adminPubkeyCommitment: proof.adminPubkeyCommitment,
             proof: proof.proof,
             publicInputs: proof.publicInputs
         )
         let response: SEPSubmissionResponse
         do {
-            response = try await client.createGroupV2(request)
+            response = try await client.createGroupTyranny(payload)
         } catch {
             throw CreateGroupError.anchorTransport(String(describing: error))
         }
@@ -174,19 +181,19 @@ struct CreateGroupInteractor: Sendable {
             members: members,
             epoch: 0,
             salt: salt,
-            commitment: proof.publicInputs.commitment,
+            commitment: proof.commitment,
             tier: tier,
             groupType: .tyranny,
             adminPubkeyHex: adminPubkeyHex,
             isPublishedOnChain: false
         )
         _ = await groups.insert(group)
-        await groups.markPublished(id: group.id, commitment: proof.publicInputs.commitment)
+        await groups.markPublished(id: group.id, commitment: proof.commitment)
 
         // 8. Send invitations
         if !invitees.isEmpty {
             onProgress(.sendingInvitations(total: invitees.count))
-            let payload = GroupInvitationPayload(
+            let invitePayload = GroupInvitationPayload(
                 version: 1,
                 groupID: groupID,
                 groupSecret: groupSecret,
@@ -194,14 +201,14 @@ struct CreateGroupInteractor: Sendable {
                 members: members,
                 epoch: 0,
                 salt: salt,
-                commitment: proof.publicInputs.commitment,
+                commitment: proof.commitment,
                 tierRaw: tier.rawValue,
                 groupTypeRaw: SEPGroupType.tyranny.rawValue,
                 adminPubkeyHex: adminPubkeyHex
             )
             let payloadBytes: Data
             do {
-                payloadBytes = try JSONEncoder().encode(payload)
+                payloadBytes = try JSONEncoder().encode(invitePayload)
             } catch {
                 throw CreateGroupError.invitationEncodingFailed
             }

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -133,6 +133,7 @@ private struct OnymQuietButton: View {
 
 private struct CreateGroupStep1View: View {
     @Bindable var flow: CreateGroupFlow
+    @FocusState private var nameFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -180,12 +181,20 @@ private struct CreateGroupStep1View: View {
 
     private var nameField: some View {
         HStack {
-            TextField("", text: $flow.name, prompt: Text("Group name").foregroundColor(OnymTokens.text3))
+            TextField(
+                "",
+                text: $flow.name,
+                prompt: Text(flow.generatedName).foregroundColor(OnymTokens.text3)
+            )
                 .font(.system(size: 17, weight: .medium))
                 .foregroundStyle(OnymTokens.text)
                 .tint(accentColor)
                 .textInputAutocapitalization(.sentences)
                 .autocorrectionDisabled()
+                .focused($nameFocused)
+                .onChange(of: nameFocused) { _, isFocused in
+                    if isFocused { flow.tappedNameFieldFocused() }
+                }
                 .onChange(of: flow.name) { _, new in
                     if new.count > 32 { flow.name = String(new.prefix(32)) }
                 }
@@ -907,18 +916,33 @@ private struct CreateGroupCreatingView: View {
                 .foregroundStyle(OnymTokens.red)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 14)
-            Button {
-                flow.tappedDismissError()
-            } label: {
-                Text("Try again")
-                    .font(.system(size: 14.5, weight: .semibold))
-                    .foregroundStyle(flow.accent.color)
-                    .padding(.horizontal, 18)
-                    .padding(.vertical, 8)
-                    .background(OnymTokens.surface2)
-                    .clipShape(Capsule())
+            HStack(spacing: 10) {
+                Button {
+                    flow.tappedCancelFromError()
+                } label: {
+                    Text("Cancel")
+                        .font(.system(size: 14.5, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text2)
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 8)
+                        .background(OnymTokens.surface3)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    flow.tappedDismissError()
+                } label: {
+                    Text("Try again")
+                        .font(.system(size: 14.5, weight: .semibold))
+                        .foregroundStyle(flow.accent.color)
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 8)
+                        .background(OnymTokens.surface2)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
         }
         .padding(14)
         .background(OnymTokens.red.opacity(0.10))

--- a/Sources/OnymIOS/Group/GroupInvitationPayload.swift
+++ b/Sources/OnymIOS/Group/GroupInvitationPayload.swift
@@ -25,7 +25,12 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
     /// always anchors first, so this is always set in practice.
     let commitment: Data?
     let tierRaw: Int
-    let groupTypeRaw: UInt32
+    /// Lowercase governance type label — `tyranny`, `anarchy`, etc.
+    /// Receiver decodes via `SEPGroupType(rawValue:)`. String spelling
+    /// matches the relayer + contract wire format so a single
+    /// `group_type` field is unambiguous across iOS, Android, and the
+    /// Stellar contract.
+    let groupTypeRaw: String
     /// Lowercase hex (96 chars) BLS pubkey of the Tyranny admin.
     /// `nil` for `.anarchy` / `.oneOnOne`.
     let adminPubkeyHex: String?

--- a/Sources/OnymIOS/Group/PersistedGroup.swift
+++ b/Sources/OnymIOS/Group/PersistedGroup.swift
@@ -27,7 +27,7 @@ final class PersistedGroup {
     var createdAt: Date
     var epoch: Int64
     var tierRaw: Int
-    var groupTypeRaw: Int
+    var groupTypeRaw: String
     var isPublishedOnChain: Bool
 
     var encryptedName: Data
@@ -42,7 +42,7 @@ final class PersistedGroup {
         createdAt: Date,
         epoch: Int64,
         tierRaw: Int,
-        groupTypeRaw: Int,
+        groupTypeRaw: String,
         isPublishedOnChain: Bool,
         encryptedName: Data,
         encryptedGroupSecret: Data,

--- a/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
+++ b/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
@@ -113,7 +113,7 @@ actor SwiftDataGroupStore: GroupStore {
             createdAt: group.createdAt,
             epoch: Int64(bitPattern: group.epoch),
             tierRaw: group.tier.rawValue,
-            groupTypeRaw: Int(group.groupType.rawValue),
+            groupTypeRaw: group.groupType.rawValue,
             isPublishedOnChain: group.isPublishedOnChain,
             encryptedName: try StorageEncryption.encrypt(group.name),
             encryptedGroupSecret: try StorageEncryption.encrypt(group.groupSecret),
@@ -132,7 +132,7 @@ actor SwiftDataGroupStore: GroupStore {
             let members = try? JSONDecoder().decode([GovernanceMember].self, from: membersJSON),
             let salt = try? StorageEncryption.decrypt(row.encryptedSalt),
             let tier = SEPTier(rawValue: row.tierRaw),
-            let groupType = SEPGroupType(rawValue: UInt32(row.groupTypeRaw))
+            let groupType = SEPGroupType(rawValue: row.groupTypeRaw)
         else {
             return nil
         }

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -13,6 +13,12 @@ struct SettingsView: View {
     @State private var showRecoveryPhrase = false
     @State private var showCreateGroup = false
 
+    /// Persisted in `UserDefaults` under the same key
+    /// `UserDefaultsNetworkPreference` reads. Toggling here changes the
+    /// network the next Create Group flow will use; existing groups
+    /// keep whatever network they were created on.
+    @AppStorage(UserDefaultsNetworkPreference.storageKey) private var useMainnet = false
+
     var body: some View {
         Form {
             Section {
@@ -69,10 +75,24 @@ struct SettingsView: View {
                     )
                 }
                 .accessibilityIdentifier("settings.anchors_row")
+
+                Toggle(isOn: $useMainnet) {
+                    HStack(spacing: 12) {
+                        SettingsIconBox(
+                            systemImage: useMainnet ? "globe.americas.fill" : "hammer.fill",
+                            background: useMainnet ? .green : .gray
+                        )
+                        Text("Use Mainnet")
+                    }
+                }
+                .accessibilityIdentifier("settings.use_mainnet_toggle")
             } header: {
                 Text("Network")
             } footer: {
-                Text("Choose the relayer that submits transactions and which contract version anchors new chats. Existing chats keep the contract they were created with.")
+                Text(useMainnet
+                    ? "New groups will be anchored on Stellar mainnet. Contracts must be deployed and allowlisted on the relayer."
+                    : "New groups will be anchored on Stellar testnet. Default while contracts are still being staged."
+                )
             }
         }
         .navigationTitle("Settings")

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -10,11 +10,14 @@ final class CreateGroupFlowTests: XCTestCase {
 
     // MARK: - Step1 → Step2
 
-    func test_canAdvanceToStep2_requiresNonEmptyNameAndAvailableGovernance() async throws {
+    func test_canAdvanceToStep2_acceptsAnyNameWhenGovernanceAvailable() async throws {
         let flow = await makeFlow()
-        XCTAssertFalse(flow.canAdvanceToStep2, "empty name blocks advance")
+        // Empty / whitespace name is fine — `effectiveName` falls
+        // back to the auto-generated placeholder.
+        flow.name = ""
+        XCTAssertTrue(flow.canAdvanceToStep2)
         flow.name = "  "
-        XCTAssertFalse(flow.canAdvanceToStep2, "whitespace-only name blocks advance")
+        XCTAssertTrue(flow.canAdvanceToStep2)
         flow.name = "Friends"
         XCTAssertTrue(flow.canAdvanceToStep2)
     }
@@ -33,10 +36,66 @@ final class CreateGroupFlowTests: XCTestCase {
         XCTAssertEqual(flow.route, .step2)
     }
 
-    func test_tappedNext_isNoOpWhenInvalid() async throws {
+    func test_tappedNext_emptyName_stillAdvances() async throws {
+        // Empty name advances — the placeholder will be used at submit.
         let flow = await makeFlow()
-        flow.tappedNext()  // empty name
+        flow.name = ""
+        flow.tappedNext()
+        XCTAssertEqual(flow.route, .step2)
+    }
+
+    func test_tappedNext_unavailableGovernance_isNoOp() async throws {
+        let flow = await makeFlow()
+        flow.governance = .anarchy
+        flow.tappedNext()
         XCTAssertEqual(flow.route, .step1)
+    }
+
+    // MARK: - Random placeholder name
+
+    func test_init_prePopulatesNameWithGeneratedPlaceholder() async throws {
+        let flow = await makeFlow()
+        XCTAssertFalse(flow.name.isEmpty,
+                       "init should pre-populate name with a friendly placeholder")
+        XCTAssertEqual(flow.name, flow.generatedName)
+        XCTAssertTrue(flow.generatedName.contains(" "),
+                      "placeholder should be 'Adjective Noun' shape")
+    }
+
+    func test_firstFocusOnNameField_clearsPlaceholder() async throws {
+        let flow = await makeFlow()
+        let original = flow.generatedName
+        XCTAssertEqual(flow.name, original)
+        flow.tappedNameFieldFocused()
+        XCTAssertEqual(flow.name, "", "first focus clears the placeholder")
+    }
+
+    func test_secondFocus_doesNotClearUserInput() async throws {
+        let flow = await makeFlow()
+        flow.tappedNameFieldFocused()  // clears placeholder
+        flow.name = "My Group"
+        flow.tappedNameFieldFocused()  // second focus — should be no-op
+        XCTAssertEqual(flow.name, "My Group")
+    }
+
+    func test_focusDoesNotClear_ifUserAlreadyEditedAwayFromPlaceholder() async throws {
+        // Edge case: programmatic name change before the field is
+        // ever focused. Focus should not stomp the user's value.
+        let flow = await makeFlow()
+        flow.name = "Manual"
+        flow.tappedNameFieldFocused()
+        XCTAssertEqual(flow.name, "Manual",
+                       "focus only clears when the field still holds the original placeholder")
+    }
+
+    func test_effectiveName_fallsBackToPlaceholder_whenEmpty() async throws {
+        let flow = await makeFlow()
+        let placeholder = flow.generatedName
+        flow.tappedNameFieldFocused()  // clears
+        XCTAssertEqual(flow.effectiveName, placeholder,
+                       "empty name should resolve to the auto-generated placeholder at submit")
+        flow.name = "Family"
+        XCTAssertEqual(flow.effectiveName, "Family")
     }
 
     // MARK: - InviteByKey
@@ -140,8 +199,23 @@ final class CreateGroupFlowTests: XCTestCase {
         flow.tappedDone()
         XCTAssertEqual(closedCount, 1)
         XCTAssertEqual(flow.route, .step1)
-        XCTAssertEqual(flow.name, "")
+        // Reset re-rolls the placeholder, so name == generatedName,
+        // not "".
+        XCTAssertEqual(flow.name, flow.generatedName)
+        XCTAssertFalse(flow.name.isEmpty)
         XCTAssertTrue(flow.invitees.isEmpty)
+    }
+
+    func test_tappedCancelFromError_closesAndResets() async throws {
+        let flow = await makeFlow()
+        var closedCount = 0
+        flow.onClose = { closedCount += 1 }
+        flow.route = .creating
+        flow.error = .anchorRejected(message: "oops")
+        flow.tappedCancelFromError()
+        XCTAssertEqual(closedCount, 1)
+        XCTAssertEqual(flow.route, .step1)
+        XCTAssertNil(flow.error)
     }
 
     // MARK: - Helpers

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -38,7 +38,19 @@ final class CreateGroupInteractorTests: XCTestCase {
         // Chain anchor was POSTed exactly once.
         let invocations = env.contractTransport.invocations
         XCTAssertEqual(invocations.count, 1)
-        XCTAssertEqual(invocations.first?.function, "create_group_v2")
+        XCTAssertEqual(invocations.first?.function, "create_group")
+    }
+
+    // MARK: - Network preference
+
+    func test_create_anchorsOnTheNetworkFromPreference() async throws {
+        // With NetworkPreference = mainnet but no mainnet contract in
+        // the manifest, the binding lookup should fail.
+        let env = await makeTestEnv(includeTyrannyContract: true, network: .mainnet)
+        await assertThrows(
+            try await env.makeInteractor().create(name: "G", invitees: []),
+            CreateGroupError.noContractBinding(.tyranny)
+        )
     }
 
     func test_create_withTwoInvitees_sendsOneInvitationPerInvitee() async throws {
@@ -166,11 +178,13 @@ final class CreateGroupInteractorTests: XCTestCase {
 
     private func makeTestEnv(
         addRelayer: Bool = true,
-        includeTyrannyContract: Bool = true
+        includeTyrannyContract: Bool = true,
+        network: AppNetwork = .testnet
     ) async -> CreateGroupTestEnv {
         let env = await CreateGroupTestEnv.make(
             addRelayer: addRelayer,
-            includeTyrannyContract: includeTyrannyContract
+            includeTyrannyContract: includeTyrannyContract,
+            network: network
         )
         return env
     }
@@ -191,9 +205,14 @@ private final class CreateGroupTestEnv {
     let inboxTransport: ConfigurableInboxTransport
     let contractTransport: ConfigurableContractTransport
     let proofGenerator: StubGroupProofGenerator
+    let networkPreference: StaticNetworkPreference
     private let keychain: KeychainStore
 
-    static func make(addRelayer: Bool, includeTyrannyContract: Bool) async -> CreateGroupTestEnv {
+    static func make(
+        addRelayer: Bool,
+        includeTyrannyContract: Bool,
+        network: AppNetwork
+    ) async -> CreateGroupTestEnv {
         let keychain = KeychainStore(
             service: "chat.onym.ios.identity.tests.create-group.\(UUID().uuidString)",
             account: "current"
@@ -247,6 +266,7 @@ private final class CreateGroupTestEnv {
             inboxTransport: ConfigurableInboxTransport(),
             contractTransport: ConfigurableContractTransport(),
             proofGenerator: StubGroupProofGenerator(),
+            networkPreference: StaticNetworkPreference(value: network),
             keychain: keychain
         )
     }
@@ -259,6 +279,7 @@ private final class CreateGroupTestEnv {
         inboxTransport: ConfigurableInboxTransport,
         contractTransport: ConfigurableContractTransport,
         proofGenerator: StubGroupProofGenerator,
+        networkPreference: StaticNetworkPreference,
         keychain: KeychainStore
     ) {
         self.identity = identity
@@ -268,6 +289,7 @@ private final class CreateGroupTestEnv {
         self.inboxTransport = inboxTransport
         self.contractTransport = contractTransport
         self.proofGenerator = proofGenerator
+        self.networkPreference = networkPreference
         self.keychain = keychain
     }
 
@@ -279,6 +301,7 @@ private final class CreateGroupTestEnv {
             relayers: relayers,
             contracts: contracts,
             groups: groups,
+            networkPreference: networkPreference,
             proofGenerator: proofGenerator,
             inboxTransport: inboxTransport,
             makeContractTransport: { [contractTransport] _ in contractTransport }
@@ -288,19 +311,22 @@ private final class CreateGroupTestEnv {
 
 // MARK: - Stubs
 
-/// Returns a deterministic 1568-byte "proof" without actually proving.
-/// Skips the ~3.5s real prover so the test suite stays fast.
+/// Returns a deterministic 1601-byte "proof" + 4-element PI bundle
+/// without actually proving. Skips the ~3.5s real prover so the test
+/// suite stays fast.
 private struct StubGroupProofGenerator: GroupProofGenerator {
     func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
         guard input.groupType == .tyranny else {
             throw GroupProofGeneratorError.notYetSupported(input.groupType)
         }
         return GroupCreateProof(
-            proof: Data(repeating: 0xAB, count: 1568),
-            publicInputs: SEPPublicInputs(
-                commitment: Data(repeating: 0xCD, count: 32),
-                epoch: 0
-            )
+            proof: Data(repeating: 0xAB, count: 1601),
+            publicInputs: [
+                Data(repeating: 0xCD, count: 32),  // commitment
+                Data(repeating: 0x00, count: 32),  // Fr(0)
+                Data(repeating: 0x42, count: 32),  // admin_pubkey_commitment
+                Data(repeating: 0x77, count: 32),  // group_id_fr
+            ]
         )
     }
 }

--- a/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
+++ b/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
@@ -34,9 +34,15 @@ final class GroupProofGeneratorTests: XCTestCase {
         )
 
         let result = try OnymGroupProofGenerator().proveCreate(input)
-        XCTAssertEqual(result.proof.count, 1568, "Common.parsePlonkProof trims the 1601-byte raw output")
-        XCTAssertEqual(result.publicInputs.commitment.count, 32)
-        XCTAssertEqual(result.publicInputs.epoch, 0, "create-group is always epoch 0")
+        XCTAssertEqual(result.proof.count, 1601,
+                       "relayer expects the raw 1601-byte plonk proof — no parsePlonkProof on the wire")
+        XCTAssertEqual(result.publicInputs.count, 4,
+                       "Tyranny PI bundle splits into 4 × 32-byte chunks (commitment + Fr(0) + admin_pkc + group_id_fr)")
+        for (i, chunk) in result.publicInputs.enumerated() {
+            XCTAssertEqual(chunk.count, 32, "PI chunk #\(i) must be 32 bytes")
+        }
+        XCTAssertEqual(result.commitment, result.publicInputs[0])
+        XCTAssertEqual(result.adminPubkeyCommitment, result.publicInputs[2])
     }
 
     func test_proveCreate_anarchy_throwsNotYetSupported() {

--- a/Tests/OnymIOSTests/SEPContractClientTests.swift
+++ b/Tests/OnymIOSTests/SEPContractClientTests.swift
@@ -3,13 +3,15 @@ import XCTest
 
 /// Pure-Swift unit tests for `SEPContractClient` — no real HTTP. A
 /// `RecordingTransport` captures the encoded invocation and returns a
-/// canned response, so we verify both the wire shape (snake_case keys,
-/// envelope structure) and the client's response decoding without
-/// touching `URLSession`.
+/// canned response, so we verify both the wire shape (camelCase
+/// envelope, snake_case payload, contractType + network top-level) and
+/// the client's response decoding without touching `URLSession`.
 final class SEPContractClientTests: XCTestCase {
     private let testContractID = "CONTRACTID000000000000000000000000000000000000000000000000"
 
-    func test_createGroupV2_sendsSnakeCasePayload() async throws {
+    // MARK: - Envelope shape
+
+    func test_createGroupTyranny_sendsCorrectEnvelopeAndPayload() async throws {
         let recorder = RecordingTransport(
             response: SEPSubmissionResponse(
                 accepted: true,
@@ -17,64 +19,66 @@ final class SEPContractClientTests: XCTestCase {
                 message: nil
             )
         )
-        let client = SEPContractClient(contractID: testContractID, transport: recorder)
+        let client = SEPContractClient(
+            contractID: testContractID,
+            contractType: .tyranny,
+            network: .testnet,
+            transport: recorder
+        )
 
-        let request = SEPCreateGroupV2Request(
-            caller: "GBABCDEF",
+        let payload = TyrannyCreateGroupPayload(
             groupID: Data(repeating: 0xAB, count: 32),
             commitment: Data(repeating: 0xCD, count: 32),
-            tier: UInt32(SEPTier.small.rawValue),
-            groupType: .tyranny,
-            memberCount: 1,
-            proof: Data(repeating: 0xEE, count: 64),
-            publicInputs: SEPPublicInputs(
-                commitment: Data(repeating: 0xCD, count: 32),
-                epoch: 0
-            )
+            tier: SEPTier.small.rawValue,
+            adminPubkeyCommitment: Data(repeating: 0x42, count: 32),
+            proof: Data(repeating: 0xEE, count: 1601),
+            publicInputs: [
+                Data(repeating: 0xCD, count: 32),
+                Data(repeating: 0x00, count: 32),
+                Data(repeating: 0x42, count: 32),
+                Data(repeating: 0x77, count: 32),
+            ]
         )
-        let response = try await client.createGroupV2(request)
+        let response = try await client.createGroupTyranny(payload)
 
         XCTAssertTrue(response.accepted)
         XCTAssertEqual(response.transactionHash, "abc123")
 
         let json = try XCTUnwrap(recorder.lastJSON())
-        XCTAssertEqual(json["function"] as? String, "create_group_v2")
-        XCTAssertEqual(json["contract_id"] as? String, testContractID)
-        let payload = try XCTUnwrap(json["payload"] as? [String: Any])
-        XCTAssertEqual(payload["caller"] as? String, "GBABCDEF")
-        XCTAssertEqual((payload["group_type"] as? NSNumber)?.uint32Value, SEPGroupType.tyranny.rawValue)
-        XCTAssertEqual((payload["member_count"] as? NSNumber)?.uint32Value, 1)
-        XCTAssertNotNil(payload["group_id"])  // Data → base64 string in JSON
-        XCTAssertNotNil(payload["public_inputs"])
+        // Top-level envelope (camelCase per relayer's RelayerRequest)
+        XCTAssertEqual(json["function"] as? String, "create_group")
+        XCTAssertEqual(json["contractID"] as? String, testContractID)
+        XCTAssertEqual(json["contractType"] as? String, "tyranny")
+        XCTAssertEqual(json["network"] as? String, "testnet")
+
+        // Payload (snake_case for the contract args)
+        let payloadJSON = try XCTUnwrap(json["payload"] as? [String: Any])
+        XCTAssertEqual((payloadJSON["tier"] as? NSNumber)?.intValue, 0)
+        XCTAssertNotNil(payloadJSON["group_id"])
+        XCTAssertNotNil(payloadJSON["admin_pubkey_commitment"])
+        XCTAssertNotNil(payloadJSON["proof"])
+        let publicInputs = try XCTUnwrap(payloadJSON["publicInputs"] as? [String])
+        XCTAssertEqual(publicInputs.count, 4, "Tyranny create needs 4 PI entries")
     }
 
-    func test_updateCommitment_routesToUpdateFunction() async throws {
+    func test_createGroupTyranny_mainnetSerializesAsPublic() async throws {
         let recorder = RecordingTransport(
             response: SEPSubmissionResponse(accepted: true, transactionHash: nil, message: nil)
         )
-        let client = SEPContractClient(contractID: testContractID, transport: recorder)
-
-        let request = SEPUpdateCommitmentRequest(
-            groupID: Data(repeating: 0x01, count: 32),
-            proof: Data(repeating: 0x02, count: 32),
-            publicInputs: SEPUpdatePublicInputs(
-                cOld: Data(repeating: 0x03, count: 32),
-                epochOld: 1,
-                cNew: Data(repeating: 0x04, count: 32)
-            )
+        let client = SEPContractClient(
+            contractID: testContractID,
+            contractType: .tyranny,
+            network: .publicNet,
+            transport: recorder
         )
-        _ = try await client.updateCommitment(request)
+        _ = try await client.createGroupTyranny(stubPayload())
 
         let json = try XCTUnwrap(recorder.lastJSON())
-        XCTAssertEqual(json["function"] as? String, "update_commitment")
-        let payload = try XCTUnwrap(json["payload"] as? [String: Any])
-        let publicInputs = try XCTUnwrap(payload["public_inputs"] as? [String: Any])
-        XCTAssertNotNil(publicInputs["c_old"])
-        XCTAssertNotNil(publicInputs["c_new"])
-        XCTAssertEqual((publicInputs["epoch_old"] as? NSNumber)?.uint64Value, 1)
+        XCTAssertEqual(json["network"] as? String, "public",
+                       "mainnet must serialise as `public` to match Stellar's terminology + relayer enum")
     }
 
-    func test_getState_sendsGroupIdInGetStateEnvelope() async throws {
+    func test_getCommitment_routesToGetCommitmentFunction() async throws {
         let entry = SEPCommitmentEntry(
             commitment: Data(repeating: 0x09, count: 32),
             epoch: 7,
@@ -83,16 +87,23 @@ final class SEPContractClientTests: XCTestCase {
             active: true
         )
         let recorder = RecordingTransport(response: entry)
-        let client = SEPContractClient(contractID: testContractID, transport: recorder)
+        let client = SEPContractClient(
+            contractID: testContractID,
+            contractType: .tyranny,
+            network: .testnet,
+            transport: recorder
+        )
 
-        let result = try await client.getState(groupID: Data(repeating: 0x55, count: 32))
+        let result = try await client.getCommitment(groupID: Data(repeating: 0x55, count: 32))
         XCTAssertEqual(result, entry)
 
         let json = try XCTUnwrap(recorder.lastJSON())
-        XCTAssertEqual(json["function"] as? String, "get_state")
+        XCTAssertEqual(json["function"] as? String, "get_commitment")
         let payload = try XCTUnwrap(json["payload"] as? [String: Any])
         XCTAssertNotNil(payload["group_id"])
     }
+
+    // MARK: - URLSession transport
 
     func test_urlSessionTransport_throwsOnNon2xx() async throws {
         let url = URL(string: "https://example.invalid/contract")!
@@ -108,10 +119,15 @@ final class SEPContractClientTests: XCTestCase {
         defer { StubURLProtocol.reset() }
         let session = StubURLProtocol.makeSession()
         let transport = URLSessionSEPContractTransport(endpoint: url, session: session)
-        let client = SEPContractClient(contractID: testContractID, transport: transport)
+        let client = SEPContractClient(
+            contractID: testContractID,
+            contractType: .tyranny,
+            network: .testnet,
+            transport: transport
+        )
 
         do {
-            _ = try await client.getState(groupID: Data(repeating: 0, count: 32))
+            _ = try await client.getCommitment(groupID: Data(repeating: 0, count: 32))
             XCTFail("expected SEPError.invalidResponse")
         } catch let SEPError.invalidResponse(statusCode, body) {
             XCTAssertEqual(statusCode, 500)
@@ -144,20 +160,28 @@ final class SEPContractClientTests: XCTestCase {
         defer { StubURLProtocol.reset() }
         let session = StubURLProtocol.makeSession()
         let transport = URLSessionSEPContractTransport(endpoint: url, session: session)
-        let client = SEPContractClient(contractID: testContractID, transport: transport)
+        let client = SEPContractClient(
+            contractID: testContractID,
+            contractType: .tyranny,
+            network: .testnet,
+            transport: transport
+        )
 
-        let request = SEPCreateGroupV2Request(
-            caller: "GBABCDEF",
+        let response = try await client.createGroupTyranny(stubPayload())
+        XCTAssertEqual(response, stub)
+    }
+
+    // MARK: - Helpers
+
+    private func stubPayload() -> TyrannyCreateGroupPayload {
+        TyrannyCreateGroupPayload(
             groupID: Data(repeating: 0, count: 32),
             commitment: Data(repeating: 0, count: 32),
             tier: 0,
-            groupType: .tyranny,
-            memberCount: 1,
-            proof: Data(),
-            publicInputs: SEPPublicInputs(commitment: Data(repeating: 0, count: 32), epoch: 0)
+            adminPubkeyCommitment: Data(repeating: 0, count: 32),
+            proof: Data(repeating: 0, count: 1601),
+            publicInputs: Array(repeating: Data(repeating: 0, count: 32), count: 4)
         )
-        let response = try await client.createGroupV2(request)
-        XCTAssertEqual(response, stub)
     }
 }
 


### PR DESCRIPTION
## Summary

Three fixes folded into one PR per request, all targeting issues
discovered after PR #26 (Create Group flow) merged:

1. **Relayer wire-format alignment.** PR-A/B/C were sending a payload
   shape that the actual `onym-relayer` rejects. Aligned to
   `onym-relayer/src/handler.rs`'s `RelayerRequest` contract.
2. **Random group-name placeholder + clear-on-focus.** Step1 now
   pre-populates the name field so the user can hit Create
   immediately without typing. First focus clears the placeholder.
3. **Cancel from error state.** The Creating screen's error banner
   was a dead-end (`Try again` only routed back to step2). Added a
   `Cancel` button that closes the whole flow.

## 1. Relayer wire-format alignment

Five drift points fixed:

| What | Before (broken) | After (matches relayer) |
|---|---|---|
| Top-level fields | `contract_id`, `function`, `payload` (snake_case, missing required fields) | `contractID`, `contractType`, `network`, `function`, `payload` (camelCase, all required) |
| Function name | `create_group_v2` (made up) | `create_group` (the relayer's actual entrypoint) |
| Proof bytes | 1568 (`Common.parsePlonkProof`-trimmed) | 1601 (raw PLONK; relayer's `decode_wire_bytes(_, _, Some(1601))` rejects anything else) |
| Public inputs | `{commitment: …, epoch: 0}` object | `[commitment_b64, fr_zero_b64, admin_pubkey_commitment_b64, group_id_fr_b64]` — JSON array of 4 base64 strings (full Tyranny PI bundle) |
| Tyranny-only `admin_pubkey_commitment` | not sent | sent as a dedicated payload field |
| `SEPGroupType` raw value | `UInt32` (4) | `String` ("tyranny") to match relayer + contract wire labels |

Refactored:
- `SEPContractInvocation<Payload>` — added `contractType` + `network`.
- New `SEPNetwork` enum (testnet / publicNet, raw values `"testnet"` / `"public"`).
- New `TyrannyCreateGroupPayload` + `TyrannyUpdateCommitmentPayload` + `GetCommitmentPayload`. Dropped the old `SEPCreateGroupV2Request` / `SEPUpdateCommitmentRequest` / `SEPGetStateRequest`.
- `SEPContractClient` constructor now takes `(contractID, contractType, network, transport)` and stamps all four onto every invocation.
- `GroupProofGenerator.GroupCreateProof.publicInputs` is now `[Data]` (4 chunks); convenience accessors `.commitment` and `.adminPubkeyCommitment` slice the bundle.
- `OnymGroupProofGenerator.proveTyrannyCreate` no longer calls `Common.parsePlonkProof` — relayer wants the raw 1601 bytes.

## 2. NetworkPreference + Settings toggle

- New `AppNetwork` enum (`testnet` / `mainnet`), `NetworkPreferenceProviding` protocol, `UserDefaultsNetworkPreference` impl backed by `UserDefaults["onym.useMainnet"]`, and `StaticNetworkPreference` test fake.
- Settings → Network section gets a "Use Mainnet" Toggle bound via `@AppStorage(UserDefaultsNetworkPreference.storageKey)`. Default is off (testnet) since contracts are only deployed there today.
- `CreateGroupInteractor` takes a `NetworkPreferenceProviding`; uses it for both the contract-binding lookup (`AnchorSelectionKey(network: …, type: .tyranny)`) AND the wire payload's top-level `network` field.

## 3. UX

- Step1 name TextField pre-populates with a random "Adjective Noun" placeholder (e.g. "Maple Garden", "Quiet Forest") generated at init. First focus on the field clears it so the user can type fresh; subsequent focuses are no-ops.
- `canAdvanceToStep2` no longer requires a non-empty name. The Step1 footer always shows "Next · Add people" (instead of the disabled "Name your group to continue" state). Submit calls `effectiveName` which falls back to the placeholder when the user leaves the field empty.
- Creating-screen error banner gains a "Cancel" pill next to "Try again". Cancel routes through `flow.tappedCancelFromError()` → `reset()` → `onClose()` so the user can bail out instead of being trapped on the error.

## SwiftData migration note

`PersistedGroup.groupTypeRaw` changed type `Int` → `String` (mirroring `SEPGroupType`'s new wire-string raw value). This is a breaking schema change for any pre-existing on-disk Groups.store from PR-B/C dev builds. Production handling: `OnymIOSApp.init` already wraps `try? SwiftDataGroupStore()` and falls back to `inMemory()` on failure, so the app launches cleanly even with a stale store — the user just loses any test groups. There's no deployed user data to migrate (PR-C only just landed); a real migration would be needed if we'd shipped to a release channel.

## Test plan

All affected suites pass on iPhone 17 Pro / iOS 26 simulator:

- `SEPContractClientTests` — rewritten for the new envelope; new test asserts `network: mainnet` serialises as `"public"` on the wire.
- `GroupProofGeneratorTests` — asserts `proof.count == 1601` (was 1568) and `publicInputs.count == 4` with each chunk 32 bytes.
- `CreateGroupInteractorTests` — function name now `"create_group"`; new test asserts the `NetworkPreference` is honoured (mainnet preference + no mainnet binding → `.noContractBinding(.tyranny)`).
- `CreateGroupFlowTests` — replaced "name required" assertions with new "any name accepted" assertions; added 5 new tests covering placeholder generation, first-focus clearing, second-focus no-op, focus-doesn't-stomp-edits, and `effectiveName` fallback. Plus one new test for `tappedCancelFromError`.
- `SwiftDataGroupStoreTests`, `ChatGroupTests` — pass unchanged.

## Manual verification

Settings now shows the new "Use Mainnet" Toggle under Network with the expected default-off state and contextual footer copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)