### PR TITLE
chore: v0.0.5 release prep — re-enable E2E, fix UI tests, suppress secret-read lint

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -113,6 +113,11 @@ struct CreateGroupInteractor: Sendable {
         // 4. Creator member (BLS pubkey + Poseidon leaf hash).
         let blsSecret: Data
         do {
+            // Proof witness for `Tyranny.proveCreate(adminSecretKey:)` +
+            // `Common.leafHash(secretKey:)`. The SDK takes the BLS
+            // secret directly; no encapsulated equivalent. Stays in
+            // this stack frame and is dropped when the function returns.
+            // onym:allow-secret-read
             blsSecret = try await identity.blsSecretKey()
         } catch {
             throw CreateGroupError.missingIdentity

--- a/Tests/OnymIOSTests/Integration/CreateGroupTyrannyE2ETests.swift
+++ b/Tests/OnymIOSTests/Integration/CreateGroupTyrannyE2ETests.swift
@@ -224,17 +224,13 @@ final class CreateGroupTyrannyE2ETests: XCTestCase {
     // MARK: - Helpers
 
     private func requireIntegrationGate() throws {
-        // Temporarily disabled — both iOS (here) and Android (PR #32 in
-        // onym-android) hit `Error(Contract, #15) InvalidCommitmentEncoding`
-        // intermittently against the v0.0.5 tyranny contract. Suspecting
-        // an SDK ↔ contract Fr-encoding mismatch; pending investigation.
-        // To re-enable: drop this `XCTSkip` and the gate falls back to the
-        // ONYM_INTEGRATION env-var check below.
-        throw XCTSkip(
-            "E2E temporarily disabled — investigating Error #15 false positive (SDK ↔ contract Fr encoding)."
-        )
-
-        // swiftlint:disable:next unreachable_code
+        // Re-enabled in v0.0.5 after PR #36 landed `randomCanonicalFr()`
+        // — the previous Error #15 was caused by uniformly-random
+        // `groupID` occasionally landing `>= r`, which the contract
+        // rejects by design (sep-tyranny/src/lib.rs:299). Releases now
+        // need this test to pass; locally, set ONYM_INTEGRATION=1 +
+        // ONYM_RELAYER_AUTH_TOKEN to run it. CI's release.yml wires
+        // both via `xcrun simctl spawn booted launchctl setenv`.
         guard ProcessInfo.processInfo.environment["ONYM_INTEGRATION"] == "1" else {
             throw XCTSkip(
                 "Set ONYM_INTEGRATION=1 (and ONYM_RELAYER_AUTH_TOKEN) to run this test."

--- a/Tests/OnymIOSUITests/PageObjects/SettingsScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/SettingsScreen.swift
@@ -1,8 +1,41 @@
 import XCTest
 
-/// Page object for the Settings tab — the app's root screen.
+/// Page object for the Settings tab. Settings is no longer the app's
+/// root screen (Chats is the default tab — see RootView), so every
+/// public method first taps the Settings tab via its stable
+/// `root_tab.settings` accessibility identifier. Idempotent: tapping
+/// a tab that's already selected is a no-op.
 struct SettingsScreen {
     let app: XCUIApplication
+
+    /// iOS 26's Liquid Glass `TabView` exposes tab items inconsistently:
+    /// sometimes via `app.tabBars.buttons[localizedLabel]`, sometimes
+    /// only via top-level `app.buttons[localizedLabel]`, and the
+    /// `.accessibilityIdentifier` modifier doesn't propagate from
+    /// `Tab(...)`. Try a few likely shapes and return the first that
+    /// exists. Localized labels are required because `Tab("Settings",
+    /// systemImage:, …)` uses the displayed string as its accessibility
+    /// label after going through iOS's localization.
+    var settingsTab: XCUIElement {
+        let candidates: [String] = ["Settings", "Настройки"]
+        for label in candidates {
+            let tabBarMatch = app.tabBars.buttons[label]
+            if tabBarMatch.exists { return tabBarMatch }
+        }
+        for label in candidates {
+            let topLevelMatch = app.buttons[label]
+            if topLevelMatch.exists { return topLevelMatch }
+        }
+        // Fall back to index 1 of the tab bar (Chats=0, Settings=1;
+        // Search has role: .search and isn't on the regular strip).
+        let tabBar = app.tabBars.firstMatch
+        if tabBar.exists, tabBar.buttons.count >= 2 {
+            return tabBar.buttons.element(boundBy: 1)
+        }
+        // Last resort — return the English label so the eventual
+        // failure message is intelligible.
+        return app.buttons["Settings"]
+    }
 
     var backupRow: XCUIElement {
         app.buttons["settings.backup_recovery_phrase_row"]
@@ -18,24 +51,42 @@ struct SettingsScreen {
         firstMatching("settings.anchors_row")
     }
 
+    /// Tap the Settings tab. Tests that need to assert tab-bar state
+    /// before drilling into a row can call this directly; the per-row
+    /// `tap*` methods already do so internally.
+    func tapSettingsTab(timeout: TimeInterval = 5) {
+        let element = settingsTab
+        if !element.waitForExistence(timeout: timeout) {
+            XCTFail(
+                "Settings tab never appeared. Hierarchy:\n\(app.debugDescription)"
+            )
+            return
+        }
+        element.tap()
+    }
+
     @discardableResult
     func waitForReady(timeout: TimeInterval = 5) -> Bool {
-        backupRow.waitForExistence(timeout: timeout)
+        tapSettingsTab(timeout: timeout)
+        return backupRow.waitForExistence(timeout: timeout)
     }
 
     func tapBackupRecoveryPhrase() {
+        tapSettingsTab()
         XCTAssertTrue(backupRow.waitForExistence(timeout: 5),
                       "settings backup row never appeared")
         backupRow.tap()
     }
 
     func tapRelayer() {
+        tapSettingsTab()
         XCTAssertTrue(relayerRow.waitForExistence(timeout: 5),
                       "settings relayer row never appeared")
         relayerRow.tap()
     }
 
     func tapAnchors() {
+        tapSettingsTab()
         XCTAssertTrue(anchorsRow.waitForExistence(timeout: 5),
                       "settings anchors row never appeared")
         anchorsRow.tap()

--- a/Tests/OnymIOSUITests/RecoveryPhraseBackupUITests.swift
+++ b/Tests/OnymIOSUITests/RecoveryPhraseBackupUITests.swift
@@ -92,6 +92,10 @@ final class RecoveryPhraseBackupUITests: XCTestCase {
         let app = AppLauncher.launchFresh(language: "ru")
         defer { app.terminate() }
 
+        // Chats is the default tab — drill into Settings before
+        // asserting the Russian Settings copy exists.
+        SettingsScreen(app: app).tapSettingsTab(timeout: 6)
+
         XCTAssertTrue(
             app.staticTexts["Настройки"].waitForExistence(timeout: 6),
             "Russian Settings nav title never appeared"


### PR DESCRIPTION
## Summary

Three small changes to prepare main for the v0.0.5 release cut.

### E2E re-enabled

\`Tests/.../CreateGroupTyrannyE2ETests.swift\`: drops the unconditional \`XCTSkip\` that was added when intermittent \`Error #15 InvalidCommitmentEncoding\` first appeared. Root cause was fixed in #36 (\`randomCanonicalFr()\`); both E2E tests now pass against testnet locally with \`ONYM_INTEGRATION=1\` + \`ONYM_RELAYER_AUTH_TOKEN\`. \`release.yml\` already wires both env vars via \`xcrun simctl spawn booted launchctl setenv\`, so the next release run will exercise the full flow.

### Lint suppression

\`Sources/.../CreateGroupInteractor.swift:113-119\`: \`scripts/lint-secrets.py\` (CI) defaults to denying any \`.blsSecretKey\` access outside \`IdentityRepository\`. The single read in \`create(...)\` is legitimate — \`Tyranny.proveCreate(adminSecretKey:)\` and \`Common.leafHash(secretKey:)\` take the BLS secret as the proving witness directly; no encapsulated equivalent exists. Annotated with \`// onym:allow-secret-read\` and a justification block.

### UI tests fixed

PR #30 made Chats the default tab and demoted Settings from the root screen, but the page-object library still assumed Settings was reachable without tab navigation. All 11 UI tests failed for that reason (25 assertion failures total). Fix:

- New \`SettingsScreen.tapSettingsTab()\` is the entry point; every \`tap*Row()\` method calls it first (idempotent on the already-active tab). \`waitForReady()\` likewise.
- iOS 26's Liquid Glass \`TabView\` doesn't propagate \`.accessibilityIdentifier\` on \`Tab(...)\` into XCUI, and the items don't surface under \`app.tabBars\` reliably either. The resolver tries (1) \`tabBars.buttons[localizedLabel]\`, (2) top-level \`app.buttons[localizedLabel]\` (this is what works on the iOS 26 simulator), (3) \`tabBars.buttons.element(boundBy: 1)\` as a final index-based fallback. English + Russian labels both tried so the locale-switch test continues to work.
- The Russian test now taps the Settings tab before asserting the Russian "Настройки" nav title.
- On failure, \`tapSettingsTab\` dumps \`app.debugDescription\` so future regressions are debuggable from CI logs without re-running.

## Test plan

- [x] Lint clean: \`python3 scripts/lint-secrets.py\` exits 0
- [x] Both E2E tests pass against testnet locally
- [x] All 11 UI tests pass locally (~3:50)
- [ ] Release workflow run for v0.0.5 — verifies the same on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)