### PR TITLE
transport: intro inbox subscription pump (PR-3 of 7: Level-2 deeplink)

### DIFF
--- a/Sources/OnymIOS/Group/IntroInboxPump.swift
+++ b/Sources/OnymIOS/Group/IntroInboxPump.swift
@@ -1,0 +1,123 @@
+import CryptoKit
+import Foundation
+
+/// Sender-side pump for intro inbox subscriptions. Mirrors
+/// `InboxFanoutInteractor` but drops inbounds into
+/// `IntroRequestStore` instead of the identity-inbox sink.
+///
+/// **Why a parallel interactor instead of one shared seam**: the
+/// two flows are likely to diverge — intro requests are interactive
+/// (sender taps Approve), invitations are autonomic (joiner sees
+/// the chat appear). Shared abstraction would leak through either
+/// a generic-type parameter or a sink interface that adds
+/// indirection without saving meaningful code.
+///
+/// Subscription set is rebuilt by reconciliation: each emission
+/// from the entries stream cancels Tasks for entries that
+/// disappeared (or whose pubkey rotated), spawns Tasks for new
+/// entries, no-ops the rest. Each per-entry Task captures the
+/// `IntroKeyEntry` so inbounds can be tagged with the matching
+/// introPub directly — no `tag → pub` reverse-lookup map needed.
+struct IntroInboxPump: Sendable {
+    let inboxTransport: any InboxTransport
+    let store: any IntroRequestStore
+    /// Maps an intro pubkey → its Nostr inbox tag. Production wires
+    /// to `Self.inboxTag(from:)` (the same
+    /// `SHA-256("sep-inbox-v1" || pub)[..8]` derivation identity
+    /// inbox tags use); tests pass an identity-equality stub.
+    let inboxTagFor: @Sendable (Data) -> TransportInboxID
+
+    init(
+        inboxTransport: any InboxTransport,
+        store: any IntroRequestStore,
+        inboxTagFor: (@Sendable (Data) -> TransportInboxID)? = nil
+    ) {
+        self.inboxTransport = inboxTransport
+        self.store = store
+        self.inboxTagFor = inboxTagFor ?? { pub in
+            TransportInboxID(rawValue: Self.inboxTag(from: pub))
+        }
+    }
+
+    /// Run until cancelled. Each entries-stream emission re-balances
+    /// the live subscription set wholesale.
+    func run(entries: AsyncStream<[IntroKeyEntry]>) async {
+        let subs = ActiveIntroSubscriptions(
+            inboxTransport: inboxTransport,
+            store: store
+        )
+        for await snapshot in entries {
+            if Task.isCancelled { break }
+            await subs.apply(snapshot, tagFor: inboxTagFor)
+        }
+        await subs.applyEmpty()
+    }
+
+    /// Mirror of `IdentityRepository.inboxTag(from:)` /
+    /// `InboxFanoutInteractor.inboxTag(from:)`. Pure function of
+    /// the pubkey; safe to recompute.
+    static func inboxTag(from publicKey: Data) -> String {
+        var hasher = SHA256()
+        hasher.update(data: Data("sep-inbox-v1".utf8))
+        hasher.update(data: publicKey)
+        let digest = hasher.finalize()
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - Subscription bookkeeping actor
+
+/// Owns the live per-entry subscription Tasks. `apply` reconciles
+/// the desired set against the live set: cancels Tasks for entries
+/// that disappeared, spawns Tasks for new ones, no-ops the rest.
+private actor ActiveIntroSubscriptions {
+    private let inboxTransport: any InboxTransport
+    private let store: any IntroRequestStore
+    /// Keyed by introPub. The captured tag travels with each Task
+    /// so cancellation can also `unsubscribe` the right inbox.
+    private var live: [Data: (tag: TransportInboxID, task: Task<Void, Never>)] = [:]
+
+    init(inboxTransport: any InboxTransport, store: any IntroRequestStore) {
+        self.inboxTransport = inboxTransport
+        self.store = store
+    }
+
+    func apply(
+        _ wanted: [IntroKeyEntry],
+        tagFor: @Sendable (Data) -> TransportInboxID
+    ) async {
+        let wantedKeys = Set(wanted.map { $0.introPublicKey })
+        // Cancel anything that disappeared.
+        for (pub, current) in live where !wantedKeys.contains(pub) {
+            current.task.cancel()
+            await inboxTransport.unsubscribe(inbox: current.tag)
+            live.removeValue(forKey: pub)
+        }
+        // Spawn anything new.
+        for entry in wanted where live[entry.introPublicKey] == nil {
+            let tag = tagFor(entry.introPublicKey)
+            let stream = inboxTransport.subscribe(inbox: tag)
+            let pubCapture = entry.introPublicKey
+            let task = Task { [store] in
+                for await message in stream {
+                    if Task.isCancelled { break }
+                    await store.record(IntroRequest(
+                        id: message.messageID,
+                        targetIntroPublicKey: pubCapture,
+                        payload: message.payload,
+                        receivedAt: message.receivedAt
+                    ))
+                }
+            }
+            live[entry.introPublicKey] = (tag, task)
+        }
+    }
+
+    func applyEmpty() async {
+        for (_, current) in live {
+            current.task.cancel()
+            await inboxTransport.unsubscribe(inbox: current.tag)
+        }
+        live.removeAll()
+    }
+}

--- a/Sources/OnymIOS/Group/IntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/IntroKeyStore.swift
@@ -48,4 +48,12 @@ protocol IntroKeyStore: Sendable {
     /// Hooked into `IdentityRepository`'s removal listeners.
     @discardableResult
     func deleteForOwner(_ ownerIdentityID: IdentityID) async -> Int
+
+    /// Hot stream of every entry owned by `ownerIdentityID`. New
+    /// subscribers get the current snapshot first; subsequent
+    /// emissions follow `save` / `revoke` / `deleteForOwner` calls.
+    /// Sorted newest-first by `createdAt`. `IntroInboxPump` subscribes
+    /// here so adding/revoking an invite immediately re-balances the
+    /// transport subscription set.
+    nonisolated func entriesStream(forOwner ownerIdentityID: IdentityID) -> AsyncStream<[IntroKeyEntry]>
 }

--- a/Sources/OnymIOS/Group/IntroRequest.swift
+++ b/Sources/OnymIOS/Group/IntroRequest.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// One inbound "request to join" envelope received over an intro
+/// inbox tag. Opaque bytes here — decryption + parsing of the inner
+/// payload (which carries the joiner's identity pubkey + group
+/// acknowledgement) happens in PR-4's `JoinRequestApprover`.
+///
+/// Mirrors the shape of `IncomingInvitationRecord`; the two stores
+/// are deliberately parallel (identity inbox vs intro inbox)
+/// because the consumer flows differ — invitations are autonomic
+/// (the joiner's chat appears), intro requests are interactive (the
+/// inviter taps Approve/Decline).
+struct IntroRequest: Equatable, Sendable {
+    /// Nostr event id; dedupe key.
+    let id: String
+    /// The inviter's intro pubkey this request was addressed to.
+    /// Doubles as the lookup key into `IntroKeyStore` —
+    /// `store.find(introPublicKey:)` returns the privkey that
+    /// decrypts `payload`.
+    let targetIntroPublicKey: Data
+    /// Sealed envelope bytes — the inner JSON is encrypted to
+    /// `targetIntroPublicKey` via X25519 + AES-GCM.
+    let payload: Data
+    let receivedAt: Date
+}

--- a/Sources/OnymIOS/Group/IntroRequestStore.swift
+++ b/Sources/OnymIOS/Group/IntroRequestStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// In-memory sink for inbound intro requests. Process-lifetime —
+/// the request approval flow (PR-4) is interactive; if the user
+/// doesn't act before the process dies, the joiner re-shares.
+///
+/// Mirrors the shape of `IncomingInvitationsRepository` — identical
+/// posture for the V1 receive-side (interactive UI consumes the
+/// stream; persistence lands later if we need durability across
+/// restarts).
+protocol IntroRequestStore: Sendable {
+    /// Hot stream of pending requests. Sorted newest-first by
+    /// `receivedAt`. UI subscribes here.
+    nonisolated var requests: AsyncStream<[IntroRequest]> { get }
+
+    /// Append a fresh request. Dedup on `IntroRequest.id`; returns
+    /// `true` on insert, `false` if the id was already present.
+    @discardableResult
+    func record(_ request: IntroRequest) async -> Bool
+
+    /// Drop a request after the user has acted on it (Approve or
+    /// Decline) so it stops cluttering the surface.
+    func consume(id: String) async
+
+    /// Snapshot read used by tests + bootstrap reads. UI prefers
+    /// the stream.
+    func current() async -> [IntroRequest]
+}
+
+actor InMemoryIntroRequestStore: IntroRequestStore {
+    private var pending: [IntroRequest] = []
+    private var continuations: [UUID: AsyncStream<[IntroRequest]>.Continuation] = [:]
+
+    @discardableResult
+    func record(_ request: IntroRequest) async -> Bool {
+        if pending.contains(where: { $0.id == request.id }) { return false }
+        pending.append(request)
+        publish()
+        return true
+    }
+
+    func consume(id: String) async {
+        let before = pending.count
+        pending.removeAll { $0.id == id }
+        if pending.count != before { publish() }
+    }
+
+    func current() async -> [IntroRequest] {
+        pending.sorted { $0.receivedAt > $1.receivedAt }
+    }
+
+    nonisolated var requests: AsyncStream<[IntroRequest]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func subscribe(id: UUID, continuation: AsyncStream<[IntroRequest]>.Continuation) {
+        continuations[id] = continuation
+        continuation.yield(pending.sorted { $0.receivedAt > $1.receivedAt })
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func publish() {
+        let snap = pending.sorted { $0.receivedAt > $1.receivedAt }
+        for cont in continuations.values { cont.yield(snap) }
+    }
+}

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -22,6 +22,10 @@ actor KeychainIntroKeyStore: IntroKeyStore {
     static let account = "blob"
 
     private let service: String
+    /// Per-owner subscriber continuations. Mutations re-emit the
+    /// filtered+sorted snapshot to every subscriber whose owner
+    /// matches.
+    private var continuations: [IdentityID: [UUID: AsyncStream<[IntroKeyEntry]>.Continuation]] = [:]
 
     init(testNamespace: String? = nil) {
         if let testNamespace, !testNamespace.isEmpty {
@@ -39,6 +43,7 @@ actor KeychainIntroKeyStore: IntroKeyStore {
         current.removeAll { $0.introPub == entry.introPublicKey }
         current.append(StoredIntroKey(from: entry))
         writeAll(current)
+        publish(forOwner: entry.ownerIdentityID)
     }
 
     func find(introPublicKey: Data) async -> IntroKeyEntry? {
@@ -56,9 +61,13 @@ actor KeychainIntroKeyStore: IntroKeyStore {
 
     func revoke(introPublicKey: Data) async {
         var current = loadAll()
-        let before = current.count
+        let removedRows = current.filter { $0.introPub == introPublicKey }
         current.removeAll { $0.introPub == introPublicKey }
-        if current.count != before { writeAll(current) }
+        if !removedRows.isEmpty {
+            writeAll(current)
+            let owners = Set(removedRows.compactMap { IdentityID($0.ownerIdentityID) })
+            for owner in owners { publish(forOwner: owner) }
+        }
     }
 
     @discardableResult
@@ -67,8 +76,46 @@ actor KeychainIntroKeyStore: IntroKeyStore {
         let before = current.count
         current.removeAll { $0.ownerIdentityID == ownerIdentityID.rawValue.uuidString }
         let removed = before - current.count
-        if removed > 0 { writeAll(current) }
+        if removed > 0 {
+            writeAll(current)
+            publish(forOwner: ownerIdentityID)
+        }
         return removed
+    }
+
+    nonisolated func entriesStream(forOwner ownerIdentityID: IdentityID) -> AsyncStream<[IntroKeyEntry]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(owner: ownerIdentityID, id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(owner: ownerIdentityID, id: id) }
+            }
+        }
+    }
+
+    private func subscribe(
+        owner: IdentityID,
+        id: UUID,
+        continuation: AsyncStream<[IntroKeyEntry]>.Continuation
+    ) async {
+        continuations[owner, default: [:]][id] = continuation
+        continuation.yield(await listForOwner(owner))
+    }
+
+    private func unsubscribe(owner: IdentityID, id: UUID) {
+        continuations[owner]?.removeValue(forKey: id)
+        if continuations[owner]?.isEmpty == true {
+            continuations.removeValue(forKey: owner)
+        }
+    }
+
+    private func publish(forOwner owner: IdentityID) {
+        guard let bucket = continuations[owner] else { return }
+        let snapshot = loadAll()
+            .filter { $0.ownerIdentityID == owner.rawValue.uuidString }
+            .sorted { $0.createdAtMillis > $1.createdAtMillis }
+            .compactMap { $0.toEntry() }
+        for cont in bucket.values { cont.yield(snapshot) }
     }
 
     /// Test helper — drop the blob entirely. No-op if it's already

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -9,6 +9,8 @@ struct OnymIOSApp: App {
     private let groupRepository: GroupRepository
     private let inboxTransport: any InboxTransport
     private let incomingInvitations: IncomingInvitationsRepository
+    private let introKeyStore: any IntroKeyStore
+    private let introRequestStore: any IntroRequestStore
 
     init() {
         let args = ProcessInfo.processInfo.arguments
@@ -90,6 +92,15 @@ struct OnymIOSApp: App {
             (try? SwiftDataInvitationStore()) ?? SwiftDataInvitationStore.inMemory()
         self.incomingInvitations = IncomingInvitationsRepository(store: invitationStore)
 
+        // Per-invite ephemeral X25519 keys for the Level-2 deeplink
+        // invite flow. Keychain-backed in production; survives across
+        // launches so an outstanding invite link can still be served.
+        let introKeyStore = KeychainIntroKeyStore()
+        self.introKeyStore = introKeyStore
+        // Process-lifetime sink for inbound "request to join"
+        // envelopes. The sender-approval UI (PR-5+) consumes this.
+        self.introRequestStore = InMemoryIntroRequestStore()
+
         // Single shared IdentitiesFlow so the toolbar picker on Chats
         // and the Settings → Identities screen observe the same state.
         let identitiesFlow = IdentitiesFlow(repository: repository)
@@ -168,6 +179,11 @@ struct OnymIOSApp: App {
                     for await removed in identityRepository.identityRemoved {
                         await groupRepository.removeForOwner(removed)
                         await incomingInvitations.removeForOwner(removed)
+                        // Cascade-wipe the removed identity's intro
+                        // privkeys so an attacker who restores a
+                        // backup post-removal can't decrypt
+                        // outstanding intro requests.
+                        await introKeyStore.deleteForOwner(removed)
                     }
                 }
                 .task {
@@ -180,6 +196,36 @@ struct OnymIOSApp: App {
                         repository: incomingInvitations
                     )
                     await fanout.run()
+                }
+                .task {
+                    // Level-2 deeplink intro pump. Subscribes to one
+                    // Nostr inbox tag per outstanding invite link
+                    // owned by the current identity; switching identity
+                    // re-balances the subscription set automatically.
+                    // No per-identity dedup map — multiple simultaneous
+                    // identities each get their own pump if they each
+                    // have outstanding invites. We start with the
+                    // current identity only; when the user switches,
+                    // the outer task restarts via .task { } onChange
+                    // semantics in a follow-up. For V1, single-active-
+                    // identity pump is sufficient.
+                    let pump = IntroInboxPump(
+                        inboxTransport: inboxTransport,
+                        store: introRequestStore
+                    )
+                    // Re-resolve the active identity on each emission
+                    // and re-subscribe to its entries stream.
+                    var currentTask: Task<Void, Never>?
+                    for await activeID in identityRepository.currentIdentityID {
+                        currentTask?.cancel()
+                        guard let activeID else {
+                            currentTask = nil
+                            continue
+                        }
+                        let entries = introKeyStore.entriesStream(forOwner: activeID)
+                        currentTask = Task { await pump.run(entries: entries) }
+                    }
+                    currentTask?.cancel()
                 }
         }
     }

--- a/Tests/OnymIOSTests/IntroInboxPumpTests.swift
+++ b/Tests/OnymIOSTests/IntroInboxPumpTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for `IntroInboxPump`. Mirrors
+/// `IntroInboxPumpTest.kt` test-for-test. Uses the shared
+/// `RecordingInboxTransport` pattern from
+/// `InboxFanoutInteractorTests` (kept private to that file — we
+/// duplicate a slimmer one here rather than refactoring two suites
+/// in one PR).
+final class IntroInboxPumpTests: XCTestCase {
+
+    private let alice = IdentityID("11111111-1111-1111-1111-111111111111")!
+    private let groupId = Data(repeating: 0x42, count: 32)
+
+    private func entry(seed: UInt8) -> IntroKeyEntry {
+        IntroKeyEntry(
+            introPublicKey: Data(repeating: seed, count: 32),
+            introPrivateKey: Data(repeating: seed &+ 1, count: 32),
+            ownerIdentityID: alice,
+            groupId: groupId,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    /// Fake tag derivation — each pubkey gets the hex of its first
+    /// 4 bytes as its tag. Doesn't have to match the production
+    /// SHA-256 derivation; the pump only needs the mapping to be
+    /// deterministic + the inverse uniquely recoverable.
+    private static func fakeTag(_ pub: Data) -> TransportInboxID {
+        TransportInboxID(rawValue: pub.prefix(4).map { String(format: "%02x", $0) }.joined())
+    }
+
+    func test_run_subscribesToEveryIntroPubInTheList() async throws {
+        let transport = PumpRecordingInboxTransport()
+        let store = InMemoryIntroRequestStore()
+        let pump = IntroInboxPump(
+            inboxTransport: transport,
+            store: store,
+            inboxTagFor: Self.fakeTag
+        )
+
+        let (entriesStream, cont) = AsyncStream.makeStream(of: [IntroKeyEntry].self)
+        cont.yield([entry(seed: 0x10), entry(seed: 0x20)])
+
+        let runTask = Task { await pump.run(entries: entriesStream) }
+        try await waitFor { await transport.subscribed.count >= 2 }
+
+        let live = await transport.subscribed
+        XCTAssertEqual(
+            Set(live),
+            Set([
+                Self.fakeTag(entry(seed: 0x10).introPublicKey),
+                Self.fakeTag(entry(seed: 0x20).introPublicKey),
+            ])
+        )
+
+        cont.finish()
+        runTask.cancel()
+    }
+
+    func test_inboundOnTaggedInbox_recordedWithMatchingIntroPub() async throws {
+        let transport = PumpRecordingInboxTransport()
+        let store = InMemoryIntroRequestStore()
+        let pump = IntroInboxPump(
+            inboxTransport: transport,
+            store: store,
+            inboxTagFor: Self.fakeTag
+        )
+
+        let e = entry(seed: 0x10)
+        let (entriesStream, cont) = AsyncStream.makeStream(of: [IntroKeyEntry].self)
+        cont.yield([e])
+
+        let runTask = Task { await pump.run(entries: entriesStream) }
+        try await waitFor { await transport.subscribed.count >= 1 }
+
+        let now = Date(timeIntervalSince1970: 1_700_000_500)
+        await transport.inject(InboundInbox(
+            inbox: Self.fakeTag(e.introPublicKey),
+            payload: Data("request-bytes".utf8),
+            receivedAt: now,
+            messageID: "ev-1"
+        ))
+
+        try await waitFor { await store.current().count >= 1 }
+        let recorded = await store.current()
+        XCTAssertEqual(recorded.count, 1)
+        // Every inbound is stamped with the introPub of the entry
+        // whose tag it landed on. PR-4's approval interactor looks
+        // up the privkey by this field.
+        XCTAssertEqual(recorded.first?.targetIntroPublicKey, e.introPublicKey)
+        XCTAssertEqual(recorded.first?.id, "ev-1")
+
+        cont.finish()
+        runTask.cancel()
+    }
+
+    func test_swappingTheListCancelsOldSubsAndStartsNewOnes() async throws {
+        let transport = PumpRecordingInboxTransport()
+        let store = InMemoryIntroRequestStore()
+        let pump = IntroInboxPump(
+            inboxTransport: transport,
+            store: store,
+            inboxTagFor: Self.fakeTag
+        )
+
+        let a = entry(seed: 0x10)
+        let c = entry(seed: 0x30)
+        let (entriesStream, cont) = AsyncStream.makeStream(of: [IntroKeyEntry].self)
+        cont.yield([a])
+
+        let runTask = Task { await pump.run(entries: entriesStream) }
+        try await waitFor { await transport.subscribed.count >= 1 }
+
+        cont.yield([c])
+        try await waitFor { await transport.unsubscribed.contains(Self.fakeTag(a.introPublicKey)) }
+        try await waitFor { await transport.subscribed.contains(Self.fakeTag(c.introPublicKey)) }
+
+        cont.finish()
+        runTask.cancel()
+    }
+
+    func test_emptyList_subscribesToNothing() async throws {
+        let transport = PumpRecordingInboxTransport()
+        let store = InMemoryIntroRequestStore()
+        let pump = IntroInboxPump(
+            inboxTransport: transport,
+            store: store,
+            inboxTagFor: Self.fakeTag
+        )
+
+        let (entriesStream, cont) = AsyncStream.makeStream(of: [IntroKeyEntry].self)
+        cont.yield([])
+
+        let runTask = Task { await pump.run(entries: entriesStream) }
+        // Give a generous window to make sure no spurious subscribes
+        // sneak in. 200ms is plenty for the actor reconciliation.
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let count = await transport.subscribed.count
+        XCTAssertEqual(count, 0, "empty entries → no subscriptions")
+
+        cont.finish()
+        runTask.cancel()
+    }
+
+    // MARK: - Helpers
+
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        interval: TimeInterval = 0.02,
+        _ predicate: @Sendable @escaping () async -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await predicate() { return }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("waitFor predicate never became true within \(timeout)s",
+                file: file, line: line)
+    }
+}
+
+// MARK: - Test doubles
+
+private actor PumpRecordingInboxTransport: InboxTransport {
+    private(set) var subscribed: [TransportInboxID] = []
+    private(set) var unsubscribed: [TransportInboxID] = []
+    private var continuations: [TransportInboxID: AsyncStream<InboundInbox>.Continuation] = [:]
+
+    func connect(to endpoints: [TransportEndpoint]) async {}
+    func disconnect() async {}
+
+    func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
+        PublishReceipt(messageID: UUID().uuidString, acceptedBy: 1)
+    }
+
+    nonisolated func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
+        AsyncStream { continuation in
+            Task { await self.register(inbox: inbox, continuation: continuation) }
+            continuation.onTermination = { _ in
+                Task { await self.releaseContinuation(inbox: inbox) }
+            }
+        }
+    }
+
+    func unsubscribe(inbox: TransportInboxID) async {
+        unsubscribed.append(inbox)
+        continuations[inbox]?.finish()
+        continuations.removeValue(forKey: inbox)
+    }
+
+    func inject(_ message: InboundInbox) {
+        continuations[message.inbox]?.yield(message)
+    }
+
+    private func register(
+        inbox: TransportInboxID,
+        continuation: AsyncStream<InboundInbox>.Continuation
+    ) {
+        subscribed.append(inbox)
+        continuations[inbox] = continuation
+    }
+
+    private func releaseContinuation(inbox: TransportInboxID) {
+        continuations.removeValue(forKey: inbox)
+    }
+}

--- a/Tests/OnymIOSTests/Support/InMemoryIntroKeyStore.swift
+++ b/Tests/OnymIOSTests/Support/InMemoryIntroKeyStore.swift
@@ -3,15 +3,21 @@ import Foundation
 
 /// Reusable in-memory `IntroKeyStore`. Same contract as
 /// `KeychainIntroKeyStore` without the Keychain plumbing — fast
-/// tests of `InviteIntroducer` and the future request-flow
-/// interactors that don't want to touch the Security framework.
+/// tests of `InviteIntroducer`, `IntroInboxPump`, and the future
+/// request-flow interactors that don't want to touch the Security
+/// framework.
 actor InMemoryIntroKeyStore: IntroKeyStore {
 
     private var entries: [IntroKeyEntry] = []
+    /// Per-owner subscriber continuations. Mutations re-emit the
+    /// filtered+sorted snapshot to every subscriber whose owner
+    /// matches.
+    private var continuations: [IdentityID: [UUID: AsyncStream<[IntroKeyEntry]>.Continuation]] = [:]
 
     func save(_ entry: IntroKeyEntry) async {
         entries.removeAll { $0.introPublicKey == entry.introPublicKey }
         entries.append(entry)
+        publish(forOwner: entry.ownerIdentityID)
     }
 
     func find(introPublicKey: Data) async -> IntroKeyEntry? {
@@ -19,19 +25,61 @@ actor InMemoryIntroKeyStore: IntroKeyStore {
     }
 
     func listForOwner(_ ownerIdentityID: IdentityID) async -> [IntroKeyEntry] {
-        entries
-            .filter { $0.ownerIdentityID == ownerIdentityID }
-            .sorted { $0.createdAt > $1.createdAt }
+        snapshotForOwner(ownerIdentityID)
     }
 
     func revoke(introPublicKey: Data) async {
+        let owners = Set(entries.filter { $0.introPublicKey == introPublicKey }.map(\.ownerIdentityID))
         entries.removeAll { $0.introPublicKey == introPublicKey }
+        for owner in owners { publish(forOwner: owner) }
     }
 
     @discardableResult
     func deleteForOwner(_ ownerIdentityID: IdentityID) async -> Int {
         let before = entries.count
         entries.removeAll { $0.ownerIdentityID == ownerIdentityID }
-        return before - entries.count
+        let removed = before - entries.count
+        if removed > 0 { publish(forOwner: ownerIdentityID) }
+        return removed
+    }
+
+    nonisolated func entriesStream(forOwner ownerIdentityID: IdentityID) -> AsyncStream<[IntroKeyEntry]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(owner: ownerIdentityID, id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(owner: ownerIdentityID, id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func subscribe(
+        owner: IdentityID,
+        id: UUID,
+        continuation: AsyncStream<[IntroKeyEntry]>.Continuation
+    ) {
+        continuations[owner, default: [:]][id] = continuation
+        continuation.yield(snapshotForOwner(owner))
+    }
+
+    private func unsubscribe(owner: IdentityID, id: UUID) {
+        continuations[owner]?.removeValue(forKey: id)
+        if continuations[owner]?.isEmpty == true {
+            continuations.removeValue(forKey: owner)
+        }
+    }
+
+    private func publish(forOwner owner: IdentityID) {
+        guard let bucket = continuations[owner] else { return }
+        let snapshot = snapshotForOwner(owner)
+        for cont in bucket.values { cont.yield(snapshot) }
+    }
+
+    private func snapshotForOwner(_ owner: IdentityID) -> [IntroKeyEntry] {
+        entries
+            .filter { $0.ownerIdentityID == owner }
+            .sorted { $0.createdAt > $1.createdAt }
     }
 }


### PR DESCRIPTION
## Summary

PR-3 of 7. Sender-side fan-out for the Level-2 deeplink invite flow. Each outstanding intro link gets its own Nostr inbox subscription; the pump records inbound "request to join" envelopes into an in-memory `IntroRequestStore` for the (PR-5+) approval UI.

**Stacked on `identity/intro-keystore` (PR-2 / #61).**

## What's in here

- `IntroRequest` — value type holding event id + targetIntroPub + encrypted payload + receivedAt
- `IntroRequestStore` — process-lifetime sink protocol with `InMemoryIntroRequestStore` impl
- `IntroInboxPump` — actor-backed reconciliation pump, modeled after `InboxFanoutInteractor`
- `IntroKeyStore.entriesStream(forOwner:)` — hot stream extension to PR-2's protocol; required for reactive subscribe on save/revoke. Implemented in both `KeychainIntroKeyStore` and `InMemoryIntroKeyStore`
- `OnymIOSApp` wiring: the new `.task` spawns a per-active-identity pump driven by the entries stream, and the existing identity-removed cascade now also calls `introKeyStore.deleteForOwner(removed)`

## A note on the multi-listener removal hook

Android needed to rewrite `IdentityRepository.removalListener` from single-slot to a `List<...>` to let the intro-keystore wipe co-exist with the chat-store wipe. **iOS already uses `AsyncStream<IdentityID>` for `identityRemoved`** — each subscriber gets its own continuation, so multi-listener semantics are built in. No `IdentityRepository` changes here; the existing `for await removed in identityRepository.identityRemoved` block in `OnymIOSApp` just got one more line.

## Cross-platform contract

Mirrors onym-android `transport/intro-inbox-subscription` (PR #62): same wholesale-reconcile semantics, same `SHA-256("sep-inbox-v1" || pub)[..8]` tag derivation, same in-memory store posture for the receive side.

## Test coverage (4 cases, mirroring `IntroInboxPumpTest.kt`)

- subscribes to every intro pub in the list
- inbound on tagged inbox is recorded with matching introPub (so PR-4's approval interactor can find the privkey by this field)
- swapping the list cancels old subs and starts new ones
- empty list subscribes to nothing

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests/IntroInboxPumpTests -only-testing:OnymIOSTests/InviteIntroducerTests -only-testing:OnymIOSTests/IntroCapabilityTests -only-testing:OnymIOSTests/IntroCapabilityInteropTests` — 33/33 pass on iPhone 17 Pro simulator
- [ ] CI green
- [ ] Coordinated with onym-android PR #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)