### PR TITLE
build: derive version from the release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,15 @@ permissions:
   contents: write   # tag push + GitHub Release creation + asset upload
   issues: write     # `report-to-issue` ticks per-class checkboxes
 
+# Pipe the dispatch tag straight into `scripts/resolve-release-version.sh`
+# (which `generate-xcodeproj.sh` sources). Setting it at workflow level
+# means every job's xcodegen run picks up the right value — the IPA's
+# `CFBundleShortVersionString` / `CFBundleVersion` (and the About
+# screen) match the tag exactly, with `git describe` only used as a
+# fallback for one-off local builds. See PR for the full chain.
+env:
+  RELEASE_VERSION: ${{ inputs.tag }}
+
 jobs:
   lint:
     name: Lint (no off-repo secret reads)
@@ -94,6 +103,11 @@ jobs:
           # Without this xcodebuild compiles pointer files into
           # Assets.car and any test that touches the icon UI fails.
           lfs: true
+          # Full history + tags so `scripts/resolve-release-version.sh`
+          # (sourced by `generate-xcodeproj.sh`) can fall back to
+          # `git describe` if `RELEASE_VERSION` ever isn't honoured.
+          # Belt + braces — the env var is the canonical path.
+          fetch-depth: 0
 
       - name: Force LFS smudge (self-hosted workspace persists across runs)
         # actions/checkout@v4 runs `git lfs fetch` but skips the smudge
@@ -197,6 +211,9 @@ jobs:
           # icon-bearing buttons miss because Assets.car holds pointer
           # text instead of pixels.
           lfs: true
+          # See unit-tests for fetch-depth rationale (git-describe
+          # fallback in `scripts/resolve-release-version.sh`).
+          fetch-depth: 0
 
       - name: Force LFS smudge (self-hosted workspace persists across runs)
         # See unit-tests for rationale. Without this the persistent
@@ -277,6 +294,9 @@ jobs:
           # shipped IPA carries pointer files instead of art and the
           # App Store install will fail icon validation.
           lfs: true
+          # See unit-tests for fetch-depth rationale (git-describe
+          # fallback in `scripts/resolve-release-version.sh`).
+          fetch-depth: 0
 
       - name: Force LFS smudge (self-hosted workspace persists across runs)
         # See unit-tests for rationale.
@@ -350,22 +370,25 @@ jobs:
         if: always()
         run: rm -f /tmp/match_key /tmp/match_known_hosts
 
-      - name: Parse version from tag
+      - name: Resolve release version (for IPA filename)
         id: version
-        env:
-          TAG: ${{ inputs.tag }}
-        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+        # `scripts/resolve-release-version.sh` is the same script
+        # `generate-xcodeproj.sh` sources earlier in this job — emits
+        # `MARKETING_VERSION=...` + `CURRENT_PROJECT_VERSION=...` lines,
+        # which `>> $GITHUB_OUTPUT` turns into step outputs. Single
+        # source of truth for the IPA filename and the bundle version.
+        run: scripts/resolve-release-version.sh >> "$GITHUB_OUTPUT"
 
       - name: Rename IPA with version
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.MARKETING_VERSION }}
         run: mv build/ios/adhoc/OnymIOS.ipa "OnymIOS-${VERSION}.ipa"
 
       - name: Upload IPA to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag }}
-          files: OnymIOS-${{ steps.version.outputs.version }}.ipa
+          files: OnymIOS-${{ steps.version.outputs.MARKETING_VERSION }}.ipa
 
   # ----------------------------------------------------------------------
   # Report XCTest outcomes back into the originating release issue.

--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/generate-xcodeproj.sh
+++ b/generate-xcodeproj.sh
@@ -20,7 +20,22 @@ if ! command -v xcodegen >/dev/null 2>&1; then
     exit 1
 fi
 
+# `MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` drive the About
+# screen and the bundle's `CFBundleShortVersionString` /
+# `CFBundleVersion`. project.yml uses `${MARKETING_VERSION}` /
+# `${CURRENT_PROJECT_VERSION}` env interpolation so the resolved
+# values get baked into the generated xcodeproj. Resolution order:
+#
+#   env RELEASE_VERSION → `git describe --tags --match 'v*'`
+#   → fallback `0.0.0-dev`.
+#
+# See scripts/resolve-release-version.sh.
+eval "$(./scripts/resolve-release-version.sh)"
+export MARKETING_VERSION CURRENT_PROJECT_VERSION
+
 xcodegen generate
 echo
 echo "Generated: $SCRIPT_DIR/OnymIOS.xcodeproj"
