### PR TITLE
group: IntroCapability + URL helpers + interop tests (PR-1 of 7: Level-2 deeplink)

### DIFF
--- a/Sources/OnymIOS/Group/IntroCapability.swift
+++ b/Sources/OnymIOS/Group/IntroCapability.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+/// The deeplink-shareable capability for the Level-2 sender-approval
+/// invite flow. Intentionally minimal — carries **no `groupSecret`**,
+/// **no member roster**. A bearer of this capability can only do one
+/// thing: send a "request to join" to the inviter's intro inbox. The
+/// actual `GroupInvitationPayload` (with `groupSecret` + members) is
+/// sealed by the inviter only after they tap Approve.
+///
+/// ## Wire shape
+///
+/// Encoded as `Base64(JSON)` and ferried via either:
+///
+///  - `https://onym.chat/join?c=<base64>` — the Universal Link form;
+///    the OS routes it straight to the app on devices that have
+///    fetched the AASA file.
+///  - `onym://join?c=<base64>` — custom-scheme fallback for clients
+///    where Universal Link routing hasn't kicked in yet.
+///
+/// The query parameter is `c` (capability) — kept short to keep the
+/// URL pasteable through SMS-character-counted channels.
+///
+/// ## Per-invite ephemeral key
+///
+/// `introPublicKey` is a **fresh X25519 pubkey minted per invite** —
+/// never the inviter's identity inbox key. The matching private key
+/// stays on the inviter's device (PR-2 keystore). This gives the
+/// inviter per-link revocation: stop listening on a given intro tag
+/// → the link goes silent. It also means link interception doesn't
+/// leak the inviter's long-term inbox key.
+///
+/// ## What's safe to ship in `groupName`
+///
+/// Optional, plaintext, **public**. The link transits cleartext
+/// channels (Telegram, SMS, etc.) — anyone observing the link can
+/// read this string. Useful for the joiner's "join this group?"
+/// preview. For sensitive group names, leave nil and let the inviter
+/// convey context out-of-band.
+///
+/// ## Cross-platform contract
+///
+/// The wire shape mirrors onym-android's `IntroCapability.kt` byte
+/// for byte:
+///
+///  - JSON keys: `intro_pub`, `group_id`, `group_name`
+///  - Inner field encoding: standard base64 *with* padding
+///    (Swift's default `JSONEncoder.dataEncodingStrategy = .base64`,
+///     matching Android's `Base64.getEncoder()`)
+///  - Outer URL payload: URL-safe base64 *without* padding
+///    (`+`/`/` → `-`/`_`, no `=` padding)
+///  - `group_name` omitted from JSON when nil (custom `encode(to:)`
+///    using `encodeIfPresent` — matches Android's
+///    `encodeDefaults = false`)
+struct IntroCapability: Codable, Equatable, Sendable {
+    /// X25519 32-byte pubkey, freshly minted per invite. Encrypts
+    /// the joiner's request envelope; the inviter's app holds the
+    /// matching private key.
+    let introPublicKey: Data
+
+    /// 32-byte canonical bls12-381 Fr (BE). The on-chain `group_id`
+    /// the joiner is asking to join. Lets the joiner verify the
+    /// group exists on chain (`get_commitment`) before sending a
+    /// request — protects against a forged link pointing at a
+    /// non-existent group.
+    let groupId: Data
+
+    /// Optional display name. Public — see type doc.
+    let groupName: String?
+
+    static let appLinkBase = "https://onym.chat/join?c="
+    static let customSchemeBase = "onym://join?c="
+
+    enum CodingKeys: String, CodingKey {
+        case introPublicKey = "intro_pub"
+        case groupId = "group_id"
+        case groupName = "group_name"
+    }
+
+    init(introPublicKey: Data, groupId: Data, groupName: String? = nil) throws {
+        guard introPublicKey.count == 32 else {
+            throw InvalidIntroCapability.shape(
+                "introPublicKey: expected 32 bytes, got \(introPublicKey.count)"
+            )
+        }
+        guard groupId.count == 32 else {
+            throw InvalidIntroCapability.shape(
+                "groupId: expected 32 bytes, got \(groupId.count)"
+            )
+        }
+        self.introPublicKey = introPublicKey
+        self.groupId = groupId
+        self.groupName = groupName
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let pub = try c.decode(Data.self, forKey: .introPublicKey)
+        let gid = try c.decode(Data.self, forKey: .groupId)
+        guard pub.count == 32 else {
+            throw InvalidIntroCapability.shape(
+                "introPublicKey: expected 32 bytes, got \(pub.count)"
+            )
+        }
+        guard gid.count == 32 else {
+            throw InvalidIntroCapability.shape(
+                "groupId: expected 32 bytes, got \(gid.count)"
+            )
+        }
+        self.introPublicKey = pub
+        self.groupId = gid
+        self.groupName = try c.decodeIfPresent(String.self, forKey: .groupName)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(introPublicKey, forKey: .introPublicKey)
+        try c.encode(groupId, forKey: .groupId)
+        try c.encodeIfPresent(groupName, forKey: .groupName)
+    }
+
+    /// Encode to the base64-of-JSON payload that lands in the URL
+    /// query string. URL-safe base64 (no `=` padding, no `+`/`/`)
+    /// so the result drops straight into a query without
+    /// percent-encoding.
+    func encode() -> String {
+        let json: Data
+        do {
+            json = try Self.jsonEncoder.encode(self)
+        } catch {
+            preconditionFailure("IntroCapability JSON encode failed: \(error)")
+        }
+        return Self.urlSafeNoPaddingBase64(json)
+    }
+
+    /// Build the Universal Link form. Drop into a share sheet or
+    /// a chat message body.
+    func toAppLink() -> String { "\(Self.appLinkBase)\(encode())" }
+
+    /// Build the custom-scheme fallback. Same payload, different
+    /// scheme — for testing in environments where Universal Link
+    /// routing hasn't been validated yet.
+    func toCustomSchemeLink() -> String { "\(Self.customSchemeBase)\(encode())" }
+
+    /// Inverse of `encode()`. Throws `InvalidIntroCapability` on any
+    /// malformed input (bad base64, bad JSON, wrong key sizes).
+    static func decode(_ payload: String) throws -> IntroCapability {
+        guard let raw = urlSafeNoPaddingBase64Decode(payload) else {
+            throw InvalidIntroCapability.base64("base64 decode failed")
+        }
+        do {
+            return try jsonDecoder.decode(IntroCapability.self, from: raw)
+        } catch let err as InvalidIntroCapability {
+            throw err
+        } catch let DecodingError.dataCorrupted(ctx) {
+            throw InvalidIntroCapability.json("JSON decode failed: \(ctx.debugDescription)")
+        } catch let DecodingError.keyNotFound(key, _) {
+            throw InvalidIntroCapability.json("missing required key: \(key.stringValue)")
+        } catch let DecodingError.typeMismatch(_, ctx) {
+            throw InvalidIntroCapability.json("type mismatch: \(ctx.debugDescription)")
+        } catch let DecodingError.valueNotFound(_, ctx) {
+            throw InvalidIntroCapability.json("missing value: \(ctx.debugDescription)")
+        } catch {
+            throw InvalidIntroCapability.json("decode failed: \(error)")
+        }
+    }
+
+    /// Pull the `c=…` query parameter out of any link form
+    /// (`appLinkBase` or `customSchemeBase`) + decode it. Returns
+    /// nil if the URL doesn't carry a capability — caller decides
+    /// whether that's an error.
+    static func fromLink(_ link: String) -> IntroCapability? {
+        guard let url = URL(string: link),
+              let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return nil }
+        guard let items = comps.queryItems else { return nil }
+        for item in items where item.name == "c" {
+            if let value = item.value {
+                return try? decode(value)
+            }
+        }
+        return nil
+    }
+
+    /// Build a share-text payload bundling the link with a human
+    /// nudge. Inviter pastes this into their share-sheet target.
+    static func shareText(link: String, groupName: String?) -> String {
+        if let name = groupName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !name.isEmpty {
+            return "Join \"\(name)\" on Onym: \(link)"
+        }
+        return "Join my chat on Onym: \(link)"
+    }
+
+    // MARK: - URL-safe base64 helpers
+
+    private static func urlSafeNoPaddingBase64(_ data: Data) -> String {
+        var s = data.base64EncodedString()
+        s = s.replacingOccurrences(of: "+", with: "-")
+        s = s.replacingOccurrences(of: "/", with: "_")
+        while s.hasSuffix("=") { s.removeLast() }
+        return s
+    }
+
+    private static func urlSafeNoPaddingBase64Decode(_ s: String) -> Data? {
+        var t = s.replacingOccurrences(of: "-", with: "+")
+        t = t.replacingOccurrences(of: "_", with: "/")
+        let pad = (4 - t.count % 4) % 4
+        t.append(String(repeating: "=", count: pad))
+        return Data(base64Encoded: t)
+    }
+
+    private static let jsonEncoder: JSONEncoder = {
+        let e = JSONEncoder()
+        // Default `.base64` + matches Android `Base64.getEncoder()`.
+        e.dataEncodingStrategy = .base64
+        return e
+    }()
+
+    private static let jsonDecoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dataDecodingStrategy = .base64
+        return d
+    }()
+}
+
+/// Decode-side failures from `IntroCapability.decode` /
+/// `IntroCapability.fromLink`. Caller maps to user-facing copy.
+enum InvalidIntroCapability: Error, Equatable, CustomStringConvertible {
+    case base64(String)
+    case json(String)
+    case shape(String)
+
+    var description: String {
+        switch self {
+        case .base64(let m): return "InvalidIntroCapability(base64): \(m)"
+        case .json(let m): return "InvalidIntroCapability(json): \(m)"
+        case .shape(let m): return "InvalidIntroCapability(shape): \(m)"
+        }
+    }
+}

