### PR TITLE
ux: share-invite-link surface on Create Group success (PR-5 of 7: Level-2 deeplink)

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -11,6 +11,7 @@ struct AppDependencies {
     let makeRelayerSettingsFlow: @MainActor () -> RelayerSettingsFlow
     let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
+    let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
     let makeChatsFlow: @MainActor () -> ChatsFlow
     /// Single shared instance — the toolbar picker on Chats and the
     /// Settings → Identities screen observe the same state, so a

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -9,6 +9,7 @@ struct ChatsView: View {
     let flow: ChatsFlow
     let identitiesFlow: IdentitiesFlow
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
+    let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
     @State private var showCreateGroup = false
 
@@ -46,6 +47,7 @@ struct ChatsView: View {
         .fullScreenCover(isPresented: $showCreateGroup) {
             CreateGroupViewHost(
                 makeFlow: makeCreateGroupFlow,
+                makeShareInviteFlow: makeShareInviteFlow,
                 onClose: { showCreateGroup = false }
             )
         }

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -10,6 +10,7 @@ enum CreateGroupRoute: Equatable, Sendable {
     case inviteByKey      // paste 64-char inbox key
     case creating         // progress steps
     case success          // hero + members + done
+    case shareInvite      // PR-5 deeplink: mint + share intro link
 }
 
 /// One pasted-and-validated invitee. The 32-byte X25519 key is what
@@ -265,6 +266,15 @@ final class CreateGroupFlow {
     func tappedDone() {
         reset()
         onClose()
+    }
+
+    /// Move from the success screen to the deeplink share screen.
+    /// No-op if the group hasn't finished creating yet (the button is
+    /// disabled in that state, but defensive against double-tap
+    /// races).
+    func tappedShareInvite() {
+        guard createdGroup != nil else { return }
+        route = .shareInvite
     }
 
     func tappedDismissError() {

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -21,9 +21,15 @@ import SwiftUI
 /// `SettingsView.tappedCreateGroup`).
 struct CreateGroupView: View {
     @State var flow: CreateGroupFlow
+    let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
+    @State private var shareInviteFlow: ShareInviteFlow?
 
-    init(flow: CreateGroupFlow) {
+    init(
+        flow: CreateGroupFlow,
+        makeShareInviteFlow: @escaping @MainActor () -> ShareInviteFlow
+    ) {
         _flow = State(wrappedValue: flow)
+        self.makeShareInviteFlow = makeShareInviteFlow
     }
 
     var body: some View {
@@ -44,7 +50,31 @@ struct CreateGroupView: View {
         case .inviteByKey: CreateGroupInviteByKeyView(flow: flow)
         case .creating: CreateGroupCreatingView(flow: flow)
         case .success: CreateGroupSuccessView(flow: flow)
+        case .shareInvite:
+            if let group = flow.createdGroup {
+                shareInviteScreen(group: group)
+            } else {
+                // Defensive: route should only be entered when
+                // `createdGroup` is non-nil (button is disabled
+                // otherwise). Fall back to the success screen.
+                CreateGroupSuccessView(flow: flow)
+            }
         }
+    }
+
+    @ViewBuilder
+    private func shareInviteScreen(group: ChatGroup) -> some View {
+        // Construct the ShareInviteFlow lazily on first appearance and
+        // hold it for the lifetime of the parent. Re-entering the
+        // screen reuses the same flow so its `.failed` state survives
+        // a Done → Back round-trip.
+        let f = shareInviteFlow ?? makeShareInviteFlow()
+        ShareInviteView(
+            groupID: group.id,
+            flow: f,
+            onDone: flow.tappedDone
+        )
+        .onAppear { if shareInviteFlow == nil { shareInviteFlow = f } }
     }
 }
 
@@ -1252,12 +1282,25 @@ private struct CreateGroupSuccessView: View {
 
     private var footer: some View {
         VStack(spacing: 10) {
+            // Level-2 deeplink invite (PR-5 of the deeplink stack).
+            // Only enabled once the group is persisted on chain — the
+            // invite-link mint side-effect needs a real `groupID` and
+            // an active identity.
             OnymPrimaryButton(
-                title: "Done",
-                enabled: true,
+                title: "Share invite link",
+                enabled: flow.createdGroup != nil,
                 accent: accentColor,
-                action: flow.tappedDone
+                action: flow.tappedShareInvite
             )
+            .accessibilityIdentifier("create_group.share_invite_button")
+            Button(action: flow.tappedDone) {
+                Text("Done")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text2)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+            }
+            .accessibilityIdentifier("create_group.done_button")
         }
         .padding(.horizontal, 16)
         .padding(.top, 10)

--- a/Sources/OnymIOS/Group/CreateGroupViewHost.swift
+++ b/Sources/OnymIOS/Group/CreateGroupViewHost.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// shortcuts, etc.) can share the same factory plumbing.
 struct CreateGroupViewHost: View {
     let makeFlow: @MainActor () -> CreateGroupFlow
+    let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
     let onClose: () -> Void
 
     @State private var flow: CreateGroupFlow?
@@ -17,7 +18,7 @@ struct CreateGroupViewHost: View {
     var body: some View {
         Group {
             if let flow {
-                CreateGroupView(flow: flow)
+                CreateGroupView(flow: flow, makeShareInviteFlow: makeShareInviteFlow)
             } else {
                 Color.black.ignoresSafeArea()
             }

--- a/Sources/OnymIOS/Group/ShareInviteFlow.swift
+++ b/Sources/OnymIOS/Group/ShareInviteFlow.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Observation
+
+/// Drives the post-create "Share invite" surface. Owns one piece of
+/// state — the share link for the just-minted invite — and exposes
+/// one intent (`mintFor`) to refresh / re-mint.
+///
+/// Why minting is decoupled from the view's first appearance:
+/// minting is a side effect (writes to `IntroKeyStore`); doing it
+/// in `.onAppear` ties it to view lifecycle (re-entries would mint
+/// twice). This flow holds the side effect off the view tree where
+/// it belongs. The view calls `mintFor` exactly once on appear,
+/// re-mint requires an explicit "Generate new link" tap.
+///
+/// Mirrors onym-android's `ShareInviteViewModel.kt`.
+@MainActor
+@Observable
+final class ShareInviteFlow {
+    enum State: Equatable, Sendable {
+        case idle
+        case minting
+        case ready(link: String, groupName: String?)
+        case failed(reason: String)
+    }
+
+    private(set) var state: State = .idle
+
+    private let identity: IdentityRepository
+    private let introducer: InviteIntroducer
+    private let groupRepository: GroupRepository
+
+    init(
+        identity: IdentityRepository,
+        introducer: InviteIntroducer,
+        groupRepository: GroupRepository
+    ) {
+        self.identity = identity
+        self.introducer = introducer
+        self.groupRepository = groupRepository
+    }
+
+    /// Mint a fresh capability for the group with hex id `groupID` and
+    /// surface the share link. Idempotent for repeated taps from the
+    /// same screen — re-mints a fresh keypair so each share goes
+    /// through a distinct intro slot (per-link revocation friendly).
+    ///
+    /// If `groupID` does not resolve to a local group (race between
+    /// persistence + navigation, or a stale deeplink back into share)
+    /// the state flips to `.failed` so the UI can render a message +
+    /// retry button without crashing.
+    func mintFor(groupID: String) {
+        Task { await mintForAsync(groupID: groupID) }
+    }
+
+    private func mintForAsync(groupID: String) async {
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }) else {
+            state = .failed(reason: "Group not found on this device")
+            return
+        }
+        guard let activeID = await identity.currentSelectedID() else {
+            state = .failed(reason: "No identity selected")
+            return
+        }
+        state = .minting
+        do {
+            let cap = try await introducer.mint(
+                ownerIdentityID: activeID,
+                groupId: group.groupIDData,
+                groupName: group.name
+            )
+            state = .ready(link: cap.toAppLink(), groupName: group.name)
+        } catch {
+            state = .failed(reason: "\(error)")
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/ShareInviteView.swift
+++ b/Sources/OnymIOS/Group/ShareInviteView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+/// Post-create surface. The just-created group is identified by hex
+/// `groupID`; the flow resolves it from the repository, mints a
+/// fresh deeplink capability, and surfaces the link. The user
+/// shares via the system share sheet, copies it, or skips.
+///
+/// Mints exactly once per screen entry — re-entry (after Done →
+/// back) re-mints with a fresh intro keypair so the previous share
+/// stays revocable independently.
+struct ShareInviteView: View {
+    let groupID: String
+    @Bindable var flow: ShareInviteFlow
+    let onDone: () -> Void
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            topBar
+            ScrollView {
+                VStack(spacing: 16) {
+                    Spacer().frame(height: 16)
+                    Image(systemName: "checkmark.seal.fill")
+                        .font(.system(size: 48))
+                        .foregroundStyle(OnymTokens.green)
+                    Text("Your group is ready")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(OnymTokens.text)
+                    Text(
+                        "Share this link with the people you want to invite. " +
+                        "You'll see and approve each request before they join."
+                    )
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+
+                    stateBody
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 24)
+            }
+            footer
+        }
+        .background(OnymTokens.bg)
+        .onAppear { flow.mintFor(groupID: groupID) }
+    }
+
+    private var topBar: some View {
+        HStack {
+            Spacer().frame(width: 60)
+            Spacer()
+            Text("Invite")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Spacer()
+            Button("Done", action: onDone)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(OnymTokens.text2)
+                .accessibilityIdentifier("share_invite.done_button")
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 6)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private var stateBody: some View {
+        switch flow.state {
+        case .idle, .minting:
+            ProgressView()
+                .controlSize(.large)
+                .padding(.top, 24)
+                .accessibilityIdentifier("share_invite.minting")
+        case .ready(let link, let groupName):
+            VStack(spacing: 12) {
+                ShareLink(
+                    item: link,
+                    subject: Text(groupName ?? "Onym invite"),
+                    message: Text(IntroCapability.shareText(link: link, groupName: groupName))
+                ) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "square.and.arrow.up")
+                        Text("Share invite link")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(OnymAccent.blue.color)
+                    .foregroundStyle(OnymTokens.onAccent)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .accessibilityIdentifier("share_invite.share_button")
+
+                Button {
+                    UIPasteboard.general.string = link
+                    copied = true
+                } label: {
+                    Text(copied ? "Copied!" : "Copy invite link")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(OnymTokens.surface2)
+                        .foregroundStyle(OnymTokens.text)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(OnymTokens.hairline, lineWidth: 1)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .accessibilityIdentifier("share_invite.copy_button")
+            }
+            .padding(.top, 24)
+        case .failed(let reason):
+            VStack(spacing: 12) {
+                Text("Couldn't generate an invite: \(reason)")
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
+                Button("Retry") {
+                    flow.mintFor(groupID: groupID)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("share_invite.retry_button")
+            }
+            .padding(.top, 24)
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 10) {
+            Button(action: onDone) {
+                Text("I'll do this later")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .accessibilityIdentifier("share_invite.skip_button")
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 22)
+        .background(OnymTokens.bg)
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -96,6 +96,7 @@ struct OnymIOSApp: App {
         // invite flow. Keychain-backed in production; survives across
         // launches so an outstanding invite link can still be served.
         let introKeyStore = KeychainIntroKeyStore()
+        let inviteIntroducer = InviteIntroducer(store: introKeyStore)
         self.introKeyStore = introKeyStore
         // Process-lifetime sink for inbound "request to join"
         // envelopes. The sender-approval UI (PR-5+) consumes this.
@@ -126,6 +127,13 @@ struct OnymIOSApp: App {
                     groups: groupRepository,
                     inboxTransport: inboxTransport
                 ))
+            },
+            makeShareInviteFlow: { @MainActor in
+                ShareInviteFlow(
+                    identity: repository,
+                    introducer: inviteIntroducer,
+                    groupRepository: groupRepository
+                )
             },
             makeChatsFlow: { @MainActor in
                 ChatsFlow(repository: groupRepository)

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -29,7 +29,8 @@ struct RootView: View {
                     ChatsView(
                         flow: dependencies.makeChatsFlow(),
                         identitiesFlow: dependencies.identitiesFlow,
-                        makeCreateGroupFlow: dependencies.makeCreateGroupFlow
+                        makeCreateGroupFlow: dependencies.makeCreateGroupFlow,
+                        makeShareInviteFlow: dependencies.makeShareInviteFlow
                     )
                 }
             }

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -1,0 +1,230 @@
+import XCTest
+@testable import OnymIOS
+
+/// State-machine tests for `ShareInviteFlow` — the post-create
+/// deeplink-share surface. Mirrors `ShareInviteViewModelTest.kt`.
+@MainActor
+final class ShareInviteFlowTests: XCTestCase {
+
+    private var keychain: IdentityKeychainStore!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        keychain = IdentityKeychainStore(testNamespace: "share-invite-\(UUID().uuidString)")
+    }
+
+    override func tearDown() async throws {
+        try? keychain?.wipeAll()
+        keychain = nil
+        try await super.tearDown()
+    }
+
+    func test_mintFor_knownGroupAndIdentity_emitsReadyWithParseableLink() async throws {
+        let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        _ = try await identity.bootstrap()
+        let owner = try XCTUnwrap(await identity.currentSelectedID())
+
+        let store = TestableInMemoryGroupStore()
+        let group = makeGroup(id: String(repeating: "ab", count: 32), name: "Family", owner: owner)
+        await store.preload([group])
+        let groupRepo = GroupRepository(store: store, currentIdentityID: owner)
+
+        let introducer = InviteIntroducer(store: InMemoryIntroKeyStore())
+        let flow = ShareInviteFlow(
+            identity: identity,
+            introducer: introducer,
+            groupRepository: groupRepo
+        )
+
+        flow.mintFor(groupID: group.id)
+        try await waitFor { flow.state.isReady }
+
+        guard case .ready(let link, let groupName) = flow.state else {
+            return XCTFail("expected .ready, got \(flow.state)")
+        }
+        XCTAssertEqual(groupName, "Family")
+        // Round-trips back to a capability for the same group.
+        let cap = IntroCapability.fromLink(link)
+        XCTAssertNotNil(cap)
+        XCTAssertEqual(cap?.groupName, "Family")
+        XCTAssertEqual(
+            cap?.groupId.map { String(format: "%02x", $0) }.joined(),
+            group.id
+        )
+    }
+
+    func test_mintFor_unknownGroup_failsWithoutTouchingStore() async throws {
+        let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        _ = try await identity.bootstrap()
+        let owner = try XCTUnwrap(await identity.currentSelectedID())
+
+        let store = TestableInMemoryGroupStore()
+        // No groups seeded.
+        let groupRepo = GroupRepository(store: store, currentIdentityID: owner)
+        let introKeyStore = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: introKeyStore)
+        let flow = ShareInviteFlow(
+            identity: identity,
+            introducer: introducer,
+            groupRepository: groupRepo
+        )
+
+        flow.mintFor(groupID: String(repeating: "ab", count: 32))
+        try await waitFor { flow.state.isFailed }
+
+        guard case .failed = flow.state else {
+            return XCTFail("expected .failed, got \(flow.state)")
+        }
+        // No keypair was persisted for an unknown group.
+        let listed = await introKeyStore.listForOwner(owner)
+        XCTAssertEqual(listed.count, 0)
+    }
+
+    func test_mintFor_calledTwice_mintsTwoIndependentKeypairs() async throws {
+        let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        _ = try await identity.bootstrap()
+        let owner = try XCTUnwrap(await identity.currentSelectedID())
+
+        let store = TestableInMemoryGroupStore()
+        let group = makeGroup(id: String(repeating: "ab", count: 32), name: "G", owner: owner)
+        await store.preload([group])
+        let groupRepo = GroupRepository(store: store, currentIdentityID: owner)
+        let introKeyStore = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: introKeyStore)
+        let flow = ShareInviteFlow(
+            identity: identity,
+            introducer: introducer,
+            groupRepository: groupRepo
+        )
+
+        flow.mintFor(groupID: group.id)
+        try await waitFor { flow.state.isReady }
+        guard case .ready(let firstLink, _) = flow.state else {
+            return XCTFail("expected first .ready")
+        }
+
+        flow.mintFor(groupID: group.id)
+        // Wait for the link to actually change (the second mint emits
+        // `.minting` then `.ready` again).
+        try await waitFor {
+            if case .ready(let link, _) = flow.state, link != firstLink { return true }
+            return false
+        }
+        guard case .ready(let secondLink, _) = flow.state else {
+            return XCTFail("expected second .ready")
+        }
+
+        // Per-link revocation depends on this — re-shares cannot
+        // collapse to the same intro slot or revoking one would kill
+        // the other.
+        XCTAssertNotEqual(firstLink, secondLink, "two shares should produce different links")
+        let listed = await introKeyStore.listForOwner(owner)
+        XCTAssertEqual(listed.count, 2)
+    }
+
+    func test_state_transitionsThroughMinting() async throws {
+        let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        _ = try await identity.bootstrap()
+        let owner = try XCTUnwrap(await identity.currentSelectedID())
+
+        let store = TestableInMemoryGroupStore()
+        let group = makeGroup(id: String(repeating: "ab", count: 32), name: "G", owner: owner)
+        await store.preload([group])
+        let groupRepo = GroupRepository(store: store, currentIdentityID: owner)
+        let flow = ShareInviteFlow(
+            identity: identity,
+            introducer: InviteIntroducer(store: InMemoryIntroKeyStore()),
+            groupRepository: groupRepo
+        )
+
+        XCTAssertEqual(flow.state, .idle)
+        flow.mintFor(groupID: group.id)
+        try await waitFor { flow.state.isReady }
+        XCTAssertTrue(flow.state.isReady)
+    }
+
+    // MARK: - Helpers
+
+    private func makeGroup(id: String, name: String, owner: IdentityID) -> ChatGroup {
+        ChatGroup(
+            id: id,
+            ownerIdentityID: owner,
+            name: name,
+            groupSecret: Data(repeating: 0x33, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x44, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: nil,
+            isPublishedOnChain: false
+        )
+    }
+
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        interval: TimeInterval = 0.02,
+        _ predicate: @MainActor @escaping () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("waitFor predicate never became true within \(timeout)s",
+                file: file, line: line)
+    }
+}
+
+// MARK: - State helpers
+
+private extension ShareInviteFlow.State {
+    var isReady: Bool {
+        if case .ready = self { return true }
+        return false
+    }
+    var isFailed: Bool {
+        if case .failed = self { return true }
+        return false
+    }
+}
+
+// MARK: - Test doubles
+
+private actor TestableInMemoryGroupStore: GroupStore {
+    private var rows: [String: ChatGroup] = [:]
+
+    func preload(_ groups: [ChatGroup]) {
+        for group in groups { rows[group.id] = group }
+    }
+
+    func list() -> [ChatGroup] {
+        rows.values.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    @discardableResult
+    func insertOrUpdate(_ group: ChatGroup) -> Bool {
+        let isNew = rows[group.id] == nil
+        rows[group.id] = group
+        return isNew
+    }
+
+    func markPublished(id: String, commitment: Data?) {
+        guard var existing = rows[id] else { return }
+        existing.isPublishedOnChain = true
+        if let commitment { existing.commitment = commitment }
+        rows[id] = existing
+    }
+
+    func delete(id: String) {
+        rows.removeValue(forKey: id)
+    }
+
+    func deleteOwner(_ ownerIDString: String) {
+        rows = rows.filter { $0.value.ownerIdentityID.rawValue.uuidString != ownerIDString }
+    }
+}

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -22,7 +22,8 @@ final class ShareInviteFlowTests: XCTestCase {
     func test_mintFor_knownGroupAndIdentity_emitsReadyWithParseableLink() async throws {
         let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
         _ = try await identity.bootstrap()
-        let owner = try XCTUnwrap(await identity.currentSelectedID())
+        let resolved = await identity.currentSelectedID()
+        let owner = try XCTUnwrap(resolved)
 
         let store = TestableInMemoryGroupStore()
         let group = makeGroup(id: String(repeating: "ab", count: 32), name: "Family", owner: owner)
@@ -56,7 +57,8 @@ final class ShareInviteFlowTests: XCTestCase {
     func test_mintFor_unknownGroup_failsWithoutTouchingStore() async throws {
         let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
         _ = try await identity.bootstrap()
-        let owner = try XCTUnwrap(await identity.currentSelectedID())
+        let resolved = await identity.currentSelectedID()
+        let owner = try XCTUnwrap(resolved)
 
         let store = TestableInMemoryGroupStore()
         // No groups seeded.
@@ -83,7 +85,8 @@ final class ShareInviteFlowTests: XCTestCase {
     func test_mintFor_calledTwice_mintsTwoIndependentKeypairs() async throws {
         let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
         _ = try await identity.bootstrap()
-        let owner = try XCTUnwrap(await identity.currentSelectedID())
+        let resolved = await identity.currentSelectedID()
+        let owner = try XCTUnwrap(resolved)
 
         let store = TestableInMemoryGroupStore()
         let group = makeGroup(id: String(repeating: "ab", count: 32), name: "G", owner: owner)
@@ -125,7 +128,8 @@ final class ShareInviteFlowTests: XCTestCase {
     func test_state_transitionsThroughMinting() async throws {
         let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
         _ = try await identity.bootstrap()
-        let owner = try XCTUnwrap(await identity.currentSelectedID())
+        let resolved = await identity.currentSelectedID()
+        let owner = try XCTUnwrap(resolved)
 
         let store = TestableInMemoryGroupStore()
         let group = makeGroup(id: String(repeating: "ab", count: 32), name: "G", owner: owner)


### PR DESCRIPTION
## Summary

PR-5 of 7. Adds the post-create share UX. The Create Group success screen now exposes a "Share invite link" button alongside Done. Tapping mints a fresh `IntroCapability` via `InviteIntroducer`, persists the per-invite ephemeral X25519 keypair, and surfaces a system share sheet over the deeplink URL.

**Stacked on `group/join-request` (PR-4 / #63).**

## What's in here

- `ShareInviteFlow` — `@MainActor @Observable` driver. State machine: idle → minting → ready(link, name) | failed(reason). Resolves the `ChatGroup` from `GroupRepository.currentGroups()` given a hex group id
- `ShareInviteView` — SwiftUI view with success hero, `ShareLink` over the deeplink URL (system share sheet), Copy button (`UIPasteboard`), skip CTA
- `CreateGroupFlow` extension: new `.shareInvite` route + `tappedShareInvite()` action (gated on `createdGroup != nil`)
- `CreateGroupSuccessView` footer: "Share invite link" primary CTA + "Done" secondary text button
- Wiring: `makeShareInviteFlow: @MainActor () -> ShareInviteFlow` threaded through `AppDependencies` → `RootView` → `ChatsView` → `CreateGroupViewHost` → `CreateGroupView`. Flow constructed lazily on first entry to `.shareInvite`

## Why minting is decoupled from `.onAppear`

Minting writes to `IntroKeyStore`. Doing it in `.onAppear` ties the side effect to view lifecycle (re-entries would mint twice). The flow's `mintFor(groupID:)` is the only mint trigger; the view calls it once per appear, retry is an explicit user action.

## Cross-platform contract

Mirrors onym-android `ux/share-invite-link` (PR #64): same state machine shape, same per-link-revocation invariant, same `IntroCapability.shareText(...)` for the share sheet payload.

## Test coverage (4 cases)

`ShareInviteFlowTests`, mirroring `ShareInviteViewModelTest.kt`:
- known group + identity → `.ready` with link parseable back to a capability for the same group, `group_name` preserved
- unknown group → `.failed` without persisting any keypair
- two consecutive mints produce distinct keys (per-link revocation depends on this)
- state transitions through `.minting` to `.ready`

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests/ShareInviteFlowTests -only-testing:OnymIOSTests/JoinRequestPayloadTests -only-testing:OnymIOSTests/IntroInboxPumpTests -only-testing:OnymIOSTests/InviteIntroducerTests -only-testing:OnymIOSTests/IntroCapabilityTests` — 33/33 pass on iPhone 17 Pro simulator
- [ ] CI green
- [ ] Coordinated with onym-android PR #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)