### PR TITLE
ci: pre-clean xcresult / derivedData before xcodebuild test on self-hosted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,11 @@ jobs:
         # NOTE: do NOT pass CODE_SIGNING_ALLOWED=NO — without the synthesised
         # `application-identifier` entitlement, every Keychain call in the
         # IdentityRepository tests fails with errSecMissingEntitlement (-34018).
+        # The pre-clean is mandatory on self-hosted runners — xcodebuild
+        # refuses to overwrite an existing -resultBundlePath / derivedData
+        # directory and exits 64.
         run: |
+          rm -rf /tmp/onym-ios-release-unit /tmp/onym-ios-unit.xcresult
           xcodebuild test \
             -project OnymIOS.xcodeproj \
             -scheme OnymIOS \
@@ -220,7 +224,10 @@ jobs:
         # Same Keychain-entitlement note as the unit job — keep CODE_SIGNING
         # at the default so XCUIApplication can use the test-isolated
         # keychain service from the App's --ui-testing branch.
+        # The pre-clean is mandatory on self-hosted runners — xcodebuild
+        # exits 64 if the -resultBundlePath / derivedData directory exists.
         run: |
+          rm -rf /tmp/onym-ios-release-ui /tmp/onym-ios-ui.xcresult
           xcodebuild test \
             -project OnymIOS.xcodeproj \
             -scheme OnymIOS \


### PR DESCRIPTION
## Summary

v0.0.7 release run failed both test jobs with:

\`\`\`
xcodebuild: error: Existing file at -resultBundlePath "/tmp/onym-ios-unit.xcresult"
\`\`\`

Self-hosted macOS runners keep their workspace between runs. The previous run's \`-resultBundlePath\` and \`-derivedDataPath\` were still on \`/tmp\`, and \`xcodebuild\` refuses to overwrite either — exits 64 before any tests run.

## Changes

\`rm -rf\` both paths before each \`xcodebuild test\` invocation in the unit + UI jobs:

- \`/tmp/onym-ios-release-unit\` + \`/tmp/onym-ios-unit.xcresult\`
- \`/tmp/onym-ios-release-ui\` + \`/tmp/onym-ios-ui.xcresult\`

The \`build\` job uses unique paths and is unaffected.

## Test plan

- [ ] Cut v0.0.8 + dispatch Release — both test jobs run to completion regardless of leftover \`/tmp\` state from prior runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)