+echo "  MARKETING_VERSION       = $MARKETING_VERSION"
+echo "  CURRENT_PROJECT_VERSION = $CURRENT_PROJECT_VERSION"
 echo "Open with: open OnymIOS.xcodeproj"

--- a/project.yml
+++ b/project.yml
@@ -39,6 +39,23 @@ targets:
       path: Info.plist
       properties:
         CFBundleDisplayName: Onym
+        # `$(...)` is Xcode's build-setting substitution, NOT xcodegen
+        # env interpolation — these strings end up verbatim in
+        # Info.plist and Xcode resolves them per build. The
+        # MARKETING_VERSION / CURRENT_PROJECT_VERSION build settings
+        # below are interpolated by xcodegen at generate time
+        # (see `${...}` in `settings.base`), so the chain is:
+        #     resolve-release-version.sh
+        #         → env MARKETING_VERSION
+        #             → xcodegen `${MARKETING_VERSION}` interpolation
+        #                 → Build Setting in pbxproj
+        #                     → `$(MARKETING_VERSION)` in Info.plist
+        #                         → Bundle.main.infoDictionary at runtime
+        # xcodegen does NOT emit these keys by default; without them
+        # Info.plist falls back to its hand-written `1.0` / `1` and the
+        # About screen ships a stale value forever.
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: true
           UISceneConfigurations: {}
@@ -81,8 +98,14 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios
-        MARKETING_VERSION: "0.0.1"
-        CURRENT_PROJECT_VERSION: 1
+        # Single source of truth: the GitHub release tag. xcodegen
+        # interpolates `${MARKETING_VERSION}` / `${CURRENT_PROJECT_VERSION}`
+        # from the env at generate time; `generate-xcodeproj.sh` always
+        # sources `scripts/resolve-release-version.sh` first so these
+        # env vars are guaranteed to be set (with a `0.0.0-dev` /
+        # `git describe` fallback for local builds between tags).
+        MARKETING_VERSION: ${MARKETING_VERSION}
+        CURRENT_PROJECT_VERSION: ${CURRENT_PROJECT_VERSION}
         SWIFT_VERSION: "5.0"
         # Asset catalog name for the AppIcon set. `AppIcon` is the
         # default — explicit so renaming the .appiconset folder fails

--- a/scripts/resolve-release-version.sh
+++ b/scripts/resolve-release-version.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Resolve the app's MARKETING_VERSION + CURRENT_PROJECT_VERSION from a
+# single source of truth — the GitHub release tag — and emit them on
+# stdout as `KEY=value` lines.
+#
+# Resolution order (matches onym-android `resolveReleaseVersion()`):
+#
+#   1. env RELEASE_VERSION      — `release.yml` pipes the dispatch
+#                                 input `tag` straight here at archive
+#                                 time. Canonical CI path.
+#   2. `git describe --tags --match 'v*' --abbrev=7`
+#                               — local dev between tags renders as
+#                                 `0.0.10-3-gca6471b`, handy in bug
+#                                 reports.
+#   3. Fallback `v0.0.0-dev`    — shallow clones, no-git sandboxes,
+#                                 fresh repos before the first tag.
+#
+# CURRENT_PROJECT_VERSION = MAJOR*10000 + MINOR*100 + PATCH (clamped to
+# ≥1 so AGP-style "0 is invalid" guards on the iOS side don't bite).
+# Monotonic across `v0.x.y` and across the future jump to `v0.1.0`.
+#
+# Usage:
+#
+#   eval "$(scripts/resolve-release-version.sh)"
+#   export MARKETING_VERSION CURRENT_PROJECT_VERSION
+#
+# Or in GitHub Actions:
+#
+#   scripts/resolve-release-version.sh >> "$GITHUB_OUTPUT"
+
+set -euo pipefail
+
+raw="${RELEASE_VERSION:-}"
+if [ -z "$raw" ]; then
+  raw="$(git describe --tags --match 'v*' --abbrev=7 2>/dev/null || true)"
+fi
+if [ -z "$raw" ]; then
+  raw="v0.0.0-dev"
+fi
+
+# Strip leading `v` (Play / About-screen convention) and any
+# `-N-gXXXX` dev suffix before parsing the numeric components.
+name="${raw#v}"
+base="${name%%-*}"
+
+major=0
+minor=0
+patch=0
+IFS='.' read -r m1 m2 m3 <<<"$base"
+[[ "$m1" =~ ^[0-9]+$ ]] && major="$m1"
+[[ "$m2" =~ ^[0-9]+$ ]] && minor="$m2"
+[[ "$m3" =~ ^[0-9]+$ ]] && patch="$m3"
+
+code=$((major * 10000 + minor * 100 + patch))
+[ "$code" -lt 1 ] && code=1
+
+printf 'MARKETING_VERSION=%s\n' "$name"
+printf 'CURRENT_PROJECT_VERSION=%s\n' "$code"


