### PR TITLE
identity: intro keystore + InviteIntroducer (PR-2 of 7: Level-2 deeplink)

### DIFF
--- a/Sources/OnymIOS/Group/IntroCapability.swift
+++ b/Sources/OnymIOS/Group/IntroCapability.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+/// The deeplink-shareable capability for the Level-2 sender-approval
+/// invite flow. Intentionally minimal — carries **no `groupSecret`**,
+/// **no member roster**. A bearer of this capability can only do one
+/// thing: send a "request to join" to the inviter's intro inbox. The
+/// actual `GroupInvitationPayload` (with `groupSecret` + members) is
+/// sealed by the inviter only after they tap Approve.
+///
+/// ## Wire shape
+///
+/// Encoded as `Base64(JSON)` and ferried via either:
+///
+///  - `https://onym.chat/join?c=<base64>` — the Universal Link form;
+///    the OS routes it straight to the app on devices that have
+///    fetched the AASA file.
+///  - `onym://join?c=<base64>` — custom-scheme fallback for clients
+///    where Universal Link routing hasn't kicked in yet.
+///
+/// The query parameter is `c` (capability) — kept short to keep the
+/// URL pasteable through SMS-character-counted channels.
+///
+/// ## Per-invite ephemeral key
+///
+/// `introPublicKey` is a **fresh X25519 pubkey minted per invite** —
+/// never the inviter's identity inbox key. The matching private key
+/// stays on the inviter's device (PR-2 keystore). This gives the
+/// inviter per-link revocation: stop listening on a given intro tag
+/// → the link goes silent. It also means link interception doesn't
+/// leak the inviter's long-term inbox key.
+///
+/// ## What's safe to ship in `groupName`
+///
+/// Optional, plaintext, **public**. The link transits cleartext
+/// channels (Telegram, SMS, etc.) — anyone observing the link can
+/// read this string. Useful for the joiner's "join this group?"
+/// preview. For sensitive group names, leave nil and let the inviter
+/// convey context out-of-band.
+///
+/// ## Cross-platform contract
+///
+/// The wire shape mirrors onym-android's `IntroCapability.kt` byte
+/// for byte:
+///
+///  - JSON keys: `intro_pub`, `group_id`, `group_name`
+///  - Inner field encoding: standard base64 *with* padding
+///    (Swift's default `JSONEncoder.dataEncodingStrategy = .base64`,
+///     matching Android's `Base64.getEncoder()`)
+///  - Outer URL payload: URL-safe base64 *without* padding
+///    (`+`/`/` → `-`/`_`, no `=` padding)
+///  - `group_name` omitted from JSON when nil (custom `encode(to:)`
+///    using `encodeIfPresent` — matches Android's
+///    `encodeDefaults = false`)
+struct IntroCapability: Codable, Equatable, Sendable {
+    /// X25519 32-byte pubkey, freshly minted per invite. Encrypts
+    /// the joiner's request envelope; the inviter's app holds the
+    /// matching private key.
+    let introPublicKey: Data
+
+    /// 32-byte canonical bls12-381 Fr (BE). The on-chain `group_id`
+    /// the joiner is asking to join. Lets the joiner verify the
+    /// group exists on chain (`get_commitment`) before sending a
+    /// request — protects against a forged link pointing at a
+    /// non-existent group.
+    let groupId: Data
+
+    /// Optional display name. Public — see type doc.
+    let groupName: String?
+
+    static let appLinkBase = "https://onym.chat/join?c="
+    static let customSchemeBase = "onym://join?c="
+
+    enum CodingKeys: String, CodingKey {
+        case introPublicKey = "intro_pub"
+        case groupId = "group_id"
+        case groupName = "group_name"
+    }
+
+    init(introPublicKey: Data, groupId: Data, groupName: String? = nil) throws {
+        guard introPublicKey.count == 32 else {
+            throw InvalidIntroCapability.shape(
+                "introPublicKey: expected 32 bytes, got \(introPublicKey.count)"
+            )
+        }
+        guard groupId.count == 32 else {
+            throw InvalidIntroCapability.shape(
+                "groupId: expected 32 bytes, got \(groupId.count)"
+            )
+        }
+        self.introPublicKey = introPublicKey
+        self.groupId = groupId
+        self.groupName = groupName
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let pub = try c.decode(Data.self, forKey: .introPublicKey)
+        let gid = try c.decode(Data.self, forKey: .groupId)
+        guard pub.count == 32 else {
+            throw InvalidIntroCapability.shape(
+                "introPublicKey: expected 32 bytes, got \(pub.count)"
+            )
+        }
+        guard gid.count == 32 else {
+            throw InvalidIntroCapability.shape(
+                "groupId: expected 32 bytes, got \(gid.count)"
+            )
+        }
+        self.introPublicKey = pub
+        self.groupId = gid
+        self.groupName = try c.decodeIfPresent(String.self, forKey: .groupName)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(introPublicKey, forKey: .introPublicKey)
+        try c.encode(groupId, forKey: .groupId)
+        try c.encodeIfPresent(groupName, forKey: .groupName)
+    }
+
+    /// Encode to the base64-of-JSON payload that lands in the URL
+    /// query string. URL-safe base64 (no `=` padding, no `+`/`/`)
+    /// so the result drops straight into a query without
+    /// percent-encoding.
+    func encode() -> String {
+        let json: Data
+        do {
+            json = try Self.jsonEncoder.encode(self)
+        } catch {
+            preconditionFailure("IntroCapability JSON encode failed: \(error)")
+        }
+        return Self.urlSafeNoPaddingBase64(json)
+    }
+
+    /// Build the Universal Link form. Drop into a share sheet or
+    /// a chat message body.
+    func toAppLink() -> String { "\(Self.appLinkBase)\(encode())" }
+
+    /// Build the custom-scheme fallback. Same payload, different
+    /// scheme — for testing in environments where Universal Link
+    /// routing hasn't been validated yet.
+    func toCustomSchemeLink() -> String { "\(Self.customSchemeBase)\(encode())" }
+
+    /// Inverse of `encode()`. Throws `InvalidIntroCapability` on any
+    /// malformed input (bad base64, bad JSON, wrong key sizes).
+    static func decode(_ payload: String) throws -> IntroCapability {
+        guard let raw = urlSafeNoPaddingBase64Decode(payload) else {
+            throw InvalidIntroCapability.base64("base64 decode failed")
+        }
+        do {
+            return try jsonDecoder.decode(IntroCapability.self, from: raw)
+        } catch let err as InvalidIntroCapability {
+            throw err
+        } catch let DecodingError.dataCorrupted(ctx) {
+            throw InvalidIntroCapability.json("JSON decode failed: \(ctx.debugDescription)")
+        } catch let DecodingError.keyNotFound(key, _) {
+            throw InvalidIntroCapability.json("missing required key: \(key.stringValue)")
+        } catch let DecodingError.typeMismatch(_, ctx) {
+            throw InvalidIntroCapability.json("type mismatch: \(ctx.debugDescription)")
+        } catch let DecodingError.valueNotFound(_, ctx) {
+            throw InvalidIntroCapability.json("missing value: \(ctx.debugDescription)")
+        } catch {
+            throw InvalidIntroCapability.json("decode failed: \(error)")
+        }
+    }
+
+    /// Pull the `c=…` query parameter out of any link form
+    /// (`appLinkBase` or `customSchemeBase`) + decode it. Returns
+    /// nil if the URL doesn't carry a capability — caller decides
+    /// whether that's an error.
+    static func fromLink(_ link: String) -> IntroCapability? {
+        guard let url = URL(string: link),
+              let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return nil }
+        guard let items = comps.queryItems else { return nil }
+        for item in items where item.name == "c" {
+            if let value = item.value {
+                return try? decode(value)
+            }
+        }
+        return nil
+    }
+
+    /// Build a share-text payload bundling the link with a human
+    /// nudge. Inviter pastes this into their share-sheet target.
+    static func shareText(link: String, groupName: String?) -> String {
+        if let name = groupName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !name.isEmpty {
+            return "Join \"\(name)\" on Onym: \(link)"
+        }
+        return "Join my chat on Onym: \(link)"
+    }
+
+    // MARK: - URL-safe base64 helpers
+
+    private static func urlSafeNoPaddingBase64(_ data: Data) -> String {
+        var s = data.base64EncodedString()
+        s = s.replacingOccurrences(of: "+", with: "-")
+        s = s.replacingOccurrences(of: "/", with: "_")
+        while s.hasSuffix("=") { s.removeLast() }
+        return s
+    }
+
+    private static func urlSafeNoPaddingBase64Decode(_ s: String) -> Data? {
+        var t = s.replacingOccurrences(of: "-", with: "+")
+        t = t.replacingOccurrences(of: "_", with: "/")
+        let pad = (4 - t.count % 4) % 4
+        t.append(String(repeating: "=", count: pad))
+        return Data(base64Encoded: t)
+    }
+
+    private static let jsonEncoder: JSONEncoder = {
+        let e = JSONEncoder()
+        // Default `.base64` + matches Android `Base64.getEncoder()`.
+        e.dataEncodingStrategy = .base64
+        return e
+    }()
+
+    private static let jsonDecoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dataDecodingStrategy = .base64
+        return d
+    }()
+}
+
+/// Decode-side failures from `IntroCapability.decode` /
+/// `IntroCapability.fromLink`. Caller maps to user-facing copy.
+enum InvalidIntroCapability: Error, Equatable, CustomStringConvertible {
+    case base64(String)
+    case json(String)
+    case shape(String)
+
+    var description: String {
+        switch self {
+        case .base64(let m): return "InvalidIntroCapability(base64): \(m)"
+        case .json(let m): return "InvalidIntroCapability(json): \(m)"
+        case .shape(let m): return "InvalidIntroCapability(shape): \(m)"
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/IntroKeyEntry.swift
+++ b/Sources/OnymIOS/Group/IntroKeyEntry.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// One per-invite ephemeral keypair persisted on the inviter's
+/// device. Maps an invite link's `introPublicKey` (the public half
+/// shipped in the `IntroCapability` inside the link) to its private
+/// counterpart + the metadata needed to dispatch a sealed
+/// `GroupInvitationPayload` when an approved request comes in.
+///
+/// - `introPrivateKey` is X25519 secret material — used to decrypt
+///   the joiner's request envelope. Never logged. Per-invite, so
+///   leaking one doesn't compromise unrelated invites.
+/// - `ownerIdentityID` scopes the entry to the identity that minted
+///   the link. Identity removal cascades a `deleteForOwner` so we
+///   don't leak intro privkeys past the identity that minted them.
+/// - `groupId` is the on-chain `group_id` the invite is for —
+///   needed when the inviter's app surfaces "Bob wants to join
+///   <group>?" so it can render the group's name.
+/// - `createdAt` drives optional expiration UI (later PRs may
+///   prune invites older than N days).
+struct IntroKeyEntry: Equatable, Sendable {
+    let introPublicKey: Data
+    let introPrivateKey: Data
+    let ownerIdentityID: IdentityID
+    let groupId: Data
+    let createdAt: Date
+
+    init(
+        introPublicKey: Data,
+        introPrivateKey: Data,
+        ownerIdentityID: IdentityID,
+        groupId: Data,
+        createdAt: Date
+    ) {
+        precondition(introPublicKey.count == 32,
+                     "introPublicKey: expected 32 bytes, got \(introPublicKey.count)")
+        precondition(introPrivateKey.count == 32,
+                     "introPrivateKey: expected 32 bytes, got \(introPrivateKey.count)")
+        precondition(groupId.count == 32,
+                     "groupId: expected 32 bytes, got \(groupId.count)")
+        self.introPublicKey = introPublicKey
+        self.introPrivateKey = introPrivateKey
+        self.ownerIdentityID = ownerIdentityID
+        self.groupId = groupId
+        self.createdAt = createdAt
+    }
+}

--- a/Sources/OnymIOS/Group/IntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/IntroKeyStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Persistence seam for per-invite ephemeral X25519 keypairs.
+///
+/// Lifecycle of one entry:
+///
+///  1. Sender taps "Share invite" → app mints a fresh X25519 keypair
+///     via `InviteIntroducer.mint`, persists via `save`.
+///  2. Joiner taps the deeplink → app sends a request envelope
+///     encrypted to `IntroKeyEntry.introPublicKey` over Nostr.
+///  3. Sender's intro-inbox fan-out (PR-3) receives → calls `find`
+///     with the targeted introPublicKey → uses
+///     `IntroKeyEntry.introPrivateKey` to decrypt the request
+///     payload.
+///  4. On Approve, sender seals the existing
+///     `GroupInvitationPayload` to the joiner's identity inbox key.
+///     `revoke` is called to retire the intro slot.
+///
+/// Owner-scoping: every entry carries an `IdentityID`. Removing an
+/// identity cascades a `deleteForOwner` so we don't leak intro
+/// privkeys past the identity that minted them — wired in PR-3 via
+/// `IdentityRepository`'s removal listeners.
+protocol IntroKeyStore: Sendable {
+    /// Persist a freshly-minted intro entry. Idempotent on
+    /// `IntroKeyEntry.introPublicKey` — re-mint with the same pub
+    /// is a no-op (shouldn't happen in practice; X25519 keypairs
+    /// are uniformly random).
+    func save(_ entry: IntroKeyEntry) async
+
+    /// Look up an entry by its public key. Returns nil when the
+    /// pubkey is unknown — happens when an old entry was
+    /// `revoke`d, or when a request envelope targets a pubkey
+    /// this device never minted (probably a forged link).
+    func find(introPublicKey: Data) async -> IntroKeyEntry?
+
+    /// Every entry minted by `ownerIdentityID`. Sorted newest
+    /// first by `IntroKeyEntry.createdAt`. UI's "Active invites"
+    /// list reads here.
+    func listForOwner(_ ownerIdentityID: IdentityID) async -> [IntroKeyEntry]
+
+    /// Single-entry deletion. Called after a request is accepted +
+    /// sealed → the intro slot is no longer useful. No-op if the
+    /// pubkey isn't present.
+    func revoke(introPublicKey: Data) async
+
+    /// Cascade for the identity-removal flow. Returns the count of
+    /// entries deleted so the caller can log the cleanup size.
+    /// Hooked into `IdentityRepository`'s removal listeners.
+    @discardableResult
+    func deleteForOwner(_ ownerIdentityID: IdentityID) async -> Int
+}

--- a/Sources/OnymIOS/Group/InviteIntroducer.swift
+++ b/Sources/OnymIOS/Group/InviteIntroducer.swift
@@ -1,0 +1,72 @@
+import Foundation
+import CryptoKit
+
+/// Mints fresh per-invite X25519 keypairs and persists them via
+/// `IntroKeyStore`. Returns an `IntroCapability` (the public-facing
+/// deeplink payload) — the caller drops it into a deeplink URL and
+/// shares.
+///
+/// **Threading**: actor-isolated. Keypair generation is microseconds;
+/// the Keychain write is the dominant cost (single `SecItemUpdate`).
+/// Cheap enough for the foreground tap handler to await directly.
+///
+/// **Why one keypair per invite instead of one per identity**: per-
+/// link revocation. The inviter can stop listening on a specific
+/// intro tag → that link goes silent without affecting other
+/// outstanding invites. A leaked link only burns its own slot.
+actor InviteIntroducer {
+    private let store: any IntroKeyStore
+    private let now: @Sendable () -> Date
+
+    init(store: any IntroKeyStore, now: @escaping @Sendable () -> Date = { Date() }) {
+        self.store = store
+        self.now = now
+    }
+
+    /// Mint a fresh intro keypair, persist it, and return the
+    /// `IntroCapability` the caller will pack into a deeplink URL.
+    ///
+    /// - Parameters:
+    ///   - ownerIdentityID: the identity that's inviting. Used for
+    ///     cascade-delete when the identity is removed.
+    ///   - groupId: the on-chain `group_id` the invite is for.
+    ///     Must be 32 bytes — throws `IntroducerError.invalidGroupID`
+    ///     otherwise.
+    ///   - groupName: optional plaintext name surfaced in the deeplink
+    ///     for the joiner's preview. Pass nil for groups whose name
+    ///     is sensitive (deeplink transits cleartext channels).
+    func mint(
+        ownerIdentityID: IdentityID,
+        groupId: Data,
+        groupName: String? = nil
+    ) async throws -> IntroCapability {
+        guard groupId.count == 32 else {
+            throw IntroducerError.invalidGroupID(actualSize: groupId.count)
+        }
+
+        // CryptoKit handles X25519 scalar clamping internally.
+        // `.rawRepresentation` returns the canonical 32-byte form
+        // for both the secret scalar and the curve point.
+        let priv = Curve25519.KeyAgreement.PrivateKey()
+        let pubBytes = priv.publicKey.rawRepresentation
+        let privBytes = priv.rawRepresentation
+
+        await store.save(IntroKeyEntry(
+            introPublicKey: pubBytes,
+            introPrivateKey: privBytes,
+            ownerIdentityID: ownerIdentityID,
+            groupId: groupId,
+            createdAt: now()
+        ))
+
+        return try IntroCapability(
+            introPublicKey: pubBytes,
+            groupId: groupId,
+            groupName: groupName
+        )
+    }
+}
+
+enum IntroducerError: Error, Equatable {
+    case invalidGroupID(actualSize: Int)
+}

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Security
+
+/// Production `IntroKeyStore` backed by a single Keychain item per
+/// device. Whole-blob persistence — every mutation rewrites the
+/// JSON-encoded list. Intro privkeys are tiny (32B each) and the
+/// realistic count is dozens, not thousands, so the rewrite cost
+/// is negligible and we get atomicity for free (one
+/// `SecItemUpdate` / `SecItemAdd` per call).
+///
+/// `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` matches the
+/// existing `IdentityKeychainStore` policy: one cached unlock per
+/// device, no iCloud Keychain sync, no encrypted-backup transfer.
+/// A backup-extracted blob is unreadable on the restoring device.
+///
+/// Mirrors onym-android's `EncryptedPrefsIntroKeyStore` —
+/// whole-blob, JSON-serialized, base64-encoded `Data` fields.
+actor KeychainIntroKeyStore: IntroKeyStore {
+
+    /// Keychain service — one fixed item across the device.
+    static let serviceDefault = "chat.onym.ios.intro_keys"
+    static let account = "blob"
+
+    private let service: String
+
+    init(testNamespace: String? = nil) {
+        if let testNamespace, !testNamespace.isEmpty {
+            self.service = "\(Self.serviceDefault).\(testNamespace)"
+        } else {
+            self.service = Self.serviceDefault
+        }
+    }
+
+    // MARK: - IntroKeyStore
+
+    func save(_ entry: IntroKeyEntry) async {
+        var current = loadAll()
+        // Idempotent on introPublicKey.
+        current.removeAll { $0.introPub == entry.introPublicKey }
+        current.append(StoredIntroKey(from: entry))
+        writeAll(current)
+    }
+
+    func find(introPublicKey: Data) async -> IntroKeyEntry? {
+        loadAll()
+            .first { $0.introPub == introPublicKey }
+            .flatMap { $0.toEntry() }
+    }
+
+    func listForOwner(_ ownerIdentityID: IdentityID) async -> [IntroKeyEntry] {
+        loadAll()
+            .filter { $0.ownerIdentityID == ownerIdentityID.rawValue.uuidString }
+            .sorted { $0.createdAtMillis > $1.createdAtMillis }
+            .compactMap { $0.toEntry() }
+    }
+
+    func revoke(introPublicKey: Data) async {
+        var current = loadAll()
+        let before = current.count
+        current.removeAll { $0.introPub == introPublicKey }
+        if current.count != before { writeAll(current) }
+    }
+
+    @discardableResult
+    func deleteForOwner(_ ownerIdentityID: IdentityID) async -> Int {
+        var current = loadAll()
+        let before = current.count
+        current.removeAll { $0.ownerIdentityID == ownerIdentityID.rawValue.uuidString }
+        let removed = before - current.count
+        if removed > 0 { writeAll(current) }
+        return removed
+    }
+
+    /// Test helper — drop the blob entirely. No-op if it's already
+    /// gone.
+    func wipeAll() {
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: Self.account,
+        ]
+        SecItemDelete(q as CFDictionary)
+    }
+
+    // MARK: - Private
+
+    private func loadAll() -> [StoredIntroKey] {
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: Self.account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(q as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return [] }
+        // Corrupted blob → discard rather than crash. Acceptable
+        // because this store holds ephemeral per-invite keys; if we
+        // lose them, the worst that happens is in-flight invites
+        // fail to deliver and the inviter re-shares.
+        return (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
+    }
+
+    private func writeAll(_ entries: [StoredIntroKey]) {
+        guard let data = try? JSONEncoder().encode(StoredIntroKeysBlob(entries: entries)) else {
+            return
+        }
+        let attrs: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: Self.account,
+        ]
+        let updateStatus = SecItemUpdate(q as CFDictionary, attrs as CFDictionary)
+        if updateStatus == errSecSuccess { return }
+        if updateStatus == errSecItemNotFound {
+            var addQ = q
+            addQ[kSecValueData as String] = data
+            addQ[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            SecItemAdd(addQ as CFDictionary, nil)
+        }
+    }
+}
+
+/// On-disk envelope. Wraps the list so future fields (sort order,
+/// schema version) can be added without re-shaping the JSON.
+private struct StoredIntroKeysBlob: Codable {
+    var entries: [StoredIntroKey]
+}
+
+private struct StoredIntroKey: Codable {
+    let introPub: Data
+    let introPriv: Data
+    let ownerIdentityID: String
+    let groupId: Data
+    let createdAtMillis: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case introPub = "intro_pub"
+        case introPriv = "intro_priv"
+        case ownerIdentityID = "owner_identity_id"
+        case groupId = "group_id"
+        case createdAtMillis = "created_at_millis"
+    }
+
+    init(from entry: IntroKeyEntry) {
+        self.introPub = entry.introPublicKey
+        self.introPriv = entry.introPrivateKey
+        self.ownerIdentityID = entry.ownerIdentityID.rawValue.uuidString
+        self.groupId = entry.groupId
+        self.createdAtMillis = Int64(entry.createdAt.timeIntervalSince1970 * 1000)
+    }
+
+    func toEntry() -> IntroKeyEntry? {
+        guard let owner = IdentityID(ownerIdentityID),
+              introPub.count == 32, introPriv.count == 32, groupId.count == 32
+        else { return nil }
+        return IntroKeyEntry(
+            introPublicKey: introPub,
+            introPrivateKey: introPriv,
+            ownerIdentityID: owner,
+            groupId: groupId,
+            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000)
+        )
+    }
+}

--- a/Tests/OnymIOSTests/IntroCapabilityInteropTests.swift
+++ b/Tests/OnymIOSTests/IntroCapabilityInteropTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import OnymIOS
+
+/// Cross-platform wire-format pin. The hand-constructed JSON byte
+/// patterns below MUST decode to the same `IntroCapability` on both
+/// onym-ios and onym-android — and a matching test in
+/// `IntroCapabilityInteropTest.kt` MUST cover the same vectors. Keep
+/// the two in lockstep; never edit one without also updating the
+/// other.
+///
+/// Why hand-constructed JSON instead of re-encoded base64 strings?
+/// JSON object key order isn't semantically meaningful, but
+/// `JSONEncoder` and `kotlinx.serialization.Json` don't promise
+/// matching key ordering on emit. So we pin the **decoder** contract
+/// — given identical input bytes, both platforms produce identical
+/// `IntroCapability` values — and let each platform freely re-encode
+/// its own way. The roundtrip test inside the same suite still
+/// proves encoder→decoder is a closed loop on each platform.
+final class IntroCapabilityInteropTests: XCTestCase {
+
+    // MARK: - Vector A — minimal, no group_name
+
+    /// `intro_pub` is 32 bytes of `0x01`, `group_id` is 32 bytes of
+    /// `0x02`. Inner base64 uses standard alphabet **with padding**
+    /// (Swift `JSONEncoder` `.base64` default + Android
+    /// `Base64.getEncoder()`). 32 bytes encodes to 44 base64 chars
+    /// (32 * 4/3 rounded up + padding).
+    func test_vectorA_decodesMinimalShape() throws {
+        let pub = Data(repeating: 0x01, count: 32)
+        let gid = Data(repeating: 0x02, count: 32)
+        let pubB64 = pub.base64EncodedString()  // 44 chars w/ trailing '='
+        let gidB64 = gid.base64EncodedString()
+        let json = #"{"intro_pub":"\#(pubB64)","group_id":"\#(gidB64)"}"#
+
+        let payload = Self.urlSafeBase64NoPadding(json.data(using: .utf8)!)
+        let cap = try IntroCapability.decode(payload)
+
+        XCTAssertEqual(cap.introPublicKey, pub)
+        XCTAssertEqual(cap.groupId, gid)
+        XCTAssertNil(cap.groupName, "Vector A omits group_name → must decode to nil")
+    }
+
+    // MARK: - Vector B — with group_name "Family"
+
+    func test_vectorB_decodesWithGroupName() throws {
+        let pub = Data((0..<32).map { UInt8($0) })          // 0x00..0x1F
+        let gid = Data((0..<32).map { UInt8(0xFF - $0) })   // 0xFF..0xE0
+        let pubB64 = pub.base64EncodedString()
+        let gidB64 = gid.base64EncodedString()
+        let json = #"{"intro_pub":"\#(pubB64)","group_id":"\#(gidB64)","group_name":"Family"}"#
+
+        let payload = Self.urlSafeBase64NoPadding(json.data(using: .utf8)!)
+        let cap = try IntroCapability.decode(payload)
+
+        XCTAssertEqual(cap.introPublicKey, pub)
+        XCTAssertEqual(cap.groupId, gid)
+        XCTAssertEqual(cap.groupName, "Family")
+    }
+
+    // MARK: - Vector C — group_name with non-ASCII (UTF-8 quoted)
+
+    /// Confirms UTF-8 round-trips through both platforms' JSON
+    /// readers — group names like "Семья" or "👨‍👩‍👧" must survive
+    /// the wire intact.
+    func test_vectorC_decodesUtf8GroupName() throws {
+        let pub = Data(repeating: 0xAB, count: 32)
+        let gid = Data(repeating: 0xCD, count: 32)
+        let pubB64 = pub.base64EncodedString()
+        let gidB64 = gid.base64EncodedString()
+        // "Семья 👨‍👩‍👧" — Cyrillic + ZWJ-emoji sequence. JSON requires
+        // either raw UTF-8 or `\uXXXX` escapes; we ship raw UTF-8
+        // since both `JSONEncoder` and `kotlinx.serialization` emit
+        // raw by default.
+        let groupName = "Семья 👨‍👩‍👧"
+        let json = #"{"intro_pub":"\#(pubB64)","group_id":"\#(gidB64)","group_name":"\#(groupName)"}"#
+
+        let payload = Self.urlSafeBase64NoPadding(json.data(using: .utf8)!)
+        let cap = try IntroCapability.decode(payload)
+
+        XCTAssertEqual(cap.introPublicKey, pub)
+        XCTAssertEqual(cap.groupId, gid)
+        XCTAssertEqual(cap.groupName, groupName)
+    }
+
+    // MARK: - Reverse direction: iOS-minted payload must round-trip
+
+    /// Encoder smoke check: decode our own emit + reconstruct.
+    /// Per-platform encoders may differ in key order, but a
+    /// freshly-minted payload must always decode back to the same
+    /// values on the same platform. Pair with a Kotlin
+    /// `@Test fun encodedHere_decodesOnAndroid()` in the matching
+    /// PR on Android.
+    func test_iosEncoded_decodesBack() throws {
+        let original = try IntroCapability(
+            introPublicKey: Data((0..<32).map { UInt8(($0 * 13 + 7) & 0xFF) }),
+            groupId: Data((0..<32).map { UInt8(($0 * 17 + 5) & 0xFF) }),
+            groupName: "Crew"
+        )
+        let payload = original.encode()
+        let decoded = try IntroCapability.decode(payload)
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - Helpers
+
+    private static func urlSafeBase64NoPadding(_ data: Data) -> String {
+        var s = data.base64EncodedString()
+        s = s.replacingOccurrences(of: "+", with: "-")
+        s = s.replacingOccurrences(of: "/", with: "_")
+        while s.hasSuffix("=") { s.removeLast() }
+        return s
+    }
+}

--- a/Tests/OnymIOSTests/IntroCapabilityTests.swift
+++ b/Tests/OnymIOSTests/IntroCapabilityTests.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import OnymIOS
+
+/// Wire-format pin for `IntroCapability`. The shape is the contract
+/// onym-android already ships — keep it stable. Mirrors
+/// `IntroCapabilityTest.kt` test-for-test.
+final class IntroCapabilityTests: XCTestCase {
+
+    private let sampleIntroPub = Data(repeating: 0xAA, count: 32)
+    private let sampleGroupId = Data(repeating: 0x42, count: 32)
+
+    // MARK: - roundtrip
+
+    func test_roundtrip_minimalShape_preservesAllFields() throws {
+        let original = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: nil
+        )
+        let encoded = original.encode()
+        let decoded = try IntroCapability.decode(encoded)
+        XCTAssertEqual(original, decoded)
+    }
+
+    func test_roundtrip_withGroupName_preservesAllFields() throws {
+        let original = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "Family"
+        )
+        let encoded = original.encode()
+        let decoded = try IntroCapability.decode(encoded)
+        XCTAssertEqual(original, decoded)
+        XCTAssertEqual(decoded.groupName, "Family")
+    }
+
+    func test_encode_isUrlSafeBase64_noPaddingOrSpecialChars() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "test"
+        )
+        let encoded = cap.encode()
+        XCTAssertFalse(encoded.contains("+"), "no `+` in URL-safe encoding")
+        XCTAssertFalse(encoded.contains("/"), "no `/` in URL-safe encoding")
+        XCTAssertFalse(encoded.contains("="), "no `=` padding")
+        XCTAssertFalse(encoded.contains(where: { $0.isWhitespace }), "no whitespace")
+    }
+
+    // MARK: - link forms
+
+    func test_toAppLink_isOnymChatJoinPath() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId
+        )
+        XCTAssertTrue(cap.toAppLink().hasPrefix("https://onym.chat/join?c="))
+    }
+
+    func test_toCustomSchemeLink_isOnymJoinScheme() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId
+        )
+        XCTAssertTrue(cap.toCustomSchemeLink().hasPrefix("onym://join?c="))
+    }
+
+    // MARK: - fromLink
+
+    func test_fromLink_appLinkForm_decodesBackToOriginal() throws {
+        let original = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "Crew"
+        )
+        let parsed = IntroCapability.fromLink(original.toAppLink())
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed, original)
+    }
+
+    func test_fromLink_customSchemeForm_decodesBackToOriginal() throws {
+        let original = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "Crew"
+        )
+        let parsed = IntroCapability.fromLink(original.toCustomSchemeLink())
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed, original)
+    }
+
+    func test_fromLink_extraQueryParams_returnsCapability_ignoringExtras() throws {
+        // Future schemas may grow tracking params (utm_*, etc.) — the
+        // parser must pluck `c=` and ignore the rest.
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "X"
+        )
+        let link = "\(cap.toAppLink())&utm_source=share-sheet&ref=foo"
+        let parsed = IntroCapability.fromLink(link)
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed, cap)
+    }
+
+    func test_fromLink_missingCapabilityParam_returnsNull() {
+        XCTAssertNil(IntroCapability.fromLink("https://onym.chat/join"))
+        XCTAssertNil(IntroCapability.fromLink("https://onym.chat/join?other=value"))
+    }
+
+    func test_fromLink_malformedUri_returnsNull() {
+        XCTAssertNil(IntroCapability.fromLink("not a url"))
+        XCTAssertNil(IntroCapability.fromLink(""))
+    }
+
+    // MARK: - decode failure modes
+
+    func test_decode_invalidBase64_throwsInvalidIntroCapability() {
+        XCTAssertThrowsError(try IntroCapability.decode("@@@not-base64@@@")) { error in
+            guard let err = error as? InvalidIntroCapability else {
+                return XCTFail("expected InvalidIntroCapability, got \(error)")
+            }
+            if case .base64 = err { /* ok */ } else {
+                XCTFail("expected .base64 case, got \(err)")
+            }
+        }
+    }
+
+    func test_decode_validBase64_butNotJson_throwsInvalidIntroCapability() {
+        let notJson = Self.urlSafeBase64("not json at all".data(using: .utf8)!)
+        XCTAssertThrowsError(try IntroCapability.decode(notJson)) { error in
+            XCTAssertTrue(error is InvalidIntroCapability)
+        }
+    }
+
+    func test_decode_validJson_butWrongPubkeySize_throwsInvalidIntroCapability() {
+        let badShape = #"{"intro_pub":"AAA=","group_id":"AAA="}"#
+        let encoded = Self.urlSafeBase64(badShape.data(using: .utf8)!)
+        XCTAssertThrowsError(try IntroCapability.decode(encoded)) { error in
+            guard let err = error as? InvalidIntroCapability else {
+                return XCTFail("expected InvalidIntroCapability, got \(error)")
+            }
+            if case .shape = err { /* ok */ } else {
+                XCTFail("expected .shape case, got \(err)")
+            }
+        }
+    }
+
+    // MARK: - constructor
+
+    func test_constructor_rejectsWrongSizedKeys() {
+        XCTAssertThrowsError(try IntroCapability(
+            introPublicKey: Data(repeating: 0, count: 31),
+            groupId: sampleGroupId
+        )) { error in
+            XCTAssertTrue(error is InvalidIntroCapability)
+        }
+        XCTAssertThrowsError(try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: Data(repeating: 0, count: 33)
+        )) { error in
+            XCTAssertTrue(error is InvalidIntroCapability)
+        }
+    }
+
+    // MARK: - shareText
+
+    func test_shareText_includesGroupName_whenSet() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId,
+            groupName: "Friends"
+        )
+        let text = IntroCapability.shareText(link: cap.toAppLink(), groupName: cap.groupName)
+        XCTAssertTrue(text.contains("\"Friends\""))
+        XCTAssertTrue(text.contains("https://onym.chat/join?c="))
+    }
+
+    func test_shareText_omitsGroupName_whenBlankOrNull() throws {
+        let cap = try IntroCapability(
+            introPublicKey: sampleIntroPub,
+            groupId: sampleGroupId
+        )
+        let text = IntroCapability.shareText(link: cap.toAppLink(), groupName: cap.groupName)
+        XCTAssertFalse(text.contains("\""), "no quoted name when nil")
+        XCTAssertTrue(text.contains("Join my chat"))
+    }
+
+    // MARK: - byte-level
+
+    func test_roundtrip_byteForByteIntroPub_isPreserved() throws {
+        // Random-ish bytes — base64+JSON+base64 must not mutate any
+        // byte position.
+        let pub = Data((0..<32).map { UInt8(($0 * 7 + 13) & 0xFF) })
+        let gid = Data((0..<32).map { UInt8(($0 * 11 + 3) & 0xFF) })
+        let cap = try IntroCapability(introPublicKey: pub, groupId: gid, groupName: "X")
+        let decoded = try IntroCapability.decode(cap.encode())
+        XCTAssertEqual(decoded.introPublicKey, pub)
+        XCTAssertEqual(decoded.groupId, gid)
+    }
+
+    // MARK: - Helpers
+
+    private static func urlSafeBase64(_ data: Data) -> String {
+        var s = data.base64EncodedString()
+        s = s.replacingOccurrences(of: "+", with: "-")
+        s = s.replacingOccurrences(of: "/", with: "_")
+        while s.hasSuffix("=") { s.removeLast() }
+        return s
+    }
+}

