### PR TITLE
group: ChatGroup.ownerIdentityID + per-identity GroupRepository filter (PR-3 of 5)

### DIFF
--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -12,6 +12,11 @@ import Foundation
 struct ChatGroup: Identifiable, Equatable, Sendable {
     /// Hex-encoded 32-byte group ID.
     let id: String
+    /// The identity that created this group. Stamped at create time
+    /// from the currently-selected identity; the chats list filters
+    /// by it so switching identities hides the other one's groups.
+    /// Removing an identity wipes every group with a matching owner.
+    let ownerIdentityID: IdentityID
     let name: String
     /// 32-byte shared secret. Used for `topicTag` derivation and message
     /// key HKDF — both still TBD on iOS, but the value must be sealed

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -154,6 +154,11 @@ struct CreateGroupInteractor: Sendable {
         guard let identitySnapshot = await identity.currentIdentity() else {
             throw CreateGroupError.missingIdentity
         }
+        guard let ownerID = await identity.currentSelectedID() else {
+            // currentIdentity() returned non-nil but currentSelectedID()
+            // returned nil — actor invariant violated, treat as missing.
+            throw CreateGroupError.missingIdentity
+        }
         let creatorMember: GovernanceMember
         do {
             creatorMember = GovernanceMember(
@@ -218,6 +223,7 @@ struct CreateGroupInteractor: Sendable {
             .map { String(format: "%02x", $0) }.joined()
         let group = ChatGroup(
             id: groupIDHex,
+            ownerIdentityID: ownerID,
             name: trimmedName,
             groupSecret: groupSecret,
             createdAt: Date(),
@@ -315,6 +321,9 @@ struct CreateGroupInteractor: Sendable {
         guard let identitySnapshot = await identity.currentIdentity() else {
             throw CreateGroupError.missingIdentity
         }
+        guard let ownerID = await identity.currentSelectedID() else {
+            throw CreateGroupError.missingIdentity
+        }
         // BLS secret keys are canonical Fr by convention. The SDK reduces
         // silently if not, but any future strictness check would silently
         // break us — so generate canonical at the source.
@@ -394,6 +403,7 @@ struct CreateGroupInteractor: Sendable {
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
         let group = ChatGroup(
             id: groupIDHex,
+            ownerIdentityID: ownerID,
             name: trimmedName,
             groupSecret: groupSecret,
             createdAt: Date(),

--- a/Sources/OnymIOS/Group/GroupRepository.swift
+++ b/Sources/OnymIOS/Group/GroupRepository.swift
@@ -1,28 +1,34 @@
 import Foundation
 
-/// Owns the `GroupStore` and exposes a reactive snapshots stream.
-/// Mirrors `IncomingInvitationsRepository`: every successful mutation
-/// is followed by a fresh snapshot pushed to all subscribers; the
-/// current list is replayed on every new subscribe.
+/// Owns the `GroupStore` and exposes a per-identity reactive snapshots
+/// stream. Mirrors `IncomingInvitationsRepository`: every successful
+/// mutation is followed by a fresh snapshot pushed to all subscribers;
+/// the current list is replayed on every new subscribe.
 ///
-/// This is the only thing in the codebase that holds a `GroupStore`
-/// reference. PR-C's `CreateGroupInteractor` calls `insert` /
-/// `markPublished` / `delete` and observes `snapshots`; views observe
-/// via the interactor.
+/// PR-3 of the multi-identity stack: the cached list always holds the
+/// full on-disk roster; subscribers receive the current identity's
+/// rows only. Switching identity (`setCurrentIdentity`) re-emits with
+/// the new filter applied.
 actor GroupRepository {
     private let store: any GroupStore
+    /// Full on-disk roster, unfiltered. The filter applies at yield
+    /// time so a switch to a previously-loaded identity is instant —
+    /// no fresh `store.list()` round-trip.
     private var cached: [ChatGroup] = []
+    private var currentIdentityID: IdentityID?
     private var continuations: [UUID: AsyncStream<[ChatGroup]>.Continuation] = [:]
 
-    init(store: any GroupStore) {
+    init(store: any GroupStore, currentIdentityID: IdentityID? = nil) {
         self.store = store
+        self.currentIdentityID = currentIdentityID
     }
+
+    // MARK: - Mutations
 
     /// Idempotent on `group.id` (delegates to
     /// `GroupStore.insertOrUpdate`). Any subsequent insert with the
     /// same id overwrites the row in place — the chain-anchor flow
-    /// uses this to flip `isPublishedOnChain` and bump the
-    /// commitment.
+    /// uses this to flip `isPublishedOnChain` and bump the commitment.
     @discardableResult
     func insert(_ group: ChatGroup) async -> Bool {
         let inserted = await store.insertOrUpdate(group)
@@ -43,11 +49,32 @@ actor GroupRepository {
         await refreshFromStore()
     }
 
+    /// Drop every group owned by `id`. Wired into
+    /// `IdentityRepository.identityRemoved` by the app shell so
+    /// removing an identity wipes its chats too.
+    func removeForOwner(_ id: IdentityID) async {
+        await store.deleteOwner(id.rawValue.uuidString)
+        await refreshFromStore()
+    }
+
+    // MARK: - Identity selection
+
+    /// Set the identity whose groups subscribers should see. Re-emits
+    /// the filtered list to every active subscriber. Pass `nil` (e.g.
+    /// after the last identity is removed) to broadcast an empty list.
+    func setCurrentIdentity(_ id: IdentityID?) {
+        guard currentIdentityID != id else { return }
+        currentIdentityID = id
+        publishFiltered()
+    }
+
     /// Force a refresh from the backing store. Used at app launch and
     /// by tests; mutators call it themselves.
     func reload() async {
         await refreshFromStore()
     }
+
+    // MARK: - Subscriptions
 
     nonisolated var snapshots: AsyncStream<[ChatGroup]> {
         AsyncStream { continuation in
@@ -69,7 +96,7 @@ actor GroupRepository {
             await refreshFromStore()
         }
         continuations[id] = continuation
-        continuation.yield(cached)
+        continuation.yield(filteredCache())
     }
 
     private func unsubscribe(id: UUID) {
@@ -78,8 +105,18 @@ actor GroupRepository {
 
     private func refreshFromStore() async {
         cached = await store.list()
+        publishFiltered()
+    }
+
+    private func publishFiltered() {
+        let view = filteredCache()
         for continuation in continuations.values {
-            continuation.yield(cached)
+            continuation.yield(view)
         }
+    }
+
+    private func filteredCache() -> [ChatGroup] {
+        guard let currentIdentityID else { return [] }
+        return cached.filter { $0.ownerIdentityID == currentIdentityID }
     }
 }

--- a/Sources/OnymIOS/Group/GroupStore.swift
+++ b/Sources/OnymIOS/Group/GroupStore.swift
@@ -24,4 +24,10 @@ protocol GroupStore: Sendable {
     func markPublished(id: String, commitment: Data?) async
 
     func delete(id: String) async
+
+    /// Delete every row whose `ownerIdentityIDString` matches.
+    /// `ownerIDString` is the UUID-string form of the removed
+    /// `IdentityID`. Used by the identity-removal hook in
+    /// `GroupRepository.removeForOwner`.
+    func deleteOwner(_ ownerIDString: String) async
 }

--- a/Sources/OnymIOS/Group/PersistedGroup.swift
+++ b/Sources/OnymIOS/Group/PersistedGroup.swift
@@ -24,6 +24,11 @@ import SwiftData
 @Model
 final class PersistedGroup {
     @Attribute(.unique) var id: String
+    /// UUID string of the identity that owns this row. Plain (not
+    /// encrypted) so SwiftData `#Predicate` can filter on it. Owner
+    /// IDs are random per-device UUIDs — no cross-device linkage,
+    /// nothing to leak.
+    var ownerIdentityIDString: String
     var createdAt: Date
     var epoch: Int64
     var tierRaw: Int
@@ -39,6 +44,7 @@ final class PersistedGroup {
 
     init(
         id: String,
+        ownerIdentityIDString: String,
         createdAt: Date,
         epoch: Int64,
         tierRaw: Int,
@@ -52,6 +58,7 @@ final class PersistedGroup {
         encryptedAdminPubkeyHex: Data?
     ) {
         self.id = id
+        self.ownerIdentityIDString = ownerIdentityIDString
         self.createdAt = createdAt
         self.epoch = epoch
         self.tierRaw = tierRaw

--- a/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
+++ b/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
@@ -12,6 +12,10 @@ actor SwiftDataGroupStore: GroupStore {
     /// Production initializer — on-disk SQLite under
     /// `Application Support/OnymIOS/Groups.store`, with
     /// `FileProtectionType.complete` on the directory.
+    ///
+    /// Per the multi-identity no-backcompat licence, schema-mismatch
+    /// errors at `ModelContainer(...)` init wipe the on-disk store and
+    /// retry once. Pre-1.0 install base, no real users to preserve.
     init() throws {
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
@@ -25,7 +29,21 @@ actor SwiftDataGroupStore: GroupStore {
         let url = storeDir.appendingPathComponent("Groups.store")
         let schema = Schema([PersistedGroup.self])
         let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
-        let container = try ModelContainer(for: schema, configurations: [config])
+        let container: ModelContainer
+        do {
+            container = try ModelContainer(for: schema, configurations: [config])
+        } catch {
+            // Schema migration failure — wipe + retry. SwiftData's
+            // SQLite trio (`.store`, `.store-shm`, `.store-wal`) all
+            // need to go.
+            for suffix in ["", "-shm", "-wal"] {
+                try? FileManager.default.removeItem(
+                    at: url.deletingPathExtension().appendingPathExtension("store\(suffix)")
+                )
+            }
+            try? FileManager.default.removeItem(at: url)
+            container = try ModelContainer(for: schema, configurations: [config])
+        }
         self.container = container
         self.context = ModelContext(container)
     }
@@ -62,6 +80,7 @@ actor SwiftDataGroupStore: GroupStore {
             predicate: #Predicate { $0.id == id }
         )
         if let existing = try? context.fetch(descriptor).first {
+            existing.ownerIdentityIDString = encoded.ownerIdentityIDString
             existing.epoch = encoded.epoch
             existing.tierRaw = encoded.tierRaw
             existing.groupTypeRaw = encoded.groupTypeRaw
@@ -104,12 +123,26 @@ actor SwiftDataGroupStore: GroupStore {
         try? context.save()
     }
 
+    /// Delete every row whose `ownerIdentityIDString` matches the
+    /// removed identity. Called from `GroupRepository.removeForOwner`
+    /// in response to `IdentityRepository.identityRemoved`.
+    func deleteOwner(_ ownerIDString: String) {
+        let descriptor = FetchDescriptor<PersistedGroup>(
+            predicate: #Predicate { $0.ownerIdentityIDString == ownerIDString }
+        )
+        if let rows = try? context.fetch(descriptor) {
+            for row in rows { context.delete(row) }
+        }
+        try? context.save()
+    }
+
     // MARK: - Mapping
 
     private static func encode(_ group: ChatGroup) throws -> PersistedGroup {
         let membersJSON = try JSONEncoder().encode(group.members)
         return PersistedGroup(
             id: group.id,
+            ownerIdentityIDString: group.ownerIdentityID.rawValue.uuidString,
             createdAt: group.createdAt,
             epoch: Int64(bitPattern: group.epoch),
             tierRaw: group.tier.rawValue,
@@ -126,6 +159,7 @@ actor SwiftDataGroupStore: GroupStore {
 
     private static func decode(_ row: PersistedGroup) -> ChatGroup? {
         guard
+            let owner = IdentityID(row.ownerIdentityIDString),
             let name = try? StorageEncryption.decryptString(row.encryptedName),
             let groupSecret = try? StorageEncryption.decrypt(row.encryptedGroupSecret),
             let membersJSON = try? StorageEncryption.decrypt(row.encryptedMembersJSON),
@@ -142,6 +176,7 @@ actor SwiftDataGroupStore: GroupStore {
         }
         return ChatGroup(
             id: row.id,
+            ownerIdentityID: owner,
             name: name,
             groupSecret: groupSecret,
             createdAt: row.createdAt,

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -173,6 +173,13 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
         return cache[currentID]
     }
 
+    /// The currently-selected identity's ID, or nil if none. Used by
+    /// the chain layer to stamp `ChatGroup.ownerIdentityID` at create
+    /// time without reaching back into the keychain.
+    func currentSelectedID() -> IdentityID? {
+        currentID
+    }
+
     /// Snapshot of every identity, ordered by insertion. View-safe
     /// (no secret material).
     func currentIdentities() -> [IdentitySummary] {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -128,6 +128,25 @@ struct OnymIOSApp: App {
                     await contractsRepository.start()
                     // Replay groups for the in-memory snapshot stream.
                     await groupRepository.reload()
+                    // Wire identity selection → group filter so the chats
+                    // list flips when the user switches identity.
+                    if let initialID = await identityRepository.currentSelectedID() {
+                        await groupRepository.setCurrentIdentity(initialID)
+                    }
+                }
+                .task {
+                    // Long-lived listener: forward every selection change.
+                    for await id in identityRepository.currentIdentityID {
+                        await groupRepository.setCurrentIdentity(id)
+                    }
+                }
+                .task {
+                    // Long-lived listener: wipe identity-scoped chats
+                    // when an identity is removed (the secrets are
+                    // already gone — this clears the on-disk groups).
+                    for await removed in identityRepository.identityRemoved {
+                        await groupRepository.removeForOwner(removed)
+                    }
                 }
         }
     }

--- a/Tests/OnymIOSTests/ChatGroupTests.swift
+++ b/Tests/OnymIOSTests/ChatGroupTests.swift
@@ -24,6 +24,7 @@ final class ChatGroupTests: XCTestCase {
     private func makeGroup(id: String) -> ChatGroup {
         ChatGroup(
             id: id,
+            ownerIdentityID: IdentityID(),
             name: "test",
             groupSecret: Data(repeating: 0, count: 32),
             createdAt: Date(timeIntervalSince1970: 0),

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -374,11 +374,22 @@ private final class CreateGroupTestEnv {
         )
         try? await contracts.refresh()
 
+        // Pre-bind the group repo to the restored identity so the
+        // multi-identity filter passes the test fixture's groups
+        // through. Without this, snapshots would be filtered to nil
+        // → [] and every "group landed in the repo" assert would
+        // fail.
+        let currentID = await identity.currentSelectedID()
+        let groups = GroupRepository(
+            store: SwiftDataGroupStore.inMemory(),
+            currentIdentityID: currentID
+        )
+
         return CreateGroupTestEnv(
             identity: identity,
             relayers: relayers,
             contracts: contracts,
-            groups: GroupRepository(store: SwiftDataGroupStore.inMemory()),
+            groups: groups,
             inboxTransport: ConfigurableInboxTransport(),
             contractTransport: ConfigurableContractTransport(),
             proofGenerator: StubGroupProofGenerator(),

--- a/Tests/OnymIOSTests/GroupRepositoryTests.swift
+++ b/Tests/OnymIOSTests/GroupRepositoryTests.swift
@@ -2,16 +2,20 @@ import XCTest
 @testable import OnymIOS
 
 /// Reactive-surface tests for `GroupRepository`. Backed by an in-memory
-/// `GroupStore` fake so the SwiftData layer doesn't pull in the
-/// Keychain-dependent `StorageEncryption` here — that's covered by
-/// `SwiftDataGroupStoreTests`. Mirrors `IncomingInvitationsRepositoryTests`.
+/// `GroupStore` fake. Every test pre-selects an identity via the repo's
+/// constructor so the filter doesn't drop the seeded groups.
 final class GroupRepositoryTests: XCTestCase {
+
+    /// One owner shared across single-identity tests so the repo's
+    /// `currentIdentityID` filter doesn't accidentally hide test data.
+    private let ownerA = IdentityID()
+    private let ownerB = IdentityID()
 
     func test_snapshots_replaysCurrentOnSubscribe() async throws {
         let store = InMemoryGroupStore()
-        let group = makeGroup(id: "aa".repeated(32), name: "Family")
+        let group = makeGroup(id: "aa".repeated(32), name: "Family", owner: ownerA)
         await store.preload([group])
-        let repo = GroupRepository(store: store)
+        let repo = GroupRepository(store: store, currentIdentityID: ownerA)
 
         var iterator = repo.snapshots.makeAsyncIterator()
         let first = await iterator.next()
@@ -21,12 +25,12 @@ final class GroupRepositoryTests: XCTestCase {
 
     func test_insert_broadcastsNewSnapshot() async throws {
         let store = InMemoryGroupStore()
-        let repo = GroupRepository(store: store)
+        let repo = GroupRepository(store: store, currentIdentityID: ownerA)
 
         var iterator = repo.snapshots.makeAsyncIterator()
         _ = await iterator.next()  // initial empty snapshot
 
-        let group = makeGroup(id: "bb".repeated(32), name: "Friends")
+        let group = makeGroup(id: "bb".repeated(32), name: "Friends", owner: ownerA)
         let inserted = await repo.insert(group)
         XCTAssertTrue(inserted)
 
@@ -37,9 +41,9 @@ final class GroupRepositoryTests: XCTestCase {
 
     func test_markPublished_broadcastsUpdatedSnapshot() async throws {
         let store = InMemoryGroupStore()
-        let group = makeGroup(id: "cc".repeated(32), name: "G")
+        let group = makeGroup(id: "cc".repeated(32), name: "G", owner: ownerA)
         await store.preload([group])
-        let repo = GroupRepository(store: store)
+        let repo = GroupRepository(store: store, currentIdentityID: ownerA)
 
         var iterator = repo.snapshots.makeAsyncIterator()
         _ = await iterator.next()
@@ -54,9 +58,9 @@ final class GroupRepositoryTests: XCTestCase {
 
     func test_delete_emptiesSnapshot() async throws {
         let store = InMemoryGroupStore()
-        let group = makeGroup(id: "dd".repeated(32), name: "G")
+        let group = makeGroup(id: "dd".repeated(32), name: "G", owner: ownerA)
         await store.preload([group])
-        let repo = GroupRepository(store: store)
+        let repo = GroupRepository(store: store, currentIdentityID: ownerA)
 
         var iterator = repo.snapshots.makeAsyncIterator()
         _ = await iterator.next()
@@ -66,11 +70,82 @@ final class GroupRepositoryTests: XCTestCase {
         XCTAssertEqual(next?.count, 0)
     }
 
+    // MARK: - Multi-identity filter
+
+    func test_snapshots_onlyContainCurrentOwnerGroups() async throws {
+        let store = InMemoryGroupStore()
+        await store.preload([
+            makeGroup(id: "aa".repeated(32), name: "A", owner: ownerA),
+            makeGroup(id: "bb".repeated(32), name: "B1", owner: ownerB),
+            makeGroup(id: "cc".repeated(32), name: "B2", owner: ownerB),
+        ])
+        let repo = GroupRepository(store: store, currentIdentityID: ownerA)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first?.map(\.name), ["A"],
+                       "subscriber must only see groups owned by the active identity")
+    }
+
+    func test_setCurrentIdentity_reEmitsFilteredSnapshot() async throws {
+        let store = InMemoryGroupStore()
+        await store.preload([
+            makeGroup(id: "aa".repeated(32), name: "A", owner: ownerA),
+            makeGroup(id: "bb".repeated(32), name: "B", owner: ownerB),
+        ])
+        let repo = GroupRepository(store: store, currentIdentityID: ownerA)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        _ = await iterator.next()  // owner A's view
+
+        await repo.setCurrentIdentity(ownerB)
+        let next = await iterator.next()
+        XCTAssertEqual(next?.map(\.name), ["B"],
+                       "switching identity re-emits with the new filter applied")
+    }
+
+    func test_setCurrentIdentity_nilEmitsEmptySnapshot() async throws {
+        let store = InMemoryGroupStore()
+        await store.preload([makeGroup(id: "aa".repeated(32), name: "A", owner: ownerA)])
+        let repo = GroupRepository(store: store, currentIdentityID: ownerA)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        _ = await iterator.next()
+
+        await repo.setCurrentIdentity(nil)
+        let next = await iterator.next()
+        XCTAssertEqual(next, [],
+                       "nil current identity → empty snapshot (no orphaned groups visible)")
+    }
+
+    func test_removeForOwner_dropsThatIdentitysGroups() async throws {
+        let store = InMemoryGroupStore()
+        await store.preload([
+            makeGroup(id: "aa".repeated(32), name: "A", owner: ownerA),
+            makeGroup(id: "bb".repeated(32), name: "B1", owner: ownerB),
+            makeGroup(id: "cc".repeated(32), name: "B2", owner: ownerB),
+        ])
+        let repo = GroupRepository(store: store, currentIdentityID: ownerB)
+
+        var iterator = repo.snapshots.makeAsyncIterator()
+        _ = await iterator.next()  // initial: 2 groups for B
+
+        await repo.removeForOwner(ownerB)
+        let next = await iterator.next()
+        XCTAssertEqual(next, [], "removeForOwner wipes the owner's groups from the store")
+
+        // Switching to A still surfaces A's group — only B's were dropped.
+        await repo.setCurrentIdentity(ownerA)
+        let stillA = await iterator.next()
+        XCTAssertEqual(stillA?.map(\.name), ["A"])
+    }
+
     // MARK: - Helpers
 
-    private func makeGroup(id: String, name: String) -> ChatGroup {
+    private func makeGroup(id: String, name: String, owner: IdentityID) -> ChatGroup {
         ChatGroup(
             id: id,
+            ownerIdentityID: owner,
             name: name,
             groupSecret: Data(repeating: 0x33, count: 32),
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
@@ -86,9 +161,7 @@ final class GroupRepositoryTests: XCTestCase {
     }
 }
 
-/// Reusable in-memory fake; lives next to the test that uses it
-/// because PR-B has only one consumer. Promote to `Tests/Support/`
-/// when PR-C's interactor tests grow a second one.
+/// Reusable in-memory fake; lives next to the test that uses it.
 private actor InMemoryGroupStore: GroupStore {
     private var rows: [String: ChatGroup] = [:]
 
@@ -118,6 +191,10 @@ private actor InMemoryGroupStore: GroupStore {
 
     func delete(id: String) {
         rows.removeValue(forKey: id)
+    }
+
+    func deleteOwner(_ ownerIDString: String) {
+        rows = rows.filter { $0.value.ownerIdentityID.rawValue.uuidString != ownerIDString }
     }
 }
 

--- a/Tests/OnymIOSTests/Integration/CreateGroupTyrannyE2ETests.swift
+++ b/Tests/OnymIOSTests/Integration/CreateGroupTyrannyE2ETests.swift
@@ -194,7 +194,14 @@ final class CreateGroupTyrannyE2ETests: XCTestCase {
             )
         }
 
-        let groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        // Pre-bind the group repo to the restored identity so the
+        // multi-identity filter passes the test's freshly-anchored
+        // group through into snapshots.
+        let currentID = await identity.currentSelectedID()
+        let groups = GroupRepository(
+            store: SwiftDataGroupStore.inMemory(),
+            currentIdentityID: currentID
+        )
         let networkPreference = StaticNetworkPreference(value: .testnet)
 
         let makeContractTransport: @Sendable (URL) -> any SEPContractTransport = { url in

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -127,7 +127,8 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         id: String,
         name: String,
         adminPubkeyHex: String? = nil,
-        createdAt: Date = Date(timeIntervalSince1970: 1_700_000_000)
+        createdAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        ownerIdentityID: IdentityID = IdentityID()
     ) -> ChatGroup {
         let member = GovernanceMember(
             publicKeyCompressed: Data(repeating: 0x11, count: 48),
@@ -135,6 +136,7 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         )
         return ChatGroup(
             id: id,
+            ownerIdentityID: ownerIdentityID,
             name: name,
             groupSecret: Data(repeating: 0x33, count: 32),
             createdAt: createdAt,


### PR DESCRIPTION
## Summary

PR **3 of 5**. Stamps every \`ChatGroup\` with the identity that created it, filters \`GroupRepository.snapshots\` by the active identity, and wires identity removal to a chat-wipe.

**Base:** \`identity/multi-identity-api\` (PR #53). Merge that first.

Per the no-backcompat licence, the SwiftData schema bump is handled by wipe-and-retry in \`SwiftDataGroupStore.init()\`.

## Schema

- \`ChatGroup.ownerIdentityID: IdentityID\` — stamped at create time.
- \`PersistedGroup.ownerIdentityIDString: String\` — plain (not encrypted) so \`#Predicate\` can filter.
- \`IdentityRepository.currentSelectedID()\` — small accessor for the chain layer.

## Repository

- \`GroupRepository.init(store:currentIdentityID:)\` caches full roster, filters at yield time.
- \`setCurrentIdentity(_:)\` re-emits the filtered list.
- \`removeForOwner(_:)\` wipes the owner's groups via new \`GroupStore.deleteOwner(_:)\`.

## App glue

\`OnymIOSApp\` adds two long-lived \`.task\` listeners:
- forward \`IdentityRepository.currentIdentityID\` → \`GroupRepository.setCurrentIdentity\`
- forward \`IdentityRepository.identityRemoved\` → \`GroupRepository.removeForOwner\`

## Tests

4 new \`GroupRepositoryTests\` covering filter + setCurrentIdentity + removeForOwner. Test helpers updated to stamp \`ownerIdentityID:\`. 359 unit tests pass.

## Stack

- PR-1 (#52) ✅
- PR-2 (#53) ✅
- **PR-3 (this)**
- PR-4 — InboxTransport fan-out
- PR-5 — identity management UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)