### PR TITLE
group: OneOnOne create-group interactor + invitation envelope (PR-2 of OneOnOne)

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -212,6 +212,7 @@ final class CreateGroupFlow {
         do {
             let invitees = self.invitees.map(\.inboxPublicKey)
             let group = try await interactor.create(
+                governanceType: governance.sepGroupType,
                 name: effectiveName,
                 invitees: invitees,
                 onProgress: { [weak self] p in

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -71,10 +71,39 @@ struct CreateGroupInteractor: Sendable {
     /// Run the full pipeline. `onProgress` is called on the actor's
     /// executor — pass `{ progress in Task { @MainActor in … } }` if
     /// you need to update SwiftUI state from it.
+    ///
+    /// `governanceType` selects the contract family. Only `.tyranny`
+    /// and `.oneOnOne` are wired today; the rest throw
+    /// `CreateGroupError.unsupportedGovernanceType` early so the UI
+    /// surfaces a clear "TBD" rather than a vague proof failure.
+    ///
+    /// `.oneOnOne` requires exactly **one** invitee — the peer. The
+    /// creator mints a fresh ephemeral BLS Fr scalar for that peer
+    /// (the founding ceremony has both keys present by SDK design)
+    /// and ships it inside the invitation envelope so the receiver
+    /// can adopt it as their per-dialog identity.
     func create(
+        governanceType: SEPGroupType = .tyranny,
         name: String,
         invitees: [Data],
         onProgress: @Sendable (CreateGroupProgress) -> Void = { _ in }
+    ) async throws -> ChatGroup {
+        switch governanceType {
+        case .tyranny:
+            return try await createTyranny(name: name, invitees: invitees, onProgress: onProgress)
+        case .oneOnOne:
+            return try await createOneOnOne(name: name, invitees: invitees, onProgress: onProgress)
+        case .anarchy, .democracy, .oligarchy:
+            throw CreateGroupError.unsupportedGovernanceType(governanceType)
+        }
+    }
+
+    // MARK: - Tyranny
+
+    private func createTyranny(
+        name: String,
+        invitees: [Data],
+        onProgress: @Sendable (CreateGroupProgress) -> Void
     ) async throws -> ChatGroup {
         // 1. Validate
         onProgress(.validating)
@@ -220,50 +249,228 @@ struct CreateGroupInteractor: Sendable {
                 groupTypeRaw: SEPGroupType.tyranny.rawValue,
                 adminPubkeyHex: adminPubkeyHex
             )
-            let payloadBytes: Data
-            do {
-                payloadBytes = try JSONEncoder().encode(invitePayload)
-            } catch {
-                throw CreateGroupError.invitationEncodingFailed
-            }
-            for (index, inboxKey) in invitees.enumerated() {
-                let sealed: Data
-                do {
-                    sealed = try await identity.sealInvitation(
-                        payload: payloadBytes,
-                        to: inboxKey
-                    )
-                } catch {
-                    throw CreateGroupError.invitationSendFailed(
-                        index: index,
-                        reason: String(describing: error)
-                    )
-                }
-                let inboxTag = Self.inboxTag(from: inboxKey)
-                let receipt: PublishReceipt
-                do {
-                    receipt = try await inboxTransport.send(
-                        sealed,
-                        to: TransportInboxID(rawValue: inboxTag)
-                    )
-                } catch {
-                    throw CreateGroupError.invitationSendFailed(
-                        index: index,
-                        reason: String(describing: error)
-                    )
-                }
-                guard receipt.acceptedBy >= 1 else {
-                    throw CreateGroupError.invitationSendFailed(
-                        index: index,
-                        reason: "no relay accepted the invitation"
-                    )
-                }
-            }
+            try await sendInvitations(invitePayload, to: invitees)
         }
 
-        // The flag was already flipped via `markPublished`; reload our
-        // in-memory snapshot to mirror the on-disk state.
-        return await groups.snapshots.first(where: { $0.contains { $0.id == group.id } })?
+        return await reloadGroup(group)
+    }
+
+    // MARK: - OneOnOne
+
+    private func createOneOnOne(
+        name: String,
+        invitees: [Data],
+        onProgress: @Sendable (CreateGroupProgress) -> Void
+    ) async throws -> ChatGroup {
+        // 1. Validate — 1-on-1 is exactly two parties: the creator and
+        //    one peer. Zero or 2+ invitees is a programmer/UI error.
+        onProgress(.validating)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw CreateGroupError.invalidName
+        }
+        guard invitees.count == 1 else {
+            throw CreateGroupError.oneOnOneRequiresExactlyOnePeer(got: invitees.count)
+        }
+        let peerInboxKey = invitees[0]
+        guard peerInboxKey.count == 32 else {
+            throw CreateGroupError.invalidInviteeKey(index: 0)
+        }
+
+        // 2. Resolve relayer + contract.
+        guard let relayerURL = await relayers.selectURL() else {
+            throw CreateGroupError.noActiveRelayer
+        }
+        let activeNetwork = networkPreference.current()
+        let key = AnchorSelectionKey(network: activeNetwork.contractNetwork, type: .oneonone)
+        guard let binding = await contracts.binding(for: key) else {
+            throw CreateGroupError.noContractBinding(.oneonone)
+        }
+
+        // 3. Group params (no tier — OneOnOne contract is fixed depth).
+        let groupID = Self.randomBytes(32)
+        let groupSecret = Self.randomBytes(32)
+        let salt = GroupCommitmentBuilder.generateSalt()
+
+        // 4. Both BLS secrets must be present at create time — the SDK's
+        //    founding ceremony is the one moment both keys exist on the
+        //    same device. The peer secret is shipped inside the
+        //    invitation envelope so the receiver adopts it as their
+        //    per-dialog identity.
+        let creatorBlsSecret: Data
+        do {
+            creatorBlsSecret = try await identity.blsSecretKey()
+        } catch {
+            throw CreateGroupError.missingIdentity
+        }
+        guard let identitySnapshot = await identity.currentIdentity() else {
+            throw CreateGroupError.missingIdentity
+        }
+        var peerBlsSecret = Self.randomBytes(32)
+        // The OneOnOne SDK rejects equal secrets. Vanishingly unlikely
+        // with 256 bits of entropy, but cheap to defend against — flip
+        // a single bit so we always differ.
+        if peerBlsSecret == creatorBlsSecret {
+            peerBlsSecret[0] ^= 0x01
+        }
+
+        let creatorMember: GovernanceMember
+        let peerMember: GovernanceMember
+        do {
+            creatorMember = GovernanceMember(
+                publicKeyCompressed: identitySnapshot.blsPublicKey,
+                leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: creatorBlsSecret)
+            )
+            peerMember = GovernanceMember(
+                publicKeyCompressed: try GroupCommitmentBuilder.computePublicKey(secretKey: peerBlsSecret),
+                leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: peerBlsSecret)
+            )
+        } catch {
+            throw CreateGroupError.sdkFailure(String(describing: error))
+        }
+        let members = [creatorMember, peerMember].sorted { lhs, rhs in
+            lhs.publicKeyCompressed.lexicographicallyPrecedes(rhs.publicKeyCompressed)
+        }
+
+        // 5. Generate proof — OneOnOne SDK takes both secrets directly.
+        onProgress(.proving)
+        let proofInput = GroupProofCreateInput(
+            groupType: .oneOnOne,
+            tier: .small,                   // ignored by SDK
+            members: members,               // ignored by SDK
+            adminBlsSecretKey: creatorBlsSecret,
+            adminIndex: 0,                  // ignored by SDK
+            groupID: groupID,
+            salt: salt,
+            peerBlsSecretKey: peerBlsSecret
+        )
+        let proof: GroupCreateProof
+        do {
+            proof = try proofGenerator.proveCreate(proofInput)
+        } catch let err as GroupProofGeneratorError {
+            throw CreateGroupError.proofGenerationFailed(err)
+        } catch {
+            throw CreateGroupError.sdkFailure(String(describing: error))
+        }
+
+        // 6. Anchor on chain.
+        onProgress(.anchoring)
+        let transport = makeContractTransport(relayerURL)
+        let client = SEPContractClient(
+            contractID: binding.contractID,
+            contractType: .oneOnOne,
+            network: activeNetwork.sepNetwork,
+            transport: transport
+        )
+        let payload = OneOnOneCreateGroupPayload(
+            groupID: groupID,
+            commitment: proof.commitment,
+            proof: proof.proof,
+            publicInputs: proof.publicInputs
+        )
+        let response: SEPSubmissionResponse
+        do {
+            response = try await client.createGroupOneOnOne(payload)
+        } catch {
+            throw CreateGroupError.anchorTransport(String(describing: error))
+        }
+        guard response.accepted else {
+            throw CreateGroupError.anchorRejected(message: response.message)
+        }
+
+        // 7. Save locally — no admin in 1-on-1, so adminPubkeyHex stays nil.
+        let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+        let group = ChatGroup(
+            id: groupIDHex,
+            name: trimmedName,
+            groupSecret: groupSecret,
+            createdAt: Date(),
+            members: members,
+            epoch: 0,
+            salt: salt,
+            commitment: proof.commitment,
+            tier: .small,
+            groupType: .oneOnOne,
+            adminPubkeyHex: nil,
+            isPublishedOnChain: false
+        )
+        _ = await groups.insert(group)
+        await groups.markPublished(id: group.id, commitment: proof.commitment)
+
+        // 8. Send the single invitation — peer secret rides inside.
+        onProgress(.sendingInvitations(total: 1))
+        let invitePayload = GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: groupSecret,
+            name: trimmedName,
+            members: members,
+            epoch: 0,
+            salt: salt,
+            commitment: proof.commitment,
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.oneOnOne.rawValue,
+            adminPubkeyHex: nil,
+            peerBlsSecret: peerBlsSecret
+        )
+        try await sendInvitations(invitePayload, to: [peerInboxKey])
+
+        return await reloadGroup(group)
+    }
+
+    // MARK: - Shared invitation send loop
+
+    private func sendInvitations(
+        _ invitePayload: GroupInvitationPayload,
+        to invitees: [Data]
+    ) async throws {
+        let payloadBytes: Data
+        do {
+            payloadBytes = try JSONEncoder().encode(invitePayload)
+        } catch {
+            throw CreateGroupError.invitationEncodingFailed
+        }
+        for (index, inboxKey) in invitees.enumerated() {
+            let sealed: Data
+            do {
+                sealed = try await identity.sealInvitation(
+                    payload: payloadBytes,
+                    to: inboxKey
+                )
+            } catch {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: String(describing: error)
+                )
+            }
+            let inboxTag = Self.inboxTag(from: inboxKey)
+            let receipt: PublishReceipt
+            do {
+                receipt = try await inboxTransport.send(
+                    sealed,
+                    to: TransportInboxID(rawValue: inboxTag)
+                )
+            } catch {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: String(describing: error)
+                )
+            }
+            guard receipt.acceptedBy >= 1 else {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: "no relay accepted the invitation"
+                )
+            }
+        }
+    }
+
+    /// Reload the freshly-published group from the repo so the caller
+    /// sees `isPublishedOnChain = true` (the flag was flipped via
+    /// `markPublished`, but the local `group` snapshot was built
+    /// before that mutation).
+    private func reloadGroup(_ group: ChatGroup) async -> ChatGroup {
+        await groups.snapshots.first(where: { $0.contains { $0.id == group.id } })?
             .first { $0.id == group.id }
             ?? group
     }
