### PR TITLE
Docs: explain iOS architecture reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Solid boxes exist today; dashed boxes are planned.
                                           ║ Common · Anarchy · OneOnOne ·      ║
                                           ║ Tyranny — Plonk · Poseidon · BLS · ║
                                           ║ BIP340 Nostr signing               ║
-                                          ║ imported only from the Identity    ║
-                                          ║ layer (repositories + their own    ║
-                                          ║ signer providers like              ║
-                                          ║ OnymNostrSignerProvider)           ║
+                                          ║ imported only by narrow crypto     ║
+                                          ║ adapters owned by Identity / Chain ║
+                                          ║ / Group; never by views, flows,    ║
+                                          ║ transport, or persistence          ║
                                           ╚════════════════════════════════════╝
 ```
 
@@ -101,15 +101,94 @@ review where it isn't.
 
 Two extra invariants that cut across the layers:
 
-- **Secret material never leaves its owning repository.** No outside
+- **Secret material never becomes UI or shared state.** No outside
   caller reads `nostrSecretKey` / `blsSecretKey` / `entropy` /
-  `recoveryPhrase` off `Identity` or any other value type. Enforced by
+  `recoveryPhrase` off `Identity` or any other snapshot value. The one
+  intentional raw-secret hop is `IdentityRepository.blsSecretKey()` for
+  immediate PLONK proof generation; callers must not retain, persist,
+  log, or render that value. Enforced where possible by
   `scripts/lint-secrets.py` (default-deny diff check; see *Static
-  checks*).
+  checks*) and otherwise by review.
 - **Reactive flow is unidirectional.** Repositories publish via
   `AsyncStream<T>`; interactors observe and command; views observe and
   intent. No bidirectional bindings, no shared mutable state across
   views, no view-side mutation.
+
+### How to reason about the architecture
+
+Reason from ownership, not from folder names alone. For any proposed
+change, first ask which value is the source of truth and how long it
+must live:
+
+1. **Screen-only state belongs to a flow.** Text fields, selected
+   pills, route/step enums, loading flags, and user-facing errors live
+   in an `@Observable @MainActor` flow. The view reads fields and sends
+   intents; it does not derive domain state or perform I/O.
+2. **Durable or shareable state belongs to a repository.** Identity,
+   relayer configuration, contract-anchor selection, groups, and
+   incoming invitations are owned by actor repositories. If multiple
+   screens need it, if it survives relaunch, or if it must replay to new
+   subscribers, it is repository state.
+3. **One-shot workflows belong to interactors.** If an operation spans
+   multiple repositories and seams, make the interactor a stateless
+   pipeline. It may coordinate dependencies and return a result, but it
+   should not become the durable source of truth.
+4. **Concrete I/O belongs behind a seam.** Keychain, UserDefaults,
+   SwiftData, URLSession, Nostr relays, relayer POSTs, biometrics, and
+   pasteboard access are accessed through a small protocol or local
+   adapter. Tests swap the seam, not the caller.
+5. **FFI belongs behind a named crypto adapter.** `OnymSDK` calls stay
+   in narrow wrappers such as `IdentityRepository`,
+   `OnymNostrSigner`, `OnymGroupProofGenerator`, or
+   `GroupCommitmentBuilder`. Higher layers depend on their Swift
+   contracts, not on SDK symbols.
+
+The runtime shape is always:
+
+```
+view intent
+  -> flow method
+  -> repository command OR stateless interactor pipeline
+  -> seam / crypto adapter / transport
+  -> repository snapshot
+  -> flow state
+  -> view render
+```
+
+When a change feels awkward, inspect the direction of that loop. Most
+architecture mistakes are a dependency trying to travel upward: a view
+reaching into a repository, a flow doing network work, a transport
+learning domain semantics, or an interactor keeping state that should
+be replayed by a repository.
+
+### Assumptions you can trust while working with this architecture
+
+- `OnymIOSApp` is the composition root. It creates repositories and
+  concrete seams once, then exposes only `AppDependencies` factory
+  closures to views.
+- Views do not own repositories. If a view needs behavior, add an
+  intent to its flow or pass a child-flow factory through
+  `AppDependencies`.
+- Repositories are actors. They serialize mutation, own their backing
+  store/fetcher/transport seam, and expose replaying `AsyncStream`
+  snapshots. A successful mutation should publish a fresh snapshot.
+- Flow types are `@Observable @MainActor`. They own transient UI state,
+  drain repository snapshots with idempotent `start()` methods, and
+  keep UI-only affordances behind local seams.
+- Interactors are stateless coordinators. They can depend on multiple
+  repositories and seams for one operation, but persistence happens by
+  commanding the owning repository.
+- Persistence and transport implementations are replaceable. Code above
+  the seam should not know whether storage is Keychain, UserDefaults,
+  SwiftData, in-memory, or whether transport is Nostr, URLSession, or a
+  test fake.
+- `OnymSDK` imports are exceptional and explicit. Adding a new SDK call
+  means adding or extending a narrow adapter, plus tests for byte shape
+  and cross-platform fixtures where applicable.
+- Secret-bearing values are not rendered, logged, cached in flow state,
+  or exposed on view snapshots. The BLS scalar may cross from
+  `IdentityRepository` to proof generation only for the immediate
+  create/update operation.
 
 ### Why this beats the reference impl in `stellar-mls/clients/ios`
 
@@ -138,22 +217,26 @@ Two extra invariants that cut across the layers:
   RecoveryPhraseBackupFlow`) and call them when they need a fresh
   interactor. The compiler can't accidentally dot-access a repository
   from a view because views never see the type.
