### PR TITLE
fix: rejection-sample groupID into canonical bls12-381 Fr

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -99,7 +99,13 @@ struct CreateGroupInteractor: Sendable {
         }
 
         // 3. Group params
-        let groupID = Self.randomBytes(32)
+        // `groupID` MUST be a canonical bls12-381 Fr (BE value < r) —
+        // sep-tyranny's `is_canonical_fr(&group_id)` rejects anything
+        // else with `Error::InvalidCommitmentEncoding` (#15). The check
+        // exists to close a same-`group_id_fr` collision via
+        // `group_id + p (mod 2^256)` — see the contract comment at
+        // sep-tyranny/src/lib.rs:290–298.
+        let groupID = Self.randomCanonicalFr()
         let groupSecret = Self.randomBytes(32)
         let salt = GroupCommitmentBuilder.generateSalt()
         let tier: SEPTier = .small
@@ -274,6 +280,47 @@ struct CreateGroupInteractor: Sendable {
         var bytes = [UInt8](repeating: 0, count: count)
         _ = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
         return Data(bytes)
+    }
+
+    /// Uniformly-random 32-byte BE value strictly less than the
+    /// bls12-381 scalar field order `r`. Rejection-samples until a
+    /// canonical value falls out — accept rate is `r / 2^256 ≈ 0.453`,
+    /// so the loop terminates in ~2.2 iterations on average.
+    ///
+    /// Why we can't just take `randomBytes(32) mod r`: the contract
+    /// rejects any non-canonical encoding outright (sep-tyranny
+    /// `Error::InvalidCommitmentEncoding`), and the SDK's silent mod-r
+    /// reduction would diverge from the contract's check on ~25% of
+    /// inputs. Generating canonically at the source removes the
+    /// reduction question entirely.
+    static func randomCanonicalFr() -> Data {
+        while true {
+            var bytes = [UInt8](repeating: 0, count: 32)
+            _ = SecRandomCopyBytes(kSecRandomDefault, 32, &bytes)
+            if isCanonicalFr(bytes) {
+                return Data(bytes)
+            }
+        }
+    }
+
+    /// True iff the 32-byte BE value is strictly less than the
+    /// bls12-381 scalar field order
+    /// `r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`.
+    /// Mirrors the contract's `is_canonical_fr` predicate
+    /// (sep-tyranny/src/lib.rs:688).
+    static func isCanonicalFr(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 32 else { return false }
+        let r: [UInt8] = [
+            0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48,
+            0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1, 0xd8, 0x05,
+            0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe,
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01,
+        ]
+        for i in 0..<32 {
+            if bytes[i] < r[i] { return true }
+            if bytes[i] > r[i] { return false }
+        }
+        return false  // bytes == r → not canonical (must be strictly less)
     }
 }
 

--- a/Tests/OnymIOSTests/CanonicalFrTests.swift
+++ b/Tests/OnymIOSTests/CanonicalFrTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import OnymIOS
+
+/// Regression coverage for the bls12-381 canonical-Fr predicate +
+/// rejection sampler that `CreateGroupInteractor` uses to mint
+/// `groupID`. The contract (`sep-tyranny/src/lib.rs:299`) rejects
+/// non-canonical `group_id` with `Error::InvalidCommitmentEncoding`
+/// (#15); these tests pin the client-side guarantee that we never
+/// hand the contract a value `>= r`.
+///
+/// `r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`
+final class CanonicalFrTests: XCTestCase {
+
+    // MARK: - isCanonicalFr boundary cases
+
+    func test_isCanonicalFr_zero_isCanonical() {
+        XCTAssertTrue(CreateGroupInteractor.isCanonicalFr([UInt8](repeating: 0, count: 32)))
+    }
+
+    func test_isCanonicalFr_one_isCanonical() {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        bytes[31] = 1
+        XCTAssertTrue(CreateGroupInteractor.isCanonicalFr(bytes))
+    }
+
+    func test_isCanonicalFr_rMinusOne_isCanonical() {
+        let rMinusOne: [UInt8] = [
+            0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48,
+            0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1, 0xd8, 0x05,
+            0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe,
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
+        ]
+        XCTAssertTrue(CreateGroupInteractor.isCanonicalFr(rMinusOne))
+    }
+
+    func test_isCanonicalFr_r_isNotCanonical() {
+        let r: [UInt8] = [
+            0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48,
+            0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1, 0xd8, 0x05,
+            0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe,
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01,
+        ]
+        XCTAssertFalse(CreateGroupInteractor.isCanonicalFr(r),
+                       "the field order itself is NOT a canonical Fr")
+    }
+
+    func test_isCanonicalFr_rPlusOne_isNotCanonical() {
+        let rPlusOne: [UInt8] = [
+            0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48,
+            0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1, 0xd8, 0x05,
+            0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe,
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x02,
+        ]
+        XCTAssertFalse(CreateGroupInteractor.isCanonicalFr(rPlusOne))
+    }
+
+    func test_isCanonicalFr_allOnes_isNotCanonical() {
+        // The exact value that triggered the testnet failure was
+        // `0xfdfb…` — same shape: high byte > 0x73 → non-canonical.
+        XCTAssertFalse(CreateGroupInteractor.isCanonicalFr([UInt8](repeating: 0xFF, count: 32)))
+    }
+
+    func test_isCanonicalFr_observedFailingValue_isNotCanonical() {
+        // The literal bytes from the diagnostic event in the failing
+        // testnet run — kept as a regression anchor.
+        let observed: [UInt8] = [
+            0xfd, 0xfb, 0xc9, 0x7d, 0x06, 0x85, 0xf2, 0xb9,
+            0xf3, 0xad, 0x24, 0xf7, 0xa4, 0xc7, 0x57, 0x41,
+            0x6b, 0xd5, 0x3a, 0x87, 0x11, 0x47, 0x7c, 0xe2,
+            0xc3, 0x59, 0x77, 0x80, 0x24, 0xdb, 0xfb, 0x0d,
+        ]
+        XCTAssertFalse(CreateGroupInteractor.isCanonicalFr(observed),
+                       "exact value that tripped Error #15 on the v0.0.5 tyranny contract")
+    }
+
+    func test_isCanonicalFr_justBelowR_highByte0x73_isCanonical() {
+        // Highest byte == 0x73 but lower bytes < r's lower bytes.
+        var bytes = [UInt8](repeating: 0, count: 32)
+        bytes[0] = 0x73
+        bytes[1] = 0xec  // < 0xed at the same position
+        XCTAssertTrue(CreateGroupInteractor.isCanonicalFr(bytes))
+    }
+
+    func test_isCanonicalFr_wrongLength_returnsFalse() {
+        XCTAssertFalse(CreateGroupInteractor.isCanonicalFr([UInt8](repeating: 0, count: 31)))
+        XCTAssertFalse(CreateGroupInteractor.isCanonicalFr([UInt8](repeating: 0, count: 33)))
+    }
+
+    // MARK: - randomCanonicalFr sampling
+
+    func test_randomCanonicalFr_alwaysCanonical_over10kSamples() {
+        // Statistically, the sampler's accept rate is `r / 2^256 ≈ 0.453`.
+        // 10k samples give a generous floor on rejected-path coverage
+        // (~5.5k rejections), and the assertion is unconditional.
+        for _ in 0..<10_000 {
+            let bytes = CreateGroupInteractor.randomCanonicalFr()
+            XCTAssertEqual(bytes.count, 32)
+            XCTAssertTrue(
+                CreateGroupInteractor.isCanonicalFr(Array(bytes)),
+                "sampler returned non-canonical bytes: \(bytes.map { String(format: "%02x", $0) }.joined())"
+            )
+        }
+    }
+
+    func test_randomCanonicalFr_isNonZeroAndDistinct() {
+        // Sanity: the sampler isn't returning a constant. 100 draws
+        // should yield 100 distinct values with overwhelming probability.
+        var seen = Set<Data>()
+        for _ in 0..<100 {
+            seen.insert(CreateGroupInteractor.randomCanonicalFr())
+        }
+        XCTAssertEqual(seen.count, 100, "sampler should not collide over 100 draws")
+        XCTAssertFalse(seen.contains(Data(repeating: 0, count: 32)),
+                       "all-zero would be a giveaway of a broken RNG")
+    }
+}


