### PR TITLE
group: join-request payload + sender + approver (PR-4 of 7: Level-2 deeplink)

### DIFF
--- a/Sources/OnymIOS/Group/GroupRepository.swift
+++ b/Sources/OnymIOS/Group/GroupRepository.swift
@@ -74,6 +74,17 @@ actor GroupRepository {
         await refreshFromStore()
     }
 
+    /// One-shot read of every cached group across **all** identities.
+    /// Used by `JoinRequestApprover` to look up a group by its raw
+    /// `group_id` bytes — the request can name any group on the
+    /// device, and the lookup must succeed regardless of which
+    /// identity is currently selected. Subscribers prefer
+    /// `snapshots`.
+    func currentGroups() async -> [ChatGroup] {
+        if cached.isEmpty { await refreshFromStore() }
+        return cached
+    }
+
     // MARK: - Subscriptions
 
     nonisolated var snapshots: AsyncStream<[ChatGroup]> {

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -1,0 +1,273 @@
+import CryptoKit
+import Foundation
+
+/// Sender-side: turn raw `IntroRequest`s into UI-renderable
+/// pending requests, and on user approval ship the actual sealed
+/// `GroupInvitationPayload` to the joiner.
+///
+/// Lifecycle:
+///  1. `start` subscribes to `IntroRequestStore.requests` and
+///     decrypts each newly-arrived envelope using the matching
+///     `IntroKeyEntry.introPrivateKey` from `IntroKeyStore`. Decrypt
+///     failures bump `decryptFailureCount` (drives a future
+///     diagnostic surface; users never see them).
+///  2. UI subscribes to `pending` and renders "X wants to join Y.
+///     Approve?" prompts.
+///  3. On Approve → seals the existing `GroupInvitationPayload`
+///     (built from the local `ChatGroup`) to the joiner's identity
+///     inbox key, ships via `inboxTransport.send`, revokes the
+///     intro key. The pump from PR-3 stops listening on that intro
+///     tag within one emission window.
+///  4. On Decline → drop the request, revoke the intro key. No
+///     NACK to the joiner; their JoinScreen times out gracefully.
+actor JoinRequestApprover {
+
+    /// UI-renderable view of one decrypted, awaiting-action request.
+    struct PendingRequest: Equatable, Sendable, Identifiable {
+        /// Stable id == `IntroRequest.id`. Approve / Decline use it
+        /// as the dedupe key.
+        let id: String
+        let joinerInboxPublicKey: Data
+        let joinerDisplayLabel: String
+        let groupId: Data
+        /// Looked up from the local `GroupRepository`. nil if the
+        /// joiner is asking about a group we don't know — surface a
+        /// "this invite isn't for any group on this device" error
+        /// in the UI rather than approving.
+        let groupName: String?
+    }
+
+    enum ApproveOutcome: Equatable, Sendable {
+        case sent
+        case unknownGroup
+        case unknownRequest
+        case noIdentityLoaded
+        case transportFailed(String)
+    }
+
+    private let identity: IdentityRepository
+    private let introKeyStore: any IntroKeyStore
+    private let introRequestStore: any IntroRequestStore
+    private let groupRepository: GroupRepository
+    private let inboxTransport: any InboxTransport
+
+    private var pendingValue: [PendingRequest] = []
+    private var pendingContinuations: [UUID: AsyncStream<[PendingRequest]>.Continuation] = [:]
+    private var decryptFailures: Int = 0
+    private var collectorTask: Task<Void, Never>?
+
+    init(
+        identity: IdentityRepository,
+        introKeyStore: any IntroKeyStore,
+        introRequestStore: any IntroRequestStore,
+        groupRepository: GroupRepository,
+        inboxTransport: any InboxTransport
+    ) {
+        self.identity = identity
+        self.introKeyStore = introKeyStore
+        self.introRequestStore = introRequestStore
+        self.groupRepository = groupRepository
+        self.inboxTransport = inboxTransport
+    }
+
+    /// Hot stream of decoded pending requests. Replays the current
+    /// snapshot to new subscribers; re-emits on every change.
+    nonisolated var pending: AsyncStream<[PendingRequest]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribePending(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribePending(id: id) }
+            }
+        }
+    }
+
+    /// Diagnostic counter — bumped each time an envelope fails to
+    /// decode (forged link campaign, corrupted intro key, etc.).
+    /// Wired to a Settings → Diagnostics view in a follow-up.
+    func decryptFailureCount() -> Int { decryptFailures }
+
+    /// Subscribe to `IntroRequestStore.requests` and keep `pending`
+    /// in sync. Idempotent — a second call replaces the prior
+    /// collector. The collector runs until `stop` or actor deinit.
+    func start() {
+        collectorTask?.cancel()
+        let store = introRequestStore
+        collectorTask = Task { [weak self] in
+            for await raw in store.requests {
+                if Task.isCancelled { break }
+                await self?.refresh(from: raw)
+            }
+        }
+    }
+
+    func stop() {
+        collectorTask?.cancel()
+        collectorTask = nil
+    }
+
+    /// Test seam — synchronously decode the current store snapshot
+    /// and emit. Lets unit tests assert the decode path without
+    /// fighting collector scheduling.
+    func pumpOnce() async {
+        let raw = await introRequestStore.current()
+        await refresh(from: raw)
+    }
+
+    /// Approve a pending request: build the `GroupInvitationPayload`
+    /// from the local group state, seal to the joiner's inbox key,
+    /// ship via Nostr, then revoke the intro slot + drop the
+    /// pending entry.
+    func approve(requestId: String) async -> ApproveOutcome {
+        guard let req = pendingValue.first(where: { $0.id == requestId }) else {
+            return .unknownRequest
+        }
+        guard await identity.currentIdentity() != nil else {
+            return .noIdentityLoaded
+        }
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.groupIDData == req.groupId }) else {
+            return .unknownGroup
+        }
+        let invite = GroupInvitationPayload(
+            version: 1,
+            groupID: group.groupIDData,
+            groupSecret: group.groupSecret,
+            name: group.name,
+            members: group.members,
+            epoch: group.epoch,
+            salt: group.salt,
+            commitment: group.commitment,
+            tierRaw: group.tier.rawValue,
+            groupTypeRaw: group.groupType.rawValue,
+            adminPubkeyHex: group.adminPubkeyHex
+        )
+        let payloadBytes: Data
+        do {
+            payloadBytes = try JSONEncoder().encode(invite)
+        } catch {
+            return .transportFailed("encode: \(error)")
+        }
+        let sealed: Data
+        do {
+            sealed = try await identity.sealInvitation(
+                payload: payloadBytes,
+                to: req.joinerInboxPublicKey
+            )
+        } catch {
+            return .transportFailed("seal: \(error)")
+        }
+        let joinerTag = TransportInboxID(
+            rawValue: IntroInboxPump.inboxTag(from: req.joinerInboxPublicKey)
+        )
+        let receipt: PublishReceipt
+        do {
+            receipt = try await inboxTransport.send(sealed, to: joinerTag)
+        } catch {
+            return .transportFailed("send: \(error)")
+        }
+        guard receipt.acceptedBy >= 1 else {
+            return .transportFailed("no relay accepted the invitation")
+        }
+        // Best-effort cleanup. Both calls run regardless of failures
+        // because the request is conceptually consumed at this point;
+        // a leaked intro key is benign.
+        if let introPub = await findIntroPub(forRequestID: requestId) {
+            await introKeyStore.revoke(introPublicKey: introPub)
+        }
+        await introRequestStore.consume(id: requestId)
+        return .sent
+    }
+
+    /// Decline a pending request: drop it + revoke the intro slot.
+    /// No NACK to the joiner — their JoinScreen times out.
+    func decline(requestId: String) async {
+        if let introPub = await findIntroPub(forRequestID: requestId) {
+            await introKeyStore.revoke(introPublicKey: introPub)
+        }
+        await introRequestStore.consume(id: requestId)
+    }
+
+    // MARK: - Private
+
+    private func subscribePending(
+        id: UUID,
+        continuation: AsyncStream<[PendingRequest]>.Continuation
+    ) {
+        pendingContinuations[id] = continuation
+        continuation.yield(pendingValue)
+    }
+
+    private func unsubscribePending(id: UUID) {
+        pendingContinuations.removeValue(forKey: id)
+    }
+
+    private func publishPending() {
+        for cont in pendingContinuations.values { cont.yield(pendingValue) }
+    }
+
+    private func refresh(from raw: [IntroRequest]) async {
+        var decoded: [PendingRequest] = []
+        for r in raw {
+            if let p = await decode(r) { decoded.append(p) }
+        }
+        pendingValue = decoded
+        publishPending()
+    }
+
+    private func decode(_ raw: IntroRequest) async -> PendingRequest? {
+        guard let entry = await introKeyStore.find(introPublicKey: raw.targetIntroPublicKey) else {
+            // Entry was already revoked, or the request landed on a
+            // pubkey we never minted (forged). Drop silently.
+            return nil
+        }
+        let privKey: Curve25519.KeyAgreement.PrivateKey
+        do {
+            privKey = try Curve25519.KeyAgreement.PrivateKey(
+                rawRepresentation: entry.introPrivateKey
+            )
+        } catch {
+            decryptFailures += 1
+            return nil
+        }
+        let plaintext: Data
+        do {
+            plaintext = try IdentityRepository.decryptSealedEnvelope(
+                envelopeBytes: raw.payload,
+                recipientX25519PrivateKey: privKey
+            )
+        } catch {
+            decryptFailures += 1
+            return nil
+        }
+        let payload: JoinRequestPayload
+        do {
+            payload = try JSONDecoder().decode(JoinRequestPayload.self, from: plaintext)
+        } catch {
+            decryptFailures += 1
+            return nil
+        }
+        // Joiner is asking about a different group than the intro
+        // entry was minted for. Forged or stale link — drop silently.
+        guard payload.groupId == entry.groupId else {
+            decryptFailures += 1
+            return nil
+        }
+        let groups = await groupRepository.currentGroups()
+        let groupName = groups.first(where: { $0.groupIDData == payload.groupId })?.name
+        return PendingRequest(
+            id: raw.id,
+            joinerInboxPublicKey: payload.joinerInboxPublicKey,
+            joinerDisplayLabel: payload.joinerDisplayLabel,
+            groupId: payload.groupId,
+            groupName: groupName
+        )
+    }
+
+    /// `PendingRequest` doesn't carry the introPub (intentional —
+    /// UI never needs it). Resolve via the raw store on demand.
+    private func findIntroPub(forRequestID id: String) async -> Data? {
+        let raw = await introRequestStore.current()
+        return raw.first { $0.id == id }?.targetIntroPublicKey
+    }
+}

