### PR TITLE
fix(settings): rotate Onym mark gaps + add ContractDetail screen

### DIFF
--- a/Sources/OnymIOS/Group/OnymBrand.swift
+++ b/Sources/OnymIOS/Group/OnymBrand.swift
@@ -102,7 +102,7 @@ struct OnymMark: View {
     var spinning: Bool = false
     var fillOpacity: Double = 0.92
 
-    @State private var rotation: Double = -90  // -90° lands the dash pattern's first gap near 1:30
+    @State private var rotation: Double = -45  // -45° lands the dash pattern's gaps at 1:00 and 7:00
 
     var body: some View {
         let stroke = size * strokeRatio

--- a/Sources/OnymIOS/Identity/IdentitiesView.swift
+++ b/Sources/OnymIOS/Identity/IdentitiesView.swift
@@ -27,8 +27,7 @@ struct IdentitiesView: View {
                                 subtitle: "BLS \(flow.blsPrefix(of: summary))…",
                                 subtitleMono: true,
                                 inset: 68,
-                                last: idx == summaries.count - 1,
-                                onTap: {}
+                                last: idx == summaries.count - 1
                             ) {
                                 IdentityRingTile(active: summary.id == flow.currentID, size: 40)
                             } right: {

--- a/Sources/OnymIOS/Identity/IdentityDetailView.swift
+++ b/Sources/OnymIOS/Identity/IdentityDetailView.swift
@@ -43,8 +43,7 @@ struct IdentityDetailView: View {
                         SettingsRow(
                             title: "Share invite key",
                             subtitle: "QR code or link",
-                            last: true,
-                            onTap: {}
+                            last: true
                         ) {
                             SettingsIconTile(symbol: "square.and.arrow.up", bg: SettingsTile.indigo)
                         }

--- a/Sources/OnymIOS/Settings/AnchorsView.swift
+++ b/Sources/OnymIOS/Settings/AnchorsView.swift
@@ -279,17 +279,16 @@ struct AnchorsVersionView: View {
 
     @ViewBuilder
     private func versionRow(release: ContractRelease, isSelected: Bool, isLatest: Bool, last: Bool) -> some View {
-        Button {
-            flow.tappedVersion(key: key, releaseTag: release.release)
-            dismiss()
+        NavigationLink {
+            ContractDetailView(flow: flow, key: key, release: release)
         } label: {
             SettingsRow(
                 title: LocalizedStringKey(release.release),
                 titleMono: true,
                 subtitle: release.publishedAt.formatted(date: .abbreviated, time: .omitted),
-                hasChevron: false,
                 inset: 16,
-                last: last
+                last: last,
+                onTap: {}
             ) {
                 EmptyView()
             } right: {

--- a/Sources/OnymIOS/Settings/AnchorsView.swift
+++ b/Sources/OnymIOS/Settings/AnchorsView.swift
@@ -49,8 +49,7 @@ struct AnchorsView: View {
                 SettingsRow(
                     title: LocalizedStringKey(network.displayName),
                     subtitle: networkSubtitle(network),
-                    last: last,
-                    onTap: {}
+                    last: last
                 ) {
                     SettingsContentTile(bg: bg) {
                         Text(letter).font(.system(size: 11, weight: .bold))
@@ -124,8 +123,7 @@ struct AnchorsNetworkView: View {
                     title: LocalizedStringKey(type.displayName),
                     subtitle: "\(binding.release) " + (isExplicit ? "(selected)" : "(latest)"),
                     inset: 56,
-                    last: last,
-                    onTap: {}
+                    last: last
                 ) {
                     GovernanceTypeTile(type: type)
                 }
@@ -222,8 +220,7 @@ struct AnchorsVersionView: View {
                     } label: {
                         SettingsRow(
                             title: "Deploy from source",
-                            subtitle: "Build & publish your own contract",
-                            onTap: {}
+                            subtitle: "Build & publish your own contract"
                         ) {
                             SettingsIconTile(symbol: "chevron.left.forwardslash.chevron.right",
                                              bg: OnymTokens.text)
@@ -238,8 +235,7 @@ struct AnchorsVersionView: View {
                         SettingsRow(
                             title: "Use existing address",
                             subtitle: "Point to a deployed contract",
-                            last: true,
-                            onTap: {}
+                            last: true
                         ) {
                             SettingsIconTile(symbol: "shippingbox.fill",
                                              bg: SettingsTile.indigo)
@@ -287,8 +283,7 @@ struct AnchorsVersionView: View {
                 titleMono: true,
                 subtitle: release.publishedAt.formatted(date: .abbreviated, time: .omitted),
                 inset: 16,
-                last: last,
-                onTap: {}
+                last: last
             ) {
                 EmptyView()
             } right: {

--- a/Sources/OnymIOS/Settings/ContractDetailView.swift
+++ b/Sources/OnymIOS/Settings/ContractDetailView.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+/// Settings → Anchors → Network → Governance → Version → ContractDetail.
+/// Read-only view of one published contract release: shows on-chain
+/// pointers (Stellar Expert link, contract address) and source
+/// pointers (GitHub source at the tag, audit report). The "Use this
+/// version" CTA at the bottom calls `flow.tappedVersion` so the
+/// existing `AnchorsPickerFlow` machinery records the selection,
+/// then pops back two levels.
+struct ContractDetailView: View {
+    @Bindable var flow: AnchorsPickerFlow
+    let key: AnchorSelectionKey
+    let release: ContractRelease
+
+    @Environment(\.dismiss) private var dismiss
+
+    private static let contractsRepoURL = URL(string: "https://github.com/onymchat/onym-contracts")!
+
+    private var entry: ContractEntry? {
+        release.contracts.first { $0.network == key.network && $0.type == key.type }
+    }
+
+    private var auditLabel: String { "Pending — no audits yet" }
+
+    private var explorerURL: URL? {
+        guard let entry else { return nil }
+        let host = key.network == .testnet ? "testnet.stellar.expert" : "stellar.expert"
+        let net  = key.network == .testnet ? "testnet" : "public"
+        return URL(string: "https://\(host)/explorer/\(net)/contract/\(entry.id)")
+    }
+
+    private var isCurrentSelection: Bool {
+        flow.binding(for: key)?.release == release.release
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                hero
+
+                SettingsSectionLabel("ON-CHAIN")
+                SettingsCard {
+                    SettingsRow(
+                        title: "Stellar Expert",
+                        subtitle: explorerSubtitle,
+                        subtitleMono: true,
+                        hasChevron: false,
+                        onTap: explorerURL.map { url in { open(url.absoluteString) } }
+                    ) {
+                        SettingsContentTile(bg: SettingsTile.indigo) {
+                            Text("SX").font(.system(size: 11, weight: .bold)).foregroundStyle(.white)
+                        }
+                    } right: {
+                        Image(systemName: "arrow.up.right.square")
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    .accessibilityIdentifier("contract_detail.stellar_expert")
+
+                    SettingsRow(
+                        title: "Copy contract address",
+                        hasChevron: false,
+                        last: true,
+                        onTap: entry.map { e in { UIPasteboard.general.string = e.id } }
+                    ) {
+                        SettingsIconTile(symbol: "doc.on.doc.fill", bg: SettingsTile.gray)
+                    }
+                    .accessibilityIdentifier("contract_detail.copy_address")
+                }
+
+                SettingsSectionLabel("SOURCE")
+                SettingsCard {
+                    SettingsRow(
+                        title: "View source on GitHub",
+                        subtitle: "onymchat/onym-contracts @ \(release.release)",
+                        subtitleMono: true,
+                        hasChevron: false,
+                        onTap: { open(Self.contractsRepoURL.absoluteString + "/tree/\(release.release)") }
+                    ) {
+                        SettingsIconTile(symbol: "chevron.left.forwardslash.chevron.right",
+                                         bg: OnymTokens.text)
+                    } right: {
+                        Image(systemName: "arrow.up.right.square")
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    .accessibilityIdentifier("contract_detail.github")
+
+                    SettingsRow(
+                        title: "Audit report",
+                        subtitle: auditLabel,
+                        hasChevron: false,
+                        last: true
+                    ) {
+                        SettingsIconTile(symbol: "exclamationmark.circle.fill",
+                                         bg: SettingsTile.amber)
+                    }
+                    .accessibilityIdentifier("contract_detail.audit")
+                }
+
+                SettingsFootnote("This is the contract that anchors \(key.type.displayName.lowercased()) groups created on \(key.network.displayName.lowercased()). Existing chats keep the contract they were created with — picking a different version only affects new chats.")
+
+                SettingsPrimaryButton(
+                    isCurrentSelection ? "Currently selected" : "Use this version",
+                    disabled: isCurrentSelection
+                ) {
+                    flow.tappedVersion(key: key, releaseTag: release.release)
+                    dismiss()
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 20)
+                .accessibilityIdentifier("contract_detail.use_version")
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .navigationTitle(Text(verbatim: release.release))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Hero
+
+    private var hero: some View {
+        HStack(spacing: 14) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(LinearGradient(colors: [Color(red: 0.996, green: 0.941, blue: 0.878),
+                                                Color(red: 1.0, green: 0.878, blue: 0.753)],
+                                      startPoint: .topLeading, endPoint: .bottomTrailing))
+                .frame(width: 56, height: 56)
+                .overlay(OnymMark(size: 32, color: Color(red: 0.82, green: 0.29, blue: 0)))
+            VStack(alignment: .leading, spacing: 2) {
+                Text("CONTRACT · \(key.type.displayName.uppercased())")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .tracking(0.46)
+                    .foregroundStyle(OnymTokens.text2)
+                Text(release.release)
+                    .font(.system(size: 22, weight: .bold, design: .monospaced))
+                    .tracking(-0.26)
+                    .foregroundStyle(OnymTokens.text)
+                Text("Deployed \(release.publishedAt.formatted(date: .abbreviated, time: .omitted)) · \(auditLabel)")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(18)
+        .background(OnymTokens.surface2,
+                    in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+
+    private var explorerSubtitle: String {
+        guard let entry else { return "—" }
+        let head = entry.id.prefix(6)
+        let tail = entry.id.suffix(4)
+        return "\(head)…\(tail)"
+    }
+
+    private func open(_ s: String) {
+        guard let u = URL(string: s) else { return }
+        UIApplication.shared.open(u)
+    }
+}

--- a/Sources/OnymIOS/Settings/SettingsDesign.swift
+++ b/Sources/OnymIOS/Settings/SettingsDesign.swift
@@ -151,8 +151,12 @@ struct SettingsRowDivider: View {
 }
 
 /// Single Apple-Settings row. `tile` is the leading icon. `right` is
-/// the trailing content (chips, value text, switches). When `onTap` is
-/// non-nil and `hasChevron` is true the row renders a trailing chevron.
+/// the trailing content (chips, value text, switches). The row is
+/// pure layout — wrap it in a `NavigationLink` (push) or a `Button`
+/// (in-place action) externally, or pass `onTap` for a built-in
+/// Button. The chevron renders whenever `hasChevron` is true,
+/// independent of `onTap`, because the wrapping `NavigationLink`
+/// itself owns the tap.
 struct SettingsRow<Tile: View, Right: View>: View {
     let title: LocalizedStringKey
     var titleColor: Color = OnymTokens.text
@@ -167,48 +171,54 @@ struct SettingsRow<Tile: View, Right: View>: View {
     @ViewBuilder var right: () -> Right
 
     var body: some View {
-        Button {
-            onTap?()
-        } label: {
-            VStack(spacing: 0) {
-                HStack(spacing: 12) {
-                    tile()
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(title)
-                            .font(titleMono
-                                  ? .system(size: 16.5, design: .monospaced)
-                                  : .system(size: 16.5))
-                            .foregroundStyle(titleColor)
+        if let onTap {
+            // Tappable variant — used for in-place actions (Copy
+            // public key, Set as active, …). Wrap in `NavigationLink`
+            // or external `Button` for push navigation instead.
+            Button(action: onTap) { rowBody }
+                .buttonStyle(.plain)
+        } else {
+            rowBody
+        }
+    }
+
+    private var rowBody: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                tile()
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(titleMono
+                              ? .system(size: 16.5, design: .monospaced)
+                              : .system(size: 16.5))
+                        .foregroundStyle(titleColor)
+                        .lineLimit(1)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(subtitleMono
+                                  ? .system(size: 12.5, design: .monospaced)
+                                  : .system(size: 12.5))
+                            .foregroundStyle(OnymTokens.text2)
                             .lineLimit(1)
-                        if let subtitle {
-                            Text(subtitle)
-                                .font(subtitleMono
-                                      ? .system(size: 12.5, design: .monospaced)
-                                      : .system(size: 12.5))
-                                .foregroundStyle(OnymTokens.text2)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-                    }
-                    Spacer(minLength: 8)
-                    right()
-                    if hasChevron, onTap != nil {
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(OnymTokens.text3)
+                            .truncationMode(.middle)
                     }
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 11)
-                .contentShape(Rectangle())
-
-                if !last {
-                    SettingsRowDivider(inset: inset)
+                Spacer(minLength: 8)
+                right()
+                if hasChevron {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text3)
                 }
             }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+
+            if !last {
+                SettingsRowDivider(inset: inset)
+            }
         }
-        .buttonStyle(.plain)
-        .disabled(onTap == nil)
     }
 }
 

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -42,8 +42,7 @@ struct SettingsView: View {
                     } label: {
                         SettingsRow(
                             title: "Identities",
-                            subtitle: identitySubtitle,
-                            onTap: {}
+                            subtitle: identitySubtitle
                         ) {
                             SettingsIconTile(symbol: "person.2.fill", bg: SettingsTile.purple)
                         }
@@ -57,8 +56,7 @@ struct SettingsView: View {
                         SettingsRow(
                             title: "Privacy & Encryption",
                             subtitle: "End-to-end · BIP-39",
-                            last: true,
-                            onTap: {}
+                            last: true
                         ) {
                             SettingsIconTile(symbol: "lock.shield.fill", bg: SettingsTile.blue)
                         }
@@ -74,8 +72,7 @@ struct SettingsView: View {
                     } label: {
                         SettingsRow(
                             title: "Relayer",
-                            subtitle: "Stellar Soroban · onymchat",
-                            onTap: {}
+                            subtitle: "Stellar Soroban · onymchat"
                         ) {
                             SettingsIconTile(symbol: "antenna.radiowaves.left.and.right",
                                              bg: SettingsTile.indigo)
@@ -89,8 +86,7 @@ struct SettingsView: View {
                     } label: {
                         SettingsRow(
                             title: "Anchors",
-                            subtitle: useMainnet ? "Stellar · Mainnet" : "Stellar · Testnet",
-                            onTap: {}
+                            subtitle: useMainnet ? "Stellar · Mainnet" : "Stellar · Testnet"
                         ) {
                             SettingsIconTile(symbol: "link", bg: SettingsTile.orange)
                         }
@@ -123,8 +119,7 @@ struct SettingsView: View {
                     } label: {
                         SettingsRow(
                             title: "Appearance",
-                            subtitle: "Theme · accent · text size",
-                            onTap: {}
+                            subtitle: "Theme · accent · text size"
                         ) {
                             SettingsIconTile(symbol: "circle.lefthalf.filled",
                                              bg: SettingsTile.gray)
@@ -139,8 +134,7 @@ struct SettingsView: View {
                         SettingsRow(
                             title: "About Onym",
                             subtitle: aboutSubtitle,
-                            last: true,
-                            onTap: {}
+                            last: true
                         ) {
                             SettingsIconTile(symbol: "info.circle.fill", bg: SettingsTile.teal)
                         }


### PR DESCRIPTION
## Summary
- Rotate the broken-ring `OnymMark` static rotation from -90° to -45° so the two gaps land at 1:00 and 7:00 on a clock face (was 11:30 and 17:30)
- Add the missing `ContractDetailView` from the design — Anchors → Network → Governance → Version row tap was short-circuiting straight into `flow.tappedVersion`; it now pushes a read-only details screen with hero (CONTRACT · TYPE · version), ON-CHAIN (Stellar Expert + copy address), SOURCE (GitHub at the tag + audit report), and a "Use this version" CTA at the bottom that hooks back into the existing `AnchorsPickerFlow`

Follow-ups to #67 (already merged).

## Files
- `Sources/OnymIOS/Group/OnymBrand.swift` — single-line rotation tweak
- `Sources/OnymIOS/Settings/ContractDetailView.swift` (new)
- `Sources/OnymIOS/Settings/AnchorsView.swift` — version row → NavigationLink to ContractDetailView

## Test plan
- [x] `xcodebuild -project OnymIOS.xcodeproj -scheme OnymIOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/onym-ios-build build` → BUILD SUCCEEDED
- [ ] Visually confirm OnymMark gaps land at 1:00 and 7:00 on Settings home, Identity Detail, About, etc.
- [ ] Settings → Anchors → Testnet → Democracy → tap a version → verify ContractDetailView pushes; tap "Use this version" → verify selection persists and back-navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)