### PR TITLE
ux: enable OneOnOne governance + Step2 single-peer variant (PR-3 of OneOnOne)

### DIFF
--- a/Sources/OnymIOS/Chain/GroupProofGenerator.swift
+++ b/Sources/OnymIOS/Chain/GroupProofGenerator.swift
@@ -37,33 +37,45 @@ protocol GroupProofGenerator: Sendable {
     func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof
 }
 
-/// Inputs for a create-group proof. The caller (PR-C interactor) is
-/// responsible for:
-/// - lex-sorting `members` by `publicKeyCompressed` before computing
-///   `adminIndex` (the SDK reuses the same sort to validate
-///   `memberLeafHashes[adminIndex] == leafHash(adminBlsSecretKey)`),
-/// - generating a fresh 32-byte salt via `GroupCommitmentBuilder.generateSalt`,
-/// - choosing the tier based on the expected member count.
+/// Inputs for a create-group proof. Per-type field requirements:
+///
+/// - **Tyranny**: needs `members` (lex-sorted by `publicKeyCompressed`),
+///   `adminBlsSecretKey` (the device's own BLS Fr), `adminIndex`
+///   (admin's position in the sorted roster), `groupID` (used as the
+///   `group_id_fr` binding scalar), `tier`, `salt`.
+/// - **OneOnOne**: needs `adminBlsSecretKey` (party 0 = creator) and
+///   `peerBlsSecretKey` (party 1 = peer — the creator mints a fresh
+///   ephemeral one and ships it inside the invitation envelope), plus
+///   `salt`. `members` / `adminIndex` / `tier` / `groupID` are
+///   ignored by the SDK call (groupID is still used as the contract's
+///   storage-key arg, but doesn't bind into the proof). Both secrets
+///   MUST differ — the SDK rejects `secretKey0 == secretKey1`.
 struct GroupProofCreateInput: Sendable {
     let groupType: SEPGroupType
     let tier: SEPTier
-    /// Lex-sorted by `publicKeyCompressed`. The packed `leafHash`es
-    /// land in the prover in this order.
+    /// Lex-sorted by `publicKeyCompressed`. Tyranny-only.
     let members: [GovernanceMember]
     /// 32 bytes BE — the sender's own BLS Fr scalar.
     let adminBlsSecretKey: Data
     /// Position of the admin in `members` (after the lex sort).
+    /// Tyranny-only.
     let adminIndex: Int
     /// 32-byte raw group ID — used directly as the `group_id_fr`
     /// per-group binding scalar in the Tyranny circuit.
     let groupID: Data
     /// 32 bytes; LE-mod-r in-circuit.
     let salt: Data
+    /// 32 bytes BE — peer's BLS Fr scalar. **Required for OneOnOne**,
+    /// nil for other types. The OneOnOne SDK rejects equal secrets,
+    /// so the caller must mint a fresh ephemeral peer key (not reuse
+    /// the device's BLS secret).
+    var peerBlsSecretKey: Data? = nil
 }
 
 enum GroupProofGeneratorError: Error, Equatable, Sendable {
     case notYetSupported(SEPGroupType)
     case adminIndexOutOfRange(index: Int, count: Int)
+    case missingPeerSecret
     case sdkFailure(String)
 }
 
