### PR TITLE
group: Anarchy create-group interactor (PR-2 of Anarchy)

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -93,7 +93,9 @@ struct CreateGroupInteractor: Sendable {
             return try await createTyranny(name: name, invitees: invitees, onProgress: onProgress)
         case .oneOnOne:
             return try await createOneOnOne(name: name, invitees: invitees, onProgress: onProgress)
-        case .anarchy, .democracy, .oligarchy:
+        case .anarchy:
+            return try await createAnarchy(name: name, invitees: invitees, onProgress: onProgress)
+        case .democracy, .oligarchy:
             throw CreateGroupError.unsupportedGovernanceType(governanceType)
         }
     }
@@ -436,6 +438,177 @@ struct CreateGroupInteractor: Sendable {
             peerBlsSecret: peerBlsSecret
         )
         try await sendInvitations(invitePayload, to: [peerInboxKey])
+
+        return await reloadGroup(group)
+    }
+
+    // MARK: - Anarchy
+
+    /// Anarchy create: founding ceremony is a membership proof at
+    /// epoch 0 over a single-member roster (just the creator). No
+    /// admin field, no peer secret. The roster grows later via
+    /// `update_commitment` (post-V1 scope) — for now any invitees the
+    /// user pastes get the standard sealed invitation envelope so they
+    /// can join via that future flow.
+    ///
+    /// Mirrors `createTyranny`'s shape (tier-bounded depth + per-call
+    /// canonical-Fr groupID + invitation send loop) but uses
+    /// `AnarchyCreateGroupPayload` (no `admin_pubkey_commitment`, adds
+    /// `member_count`) and saves the group with `groupType: .anarchy,
+    /// adminPubkeyHex: nil`.
+    private func createAnarchy(
+        name: String,
+        invitees: [Data],
+        onProgress: @Sendable (CreateGroupProgress) -> Void
+    ) async throws -> ChatGroup {
+        // 1. Validate
+        onProgress(.validating)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw CreateGroupError.invalidName
+        }
+        for (index, key) in invitees.enumerated() {
+            guard key.count == 32 else {
+                throw CreateGroupError.invalidInviteeKey(index: index)
+            }
+        }
+
+        // 2. Resolve relayer + contract.
+        guard let relayerURL = await relayers.selectURL() else {
+            throw CreateGroupError.noActiveRelayer
+        }
+        let activeNetwork = networkPreference.current()
+        let key = AnchorSelectionKey(network: activeNetwork.contractNetwork, type: .anarchy)
+        guard let binding = await contracts.binding(for: key) else {
+            throw CreateGroupError.noContractBinding(.anarchy)
+        }
+
+        // 3. Group params. sep-anarchy doesn't gate `group_id`
+        // canonicality today (no proof binding), but use the canonical
+        // sampler anyway for consistency with Tyranny / OneOnOne.
+        let groupID = Self.randomCanonicalFr()
+        let groupSecret = Self.randomBytes(32)
+        let salt = GroupCommitmentBuilder.generateSalt()
+        let tier: SEPTier = .small
+
+        // 4. Creator member.
+        let blsSecret: Data
+        do {
+            // Proof witness for `Anarchy.proveMembership(proverSecretKey:)` +
+            // `Common.leafHash(secretKey:)`. Same justification as the
+            // Tyranny / OneOnOne paths.
+            // onym:allow-secret-read
+            blsSecret = try await identity.blsSecretKey()
+        } catch {
+            throw CreateGroupError.missingIdentity
+        }
+        guard let identitySnapshot = await identity.currentIdentity() else {
+            throw CreateGroupError.missingIdentity
+        }
+        guard let ownerID = await identity.currentSelectedID() else {
+            // currentIdentity() returned non-nil but currentSelectedID()
+            // returned nil — actor invariant violated, treat as missing.
+            throw CreateGroupError.missingIdentity
+        }
+        let creatorMember: GovernanceMember
+        do {
+            creatorMember = GovernanceMember(
+                publicKeyCompressed: identitySnapshot.blsPublicKey,
+                leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: blsSecret)
+            )
+        } catch {
+            throw CreateGroupError.sdkFailure(String(describing: error))
+        }
+        let members = [creatorMember]  // single-element list, already sorted
+
+        // 5. Generate proof — Anarchy.proveMembership at epoch 0.
+        onProgress(.proving)
+        let proofInput = GroupProofCreateInput(
+            groupType: .anarchy,
+            tier: tier,
+            members: members,
+            adminBlsSecretKey: blsSecret,    // re-used as `proverSecretKey`
+            adminIndex: 0,                    // creator's leaf position
+            groupID: groupID,                 // not bound into proof for Anarchy
+            salt: salt
+        )
+        let proof: GroupCreateProof
+        do {
+            proof = try proofGenerator.proveCreate(proofInput)
+        } catch let err as GroupProofGeneratorError {
+            throw CreateGroupError.proofGenerationFailed(err)
+        } catch {
+            throw CreateGroupError.sdkFailure(String(describing: error))
+        }
+
+        // 6. Anchor on chain.
+        onProgress(.anchoring)
+        let transport = makeContractTransport(relayerURL)
+        let client = SEPContractClient(
+            contractID: binding.contractID,
+            contractType: .anarchy,
+            network: activeNetwork.sepNetwork,
+            transport: transport
+        )
+        let payload = AnarchyCreateGroupPayload(
+            groupID: groupID,
+            commitment: proof.commitment,
+            tier: tier.rawValue,
+            memberCount: members.count,
+            proof: proof.proof,
+            publicInputs: proof.publicInputs
+        )
+        let response: SEPSubmissionResponse
+        do {
+            response = try await client.createGroupAnarchy(payload)
+        } catch {
+            throw CreateGroupError.anchorTransport(String(describing: error))
+        }
+        guard response.accepted else {
+            throw CreateGroupError.anchorRejected(message: response.message)
+        }
+
+        // 7. Save locally — no admin in Anarchy, so adminPubkeyHex stays nil.
+        let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+        let group = ChatGroup(
+            id: groupIDHex,
+            ownerIdentityID: ownerID,
+            name: trimmedName,
+            groupSecret: groupSecret,
+            createdAt: Date(),
+            members: members,
+            epoch: 0,
+            salt: salt,
+            commitment: proof.commitment,
+            tier: tier,
+            groupType: .anarchy,
+            adminPubkeyHex: nil,
+            isPublishedOnChain: false
+        )
+        _ = await groups.insert(group)
+        await groups.markPublished(id: group.id, commitment: proof.commitment)
+
+        // 8. Send invitations (if any). Anarchy invitations carry no
+        // admin field and no peer secret — the receiver uses their
+        // own BLS identity when they later add themselves via
+        // `update_commitment`.
+        if !invitees.isEmpty {
+            onProgress(.sendingInvitations(total: invitees.count))
+            let invitePayload = GroupInvitationPayload(
+                version: 1,
+                groupID: groupID,
+                groupSecret: groupSecret,
+                name: trimmedName,
+                members: members,
+                epoch: 0,
+                salt: salt,
+                commitment: proof.commitment,
+                tierRaw: tier.rawValue,
+                groupTypeRaw: SEPGroupType.anarchy.rawValue,
+                adminPubkeyHex: nil
+            )
+            try await sendInvitations(invitePayload, to: invitees)
+        }
 
         return await reloadGroup(group)
     }

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -245,15 +245,80 @@ final class CreateGroupInteractorTests: XCTestCase {
         )
     }
 