@@ -348,6 +555,12 @@ enum CreateGroupError: Error, Equatable, Sendable {
     case invitationEncodingFailed
     case invitationSendFailed(index: Int, reason: String)
     case sdkFailure(String)
+    /// `.oneOnOne` requires exactly one invitee (the peer); the UI
+    /// gates this but the interactor double-checks.
+    case oneOnOneRequiresExactlyOnePeer(got: Int)
+    /// Caller passed `.anarchy` / `.democracy` / `.oligarchy` — not
+    /// wired to the chain yet.
+    case unsupportedGovernanceType(SEPGroupType)
 }
 
 extension CreateGroupError: LocalizedError {
@@ -372,6 +585,10 @@ extension CreateGroupError: LocalizedError {
             return "Invitation #\(index + 1) failed: \(reason)"
         case let .sdkFailure(message):
             return "SDK failure: \(message)"
+        case let .oneOnOneRequiresExactlyOnePeer(got):
+            return "1-on-1 dialog needs exactly 1 peer (got \(got))"
+        case let .unsupportedGovernanceType(type):
+            return "\(type.rawValue) is not supported yet"
         }
     }
 }

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -288,7 +288,11 @@ struct CreateGroupInteractor: Sendable {
         }
 
         // 3. Group params (no tier — OneOnOne contract is fixed depth).