@@ -75,13 +87,36 @@ struct OnymGroupProofGenerator: GroupProofGenerator {
         switch input.groupType {
         case .tyranny:
             return try proveTyrannyCreate(input)
-        case .anarchy, .oneOnOne, .democracy, .oligarchy:
-            // PR-B ships Tyranny only — see `project_create_group_plan`
-            // memory note. The other types stay stubbed until their own
-            // slice; wiring them here without a UI to drive them just
-            // accumulates dead code.
+        case .oneOnOne:
+            return try proveOneOnOneCreate(input)
+        case .anarchy, .democracy, .oligarchy:
             throw GroupProofGeneratorError.notYetSupported(input.groupType)
         }
+    }
+
+    private func proveOneOnOneCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
+        guard let peerSecret = input.peerBlsSecretKey else {
+            throw GroupProofGeneratorError.missingPeerSecret
+        }
+        let result: OneOnOne.CreateProof
+        do {
+            result = try OneOnOne.proveCreate(
+                secretKey0: input.adminBlsSecretKey,
+                secretKey1: peerSecret,
+                salt: input.salt
+            )
+        } catch {
+            throw GroupProofGeneratorError.sdkFailure(String(describing: error))
+        }
+        // OneOnOne returns a single 32B commitment (not a bundled PI
+        // blob). The contract's `create_membership_public_inputs`
+        // expects 2 entries — `[commitment, Fr(0)]` — to match the
+        // shared anarchy depth-5 membership-VK shape.
+        let frZero = Data(repeating: 0, count: 32)
+        return GroupCreateProof(
+            proof: result.proof,
+            publicInputs: [result.commitment, frZero]
+        )
     }
 
     private func proveTyrannyCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {

--- a/Sources/OnymIOS/Chain/SEPContractClient.swift
+++ b/Sources/OnymIOS/Chain/SEPContractClient.swift
@@ -95,6 +95,10 @@ struct SEPContractClient: Sendable {
         try await invoke("update_commitment", payload: payload, responseType: SEPSubmissionResponse.self)
     }
 
+    func createGroupOneOnOne(_ payload: OneOnOneCreateGroupPayload) async throws -> SEPSubmissionResponse {
+        try await invoke("create_group", payload: payload, responseType: SEPSubmissionResponse.self)
+    }
+
     func getCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
         try await invoke(
             "get_commitment",

--- a/Sources/OnymIOS/Chain/SEPContractTypes.swift
+++ b/Sources/OnymIOS/Chain/SEPContractTypes.swift
@@ -109,6 +109,31 @@ struct TyrannyCreateGroupPayload: Encodable, Equatable, Sendable {
     }
 }
 
+/// `create_group` payload for the OneOnOne (1v1) contract. Simpler
+/// than Tyranny — no tier (1v1 is fixed at depth 5, exactly 2
+/// members), no admin_pubkey_commitment. The `publicInputs` vector
+/// is the standard membership-style 2-element form
+/// `[commitment, Fr(0)]` that the contract's
+/// `create_membership_public_inputs` expects.
+///
+/// Relayer handler: `add_create_group_args` →
+/// `ContractType::OneOnOne` arm.
+struct OneOnOneCreateGroupPayload: Encodable, Equatable, Sendable {
+    let groupID: Data
+    let commitment: Data
+    /// 1601-byte raw PLONK proof — same constraint as Tyranny.
+    let proof: Data
+    /// 2 elements × 32 bytes — `[commitment, Fr(0)]`.
+    let publicInputs: [Data]
+
+    enum CodingKeys: String, CodingKey {
+        case groupID = "group_id"
+        case commitment
+        case proof
+        case publicInputs
+    }
+}
+
 /// `update_commitment` payload — Tyranny variant. Same 4-element PI
 /// shape as create, but the SDK's `Tyranny.UpdateProof.publicInputs`
 /// is 160 bytes = 5 chunks (`c_old || epoch_old || c_new ||

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -130,11 +130,38 @@ final class CreateGroupFlow {
     }
 
     /// Label for the primary "Create" CTA. Mirrors the design
-    /// (`Create empty group` / `Create with N people`).
+    /// (`Create empty group` / `Create with N people`). For 1-on-1
+    /// dialogs the count is implicit so the copy switches to
+    /// `Start dialog` / `Add the other person` instead.
     var createCTALabel: String {
-        if invitees.isEmpty { return "Create empty group" }
-        let n = invitees.count
-        return "Create with \(n) \(n == 1 ? "person" : "people")"
+        switch governance {
+        case .oneOnOne:
+            return invitees.isEmpty ? "Add the other person" : "Start dialog"
+        case .tyranny, .anarchy:
+            if invitees.isEmpty { return "Create empty group" }
+            let n = invitees.count
+            return "Create with \(n) \(n == 1 ? "person" : "people")"
+        }
+    }
+
+    /// Whether the Step2 "Create" button should be tappable. Tyranny /
+    /// anarchy accept any roster size (including zero); 1-on-1
+    /// requires exactly one invitee — the peer.
+    var canCreate: Bool {
+        switch governance {
+        case .oneOnOne: invitees.count == 1
+        case .tyranny, .anarchy: true
+        }
+    }
+
+    /// Whether the Step2 "Invite by inbox key" entry point should be
+    /// shown. 1-on-1 caps at one peer, so once the user has added the
+    /// peer we hide the row to avoid implying they can add more.
+    var canAddMoreInvitees: Bool {
+        switch governance {
+        case .oneOnOne: invitees.isEmpty
+        case .tyranny, .anarchy: true
+        }
     }
 
     // MARK: - InviteByKey

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -212,6 +212,7 @@ final class CreateGroupFlow {
         do {
             let invitees = self.invitees.map(\.inboxPublicKey)
             let group = try await interactor.create(
+                governanceType: governance.sepGroupType,
                 name: effectiveName,
                 invitees: invitees,
                 onProgress: { [weak self] p in

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -299,6 +299,11 @@ struct CreateGroupInteractor: Sendable {
         //    per-dialog identity.
         let creatorBlsSecret: Data
         do {
+            // Proof witness for `OneOnOne.proveCreate(secretKey0:)` +
+            // `Common.leafHash(secretKey:)`. Same justification as the
+            // Tyranny path — SDK takes the BLS secret directly. Stays
+            // in this stack frame.
+            // onym:allow-secret-read
             creatorBlsSecret = try await identity.blsSecretKey()
         } catch {
             throw CreateGroupError.missingIdentity

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -71,10 +71,39 @@ struct CreateGroupInteractor: Sendable {
     /// Run the full pipeline. `onProgress` is called on the actor's
     /// executor — pass `{ progress in Task { @MainActor in … } }` if
     /// you need to update SwiftUI state from it.
+    ///
+    /// `governanceType` selects the contract family. Only `.tyranny`
+    /// and `.oneOnOne` are wired today; the rest throw
+    /// `CreateGroupError.unsupportedGovernanceType` early so the UI
+    /// surfaces a clear "TBD" rather than a vague proof failure.
+    ///
+    /// `.oneOnOne` requires exactly **one** invitee — the peer. The
+    /// creator mints a fresh ephemeral BLS Fr scalar for that peer
+    /// (the founding ceremony has both keys present by SDK design)
+    /// and ships it inside the invitation envelope so the receiver
+    /// can adopt it as their per-dialog identity.
     func create(
+        governanceType: SEPGroupType = .tyranny,
         name: String,
         invitees: [Data],
         onProgress: @Sendable (CreateGroupProgress) -> Void = { _ in }
+    ) async throws -> ChatGroup {
+        switch governanceType {
+        case .tyranny:
+            return try await createTyranny(name: name, invitees: invitees, onProgress: onProgress)
+        case .oneOnOne:
+            return try await createOneOnOne(name: name, invitees: invitees, onProgress: onProgress)
+        case .anarchy, .democracy, .oligarchy:
+            throw CreateGroupError.unsupportedGovernanceType(governanceType)
+        }
+    }
+
+    // MARK: - Tyranny
+
+    private func createTyranny(
+        name: String,
+        invitees: [Data],
+        onProgress: @Sendable (CreateGroupProgress) -> Void
     ) async throws -> ChatGroup {
         // 1. Validate
         onProgress(.validating)
@@ -220,50 +249,228 @@ struct CreateGroupInteractor: Sendable {
                 groupTypeRaw: SEPGroupType.tyranny.rawValue,
                 adminPubkeyHex: adminPubkeyHex
             )
-            let payloadBytes: Data
-            do {
-                payloadBytes = try JSONEncoder().encode(invitePayload)
-            } catch {
-                throw CreateGroupError.invitationEncodingFailed
-            }
-            for (index, inboxKey) in invitees.enumerated() {
-                let sealed: Data
-                do {
-                    sealed = try await identity.sealInvitation(
-                        payload: payloadBytes,
-                        to: inboxKey
-                    )
-                } catch {
-                    throw CreateGroupError.invitationSendFailed(
-                        index: index,
-                        reason: String(describing: error)
-                    )
-                }
-                let inboxTag = Self.inboxTag(from: inboxKey)
-                let receipt: PublishReceipt
-                do {
-                    receipt = try await inboxTransport.send(
-                        sealed,
-                        to: TransportInboxID(rawValue: inboxTag)
-                    )
-                } catch {
-                    throw CreateGroupError.invitationSendFailed(
-                        index: index,
-                        reason: String(describing: error)
-                    )
-                }
-                guard receipt.acceptedBy >= 1 else {
-                    throw CreateGroupError.invitationSendFailed(
-                        index: index,
-                        reason: "no relay accepted the invitation"
-                    )
-                }
-            }
+            try await sendInvitations(invitePayload, to: invitees)
         }
 
-        // The flag was already flipped via `markPublished`; reload our
-        // in-memory snapshot to mirror the on-disk state.
-        return await groups.snapshots.first(where: { $0.contains { $0.id == group.id } })?
+        return await reloadGroup(group)
+    }
+
+    // MARK: - OneOnOne
+
+    private func createOneOnOne(
+        name: String,
+        invitees: [Data],
+        onProgress: @Sendable (CreateGroupProgress) -> Void
+    ) async throws -> ChatGroup {
+        // 1. Validate — 1-on-1 is exactly two parties: the creator and
+        //    one peer. Zero or 2+ invitees is a programmer/UI error.
+        onProgress(.validating)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw CreateGroupError.invalidName
+        }
+        guard invitees.count == 1 else {
+            throw CreateGroupError.oneOnOneRequiresExactlyOnePeer(got: invitees.count)
+        }
+        let peerInboxKey = invitees[0]
+        guard peerInboxKey.count == 32 else {
+            throw CreateGroupError.invalidInviteeKey(index: 0)
+        }
+
+        // 2. Resolve relayer + contract.
+        guard let relayerURL = await relayers.selectURL() else {
+            throw CreateGroupError.noActiveRelayer
+        }
+        let activeNetwork = networkPreference.current()
+        let key = AnchorSelectionKey(network: activeNetwork.contractNetwork, type: .oneonone)
+        guard let binding = await contracts.binding(for: key) else {
+            throw CreateGroupError.noContractBinding(.oneonone)
+        }
+
+        // 3. Group params (no tier — OneOnOne contract is fixed depth).
+        let groupID = Self.randomBytes(32)
+        let groupSecret = Self.randomBytes(32)
+        let salt = GroupCommitmentBuilder.generateSalt()
+
+        // 4. Both BLS secrets must be present at create time — the SDK's
+        //    founding ceremony is the one moment both keys exist on the
+        //    same device. The peer secret is shipped inside the
+        //    invitation envelope so the receiver adopts it as their
+        //    per-dialog identity.
+        let creatorBlsSecret: Data
+        do {
+            creatorBlsSecret = try await identity.blsSecretKey()
+        } catch {
+            throw CreateGroupError.missingIdentity
+        }
+        guard let identitySnapshot = await identity.currentIdentity() else {
+            throw CreateGroupError.missingIdentity
+        }
+        var peerBlsSecret = Self.randomBytes(32)
+        // The OneOnOne SDK rejects equal secrets. Vanishingly unlikely
+        // with 256 bits of entropy, but cheap to defend against — flip
+        // a single bit so we always differ.
+        if peerBlsSecret == creatorBlsSecret {
+            peerBlsSecret[0] ^= 0x01
+        }
+
+        let creatorMember: GovernanceMember
+        let peerMember: GovernanceMember
+        do {
+            creatorMember = GovernanceMember(
+                publicKeyCompressed: identitySnapshot.blsPublicKey,
+                leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: creatorBlsSecret)
+            )
+            peerMember = GovernanceMember(
+                publicKeyCompressed: try GroupCommitmentBuilder.computePublicKey(secretKey: peerBlsSecret),
+                leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: peerBlsSecret)
+            )
+        } catch {
+            throw CreateGroupError.sdkFailure(String(describing: error))
+        }
+        let members = [creatorMember, peerMember].sorted { lhs, rhs in
+            lhs.publicKeyCompressed.lexicographicallyPrecedes(rhs.publicKeyCompressed)
+        }
+
+        // 5. Generate proof — OneOnOne SDK takes both secrets directly.
+        onProgress(.proving)
+        let proofInput = GroupProofCreateInput(
+            groupType: .oneOnOne,
+            tier: .small,                   // ignored by SDK
+            members: members,               // ignored by SDK
+            adminBlsSecretKey: creatorBlsSecret,
+            adminIndex: 0,                  // ignored by SDK
+            groupID: groupID,
+            salt: salt,
+            peerBlsSecretKey: peerBlsSecret
+        )
+        let proof: GroupCreateProof
+        do {
+            proof = try proofGenerator.proveCreate(proofInput)
+        } catch let err as GroupProofGeneratorError {
+            throw CreateGroupError.proofGenerationFailed(err)
+        } catch {
+            throw CreateGroupError.sdkFailure(String(describing: error))
+        }
+
+        // 6. Anchor on chain.
+        onProgress(.anchoring)
+        let transport = makeContractTransport(relayerURL)
+        let client = SEPContractClient(
+            contractID: binding.contractID,
+            contractType: .oneOnOne,
+            network: activeNetwork.sepNetwork,
+            transport: transport
+        )
+        let payload = OneOnOneCreateGroupPayload(
+            groupID: groupID,
+            commitment: proof.commitment,
+            proof: proof.proof,
+            publicInputs: proof.publicInputs
+        )
+        let response: SEPSubmissionResponse
+        do {
+            response = try await client.createGroupOneOnOne(payload)
+        } catch {
+            throw CreateGroupError.anchorTransport(String(describing: error))
+        }
+        guard response.accepted else {
+            throw CreateGroupError.anchorRejected(message: response.message)
+        }
+
+        // 7. Save locally — no admin in 1-on-1, so adminPubkeyHex stays nil.
+        let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+        let group = ChatGroup(
+            id: groupIDHex,
+            name: trimmedName,
+            groupSecret: groupSecret,
+            createdAt: Date(),
+            members: members,
+            epoch: 0,
+            salt: salt,
+            commitment: proof.commitment,
+            tier: .small,
+            groupType: .oneOnOne,
+            adminPubkeyHex: nil,
+            isPublishedOnChain: false
+        )
+        _ = await groups.insert(group)
+        await groups.markPublished(id: group.id, commitment: proof.commitment)
+
+        // 8. Send the single invitation — peer secret rides inside.
+        onProgress(.sendingInvitations(total: 1))
+        let invitePayload = GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: groupSecret,
+            name: trimmedName,
+            members: members,
+            epoch: 0,
+            salt: salt,
+            commitment: proof.commitment,
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.oneOnOne.rawValue,
+            adminPubkeyHex: nil,
+            peerBlsSecret: peerBlsSecret
+        )
+        try await sendInvitations(invitePayload, to: [peerInboxKey])
+
+        return await reloadGroup(group)
+    }
+
+    // MARK: - Shared invitation send loop
+
+    private func sendInvitations(
+        _ invitePayload: GroupInvitationPayload,
+        to invitees: [Data]
+    ) async throws {
+        let payloadBytes: Data
+        do {
+            payloadBytes = try JSONEncoder().encode(invitePayload)
+        } catch {
+            throw CreateGroupError.invitationEncodingFailed
+        }
+        for (index, inboxKey) in invitees.enumerated() {
+            let sealed: Data
+            do {
+                sealed = try await identity.sealInvitation(
+                    payload: payloadBytes,
+                    to: inboxKey
+                )
+            } catch {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: String(describing: error)
+                )
+            }
+            let inboxTag = Self.inboxTag(from: inboxKey)
+            let receipt: PublishReceipt
+            do {
+                receipt = try await inboxTransport.send(
+                    sealed,
+                    to: TransportInboxID(rawValue: inboxTag)
+                )
+            } catch {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: String(describing: error)
+                )
+            }
+            guard receipt.acceptedBy >= 1 else {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: "no relay accepted the invitation"
+                )
+            }
+        }
+    }
+
+    /// Reload the freshly-published group from the repo so the caller
+    /// sees `isPublishedOnChain = true` (the flag was flipped via
+    /// `markPublished`, but the local `group` snapshot was built
+    /// before that mutation).
+    private func reloadGroup(_ group: ChatGroup) async -> ChatGroup {
+        await groups.snapshots.first(where: { $0.contains { $0.id == group.id } })?
             .first { $0.id == group.id }
             ?? group
     }
