### PR TITLE
transport: deeplink capture + URL scheme + Universal Link entitlement (PR-6 of 7: Level-2 deeplink)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -18,6 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>chat.onym.ios.join</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>onym</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>UIApplicationSceneManifest</key>

--- a/OnymIOS.entitlements
+++ b/OnymIOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:onym.chat</string>
+	</array>
+</dict>
+</plist>

--- a/Sources/OnymIOS/Group/IntroCapability.swift
+++ b/Sources/OnymIOS/Group/IntroCapability.swift
@@ -51,7 +51,13 @@ import Foundation
 ///  - `group_name` omitted from JSON when nil (custom `encode(to:)`
 ///    using `encodeIfPresent` — matches Android's
 ///    `encodeDefaults = false`)
-struct IntroCapability: Codable, Equatable, Sendable {
+struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
+    /// `id` for SwiftUI `.sheet(item:)` / `.fullScreenCover(item:)`
+    /// presentation. The intro pubkey is uniformly random per
+    /// invite, so it's a stable identity for one in-flight
+    /// capability — two distinct invites can never collide.
+    var id: Data { introPublicKey }
+
     /// X25519 32-byte pubkey, freshly minted per invite. Encrypts
     /// the joiner's request envelope; the inviter's app holds the
     /// matching private key.

--- a/Sources/OnymIOS/Group/JoinInviteCapturedPlaceholderView.swift
+++ b/Sources/OnymIOS/Group/JoinInviteCapturedPlaceholderView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Placeholder destination for inbound `https://onym.chat/join?c=…`
+/// deeplinks. **PR-7 will replace this** with a real `JoinView` +
+/// `JoinFlow` that ships the actual join request via
+/// `JoinRequestSender` and watches for the sealed invitation to
+/// arrive. PR-6's job is just to prove the deeplink wiring works
+/// end-to-end (tap a link → land on a screen that knows the
+/// capability).
+///
+/// Renders the inviter's intro pubkey hex prefix + group_id hex
+/// prefix so a manual tester can confirm the right capability was
+/// decoded from the URL. No interaction wired beyond Back.
+struct JoinInviteCapturedPlaceholderView: View {
+    let capability: IntroCapability
+    let onBack: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            topBar
+            ScrollView {
+                VStack(spacing: 16) {
+                    Spacer().frame(height: 24)
+                    Image(systemName: "link.circle.fill")
+                        .font(.system(size: 48))
+                        .foregroundStyle(OnymAccent.blue.color)
+                    Text(capability.groupName ?? "Join invite")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(OnymTokens.text)
+                    Text("Capability captured. The full join flow lands in PR-7.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.text2)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+
+                    diagnostics
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 24)
+            }
+        }
+        .background(OnymTokens.bg)
+    }
+
+    private var topBar: some View {
+        HStack {
+            Button(action: onBack) {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                    Text("Back")
+                }
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(OnymTokens.text2)
+            }
+            .accessibilityIdentifier("join_invite.back_button")
+            Spacer()
+            Text("Join invite")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Spacer()
+            Spacer().frame(width: 60)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 6)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private var diagnostics: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            row("intro_pub", value: hexPrefix(capability.introPublicKey))
+            row("group_id", value: hexPrefix(capability.groupId))
+            if let name = capability.groupName, !name.isEmpty {
+                row("group_name", value: name)
+            }
+        }
+        .padding(14)
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+    }
+
+    private func row(_ key: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(key)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(OnymTokens.text3)
+            Text(value)
+                .font(.system(size: 12, weight: .regular, design: .monospaced))
+                .foregroundStyle(OnymTokens.text)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func hexPrefix(_ data: Data, count: Int = 8) -> String {
+        let prefix = data.prefix(count)
+        return prefix.map { String(format: "%02x", $0) }.joined() + "…"
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -12,6 +12,13 @@ struct OnymIOSApp: App {
     private let introKeyStore: any IntroKeyStore
     private let introRequestStore: any IntroRequestStore
 
+    /// Captured intro capability from a Universal Link or custom-
+    /// scheme deeplink (`https://onym.chat/join?c=…` /
+    /// `onym://join?c=…`). Drives a `.sheet(item:)` over RootView —
+    /// PR-6 surfaces a placeholder; PR-7 will replace it with the
+    /// real `JoinView` + `JoinFlow`.
+    @State private var pendingCapability: IntroCapability?
+
     init() {
         let args = ProcessInfo.processInfo.arguments
         let repository: IdentityRepository
@@ -234,6 +241,32 @@ struct OnymIOSApp: App {
                         currentTask = Task { await pump.run(entries: entries) }
                     }
                     currentTask?.cancel()
+                }
+                .onOpenURL { url in
+                    // Custom URL scheme (`onym://join?c=…`) and
+                    // Universal Link cold-start both surface here on
+                    // SwiftUI 4+. The allowlist in DeeplinkCapture
+                    // guards against forged ACTION_VIEW analogues.
+                    if let cap = DeeplinkCapture.introCapability(from: url) {
+                        pendingCapability = cap
+                    }
+                }
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                    // Universal Link warm-start (e.g. backgrounded
+                    // app foregrounded by tapping a link in
+                    // Messages). On modern iOS `.onOpenURL` typically
+                    // covers this too, but the dual handler matches
+                    // Apple's documented best-practice and removes
+                    // a class of "did the link tap arrive?" bugs.
+                    if let cap = DeeplinkCapture.introCapability(from: activity.webpageURL) {
+                        pendingCapability = cap
+                    }
+                }
+                .sheet(item: $pendingCapability) { cap in
+                    JoinInviteCapturedPlaceholderView(
+                        capability: cap,
+                        onBack: { pendingCapability = nil }
+                    )
                 }
         }
     }

