### PR TITLE
ux: enable Anarchy governance card (PR-3 of Anarchy)

### DIFF
--- a/Sources/OnymIOS/Group/OnymBrand.swift
+++ b/Sources/OnymIOS/Group/OnymBrand.swift
@@ -179,12 +179,11 @@ enum OnymUIGovernance: String, CaseIterable, Identifiable, Sendable {
     }
 
     /// True when this governance type is wired through the chain
-    /// layer end-to-end. Anarchy stays gated behind a "Soon" pill
-    /// until its create flow ships; Tyranny + 1-on-1 are live.
+    /// layer end-to-end. All three currently surfaced types
+    /// (Tyranny, 1-on-1, Anarchy) are live.
     var isAvailable: Bool {
         switch self {
-        case .tyranny, .oneOnOne: true
-        case .anarchy: false
+        case .tyranny, .oneOnOne, .anarchy: true
         }
     }
 

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -22,13 +22,6 @@ final class CreateGroupFlowTests: XCTestCase {
         XCTAssertTrue(flow.canAdvanceToStep2)
     }
 
-    func test_unavailableGovernance_blocksAdvance() async throws {
-        let flow = await makeFlow()
-        flow.name = "Friends"
-        flow.governance = .anarchy   // not yet supported
-        XCTAssertFalse(flow.canAdvanceToStep2)
-    }
-
     func test_tappedNext_advancesToStep2() async throws {
         let flow = await makeFlow()
         flow.name = "Friends"
@@ -42,13 +35,6 @@ final class CreateGroupFlowTests: XCTestCase {
         flow.name = ""
         flow.tappedNext()
         XCTAssertEqual(flow.route, .step2)
-    }
-
-    func test_tappedNext_unavailableGovernance_isNoOp() async throws {
-        let flow = await makeFlow()
-        flow.governance = .anarchy
-        flow.tappedNext()
-        XCTAssertEqual(flow.route, .step1)
     }
 
     // MARK: - Random placeholder name
@@ -248,6 +234,43 @@ final class CreateGroupFlowTests: XCTestCase {
         let flow = await makeFlow()
         flow.governance = .tyranny
         XCTAssertTrue(flow.canCreate, "Tyranny accepts any roster size, including zero")
+    }
+
+    // MARK: - Anarchy governance gates
+
+    func test_anarchy_isNowAvailable() async throws {
+        // PR-3 of Anarchy flips the gate — Step1 should advance with .anarchy.
+        let flow = await makeFlow()
+        flow.governance = .anarchy
+        XCTAssertTrue(flow.canAdvanceToStep2)
+    }
+
+    func test_anarchy_canCreate_alwaysTrue() async throws {
+        // Anarchy behaves like Tyranny — any roster size, no required peer.
+        let flow = await makeFlow()
+        flow.governance = .anarchy
+        XCTAssertTrue(flow.canCreate, "Anarchy accepts any roster size, including zero")
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertTrue(flow.canCreate, "still true with one invitee")
+    }
+
+    func test_anarchy_canAddMoreInvitees_alwaysTrue() async throws {
+        let flow = await makeFlow()
+        flow.governance = .anarchy
+        XCTAssertTrue(flow.canAddMoreInvitees)
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertTrue(flow.canAddMoreInvitees, "Anarchy doesn't cap invitee count")
+    }
+
+    func test_anarchy_createCTALabel_matchesTyrannyShape() async throws {
+        let flow = await makeFlow()
+        flow.governance = .anarchy
+        XCTAssertEqual(flow.createCTALabel, "Create empty group")
+        flow.inviteeInput = String(repeating: "aa", count: 32)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.createCTALabel, "Create with 1 person")
     }
 
     // MARK: - onClose


### PR DESCRIPTION
## Summary

PR **3 of 3** in the Anarchy stacked series. Final slice — flips the governance gate so users can pick "Anarchy" on Step 1.

**Base:** \`group/anarchy-interactor\` (PR #50). Merge that first.

> **Acceptance criteria reached on this branch:** a user can create an Anarchy group on iOS by picking the Anarchy card on Step 1, optionally pasting invitee inbox keys, and tapping Create.

### Changes

- \`OnymUIGovernance.isAvailable\` now returns true for all three surfaced types. The "Soon" pill drops off the Anarchy card automatically.
- View-side copy already covers \`.anarchy\` (added during the OneOnOne UI PR). \`CreateGroupFlow.canCreate / canAddMoreInvitees / createCTALabel\` already group Anarchy with Tyranny — no flow changes needed.

### Tests

- Drops \`test_unavailableGovernance_blocksAdvance\` + \`test_tappedNext_unavailableGovernance_isNoOp\` — both used \`.anarchy\` as the unavailable type. Nothing left at this layer to test as "unavailable".
- 4 new tests: \`anarchy_isNowAvailable\`, \`anarchy_canCreate_alwaysTrue\`, \`anarchy_canAddMoreInvitees_alwaysTrue\`, \`anarchy_createCTALabel_matchesTyrannyShape\`.
- 336 unit tests pass.

## Stack

- **PR-1 (#49)** — chain seam (types + client method + proof generator)
- **PR-2 (#50)** — interactor branch
- **PR-3 (this)** — UI surface

## Merge order

Per the stacked-PR memory: **don't \`--delete-branch\` until the whole stack lands**, or pre-retarget each child to \`main\` before touching the parent. Otherwise GitHub auto-closes the children when their stacked base disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)