### PR TITLE
chain: OneOnOne create_group seam (PR-1 of OneOnOne)

### DIFF
--- a/Sources/OnymIOS/Chain/GroupProofGenerator.swift
+++ b/Sources/OnymIOS/Chain/GroupProofGenerator.swift
@@ -37,33 +37,45 @@ protocol GroupProofGenerator: Sendable {
     func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof
 }
 
-/// Inputs for a create-group proof. The caller (PR-C interactor) is
-/// responsible for:
-/// - lex-sorting `members` by `publicKeyCompressed` before computing
-///   `adminIndex` (the SDK reuses the same sort to validate
-///   `memberLeafHashes[adminIndex] == leafHash(adminBlsSecretKey)`),
-/// - generating a fresh 32-byte salt via `GroupCommitmentBuilder.generateSalt`,
-/// - choosing the tier based on the expected member count.
+/// Inputs for a create-group proof. Per-type field requirements:
+///
+/// - **Tyranny**: needs `members` (lex-sorted by `publicKeyCompressed`),
+///   `adminBlsSecretKey` (the device's own BLS Fr), `adminIndex`
+///   (admin's position in the sorted roster), `groupID` (used as the
+///   `group_id_fr` binding scalar), `tier`, `salt`.
+/// - **OneOnOne**: needs `adminBlsSecretKey` (party 0 = creator) and
+///   `peerBlsSecretKey` (party 1 = peer — the creator mints a fresh
+///   ephemeral one and ships it inside the invitation envelope), plus
+///   `salt`. `members` / `adminIndex` / `tier` / `groupID` are
+///   ignored by the SDK call (groupID is still used as the contract's
+///   storage-key arg, but doesn't bind into the proof). Both secrets
+///   MUST differ — the SDK rejects `secretKey0 == secretKey1`.
 struct GroupProofCreateInput: Sendable {
     let groupType: SEPGroupType
     let tier: SEPTier
-    /// Lex-sorted by `publicKeyCompressed`. The packed `leafHash`es
-    /// land in the prover in this order.
+    /// Lex-sorted by `publicKeyCompressed`. Tyranny-only.
     let members: [GovernanceMember]
     /// 32 bytes BE — the sender's own BLS Fr scalar.
     let adminBlsSecretKey: Data
     /// Position of the admin in `members` (after the lex sort).
+    /// Tyranny-only.
     let adminIndex: Int
     /// 32-byte raw group ID — used directly as the `group_id_fr`
     /// per-group binding scalar in the Tyranny circuit.
     let groupID: Data
     /// 32 bytes; LE-mod-r in-circuit.
     let salt: Data
+    /// 32 bytes BE — peer's BLS Fr scalar. **Required for OneOnOne**,
+    /// nil for other types. The OneOnOne SDK rejects equal secrets,
+    /// so the caller must mint a fresh ephemeral peer key (not reuse
+    /// the device's BLS secret).
+    var peerBlsSecretKey: Data? = nil
 }
 
 enum GroupProofGeneratorError: Error, Equatable, Sendable {
     case notYetSupported(SEPGroupType)
     case adminIndexOutOfRange(index: Int, count: Int)
+    case missingPeerSecret
     case sdkFailure(String)
 }
 