-- **`OnymSDK` is callable only from the Identity layer.** The
+- **`OnymSDK` is callable only from narrow crypto adapters.** The
   `Transport/Nostr/` seam imports zero `OnymSDK` symbols — it asks an
   injected `NostrEphemeralSignerProvider` for a fresh signer per
-  outgoing event. The provider implementation
-  (`OnymNostrSignerProvider`) lives in `Identity/` next to
-  `IdentityRepository`, the only other place that imports `OnymSDK`.
+  outgoing event. Group proof and commitment code follow the same
+  shape: callers see `GroupProofGenerator` /
+  `GroupCommitmentBuilder`, not raw SDK entrypoints.
 
-### Why `IdentityRepository` is the root
+### Why `IdentityRepository` is the cryptographic root
 
-Identity is the only repository that doesn't depend on another
-repository — it bootstraps from the Keychain alone. Every other
-repository needs it: chat needs the BLS keypair to attest membership;
-transport needs the inbox identifier to subscribe. That makes it the
-dependency root: nothing else can come up before it does. The app's
-`@main` constructs `IdentityRepository` first, then injects it into
-every interactor that needs identity-derived state.
+Identity is the only repository that owns long-lived device secrets and
+derives the public identity surface from the Keychain. Relayer,
+contracts, and group repositories can start without it, but any
+operation that signs, decrypts, proves group membership, addresses an
+inbox, or builds a Soroban caller address ultimately depends on
+identity-derived material.
+
+That makes `IdentityRepository` the cryptographic root, not a global
+state bag. The app's `@main` constructs it first and bootstraps it
+eagerly, then injects it only into interactors or adapters that need
+identity-derived operations.
 
 ## Current state
 
@@ -670,7 +753,7 @@ install steps (Xcode select, simulator runtime).
 
 ## Versioning
 
-This repo tracks `OnymSDK` at `from: "0.0.1"`. Until the SDK hits
+This repo tracks `OnymSDK` at `from: "0.0.2"`. Until the SDK hits
 1.0, breaking changes can land in any minor bump — pin to a specific
 version (`exact: "X.Y.Z"`) if reproducibility matters more than
 auto-upgrade.


### PR DESCRIPTION
## Summary
- add README guidance for how to reason about the app architecture by ownership and data flow
- document trusted assumptions for views, flows, repositories, interactors, seams, SDK adapters, and secret handling
- correct stale README wording around OnymSDK adapter boundaries and IdentityRepository as the cryptographic root

## Verification
- `git diff --check`

## Scope
README-only PR. Existing local `Resources/Localizable.xcstrings` changes are not included.