--- a/Tests/OnymIOSTests/IntroCapabilityInteropTests.swift
+++ b/Tests/OnymIOSTests/IntroCapabilityInteropTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import OnymIOS
+
+/// Cross-platform wire-format pin. The hand-constructed JSON byte
+/// patterns below MUST decode to the same `IntroCapability` on both
+/// onym-ios and onym-android — and a matching test in
+/// `IntroCapabilityInteropTest.kt` MUST cover the same vectors. Keep
+/// the two in lockstep; never edit one without also updating the
+/// other.
+///
+/// Why hand-constructed JSON instead of re-encoded base64 strings?
+/// JSON object key order isn't semantically meaningful, but
+/// `JSONEncoder` and `kotlinx.serialization.Json` don't promise
+/// matching key ordering on emit. So we pin the **decoder** contract
+/// — given identical input bytes, both platforms produce identical
+/// `IntroCapability` values — and let each platform freely re-encode
+/// its own way. The roundtrip test inside the same suite still
+/// proves encoder→decoder is a closed loop on each platform.
+final class IntroCapabilityInteropTests: XCTestCase {
+
+    // MARK: - Vector A — minimal, no group_name
+
+    /// `intro_pub` is 32 bytes of `0x01`, `group_id` is 32 bytes of
+    /// `0x02`. Inner base64 uses standard alphabet **with padding**
+    /// (Swift `JSONEncoder` `.base64` default + Android
+    /// `Base64.getEncoder()`). 32 bytes encodes to 44 base64 chars
+    /// (32 * 4/3 rounded up + padding).
+    func test_vectorA_decodesMinimalShape() throws {
+        let pub = Data(repeating: 0x01, count: 32)
+        let gid = Data(repeating: 0x02, count: 32)
+        let pubB64 = pub.base64EncodedString()  // 44 chars w/ trailing '='
+        let gidB64 = gid.base64EncodedString()
+        let json = #"{"intro_pub":"\#(pubB64)","group_id":"\#(gidB64)"}"#
+
+        let payload = Self.urlSafeBase64NoPadding(json.data(using: .utf8)!)
+        let cap = try IntroCapability.decode(payload)
+
+        XCTAssertEqual(cap.introPublicKey, pub)
+        XCTAssertEqual(cap.groupId, gid)
+        XCTAssertNil(cap.groupName, "Vector A omits group_name → must decode to nil")
+    }
+
+    // MARK: - Vector B — with group_name "Family"
+
+    func test_vectorB_decodesWithGroupName() throws {
+        let pub = Data((0..<32).map { UInt8($0) })          // 0x00..0x1F
+        let gid = Data((0..<32).map { UInt8(0xFF - $0) })   // 0xFF..0xE0
+        let pubB64 = pub.base64EncodedString()
+        let gidB64 = gid.base64EncodedString()
+        let json = #"{"intro_pub":"\#(pubB64)","group_id":"\#(gidB64)","group_name":"Family"}"#
+
+        let payload = Self.urlSafeBase64NoPadding(json.data(using: .utf8)!)
+        let cap = try IntroCapability.decode(payload)
+
+        XCTAssertEqual(cap.introPublicKey, pub)
+        XCTAssertEqual(cap.groupId, gid)
+        XCTAssertEqual(cap.groupName, "Family")
+    }
+
+    // MARK: - Vector C — group_name with non-ASCII (UTF-8 quoted)
+
+    /// Confirms UTF-8 round-trips through both platforms' JSON
+    /// readers — group names like "Семья" or "👨‍👩‍👧" must survive
+    /// the wire intact.
+    func test_vectorC_decodesUtf8GroupName() throws {
+        let pub = Data(repeating: 0xAB, count: 32)
+        let gid = Data(repeating: 0xCD, count: 32)
+        let pubB64 = pub.base64EncodedString()
+        let gidB64 = gid.base64EncodedString()
+        // "Семья 👨‍👩‍👧" — Cyrillic + ZWJ-emoji sequence. JSON requires
+        // either raw UTF-8 or `\uXXXX` escapes; we ship raw UTF-8
+        // since both `JSONEncoder` and `kotlinx.serialization` emit
+        // raw by default.
+        let groupName = "Семья 👨‍👩‍👧"
+        let json = #"{"intro_pub":"\#(pubB64)","group_id":"\#(gidB64)","group_name":"\#(groupName)"}"#
+
+        let payload = Self.urlSafeBase64NoPadding(json.data(using: .utf8)!)
+        let cap = try IntroCapability.decode(payload)
+
+        XCTAssertEqual(cap.introPublicKey, pub)
+        XCTAssertEqual(cap.groupId, gid)
+        XCTAssertEqual(cap.groupName, groupName)
+    }
+
+    // MARK: - Reverse direction: iOS-minted payload must round-trip
+
+    /// Encoder smoke check: decode our own emit + reconstruct.
+    /// Per-platform encoders may differ in key order, but a
+    /// freshly-minted payload must always decode back to the same
+    /// values on the same platform. Pair with a Kotlin
+    /// `@Test fun encodedHere_decodesOnAndroid()` in the matching
+    /// PR on Android.
+    func test_iosEncoded_decodesBack() throws {
+        let original = try IntroCapability(
+            introPublicKey: Data((0..<32).map { UInt8(($0 * 13 + 7) & 0xFF) }),
+            groupId: Data((0..<32).map { UInt8(($0 * 17 + 5) & 0xFF) }),
+            groupName: "Crew"
+        )
+        let payload = original.encode()
+        let decoded = try IntroCapability.decode(payload)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - Helpers
+
+    private static func urlSafeBase64NoPadding(_ data: Data) -> String {
+        var s = data.base64EncodedString()
+        s = s.replacingOccurrences(of: "+", with: "-")
+        s = s.replacingOccurrences(of: "/", with: "_")
+        while s.hasSuffix("=") { s.removeLast() }
+        return s
+    }
+}

--- a/Tests/OnymIOSTests/IntroCapabilityTests.swift
+++ b/Tests/OnymIOSTests/IntroCapabilityTests.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import OnymIOS
+
+/// Wire-format pin for `IntroCapability`. The shape is the contract
+/// onym-android already ships — keep it stable. Mirrors
+/// `IntroCapabilityTest.kt` test-for-test.
+final class IntroCapabilityTests: XCTestCase {
+
+    private let sampleIntroPub = Data(repeating: 0xAA, count: 32)
+    private let sampleGroupId = Data(repeating: 0x42, count: 32)
+
+    // MARK: - roundtrip
+
+    func test_roundtrip_minimalShape_preservesAllFields() throws {
+        let original = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: nil
+        )
+        let encoded = original.encode()
+        let decoded = try IntroCapability.decode(encoded)
+        XCTAssertEqual(original, decoded)
+    }
+
+    func test_roundtrip_withGroupName_preservesAllFields() throws {
+        let original = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "Family"
+        )
+        let encoded = original.encode()
+        let decoded = try IntroCapability.decode(encoded)
+        XCTAssertEqual(original, decoded)
+        XCTAssertEqual(decoded.groupName, "Family")
+    }
+
+    func test_encode_isUrlSafeBase64_noPaddingOrSpecialChars() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "test"
+        )
+        let encoded = cap.encode()
+        XCTAssertFalse(encoded.contains("+"), "no `+` in URL-safe encoding")
+        XCTAssertFalse(encoded.contains("/"), "no `/` in URL-safe encoding")
+        XCTAssertFalse(encoded.contains("="), "no `=` padding")
+        XCTAssertFalse(encoded.contains(where: { $0.isWhitespace }), "no whitespace")
+    }
+
+    // MARK: - link forms
+
+    func test_toAppLink_isOnymChatJoinPath() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId
+        )
+        XCTAssertTrue(cap.toAppLink().hasPrefix("https://onym.chat/join?c="))
+    }
+
+    func test_toCustomSchemeLink_isOnymJoinScheme() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId
+        )
+        XCTAssertTrue(cap.toCustomSchemeLink().hasPrefix("onym://join?c="))
+    }
+
+    // MARK: - fromLink
+
+    func test_fromLink_appLinkForm_decodesBackToOriginal() throws {
+        let original = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "Crew"
+        )
+        let parsed = IntroCapability.fromLink(original.toAppLink())
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed, original)
+    }
+
+    func test_fromLink_customSchemeForm_decodesBackToOriginal() throws {
+        let original = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "Crew"
+        )
+        let parsed = IntroCapability.fromLink(original.toCustomSchemeLink())
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed, original)
+    }
+
+    func test_fromLink_extraQueryParams_returnsCapability_ignoringExtras() throws {
+        // Future schemas may grow tracking params (utm_*, etc.) — the
+        // parser must pluck `c=` and ignore the rest.
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "X"
+        )
+        let link = "\(cap.toAppLink())&utm_source=share-sheet&ref=foo"
+        let parsed = IntroCapability.fromLink(link)
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed, cap)
+    }
+
+    func test_fromLink_missingCapabilityParam_returnsNull() {
+        XCTAssertNil(IntroCapability.fromLink("https://onym.chat/join"))
+        XCTAssertNil(IntroCapability.fromLink("https://onym.chat/join?other=value"))
+    }
+
+    func test_fromLink_malformedUri_returnsNull() {
+        XCTAssertNil(IntroCapability.fromLink("not a url"))
+        XCTAssertNil(IntroCapability.fromLink(""))
+    }
+
+    // MARK: - decode failure modes
+
+    func test_decode_invalidBase64_throwsInvalidIntroCapability() {
+        XCTAssertThrowsError(try IntroCapability.decode("@@@not-base64@@@")) { error in
+            guard let err = error as? InvalidIntroCapability else {
+                return XCTFail("expected InvalidIntroCapability, got \(error)")
+            }
+            if case .base64 = err { /* ok */ } else {
+                XCTFail("expected .base64 case, got \(err)")
+            }
+        }
+    }
+
+    func test_decode_validBase64_butNotJson_throwsInvalidIntroCapability() {
+        let notJson = Self.urlSafeBase64("not json at all".data(using: .utf8)!)
+        XCTAssertThrowsError(try IntroCapability.decode(notJson)) { error in
+            XCTAssertTrue(error is InvalidIntroCapability)
+        }
+    }
+
+    func test_decode_validJson_butWrongPubkeySize_throwsInvalidIntroCapability() {
+        let badShape = #"{"intro_pub":"AAA=","group_id":"AAA="}"#
+        let encoded = Self.urlSafeBase64(badShape.data(using: .utf8)!)
+        XCTAssertThrowsError(try IntroCapability.decode(encoded)) { error in
+            guard let err = error as? InvalidIntroCapability else {
+                return XCTFail("expected InvalidIntroCapability, got \(error)")
+            }
+            if case .shape = err { /* ok */ } else {
+                XCTFail("expected .shape case, got \(err)")
+            }
+        }
+    }
+
+    // MARK: - constructor
+
+    func test_constructor_rejectsWrongSizedKeys() {
+        XCTAssertThrowsError(try IntroCapability(
+            introPublicKey: Data(repeating: 0, count: 31),
+            groupId: sampleGroupId
+        )) { error in
+            XCTAssertTrue(error is InvalidIntroCapability)
+        }
+        XCTAssertThrowsError(try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: Data(repeating: 0, count: 33)
+        )) { error in
+            XCTAssertTrue(error is InvalidIntroCapability)
+        }
+    }
+
+    // MARK: - shareText
+
+    func test_shareText_includesGroupName_whenSet() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "Friends"
+        )
+        let text = IntroCapability.shareText(link: cap.toAppLink(), groupName: cap.groupName)
+        XCTAssertTrue(text.contains("\"Friends\""))
+        XCTAssertTrue(text.contains("https://onym.chat/join?c="))
+    }
+
+    func test_shareText_omitsGroupName_whenBlankOrNull() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId
+        )
+        let text = IntroCapability.shareText(link: cap.toAppLink(), groupName: cap.groupName)
+        XCTAssertFalse(text.contains("\""), "no quoted name when nil")
+        XCTAssertTrue(text.contains("Join my chat"))
+    }
+
+    // MARK: - byte-level
+
+    func test_roundtrip_byteForByteIntroPub_isPreserved() throws {
+        // Random-ish bytes — base64+JSON+base64 must not mutate any
+        // byte position.
+        let pub = Data((0..<32).map { UInt8(($0 * 7 + 13) & 0xFF) })
+        let gid = Data((0..<32).map { UInt8(($0 * 11 + 3) & 0xFF) })
+        let cap = try IntroCapability(introPublicKey: pub, groupId: gid, groupName: "X")
+        let decoded = try IntroCapability.decode(cap.encode())
+        XCTAssertEqual(decoded.introPublicKey, pub)
+        XCTAssertEqual(decoded.groupId, gid)
+    }
+
+    // MARK: - Helpers
+
+    private static func urlSafeBase64(_ data: Data) -> String {
+        var s = data.base64EncodedString()
+        s = s.replacingOccurrences(of: "+", with: "-")
+        s = s.replacingOccurrences(of: "/", with: "_")
+        while s.hasSuffix("=") { s.removeLast() }
+        return s
+    }
+}


