### PR TITLE
ci: drop `labeled` trigger to stop dispatching Release twice per issue

### DIFF
--- a/.github/workflows/release-from-issue.yml
+++ b/.github/workflows/release-from-issue.yml
@@ -11,7 +11,12 @@ name: Release from issue
 
 on:
   issues:
-    types: [opened, labeled]
+    # Only `opened` — the issue template auto-applies the `release`
+    # label as part of issue creation, so the `opened` event payload
+    # already includes it. Listening for `labeled` too would dispatch
+    # Release twice per submission (once per event); confirmed during
+    # the dry-run on issue #42.
+    types: [opened]
 
 permissions:
   issues: write       # edit body + post failure comments
@@ -20,8 +25,9 @@ permissions:
 
 jobs:
   trigger:
-    # Skip unless the issue carries the `release` label. `labeled` event
-    # only fires for the label being added, so checking the array on
+    # Skip unless the issue carries the `release` label. Defensive — if
+    # someone opens a non-release issue manually, this filter blocks
+    # the run before it touches the body or dispatches anything.
     # `opened` is enough.
     if: contains(github.event.issue.labels.*.name, 'release')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Verified during the dry-run on issue #42: the orchestrator fired twice (runs [25273326248](https://github.com/onymchat/onym-ios/actions/runs/25273326248) + [25273326258](https://github.com/onymchat/onym-ios/actions/runs/25273326258)), each dispatching Release ([25273328747](https://github.com/onymchat/onym-ios/actions/runs/25273328747) + [25273329015](https://github.com/onymchat/onym-ios/actions/runs/25273329015)).

Root cause: GitHub fires both an \`opened\` and a \`labeled\` event when an issue template auto-applies its label as part of issue creation. The orchestrator listened for both.

## Fix

Drop \`labeled\` from the trigger list. The template auto-applies \`release\` so the \`opened\` event payload already carries it; the existing \`if: contains(...labels.*.name, 'release')\` filter still gates defensively.

Manual retroactive labeling (someone opens a plain issue, adds the \`release\` label later) was not part of the V1 spec, so no UX is lost.

## Test plan

- [ ] After merge: open a fresh Release issue, watch only ONE \`Release from issue\` run dispatch one \`Release\` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)