### PR TITLE
ci: ship marker comments via textarea defaults, not markdown blocks

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -30,23 +30,29 @@ body:
       label: Release notes (optional)
       description: Free-text highlights. The Release workflow generates a per-commit changelog automatically; use this for higher-level prose.
 
-  - type: markdown
+  # The next two textareas exist purely to inject HTML comment markers
+  # into the submitted issue body. `type: markdown` blocks render only
+  # in the form UI and are stripped from the issue body — only `input`,
+  # `textarea`, `dropdown`, and `checkboxes` carry through. The
+  # description discourages editing; the orchestrator + report jobs
+  # rewrite the content between markers anyway.
+  - type: textarea
+    id: ui_tests
     attributes:
+      label: Test results
+      description: Auto-populated by the `release-from-issue` workflow within ~30 seconds. Don't edit unless you want to override.
       value: |
-        ## Test results
-
         <!-- UI_TESTS_START -->
-        _Pending — the `release-from-issue` workflow will replace this paragraph with a per-class checklist within ~30 seconds of submitting._
+        _Pending — will populate with one checkbox per discovered `XCTestCase` subclass._
         <!-- UI_TESTS_END -->
 
-  - type: markdown
+  - type: textarea
+    id: manual_qa
     attributes:
+      label: Manual QA
+      description: Tick these off against the IPA attached to the GitHub Release. Automation never touches this section — feel free to edit/extend.
       value: |
-        ## Manual QA
-
         <!-- MANUAL_QA_START -->
-        Run through these against the IPA attached to the GitHub Release. Tick as you go.
-
         ### Install + onboarding
         - [ ] Fresh install via TestFlight or AltStore signs in cleanly
         - [ ] First-run BIP39 generation produces a 12-word phrase


### PR DESCRIPTION
## Summary

Issue #42 (the dry-run of #41's automation) failed at the orchestrator's hydrate step:

\`\`\`
FATAL: markers '<!-- UI_TESTS_START -->'/'<!-- UI_TESTS_END -->' not found in issue body
\`\`\`

Root cause: I put the marker comments inside \`type: markdown\` form blocks. \`markdown\` blocks render in the form UI but **GitHub strips them from the submitted issue body**. Only \`input\`, \`textarea\`, \`dropdown\`, and \`checkboxes\` carry through.

## Fix

Switch the two \`markdown\` blocks to \`textarea\` with the markers in the default \`value:\`. Textarea content ships to the body verbatim. Field descriptions discourage editing; the orchestrator + report jobs rewrite content between the markers anyway, so a stray edit gets overwritten.

The intro \`markdown\` block stays — it's purely instructional and never needed to reach the body.

## Test plan

- [x] Verified \`apply_results.py\` round-trips correctly against a body shape that simulates a textarea-shipped form (markers preserved, only matched class flips \`[ ]→[x]\`)
- [ ] After merge: open a fresh Release issue with \`tag: v0.0.10\` — body should contain the markers and the orchestrator should hydrate within ~30s

## Cleanup

Issue #42 is permanently stuck (its body has no markers and re-triggering won't repopulate the body). Close + reopen via the new template once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)