--- a/Sources/OnymIOS/Group/JoinRequestPayload.swift
+++ b/Sources/OnymIOS/Group/JoinRequestPayload.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Inner plaintext of the sealed envelope a joiner sends to an
+/// inviter's intro inbox. Carries everything the inviter's app
+/// needs to ship the actual sealed `GroupInvitationPayload` back:
+///
+///  - `joinerInboxPublicKey` — where the sealed invitation will be
+///    posted (the joiner's identity inbox X25519 key).
+///  - `joinerDisplayLabel` — UI hint for the inviter's "X wants to
+///    join Y. Approve?" prompt. Joiner-controlled, **untrusted**;
+///    the inviter's app should also surface
+///    `joinerInboxPublicKey`'s hex prefix so the inviter can
+///    verify out-of-band when the label can't be cross-checked.
+///  - `groupId` — echoed back so the inviter's approval handler can
+///    cross-check that the joiner is asking about the right group.
+///
+/// The OUTER envelope is the standard `SealedEnvelope` (X25519 +
+/// AES-GCM sealed to the inviter's intro pubkey + Ed25519-signed
+/// by the joiner's identity key). Reuses the existing seal/decrypt
+/// machinery on `IdentityRepository`.
+///
+/// Wire-format-equivalent to onym-android's `JoinRequestPayload.kt`:
+/// snake_case keys, base64 `Data` fields (Swift `JSONEncoder`'s
+/// `.base64` default + Kotlin's `Base64.getEncoder()` produce the
+/// same bytes).
+struct JoinRequestPayload: Codable, Equatable, Sendable {
+    let joinerInboxPublicKey: Data
+    let joinerDisplayLabel: String
+    let groupId: Data
+
+    enum CodingKeys: String, CodingKey {
+        case joinerInboxPublicKey = "joiner_inbox_pub"
+        case joinerDisplayLabel = "joiner_display_label"
+        case groupId = "group_id"
+    }
+
+    init(
+        joinerInboxPublicKey: Data,
+        joinerDisplayLabel: String,
+        groupId: Data
+    ) throws {
+        guard joinerInboxPublicKey.count == 32 else {
+            throw JoinRequestPayloadError.shape(
+                "joinerInboxPublicKey: expected 32 bytes, got \(joinerInboxPublicKey.count)"
+            )
+        }
+        guard groupId.count == 32 else {
+            throw JoinRequestPayloadError.shape(
+                "groupId: expected 32 bytes, got \(groupId.count)"
+            )
+        }
+        self.joinerInboxPublicKey = joinerInboxPublicKey
+        self.joinerDisplayLabel = joinerDisplayLabel
+        self.groupId = groupId
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let pub = try c.decode(Data.self, forKey: .joinerInboxPublicKey)
+        let label = try c.decode(String.self, forKey: .joinerDisplayLabel)
+        let gid = try c.decode(Data.self, forKey: .groupId)
+        guard pub.count == 32 else {
+            throw JoinRequestPayloadError.shape(
+                "joinerInboxPublicKey: expected 32 bytes, got \(pub.count)"
+            )
+        }
+        guard gid.count == 32 else {
+            throw JoinRequestPayloadError.shape(
+                "groupId: expected 32 bytes, got \(gid.count)"
+            )
+        }
+        self.joinerInboxPublicKey = pub
+        self.joinerDisplayLabel = label
+        self.groupId = gid
+    }
+}
+
+enum JoinRequestPayloadError: Error, Equatable {
+    case shape(String)
+}

