### PR TITLE
ux: enable OneOnOne governance + Step2 single-peer variant (PR-3 of OneOnOne)

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -130,11 +130,38 @@ final class CreateGroupFlow {
     }
 
     /// Label for the primary "Create" CTA. Mirrors the design
-    /// (`Create empty group` / `Create with N people`).
+    /// (`Create empty group` / `Create with N people`). For 1-on-1
+    /// dialogs the count is implicit so the copy switches to
+    /// `Start dialog` / `Add the other person` instead.
     var createCTALabel: String {
-        if invitees.isEmpty { return "Create empty group" }
-        let n = invitees.count
-        return "Create with \(n) \(n == 1 ? "person" : "people")"
+        switch governance {
+        case .oneOnOne:
+            return invitees.isEmpty ? "Add the other person" : "Start dialog"
+        case .tyranny, .anarchy:
+            if invitees.isEmpty { return "Create empty group" }
+            let n = invitees.count
+            return "Create with \(n) \(n == 1 ? "person" : "people")"
+        }
+    }
+
+    /// Whether the Step2 "Create" button should be tappable. Tyranny /
+    /// anarchy accept any roster size (including zero); 1-on-1
+    /// requires exactly one invitee — the peer.
+    var canCreate: Bool {
+        switch governance {
+        case .oneOnOne: invitees.count == 1
+        case .tyranny, .anarchy: true
+        }
+    }
+
+    /// Whether the Step2 "Invite by inbox key" entry point should be
+    /// shown. 1-on-1 caps at one peer, so once the user has added the
+    /// peer we hide the row to avoid implying they can add more.
+    var canAddMoreInvitees: Bool {
+        switch governance {
+        case .oneOnOne: invitees.isEmpty
+        case .tyranny, .anarchy: true
+        }
     }
 
     // MARK: - InviteByKey

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -455,7 +455,7 @@ private struct CreateGroupStep2View: View {
                 Text("\(flow.governance.label). ")
                     .font(.system(size: 12.5, weight: .semibold))
                     .foregroundColor(OnymTokens.text)
-                + Text("You\u{2019}ll be the only admin.")
+                + Text(typeBannerSub)
                     .font(.system(size: 12.5))
                     .foregroundColor(OnymTokens.text2)
             )