### PR DESCRIPTION
## Summary

Make the **git tag the single source of truth** for the bundle's `CFBundleShortVersionString` / `CFBundleVersion` and the About screen. We cut `v0.0.12` but the IPA still reports `1.0` (build 1) because the values are hard-coded in `project.yml` / `Info.plist` — this fixes that, permanently.

Mirrors [onym-android #73](https://github.com/onymchat/onym-android/pull/73); same resolution order, adapted to the iOS toolchain (xcodegen at the configure step instead of Gradle).

## Substitution chain

```
scripts/resolve-release-version.sh
    → env MARKETING_VERSION / CURRENT_PROJECT_VERSION
        → xcodegen ${MARKETING_VERSION} / ${CURRENT_PROJECT_VERSION}
            → Build Setting in pbxproj
                → $(MARKETING_VERSION) / $(CURRENT_PROJECT_VERSION) in Info.plist
                    → Bundle.main.infoDictionary at runtime
                        → AboutView / SettingsView footer
```

`scripts/resolve-release-version.sh` resolves (in order):

1. env `RELEASE_VERSION` — `release.yml` pipes `inputs.tag` in. Canonical CI path.
2. `git describe --tags --match 'v*' --abbrev=7` — local dev between tags renders as `0.0.12-12-g5e64b53`, useful in bug reports.
3. Fallback `0.0.0-dev` / 1 — shallow clones, fresh repos before the first tag.

`CURRENT_PROJECT_VERSION` is `MAJOR*10000 + MINOR*100 + PATCH` from the resolved name (any `-N-gXXXX` suffix ignored), clamped to ≥1. Monotonic across `v0.x.y` and the eventual jump to `v0.1.0`.

## Workflow changes (`release.yml`)

- Workflow-level `env: RELEASE_VERSION: ${{ inputs.tag }}` so every job's `generate-xcodeproj.sh` invocation picks up the same value.
- `fetch-depth: 0` on the three macOS checkouts (unit-tests, ui-tests, build) so the `git describe` fallback works if the env ever isn't honoured.
- Replaced the duplicated `Parse version from tag` step with a single call to `scripts/resolve-release-version.sh` written to `$GITHUB_OUTPUT`. The IPA filename + GH Release attachment now consume `steps.version.outputs.MARKETING_VERSION`.

## Tradeoff

This is xcodegen-coupled: opening `OnymIOS.xcodeproj` directly in Xcode without running `generate-xcodeproj.sh` first keeps whatever version was baked in last regen. Same trap Gradle has if you skip the configure phase, just less obvious. README already directs contributors to run the script after pulling.

## Test plan

- [x] No env, default branch (12 commits past `v0.0.12`): Info.plist → `0.0.12-12-g5e64b53` / `12`
- [x] `RELEASE_VERSION=v0.1.0`: Info.plist → `0.1.0` / `100`
- [x] `RELEASE_VERSION=v0.0.13`: Info.plist → `0.0.13` / `13`
- [x] `xcodebuild build` — green; bundled `.app/Info.plist` carries the resolved values
- [ ] First post-merge release: `gh workflow run Release -f tag=v0.0.13` → About screen reads "Version 0.0.13 (build 13)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)