--- a/Sources/OnymIOS/Transport/DeeplinkCapture.swift
+++ b/Sources/OnymIOS/Transport/DeeplinkCapture.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Glue between iOS `URL`s and the platform-agnostic
+/// `IntroCapability.fromLink` decoder. Lives in `Transport/` so the
+/// `Group/` package stays UI-framework-free (Foundation only —
+/// testable on plain XCTest).
+///
+/// One function:
+///
+///  - `introCapability(from:)` is pure (`URL?` in,
+///    `IntroCapability?` out) and unit-testable. Holds the
+///    **scheme/host allowlist** — the Info.plist `CFBundleURLTypes`
+///    + Universal Links AASA already gate inbound URLs to
+///    `https://onym.chat/join*` and `onym://join`, but a
+///    misconfigured share target could still surface other URLs
+///    to `.onOpenURL`. We re-check here as defense in depth and
+///    so the pre-flight reasoning lives in code, not in
+///    Info.plist.
+///
+/// Returns `nil` for non-deeplink URLs so callers can fall through
+/// to normal app launch without special-casing.
+///
+/// Mirrors onym-android's `DeeplinkCapture.kt`.
+enum DeeplinkCapture {
+
+    /// Allowlist of `(scheme, host)` pairs that may carry an
+    /// `IntroCapability`. Mirrors the URL-types in `Info.plist`
+    /// + the `applinks:onym.chat` entitlement; keep them in
+    /// lockstep.
+    private static let allowed: Set<Pair> = [
+        Pair(scheme: "https", host: "onym.chat"),
+        Pair(scheme: "onym", host: "join"),
+    ]
+
+    /// Extract a capability from a `URL`. Returns `nil` for:
+    ///  - non-onym URLs (host/scheme not on the allowlist)
+    ///  - URLs that parse but have no `c=` query parameter
+    ///  - URLs with a malformed `c=` payload (bad base64, bad JSON,
+    ///    wrong byte sizes)
+    ///
+    /// Tolerates `nil` URL so callers can pipe `.onOpenURL`'s
+    /// optional-style argument straight through.
+    static func introCapability(from url: URL?) -> IntroCapability? {
+        guard let url else { return nil }
+        return introCapability(fromString: url.absoluteString)
+    }
+
+    /// String overload — useful for `NSUserActivity.webpageURL`
+    /// fallbacks and for the unit tests (which never need a real
+    /// `URL` ceremony).
+    static func introCapability(fromString rawURL: String?) -> IntroCapability? {
+        guard let rawURL, !rawURL.isEmpty else { return nil }
+        guard let comps = URLComponents(string: rawURL),
+              let scheme = comps.scheme?.lowercased(),
+              let host = comps.host?.lowercased()
+        else { return nil }
+        guard allowed.contains(Pair(scheme: scheme, host: host)) else { return nil }
+        return IntroCapability.fromLink(rawURL)
+    }
+
+    private struct Pair: Hashable {
+        let scheme: String
+        let host: String
+    }
+}

