### PR TITLE
ci: force LFS smudge after checkout on persistent self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,14 @@ jobs:
           # Assets.car and any test that touches the icon UI fails.
           lfs: true
 
+      - name: Force LFS smudge (self-hosted workspace persists across runs)
+        # actions/checkout@v4 runs `git lfs fetch` but skips the smudge
+        # if the working tree's pointer files match the index — which
+        # they do on a runner whose previous checkout was lfs-less.
+        # `git lfs pull` re-runs fetch + checkout unconditionally and
+        # is cheap once objects are already cached locally.
+        run: git lfs pull
+
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.app
 
@@ -182,6 +190,12 @@ jobs:
           # text instead of pixels.
           lfs: true
 
+      - name: Force LFS smudge (self-hosted workspace persists across runs)
+        # See unit-tests for rationale. Without this the persistent
+        # runner workspace keeps stale pointer files from prior lfs-less
+        # checkouts and xcodebuild compiles them into Assets.car.
+        run: git lfs pull
+
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.app
 
@@ -254,6 +268,10 @@ jobs:
           # shipped IPA carries pointer files instead of art and the
           # App Store install will fail icon validation.
           lfs: true
+
+      - name: Force LFS smudge (self-hosted workspace persists across runs)
+        # See unit-tests for rationale.
+        run: git lfs pull
 
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.app


### PR DESCRIPTION
## Summary

PR #38 added \`lfs: true\` to the test + build checkouts but v0.0.8 still failed with:

\`\`\`
The stickers icon set, app icon set, or icon stack named "AppIcon"
did not have any applicable content.
\`\`\`

The build log shows literal \`version https://git-lfs.github.com/spec/v1\` content reaching \`CompileAssetCatalog\` — the PNGs are still pointer files even though \"Fetching LFS objects\" reported success.

## Root cause

Known \`actions/checkout@v4\` quirk on **persistent self-hosted runners**: when a workspace was previously checked out without \`lfs: true\`, pointer files end up in the index registered by their pointer hash. Subsequent checkouts re-fetch the LFS objects but skip the working-tree smudge because git considers the files up-to-date with the index. Fresh ephemeral runners are unaffected.

## Fix

Adds an explicit \`git lfs pull\` step after each LFS checkout (unit-tests, UI-tests, build). \`git lfs pull\` runs fetch + checkout unconditionally and is cheap once objects are cached locally. Once the workspace holds real PNGs the smudge state self-heals on subsequent runs, but the pull is idempotent and guards against future regressions.

## Test plan

- [ ] Cut v0.0.9 + dispatch Release — \`CompileAssetCatalog\` succeeds, both test jobs run to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)