### PR TITLE
transport: inbox fan-out across identities (PR-4 of 5)

### DIFF
--- a/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
+++ b/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
@@ -1,0 +1,149 @@
+import CryptoKit
+import Foundation
+
+/// Fan out an `InboxTransport` subscription across every persisted
+/// identity. Spawns one concurrent subscription Task per identity;
+/// re-syncs the set whenever identities are added or removed (with a
+/// 250ms debounce to coalesce rapid changes).
+///
+/// Without this, messages addressed to a non-current identity drop on
+/// the floor while the user is on a different identity. PR-4 of the
+/// multi-identity stack.
+///
+/// Cancellation: the caller owns the top-level Task; per-identity
+/// subscription Tasks are torn down via `unsubscribe` + `Task.cancel()`
+/// when an identity disappears or when `run` is cancelled.
+struct InboxFanoutInteractor: Sendable {
+    let inboxTransport: any InboxTransport
+    let identityRepository: IdentityRepository
+    let repository: IncomingInvitationsRepository
+    /// Coalescing window — multiple identity changes within this many
+    /// milliseconds collapse into one re-subscribe.
+    let debounceMilliseconds: UInt64
+
+    init(
+        inboxTransport: any InboxTransport,
+        identityRepository: IdentityRepository,
+        repository: IncomingInvitationsRepository,
+        debounceMilliseconds: UInt64 = 250
+    ) {
+        self.inboxTransport = inboxTransport
+        self.identityRepository = identityRepository
+        self.repository = repository
+        self.debounceMilliseconds = debounceMilliseconds
+    }
+
+    /// Run until cancelled. Subscribes to every identity's inbox tag
+    /// and keeps the set in sync as identities come and go.
+    func run() async {
+        let subscriptions = ActiveSubscriptions(
+            inboxTransport: inboxTransport,
+            repository: repository
+        )
+
+        // Apply the current identity set immediately on launch (the
+        // identitiesStream replays the current value on subscribe but
+        // only delivers it once we await the first element).
+        let initial = await identityRepository.currentIdentities()
+        await subscriptions.apply(
+            Set(initial.map(\.id)),
+            tagsByID: Self.tagsByID(initial)
+        )
+
+        var pending: Set<IdentityID> = Set(initial.map(\.id))
+        var pendingTags: [IdentityID: TransportInboxID] = Self.tagsByID(initial)
+        var debounceHandle: Task<Void, Never>?
+
+        for await summaries in identityRepository.identitiesStream {
+            if Task.isCancelled { break }
+            let nextIDs = Set(summaries.map(\.id))
+            let nextTags = Self.tagsByID(summaries)
+            guard nextIDs != pending || nextTags != pendingTags else { continue }
+            pending = nextIDs
+            pendingTags = nextTags
+
+            // Debounce: cancel any prior pending sync, schedule a new
+            // one. The actor (`subscriptions`) serializes the apply,
+            // so concurrent fires can't interleave.
+            debounceHandle?.cancel()
+            debounceHandle = Task { [pending, pendingTags] in
+                try? await Task.sleep(nanoseconds: debounceMilliseconds * 1_000_000)
+                if Task.isCancelled { return }
+                await subscriptions.apply(pending, tagsByID: pendingTags)
+            }
+        }
+
+        // Stream closed — tear down everything.
+        debounceHandle?.cancel()
+        await subscriptions.applyEmpty()
+    }
+
+    private static func tagsByID(_ summaries: [IdentitySummary]) -> [IdentityID: TransportInboxID] {
+        var out: [IdentityID: TransportInboxID] = [:]
+        for s in summaries {
+            out[s.id] = TransportInboxID(rawValue: Self.inboxTag(from: s.inboxPublicKey))
+        }
+        return out
+    }
+
+    /// Mirror of `IdentityRepository.inboxTag(from:)`. Pure function of
+    /// the inbox pubkey; safe to recompute here without going back
+    /// through the actor.
+    private static func inboxTag(from inboxPublicKey: Data) -> String {
+        var hasher = SHA256()
+        hasher.update(data: Data("sep-inbox-v1".utf8))
+        hasher.update(data: inboxPublicKey)
+        let digest = hasher.finalize()
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - Subscription bookkeeping actor
+
+/// Owns the live per-identity subscription Tasks. `apply` reconciles
+/// the desired set against the live set: cancels Tasks for identities
+/// that disappeared or whose inbox tag changed, spawns Tasks for new
+/// ones, no-ops the rest.
+private actor ActiveSubscriptions {
+    private let inboxTransport: any InboxTransport
+    private let repository: IncomingInvitationsRepository
+    private var live: [IdentityID: (tag: TransportInboxID, task: Task<Void, Never>)] = [:]
+
+    init(inboxTransport: any InboxTransport, repository: IncomingInvitationsRepository) {
+        self.inboxTransport = inboxTransport
+        self.repository = repository
+    }
+
+    func apply(_ wanted: Set<IdentityID>, tagsByID: [IdentityID: TransportInboxID]) async {
+        for (id, current) in live {
+            if !wanted.contains(id) || tagsByID[id] != current.tag {
+                current.task.cancel()
+                await inboxTransport.unsubscribe(inbox: current.tag)
+                live.removeValue(forKey: id)
+            }
+        }
+        for id in wanted {
+            guard let tag = tagsByID[id], live[id] == nil else { continue }
+            let stream = inboxTransport.subscribe(inbox: tag)
+            let task = Task { [repository] in
+                for await message in stream {
+                    if Task.isCancelled { break }
+                    await repository.recordIncoming(
+                        id: message.messageID,
+                        payload: message.payload,
+                        receivedAt: message.receivedAt
+                    )
+                }
+            }
+            live[id] = (tag, task)
+        }
+    }
+
+    func applyEmpty() async {
+        for (_, current) in live {
+            current.task.cancel()
+            await inboxTransport.unsubscribe(inbox: current.tag)
+        }
+        live.removeAll()
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -7,6 +7,8 @@ struct OnymIOSApp: App {
     private let relayerRepository: RelayerRepository
     private let contractsRepository: ContractsRepository
     private let groupRepository: GroupRepository
+    private let inboxTransport: any InboxTransport
+    private let incomingInvitations: IncomingInvitationsRepository
 
     init() {
         let args = ProcessInfo.processInfo.arguments
@@ -79,6 +81,14 @@ struct OnymIOSApp: App {
         let inboxTransport = NostrInboxTransport(
             signerProvider: OnymNostrSignerProvider()
         )
+        self.inboxTransport = inboxTransport
+
+        // Incoming invitations repository — falls back to in-memory if
+        // the on-disk store can't open (same protection-class concerns
+        // as `SwiftDataGroupStore`).
+        let invitationStore: any InvitationStore =
+            (try? SwiftDataInvitationStore()) ?? SwiftDataInvitationStore.inMemory()
+        self.incomingInvitations = IncomingInvitationsRepository(store: invitationStore)
 
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
@@ -147,6 +157,17 @@ struct OnymIOSApp: App {
                     for await removed in identityRepository.identityRemoved {
                         await groupRepository.removeForOwner(removed)
                     }
+                }
+                .task {
+                    // PR-4: subscribe to every identity's inbox
+                    // concurrently. Without this, messages addressed
+                    // to a non-current identity drop on the floor.
+                    let fanout = InboxFanoutInteractor(
+                        inboxTransport: inboxTransport,
+                        identityRepository: identityRepository,
+                        repository: incomingInvitations
+                    )
+                    await fanout.run()
                 }
         }
     }

--- a/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
+++ b/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
@@ -1,0 +1,273 @@
+import CryptoKit
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for `InboxFanoutInteractor`. Uses a real
+/// `IdentityRepository` (isolated keychain) so the inbox-tag derivation
+/// matches what production sees, plus a fake `InboxTransport` that
+/// records subscribe/unsubscribe + can inject inbound messages.
+@MainActor
+final class InboxFanoutInteractorTests: XCTestCase {
+    private var keychain: IdentityKeychainStore!
+    private var identity: IdentityRepository!
+    private var invitationsStore: FanoutInvitationStore!
+    private var invitations: IncomingInvitationsRepository!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        keychain = IdentityKeychainStore(testNamespace: "fanout-\(UUID().uuidString)")
+        identity = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory()
+        )
+        invitationsStore = FanoutInvitationStore()
+        invitations = IncomingInvitationsRepository(store: invitationsStore)
+    }
+
+    override func tearDown() async throws {
+        try? keychain?.wipeAll()
+        keychain = nil
+        identity = nil
+        invitationsStore = nil
+        invitations = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Initial subscription set
+
+    func test_run_subscribesToEveryExistingIdentity() async throws {
+        // Seed two identities BEFORE running.
+        _ = try await identity.bootstrap()                      // Identity 1
+        _ = try await identity.add(name: "Work")                // Identity 2
+        let summaries = await identity.currentIdentities()
+        XCTAssertEqual(summaries.count, 2)
+
+        let transport = RecordingInboxTransport()
+        let fanout = InboxFanoutInteractor(
+            inboxTransport: transport,
+            identityRepository: identity,
+            repository: invitations,
+            debounceMilliseconds: 1   // tight for tests
+        )
+        let runTask = Task { await fanout.run() }
+        defer { runTask.cancel() }
+
+        // Wait until both subscribe calls land.
+        try await waitFor { await transport.subscribed.count >= 2 }
+        let live = await transport.subscribed
+        XCTAssertEqual(live.count, 2)
+        // Tags match the identities' inbox tags.
+        let expectedTags = Set(summaries.map(\.inboxPublicKey).map(Self.expectedTag))
+        XCTAssertEqual(Set(live.map(\.rawValue)), expectedTags)
+    }
+
+    // MARK: - Add / remove during run
+
+    func test_addingIdentity_triggersNewSubscription() async throws {
+        _ = try await identity.bootstrap()  // Identity 1
+
+        let transport = RecordingInboxTransport()
+        let fanout = InboxFanoutInteractor(
+            inboxTransport: transport,
+            identityRepository: identity,
+            repository: invitations,
+            debounceMilliseconds: 1
+        )
+        let runTask = Task { await fanout.run() }
+        defer { runTask.cancel() }
+
+        try await waitFor { await transport.subscribed.count >= 1 }
+        let count1 = await transport.subscribed.count
+        XCTAssertEqual(count1, 1)
+
+        _ = try await identity.add(name: "Work")
+        try await waitFor { await transport.subscribed.count >= 2 }
+        let count2 = await transport.subscribed.count
+        XCTAssertEqual(count2, 2)
+    }
+
+    func test_removingIdentity_triggersUnsubscribe() async throws {
+        _ = try await identity.bootstrap()
+        let workID = try await identity.add(name: "Work")
+        let summaries = await identity.currentIdentities()
+        let workSummary = try XCTUnwrap(summaries.first(where: { $0.id == workID }))
+
+        let transport = RecordingInboxTransport()
+        let fanout = InboxFanoutInteractor(
+            inboxTransport: transport,
+            identityRepository: identity,
+            repository: invitations,
+            debounceMilliseconds: 1
+        )
+        let runTask = Task { await fanout.run() }
+        defer { runTask.cancel() }
+
+        try await waitFor { await transport.subscribed.count >= 2 }
+        try await identity.remove(workID)
+        try await waitFor { await transport.unsubscribed.count >= 1 }
+
+        let dropped = await transport.unsubscribed
+        XCTAssertEqual(dropped.first?.rawValue, Self.expectedTag(workSummary.inboxPublicKey))
+        // The remaining identity stays subscribed.
+        let totalSubscribes = await transport.subscribed.count
+        XCTAssertEqual(totalSubscribes, 2,
+                       "subscribe is cumulative — only unsubscribe should fire on remove")
+    }
+
+    // MARK: - Inbound delivery
+
+    func test_inboundMessage_landsInRepository() async throws {
+        let activeIdentity = try await identity.bootstrap()
+        let summaries = await identity.currentIdentities()
+        let summary = try XCTUnwrap(
+            summaries.first(where: { $0.blsPublicKey == activeIdentity.blsPublicKey })
+        )
+        let tag = TransportInboxID(rawValue: Self.expectedTag(summary.inboxPublicKey))
+
+        let transport = RecordingInboxTransport()
+        let fanout = InboxFanoutInteractor(
+            inboxTransport: transport,
+            identityRepository: identity,
+            repository: invitations,
+            debounceMilliseconds: 1
+        )
+        let runTask = Task { await fanout.run() }
+        defer { runTask.cancel() }
+
+        try await waitFor { await transport.subscribed.contains(tag) }
+
+        await transport.inject(
+            InboundInbox(
+                inbox: tag,
+                payload: Data("envelope-bytes".utf8),
+                receivedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                messageID: "msg-1"
+            )
+        )
+
+        let store = invitationsStore!
+        try await waitFor { await store.count >= 1 }
+        let stored = await store.snapshot()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.id, "msg-1")
+    }
+
+    // MARK: - Helpers
+
+    /// Mirror of `IdentityRepository.inboxTag(from:)` (private). Kept
+    /// as test code so a drift in the production formula breaks here
+    /// loudly.
+    private static func expectedTag(_ inboxPublicKey: Data) -> String {
+        var hasher = _TagHasher()
+        hasher.update(Data("sep-inbox-v1".utf8))
+        hasher.update(inboxPublicKey)
+        let digest = hasher.finalize()
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Simple poll-until-true helper. The fanout uses async tasks +
+    /// debouncing, so deterministic waits aren't possible without
+    /// gluing into the interactor's internals.
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        interval: TimeInterval = 0.02,
+        _ predicate: @Sendable @escaping () async -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await predicate() { return }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("waitFor predicate never became true within \(timeout)s",
+                file: file, line: line)
+    }
+}
+
+// MARK: - Test doubles
+
+/// Tiny SHA-256 wrapper — keeps the inbox-tag derivation in the test
+/// file readable without leaking CryptoKit's API into call sites.
+private struct _TagHasher {
+    private var data = Data()
+    mutating func update(_ chunk: Data) { data.append(chunk) }
+    func finalize() -> [UInt8] { Array(SHA256.hash(data: data)) }
+}
+
+private actor RecordingInboxTransport: InboxTransport {
+    private(set) var subscribed: [TransportInboxID] = []
+    private(set) var unsubscribed: [TransportInboxID] = []
+    private var continuations: [TransportInboxID: AsyncStream<InboundInbox>.Continuation] = [:]
+
+    func connect(to endpoints: [TransportEndpoint]) async {}
+    func disconnect() async {}
+
+    func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
+        PublishReceipt(messageID: UUID().uuidString, acceptedBy: 1)
+    }
+
+    nonisolated func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
+        AsyncStream { continuation in
+            Task { await self.registerSubscription(inbox: inbox, continuation: continuation) }
+            continuation.onTermination = { _ in
+                Task { await self.releaseContinuation(inbox: inbox) }
+            }
+        }
+    }
+
+    func unsubscribe(inbox: TransportInboxID) async {
+        unsubscribed.append(inbox)
+        continuations[inbox]?.finish()
+        continuations.removeValue(forKey: inbox)
+    }
+
+    func inject(_ message: InboundInbox) {
+        continuations[message.inbox]?.yield(message)
+    }
+
+    private func registerSubscription(
+        inbox: TransportInboxID,
+        continuation: AsyncStream<InboundInbox>.Continuation
+    ) {
+        subscribed.append(inbox)
+        continuations[inbox] = continuation
+    }
+
+    private func releaseContinuation(inbox: TransportInboxID) {
+        continuations.removeValue(forKey: inbox)
+    }
+}
+
+private actor FanoutInvitationStore: InvitationStore {
+    private var rows: [String: IncomingInvitationRecord] = [:]
+
+    var count: Int { rows.count }
+    func snapshot() -> [IncomingInvitationRecord] { Array(rows.values) }
+
+    func list() -> [IncomingInvitationRecord] {
+        rows.values.sorted { $0.receivedAt > $1.receivedAt }
+    }
+
+    @discardableResult
+    func save(_ record: IncomingInvitationRecord) -> Bool {
+        guard rows[record.id] == nil else { return false }
+        rows[record.id] = record
+        return true
+    }
+
+    func updateStatus(id: String, status: IncomingInvitationStatus) {
+        guard var existing = rows[id] else { return }
+        existing = IncomingInvitationRecord(
+            id: existing.id,
+            payload: existing.payload,
+            receivedAt: existing.receivedAt,
+            status: status
+        )
+        rows[id] = existing
+    }
+
+    func delete(id: String) {
+        rows.removeValue(forKey: id)
+    }
+}


### PR DESCRIPTION
## Summary

PR **4 of 5**. Wires \`InboxTransport.subscribe\` to fan out across every persisted identity. Without this, messages addressed to a non-current identity drop on the floor.

**Base:** \`group/multi-identity-ownership\` (PR #54). Merge that first.

## What lands

- \`InboxFanoutInteractor\` — owns N concurrent per-identity subscription Tasks. Reacts to \`identitiesStream\` and reconciles via cancel + spawn. Identity-set churn is debounced (default 250ms per spec).
- \`OnymIOSApp\` constructs an \`IncomingInvitationsRepository\` and runs the fanout in a long-lived \`.task\`.

## Out of scope (deferred)

Per-identity decryption routing. The fan-out persists every envelope addressed to any of our identities, but \`IdentityRepository.decryptInvitation\` still uses the current identity's private key. Cross-identity envelopes get persisted but won't decrypt until the user switches to the target identity. Acceptance criteria don't require this for V1; lifting it is a follow-up that adds \`ownerIdentityID\` to the invitation row.

## Tests

4 new \`InboxFanoutInteractorTests\` covering subscribe-on-startup, runtime add → new subscribe, runtime remove → unsubscribe, inbound delivery → repository.

363 unit tests pass.

## Stack

- PR-1 (#52) ✅
- PR-2 (#53) ✅
- PR-3 (#54) ✅
- **PR-4 (this)**
- PR-5 — identity management UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)