@@ -75,13 +87,36 @@ struct OnymGroupProofGenerator: GroupProofGenerator {
         switch input.groupType {
         case .tyranny:
             return try proveTyrannyCreate(input)
-        case .anarchy, .oneOnOne, .democracy, .oligarchy:
-            // PR-B ships Tyranny only — see `project_create_group_plan`
-            // memory note. The other types stay stubbed until their own
-            // slice; wiring them here without a UI to drive them just
-            // accumulates dead code.
+        case .oneOnOne:
+            return try proveOneOnOneCreate(input)
+        case .anarchy, .democracy, .oligarchy:
             throw GroupProofGeneratorError.notYetSupported(input.groupType)
         }
+    }
+
+    private func proveOneOnOneCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
+        guard let peerSecret = input.peerBlsSecretKey else {
+            throw GroupProofGeneratorError.missingPeerSecret
+        }
+        let result: OneOnOne.CreateProof
+        do {
+            result = try OneOnOne.proveCreate(
+                secretKey0: input.adminBlsSecretKey,
+                secretKey1: peerSecret,
+                salt: input.salt
+            )
+        } catch {
+            throw GroupProofGeneratorError.sdkFailure(String(describing: error))
+        }
+        // OneOnOne returns a single 32B commitment (not a bundled PI
+        // blob). The contract's `create_membership_public_inputs`
+        // expects 2 entries — `[commitment, Fr(0)]` — to match the
+        // shared anarchy depth-5 membership-VK shape.
+        let frZero = Data(repeating: 0, count: 32)
+        return GroupCreateProof(
+            proof: result.proof,
+            publicInputs: [result.commitment, frZero]
+        )
     }
 
     private func proveTyrannyCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {

--- a/Sources/OnymIOS/Chain/SEPContractClient.swift
+++ b/Sources/OnymIOS/Chain/SEPContractClient.swift
@@ -95,6 +95,10 @@ struct SEPContractClient: Sendable {
         try await invoke("update_commitment", payload: payload, responseType: SEPSubmissionResponse.self)
     }
 
+    func createGroupOneOnOne(_ payload: OneOnOneCreateGroupPayload) async throws -> SEPSubmissionResponse {
+        try await invoke("create_group", payload: payload, responseType: SEPSubmissionResponse.self)
+    }
+
     func getCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
         try await invoke(
             "get_commitment",

--- a/Sources/OnymIOS/Chain/SEPContractTypes.swift
+++ b/Sources/OnymIOS/Chain/SEPContractTypes.swift
@@ -109,6 +109,31 @@ struct TyrannyCreateGroupPayload: Encodable, Equatable, Sendable {
     }
 }
 
+/// `create_group` payload for the OneOnOne (1v1) contract. Simpler
+/// than Tyranny — no tier (1v1 is fixed at depth 5, exactly 2
+/// members), no admin_pubkey_commitment. The `publicInputs` vector
+/// is the standard membership-style 2-element form
+/// `[commitment, Fr(0)]` that the contract's
+/// `create_membership_public_inputs` expects.
+///
+/// Relayer handler: `add_create_group_args` →
+/// `ContractType::OneOnOne` arm.
+struct OneOnOneCreateGroupPayload: Encodable, Equatable, Sendable {
+    let groupID: Data
+    let commitment: Data
+    /// 1601-byte raw PLONK proof — same constraint as Tyranny.
+    let proof: Data
+    /// 2 elements × 32 bytes — `[commitment, Fr(0)]`.
+    let publicInputs: [Data]
+
+    enum CodingKeys: String, CodingKey {
+        case groupID = "group_id"
+        case commitment
+        case proof
+        case publicInputs
+    }
+}
+
 /// `update_commitment` payload — Tyranny variant. Same 4-element PI
 /// shape as create, but the SDK's `Tyranny.UpdateProof.publicInputs`
 /// is 160 bytes = 5 chunks (`c_old || epoch_old || c_new ||

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -383,6 +383,8 @@ extension GroupProofGeneratorError: LocalizedError {
             return "\(type) is not supported yet — only Tyranny ships in this release"
         case let .adminIndexOutOfRange(index, count):
             return "Admin index \(index) is out of range for \(count) members"
+        case .missingPeerSecret:
+            return "1-on-1 dialog is missing the peer's BLS secret"
         case let .sdkFailure(message):
             return "Proof generation failed: \(message)"
         }

--- a/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
+++ b/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
@@ -55,13 +55,32 @@ final class GroupProofGeneratorTests: XCTestCase {
         }
     }
 