### PR DESCRIPTION
## Summary

PR-1 of a 7-PR vertical stack implementing the Level-2 sender-approval deeplink invitation flow on onym-ios — wire-format-equivalent with what's shipping on onym-android.

This PR introduces the `IntroCapability` value type — the deeplink-shareable Level-2 invite capability. Carries **no `groupSecret`** and **no member roster** (Level-2 means: only the inviter can complete the invite, by tapping Approve in their app after the joiner sends a request).

**Wire shape:**
- JSON keys: `intro_pub` (32B X25519 pub), `group_id` (32B), `group_name` (optional)
- Inner field encoding: standard base64 *with* padding
- Outer URL payload: URL-safe base64 *without* padding
- `group_name` omitted from JSON when `nil` (custom encoder using `encodeIfPresent` — matches Kotlin's `encodeDefaults = false`)
- Universal Link form: `https://onym.chat/join?c=<base64>`
- Custom-scheme fallback: `onym://join?c=<base64>`

## Cross-platform contract

Mirrors onym-android's [`IntroCapability.kt`](https://github.com/onymchat/onym-android/blob/main/app/src/main/kotlin/chat/onym/android/group/IntroCapability.kt) (PR #60). The interop tests pin the **decoder** contract: given identical input JSON bytes, both platforms produce identical `IntroCapability` values. We don't pin re-encoded base64 strings because JSON object key ordering isn't promised by either `JSONEncoder` or `kotlinx.serialization.Json`. The roundtrip tests still prove encoder→decoder is a closed loop on each platform.

## Test coverage (21 cases)

**`IntroCapabilityTests` (17):**
- minimal + with-name roundtrip
- URL-safe base64 emit
- App-link / custom-scheme link forms
- `fromLink` with extras / missing / malformed
- decode failure modes (bad base64, bad JSON, wrong-sized keys)
- constructor size validation
- `shareText` copy with/without group name
- byte-for-byte preservation under random input

**`IntroCapabilityInteropTests` (4):**
- Vector A: minimal shape, no `group_name`
- Vector B: with `group_name`
- Vector C: UTF-8 `group_name` (Cyrillic + ZWJ-emoji)
- iOS-encoded → iOS-decoded roundtrip

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests/IntroCapabilityTests -only-testing:OnymIOSTests/IntroCapabilityInteropTests` — 21/21 pass locally on iPhone 17 Pro simulator
- [ ] CI green
- [ ] Coordinated with onym-android PR #60 (matching wire format)

## Stack

This is PR 1 of 7. Subsequent PRs:
2. `identity/intro-keystore` — `IntroKeyEntry`, `KeychainIntroKeyStore`, `InviteIntroducer`
3. `transport/intro-inbox-subscription` — Nostr inbox pump for intro requests
4. `group/join-request` — `JoinRequestPayload`, sender + approver
5. `ux/share-invite-link` — share-sheet UI on the create-group success screen
6. `transport/deeplink-intent-filter` — Universal Link + URL scheme wiring
7. `ux/joinscreen` — join screen UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)