### PR TITLE
feat(group): persist member alias + inbox key per group member

### DIFF
--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -25,13 +25,18 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     let createdAt: Date
 
     var members: [GovernanceMember]
-    /// View-facing supplement to `members`, keyed by lowercase BLS
-    /// pubkey hex. Populated for the creator at group-create time and
-    /// extended as new members announce themselves (post-PR fanout).
-    /// May be sparser than `members` — a member without a profile is
-    /// still a valid roster entry, just one we can't render by name
-    /// yet. The reverse must never hold: every key here MUST appear
-    /// in `members`.
+    /// View-facing directory of people the local user has interacted
+    /// with through this group, keyed by lowercase BLS pubkey hex.
+    /// Populated for the creator at group-create time and extended as
+    /// joiners are admitted (post-PR fanout).
+    ///
+    /// Independent of `members`: V1 group rosters are static
+    /// on-chain (`update_commitment` is post-V1 in the SEP
+    /// contracts), so a joiner is "in the group" at the app level —
+    /// receiving messages, listed in the chat detail — without yet
+    /// being a `GovernanceMember` in the cryptographic Merkle tree.
+    /// `members` is the on-chain truth; `memberProfiles` is the
+    /// app-level "who am I talking to" directory. They may diverge.
     var memberProfiles: [String: MemberProfile]
     var epoch: UInt64
     var salt: Data

--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -25,6 +25,14 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     let createdAt: Date
 
     var members: [GovernanceMember]