--- a/Tests/OnymIOSTests/InviteIntroducerTests.swift
+++ b/Tests/OnymIOSTests/InviteIntroducerTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import OnymIOS
+
+/// Unit tests for `InviteIntroducer` + `IntroKeyStore` contract.
+/// Backed by `InMemoryIntroKeyStore` — the Keychain-backed prod
+/// impl gets exercised via the round-trip tests in
+/// `KeychainIntroKeyStoreTests` (separate suite).
+///
+/// Mirrors `InviteIntroducerTest.kt` test-for-test.
+final class InviteIntroducerTests: XCTestCase {
+
+    private let alice = IdentityID("11111111-1111-1111-1111-111111111111")!
+    private let bob = IdentityID("22222222-2222-2222-2222-222222222222")!
+    private let sampleGroupId = Data(repeating: 0x42, count: 32)
+
+    func test_mint_producesDistinctKeypairs_acrossInvocations() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let cap1 = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+        let cap2 = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        XCTAssertEqual(cap1.introPublicKey.count, 32)
+        XCTAssertEqual(cap2.introPublicKey.count, 32)
+        XCTAssertNotEqual(
+            cap1.introPublicKey, cap2.introPublicKey,
+            "two mints for the same group must produce distinct intro pubkeys"
+        )
+    }
+
+    func test_mint_persistsKeypair_recoverableViaFind() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let cap = try await introducer.mint(
+            ownerIdentityID: alice,
+            groupId: sampleGroupId,
+            groupName: "Family"
+        )
+        let entry = await store.find(introPublicKey: cap.introPublicKey)
+        XCTAssertNotNil(entry)
+        XCTAssertEqual(entry?.ownerIdentityID, alice)
+        XCTAssertEqual(entry?.groupId, sampleGroupId)
+        // Private key must round-trip — that's what decrypts requests
+        // in PR-3+.
+        XCTAssertEqual(entry?.introPrivateKey.count, 32)
+        XCTAssertEqual(entry?.introPublicKey, cap.introPublicKey)
+    }
+
+    func test_mint_capabilityCarriesGroupName_notTheStore() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let cap = try await introducer.mint(
+            ownerIdentityID: alice,
+            groupId: sampleGroupId,
+            groupName: "Family"
+        )
+        XCTAssertEqual(cap.groupName, "Family")
+        // The store doesn't persist the name — names live in the
+        // ChatGroup row, not in the per-invite store. Keeps the
+        // intro store tightly scoped to crypto material.
+        let entry = await store.find(introPublicKey: cap.introPublicKey)
+        XCTAssertNotNil(entry)
+        XCTAssertEqual(entry?.introPublicKey.count, 32)
+    }
+
+    func test_listForOwner_returnsOnlyMatchingIdentitysEntries() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        _ = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+        _ = try await introducer.mint(ownerIdentityID: alice, groupId: Data(repeating: 0x55, count: 32))
+        _ = try await introducer.mint(ownerIdentityID: bob, groupId: sampleGroupId)
+
+        let aliceList = await store.listForOwner(alice)
+        let bobList = await store.listForOwner(bob)
+        XCTAssertEqual(aliceList.count, 2)
+        XCTAssertEqual(bobList.count, 1)
+        XCTAssertTrue(aliceList.allSatisfy { $0.ownerIdentityID == alice })
+    }
+
+    func test_revoke_removesEntry() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let cap = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+        let beforeRevoke = await store.find(introPublicKey: cap.introPublicKey)
+        XCTAssertNotNil(beforeRevoke)
+
+        await store.revoke(introPublicKey: cap.introPublicKey)
+        let afterRevoke = await store.find(introPublicKey: cap.introPublicKey)
+        XCTAssertNil(afterRevoke)
+    }
+
+    func test_deleteForOwner_cascadesAllOwnedEntries_returnsCount() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        _ = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+        _ = try await introducer.mint(ownerIdentityID: alice, groupId: Data(repeating: 0x55, count: 32))
+        _ = try await introducer.mint(ownerIdentityID: bob, groupId: sampleGroupId)
+
+        let removed = await store.deleteForOwner(alice)
+        XCTAssertEqual(removed, 2)
+        let aliceAfter = await store.listForOwner(alice)
+        let bobAfter = await store.listForOwner(bob)
+        XCTAssertEqual(aliceAfter.count, 0)
+        XCTAssertEqual(bobAfter.count, 1)
+    }
+
+    func test_mint_rejectsWrongSizedGroupId() async {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        do {
+            _ = try await introducer.mint(
+                ownerIdentityID: alice,
+                groupId: Data(repeating: 0, count: 31)
+            )
+            XCTFail("expected IntroducerError.invalidGroupID")
+        } catch IntroducerError.invalidGroupID {
+            // expected
+        } catch {
+            XCTFail("expected IntroducerError.invalidGroupID, got \(error)")
+        }
+    }
+
+    func test_mint_clockProvider_stampsCreatedAt() async throws {
+        let store = InMemoryIntroKeyStore()
+        let frozen = Date(timeIntervalSince1970: 1_700_000_000)
+        let introducer = InviteIntroducer(store: store, now: { frozen })
+
+        let cap = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+        let entry = await store.find(introPublicKey: cap.introPublicKey)
+        XCTAssertNotNil(entry)
+        XCTAssertEqual(entry?.createdAt, frozen)
+    }
+}

