### PR TITLE
chain: IdentityID + per-identity IdentityKeychainStore (PR-1 of 5: multi-identity)

### DIFF
--- a/Sources/OnymIOS/Identity/IdentityID.swift
+++ b/Sources/OnymIOS/Identity/IdentityID.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Stable opaque handle for one of the user's identities.
+///
+/// Backed by a UUID, but type-distinct so the compiler stops us from
+/// accidentally passing a `UUID` from another domain (e.g. an
+/// `OnymInvitee.id`) anywhere an identity is expected.
+///
+/// Persisted via the keychain `kSecAttrService` suffix
+/// (`chat.onym.ios.identity.<uuidString>`) and inside `ChatGroup` rows
+/// (post-PR-3) so any group can be traced back to the identity that
+/// owns it without a separate join table.
+struct IdentityID: Hashable, Codable, Sendable, CustomStringConvertible {
+    let rawValue: UUID
+
+    init(_ rawValue: UUID = UUID()) {
+        self.rawValue = rawValue
+    }
+
+    /// `nil` if `string` isn't a parseable UUID. Used when reconstructing
+    /// the ID from a keychain service suffix or a persisted ChatGroup row.
+    init?(_ string: String) {
+        guard let uuid = UUID(uuidString: string) else { return nil }
+        self.rawValue = uuid
+    }
+
+    var description: String { rawValue.uuidString }
+
+    // Codable round-trips as the UUID's string form so persisted JSON +
+    // keychain service names stay readable.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let str = try container.decode(String.self)
+        guard let uuid = UUID(uuidString: str) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "IdentityID: \(str.prefix(40)) is not a UUID"
+            )
+        }
+        self.rawValue = uuid
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue.uuidString)
+    }
+}

--- a/Sources/OnymIOS/Identity/IdentityKeychainStore.swift
+++ b/Sources/OnymIOS/Identity/IdentityKeychainStore.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Security
+
+/// Per-identity Keychain store. Each identity gets its own
+/// `kSecClassGenericPassword` item under the service name
+/// `chat.onym.ios.identity.<uuid>`. Listing identities is a single
+/// `SecItemCopyMatching` over that service-name prefix.
+///
+/// Same `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` policy as
+/// the legacy single-slot `KeychainStore` — one cached unlock per
+/// device, no iCloud Keychain sync, no encrypted-backup transfer.
+///
+/// Replaces the singleton `KeychainStore` in PR-2 (the legacy store
+/// is left in tree here so PR-1 stays mergeable; the
+/// `IdentityRepository` rewrite + call-site cascade lands in PR-2).
+struct IdentityKeychainStore: Sendable {
+    /// Service-name prefix shared by every per-identity item. Listing
+    /// identities walks every item whose service starts with this.
+    static let servicePrefix = "chat.onym.ios.identity."
+
+    /// Stable account string used for every item. The discriminator is
+    /// the per-identity service suffix; account is constant so reading
+    /// back doesn't need to remember it.
+    static let account = "current"
+
+    /// Optional injection seam for tests — production uses the default
+    /// init which targets the real Keychain. Tests pass a `serviceSuffix`
+    /// override that namespaces test runs and lets `wipeAll` clean up
+    /// reliably across teardowns.
+    let testNamespace: String?
+
+    init(testNamespace: String? = nil) {
+        self.testNamespace = testNamespace
+    }
+
+    // MARK: - Public API
+
+    /// Every identity currently persisted. Order is keychain-internal
+    /// (effectively undefined) — the repository sorts by display name
+    /// before showing the picker.
+    func list() throws -> [IdentityID] {
+        let prefix = servicePrefix(for: testNamespace)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return [] }
+        guard status == errSecSuccess else {
+            throw IdentityError.keychainRead(status)
+        }
+        guard let items = result as? [[String: Any]] else { return [] }
+        return items.compactMap { attrs in
+            guard let service = attrs[kSecAttrService as String] as? String,
+                  service.hasPrefix(prefix)
+            else { return nil }
+            let suffix = String(service.dropFirst(prefix.count))
+            return IdentityID(suffix)
+        }
+    }
+
+    /// Read the secret bundle for `id`. Returns `nil` for
+    /// `errSecItemNotFound`; throws for any other keychain error.
+    func read(_ id: IdentityID) throws -> StoredSnapshot? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service(for: id),
+            kSecAttrAccount as String: Self.account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw IdentityError.keychainRead(status)
+        }
+        do {
+            return try JSONDecoder().decode(StoredSnapshot.self, from: data)
+        } catch {
+            throw IdentityError.storedSnapshotInvalid(reason: "decode failed: \(error)")
+        }
+    }
+
+    /// Insert-or-update `snapshot` for `id`. Idempotent.
+    func write(_ id: IdentityID, _ snapshot: StoredSnapshot) throws {
+        let data = try JSONEncoder().encode(snapshot)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service(for: id),
+            kSecAttrAccount as String: Self.account,
+        ]
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess { return }
+        if updateStatus == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw IdentityError.keychainWrite(addStatus)
+            }
+            return
+        }
+        throw IdentityError.keychainWrite(updateStatus)
+    }
+
+    /// Drop the keychain item for `id`. No-op if it's already gone.
+    func wipe(_ id: IdentityID) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service(for: id),
+            kSecAttrAccount as String: Self.account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw IdentityError.keychainDelete(status)
+        }
+    }
+
+    /// Drop every per-identity item — used by tests in `tearDown` and
+    /// (eventually) the user-facing "reset all identities" flow.
+    func wipeAll() throws {
+        let prefix = servicePrefix(for: testNamespace)
+        let listQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(listQuery as CFDictionary, &result)
+        if status == errSecItemNotFound { return }
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            if status == errSecSuccess { return }
+            throw IdentityError.keychainRead(status)
+        }
+        for attrs in items {
+            guard let service = attrs[kSecAttrService as String] as? String,
+                  service.hasPrefix(prefix)
+            else { continue }
+            let deleteQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: Self.account,
+            ]
+            let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
+            guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                throw IdentityError.keychainDelete(deleteStatus)
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    /// Per-identity service name. Tests override the prefix via
+    /// `testNamespace` so concurrent test runs don't stomp on each
+    /// other's keychain entries.
+    private func service(for id: IdentityID) -> String {
+        servicePrefix(for: testNamespace) + id.rawValue.uuidString
+    }
+
+    /// Returns the prefix used to list/match per-identity items. The
+    /// `testNamespace` (when set) is folded into the prefix so a test
+    /// can `wipeAll` reliably without touching production identities.
+    private func servicePrefix(for namespace: String?) -> String {
+        if let namespace, !namespace.isEmpty {
+            return "\(Self.servicePrefix)\(namespace)."
+        }
+        return Self.servicePrefix
+    }
+}