--- a/Sources/OnymIOS/Group/JoinRequestSender.swift
+++ b/Sources/OnymIOS/Group/JoinRequestSender.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Joiner-side: tap-the-deeplink → ship a sealed `JoinRequestPayload`
+/// to the inviter's intro inbox.
+///
+/// Flow:
+///  1. Build the payload (joiner's inbox pubkey + display label +
+///     group id echo).
+///  2. Seal the payload to `IntroCapability.introPublicKey` using
+///     the existing `IdentityRepository.sealInvitation` (X25519
+///     ECDH against intro_pub + AES-GCM + Ed25519 signature with
+///     the joiner's long-term key).
+///  3. POST the sealed bytes to the Nostr inbox tag derived from
+///     intro_pub (same `sep-inbox-v1` derivation the identity inbox
+///     uses).
+///  4. Surface success/failure to the JoinScreen UI (PR-7).
+actor JoinRequestSender {
+    private let identity: IdentityRepository
+    private let inboxTransport: any InboxTransport
+
+    init(identity: IdentityRepository, inboxTransport: any InboxTransport) {
+        self.identity = identity
+        self.inboxTransport = inboxTransport
+    }
+
+    enum Outcome: Equatable, Sendable {
+        case sent
+        case noIdentityLoaded
+        case transportFailed(String)
+    }
+
+    /// - Parameters:
+    ///   - capability: decoded from the deeplink's `?c=…` payload.
+    ///   - joinerDisplayLabel: surfaced in the inviter's approval
+    ///     prompt. Joiner-controlled untrusted text — keep short
+    ///     (Nostr relays typically cap event size at ~64KB and we
+    ///     don't want to bloat the request envelope).
+    func send(
+        capability: IntroCapability,
+        joinerDisplayLabel: String
+    ) async -> Outcome {
+        guard let active = await identity.currentIdentity() else {
+            return .noIdentityLoaded
+        }
+        let payload: JoinRequestPayload
+        do {
+            payload = try JoinRequestPayload(
+                joinerInboxPublicKey: active.inboxPublicKey,
+                joinerDisplayLabel: joinerDisplayLabel,
+                groupId: capability.groupId
+            )
+        } catch {
+            return .transportFailed("payload: \(error)")
+        }
+        let payloadBytes: Data
+        do {
+            payloadBytes = try JSONEncoder().encode(payload)
+        } catch {
+            return .transportFailed("encode: \(error)")
+        }
+        let sealed: Data
+        do {
+            sealed = try await identity.sealInvitation(
+                payload: payloadBytes,
+                to: capability.introPublicKey
+            )
+        } catch {
+            return .transportFailed("seal: \(error)")
+        }
+        let tag = TransportInboxID(rawValue: IntroInboxPump.inboxTag(from: capability.introPublicKey))
+        let receipt: PublishReceipt
+        do {
+            receipt = try await inboxTransport.send(sealed, to: tag)
+        } catch {
+            return .transportFailed("send: \(error)")
+        }
+        guard receipt.acceptedBy >= 1 else {
+            return .transportFailed("no relay accepted the request")
+        }
+        return .sent
+    }
+}

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -254,6 +254,31 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// envelope decrypts under the right key — even when the receiving
     /// identity isn't the currently-selected one.
     func decryptInvitation(envelopeBytes: Data, asIdentity identityID: IdentityID) throws -> Data {
+        guard let snapshot = try keychain.read(identityID) else {
+            throw InvitationDecryptError.identityNotLoaded
+        }
+        let privateKey = try Self.inboxKeyAgreementPrivateKey(
+            fromNostrSecret: snapshot.nostrSecretKey
+        )
+        return try Self.decryptSealedEnvelope(
+            envelopeBytes: envelopeBytes,
+            recipientX25519PrivateKey: privateKey
+        )
+    }
+
+    /// Static decrypt for callers that already hold the X25519 private
+    /// key — used by `JoinRequestApprover` to open envelopes sealed
+    /// to a per-invite ephemeral introPub (where the matching privkey
+    /// lives in `IntroKeyStore`, not in the identity keychain).
+    ///
+    /// Same wire-format guarantees as `decryptInvitation(envelopeBytes:asIdentity:)`:
+    /// requires `scheme = "x25519-aes-256-gcm-v1"`, verifies the
+    /// optional Ed25519 signature on the ephemeral pubkey when
+    /// present, runs ECDH + HKDF + AES-GCM open.
+    static func decryptSealedEnvelope(
+        envelopeBytes: Data,
+        recipientX25519PrivateKey: Curve25519.KeyAgreement.PrivateKey
+    ) throws -> Data {
         let envelope: SealedEnvelope
         do {
             envelope = try JSONDecoder().decode(SealedEnvelope.self, from: envelopeBytes)
@@ -286,16 +311,9 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
             }
         }
 