--- a/Tests/OnymIOSTests/DeeplinkCaptureTests.swift
+++ b/Tests/OnymIOSTests/DeeplinkCaptureTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import OnymIOS
+
+/// Pure-XCTest tests for `DeeplinkCapture.introCapability(from:)`.
+/// The `URL` overload is one line of glue; the host/scheme allowlist
+/// + `IntroCapability.fromLink` call live here and are exercised
+/// via the `String?` form.
+///
+/// Mirrors `DeeplinkCaptureTest.kt` test-for-test. Pin the allowlist
+/// semantics:
+///  - `https://onym.chat/join?c=…` → decoded
+///  - `onym://join?c=…` → decoded
+///  - any other scheme/host → nil (Info.plist + entitlements are
+///    the primary gate; this is defense in depth)
+///  - malformed payload → nil (`fromLink`'s `InvalidIntroCapability`
+///    is swallowed; the activity should no-op rather than crash on
+///    a dud URL)
+final class DeeplinkCaptureTests: XCTestCase {
+
+    private let introPub = Data((0..<32).map { UInt8($0) })
+    private let groupId = Data((0..<32).map { UInt8(0x40 + $0) })
+
+    private func fixture(name: String? = nil) throws -> IntroCapability {
+        try IntroCapability(
+            introPublicKey: introPub,
+            groupId: groupId,
+            groupName: name
+        )
+    }
+
+    func test_universalLink_decodes() throws {
+        let link = try fixture(name: "Test").toAppLink()
+        let decoded = DeeplinkCapture.introCapability(fromString: link)
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.introPublicKey, introPub)
+        XCTAssertEqual(decoded?.groupId, groupId)
+        XCTAssertEqual(decoded?.groupName, "Test")
+    }
+
+    func test_customScheme_decodes() throws {
+        let link = try fixture().toCustomSchemeLink()
+        let decoded = DeeplinkCapture.introCapability(fromString: link)
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.introPublicKey, introPub)
+        XCTAssertNil(decoded?.groupName)
+    }
+
+    func test_foreignHost_returnsNil() throws {
+        // Same path + valid `c=` payload but the host isn't ours.
+        // A malicious app could open this URL at us; the in-code
+        // allowlist makes the boundary explicit.
+        let good = try fixture().encode()
+        let link = "https://example.com/join?c=\(good)"
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: link))
+    }
+
+    func test_foreignScheme_returnsNil() throws {
+        let good = try fixture().encode()
+        let link = "ftp://onym.chat/join?c=\(good)"
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: link))
+    }
+
+    func test_nilOrEmpty_returnsNil() {
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: nil))
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: ""))
+        XCTAssertNil(DeeplinkCapture.introCapability(from: nil))
+    }
+
+    func test_malformedURL_returnsNil() {
+        // `URLComponents` accepts more strings than you'd think.
+        // What we really care about is that nothing crashes; the
+        // allowlist filters out anything without a known
+        // (scheme, host) pair.
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: "not a url"))
+    }
+
+    func test_knownHostMissingC_returnsNil() {
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: "https://onym.chat/join"))
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: "onym://join"))
+    }
+
+    func test_knownHostBadCPayload_returnsNil() {
+        // Allowed scheme/host, but the `c` value is not valid
+        // base64 + the JSON payload doesn't decode. `fromLink`
+        // returns nil; we propagate that → callers no-op.
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: "https://onym.chat/join?c=not-base64!!!"))
+    }
+
+    func test_caseInsensitiveSchemeAndHost_decodes() throws {
+        // RFC 3986: scheme + host are case-insensitive. Build a
+        // deliberately mixed-case form to pin the normalization.
+        let good = try fixture().encode()
+        let link = "HTTPS://Onym.Chat/join?c=\(good)"
+        XCTAssertNotNil(DeeplinkCapture.introCapability(fromString: link))
+    }
+
+    func test_introCapability_fromURL_overload() throws {
+        // Smoke check: the `URL?` adapter routes through the same
+        // logic. We trust this delegation pattern but want one
+        // direct test so a future refactor that breaks the bridge
+        // surfaces here.
+        let link = try fixture(name: "U").toAppLink()
+        let url = URL(string: link)
+        let decoded = DeeplinkCapture.introCapability(from: url)
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.groupName, "U")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -55,6 +55,29 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
+        # PR-6: custom URL scheme for the Level-2 deeplink invite
+        # fallback. `onym://join?c=…` lands in `.onOpenURL`. The
+        # CFBundleURLName uses bundle-prefix namespacing per Apple
+        # convention; CFBundleURLSchemes must be `onym` (not the
+        # bundle id) to match the Android scheme so the same URL
+        # works on both platforms.
+        CFBundleURLTypes:
+          - CFBundleTypeRole: Editor
+            CFBundleURLName: chat.onym.ios.join
+            CFBundleURLSchemes:
+              - onym
+    entitlements:
+      path: OnymIOS.entitlements
+      properties:
+        # PR-6: Universal Links for `https://onym.chat/join*` and
+        # `https://onym.chat/onboard*`. The matching AASA file at
+        # `https://onym.chat/.well-known/apple-app-site-association`
+        # must list the team-prefixed app id (5V5EUT3ZXJ.chat.onym.ios)
+        # against `appIDs`. Without the AASA file the OS still
+        # routes the URL through the browser; the app only takes
+        # over once Apple's CDN has fetched + validated the file.
+        com.apple.developer.associated-domains:
+          - applinks:onym.chat
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios
@@ -69,6 +92,7 @@ targets:
         TARGETED_DEVICE_FAMILY: "1,2"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
