### PR TITLE
ux: scrollable + selectable error banner on Creating screen

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -911,11 +911,22 @@ private struct CreateGroupCreatingView: View {
 
     private func errorBanner(_ error: CreateGroupError) -> some View {
         VStack(spacing: 12) {
-            Text(error.localizedDescription)
-                .font(.system(size: 13))
-                .foregroundStyle(OnymTokens.red)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 14)
+            // Soroban diagnostic chains can be 500+ chars; keep the
+            // banner from eating the whole screen. ScrollView caps the
+            // height; .textSelection(.enabled) lets the user copy the
+            // error for bug reports.
+            ScrollView(.vertical, showsIndicators: true) {
+                Text(error.localizedDescription)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(OnymTokens.red)
+                    .multilineTextAlignment(.leading)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 200)
+
             HStack(spacing: 10) {
                 Button {
                     flow.tappedCancelFromError()


### PR DESCRIPTION
## Summary

Soroban diagnostic chains can be 500+ chars (proof-verify failures spell out the contract IDs + error codes + bytes payloads). The center-aligned single `Text` was eating the whole bottom of the screen and clipping rest of the layout.

Three small tweaks:

- Wrap the error `Text` in a vertical `ScrollView` capped at **200 pt** height.
- Switch to **monospaced + left-aligned** for hex/diagnostic readability.
- Add `.textSelection(.enabled)` so users can copy the message into a bug report.

## Before / after

Before: the diagnostic text wrapped center-aligned and grew downward off-screen, pushing the Cancel/Try-again buttons below the fold.

After: the diagnostic stays inside a 200pt scrollable region; the action buttons remain visible right under it; long-press selects the text for copy.

## Test plan

- [x] Builds clean on iPhone 17 Pro / iOS 26
- Manual: reproduce the 502 with a bad relayer payload → error banner shows the full text scrollable, Cancel + Try again remain reachable, long-press shows the iOS Copy menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)