### PR TITLE
ci: enable LFS on iOS checkouts in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,11 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Asset catalogs (AppIcon, LaunchLogo) are LFS-tracked PNGs.
+          # Without this xcodebuild compiles pointer files into
+          # Assets.car and any test that touches the icon UI fails.
+          lfs: true
 
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.app
@@ -166,6 +171,12 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # See unit-tests checkout — LFS PNGs are needed for the app
+          # under test's Assets.car. Without this, XCUI queries against
+          # icon-bearing buttons miss because Assets.car holds pointer
+          # text instead of pixels.
+          lfs: true
 
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.app
@@ -231,6 +242,11 @@ jobs:
     needs: [lint, create-release, unit-tests, ui-tests]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # AppIcon + LaunchLogo PNGs are LFS-tracked. Without this the
+          # shipped IPA carries pointer files instead of art and the
+          # App Store install will fail icon validation.
+          lfs: true
 
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.app


### PR DESCRIPTION
## Summary

Asset catalogs (\`AppIcon\`, \`LaunchLogo\`) are LFS-tracked PNGs. \`actions/checkout@v4\` defaults to \`lfs: false\`, so the unit-tests, UI-tests, and build jobs were compiling pointer files into \`Assets.car\`.

**Symptoms:**
- UI tests miss icon-bearing accessibility elements
- Shipped IPA carries pointer text instead of art → App Store icon validation fails
- Same root cause as today's parallel Android failure

## Changes

Adds \`lfs: true\` to three checkouts:
- \`unit-tests\` job
- \`ui-tests\` job
- \`build\` job

\`lint\` and \`create-release\` intentionally stay LFS-free — neither reads asset bytes.

## Test plan

- [ ] Re-trigger Release workflow for v0.0.6 (or cut v0.0.7) — verify unit + UI tests pass and the IPA carries real PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)