### PR TITLE
chain: Anarchy create_group seam (PR-1 of Anarchy)

### DIFF
--- a/Sources/OnymIOS/Chain/GroupProofGenerator.swift
+++ b/Sources/OnymIOS/Chain/GroupProofGenerator.swift
@@ -89,9 +89,55 @@ struct OnymGroupProofGenerator: GroupProofGenerator {
             return try proveTyrannyCreate(input)
         case .oneOnOne:
             return try proveOneOnOneCreate(input)
-        case .anarchy, .democracy, .oligarchy:
+        case .anarchy:
+            return try proveAnarchyCreate(input)
+        case .democracy, .oligarchy:
             throw GroupProofGeneratorError.notYetSupported(input.groupType)
         }
+    }
+
+    /// Anarchy create: there's no dedicated `proveCreate` SDK call —
+    /// the founding ceremony is a regular membership proof at epoch 0
+    /// over a single-member roster (just the creator). The contract's
+    /// `create_group` arm verifies it as a membership proof and stores
+    /// the resulting commitment as the group's epoch-0 anchor.
+    private func proveAnarchyCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
+        guard input.adminIndex >= 0, input.adminIndex < input.members.count else {
+            // `adminIndex` is the prover's index for membership; field
+            // name is shared with Tyranny but Anarchy has no admin
+            // privileges — it's purely "which leaf am I".
+            throw GroupProofGeneratorError.adminIndexOutOfRange(
+                index: input.adminIndex,
+                count: input.members.count
+            )
+        }
+        var packedLeaves = Data(capacity: input.members.count * 32)
+        for member in input.members {
+            packedLeaves.append(member.leafHash)
+        }
+
+        let result: Anarchy.MembershipProof
+        do {
+            result = try Anarchy.proveMembership(
+                depth: input.tier.depth,
+                memberLeafHashes: packedLeaves,
+                proverSecretKey: input.adminBlsSecretKey,
+                proverIndex: input.adminIndex,
+                epoch: 0,
+                salt: input.salt
+            )
+        } catch {
+            throw GroupProofGeneratorError.sdkFailure(String(describing: error))
+        }
+
+        // MembershipProof carries a single 32B commitment, not a bundled
+        // PI blob. The contract expects `[commitment, Fr(0)]` as the
+        // 2-element PI vector — same shape OneOnOne uses.
+        let frZero = Data(repeating: 0, count: 32)
+        return GroupCreateProof(
+            proof: result.proof,
+            publicInputs: [result.commitment, frZero]
+        )
     }
 
     private func proveOneOnOneCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {

--- a/Sources/OnymIOS/Chain/SEPContractClient.swift
+++ b/Sources/OnymIOS/Chain/SEPContractClient.swift
@@ -99,6 +99,10 @@ struct SEPContractClient: Sendable {
         try await invoke("create_group", payload: payload, responseType: SEPSubmissionResponse.self)
     }
 
+    func createGroupAnarchy(_ payload: AnarchyCreateGroupPayload) async throws -> SEPSubmissionResponse {
+        try await invoke("create_group", payload: payload, responseType: SEPSubmissionResponse.self)
+    }
+
     func getCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
         try await invoke(
             "get_commitment",

--- a/Sources/OnymIOS/Chain/SEPContractTypes.swift
+++ b/Sources/OnymIOS/Chain/SEPContractTypes.swift
@@ -134,6 +134,38 @@ struct OneOnOneCreateGroupPayload: Encodable, Equatable, Sendable {
     }
 }
 
+/// `create_group` payload for the Anarchy contract. Membership-style
+/// 2-element PI like OneOnOne, but adds `tier` (selects the membership
+/// VK + tree depth) and `member_count` (informational — the contract
+/// stores it but doesn't validate; sentinel `0` means "not tracked").
+/// No admin field — Anarchy gives all members equal control.
+///
+/// Relayer handler: `add_create_group_args` → `ContractType::Anarchy`
+/// arm (tier + member_count → `--tier` / `--member-count` CLI flags).
+/// Contract: `sep-anarchy/src/lib.rs::create_group` (lines 347–410).
+struct AnarchyCreateGroupPayload: Encodable, Equatable, Sendable {
+    let groupID: Data
+    let commitment: Data
+    let tier: Int
+    /// Roster size at create time — `1` for a creator-only founding,
+    /// growing later via `update_commitment`. The contract accepts any
+    /// value without validation; we always send the real count.
+    let memberCount: Int
+    /// 1601-byte raw PLONK proof — same constraint as Tyranny / 1-on-1.
+    let proof: Data
+    /// 2 elements × 32 bytes — `[commitment, Fr(0)]`.
+    let publicInputs: [Data]
+
+    enum CodingKeys: String, CodingKey {
+        case groupID = "group_id"
+        case commitment
+        case tier
+        case memberCount = "member_count"
+        case proof
+        case publicInputs
+    }
+}
+
 /// `update_commitment` payload — Tyranny variant. Same 4-element PI
 /// shape as create, but the SDK's `Tyranny.UpdateProof.publicInputs`
 /// is 160 bytes = 5 chunks (`c_old || epoch_old || c_new ||

--- a/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
+++ b/Tests/OnymIOSTests/GroupProofGeneratorTests.swift
@@ -45,12 +45,48 @@ final class GroupProofGeneratorTests: XCTestCase {
         XCTAssertEqual(result.adminPubkeyCommitment, result.publicInputs[2])
     }
 
-    func test_proveCreate_anarchy_throwsNotYetSupported() {
-        let input = stubInput(groupType: .anarchy)
+    func test_proveCreate_anarchy_returnsRawProofAnd2ElementPI() throws {
+        // Founding ceremony: single-member roster (the creator).
+        // Anarchy uses the membership circuit at epoch 0 — no admin
+        // privileges, no group_id_fr binding.
+        let creatorSecret = fr(1)
+        let creatorMember = try GovernanceMember(
+            publicKeyCompressed: Common.publicKey(secretKey: creatorSecret),
+            leafHash: Common.leafHash(secretKey: creatorSecret)
+        )
+        let input = GroupProofCreateInput(
+            groupType: .anarchy,
+            tier: .small,
+            members: [creatorMember],
+            adminBlsSecretKey: creatorSecret,
+            adminIndex: 0,                  // creator's leaf position
+            groupID: Data(repeating: 0xAB, count: 32),  // not bound into proof
+            salt: Data(repeating: 0xEE, count: 32)
+        )
+        let result = try OnymGroupProofGenerator().proveCreate(input)
+        XCTAssertEqual(result.proof.count, 1601,
+                       "Anarchy returns the same raw 1601-byte plonk proof as Tyranny / 1-on-1")
+        XCTAssertEqual(result.publicInputs.count, 2,
+                       "Anarchy PI = [commitment, Fr(0)] — 2 entries")
+        XCTAssertEqual(result.publicInputs[0].count, 32)
+        XCTAssertEqual(result.publicInputs[1], Data(repeating: 0, count: 32),
+                       "Fr(0) tail must be 32 zero bytes")
+    }
+
+    func test_proveCreate_anarchy_proverIndexOutOfRange_throws() {
+        let input = GroupProofCreateInput(
+            groupType: .anarchy,
+            tier: .small,
+            members: [],   // empty roster — index 0 is out of range
+            adminBlsSecretKey: fr(1),
+            adminIndex: 0,
+            groupID: Data(repeating: 0, count: 32),
+            salt: Data(repeating: 0, count: 32)
+        )
         XCTAssertThrowsError(try OnymGroupProofGenerator().proveCreate(input)) { error in
             XCTAssertEqual(
                 error as? GroupProofGeneratorError,
-                .notYetSupported(.anarchy)
+                .adminIndexOutOfRange(index: 0, count: 0)
             )
         }
     }

--- a/Tests/OnymIOSTests/SEPContractClientTests.swift
+++ b/Tests/OnymIOSTests/SEPContractClientTests.swift
@@ -110,6 +110,59 @@ final class SEPContractClientTests: XCTestCase {
                        "OneOnOne create needs 2 PI entries: [commitment, Fr(0)]")
     }
 
+    func test_createGroupAnarchy_sendsCorrectEnvelopeAndPayload() async throws {
+        let recorder = RecordingTransport(
+            response: SEPSubmissionResponse(
+                accepted: true,
+                transactionHash: "anarchytx",
+                message: nil
+            )
+        )
+        let client = SEPContractClient(
+            contractID: testContractID,
+            contractType: .anarchy,
+            network: .testnet,
+            transport: recorder
+        )
+
+        let payload = AnarchyCreateGroupPayload(
+            groupID: Data(repeating: 0xAB, count: 32),
+            commitment: Data(repeating: 0xCD, count: 32),
+            tier: SEPTier.small.rawValue,
+            memberCount: 1,
+            proof: Data(repeating: 0xEE, count: 1601),
+            publicInputs: [
+                Data(repeating: 0xCD, count: 32),
+                Data(repeating: 0x00, count: 32),
+            ]
+        )
+        let response = try await client.createGroupAnarchy(payload)
+
+        XCTAssertTrue(response.accepted)
+        XCTAssertEqual(response.transactionHash, "anarchytx")
+
+        let json = try XCTUnwrap(recorder.lastJSON())
+        XCTAssertEqual(json["function"] as? String, "create_group")
+        XCTAssertEqual(json["contractID"] as? String, testContractID)
+        XCTAssertEqual(json["contractType"] as? String, "anarchy",
+                       "Anarchy contract type wire spelling must match relayer's ContractType enum")
+        XCTAssertEqual(json["network"] as? String, "testnet")
+
+        let payloadJSON = try XCTUnwrap(json["payload"] as? [String: Any])
+        XCTAssertNotNil(payloadJSON["group_id"])
+        XCTAssertNotNil(payloadJSON["commitment"])
+        XCTAssertNotNil(payloadJSON["proof"])
+        XCTAssertEqual((payloadJSON["tier"] as? NSNumber)?.intValue, 0,
+                       "tier ships as raw Int (0=small)")
+        XCTAssertEqual((payloadJSON["member_count"] as? NSNumber)?.intValue, 1,
+                       "member_count is informational but always sent")
+        XCTAssertNil(payloadJSON["admin_pubkey_commitment"],
+                     "Anarchy has no admin field — equal control by design")
+        let publicInputs = try XCTUnwrap(payloadJSON["publicInputs"] as? [String])
+        XCTAssertEqual(publicInputs.count, 2,
+                       "Anarchy create needs 2 PI entries: [commitment, Fr(0)]")
+    }
+
     func test_createGroupTyranny_mainnetSerializesAsPublic() async throws {
         let recorder = RecordingTransport(
             response: SEPSubmissionResponse(accepted: true, transactionHash: nil, message: nil)


### PR DESCRIPTION
## Summary

PR **1 of 3** in the Anarchy stacked series. Adds the chain-layer pieces for an Anarchy group create. Nothing UI-visible yet — \`OnymUIGovernance.anarchy.isAvailable\` stays false until PR-3.

- \`AnarchyCreateGroupPayload\` — wire shape for \`sep-anarchy.create_group\`: \`group_id\` + \`commitment\` + \`tier\` (0/1/2) + \`member_count\` (informational) + 1601-byte raw proof + 2-element \`publicInputs\` (\`[commitment, Fr(0)]\`). **No** \`admin_pubkey_commitment\` — Anarchy gives all members equal control.
- \`SEPContractClient.createGroupAnarchy(_:)\`.
- \`GroupProofGenerator.proveCreate\` branches on \`.anarchy\` and calls \`Anarchy.proveMembership(...)\` with \`epoch=0\`. The Anarchy SDK has no dedicated \`proveCreate\` — the founding ceremony **is** a regular membership proof over the single-member roster.

## Tests

- \`proveCreate_anarchy_returnsRawProofAnd2ElementPI\` — runs the real SDK circuit, asserts shape.
- \`proveCreate_anarchy_proverIndexOutOfRange_throws\` — validates the prover-index guard.
- \`createGroupAnarchy_sendsCorrectEnvelopeAndPayload\` — verifies \`contractType == "anarchy"\` on the wire, \`tier\` + \`member_count\` ship as snake-case ints, \`admin_pubkey_commitment\` does NOT leak.

All 15 affected unit tests pass locally.

## Stack

- **PR-1 (this)** — chain seam (types + client method + proof generator)
- **PR-2** — interactor branch + invitation envelope wiring
- **PR-3** — UI surface: enable governance card, drop "Soon" pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)