-    func test_create_anarchy_throws_unsupported() async throws {
-        let env = await makeTestEnv()
+    // MARK: - Anarchy
+
+    func test_create_anarchy_anchorsOnAnarchyContractAndShipsInvitations() async throws {
+        let env = await makeTestEnv(includeAnarchyContract: true)
+        let interactor = env.makeInteractor()
+
+        let inviteeKey = Data(repeating: 0xCC, count: 32)
+        let group = try await interactor.create(
+            governanceType: .anarchy,
+            name: "Open Garden",
+            invitees: [inviteeKey]
+        )
+
+        XCTAssertEqual(group.groupType, .anarchy)
+        XCTAssertEqual(group.members.count, 1, "creator-only roster at create time")
+        XCTAssertNil(group.adminPubkeyHex, "Anarchy has no admin")
+        XCTAssertEqual(group.tier, .small)
+        XCTAssertTrue(group.isPublishedOnChain)
+
+        let invocations = env.contractTransport.invocations
+        XCTAssertEqual(invocations.count, 1)
+        XCTAssertEqual(invocations.first?.function, "create_group")
+        let body = try XCTUnwrap(invocations.first.flatMap {
+            try? JSONSerialization.jsonObject(with: $0.payload) as? [String: Any]
+        })
+        XCTAssertEqual(body["contractType"] as? String, "anarchy")
+        let payload = try XCTUnwrap(body["payload"] as? [String: Any])
+        XCTAssertNil(payload["admin_pubkey_commitment"], "no admin field on Anarchy wire")
+        XCTAssertEqual((payload["tier"] as? NSNumber)?.intValue, 0, "tier=small=0")
+        XCTAssertEqual((payload["member_count"] as? NSNumber)?.intValue, 1)
+        let publicInputs = try XCTUnwrap(payload["publicInputs"] as? [String])
+        XCTAssertEqual(publicInputs.count, 2, "Anarchy ships [commitment, Fr(0)]")
+
+        // The invitation got sent.
+        let sends = await env.inboxTransport.sends
+        XCTAssertEqual(sends.count, 1)
+    }
+
+    func test_create_anarchy_zeroInvitees_anchorsButSendsNothing() async throws {
+        let env = await makeTestEnv(includeAnarchyContract: true)
+        let interactor = env.makeInteractor()
+        let group = try await interactor.create(
+            governanceType: .anarchy,
+            name: "Solo Anarchy",
+            invitees: []
+        )
+        XCTAssertTrue(group.isPublishedOnChain)
+        let sends = await env.inboxTransport.sends
+        XCTAssertTrue(sends.isEmpty, "no invitees → no sends")
+    }
+
+    func test_create_anarchy_noContractBinding_throws() async throws {
+        let env = await makeTestEnv(includeAnarchyContract: false)
         await assertThrows(
             try await env.makeInteractor().create(
                 governanceType: .anarchy,
                 name: "G",
                 invitees: []
             ),
-            CreateGroupError.unsupportedGovernanceType(.anarchy)
+            CreateGroupError.noContractBinding(.anarchy)
+        )
+    }
+
+    func test_create_democracy_throws_unsupported() async throws {
+        // Anarchy is now supported — the unsupported guardrail still
+        // fires for democracy / oligarchy.
+        let env = await makeTestEnv()
+        await assertThrows(
+            try await env.makeInteractor().create(
+                governanceType: .democracy,
+                name: "G",
+                invitees: []
+            ),
+            CreateGroupError.unsupportedGovernanceType(.democracy)
         )
     }
 
@@ -279,12 +344,14 @@ final class CreateGroupInteractorTests: XCTestCase {
         addRelayer: Bool = true,
         includeTyrannyContract: Bool = true,
         includeOneOnOneContract: Bool = false,
+        includeAnarchyContract: Bool = false,
         network: AppNetwork = .testnet
     ) async -> CreateGroupTestEnv {
         let env = await CreateGroupTestEnv.make(
             addRelayer: addRelayer,
             includeTyrannyContract: includeTyrannyContract,
             includeOneOnOneContract: includeOneOnOneContract,
+            includeAnarchyContract: includeAnarchyContract,
             network: network
         )
         return env
@@ -313,6 +380,7 @@ private final class CreateGroupTestEnv {
         addRelayer: Bool,
         includeTyrannyContract: Bool,
         includeOneOnOneContract: Bool = false,
+        includeAnarchyContract: Bool = false,
         network: AppNetwork
     ) async -> CreateGroupTestEnv {
         let keychain = IdentityKeychainStore(
@@ -355,6 +423,13 @@ private final class CreateGroupTestEnv {
                 network: .testnet,
                 type: .oneonone,
                 id: "C1V1CONTRACTTEST000000000000000000000000000000000000000"
+            ))
+        }
+        if includeAnarchyContract {
+            contractEntries.append(ContractEntry(
+                network: .testnet,
+                type: .anarchy,
+                id: "CANARCHYCONTRACTTEST00000000000000000000000000000000000"
             ))
         }
         let manifest = ContractsManifest(
@@ -465,6 +540,23 @@ private struct StubGroupProofGenerator: GroupProofGenerator {
                 proof: Data(repeating: 0xCC, count: 1601),
                 publicInputs: [
                     Data(repeating: 0xEE, count: 32),  // commitment
+                    Data(repeating: 0x00, count: 32),  // Fr(0)
+                ]
+            )
+        case .anarchy:
+            // Mirror the real Anarchy proveMembership-at-epoch-0 shape:
+            // 2-element PI like OneOnOne, no admin field. Validate the
+            // prover-index guard so the interactor branch stays honest.
+            guard input.adminIndex >= 0, input.adminIndex < input.members.count else {
+                throw GroupProofGeneratorError.adminIndexOutOfRange(
+                    index: input.adminIndex,
+                    count: input.members.count
+                )
+            }
+            return GroupCreateProof(
+                proof: Data(repeating: 0xDD, count: 1601),
+                publicInputs: [
+                    Data(repeating: 0xBE, count: 32),  // commitment
                     Data(repeating: 0x00, count: 32),  // Fr(0)
                 ]
             )


### PR DESCRIPTION
## Summary

PR **2 of 3** in the Anarchy stacked series. Wires the create pipeline end-to-end for \`.anarchy\`. UI surface still gated behind PR-3.

**Base:** \`chain/anarchy-create\` (PR #49). Merge that first.

### Interactor

- \`CreateGroupInteractor.create\` now branches on \`.anarchy\` and calls the new \`createAnarchy(...)\`. Mirrors \`createTyranny\` structurally (canonical-Fr \`groupID\`, tier-bounded depth, invitation send loop) but uses \`AnarchyCreateGroupPayload\` and saves the group with \`groupType: .anarchy, adminPubkeyHex: nil\`.
- Founding ceremony is \`Anarchy.proveMembership(...)\` at epoch 0 over the single-member roster (just the creator).
- \`.democracy / .oligarchy\` still throw \`unsupportedGovernanceType\`.

### Tests

- \`test_create_anarchy_anchorsOnAnarchyContractAndShipsInvitations\` — verifies wire shape (\`contractType = "anarchy"\`, \`tier\` + \`member_count\` present, no admin field, 2-element PI), 1 member, nil admin, 1 invitation sent.
- \`test_create_anarchy_zeroInvitees_anchorsButSendsNothing\`
- \`test_create_anarchy_noContractBinding_throws\`
- \`test_create_democracy_throws_unsupported\` (replaces the now-obsolete anarchy-throws test).
- \`StubGroupProofGenerator\` extended with an Anarchy arm that enforces the prover-index guard.

334 unit tests pass.

## Stack

- **PR-1 (#49)** — chain seam
- **PR-2 (this)** — interactor
- **PR-3** — UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)