+    /// View-facing supplement to `members`, keyed by lowercase BLS
+    /// pubkey hex. Populated for the creator at group-create time and
+    /// extended as new members announce themselves (post-PR fanout).
+    /// May be sparser than `members` — a member without a profile is
+    /// still a valid roster entry, just one we can't render by name
+    /// yet. The reverse must never hold: every key here MUST appear
+    /// in `members`.
+    var memberProfiles: [String: MemberProfile]
     var epoch: UInt64
     var salt: Data
     /// Latest verified Poseidon commitment. `nil` until the first

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -223,6 +223,10 @@ struct CreateGroupInteractor: Sendable {
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
         let adminPubkeyHex = identitySnapshot.blsPublicKey
             .map { String(format: "%02x", $0) }.joined()
+        let creatorProfiles = await Self.creatorProfiles(
+            from: identitySnapshot,
+            identity: identity
+        )
         let group = ChatGroup(
             id: groupIDHex,
             ownerIdentityID: ownerID,
@@ -230,6 +234,7 @@ struct CreateGroupInteractor: Sendable {
             groupSecret: groupSecret,
             createdAt: Date(),
             members: members,
+            memberProfiles: creatorProfiles,
             epoch: 0,
             salt: salt,
             commitment: proof.commitment,
@@ -403,6 +408,10 @@ struct CreateGroupInteractor: Sendable {
 
         // 7. Save locally — no admin in 1-on-1, so adminPubkeyHex stays nil.
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+        let creatorProfiles = await Self.creatorProfiles(
+            from: identitySnapshot,
+            identity: identity
+        )
         let group = ChatGroup(
             id: groupIDHex,
             ownerIdentityID: ownerID,
@@ -410,6 +419,7 @@ struct CreateGroupInteractor: Sendable {
             groupSecret: groupSecret,
             createdAt: Date(),
             members: members,
+            memberProfiles: creatorProfiles,
             epoch: 0,
             salt: salt,
             commitment: proof.commitment,
@@ -570,6 +580,10 @@ struct CreateGroupInteractor: Sendable {
 
         // 7. Save locally — no admin in Anarchy, so adminPubkeyHex stays nil.
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+        let creatorProfiles = await Self.creatorProfiles(
+            from: identitySnapshot,
+            identity: identity
+        )
         let group = ChatGroup(
             id: groupIDHex,
             ownerIdentityID: ownerID,
@@ -577,6 +591,7 @@ struct CreateGroupInteractor: Sendable {
             groupSecret: groupSecret,
             createdAt: Date(),
             members: members,
+            memberProfiles: creatorProfiles,
             epoch: 0,
             salt: salt,
             commitment: proof.commitment,
@@ -668,6 +683,32 @@ struct CreateGroupInteractor: Sendable {
         await groups.snapshots.first(where: { $0.contains { $0.id == group.id } })?
             .first { $0.id == group.id }
             ?? group
+    }
+
+    // MARK: - Member profiles
+
+    /// Build the single-entry `memberProfiles` map for a freshly-created
+    /// group: just the creator, keyed by their lowercase BLS pubkey
+    /// hex. Alias is read once at create time — a later identity
+    /// rename doesn't backfill historical groups.
+    ///
+    /// Empty alias when the identity has no name resolved (very early
+    /// post-bootstrap window). Renders as a blank label with the BLS
+    /// fingerprint still visible — better than crashing or showing
+    /// stale state.
+    private static func creatorProfiles(
+        from identitySnapshot: Identity,
+        identity: IdentityRepository
+    ) async -> [String: MemberProfile] {
+        let alias = await identity.currentIdentityName() ?? ""
+        let creatorBlsHex = identitySnapshot.blsPublicKey
+            .map { String(format: "%02x", $0) }.joined()
+        return [
+            creatorBlsHex: MemberProfile(
+                alias: alias,
+                inboxPublicKey: identitySnapshot.inboxPublicKey
+            )
+        ]
     }
 
     // MARK: - Helpers

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -1,10 +1,16 @@
 import Foundation
 
-/// View-facing supplement to the cryptographic `GovernanceMember`
-/// roster on a `ChatGroup`. Carries what the UI needs to render "X
-/// joined" / "you are talking to Y" without crossing into secret
-/// material. Stored on `ChatGroup.memberProfiles` keyed by the
-/// member's lowercase BLS pubkey hex.
+/// View-facing directory entry for one peer the local user has
+/// interacted with through a group. Carries what the UI needs to
+/// render "X joined" / "you are talking to Y" without crossing into
+/// secret material. Stored on `ChatGroup.memberProfiles` keyed by
+/// the peer's lowercase BLS pubkey hex.
+///
+/// Distinct from `GovernanceMember`: that's the on-chain Merkle-tree
+/// roster (V1: creator only, static). `MemberProfile` covers the
+/// app-level "who's in this conversation" set, which V1 grows as
+/// joiners are admitted even though the on-chain roster doesn't
+/// change.
 ///
 /// Trust: `alias` is self-asserted by its owner — never load-bearing.
 /// Surfaces should always offer the member's BLS-pubkey fingerprint

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// View-facing supplement to the cryptographic `GovernanceMember`
+/// roster on a `ChatGroup`. Carries what the UI needs to render "X
+/// joined" / "you are talking to Y" without crossing into secret
+/// material. Stored on `ChatGroup.memberProfiles` keyed by the
+/// member's lowercase BLS pubkey hex.
+///
+/// Trust: `alias` is self-asserted by its owner — never load-bearing.
+/// Surfaces should always offer the member's BLS-pubkey fingerprint
+/// alongside (matches the inviter-approval pattern documented on
+/// `JoinRequestPayload`).
+///
+/// `inboxPublicKey` is the 32-byte X25519 raw pub. Persisted so the
+/// admin (or any authorized fanout sender, in future governance
+/// models) can reach every member's inbox to announce roster changes
+/// without re-deriving from the join request each time.
+struct MemberProfile: Codable, Equatable, Hashable, Sendable {
+    let alias: String
+    let inboxPublicKey: Data
+}

--- a/Sources/OnymIOS/Group/PersistedGroup.swift
+++ b/Sources/OnymIOS/Group/PersistedGroup.swift
@@ -16,6 +16,7 @@ import SwiftData
 /// - `name` — user-supplied; can leak intent.
 /// - `groupSecret` — drives all message-key derivation.
 /// - `membersJSON` — the lex-sorted roster (BLS pubkeys + leaf hashes).
+/// - `memberProfilesJSON` — alias + inbox-key per member (sparse map).
 /// - `salt`, `commitment`, `adminPubkeyHex`.
 ///
 /// Decryption boundary lives in `SwiftDataGroupStore`, not here —
@@ -41,6 +42,9 @@ final class PersistedGroup {
     var encryptedSalt: Data
     var encryptedCommitment: Data?
     var encryptedAdminPubkeyHex: Data?
+    /// Optional so SwiftData's lightweight migration can land an extra
+    /// column on existing rows without a wipe. `nil` decodes to `[:]`.
+    var encryptedMemberProfilesJSON: Data?
 
     init(
         id: String,
@@ -55,7 +59,8 @@ final class PersistedGroup {
         encryptedMembersJSON: Data,
         encryptedSalt: Data,
         encryptedCommitment: Data?,
-        encryptedAdminPubkeyHex: Data?
+        encryptedAdminPubkeyHex: Data?,
+        encryptedMemberProfilesJSON: Data?
     ) {
         self.id = id
         self.ownerIdentityIDString = ownerIdentityIDString
@@ -70,5 +75,6 @@ final class PersistedGroup {
         self.encryptedSalt = encryptedSalt
         self.encryptedCommitment = encryptedCommitment
         self.encryptedAdminPubkeyHex = encryptedAdminPubkeyHex
+        self.encryptedMemberProfilesJSON = encryptedMemberProfilesJSON
     }
 }

--- a/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
+++ b/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
@@ -91,6 +91,7 @@ actor SwiftDataGroupStore: GroupStore {
             existing.encryptedSalt = encoded.encryptedSalt
             existing.encryptedCommitment = encoded.encryptedCommitment
             existing.encryptedAdminPubkeyHex = encoded.encryptedAdminPubkeyHex
+            existing.encryptedMemberProfilesJSON = encoded.encryptedMemberProfilesJSON
             try? context.save()
             return false
         }
@@ -140,6 +141,15 @@ actor SwiftDataGroupStore: GroupStore {
 
     private static func encode(_ group: ChatGroup) throws -> PersistedGroup {
         let membersJSON = try JSONEncoder().encode(group.members)
+        // Empty profile maps stay nil on disk so existing rows can
+        // migrate in without forcing a JSON-encoded empty dict.
+        let encryptedProfilesJSON: Data?
+        if group.memberProfiles.isEmpty {
+            encryptedProfilesJSON = nil
+        } else {
+            let profilesJSON = try JSONEncoder().encode(group.memberProfiles)
+            encryptedProfilesJSON = try StorageEncryption.encrypt(profilesJSON)
+        }
         return PersistedGroup(
             id: group.id,
             ownerIdentityIDString: group.ownerIdentityID.rawValue.uuidString,
@@ -153,7 +163,8 @@ actor SwiftDataGroupStore: GroupStore {
             encryptedMembersJSON: try StorageEncryption.encrypt(membersJSON),
             encryptedSalt: try StorageEncryption.encrypt(group.salt),
             encryptedCommitment: try group.commitment.map(StorageEncryption.encrypt),
-            encryptedAdminPubkeyHex: try group.adminPubkeyHex.map(StorageEncryption.encrypt)
+            encryptedAdminPubkeyHex: try group.adminPubkeyHex.map(StorageEncryption.encrypt),
+            encryptedMemberProfilesJSON: encryptedProfilesJSON
         )
     }
 
@@ -174,6 +185,13 @@ actor SwiftDataGroupStore: GroupStore {
         let adminPubkeyHex = row.encryptedAdminPubkeyHex.flatMap {
             try? StorageEncryption.decryptString($0)
         }
+        // Missing column / decode failure → empty directory. Profiles
+        // are advisory; losing the map only costs us friendly rendering
+        // until the next member-announcement message arrives.
+        let memberProfiles: [String: MemberProfile] = row.encryptedMemberProfilesJSON
+            .flatMap { try? StorageEncryption.decrypt($0) }
+            .flatMap { try? JSONDecoder().decode([String: MemberProfile].self, from: $0) }
+            ?? [:]
         return ChatGroup(
             id: row.id,
             ownerIdentityID: owner,
@@ -181,6 +199,7 @@ actor SwiftDataGroupStore: GroupStore {
             groupSecret: groupSecret,
             createdAt: row.createdAt,
             members: members,
+            memberProfiles: memberProfiles,
             epoch: UInt64(bitPattern: row.epoch),
             salt: salt,
             commitment: commitment,

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -205,6 +205,18 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
         currentID
     }
 
+    /// The currently-selected identity's user-visible alias, or nil
+    /// if no identity is selected. Cheap actor-local read against the
+    /// in-memory `names` cache; callers that stamp the alias into
+    /// outgoing wire payloads (e.g. creator's `MemberProfile` at
+    /// group-create time) read this once at send time and don't
+    /// re-resolve later — a rename after the fact doesn't backfill
+    /// already-shipped state.
+    func currentIdentityName() -> String? {
+        guard let currentID else { return nil }
+        return names[currentID]
+    }
+
     /// Snapshot of every identity, ordered by insertion. View-safe
     /// (no secret material).
     func currentIdentities() -> [IdentitySummary] {

--- a/Tests/OnymIOSTests/ChatGroupTests.swift
+++ b/Tests/OnymIOSTests/ChatGroupTests.swift
@@ -29,6 +29,7 @@ final class ChatGroupTests: XCTestCase {
             groupSecret: Data(repeating: 0, count: 32),
             createdAt: Date(timeIntervalSince1970: 0),
             members: [],
+            memberProfiles: [:],
             epoch: 0,
             salt: Data(repeating: 0, count: 32),
             commitment: nil,

--- a/Tests/OnymIOSTests/GroupRepositoryTests.swift
+++ b/Tests/OnymIOSTests/GroupRepositoryTests.swift
@@ -150,6 +150,7 @@ final class GroupRepositoryTests: XCTestCase {
             groupSecret: Data(repeating: 0x33, count: 32),
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
             members: [],
+            memberProfiles: [:],
             epoch: 0,
             salt: Data(repeating: 0x44, count: 32),
             commitment: nil,

--- a/Tests/OnymIOSTests/JoinFlowTests.swift
+++ b/Tests/OnymIOSTests/JoinFlowTests.swift
@@ -132,6 +132,7 @@ final class JoinFlowTests: XCTestCase {
             groupSecret: Data(repeating: 0x55, count: 32),
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
             members: [],
+            memberProfiles: [:],
             epoch: 0,
             salt: Data(repeating: 0x66, count: 32),
             commitment: nil,

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -157,6 +157,7 @@ final class ShareInviteFlowTests: XCTestCase {
             groupSecret: Data(repeating: 0x33, count: 32),
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
             members: [],
+            memberProfiles: [:],
             epoch: 0,
             salt: Data(repeating: 0x44, count: 32),
             commitment: nil,

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -48,6 +48,42 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         XCTAssertEqual(first.members.count, group.members.count)
         XCTAssertEqual(first.members.first?.publicKeyCompressed,
                        group.members.first?.publicKeyCompressed)
+        XCTAssertEqual(first.memberProfiles, group.memberProfiles)
+    }
+
+    // MARK: - Member profiles
+
+    func test_insertOrUpdate_persistsMemberProfiles() async {
+        let aliceHex = "11".repeated(48)
+        let bobHex = "22".repeated(48)
+        let profiles: [String: MemberProfile] = [
+            aliceHex: MemberProfile(
+                alias: "alice",
+                inboxPublicKey: Data(repeating: 0xAA, count: 32)
+            ),
+            bobHex: MemberProfile(
+                alias: "bob",
+                inboxPublicKey: Data(repeating: 0xBB, count: 32)
+            ),
+        ]
+        let group = makeGroup(
+            id: "ab".repeated(32),
+            name: "Profiled",
+            memberProfiles: profiles
+        )
+        _ = await store.insertOrUpdate(group)
+
+        let listed = await store.list()
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed[0].memberProfiles, profiles)
+    }
+
+    func test_insertOrUpdate_emptyProfilesRoundtripAsEmptyDict() async {
+        let group = makeGroup(id: "cd".repeated(32), name: "No profiles")
+        _ = await store.insertOrUpdate(group)
+
+        let listed = await store.list()
+        XCTAssertEqual(listed[0].memberProfiles, [:])
     }
 
     // MARK: - Idempotence
@@ -128,7 +164,8 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         name: String,
         adminPubkeyHex: String? = nil,
         createdAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
-        ownerIdentityID: IdentityID = IdentityID()
+        ownerIdentityID: IdentityID = IdentityID(),
+        memberProfiles: [String: MemberProfile] = [:]
     ) -> ChatGroup {
         let member = GovernanceMember(
             publicKeyCompressed: Data(repeating: 0x11, count: 48),
@@ -141,6 +178,7 @@ final class SwiftDataGroupStoreTests: XCTestCase {
             groupSecret: Data(repeating: 0x33, count: 32),
             createdAt: createdAt,
             members: [member],
+            memberProfiles: memberProfiles,
             epoch: 0,
             salt: Data(repeating: 0x44, count: 32),
             commitment: Data(repeating: 0x55, count: 32),


### PR DESCRIPTION
## Summary

PR 1 of the new-member announcement stack ([plan](#)).

- Introduces `MemberProfile` (alias + inbox public key) — a `Codable` value type carried alongside the cryptographic `GovernanceMember` roster.
- Adds `ChatGroup.memberProfiles: [String: MemberProfile]` keyed by lowercase BLS pubkey hex. Sparser than `members` is fine; sparser than `members` is the expected steady state until profiles arrive over the wire.
- Persists via `PersistedGroup.encryptedMemberProfilesJSON` (optional column for SwiftData lightweight migration).
- Backfills the creator's profile in all three create paths (Tyranny / OneOnOne / Anarchy) using a new `IdentityRepository.currentIdentityName()` helper. Captured once at create time — a later identity rename does not backfill historical groups.

This PR ships **no wire change and no fanout**. The directory is groundwork for PRs 2–6 of the stack:

- **PR 2** — Approver UI (driving the existing single-recipient approve path by hand)
- **PR 3** — `MemberAnnouncementPayload` wire format
- **PR 4** — Approver fanout to existing members
- **PR 5** — Inbox dispatcher merges incoming announcements into `memberProfiles`
- **PR 6** — UI: "X joined" + member roster

## Test plan

- [x] `xcodebuild test -only-testing:OnymIOSTests` — 444/444 pass (3 skipped, pre-existing)
- [x] Two new round-trip tests in `SwiftDataGroupStoreTests` covering populated + empty profile maps
- [x] Existing fixture builders (5 test files) updated to pass `memberProfiles: [:]`
- [ ] Manual: create a group, force-quit, relaunch — creator's alias still displays (tests cover round-trip; manual step covers SwiftData migration on real device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)