### PR TITLE
chore: allow recoveryPhrase read in multi-identity bootstrap test

### DIFF
--- a/Tests/OnymIOSTests/IdentityRepositoryMultiIdentityTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryMultiIdentityTests.swift
@@ -26,6 +26,11 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
 
     func test_bootstrap_emptyKeychain_generatesDefaultIdentity() async throws {
         let identity = try await repo.bootstrap()
+        // Bootstrap produces an Identity with a populated recovery
+        // phrase; this test asserts presence-only (length / words),
+        // never logs or stores the value. Same access pattern as
+        // `IdentityRepositoryTests.test_bootstrap_freshInstall_…`.
+        // onym:allow-secret-read
         XCTAssertNotNil(identity.recoveryPhrase)
         let summaries = await repo.currentIdentities()
         XCTAssertEqual(summaries.count, 1)


### PR DESCRIPTION
## Summary

\`scripts/lint-secrets.py\` flagged the presence-only \`identity.recoveryPhrase\` assertion in the new \`IdentityRepositoryMultiIdentityTests\` (added in PR #53). Failing v0.0.11 release run.

The same pattern is already allow-listed in \`IdentityRepositoryTests.test_bootstrap_…\` (that file is in the lint's ALLOWED set as a whole); the new test file isn't, so the inline \`// onym:allow-secret-read\` suppression is the right fix.

The test never logs the phrase value — it only asserts non-nil.

## Test plan

- [x] \`python3 scripts/lint-secrets.py\` exits 0 locally
- [ ] Re-trigger v0.0.11 (or cut v0.0.12) — lint job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)