--- a/Tests/OnymIOSTests/Support/InMemoryIntroKeyStore.swift
+++ b/Tests/OnymIOSTests/Support/InMemoryIntroKeyStore.swift
@@ -1,0 +1,37 @@
+import Foundation
+@testable import OnymIOS
+
+/// Reusable in-memory `IntroKeyStore`. Same contract as
+/// `KeychainIntroKeyStore` without the Keychain plumbing — fast
+/// tests of `InviteIntroducer` and the future request-flow
+/// interactors that don't want to touch the Security framework.
+actor InMemoryIntroKeyStore: IntroKeyStore {
+
+    private var entries: [IntroKeyEntry] = []
+
+    func save(_ entry: IntroKeyEntry) async {
+        entries.removeAll { $0.introPublicKey == entry.introPublicKey }
+        entries.append(entry)
+    }
+
+    func find(introPublicKey: Data) async -> IntroKeyEntry? {
+        entries.first { $0.introPublicKey == introPublicKey }
+    }
+
+    func listForOwner(_ ownerIdentityID: IdentityID) async -> [IntroKeyEntry] {
+        entries
+            .filter { $0.ownerIdentityID == ownerIdentityID }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    func revoke(introPublicKey: Data) async {
+        entries.removeAll { $0.introPublicKey == introPublicKey }
+    }
+
+    @discardableResult
+    func deleteForOwner(_ ownerIdentityID: IdentityID) async -> Int {
+        let before = entries.count
+        entries.removeAll { $0.ownerIdentityID == ownerIdentityID }
+        return before - entries.count
+    }
+}


### PR DESCRIPTION
## Summary

PR-2 of 7. Per-invite ephemeral X25519 keypair persistence for the Level-2 deeplink invitation flow.

**Stacked on `group/intro-capability` (PR-1 / #60).** Merge target is the previous branch, not main — change to main once #60 lands.

## What's in here

- `IntroKeyEntry` — value type bundling pubkey + privkey + owner identity + group_id + createdAt
- `IntroKeyStore` — protocol seam (`save`, `find(introPublicKey:)`, `listForOwner`, `revoke`, `deleteForOwner`)
- `KeychainIntroKeyStore` — production actor, single Keychain item with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. Whole-blob persistence (JSON-encoded list rewrite per mutation — atomic + cheap for the realistic invite count of ~dozens)
- `InviteIntroducer` — actor that mints the X25519 keypair via `CryptoKit.Curve25519.KeyAgreement.PrivateKey` (CryptoKit handles scalar clamping), persists, returns the `IntroCapability`
- `InMemoryIntroKeyStore` — test helper

**Why per-invite** (not per-identity): per-link revocation. Stop listening on a given intro tag → that link goes silent without affecting other outstanding invites. A leaked link only burns its own slot.

**Identity removal cascade** is wired in PR-3 via `IdentityRepository`'s removal listeners. `deleteForOwner` exists on the seam from this PR so the wiring layer can be added without touching the store.

## Cross-platform contract

Mirrors onym-android `identity/intro-keystore` (PR #61) byte for byte: same JSON shape (`intro_pub`, `intro_priv`, `owner_identity_id`, `group_id`, `created_at_millis`), same base64 encoding for `Data` fields, same idempotent-on-pubkey semantics.

## Test coverage (8 cases)

`InviteIntroducerTests`, mirroring `InviteIntroducerTest.kt`:
- distinct keypairs across mint() invocations
- persist + find round-trip
- group_name lives on the cap, not the store
- listForOwner filters by identity
- revoke removes a single entry
- deleteForOwner cascades + returns count
- mint rejects wrong-sized group_id
- clock provider stamps createdAt

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests/InviteIntroducerTests -only-testing:OnymIOSTests/IntroCapabilityTests -only-testing:OnymIOSTests/IntroCapabilityInteropTests` — 29/29 pass on iPhone 17 Pro simulator
- [ ] CI green
- [ ] Coordinated with onym-android PR #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)