--- a/Tests/OnymIOSTests/IdentityIDTests.swift
+++ b/Tests/OnymIOSTests/IdentityIDTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import OnymIOS
+
+final class IdentityIDTests: XCTestCase {
+    func test_init_default_generatesDistinctIDs() {
+        let a = IdentityID()
+        let b = IdentityID()
+        XCTAssertNotEqual(a, b, "default init must mint a fresh UUID each time")
+    }
+
+    func test_init_fromString_acceptsValidUUID() {
+        let uuid = UUID()
+        let id = IdentityID(uuid.uuidString)
+        XCTAssertEqual(id?.rawValue, uuid)
+    }
+
+    func test_init_fromString_rejectsNonUUID() {
+        XCTAssertNil(IdentityID("not-a-uuid"))
+        XCTAssertNil(IdentityID(""))
+        XCTAssertNil(IdentityID("12345"))
+    }
+
+    func test_codable_roundTripsAsUUIDString() throws {
+        let id = IdentityID()
+        let encoded = try JSONEncoder().encode(id)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(json, "\"\(id.rawValue.uuidString)\"",
+                       "Codable must round-trip as a JSON string for keychain-suffix readability")
+        let decoded = try JSONDecoder().decode(IdentityID.self, from: encoded)
+        XCTAssertEqual(decoded, id)
+    }
+
+    func test_codable_rejectsNonUUIDPayload() {
+        let bogus = #""not-a-uuid""#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(IdentityID.self, from: bogus))
+    }
+
+    func test_description_isUUIDString() {
+        let uuid = UUID()
+        let id = IdentityID(uuid)
+        XCTAssertEqual(id.description, uuid.uuidString)
+    }
+
+    func test_hashable_isStableAcrossInits() {
+        let uuid = UUID()
+        let a = IdentityID(uuid)
+        let b = IdentityID(uuid)
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+}

--- a/Tests/OnymIOSTests/IdentityKeychainStoreTests.swift
+++ b/Tests/OnymIOSTests/IdentityKeychainStoreTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import OnymIOS
+
+/// Per-identity keychain store tests. Each test gets a unique
+/// `testNamespace` so concurrent runs don't stomp on each other; the
+/// `tearDown` `wipeAll()` only clears items inside that namespace.
+final class IdentityKeychainStoreTests: XCTestCase {
+    private var store: IdentityKeychainStore!
+
+    override func setUp() {
+        super.setUp()
+        store = IdentityKeychainStore(testNamespace: "tests-\(UUID().uuidString)")
+    }
+
+    override func tearDown() {
+        try? store.wipeAll()
+        store = nil
+        super.tearDown()
+    }
+
+    // MARK: - Read / write
+
+    func test_read_unknownID_returnsNil() throws {
+        XCTAssertNil(try store.read(IdentityID()))
+    }
+
+    func test_writeThenRead_roundTripsBundle() throws {
+        let id = IdentityID()
+        let snapshot = StoredSnapshot(
+            entropy: Data(repeating: 0xAA, count: 16),
+            nostrSecretKey: Data(repeating: 0x01, count: 32),
+            blsSecretKey: Data(repeating: 0x02, count: 32)
+        )
+        try store.write(id, snapshot)
+        let loaded = try store.read(id)
+        XCTAssertEqual(loaded, snapshot)
+    }
+
+    func test_write_isUpdateInPlace() throws {
+        let id = IdentityID()
+        let v1 = StoredSnapshot(
+            entropy: nil,
+            nostrSecretKey: Data(repeating: 0x01, count: 32),
+            blsSecretKey: Data(repeating: 0x02, count: 32)
+        )
+        let v2 = StoredSnapshot(
+            entropy: Data(repeating: 0x99, count: 16),
+            nostrSecretKey: Data(repeating: 0x03, count: 32),
+            blsSecretKey: Data(repeating: 0x04, count: 32)
+        )
+        try store.write(id, v1)
+        try store.write(id, v2)
+        XCTAssertEqual(try store.read(id), v2,
+                       "second write must overwrite, not duplicate the keychain item")
+    }
+
+    // MARK: - List
+
+    func test_list_emptyByDefault() throws {
+        XCTAssertEqual(try store.list(), [])
+    }
+
+    func test_list_returnsEveryWrittenID() throws {
+        let ids = (0..<3).map { _ in IdentityID() }
+        for id in ids {
+            try store.write(id, sampleSnapshot())
+        }
+        let listed = try store.list()
+        XCTAssertEqual(Set(listed), Set(ids),
+                       "list() returns every written ID; order isn't guaranteed")
+    }
+
+    func test_list_namespaceIsolated() throws {
+        let other = IdentityKeychainStore(testNamespace: "other-\(UUID().uuidString)")
+        defer { try? other.wipeAll() }
+        try store.write(IdentityID(), sampleSnapshot())
+        try other.write(IdentityID(), sampleSnapshot())
+        XCTAssertEqual(try store.list().count, 1)
+        XCTAssertEqual(try other.list().count, 1,
+                       "test namespaces must not see each other's identities")
+    }
+
+    // MARK: - Wipe
+
+    func test_wipe_dropsOneIdentityLeavesOthers() throws {
+        let keep = IdentityID()
+        let drop = IdentityID()
+        try store.write(keep, sampleSnapshot())
+        try store.write(drop, sampleSnapshot())
+        try store.wipe(drop)
+        XCTAssertNotNil(try store.read(keep))
+        XCTAssertNil(try store.read(drop))
+    }
+
+    func test_wipe_unknownID_isNoOp() throws {
+        XCTAssertNoThrow(try store.wipe(IdentityID()))
+    }
+
+    func test_wipeAll_clearsEverythingInNamespace() throws {
+        for _ in 0..<3 {
+            try store.write(IdentityID(), sampleSnapshot())
+        }
+        try store.wipeAll()
+        XCTAssertEqual(try store.list(), [])
+    }
+
+    // MARK: - Helpers
+
+    private func sampleSnapshot() -> StoredSnapshot {
+        StoredSnapshot(
+            entropy: nil,
+            nostrSecretKey: Data(repeating: 0x42, count: 32),
+            blsSecretKey: Data(repeating: 0x43, count: 32)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

PR **1 of 5** in the multi-identity stacked series. Adds the foundation the rest of the stack builds on — no call sites change yet, legacy \`KeychainStore\` stays in tree, PR-1 is independently mergeable.

## What lands

- **\`IdentityID\`** — UUID-backed \`Hashable + Codable + Sendable\` value type. Type-distinct so we can't pass an \`OnymInvitee.id\` where an identity is expected. Codable as a UUID string so keychain suffixes + persisted JSON stay readable.
- **\`IdentityKeychainStore\`** — per-identity Keychain wrapper. Each identity gets its own \`kSecClassGenericPassword\` item under \`service = "chat.onym.ios.identity.<uuid>"\`. Same \`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly\` policy. API: \`list / read / write / wipe / wipeAll\`. \`testNamespace\` seam isolates concurrent test runs.

## Tests

13 new — \`IdentityIDTests\` + \`IdentityKeychainStoreTests\`. All pass.

## Stack

- **PR-1 (this)** — chain: IdentityID + keyed keychain
- **PR-2** — identity: IdentityRepository multi-identity API (retires the legacy KeychainStore + cascades through every \`identity.currentIdentity()\` callsite)
- **PR-3** — group: ChatGroup.ownerIdentityID + GroupRepository filter
- **PR-4** — transport: inbox fan-out across identities
- **PR-5** — ux: identity management UI

## Merge order

Per the saved [stacked-PR memory](https://github.com/onymchat/onym-ios/blob/main/MEMORY.md): don't \`--delete-branch\` the parent until the whole stack lands, or pre-retarget every child to \`main\` before merging the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)