-    func test_proveCreate_oneOnOne_throwsNotYetSupported() {
-        let input = stubInput(groupType: .oneOnOne)
+    func test_proveCreate_oneOnOne_returnsRawProofAnd2ElementPI() throws {
+        // Two distinct BLS Fr scalars (the SDK rejects equal secrets).
+        let input = GroupProofCreateInput(
+            groupType: .oneOnOne,
+            tier: .small,                     // ignored for oneOnOne
+            members: [],                      // ignored for oneOnOne
+            adminBlsSecretKey: fr(1),
+            adminIndex: 0,                    // ignored for oneOnOne
+            groupID: Data(repeating: 0, count: 32),
+            salt: Data(repeating: 0xEE, count: 32),
+            peerBlsSecretKey: fr(2)
+        )
+        let result = try OnymGroupProofGenerator().proveCreate(input)
+        XCTAssertEqual(result.proof.count, 1601,
+                       "OneOnOne returns the same raw 1601-byte plonk proof as Tyranny")
+        XCTAssertEqual(result.publicInputs.count, 2,
+                       "OneOnOne PI = [commitment, Fr(0)] — 2 entries")
+        XCTAssertEqual(result.publicInputs[0].count, 32)
+        XCTAssertEqual(result.publicInputs[1], Data(repeating: 0, count: 32),
+                       "Fr(0) tail must be 32 zero bytes")
+    }
+
+    func test_proveCreate_oneOnOne_missingPeerSecret_throws() {
+        let input = stubInput(groupType: .oneOnOne)   // no peerBlsSecretKey
         XCTAssertThrowsError(try OnymGroupProofGenerator().proveCreate(input)) { error in
-            XCTAssertEqual(
-                error as? GroupProofGeneratorError,
-                .notYetSupported(.oneOnOne)
-            )
+            XCTAssertEqual(error as? GroupProofGeneratorError, .missingPeerSecret)
         }
     }
 

--- a/Tests/OnymIOSTests/SEPContractClientTests.swift
+++ b/Tests/OnymIOSTests/SEPContractClientTests.swift
@@ -61,6 +61,55 @@ final class SEPContractClientTests: XCTestCase {
         XCTAssertEqual(publicInputs.count, 4, "Tyranny create needs 4 PI entries")
     }
 
+    func test_createGroupOneOnOne_sendsCorrectEnvelopeAndPayload() async throws {
+        let recorder = RecordingTransport(
+            response: SEPSubmissionResponse(
+                accepted: true,
+                transactionHash: "1v1tx",
+                message: nil
+            )
+        )
+        let client = SEPContractClient(
+            contractID: testContractID,
+            contractType: .oneOnOne,
+            network: .testnet,
+            transport: recorder
+        )
+
+        let payload = OneOnOneCreateGroupPayload(
+            groupID: Data(repeating: 0xAB, count: 32),
+            commitment: Data(repeating: 0xCD, count: 32),
+            proof: Data(repeating: 0xEE, count: 1601),
+            publicInputs: [
+                Data(repeating: 0xCD, count: 32),
+                Data(repeating: 0x00, count: 32),
+            ]
+        )
+        let response = try await client.createGroupOneOnOne(payload)
+
+        XCTAssertTrue(response.accepted)
+        XCTAssertEqual(response.transactionHash, "1v1tx")
+
+        let json = try XCTUnwrap(recorder.lastJSON())
+        XCTAssertEqual(json["function"] as? String, "create_group")
+        XCTAssertEqual(json["contractID"] as? String, testContractID)
+        XCTAssertEqual(json["contractType"] as? String, "oneonone",
+                       "OneOnOne contract type wire spelling must match relayer's ContractType enum")
+        XCTAssertEqual(json["network"] as? String, "testnet")
+
+        let payloadJSON = try XCTUnwrap(json["payload"] as? [String: Any])
+        XCTAssertNotNil(payloadJSON["group_id"])
+        XCTAssertNotNil(payloadJSON["commitment"])
+        XCTAssertNotNil(payloadJSON["proof"])
+        XCTAssertNil(payloadJSON["tier"],
+                     "OneOnOne is fixed-depth — no tier field on the wire")
+        XCTAssertNil(payloadJSON["admin_pubkey_commitment"],
+                     "OneOnOne has no admin_pubkey_commitment — that's Tyranny-only")
+        let publicInputs = try XCTUnwrap(payloadJSON["publicInputs"] as? [String])
+        XCTAssertEqual(publicInputs.count, 2,
+                       "OneOnOne create needs 2 PI entries: [commitment, Fr(0)]")
+    }
+
     func test_createGroupTyranny_mainnetSerializesAsPublic() async throws {
         let recorder = RecordingTransport(
             response: SEPSubmissionResponse(accepted: true, transactionHash: nil, message: nil)


### PR DESCRIPTION
## Summary

PR **1 of 3** in the OneOnOne stacked series. Adds the chain-layer pieces for a 1-on-1 dialog create. Nothing UI-visible yet — the `OnymUIGovernance.oneOnOne.isAvailable` gate stays false until PR-3.

- `OneOnOneCreateGroupPayload` — wire shape for `sep-oneonone.create_group`: `group_id` + `commitment` + 1601-byte `proof` + 2-element `publicInputs` (`[commitment, Fr(0)]`). No `tier`, no `admin_pubkey_commitment` (Tyranny-only).
- `SEPContractClient.createGroupOneOnOne(_:)` — pinned to `create_group` via the same generic invoke as Tyranny.
- `GroupProofGenerator.proveCreate` now branches on `.oneOnOne` and calls `OneOnOne.proveCreate(secretKey0:secretKey1:salt:)`. Returns `GroupCreateProof` with `publicInputs = [commitment, Fr(0)]` so the contract's `create_membership_public_inputs` is satisfied.
- `GroupProofCreateInput` gains optional `peerBlsSecretKey`. Required for oneOnOne (`.missingPeerSecret` thrown otherwise); ignored elsewhere.

## Tests

- `proveCreate_oneOnOne_returnsRawProofAnd2ElementPI` — runs the real SDK circuit, asserts `proof.count == 1601` and PI shape == `[_, Fr(0)]`.
- `proveCreate_oneOnOne_missingPeerSecret_throws` — guards the new required field.
- `createGroupOneOnOne_sendsCorrectEnvelopeAndPayload` — verifies `contractType == "oneonone"` on the wire and that `tier` / `admin_pubkey_commitment` do NOT leak into the payload.

All 13 affected unit tests pass locally.

## Architectural notes

- OneOnOne mints **both BLS secrets** at create time by design (the SDK's founding ceremony has both keys present in one place). PR-2 will mint a fresh ephemeral peer secret on the creator's device and ship it inside the invitation envelope so the peer adopts it as the dialog identity. Keeps the paste-only inbox-key UX consistent with Tyranny.
- `groupID` is passed for storage-key purposes but does **not** bind into the proof (unlike Tyranny's `group_id_fr`).

## Stack

- **PR-1 (this)** — chain seam (types + client method + proof generator)
- **PR-2** — interactor + ephemeral peer secret + invitation envelope wiring
- **PR-3** — UI surface: enable governance card, single-peer Step 2, validation, drop "Soon" pill

## Test plan

- [x] Unit: `OnymIOSTests/GroupProofGeneratorTests` (5 tests, includes real SDK circuit)
- [x] Unit: `OnymIOSTests/SEPContractClientTests` (8 tests, envelope + auth + 2xx/non-2xx paths)
- [ ] E2E (deferred to PR-3) — full create-group flow on testnet from the simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)