@@ -348,6 +555,12 @@ enum CreateGroupError: Error, Equatable, Sendable {
     case invitationEncodingFailed
     case invitationSendFailed(index: Int, reason: String)
     case sdkFailure(String)
+    /// `.oneOnOne` requires exactly one invitee (the peer); the UI
+    /// gates this but the interactor double-checks.
+    case oneOnOneRequiresExactlyOnePeer(got: Int)
+    /// Caller passed `.anarchy` / `.democracy` / `.oligarchy` — not
+    /// wired to the chain yet.
+    case unsupportedGovernanceType(SEPGroupType)
 }
 
 extension CreateGroupError: LocalizedError {
@@ -372,6 +585,10 @@ extension CreateGroupError: LocalizedError {
             return "Invitation #\(index + 1) failed: \(reason)"
         case let .sdkFailure(message):
             return "SDK failure: \(message)"
+        case let .oneOnOneRequiresExactlyOnePeer(got):
+            return "1-on-1 dialog needs exactly 1 peer (got \(got))"
+        case let .unsupportedGovernanceType(type):
+            return "\(type.rawValue) is not supported yet"
         }
     }
 }

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -383,6 +383,8 @@ extension GroupProofGeneratorError: LocalizedError {
             return "\(type) is not supported yet — only Tyranny ships in this release"
         case let .adminIndexOutOfRange(index, count):
             return "Admin index \(index) is out of range for \(count) members"
+        case .missingPeerSecret:
+            return "1-on-1 dialog is missing the peer's BLS secret"
         case let .sdkFailure(message):
             return "Proof generation failed: \(message)"
         }

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -455,7 +455,7 @@ private struct CreateGroupStep2View: View {
                 Text("\(flow.governance.label). ")
                     .font(.system(size: 12.5, weight: .semibold))
                     .foregroundColor(OnymTokens.text)
-                + Text("You\u{2019}ll be the only admin.")
+                + Text(typeBannerSub)
                     .font(.system(size: 12.5))
                     .foregroundColor(OnymTokens.text2)
             )
