### PR TITLE
ux: Chats tab + relocate Create Group entry from Settings

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -10,4 +10,5 @@ struct AppDependencies {
     let makeRelayerSettingsFlow: @MainActor () -> RelayerSettingsFlow
     let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
+    let makeChatsFlow: @MainActor () -> ChatsFlow
 }

--- a/Sources/OnymIOS/Chats/ChatsFlow.swift
+++ b/Sources/OnymIOS/Chats/ChatsFlow.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Observation
+
+/// Stateless interactor for the Chats tab. Drains
+/// `GroupRepository.snapshots` into `state.groups`; the view reads
+/// from `state` and re-renders on every push. No mutating intents
+/// today — the row UI is read-only and the only action is
+/// "open Create Group", which is owned by the view's
+/// `.fullScreenCover`.
+///
+/// Mirrors `AnchorsPickerFlow`'s shape: own a `snapshotTask`,
+/// idempotent `start()`, plain `stop()`.
+@MainActor
+@Observable
+final class ChatsFlow {
+    private(set) var groups: [ChatGroup] = []
+
+    private let repository: GroupRepository
+    private var snapshotTask: Task<Void, Never>?
+
+    init(repository: GroupRepository) {
+        self.repository = repository
+    }
+
+    /// Begin draining repository snapshots. Idempotent.
+    func start() {
+        guard snapshotTask == nil else { return }
+        snapshotTask = Task { [weak self] in
+            guard let self else { return }
+            for await snapshot in self.repository.snapshots {
+                self.groups = snapshot
+            }
+        }
+    }
+
+    func stop() {
+        snapshotTask?.cancel()
+        snapshotTask = nil
+    }
+}

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+/// Chats tab — root list of groups the user has created. PR-C only
+/// supports Tyranny groups; this list is whatever
+/// `GroupRepository.snapshots` emits. Tapping a row is a no-op for
+/// now (chat screen is a future slice). The empty state is the only
+/// entry point to Create Group post-PR-D wiring.
+struct ChatsView: View {
+    let flow: ChatsFlow
+    let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
+
+    @State private var showCreateGroup = false
+
+    var body: some View {
+        Group {
+            if flow.groups.isEmpty {
+                emptyState
+            } else {
+                groupList
+            }
+        }
+        .navigationTitle("Chats")
+        .toolbar {
+            // Plus button mirrors iOS Mail / Messages — useful once
+            // the user already has at least one chat. Hidden in the
+            // empty state because the central CTA already covers it.
+            if !flow.groups.isEmpty {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showCreateGroup = true
+                    } label: {
+                        Image(systemName: "square.and.pencil")
+                    }
+                    .accessibilityIdentifier("chats.create_group_toolbar")
+                }
+            }
+        }
+        .task { flow.start() }
+        .fullScreenCover(isPresented: $showCreateGroup) {
+            CreateGroupViewHost(
+                makeFlow: makeCreateGroupFlow,
+                onClose: { showCreateGroup = false }
+            )
+        }
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 18) {
+            Spacer()
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.10))
+                    .frame(width: 88, height: 88)
+                Image(systemName: "bubble.left.and.bubble.right.fill")
+                    .font(.system(size: 36, weight: .regular))
+                    .foregroundStyle(Color.accentColor)
+            }
+            VStack(spacing: 6) {
+                Text("No chats yet")
+                    .font(.title3.weight(.semibold))
+                Text("Create an end-to-end encrypted group anchored on Stellar.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+            Button {
+                showCreateGroup = true
+            } label: {
+                Text("Create Group")
+                    .font(.headline)
+                    .frame(maxWidth: 220)
+                    .frame(height: 50)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .padding(.top, 4)
+            .accessibilityIdentifier("chats.create_group_empty_cta")
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Populated list
+
+    private var groupList: some View {
+        List(flow.groups) { group in
+            ChatsRow(group: group)
+                .listRowSeparator(.visible)
+        }
+        .listStyle(.plain)
+    }
+}
+
+private struct ChatsRow: View {
+    let group: ChatGroup
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Reuse the broken-ring brand mark as the per-chat avatar
+            // — same identity the user saw on the Create Group hero.
+            // Once group avatars / uploads ship this becomes the
+            // image-or-mark fallback.
+            OnymGroupAvatar(
+                size: 44,
+                accent: OnymAccent.blue.color,
+                ringPulse: false,
+                spinning: false,
+                brand: false
+            )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(group.name.isEmpty ? "(Unnamed)" : group.name)
+                    .font(.system(size: 16, weight: .semibold))
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Image(systemName: "lock.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if group.isPublishedOnChain {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.caption)
+                    .foregroundStyle(Color.green)
+                    .accessibilityLabel("Published on chain")
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityIdentifier("chats.row.\(group.id)")
+    }
+
+    private var subtitle: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        let relative = formatter.localizedString(for: group.createdAt, relativeTo: Date())
+        return "\(group.groupType.label.capitalized) · created \(relative)"
+    }
+}
+
+private extension SEPGroupType {
+    /// Display-friendly label for the row subtitle. Matches
+    /// `OnymUIGovernance.label` but doesn't need the no-break hyphen
+    /// treatment here.
+    var label: String {
+        switch self {
+        case .anarchy:   "Anarchy"
+        case .oneOnOne:  "1-on-1"
+        case .democracy: "Democracy"
+        case .oligarchy: "Oligarchy"
+        case .tyranny:   "Tyranny"
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/CreateGroupViewHost.swift
+++ b/Sources/OnymIOS/Group/CreateGroupViewHost.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Host view that constructs the `CreateGroupFlow` exactly once on
+/// first render and wires its `onClose` callback to the parent's
+/// dismiss state. Inlining this construction inside `.fullScreenCover`
+/// would re-make the flow on every state mutation.
+///
+/// Lives outside `CreateGroupView.swift` so any tab / screen that
+/// wants to present the flow (currently `ChatsView`, future settings
+/// shortcuts, etc.) can share the same factory plumbing.
+struct CreateGroupViewHost: View {
+    let makeFlow: @MainActor () -> CreateGroupFlow
+    let onClose: () -> Void
+
+    @State private var flow: CreateGroupFlow?
+
+    var body: some View {
+        Group {
+            if let flow {
+                CreateGroupView(flow: flow)
+            } else {
+                Color.black.ignoresSafeArea()
+            }
+        }
+        .onAppear {
+            if flow == nil {
+                let f = makeFlow()
+                f.onClose = onClose
+                flow = f
+            }
+        }
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -101,6 +101,9 @@ struct OnymIOSApp: App {
                     groups: groupRepository,
                     inboxTransport: inboxTransport
                 ))
+            },
+            makeChatsFlow: { @MainActor in
+                ChatsFlow(repository: groupRepository)
             }
         )
     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -5,29 +5,40 @@ import SwiftUI
 /// "search" slot (separate from the regular tab strip), matching the
 /// stellar-mls / Apple-default Liquid Glass shape.
 ///
-/// Currently two tabs:
-///   - `.settings` — entry point for the recovery-phrase backup flow
-///   - `.search` — placeholder so the system search slot is occupied;
-///                 real search lands in a future chunk
+/// Three tabs:
+///   - `.chats`    — list of groups the user has created. Default tab on launch.
+///                   Empty state hosts the only entry point to Create Group.
+///   - `.settings` — recovery-phrase backup, relayer config, anchors picker.
+///   - `.search`   — placeholder occupying the system search slot; real
+///                   search lands in a future chunk.
 struct RootView: View {
     private enum RootTab: Hashable {
+        case chats
         case settings
         case search
     }
 
     let dependencies: AppDependencies
 
-    @State private var selectedTab: RootTab = .settings
+    @State private var selectedTab: RootTab = .chats
 
     var body: some View {
         TabView(selection: $selectedTab) {
+            Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: .chats) {
+                NavigationStack {
+                    ChatsView(
+                        flow: dependencies.makeChatsFlow(),
+                        makeCreateGroupFlow: dependencies.makeCreateGroupFlow
+                    )
+                }
+            }
+
             Tab("Settings", systemImage: "gearshape", value: .settings) {
                 NavigationStack {
                     SettingsView(
                         makeBackupFlow: dependencies.makeRecoveryPhraseBackupFlow,
                         makeRelayerSettingsFlow: dependencies.makeRelayerSettingsFlow,
-                        makeAnchorsPickerFlow: dependencies.makeAnchorsPickerFlow,
-                        makeCreateGroupFlow: dependencies.makeCreateGroupFlow
+                        makeAnchorsPickerFlow: dependencies.makeAnchorsPickerFlow
                     )
                 }
             }

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -1,17 +1,14 @@
 import SwiftUI
 
-/// Settings tab — entry point for the recovery-phrase backup flow.
-/// Minimal first cut: one Security section with the Backup row that
-/// presents `RecoveryPhraseBackupView` as a sheet. More sections land
-/// as the app grows (preferences, advanced, about).
+/// Settings tab — Security + Network sections. The Create Group entry
+/// point lives on the Chats tab now (`ChatsView` empty-state CTA +
+/// toolbar plus button); Settings is purely configuration.
 struct SettingsView: View {
     let makeBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
     let makeRelayerSettingsFlow: @MainActor () -> RelayerSettingsFlow
     let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
-    let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
 
     @State private var showRecoveryPhrase = false
-    @State private var showCreateGroup = false
 
     /// Persisted in `UserDefaults` under the same key
     /// `UserDefaultsNetworkPreference` reads. Toggling here changes the
@@ -21,23 +18,6 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
-            Section {
-                Button {
-                    showCreateGroup = true
-                } label: {
-                    row(
-                        icon: SettingsIconBox(systemImage: "person.3.fill", background: .green),
-                        title: "Create Group"
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("settings.create_group_row")
-            } header: {
-                Text("Groups")
-            } footer: {
-                Text("Create an end-to-end encrypted group anchored on Stellar testnet. Only Tyranny is available right now.")
-            }
-
             Section {
                 Button {
                     showRecoveryPhrase = true
@@ -99,12 +79,6 @@ struct SettingsView: View {
         .sheet(isPresented: $showRecoveryPhrase) {
             RecoveryPhraseBackupView(flow: makeBackupFlow())
         }
-        .fullScreenCover(isPresented: $showCreateGroup) {
-            CreateGroupViewHost(
-                makeFlow: makeCreateGroupFlow,
-                onClose: { showCreateGroup = false }
-            )
-        }
     }
 
     @ViewBuilder
@@ -117,34 +91,6 @@ struct SettingsView: View {
             Image(systemName: "chevron.right")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.tertiary)
-        }
-    }
-}
-
-/// Host view that constructs the `CreateGroupFlow` exactly once on
-/// first render and wires its `onClose` callback to the parent's
-/// dismiss state. Inlining this construction inside `.fullScreenCover`
-/// would re-make the flow on every state mutation.
-private struct CreateGroupViewHost: View {
-    let makeFlow: @MainActor () -> CreateGroupFlow
-    let onClose: () -> Void
-
-    @State private var flow: CreateGroupFlow?
-
-    var body: some View {
-        Group {
-            if let flow {
-                CreateGroupView(flow: flow)
-            } else {
-                Color.black.ignoresSafeArea()
-            }
-        }
-        .onAppear {
-            if flow == nil {
-                let f = makeFlow()
-                f.onClose = onClose
-                flow = f
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

New leftmost **Chats** tab housing the list of groups the user has created, with an empty-state CTA that's now the only entry point to Create Group. The Settings → Groups section is gone — Settings is purely configuration again.

## What landed

- **`Chats/ChatsFlow.swift`** — `@Observable @MainActor` view-model. Drains `GroupRepository.snapshots` into `groups: [ChatGroup]`. Mirrors the `AnchorsPickerFlow` shape (idempotent `start()`, plain `stop()`).
- **`Chats/ChatsView.swift`** — root list view. Empty state: bubble icon + "No chats yet" + helper text + prominent `Create Group` button. Populated state: `List` of rows showing group avatar, name, governance type + relative `createdAt`, and a green `checkmark.seal.fill` when `isPublishedOnChain == true`. Toolbar plus-button (`square.and.pencil`) appears only when at least one chat exists. Tap on a row is a no-op for now — chat screen lives in a future slice.
- **`Group/CreateGroupViewHost.swift`** — lifted out of `SettingsView.swift` into its own file so multiple entry points can present the flow without duplicating the lazy-init plumbing. Same behavior as before.
- **`RootView.swift`** — three tabs: `.chats` (leftmost, **default selected**), `.settings` (middle), `.search` (right via `.search` role).
- **`AppDependencies.swift` + `OnymIOSApp.swift`** — `makeChatsFlow: @MainActor () -> ChatsFlow` factory wired to the existing `groupRepository`.
- **`Settings/SettingsView.swift`** — Groups section + showCreateGroup state + the `.fullScreenCover` removed. SettingsView no longer needs `makeCreateGroupFlow` in its init.

## Visual

Empty-state screenshot in the comments — leftmost tab "Chats" selected on launch, vertically-centered icon + tagline + Create Group button.

## Test plan

- [x] Builds clean on iPhone 17 Pro / iOS 26
- [x] Empty state renders + Create Group CTA presents the existing flow via `.fullScreenCover`
- [ ] Manual: create a group end-to-end (blocked on contracts release per onym-contracts #31), then verify the row shows up sorted by createdAt desc with the on-chain checkmark
- Existing PR-A/B/C unit tests untouched, still pass

## Out of scope

- Tapping a row → chat screen (no chat screen yet — placeholder). Once the chat screen ships, the row tap navigates there via `NavigationStack` path.
- Search tab content (still placeholder).
- Group avatars / uploads (the broken-ring brand mark is the placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)