### PR DESCRIPTION
## Summary

Root cause + fix for the intermittent E2E \`Error(Contract, #15) InvalidCommitmentEncoding\` on the v0.0.5 \`sep-tyranny\` contract.

The interactor was generating \`groupID = randomBytes(32)\` — a uniformly-random 32-byte draw. With probability \`(2^256 - r) / 2^256 ≈ 0.547\` the value lands \`>= r\` (bls12-381 scalar order, high byte \`0x73\`). \`sep-tyranny/src/lib.rs:299\` rejects any non-canonical \`group_id\`:

\`\`\`rust
if !is_canonical_fr(&group_id) {
    return Err(Error::InvalidCommitmentEncoding);
}
\`\`\`

The check exists by design — see the contract comment at lines 290–298 — to close a \`group_id_A\` vs \`group_id_A + p (mod 2^256)\` collision in \`group_id_fr\`. So the failures were neither flaky nor an SDK↔contract Fr-encoding divergence; they were uniformly-random encoding occasionally landing in the rejected region.

The literal failing value from the last testnet diagnostic event was \`0xfdfb…fb0d\` (high byte \`0xfd > 0x73\`) — kept as a regression test anchor.

## Changes

- \`CreateGroupInteractor\`:
  - New \`randomCanonicalFr()\` rejection-samples until \`< r\`. Accept rate ≈ 0.453, so ~2.2 iterations on average.
  - New \`isCanonicalFr(_:)\` mirrors the contract predicate as a constant-r byte-by-byte compare.
  - \`groupID\` now goes through \`randomCanonicalFr()\`. \`groupSecret\` / \`salt\` unchanged — neither is treated as canonical Fr by any contract.
- \`CanonicalFrTests\` (11 new):
  - Boundary cases: \`0\`, \`1\`, \`r-1\` canonical; \`r\`, \`r+1\`, \`0xFF…FF\` non-canonical; \`wrongLength → false\` guard.
  - The literal failing testnet value pinned.
  - 10k-sample sweep: every draw passes \`isCanonicalFr\` (21ms total).
  - 100-draw distinctness sanity.

## Test plan

- [x] \`CanonicalFrTests\` (11 tests, all pass)
- [x] \`CreateGroupInteractorTests\` (10 tests, all pass — no behaviour change to existing happy paths)
- [ ] **Re-enable Tyranny E2E** locally after merge: drop the unconditional \`XCTSkip\` at \`Tests/OnymIOSTests/Integration/CreateGroupTyrannyE2ETests.swift:233\` and run with \`ONYM_INTEGRATION=1 ONYM_RELAYER_AUTH_TOKEN=…\`. Expecting both tests to pass now.

## Notes

- Same root cause likely affects Android (PR #32 in onym-android also reports Error #15). Mirror this fix there.
- OneOnOne contract doesn't gate \`group_id\` canonicality (no proof binding), so the in-flight OneOnOne stack (#33/#34/#35) was unaffected — but using canonical \`groupID\` everywhere is the right default and PR #34 inherits the fix when it rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)