@@ -486,10 +486,10 @@ private struct CreateGroupStep2View: View {
                 .font(.system(size: 36, weight: .light))
                 .foregroundStyle(OnymTokens.text3)
                 .padding(.top, 28)
-            Text("No invitees yet")
+            Text(emptyStateTitle)
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(OnymTokens.text)
-            Text("Use \u{201C}Invite by inbox key\u{201D} below to add someone.")
+            Text(emptyStateSubtitle)
                 .font(.system(size: 12.5))
                 .foregroundStyle(OnymTokens.text2)
                 .multilineTextAlignment(.center)
@@ -497,6 +497,30 @@ private struct CreateGroupStep2View: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.bottom, 20)
+    }
+
+    private var emptyStateTitle: String {
+        switch flow.governance {
+        case .oneOnOne: "Add the other person"
+        case .tyranny, .anarchy: "No invitees yet"
+        }
+    }
+
+    private var emptyStateSubtitle: String {
+        switch flow.governance {
+        case .oneOnOne:
+            "Paste their inbox key below to start a private dialog."
+        case .tyranny, .anarchy:
+            "Use \u{201C}Invite by inbox key\u{201D} below to add someone."
+        }
+    }
+
+    private var typeBannerSub: String {
+        switch flow.governance {
+        case .oneOnOne: "Just the two of you. No one else can join."
+        case .tyranny: "You\u{2019}ll be the only admin."
+        case .anarchy: "Everyone has equal control."
+        }
     }
 
     private var inviteesList: some View {
@@ -554,41 +578,43 @@ private struct CreateGroupStep2View: View {
 
     private var footer: some View {
         VStack(spacing: 10) {
-            Button(action: flow.tappedInviteByKey) {
-                HStack(spacing: 12) {
-                    ZStack {
-                        Circle().fill(accentColor.opacity(0.22))
-                        Image(systemName: "key.fill")
+            if flow.canAddMoreInvitees {
+                Button(action: flow.tappedInviteByKey) {
+                    HStack(spacing: 12) {
+                        ZStack {
+                            Circle().fill(accentColor.opacity(0.22))
+                            Image(systemName: "key.fill")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(accentColor)
+                        }
+                        .frame(width: 30, height: 30)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Invite by inbox key")
+                                .font(.system(size: 13.5, weight: .semibold))
+                                .foregroundStyle(OnymTokens.text)
+                            Text("Paste a 64-char key")
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(OnymTokens.text2)
+                        }
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(accentColor)
+                            .foregroundStyle(OnymTokens.text3)
                     }
-                    .frame(width: 30, height: 30)
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Invite by inbox key")
-                            .font(.system(size: 13.5, weight: .semibold))
-                            .foregroundStyle(OnymTokens.text)
-                        Text("Paste a 64-char key")
-                            .font(.system(size: 11.5))
-                            .foregroundStyle(OnymTokens.text2)
-                    }
-                    Spacer(minLength: 0)
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(OnymTokens.text3)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(OnymTokens.surface2)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12).stroke(OnymTokens.hairlineStrong, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(OnymTokens.surface2)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12).stroke(OnymTokens.hairlineStrong, lineWidth: 1)
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
 
             OnymPrimaryButton(
                 title: flow.createCTALabel,
-                enabled: true,
+                enabled: flow.canCreate,
                 accent: accentColor,
                 action: flow.tappedCreate
             )

--- a/Sources/OnymIOS/Group/OnymBrand.swift
+++ b/Sources/OnymIOS/Group/OnymBrand.swift
@@ -178,8 +178,15 @@ enum OnymUIGovernance: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    /// Per-PR-C scope: only Tyranny is wired to the chain layer.
-    var isAvailable: Bool { self == .tyranny }
+    /// True when this governance type is wired through the chain
+    /// layer end-to-end. Anarchy stays gated behind a "Soon" pill
+    /// until its create flow ships; Tyranny + 1-on-1 are live.
+    var isAvailable: Bool {
+        switch self {
+        case .tyranny, .oneOnOne: true
+        case .anarchy: false
+        }
+    }
 
     var sepGroupType: SEPGroupType {
         switch self {

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -185,6 +185,71 @@ final class CreateGroupFlowTests: XCTestCase {
         XCTAssertEqual(flow.createCTALabel, "Create with 2 people")
     }
 
+    // MARK: - OneOnOne governance gates
+
+    func test_oneOnOne_isNowAvailable() async throws {
+        // PR-3 flips the gate — Step1 should advance with .oneOnOne.
+        let flow = await makeFlow()
+        flow.governance = .oneOnOne
+        XCTAssertTrue(flow.canAdvanceToStep2)
+    }
+
+    func test_oneOnOne_canCreate_requiresExactlyOneInvitee() async throws {
+        let flow = await makeFlow()
+        flow.governance = .oneOnOne
+
+        // 0 invitees: not allowed
+        XCTAssertFalse(flow.canCreate, "1-on-1 with 0 invitees can't create")
+
+        // 1 invitee: allowed
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertTrue(flow.canCreate, "1-on-1 with 1 invitee can create")
+
+        // 2 invitees: not allowed (UI hides the entry point so this is
+        // a guardrail, but the property must still flip).
+        flow.invitees.append(OnymInvitee(
+            id: UUID(),
+            inboxPublicKey: Data(repeating: 0xBB, count: 32),
+            displayLabel: "bb…bb"
+        ))
+        XCTAssertFalse(flow.canCreate, "1-on-1 with 2 invitees can't create")
+    }
+
+    func test_oneOnOne_canAddMoreInvitees_capsAtOne() async throws {
+        let flow = await makeFlow()
+        flow.governance = .oneOnOne
+        XCTAssertTrue(flow.canAddMoreInvitees)
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertFalse(flow.canAddMoreInvitees,
+                       "1-on-1 hides the Invite-by-key row once the peer is added")
+    }
+
+    func test_oneOnOne_createCTALabel_promptsForPeerThenStartsDialog() async throws {
+        let flow = await makeFlow()
+        flow.governance = .oneOnOne
+        XCTAssertEqual(flow.createCTALabel, "Add the other person")
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.createCTALabel, "Start dialog")
+    }
+
+    func test_tyranny_canAddMoreInvitees_alwaysTrue() async throws {
+        let flow = await makeFlow()
+        flow.governance = .tyranny
+        XCTAssertTrue(flow.canAddMoreInvitees)
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertTrue(flow.canAddMoreInvitees, "Tyranny doesn't cap invitee count")
+    }
+
+    func test_tyranny_canCreate_alwaysTrue() async throws {
+        let flow = await makeFlow()
+        flow.governance = .tyranny
+        XCTAssertTrue(flow.canCreate, "Tyranny accepts any roster size, including zero")
+    }
+
     // MARK: - onClose
 
     func test_tappedDone_resetsAndCallsOnClose() async throws {


### PR DESCRIPTION
**Re-opened from #35** after PR #34 → #46 squash-merged. Same content, rebased onto current main.

## Summary

PR 3 of 3. Final slice — flips the governance gate so users can pick "1-on-1" on Step 1 and walks them through dialog creation end to end.

> **Acceptance criteria reached on this branch:** a user can create a 1-on-1 group on iOS by picking the dialog card on Step 1, pasting one peer's inbox key, and tapping **Start dialog**.

### Changes

- \`OnymUIGovernance.isAvailable\` returns true for both \`.tyranny\` and \`.oneOnOne\` (still false for \`.anarchy\`). The "Soon" pill drops off the dialog card automatically.
- \`CreateGroupFlow.canCreate\` governs the Create button: Tyranny / anarchy = always true; 1-on-1 = exactly one invitee.
- \`CreateGroupFlow.canAddMoreInvitees\` hides "Invite by inbox key" once the dialog peer is added.
- \`CreateGroupFlow.createCTALabel\` swaps to "Add the other person" / "Start dialog" for 1-on-1.
- \`CreateGroupView.typeBanner\` + empty-state copy branch on \`flow.governance\` so the dialog flow doesn't say "You'll be the only admin".

## Test plan

- [x] 6 new \`CreateGroupFlowTests\` covering the new gates + Tyranny regression guards
- [x] 329 unit tests pass post-rebase

## Stack

- **PR-1 (#33)** — chain seam ✅ merged
- **PR-2 (#46)** — interactor + invitation envelope ✅ merged
- **PR-3 (this)** — UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)