-        guard let snapshot = try keychain.read(identityID) else {
-            throw InvitationDecryptError.identityNotLoaded
-        }
-        let privateKey = try Self.inboxKeyAgreementPrivateKey(
-            fromNostrSecret: snapshot.nostrSecretKey
-        )
-
         do {
             let ephPub = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: ephPubData)
-            let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: ephPub)
+            let sharedSecret = try recipientX25519PrivateKey.sharedSecretFromKeyAgreement(with: ephPub)
             let key = sharedSecret.hkdfDerivedSymmetricKey(
                 using: SHA256.self,
                 salt: Data("sep-invitation-v1".utf8),

--- a/Tests/OnymIOSTests/JoinRequestPayloadTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestPayloadTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import OnymIOS
+
+/// Wire-format pin for `JoinRequestPayload`. Mirrors
+/// `JoinRequestPayloadTest.kt`. Cross-platform parity is checked
+/// via the snake_case key spelling assertions — Swift `JSONEncoder`
+/// + Kotlin `kotlinx.serialization.Json` both serialize `Data` /
+/// `ByteArray` to standard base64 with padding by default.
+final class JoinRequestPayloadTests: XCTestCase {
+
+    func test_roundtrip_preservesAllFields() throws {
+        let original = try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0xAA, count: 32),
+            joinerDisplayLabel: "Bob",
+            groupId: Data(repeating: 0x42, count: 32)
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(JoinRequestPayload.self, from: encoded)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_snake_case_keys_match_android_parity() throws {
+        // Cross-platform interop pin — Android uses snake_case
+        // SerialName annotations; Swift must match for the
+        // sealed-then-decoded round-trip to work.
+        let payload = try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0, count: 32),
+            joinerDisplayLabel: "Bob",
+            groupId: Data(repeating: 0, count: 32)
+        )
+        let encoded = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNotNil(obj?["joiner_inbox_pub"])
+        XCTAssertNotNil(obj?["joiner_display_label"])
+        XCTAssertNotNil(obj?["group_id"])
+        XCTAssertEqual(obj?["joiner_display_label"] as? String, "Bob")
+    }
+
+    func test_constructor_rejectsWrongSizedKeys() {
+        XCTAssertThrowsError(try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0, count: 31),
+            joinerDisplayLabel: "x",
+            groupId: Data(repeating: 0, count: 32)
+        )) { error in
+            XCTAssertTrue(error is JoinRequestPayloadError)
+        }
+        XCTAssertThrowsError(try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0, count: 32),
+            joinerDisplayLabel: "x",
+            groupId: Data(repeating: 0, count: 33)
+        )) { error in
+            XCTAssertTrue(error is JoinRequestPayloadError)
+        }
+    }
+
+    func test_decoder_rejectsWrongSizedKeys() {
+        let payloadJSON = #"""
+        {"joiner_inbox_pub":"AAA=","joiner_display_label":"Bob","group_id":"AAA="}
+        """#
+        let bytes = payloadJSON.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(JoinRequestPayload.self, from: bytes)) { error in
+            XCTAssertTrue(error is JoinRequestPayloadError)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR-4 of 7. Adds the request/response halves of the Level-2 deeplink invite flow.

The joiner sends a sealed `JoinRequestPayload` to the inviter's intro inbox; the inviter's approver decrypts it, looks up the local `ChatGroup`, seals the existing `GroupInvitationPayload` to the joiner's identity inbox, and ships it back via Nostr.

**Stacked on `transport/intro-inbox-subscription` (PR-3 / #62).**

## What's in here

- `JoinRequestPayload` — codable value type with snake_case wire keys (`joiner_inbox_pub`, `joiner_display_label`, `group_id`). 32-byte size validation in both throwing init AND custom `init(from:)` so badly-shaped wire data also fails closed
- `JoinRequestSender` — joiner-side actor. Builds + seals + ships, surfaces `.sent` / `.noIdentityLoaded` / `.transportFailed`
- `JoinRequestApprover` — sender-side actor. Subscribes to `IntroRequestStore.requests`, decodes per-invite envelopes, exposes `pending` AsyncStream of decoded UI-renderable rows, `approve(requestId:)` rebuilds the `GroupInvitationPayload` from local state and ships it back, `decline` revokes silently
- Static `IdentityRepository.decryptSealedEnvelope(envelopeBytes:recipientX25519PrivateKey:)` — extracted from the existing per-identity decrypt path so the approver can reuse the wire-format guarantees (scheme check, optional M-5 Ed25519 sig verification, ECDH + HKDF + AES-GCM open) when decrypting with a per-invite intro privkey
- `GroupRepository.currentGroups()` — one-shot cross-identity snapshot read for the approver

## Cross-platform contract

Mirrors onym-android `group/join-request` (PR #63): same wire shape, same decode-then-cross-check-against-IntroKeyEntry defensive posture (drops requests where joiner asks about a different group than the intro entry was minted for — forged or stale link → silent drop).

## Test coverage

**`JoinRequestPayloadTests` (4 cases, mirroring `JoinRequestPayloadTest.kt`):**
- roundtrip preserves all fields
- snake_case keys match Android parity (verified by parsing the JSON output and asserting key names)
- constructor rejects wrong-sized keys
- decoder also rejects wrong-sized keys (defense in depth — bad wire bytes shouldn't construct an invalid value)

**Regression: 26 existing decrypt/seal tests still pass after extracting the static helper.**

Sender + Approver behavioral tests are deferred to PR-5/PR-7 where the UI flow tests exercise the full path end-to-end with fakes — adding standalone unit tests for the sender + approver here would duplicate that coverage without testing anything beyond what the payload tests + UI integration already cover.

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests/JoinRequestPayloadTests -only-testing:OnymIOSTests/IdentityRepositoryInvitationDecryptTests -only-testing:OnymIOSTests/IdentityRepositorySealInvitationTests -only-testing:OnymIOSTests/IntroInboxPumpTests -only-testing:OnymIOSTests/InviteIntroducerTests` — 30/30 pass on iPhone 17 Pro simulator
- [ ] CI green
- [ ] Coordinated with onym-android PR #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)