-        let groupID = Self.randomBytes(32)
+        // sep-oneonone doesn't gate `group_id` canonicality today (no
+        // proof binding), but we use the canonical sampler anyway for
+        // consistency with Tyranny + to keep all on-chain group IDs
+        // valid Fr scalars in case a future contract rev adds the check.
+        let groupID = Self.randomCanonicalFr()
         let groupSecret = Self.randomBytes(32)
         let salt = GroupCommitmentBuilder.generateSalt()
 
@@ -299,6 +303,11 @@ struct CreateGroupInteractor: Sendable {
         //    per-dialog identity.
         let creatorBlsSecret: Data
         do {
+            // Proof witness for `OneOnOne.proveCreate(secretKey0:)` +
+            // `Common.leafHash(secretKey:)`. Same justification as the
+            // Tyranny path — SDK takes the BLS secret directly. Stays
+            // in this stack frame.
+            // onym:allow-secret-read
             creatorBlsSecret = try await identity.blsSecretKey()
         } catch {
             throw CreateGroupError.missingIdentity
@@ -306,12 +315,15 @@ struct CreateGroupInteractor: Sendable {
         guard let identitySnapshot = await identity.currentIdentity() else {
             throw CreateGroupError.missingIdentity
         }
-        var peerBlsSecret = Self.randomBytes(32)
+        // BLS secret keys are canonical Fr by convention. The SDK reduces
+        // silently if not, but any future strictness check would silently
+        // break us — so generate canonical at the source.
+        var peerBlsSecret = Self.randomCanonicalFr()
         // The OneOnOne SDK rejects equal secrets. Vanishingly unlikely
-        // with 256 bits of entropy, but cheap to defend against — flip
-        // a single bit so we always differ.
-        if peerBlsSecret == creatorBlsSecret {
-            peerBlsSecret[0] ^= 0x01
+        // with 256 bits of entropy, but cheap to defend against —
+        // resample on the off chance of a collision.
+        while peerBlsSecret == creatorBlsSecret {
+            peerBlsSecret = Self.randomCanonicalFr()
         }
 
         let creatorMember: GovernanceMember

--- a/Sources/OnymIOS/Group/GroupInvitationPayload.swift
+++ b/Sources/OnymIOS/Group/GroupInvitationPayload.swift
@@ -34,6 +34,16 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
     /// Lowercase hex (96 chars) BLS pubkey of the Tyranny admin.
     /// `nil` for `.anarchy` / `.oneOnOne`.
     let adminPubkeyHex: String?
+    /// 32-byte BLS Fr scalar minted by the creator for the peer party
+    /// in a 1-on-1 dialog. The receiver MUST adopt this as their
+    /// per-dialog BLS identity — the founding proof was generated with
+    /// both parties' secrets, so there is no other key the receiver
+    /// could use to derive the same per-epoch keys. `nil` for every
+    /// other governance type.
+    ///
+    /// Decoded via `decodeIfPresent` so older invitations (and other
+    /// group types that never set this field) round-trip cleanly.
+    let peerBlsSecret: Data?
 
     enum CodingKeys: String, CodingKey {
         case version
@@ -47,5 +57,50 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         case tierRaw = "tier_raw"
         case groupTypeRaw = "group_type_raw"
         case adminPubkeyHex = "admin_pubkey_hex"
+        case peerBlsSecret = "peer_bls_secret"
+    }
+
+    init(
+        version: Int,
+        groupID: Data,
+        groupSecret: Data,
+        name: String,
+        members: [GovernanceMember],
+        epoch: UInt64,
+        salt: Data,
+        commitment: Data?,
+        tierRaw: Int,
+        groupTypeRaw: String,
+        adminPubkeyHex: String?,
+        peerBlsSecret: Data? = nil
+    ) {
+        self.version = version
+        self.groupID = groupID
+        self.groupSecret = groupSecret
+        self.name = name
+        self.members = members
+        self.epoch = epoch
+        self.salt = salt
+        self.commitment = commitment
+        self.tierRaw = tierRaw
+        self.groupTypeRaw = groupTypeRaw
+        self.adminPubkeyHex = adminPubkeyHex
+        self.peerBlsSecret = peerBlsSecret
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decode(Int.self, forKey: .version)
+        groupID = try c.decode(Data.self, forKey: .groupID)
+        groupSecret = try c.decode(Data.self, forKey: .groupSecret)
+        name = try c.decode(String.self, forKey: .name)
+        members = try c.decode([GovernanceMember].self, forKey: .members)
+        epoch = try c.decode(UInt64.self, forKey: .epoch)
+        salt = try c.decode(Data.self, forKey: .salt)
+        commitment = try c.decodeIfPresent(Data.self, forKey: .commitment)
+        tierRaw = try c.decode(Int.self, forKey: .tierRaw)
+        groupTypeRaw = try c.decode(String.self, forKey: .groupTypeRaw)
+        adminPubkeyHex = try c.decodeIfPresent(String.self, forKey: .adminPubkeyHex)
+        peerBlsSecret = try c.decodeIfPresent(Data.self, forKey: .peerBlsSecret)
     }
 }

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -158,6 +158,105 @@ final class CreateGroupInteractorTests: XCTestCase {
         }
     }
 
+    // MARK: - OneOnOne
+
+    func test_create_oneOnOne_anchorsOnOneOnOneContractAndShipsPeerSecret() async throws {
+        let env = await makeTestEnv(includeOneOnOneContract: true)
+        let interactor = env.makeInteractor()
+        let peerInbox = Data(repeating: 0xAA, count: 32)
+
+        let group = try await interactor.create(
+            governanceType: .oneOnOne,
+            name: "Alice & Bob",
+            invitees: [peerInbox]
+        )
+
+        // Group has both members, no admin, fixed-depth tier.
+        XCTAssertEqual(group.groupType, .oneOnOne)
+        XCTAssertEqual(group.members.count, 2, "creator + peer")
+        XCTAssertNil(group.adminPubkeyHex, "1-on-1 has no admin")
+        XCTAssertEqual(group.tier, .small)
+        XCTAssertTrue(group.isPublishedOnChain)
+
+        // Anchored on the OneOnOne contract via `create_group`.
+        let invocations = env.contractTransport.invocations
+        XCTAssertEqual(invocations.count, 1)
+        XCTAssertEqual(invocations.first?.function, "create_group")
+        let body = try XCTUnwrap(invocations.first.flatMap {
+            try? JSONSerialization.jsonObject(with: $0.payload) as? [String: Any]
+        })
+        XCTAssertEqual(body["contractType"] as? String, "oneonone")
+        let payload = try XCTUnwrap(body["payload"] as? [String: Any])
+        XCTAssertNil(payload["admin_pubkey_commitment"], "no admin field on OneOnOne wire")
+        XCTAssertNil(payload["tier"], "no tier field on OneOnOne wire")
+        let publicInputs = try XCTUnwrap(payload["publicInputs"] as? [String])
+        XCTAssertEqual(publicInputs.count, 2, "OneOnOne ships [commitment, Fr(0)]")
+
+        // One sealed invitation went out to the peer's inbox.
+        let sends = await env.inboxTransport.sends
+        XCTAssertEqual(sends.count, 1)
+
+        // The sealed payload contains the peer's BLS secret. We can't
+        // inspect the sealed bytes (they're AES-GCM-encrypted), but
+        // sealInvitation is a passthrough wrapper around AES-GCM seal —
+        // peeking at what the interactor handed to `sealInvitation` is
+        // out of scope, so we settle for verifying the public-input
+        // commitment came from our stub (proves the OneOnOne arm ran).
+        XCTAssertNotNil(group.commitment)
+        XCTAssertEqual(group.commitment, Data(repeating: 0xEE, count: 32))
+    }
+
+    func test_create_oneOnOne_zeroInvitees_throws() async throws {
+        let env = await makeTestEnv(includeOneOnOneContract: true)
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .oneOnOne,
+                name: "Solo",
+                invitees: []
+            ),
+            CreateGroupError.oneOnOneRequiresExactlyOnePeer(got: 0)
+        )
+    }
+
+    func test_create_oneOnOne_twoInvitees_throws() async throws {
+        let env = await makeTestEnv(includeOneOnOneContract: true)
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .oneOnOne,
+                name: "Crowd",
+                invitees: [
+                    Data(repeating: 0xAA, count: 32),
+                    Data(repeating: 0xBB, count: 32),
+                ]
+            ),
+            CreateGroupError.oneOnOneRequiresExactlyOnePeer(got: 2)
+        )
+    }
+
+    func test_create_oneOnOne_noContractBinding_throws() async throws {
+        let env = await makeTestEnv(includeOneOnOneContract: false)
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .oneOnOne,
+                name: "G",
+                invitees: [Data(repeating: 0xAA, count: 32)]
+            ),
+            CreateGroupError.noContractBinding(.oneonone)
+        )
+    }
+
+    func test_create_anarchy_throws_unsupported() async throws {
+        let env = await makeTestEnv()
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .anarchy,
+                name: "G",
+                invitees: []
+            ),
+            CreateGroupError.unsupportedGovernanceType(.anarchy)
+        )
+    }
+
     // MARK: - Helpers
 
     private func assertThrows<T: Sendable>(
@@ -179,11 +278,13 @@ final class CreateGroupInteractorTests: XCTestCase {
     private func makeTestEnv(
         addRelayer: Bool = true,
         includeTyrannyContract: Bool = true,
+        includeOneOnOneContract: Bool = false,
         network: AppNetwork = .testnet
     ) async -> CreateGroupTestEnv {
         let env = await CreateGroupTestEnv.make(
             addRelayer: addRelayer,
             includeTyrannyContract: includeTyrannyContract,
+            includeOneOnOneContract: includeOneOnOneContract,
             network: network
         )
         return env
@@ -211,6 +312,7 @@ private final class CreateGroupTestEnv {
     static func make(
         addRelayer: Bool,
         includeTyrannyContract: Bool,
+        includeOneOnOneContract: Bool = false,
         network: AppNetwork
     ) async -> CreateGroupTestEnv {
         let keychain = KeychainStore(
@@ -238,9 +340,21 @@ private final class CreateGroupTestEnv {
             await relayers.setPrimary(url: URL(string: "https://relayer.test.example")!)
         }
 
-        let contractEntries: [ContractEntry] = includeTyrannyContract
-            ? [ContractEntry(network: .testnet, type: .tyranny, id: "CTYRANNYTEST00000000000000000000000000000000000000000000")]
-            : []
+        var contractEntries: [ContractEntry] = []
+        if includeTyrannyContract {
+            contractEntries.append(ContractEntry(
+                network: .testnet,
+                type: .tyranny,
+                id: "CTYRANNYTEST00000000000000000000000000000000000000000000"
+            ))
+        }
+        if includeOneOnOneContract {
+            contractEntries.append(ContractEntry(
+                network: .testnet,
+                type: .oneonone,
+                id: "C1V1CONTRACTTEST000000000000000000000000000000000000000"
+            ))
+        }
         let manifest = ContractsManifest(
             version: 1,
             releases: [
@@ -311,23 +425,39 @@ private final class CreateGroupTestEnv {
 
 // MARK: - Stubs
 
-/// Returns a deterministic 1601-byte "proof" + 4-element PI bundle
+/// Returns a deterministic 1601-byte "proof" + per-type PI bundle
 /// without actually proving. Skips the ~3.5s real prover so the test
 /// suite stays fast.
 private struct StubGroupProofGenerator: GroupProofGenerator {
     func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
-        guard input.groupType == .tyranny else {
+        switch input.groupType {
+        case .tyranny:
+            return GroupCreateProof(
+                proof: Data(repeating: 0xAB, count: 1601),
+                publicInputs: [
+                    Data(repeating: 0xCD, count: 32),  // commitment
+                    Data(repeating: 0x00, count: 32),  // Fr(0)
+                    Data(repeating: 0x42, count: 32),  // admin_pubkey_commitment
+                    Data(repeating: 0x77, count: 32),  // group_id_fr
+                ]
+            )
+        case .oneOnOne:
+            // Mirror the real OneOnOne SDK shape: raise if peer secret
+            // missing so the interactor's OneOnOne branch stays honest
+            // in tests.
+            guard input.peerBlsSecretKey != nil else {
+                throw GroupProofGeneratorError.missingPeerSecret
+            }
+            return GroupCreateProof(
+                proof: Data(repeating: 0xCC, count: 1601),
+                publicInputs: [
+                    Data(repeating: 0xEE, count: 32),  // commitment
+                    Data(repeating: 0x00, count: 32),  // Fr(0)
+                ]
+            )
+        default:
             throw GroupProofGeneratorError.notYetSupported(input.groupType)
         }
-        return GroupCreateProof(
-            proof: Data(repeating: 0xAB, count: 1601),
-            publicInputs: [
-                Data(repeating: 0xCD, count: 32),  // commitment
-                Data(repeating: 0x00, count: 32),  // Fr(0)
-                Data(repeating: 0x42, count: 32),  // admin_pubkey_commitment
-                Data(repeating: 0x77, count: 32),  // group_id_fr
-            ]
-        )
     }
 }
 


### PR DESCRIPTION
## Summary

PR **2 of 3** in the OneOnOne stacked series. Wires the create pipeline end-to-end for `.oneOnOne` — proof generation through chain anchor through invitation send. UI surface still gated behind PR-3.

**Base:** \`chain/oneonone-create\` (PR #33). Merge that first.

### Interactor

- \`CreateGroupInteractor.create\` now takes \`governanceType:\` and branches into per-type pipelines. Tyranny path is unchanged (extracted into \`createTyranny\`); OneOnOne path is the new \`createOneOnOne\`.
- **OneOnOne flow:** validate exactly one invitee → mint a fresh ephemeral 32-byte BLS Fr scalar for the peer (XOR-bumped on the vanishingly-unlikely collision with the creator's secret) → derive both members and lex-sort → call \`proveCreate\` with both secrets → POST \`OneOnOneCreateGroupPayload\` to the OneOnOne contract → save group with \`adminPubkeyHex = nil\` → ship the peer secret inside the sealed invitation envelope.
- Two new errors: \`oneOnOneRequiresExactlyOnePeer(got:)\` and \`unsupportedGovernanceType(_:)\`.

### Invitation envelope

- \`GroupInvitationPayload.peerBlsSecret: Data?\` — optional \`peer_bls_secret\` field. Only set on \`.oneOnOne\`. Decoded via \`decodeIfPresent\` so older invitations and non-OneOnOne envelopes round-trip cleanly.
- The receiver MUST adopt this secret as their per-dialog BLS identity — the founding proof was generated with both parties' secrets, so there is no other key the receiver could use to derive matching per-epoch keys.

### Flow

- \`CreateGroupFlow.submit\` passes \`governance.sepGroupType\` to the interactor (was hardcoded to \`.tyranny\`). Behaviourally a no-op until PR-3 ungates the OneOnOne governance card.

## Test plan

- [x] 5 new \`CreateGroupInteractorTests\` covering OneOnOne happy + validation paths
- [x] All 312 unit tests pass (2 skipped — the known Tyranny E2E)
- [ ] E2E (deferred to PR-3)

## Stack

- **PR-1 (#33)** — chain seam
- **PR-2 (this)** — interactor + invitation envelope
- **PR-3** — UI surface + Step2 single-peer variant + governance gate flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)