+        CODE_SIGN_ENTITLEMENTS: OnymIOS.entitlements
 
   OnymIOSTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary

PR-6 of 7. Wires the iOS side of the Level-2 deeplink invite to the actual URL transport. Tapping a `https://onym.chat/join?c=…` (Universal Link) or `onym://join?c=…` (custom-scheme fallback) URL anywhere on the device routes into the app, decodes the `IntroCapability`, and presents a placeholder screen displaying the captured fields.

PR-7 will replace the placeholder with the real `JoinFlow` + `JoinView`.

**Stacked on `ux/share-invite-link` (PR-5 / #64).**

## What's in here

- `DeeplinkCapture.introCapability(from:)` — pure adapter from `URL?` (and `String?`) to `IntroCapability?`. Holds the scheme/host allowlist (`https://onym.chat`, `onym://join`) as defense in depth on top of the Info.plist + entitlements gates. Lowercases scheme + host before allowlist lookup so RFC 3986 case-insensitivity holds.
- `JoinInviteCapturedPlaceholderView` — diagnostic surface showing intro_pub hex prefix + group_id hex prefix + group name. Replaces in PR-7.
- `IntroCapability: Identifiable` — `id == introPublicKey` (uniformly random per invite). Drives `.sheet(item:)` presentation.
- `OnymIOSApp`: `@State pendingCapability` slot + `.onOpenURL` + `.onContinueUserActivity(NSUserActivityTypeBrowsingWeb)` + `.sheet(item:)` over RootView
- `Info.plist`: `CFBundleURLTypes` with `CFBundleURLSchemes = ["onym"]`, `CFBundleURLName = "chat.onym.ios.join"`. The scheme is `onym` (not bundle-prefixed) so `onym://join?c=…` works identically on iOS and Android
- `OnymIOS.entitlements` + `project.yml`: `com.apple.developer.associated-domains: applinks:onym.chat`

## AASA file is a server-side follow-up

The matching AASA file at `https://onym.chat/.well-known/apple-app-site-association` must list `5V5EUT3ZXJ.chat.onym.ios` against `appIDs`. Not in this repo (server-side, like Android's `assetlinks.json`). Without it the OS still routes the URL through the browser; the app only takes over once Apple's CDN has fetched + validated the file.

## Cross-platform contract

Mirrors onym-android `transport/deeplink-intent-filter` (PR #65): same allowlist pairs, same identifiable-by-introPub pattern, same placeholder posture.

## Test coverage (10 cases, mirroring `DeeplinkCaptureTest.kt`)

`DeeplinkCaptureTests`:
- universal-link decodes
- custom-scheme decodes
- foreign host returns nil (defense in depth — manifest is primary gate)
- foreign scheme returns nil
- nil / empty / malformed URL return nil
- known host missing `c` returns nil
- known host with bad `c` payload returns nil
- mixed-case scheme + host normalizes (RFC 3986)
- `URL?` overload smoke check

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests/DeeplinkCaptureTests -only-testing:OnymIOSTests/ShareInviteFlowTests -only-testing:OnymIOSTests/IntroCapabilityTests -only-testing:OnymIOSTests/IntroCapabilityInteropTests` — 35/35 pass on iPhone 17 Pro simulator
- [ ] CI green
- [ ] AASA file deployed to `onym.chat` (separate repo / infra task)
- [ ] Coordinated with onym-android PR #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)