@@ -486,10 +486,10 @@ private struct CreateGroupStep2View: View {
                 .font(.system(size: 36, weight: .light))
                 .foregroundStyle(OnymTokens.text3)
                 .padding(.top, 28)
-            Text("No invitees yet")
+            Text(emptyStateTitle)
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(OnymTokens.text)
-            Text("Use \u{201C}Invite by inbox key\u{201D} below to add someone.")
+            Text(emptyStateSubtitle)
                 .font(.system(size: 12.5))
                 .foregroundStyle(OnymTokens.text2)
                 .multilineTextAlignment(.center)
@@ -497,6 +497,30 @@ private struct CreateGroupStep2View: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.bottom, 20)
+    }
+
+    private var emptyStateTitle: String {
+        switch flow.governance {
+        case .oneOnOne: "Add the other person"
+        case .tyranny, .anarchy: "No invitees yet"
+        }
+    }
+
+    private var emptyStateSubtitle: String {
+        switch flow.governance {
+        case .oneOnOne:
+            "Paste their inbox key below to start a private dialog."
+        case .tyranny, .anarchy:
+            "Use \u{201C}Invite by inbox key\u{201D} below to add someone."
+        }
+    }
+
+    private var typeBannerSub: String {
+        switch flow.governance {
+        case .oneOnOne: "Just the two of you. No one else can join."
+        case .tyranny: "You\u{2019}ll be the only admin."
+        case .anarchy: "Everyone has equal control."
+        }
     }
 
     private var inviteesList: some View {
@@ -554,41 +578,43 @@ private struct CreateGroupStep2View: View {
 
     private var footer: some View {
         VStack(spacing: 10) {
-            Button(action: flow.tappedInviteByKey) {
-                HStack(spacing: 12) {
-                    ZStack {
-                        Circle().fill(accentColor.opacity(0.22))
-                        Image(systemName: "key.fill")
+            if flow.canAddMoreInvitees {
+                Button(action: flow.tappedInviteByKey) {
+                    HStack(spacing: 12) {
+                        ZStack {
+                            Circle().fill(accentColor.opacity(0.22))
+                            Image(systemName: "key.fill")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(accentColor)
+                        }
+                        .frame(width: 30, height: 30)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Invite by inbox key")
+                                .font(.system(size: 13.5, weight: .semibold))
+                                .foregroundStyle(OnymTokens.text)
+                            Text("Paste a 64-char key")
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(OnymTokens.text2)
+                        }
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(accentColor)
+                            .foregroundStyle(OnymTokens.text3)
                     }
-                    .frame(width: 30, height: 30)
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Invite by inbox key")
-                            .font(.system(size: 13.5, weight: .semibold))
-                            .foregroundStyle(OnymTokens.text)
-                        Text("Paste a 64-char key")
-                            .font(.system(size: 11.5))
-                            .foregroundStyle(OnymTokens.text2)
-                    }
-                    Spacer(minLength: 0)
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(OnymTokens.text3)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(OnymTokens.surface2)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12).stroke(OnymTokens.hairlineStrong, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(OnymTokens.surface2)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12).stroke(OnymTokens.hairlineStrong, lineWidth: 1)
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
 
             OnymPrimaryButton(
                 title: flow.createCTALabel,
-                enabled: true,
+                enabled: flow.canCreate,
                 accent: accentColor,
                 action: flow.tappedCreate
             )

--- a/Sources/OnymIOS/Group/GroupInvitationPayload.swift
+++ b/Sources/OnymIOS/Group/GroupInvitationPayload.swift
@@ -34,6 +34,16 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
     /// Lowercase hex (96 chars) BLS pubkey of the Tyranny admin.
     /// `nil` for `.anarchy` / `.oneOnOne`.
     let adminPubkeyHex: String?
+    /// 32-byte BLS Fr scalar minted by the creator for the peer party
+    /// in a 1-on-1 dialog. The receiver MUST adopt this as their
+    /// per-dialog BLS identity — the founding proof was generated with
+    /// both parties' secrets, so there is no other key the receiver
+    /// could use to derive the same per-epoch keys. `nil` for every
+    /// other governance type.
+    ///
+    /// Decoded via `decodeIfPresent` so older invitations (and other
+    /// group types that never set this field) round-trip cleanly.
+    let peerBlsSecret: Data?
 
     enum CodingKeys: String, CodingKey {
         case version
@@ -47,5 +57,50 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         case tierRaw = "tier_raw"
         case groupTypeRaw = "group_type_raw"
         case adminPubkeyHex = "admin_pubkey_hex"
+        case peerBlsSecret = "peer_bls_secret"
+    }
+
+    init(
+        version: Int,
+        groupID: Data,
+        groupSecret: Data,
+        name: String,
+        members: [GovernanceMember],
+        epoch: UInt64,
+        salt: Data,
+        commitment: Data?,
+        tierRaw: Int,
+        groupTypeRaw: String,
+        adminPubkeyHex: String?,
+        peerBlsSecret: Data? = nil
+    ) {
+        self.version = version
+        self.groupID = groupID
+        self.groupSecret = groupSecret
+        self.name = name
+        self.members = members
+        self.epoch = epoch
+        self.salt = salt
+        self.commitment = commitment
+        self.tierRaw = tierRaw
+        self.groupTypeRaw = groupTypeRaw
+        self.adminPubkeyHex = adminPubkeyHex
+        self.peerBlsSecret = peerBlsSecret
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decode(Int.self, forKey: .version)
+        groupID = try c.decode(Data.self, forKey: .groupID)
+        groupSecret = try c.decode(Data.self, forKey: .groupSecret)
+        name = try c.decode(String.self, forKey: .name)
+        members = try c.decode([GovernanceMember].self, forKey: .members)
+        epoch = try c.decode(UInt64.self, forKey: .epoch)
+        salt = try c.decode(Data.self, forKey: .salt)
+        commitment = try c.decodeIfPresent(Data.self, forKey: .commitment)
+        tierRaw = try c.decode(Int.self, forKey: .tierRaw)
+        groupTypeRaw = try c.decode(String.self, forKey: .groupTypeRaw)
+        adminPubkeyHex = try c.decodeIfPresent(String.self, forKey: .adminPubkeyHex)
+        peerBlsSecret = try c.decodeIfPresent(Data.self, forKey: .peerBlsSecret)
     }
 }

--- a/Sources/OnymIOS/Group/OnymBrand.swift
+++ b/Sources/OnymIOS/Group/OnymBrand.swift
@@ -178,8 +178,15 @@ enum OnymUIGovernance: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    /// Per-PR-C scope: only Tyranny is wired to the chain layer.
-    var isAvailable: Bool { self == .tyranny }
+    /// True when this governance type is wired through the chain
+    /// layer end-to-end. Anarchy stays gated behind a "Soon" pill
+    /// until its create flow ships; Tyranny + 1-on-1 are live.
+    var isAvailable: Bool {
+        switch self {
+        case .tyranny, .oneOnOne: true
+        case .anarchy: false
+        }
+    }
 
     var sepGroupType: SEPGroupType {
         switch self {

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -185,6 +185,71 @@ final class CreateGroupFlowTests: XCTestCase {
         XCTAssertEqual(flow.createCTALabel, "Create with 2 people")
     }
 
+    // MARK: - OneOnOne governance gates
+
+    func test_oneOnOne_isNowAvailable() async throws {
+        // PR-3 flips the gate — Step1 should advance with .oneOnOne.
+        let flow = await makeFlow()
+        flow.governance = .oneOnOne
+        XCTAssertTrue(flow.canAdvanceToStep2)
+    }
+
+    func test_oneOnOne_canCreate_requiresExactlyOneInvitee() async throws {
+        let flow = await makeFlow()
+        flow.governance = .oneOnOne
+
+        // 0 invitees: not allowed
+        XCTAssertFalse(flow.canCreate, "1-on-1 with 0 invitees can't create")
+
+        // 1 invitee: allowed
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertTrue(flow.canCreate, "1-on-1 with 1 invitee can create")
+
+        // 2 invitees: not allowed (UI hides the entry point so this is
+        // a guardrail, but the property must still flip).
+        flow.invitees.append(OnymInvitee(
+            id: UUID(),
+            inboxPublicKey: Data(repeating: 0xBB, count: 32),
+            displayLabel: "bb…bb"
+        ))
+        XCTAssertFalse(flow.canCreate, "1-on-1 with 2 invitees can't create")
+    }
+
+    func test_oneOnOne_canAddMoreInvitees_capsAtOne() async throws {
+        let flow = await makeFlow()
+        flow.governance = .oneOnOne
+        XCTAssertTrue(flow.canAddMoreInvitees)
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertFalse(flow.canAddMoreInvitees,
+                       "1-on-1 hides the Invite-by-key row once the peer is added")
+    }
+
+    func test_oneOnOne_createCTALabel_promptsForPeerThenStartsDialog() async throws {
+        let flow = await makeFlow()
+        flow.governance = .oneOnOne
+        XCTAssertEqual(flow.createCTALabel, "Add the other person")
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.createCTALabel, "Start dialog")
+    }
+
+    func test_tyranny_canAddMoreInvitees_alwaysTrue() async throws {
+        let flow = await makeFlow()
+        flow.governance = .tyranny
+        XCTAssertTrue(flow.canAddMoreInvitees)
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertTrue(flow.canAddMoreInvitees, "Tyranny doesn't cap invitee count")
+    }
+
+    func test_tyranny_canCreate_alwaysTrue() async throws {
+        let flow = await makeFlow()
+        flow.governance = .tyranny
+        XCTAssertTrue(flow.canCreate, "Tyranny accepts any roster size, including zero")
+    }
+
     // MARK: - onClose
 
     func test_tappedDone_resetsAndCallsOnClose() async throws {

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -158,6 +158,105 @@ final class CreateGroupInteractorTests: XCTestCase {
         }
     }
 
+    // MARK: - OneOnOne
+
+    func test_create_oneOnOne_anchorsOnOneOnOneContractAndShipsPeerSecret() async throws {
+        let env = await makeTestEnv(includeOneOnOneContract: true)
+        let interactor = env.makeInteractor()
+        let peerInbox = Data(repeating: 0xAA, count: 32)
+
+        let group = try await interactor.create(
+            governanceType: .oneOnOne,
+            name: "Alice & Bob",
+            invitees: [peerInbox]
+        )
+
+        // Group has both members, no admin, fixed-depth tier.
+        XCTAssertEqual(group.groupType, .oneOnOne)
+        XCTAssertEqual(group.members.count, 2, "creator + peer")
+        XCTAssertNil(group.adminPubkeyHex, "1-on-1 has no admin")
+        XCTAssertEqual(group.tier, .small)
+        XCTAssertTrue(group.isPublishedOnChain)
+
+        // Anchored on the OneOnOne contract via `create_group`.
+        let invocations = env.contractTransport.invocations
+        XCTAssertEqual(invocations.count, 1)
+        XCTAssertEqual(invocations.first?.function, "create_group")
+        let body = try XCTUnwrap(invocations.first.flatMap {
+            try? JSONSerialization.jsonObject(with: $0.payload) as? [String: Any]
+        })
+        XCTAssertEqual(body["contractType"] as? String, "oneonone")
+        let payload = try XCTUnwrap(body["payload"] as? [String: Any])
+        XCTAssertNil(payload["admin_pubkey_commitment"], "no admin field on OneOnOne wire")
+        XCTAssertNil(payload["tier"], "no tier field on OneOnOne wire")
+        let publicInputs = try XCTUnwrap(payload["publicInputs"] as? [String])
+        XCTAssertEqual(publicInputs.count, 2, "OneOnOne ships [commitment, Fr(0)]")
+
+        // One sealed invitation went out to the peer's inbox.
+        let sends = await env.inboxTransport.sends
+        XCTAssertEqual(sends.count, 1)
+
+        // The sealed payload contains the peer's BLS secret. We can't
+        // inspect the sealed bytes (they're AES-GCM-encrypted), but
+        // sealInvitation is a passthrough wrapper around AES-GCM seal —
+        // peeking at what the interactor handed to `sealInvitation` is
+        // out of scope, so we settle for verifying the public-input
+        // commitment came from our stub (proves the OneOnOne arm ran).
+        XCTAssertNotNil(group.commitment)
+        XCTAssertEqual(group.commitment, Data(repeating: 0xEE, count: 32))
+    }
+
+    func test_create_oneOnOne_zeroInvitees_throws() async throws {
+        let env = await makeTestEnv(includeOneOnOneContract: true)
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .oneOnOne,
+                name: "Solo",
+                invitees: []
+            ),
+            CreateGroupError.oneOnOneRequiresExactlyOnePeer(got: 0)
+        )
+    }
+
+    func test_create_oneOnOne_twoInvitees_throws() async throws {
+        let env = await makeTestEnv(includeOneOnOneContract: true)
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .oneOnOne,
+                name: "Crowd",
+                invitees: [
+                    Data(repeating: 0xAA, count: 32),
+                    Data(repeating: 0xBB, count: 32),
+                ]
+            ),
+            CreateGroupError.oneOnOneRequiresExactlyOnePeer(got: 2)
+        )
+    }
+
+    func test_create_oneOnOne_noContractBinding_throws() async throws {
+        let env = await makeTestEnv(includeOneOnOneContract: false)
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .oneOnOne,
+                name: "G",
+                invitees: [Data(repeating: 0xAA, count: 32)]
+            ),
+            CreateGroupError.noContractBinding(.oneonone)
+        )
+    }
+
+    func test_create_anarchy_throws_unsupported() async throws {
+        let env = await makeTestEnv()
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .anarchy,
+                name: "G",
+                invitees: []
+            ),
+            CreateGroupError.unsupportedGovernanceType(.anarchy)
+        )
+    }
+
     // MARK: - Helpers
 
     private func assertThrows<T: Sendable>(
@@ -179,11 +278,13 @@ final class CreateGroupInteractorTests: XCTestCase {
     private func makeTestEnv(
         addRelayer: Bool = true,
         includeTyrannyContract: Bool = true,
+        includeOneOnOneContract: Bool = false,
         network: AppNetwork = .testnet
     ) async -> CreateGroupTestEnv {
         let env = await CreateGroupTestEnv.make(
             addRelayer: addRelayer,
             includeTyrannyContract: includeTyrannyContract,
+            includeOneOnOneContract: includeOneOnOneContract,
             network: network
         )
         return env
@@ -211,6 +312,7 @@ private final class CreateGroupTestEnv {
     static func make(
         addRelayer: Bool,
         includeTyrannyContract: Bool,
+        includeOneOnOneContract: Bool = false,
         network: AppNetwork
     ) async -> CreateGroupTestEnv {
         let keychain = KeychainStore(
@@ -238,9 +340,21 @@ private final class CreateGroupTestEnv {
             await relayers.setPrimary(url: URL(string: "https://relayer.test.example")!)
         }
 
-        let contractEntries: [ContractEntry] = includeTyrannyContract
-            ? [ContractEntry(network: .testnet, type: .tyranny, id: "CTYRANNYTEST00000000000000000000000000000000000000000000")]
-            : []
+        var contractEntries: [ContractEntry] = []
+        if includeTyrannyContract {
+            contractEntries.append(ContractEntry(
+                network: .testnet,
+                type: .tyranny,
+                id: "CTYRANNYTEST00000000000000000000000000000000000000000000"
+            ))
+        }
+        if includeOneOnOneContract {
+            contractEntries.append(ContractEntry(
+                network: .testnet,
+                type: .oneonone,
+                id: "C1V1CONTRACTTEST000000000000000000000000000000000000000"
+            ))
+        }
         let manifest = ContractsManifest(
             version: 1,
             releases: [
@@ -311,23 +425,39 @@ private final class CreateGroupTestEnv {
 
 // MARK: - Stubs
 
-/// Returns a deterministic 1601-byte "proof" + 4-element PI bundle
+/// Returns a deterministic 1601-byte "proof" + per-type PI bundle
 /// without actually proving. Skips the ~3.5s real prover so the test
 /// suite stays fast.
 private struct StubGroupProofGenerator: GroupProofGenerator {
     func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
-        guard input.groupType == .tyranny else {
+        switch input.groupType {
+        case .tyranny:
+            return GroupCreateProof(
+                proof: Data(repeating: 0xAB, count: 1601),
+                publicInputs: [
+                    Data(repeating: 0xCD, count: 32),  // commitment
+                    Data(repeating: 0x00, count: 32),  // Fr(0)
+                    Data(repeating: 0x42, count: 32),  // admin_pubkey_commitment
+                    Data(repeating: 0x77, count: 32),  // group_id_fr
+                ]
+            )
+        case .oneOnOne:
+            // Mirror the real OneOnOne SDK shape: raise if peer secret
+            // missing so the interactor's OneOnOne branch stays honest
+            // in tests.
+            guard input.peerBlsSecretKey != nil else {
+                throw GroupProofGeneratorError.missingPeerSecret
+            }
+            return GroupCreateProof(
+                proof: Data(repeating: 0xCC, count: 1601),
+                publicInputs: [
+                    Data(repeating: 0xEE, count: 32),  // commitment
+                    Data(repeating: 0x00, count: 32),  // Fr(0)
+                ]
+            )
+        default:
             throw GroupProofGeneratorError.notYetSupported(input.groupType)
         }
-        return GroupCreateProof(
-            proof: Data(repeating: 0xAB, count: 1601),
-            publicInputs: [
-                Data(repeating: 0xCD, count: 32),  // commitment
-                Data(repeating: 0x00, count: 32),  // Fr(0)
-                Data(repeating: 0x42, count: 32),  // admin_pubkey_commitment
-                Data(repeating: 0x77, count: 32),  // group_id_fr
-            ]
-        )
     }
 }
 

--- a/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
+++ b/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
@@ -55,13 +55,32 @@ final class GroupProofGeneratorTests: XCTestCase {
         }
     }
 
-    func test_proveCreate_oneOnOne_throwsNotYetSupported() {
-        let input = stubInput(groupType: .oneOnOne)
+    func test_proveCreate_oneOnOne_returnsRawProofAnd2ElementPI() throws {
+        // Two distinct BLS Fr scalars (the SDK rejects equal secrets).
+        let input = GroupProofCreateInput(
+            groupType: .oneOnOne,
+            tier: .small,                     // ignored for oneOnOne
+            members: [],                      // ignored for oneOnOne
+            adminBlsSecretKey: fr(1),
+            adminIndex: 0,                    // ignored for oneOnOne
+            groupID: Data(repeating: 0, count: 32),
+            salt: Data(repeating: 0xEE, count: 32),
+            peerBlsSecretKey: fr(2)
+        )
+        let result = try OnymGroupProofGenerator().proveCreate(input)
+        XCTAssertEqual(result.proof.count, 1601,
+                       "OneOnOne returns the same raw 1601-byte plonk proof as Tyranny")
+        XCTAssertEqual(result.publicInputs.count, 2,
+                       "OneOnOne PI = [commitment, Fr(0)] — 2 entries")
+        XCTAssertEqual(result.publicInputs[0].count, 32)
+        XCTAssertEqual(result.publicInputs[1], Data(repeating: 0, count: 32),
+                       "Fr(0) tail must be 32 zero bytes")
+    }
+
+    func test_proveCreate_oneOnOne_missingPeerSecret_throws() {
+        let input = stubInput(groupType: .oneOnOne)   // no peerBlsSecretKey
         XCTAssertThrowsError(try OnymGroupProofGenerator().proveCreate(input)) { error in
-            XCTAssertEqual(
-                error as? GroupProofGeneratorError,
-                .notYetSupported(.oneOnOne)
-            )
+            XCTAssertEqual(error as? GroupProofGeneratorError, .missingPeerSecret)
         }
     }
 

--- a/Tests/OnymIOSTests/SEPContractClientTests.swift
+++ b/Tests/OnymIOSTests/SEPContractClientTests.swift
@@ -61,6 +61,55 @@ final class SEPContractClientTests: XCTestCase {
         XCTAssertEqual(publicInputs.count, 4, "Tyranny create needs 4 PI entries")
     }
 
+    func test_createGroupOneOnOne_sendsCorrectEnvelopeAndPayload() async throws {
+        let recorder = RecordingTransport(
+            response: SEPSubmissionResponse(
+                accepted: true,
+                transactionHash: "1v1tx",
+                message: nil
+            )
+        )
+        let client = SEPContractClient(
+            contractID: testContractID,
+            contractType: .oneOnOne,
+            network: .testnet,
+            transport: recorder
+        )
+
+        let payload = OneOnOneCreateGroupPayload(
+            groupID: Data(repeating: 0xAB, count: 32),
+            commitment: Data(repeating: 0xCD, count: 32),
+            proof: Data(repeating: 0xEE, count: 1601),
+            publicInputs: [
+                Data(repeating: 0xCD, count: 32),
+                Data(repeating: 0x00, count: 32),
+            ]
+        )
+        let response = try await client.createGroupOneOnOne(payload)
+
+        XCTAssertTrue(response.accepted)
+        XCTAssertEqual(response.transactionHash, "1v1tx")
+
+        let json = try XCTUnwrap(recorder.lastJSON())
+        XCTAssertEqual(json["function"] as? String, "create_group")
+        XCTAssertEqual(json["contractID"] as? String, testContractID)
+        XCTAssertEqual(json["contractType"] as? String, "oneonone",
+                       "OneOnOne contract type wire spelling must match relayer's ContractType enum")
+        XCTAssertEqual(json["network"] as? String, "testnet")
+
+        let payloadJSON = try XCTUnwrap(json["payload"] as? [String: Any])
+        XCTAssertNotNil(payloadJSON["group_id"])
+        XCTAssertNotNil(payloadJSON["commitment"])
+        XCTAssertNotNil(payloadJSON["proof"])
+        XCTAssertNil(payloadJSON["tier"],
+                     "OneOnOne is fixed-depth — no tier field on the wire")
+        XCTAssertNil(payloadJSON["admin_pubkey_commitment"],
+                     "OneOnOne has no admin_pubkey_commitment — that's Tyranny-only")
+        let publicInputs = try XCTUnwrap(payloadJSON["publicInputs"] as? [String])
+        XCTAssertEqual(publicInputs.count, 2,
+                       "OneOnOne create needs 2 PI entries: [commitment, Fr(0)]")
+    }
+
     func test_createGroupTyranny_mainnetSerializesAsPublic() async throws {
         let recorder = RecordingTransport(
             response: SEPSubmissionResponse(accepted: true, transactionHash: nil, message: nil)


### PR DESCRIPTION
## Summary

PR **3 of 3** in the OneOnOne stacked series. Final slice — flips the governance gate so users can pick "1-on-1" on Step 1 and walks them through dialog creation end to end.

**Base:** \`interactor/oneonone-create\` (PR #34). Merge that first.

> **Acceptance criteria reached on this branch:** a user can create a 1-on-1 group on iOS by picking the dialog card on Step 1, pasting one peer's inbox key, and tapping **Start dialog**.

### Governance gate

- \`OnymUIGovernance.isAvailable\` returns true for both \`.tyranny\` and \`.oneOnOne\` (still false for \`.anarchy\`). The "Soon" pill drops off the dialog card automatically.

### Step 2 — single-peer variant

- \`CreateGroupFlow.canCreate\` governs the Create button: Tyranny / anarchy = always true (zero-invitee group is valid); 1-on-1 = **exactly one invitee**.
- \`CreateGroupFlow.canAddMoreInvitees\` hides the "Invite by inbox key" entry once the dialog peer is added, so the UI doesn't imply more peers are accepted.
- \`CreateGroupFlow.createCTALabel\`:
  - 1-on-1 empty: \`"Add the other person"\`
  - 1-on-1 with peer: \`"Start dialog"\`
  - Tyranny / anarchy: existing \`"Create empty group"\` / \`"Create with N people"\`.
- \`CreateGroupView.typeBanner\` + empty-state copy branch on \`flow.governance\` so the dialog flow doesn't say "You'll be the only admin" — that's Tyranny-specific.

### Tests

- 6 new \`CreateGroupFlowTests\` covering the new gates + regression guards for Tyranny.
- 318 unit tests pass (2 skipped — the known Tyranny E2E).

## Stack

- **PR-1 (#33)** — chain seam (types + client method + proof generator)
- **PR-2 (#34)** — interactor + invitation envelope (peer secret rides inside)
- **PR-3 (this)** — UI surface

## Test plan

- [x] Unit tests across all three layers
- [ ] **Manual**: open Create Group → tap "1-on-1" card → Next → paste a peer's inbox key → Start dialog → see Success → group lands in Chats tab
- [ ] **E2E (deferred)**: real-testnet OneOnOne create-group test, mirrors the Tyranny one. Will land as a follow-up once the Tyranny E2E #15 is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)