### PR TITLE
feat(group): add MemberAnnouncementPayload wire format

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -18,4 +18,9 @@ struct AppDependencies {
     /// Settings → Identities screen observe the same state, so a
     /// factory closure here would split them.
     let identitiesFlow: IdentitiesFlow
+    /// Single shared instance — the toolbar badge on Chats and the
+    /// modal `ApproveRequestsView` observe the same `pending` list,
+    /// and the underlying collector should run for the app's
+    /// lifetime regardless of which surface is mounted.
+    let approveRequestsFlow: ApproveRequestsFlow
 }

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct ChatsView: View {
     let flow: ChatsFlow
     let identitiesFlow: IdentitiesFlow
+    let approveRequestsFlow: ApproveRequestsFlow
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
@@ -28,6 +29,12 @@ struct ChatsView: View {
             ToolbarItem(placement: .topBarLeading) {
                 IdentityPickerMenu(flow: identitiesFlow)
             }
+            // Pending join requests — always rendered so the surface
+            // is discoverable even before the first request lands;
+            // the badge only appears when `pending.count > 0`.
+            ToolbarItem(placement: .topBarTrailing) {
+                ApproveRequestsToolbarButton(flow: approveRequestsFlow)
+            }
             // Plus button mirrors iOS Mail / Messages — useful once
             // the user already has at least one chat. Hidden in the
             // empty state because the central CTA already covers it.
@@ -44,6 +51,7 @@ struct ChatsView: View {
         }
         .task { flow.start() }
         .task { await identitiesFlow.start() }
+        .task { await approveRequestsFlow.start() }
         .fullScreenCover(isPresented: $showCreateGroup) {
             CreateGroupViewHost(
                 makeFlow: makeCreateGroupFlow,

--- a/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Observation
+
+/// `@Observable @MainActor` view-model for the approver UI. Mirrors
+/// `IdentitiesFlow`'s posture — one shared instance lives in
+/// `AppDependencies`, the toolbar badge on `ChatsView` watches
+/// `pending.count`, and the modal `ApproveRequestsView` consumes the
+/// full list + dispatches Approve / Decline taps.
+///
+/// Purely a thin wrapper over `JoinRequestApprover` — no UI logic
+/// beyond mapping `ApproveOutcome` to a user-facing reason string.
+/// `start()` is idempotent so any view's `.task` can call it without
+/// double-subscribing.
+@MainActor
+@Observable
+final class ApproveRequestsFlow {
+    /// Decoded pending requests, newest-first.
+    var pending: [JoinRequestApprover.PendingRequest] = []
+    /// Last failed-approve reason, or nil. Cleared on the next
+    /// successful Approve / Decline / dismiss.
+    var lastError: String?
+
+    private let approver: any JoinRequestApproving
+    private var streamingTask: Task<Void, Never>?
+
+    init(approver: any JoinRequestApproving) {
+        self.approver = approver
+    }
+
+    /// Start the underlying collector + mirror `pending` snapshots
+    /// into the @Observable property. Idempotent.
+    func start() async {
+        guard streamingTask == nil else { return }
+        await approver.start()
+        let stream = approver.pending
+        streamingTask = Task { @MainActor [weak self] in
+            for await snapshot in stream {
+                guard let self else { break }
+                self.pending = snapshot
+            }
+        }
+    }
+
+    /// Cancel observation. The approver's collector keeps running so
+    /// the next `start()` re-attaches without losing requests that
+    /// arrived in the gap.
+    func stop() {
+        streamingTask?.cancel()
+        streamingTask = nil
+    }
+
+    func approve(_ id: String) {
+        let approver = self.approver
+        Task { @MainActor [weak self] in
+            let outcome = await approver.approve(requestId: id)
+            self?.lastError = Self.failureReason(for: outcome)
+        }
+    }
+
+    func decline(_ id: String) {
+        let approver = self.approver
+        Task { @MainActor [weak self] in
+            await approver.decline(requestId: id)
+            self?.lastError = nil
+        }
+    }
+
+    func dismissError() { lastError = nil }
+
+    private static func failureReason(
+        for outcome: JoinRequestApprover.ApproveOutcome
+    ) -> String? {
+        switch outcome {
+        case .sent: return nil
+        case .unknownGroup:
+            return "This invite isn\u{2019}t for any group on this device."
+        case .unknownRequest:
+            return "Request expired or was already handled."
+        case .noIdentityLoaded:
+            return "Sign in first."
+        case .transportFailed(let reason):
+            return "Couldn\u{2019}t send: \(reason)"
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/ApproveRequestsView.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsView.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+
+/// Modal surface listing pending join requests with Approve / Decline
+/// actions. Driven by the shared `ApproveRequestsFlow`. Empty state
+/// is the steady state for users with no outstanding invite links.
+///
+/// Trust framing: each row shows the joiner's self-asserted alias
+/// alongside the inbox-pubkey hex prefix as an out-of-band
+/// fingerprint, matching the guidance documented on
+/// `JoinRequestPayload`. Inviters who care about provenance can
+/// verify the prefix with the joiner over a side channel before
+/// approving.
+struct ApproveRequestsView: View {
+    @Bindable var flow: ApproveRequestsFlow
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            topBar
+            if let error = flow.lastError {
+                errorBanner(error)
+            }
+            if flow.pending.isEmpty {
+                emptyState
+            } else {
+                requestList
+            }
+        }
+        .background(OnymTokens.bg)
+    }
+
+    // MARK: - Top bar
+
+    private var topBar: some View {
+        HStack {
+            Button(action: onClose) {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                    Text("Close")
+                }
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(OnymTokens.text2)
+            }
+            .accessibilityIdentifier("approve_requests.close_button")
+            Spacer()
+            Text("Join requests")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Spacer()
+            Spacer().frame(width: 60)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 6)
+        .padding(.bottom, 8)
+    }
+
+    // MARK: - Error
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(OnymTokens.red)
+            Text(message)
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button {
+                flow.dismissError()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .accessibilityIdentifier("approve_requests.error_dismiss")
+        }
+        .padding(12)
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(OnymTokens.red.opacity(0.4), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+        .accessibilityIdentifier("approve_requests.error_banner")
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 14) {
+            Spacer()
+            Image(systemName: "tray")
+                .font(.system(size: 44))
+                .foregroundStyle(OnymTokens.text3)
+            Text("No pending requests")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text("People who tap one of your invite links show up here.")
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("approve_requests.empty")
+    }
+
+    // MARK: - Request list
+
+    private var requestList: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                Spacer().frame(height: 8)
+                ForEach(flow.pending) { request in
+                    requestCard(request)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+        }
+    }
+
+    private func requestCard(_ request: JoinRequestApprover.PendingRequest) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(displayAlias(request.joinerDisplayLabel))
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("wants to join \u{201C}\(request.groupName ?? "Unknown group")\u{201D}")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            fingerprintRow(label: "inbox", value: hexPrefix(request.joinerInboxPublicKey))
+            HStack(spacing: 8) {
+                Button {
+                    flow.decline(request.id)
+                } label: {
+                    Text("Decline")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 11)
+                        .background(OnymTokens.surface3)
+                        .foregroundStyle(OnymTokens.text)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .accessibilityIdentifier("approve_requests.decline_button.\(request.id)")
+                .disabled(request.groupName == nil)
+                Button {
+                    flow.approve(request.id)
+                } label: {
+                    Text("Approve")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 11)
+                        .background(OnymAccent.blue.color)
+                        .foregroundStyle(OnymTokens.onAccent)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .accessibilityIdentifier("approve_requests.approve_button.\(request.id)")
+                .disabled(request.groupName == nil)
+            }
+            if request.groupName == nil {
+                Text("This request is for a group that isn\u{2019}t on this device. Decline to clear it.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+        }
+        .padding(14)
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .accessibilityIdentifier("approve_requests.row.\(request.id)")
+    }
+
+    private func fingerprintRow(label: String, value: String) -> some View {
+        HStack(spacing: 6) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(OnymTokens.text3)
+            Text(value)
+                .font(.system(size: 12, weight: .regular, design: .monospaced))
+                .foregroundStyle(OnymTokens.text2)
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func displayAlias(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "(unnamed)" : trimmed
+    }
+
+    private func hexPrefix(_ data: Data, count: Int = 8) -> String {
+        let prefix = data.prefix(count)
+        return prefix.map { String(format: "%02x", $0) }.joined() + "\u{2026}"
+    }
+}
+
+/// Toolbar entry-point — a small icon with a numeric badge when there
+/// are pending requests. Tapping presents the modal `ApproveRequestsView`.
+/// Always shown so the surface is discoverable even before the first
+/// request lands.
+struct ApproveRequestsToolbarButton: View {
+    @Bindable var flow: ApproveRequestsFlow
+    @State private var showSheet = false
+
+    var body: some View {
+        Button {
+            showSheet = true
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: "person.crop.circle.badge.plus")
+                    .font(.system(size: 17))
+                if !flow.pending.isEmpty {
+                    Text("\(flow.pending.count)")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Capsule().fill(OnymTokens.red))
+                        .offset(x: 8, y: -6)
+                        .accessibilityIdentifier("approve_requests.toolbar_badge")
+                }
+            }
+        }
+        .accessibilityLabel("Join requests")
+        .accessibilityIdentifier("approve_requests.toolbar_button")
+        .sheet(isPresented: $showSheet) {
+            ApproveRequestsView(flow: flow, onClose: { showSheet = false })
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -25,13 +25,18 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     let createdAt: Date
 
     var members: [GovernanceMember]
-    /// View-facing supplement to `members`, keyed by lowercase BLS
-    /// pubkey hex. Populated for the creator at group-create time and
-    /// extended as new members announce themselves (post-PR fanout).
-    /// May be sparser than `members` — a member without a profile is
-    /// still a valid roster entry, just one we can't render by name
-    /// yet. The reverse must never hold: every key here MUST appear
-    /// in `members`.
+    /// View-facing directory of people the local user has interacted
+    /// with through this group, keyed by lowercase BLS pubkey hex.
+    /// Populated for the creator at group-create time and extended as
+    /// joiners are admitted (post-PR fanout).
+    ///
+    /// Independent of `members`: V1 group rosters are static
+    /// on-chain (`update_commitment` is post-V1 in the SEP
+    /// contracts), so a joiner is "in the group" at the app level —
+    /// receiving messages, listed in the chat detail — without yet
+    /// being a `GovernanceMember` in the cryptographic Merkle tree.
+    /// `members` is the on-chain truth; `memberProfiles` is the
+    /// app-level "who am I talking to" directory. They may diverge.
     var memberProfiles: [String: MemberProfile]
     var epoch: UInt64
     var salt: Data

--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -25,6 +25,14 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     let createdAt: Date
 
     var members: [GovernanceMember]
+    /// View-facing supplement to `members`, keyed by lowercase BLS
+    /// pubkey hex. Populated for the creator at group-create time and
+    /// extended as new members announce themselves (post-PR fanout).
+    /// May be sparser than `members` — a member without a profile is
+    /// still a valid roster entry, just one we can't render by name
+    /// yet. The reverse must never hold: every key here MUST appear
+    /// in `members`.
+    var memberProfiles: [String: MemberProfile]
     var epoch: UInt64
     var salt: Data
     /// Latest verified Poseidon commitment. `nil` until the first

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -223,6 +223,10 @@ struct CreateGroupInteractor: Sendable {
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
         let adminPubkeyHex = identitySnapshot.blsPublicKey
             .map { String(format: "%02x", $0) }.joined()
+        let creatorProfiles = await Self.creatorProfiles(
+            from: identitySnapshot,
+            identity: identity
+        )
         let group = ChatGroup(
             id: groupIDHex,
             ownerIdentityID: ownerID,
@@ -230,6 +234,7 @@ struct CreateGroupInteractor: Sendable {
             groupSecret: groupSecret,
             createdAt: Date(),
             members: members,
+            memberProfiles: creatorProfiles,
             epoch: 0,
             salt: salt,
             commitment: proof.commitment,
@@ -403,6 +408,10 @@ struct CreateGroupInteractor: Sendable {
 
         // 7. Save locally — no admin in 1-on-1, so adminPubkeyHex stays nil.
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+        let creatorProfiles = await Self.creatorProfiles(
+            from: identitySnapshot,
+            identity: identity
+        )
         let group = ChatGroup(
             id: groupIDHex,
             ownerIdentityID: ownerID,
@@ -410,6 +419,7 @@ struct CreateGroupInteractor: Sendable {
             groupSecret: groupSecret,
             createdAt: Date(),
             members: members,
+            memberProfiles: creatorProfiles,
             epoch: 0,
             salt: salt,
             commitment: proof.commitment,
@@ -570,6 +580,10 @@ struct CreateGroupInteractor: Sendable {
 
         // 7. Save locally — no admin in Anarchy, so adminPubkeyHex stays nil.
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+        let creatorProfiles = await Self.creatorProfiles(
+            from: identitySnapshot,
+            identity: identity
+        )
         let group = ChatGroup(
             id: groupIDHex,
             ownerIdentityID: ownerID,
@@ -577,6 +591,7 @@ struct CreateGroupInteractor: Sendable {
             groupSecret: groupSecret,
             createdAt: Date(),
             members: members,
+            memberProfiles: creatorProfiles,
             epoch: 0,
             salt: salt,
             commitment: proof.commitment,
@@ -668,6 +683,32 @@ struct CreateGroupInteractor: Sendable {
         await groups.snapshots.first(where: { $0.contains { $0.id == group.id } })?
             .first { $0.id == group.id }
             ?? group
+    }
+
+    // MARK: - Member profiles
+
+    /// Build the single-entry `memberProfiles` map for a freshly-created
+    /// group: just the creator, keyed by their lowercase BLS pubkey
+    /// hex. Alias is read once at create time — a later identity
+    /// rename doesn't backfill historical groups.
+    ///
+    /// Empty alias when the identity has no name resolved (very early
+    /// post-bootstrap window). Renders as a blank label with the BLS
+    /// fingerprint still visible — better than crashing or showing
+    /// stale state.
+    private static func creatorProfiles(
+        from identitySnapshot: Identity,
+        identity: IdentityRepository
+    ) async -> [String: MemberProfile] {
+        let alias = await identity.currentIdentityName() ?? ""
+        let creatorBlsHex = identitySnapshot.blsPublicKey
+            .map { String(format: "%02x", $0) }.joined()
+        return [
+            creatorBlsHex: MemberProfile(
+                alias: alias,
+                inboxPublicKey: identitySnapshot.inboxPublicKey
+            )
+        ]
     }
 
     // MARK: - Helpers

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -1,6 +1,17 @@
 import CryptoKit
 import Foundation
 
+/// Test seam used by `ApproveRequestsFlow`. The production conformer
+/// is `JoinRequestApprover` itself; tests inject a stub instead of
+/// standing up the full keychain + transport stack just to exercise
+/// the flow's bookkeeping.
+protocol JoinRequestApproving: Sendable {
+    var pending: AsyncStream<[JoinRequestApprover.PendingRequest]> { get }
+    func start() async
+    func approve(requestId: String) async -> JoinRequestApprover.ApproveOutcome
+    func decline(requestId: String) async
+}
+
 /// Sender-side: turn raw `IntroRequest`s into UI-renderable
 /// pending requests, and on user approval ship the actual sealed
 /// `GroupInvitationPayload` to the joiner.
@@ -20,7 +31,7 @@ import Foundation
 ///     tag within one emission window.
 ///  4. On Decline → drop the request, revoke the intro key. No
 ///     NACK to the joiner; their JoinScreen times out gracefully.
-actor JoinRequestApprover {
+actor JoinRequestApprover: JoinRequestApproving {
 
     /// UI-renderable view of one decrypted, awaiting-action request.
     struct PendingRequest: Equatable, Sendable, Identifiable {

--- a/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
+++ b/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// Plaintext payload that the admin seals (via
+/// `IdentityRepository.sealInvitation`, X25519 + AES-GCM, signed by
+/// the admin's Ed25519 stellar key) and ships to every existing
+/// member's inbox after they Approve a join request. Tells receivers
+/// "this person just joined the group — append them to your local
+/// roster".
+///
+/// Sits alongside `GroupInvitationPayload`:
+///   - `GroupInvitationPayload` is the joiner's first taste of a
+///     group — full state needed to render messages.
+///   - `MemberAnnouncementPayload` is incremental — existing
+///     members already know the group, they just need to learn
+///     about one new entry in the roster.
+///
+/// ## Trust
+///
+/// `newMember.alias` and `adminAlias` are self-asserted. Receivers
+/// that care about provenance should display the BLS-pubkey
+/// fingerprint alongside (matches the inviter-approval guidance on
+/// `JoinRequestPayload`). The OUTER `SealedEnvelope` carries the
+/// admin's Ed25519 signature over the ephemeral key — receivers
+/// MUST cross-check `senderEd25519PublicKey` against the group's
+/// stored `adminPubkeyHex` (or, for governance models without an
+/// admin, against the existing-member set) before mutating local
+/// state. That signature check lives in the dispatcher (PR 5),
+/// not here — this type is a pure value carrier.
+///
+/// ## Versioning
+///
+/// `version = 1` is the only shape receivers handle today. Future
+/// fields land via non-failing `decodeIfPresent` decoders so older
+/// builds round-trip unknown announcements as best-effort.
+///
+/// ## Cross-platform parity
+///
+/// Wire format authored on iOS first; onym-android mirrors the
+/// snake_case keys + base64 `Data` encoding (Swift `JSONEncoder`'s
+/// `.base64` default + Kotlin's `Base64.getEncoder()` produce the
+/// same bytes).
+struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
+    let version: Int
+    /// 32-byte group ID — receivers cross-check against their
+    /// local `ChatGroup.groupIDData` to refuse announcements for
+    /// groups they don't know about.
+    let groupId: Data
+    let newMember: AnnouncedMember
+    /// Admin's user-visible alias at send time. Carried alongside
+    /// the announcement so the receiver can render "Y admitted X"
+    /// without needing a prior alias map keyed by admin pubkey
+    /// (which the receiver does have, but rendering becomes
+    /// strictly local-state-free this way).
+    let adminAlias: String
+
+    /// One member's full directory entry — both the cryptographic
+    /// material the receiver needs to extend their roster and the
+    /// view-facing alias / inbox key that lets the local UI render
+    /// "X joined" + the local store remember how to fan out to X
+    /// in future announcements.
+    struct AnnouncedMember: Codable, Equatable, Sendable {
+        /// 48-byte arkworks-compressed BLS12-381 G1 pubkey.
+        let blsPub: Data
+        /// 32-byte Poseidon leaf hash.
+        let leafHash: Data
+        /// 32-byte X25519 raw inbox public key.
+        let inboxPub: Data
+        /// Self-asserted display alias.
+        let alias: String
+
+        enum CodingKeys: String, CodingKey {
+            case blsPub = "bls_pub"
+            case leafHash = "leaf_hash"
+            case inboxPub = "inbox_pub"
+            case alias
+        }
+
+        init(blsPub: Data, leafHash: Data, inboxPub: Data, alias: String) throws {
+            try Self.validate(blsPub: blsPub, leafHash: leafHash, inboxPub: inboxPub)
+            self.blsPub = blsPub
+            self.leafHash = leafHash
+            self.inboxPub = inboxPub
+            self.alias = alias
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            let bls = try c.decode(Data.self, forKey: .blsPub)
+            let leaf = try c.decode(Data.self, forKey: .leafHash)
+            let inbox = try c.decode(Data.self, forKey: .inboxPub)
+            let alias = try c.decode(String.self, forKey: .alias)
+            try Self.validate(blsPub: bls, leafHash: leaf, inboxPub: inbox)
+            self.blsPub = bls
+            self.leafHash = leaf
+            self.inboxPub = inbox
+            self.alias = alias
+        }
+
+        private static func validate(blsPub: Data, leafHash: Data, inboxPub: Data) throws {
+            guard blsPub.count == 48 else {
+                throw MemberAnnouncementPayloadError.shape(
+                    "blsPub: expected 48 bytes, got \(blsPub.count)"
+                )
+            }
+            guard leafHash.count == 32 else {
+                throw MemberAnnouncementPayloadError.shape(
+                    "leafHash: expected 32 bytes, got \(leafHash.count)"
+                )
+            }
+            guard inboxPub.count == 32 else {
+                throw MemberAnnouncementPayloadError.shape(
+                    "inboxPub: expected 32 bytes, got \(inboxPub.count)"
+                )
+            }
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case groupId = "group_id"
+        case newMember = "new_member"
+        case adminAlias = "admin_alias"
+    }
+
+    init(version: Int, groupId: Data, newMember: AnnouncedMember, adminAlias: String) throws {
+        guard groupId.count == 32 else {
+            throw MemberAnnouncementPayloadError.shape(
+                "groupId: expected 32 bytes, got \(groupId.count)"
+            )
+        }
+        self.version = version
+        self.groupId = groupId
+        self.newMember = newMember
+        self.adminAlias = adminAlias
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let v = try c.decode(Int.self, forKey: .version)
+        let gid = try c.decode(Data.self, forKey: .groupId)
+        guard gid.count == 32 else {
+            throw MemberAnnouncementPayloadError.shape(
+                "groupId: expected 32 bytes, got \(gid.count)"
+            )
+        }
+        self.version = v
+        self.groupId = gid
+        self.newMember = try c.decode(AnnouncedMember.self, forKey: .newMember)
+        self.adminAlias = try c.decode(String.self, forKey: .adminAlias)
+    }
+}
+
+enum MemberAnnouncementPayloadError: Error, Equatable {
+    case shape(String)
+}

--- a/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
+++ b/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
@@ -53,16 +53,23 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
     /// strictly local-state-free this way).
     let adminAlias: String
 
-    /// One member's full directory entry — both the cryptographic
-    /// material the receiver needs to extend their roster and the
-    /// view-facing alias / inbox key that lets the local UI render
-    /// "X joined" + the local store remember how to fan out to X
-    /// in future announcements.
+    /// One member's directory entry. App-level only — the
+    /// cryptographic Poseidon leaf hash is intentionally absent.
+    /// V1 group rosters are static on-chain (the joiner is not yet a
+    /// member of the Merkle tree; `update_commitment` is post-V1
+    /// scope in the SEP contracts), so the leaf hash is meaningless
+    /// to ship today. When on-chain joiner ceremonies land, a
+    /// `leaf_hash` field can return via a non-failing
+    /// `decodeIfPresent` decoder without breaking older receivers.
+    ///
+    /// `blsPub` is still carried as the **stable cross-device
+    /// identifier**: it's HKDF-derived from the joiner's identity
+    /// secret, so the same pubkey persists across recovery-phrase
+    /// restores and forms the dedup key in
+    /// `ChatGroup.memberProfiles`.
     struct AnnouncedMember: Codable, Equatable, Sendable {
         /// 48-byte arkworks-compressed BLS12-381 G1 pubkey.
         let blsPub: Data
-        /// 32-byte Poseidon leaf hash.
-        let leafHash: Data
         /// 32-byte X25519 raw inbox public key.
         let inboxPub: Data
         /// Self-asserted display alias.
@@ -70,15 +77,13 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
 
         enum CodingKeys: String, CodingKey {
             case blsPub = "bls_pub"
-            case leafHash = "leaf_hash"
             case inboxPub = "inbox_pub"
             case alias
         }
 
-        init(blsPub: Data, leafHash: Data, inboxPub: Data, alias: String) throws {
-            try Self.validate(blsPub: blsPub, leafHash: leafHash, inboxPub: inboxPub)
+        init(blsPub: Data, inboxPub: Data, alias: String) throws {
+            try Self.validate(blsPub: blsPub, inboxPub: inboxPub)
             self.blsPub = blsPub
-            self.leafHash = leafHash
             self.inboxPub = inboxPub
             self.alias = alias
         }
@@ -86,25 +91,18 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             let bls = try c.decode(Data.self, forKey: .blsPub)
-            let leaf = try c.decode(Data.self, forKey: .leafHash)
             let inbox = try c.decode(Data.self, forKey: .inboxPub)
             let alias = try c.decode(String.self, forKey: .alias)
-            try Self.validate(blsPub: bls, leafHash: leaf, inboxPub: inbox)
+            try Self.validate(blsPub: bls, inboxPub: inbox)
             self.blsPub = bls
-            self.leafHash = leaf
             self.inboxPub = inbox
             self.alias = alias
         }
 
-        private static func validate(blsPub: Data, leafHash: Data, inboxPub: Data) throws {
+        private static func validate(blsPub: Data, inboxPub: Data) throws {
             guard blsPub.count == 48 else {
                 throw MemberAnnouncementPayloadError.shape(
                     "blsPub: expected 48 bytes, got \(blsPub.count)"
-                )
-            }
-            guard leafHash.count == 32 else {
-                throw MemberAnnouncementPayloadError.shape(
-                    "leafHash: expected 32 bytes, got \(leafHash.count)"
                 )
             }
             guard inboxPub.count == 32 else {

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -1,10 +1,16 @@
 import Foundation
 
-/// View-facing supplement to the cryptographic `GovernanceMember`
-/// roster on a `ChatGroup`. Carries what the UI needs to render "X
-/// joined" / "you are talking to Y" without crossing into secret
-/// material. Stored on `ChatGroup.memberProfiles` keyed by the
-/// member's lowercase BLS pubkey hex.
+/// View-facing directory entry for one peer the local user has
+/// interacted with through a group. Carries what the UI needs to
+/// render "X joined" / "you are talking to Y" without crossing into
+/// secret material. Stored on `ChatGroup.memberProfiles` keyed by
+/// the peer's lowercase BLS pubkey hex.
+///
+/// Distinct from `GovernanceMember`: that's the on-chain Merkle-tree
+/// roster (V1: creator only, static). `MemberProfile` covers the
+/// app-level "who's in this conversation" set, which V1 grows as
+/// joiners are admitted even though the on-chain roster doesn't
+/// change.
 ///
 /// Trust: `alias` is self-asserted by its owner — never load-bearing.
 /// Surfaces should always offer the member's BLS-pubkey fingerprint

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// View-facing supplement to the cryptographic `GovernanceMember`
+/// roster on a `ChatGroup`. Carries what the UI needs to render "X
+/// joined" / "you are talking to Y" without crossing into secret
+/// material. Stored on `ChatGroup.memberProfiles` keyed by the
+/// member's lowercase BLS pubkey hex.
+///
+/// Trust: `alias` is self-asserted by its owner — never load-bearing.
+/// Surfaces should always offer the member's BLS-pubkey fingerprint
+/// alongside (matches the inviter-approval pattern documented on
+/// `JoinRequestPayload`).
+///
+/// `inboxPublicKey` is the 32-byte X25519 raw pub. Persisted so the
+/// admin (or any authorized fanout sender, in future governance
+/// models) can reach every member's inbox to announce roster changes
+/// without re-deriving from the join request each time.
+struct MemberProfile: Codable, Equatable, Hashable, Sendable {
+    let alias: String
+    let inboxPublicKey: Data
+}

--- a/Sources/OnymIOS/Group/PersistedGroup.swift
+++ b/Sources/OnymIOS/Group/PersistedGroup.swift
@@ -16,6 +16,7 @@ import SwiftData
 /// - `name` — user-supplied; can leak intent.
 /// - `groupSecret` — drives all message-key derivation.
 /// - `membersJSON` — the lex-sorted roster (BLS pubkeys + leaf hashes).
+/// - `memberProfilesJSON` — alias + inbox-key per member (sparse map).
 /// - `salt`, `commitment`, `adminPubkeyHex`.
 ///
 /// Decryption boundary lives in `SwiftDataGroupStore`, not here —
@@ -41,6 +42,9 @@ final class PersistedGroup {
     var encryptedSalt: Data
     var encryptedCommitment: Data?
     var encryptedAdminPubkeyHex: Data?
+    /// Optional so SwiftData's lightweight migration can land an extra
+    /// column on existing rows without a wipe. `nil` decodes to `[:]`.
+    var encryptedMemberProfilesJSON: Data?
 
     init(
         id: String,
@@ -55,7 +59,8 @@ final class PersistedGroup {
         encryptedMembersJSON: Data,
         encryptedSalt: Data,
         encryptedCommitment: Data?,
-        encryptedAdminPubkeyHex: Data?
+        encryptedAdminPubkeyHex: Data?,
+        encryptedMemberProfilesJSON: Data?
     ) {
         self.id = id
         self.ownerIdentityIDString = ownerIdentityIDString
@@ -70,5 +75,6 @@ final class PersistedGroup {
         self.encryptedSalt = encryptedSalt
         self.encryptedCommitment = encryptedCommitment
         self.encryptedAdminPubkeyHex = encryptedAdminPubkeyHex
+        self.encryptedMemberProfilesJSON = encryptedMemberProfilesJSON
     }
 }

--- a/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
+++ b/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
@@ -91,6 +91,7 @@ actor SwiftDataGroupStore: GroupStore {
             existing.encryptedSalt = encoded.encryptedSalt
             existing.encryptedCommitment = encoded.encryptedCommitment
             existing.encryptedAdminPubkeyHex = encoded.encryptedAdminPubkeyHex
+            existing.encryptedMemberProfilesJSON = encoded.encryptedMemberProfilesJSON
             try? context.save()
             return false
         }
@@ -140,6 +141,15 @@ actor SwiftDataGroupStore: GroupStore {
 
     private static func encode(_ group: ChatGroup) throws -> PersistedGroup {
         let membersJSON = try JSONEncoder().encode(group.members)
+        // Empty profile maps stay nil on disk so existing rows can
+        // migrate in without forcing a JSON-encoded empty dict.
+        let encryptedProfilesJSON: Data?
+        if group.memberProfiles.isEmpty {
+            encryptedProfilesJSON = nil
+        } else {
+            let profilesJSON = try JSONEncoder().encode(group.memberProfiles)
+            encryptedProfilesJSON = try StorageEncryption.encrypt(profilesJSON)
+        }
         return PersistedGroup(
             id: group.id,
             ownerIdentityIDString: group.ownerIdentityID.rawValue.uuidString,
@@ -153,7 +163,8 @@ actor SwiftDataGroupStore: GroupStore {
             encryptedMembersJSON: try StorageEncryption.encrypt(membersJSON),
             encryptedSalt: try StorageEncryption.encrypt(group.salt),
             encryptedCommitment: try group.commitment.map(StorageEncryption.encrypt),
-            encryptedAdminPubkeyHex: try group.adminPubkeyHex.map(StorageEncryption.encrypt)
+            encryptedAdminPubkeyHex: try group.adminPubkeyHex.map(StorageEncryption.encrypt),
+            encryptedMemberProfilesJSON: encryptedProfilesJSON
         )
     }
 
@@ -174,6 +185,13 @@ actor SwiftDataGroupStore: GroupStore {
         let adminPubkeyHex = row.encryptedAdminPubkeyHex.flatMap {
             try? StorageEncryption.decryptString($0)
         }
+        // Missing column / decode failure → empty directory. Profiles
+        // are advisory; losing the map only costs us friendly rendering
+        // until the next member-announcement message arrives.
+        let memberProfiles: [String: MemberProfile] = row.encryptedMemberProfilesJSON
+            .flatMap { try? StorageEncryption.decrypt($0) }
+            .flatMap { try? JSONDecoder().decode([String: MemberProfile].self, from: $0) }
+            ?? [:]
         return ChatGroup(
             id: row.id,
             ownerIdentityID: owner,
@@ -181,6 +199,7 @@ actor SwiftDataGroupStore: GroupStore {
             groupSecret: groupSecret,
             createdAt: row.createdAt,
             members: members,
+            memberProfiles: memberProfiles,
             epoch: UInt64(bitPattern: row.epoch),
             salt: salt,
             commitment: commitment,

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -205,6 +205,18 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
         currentID
     }
 
+    /// The currently-selected identity's user-visible alias, or nil
+    /// if no identity is selected. Cheap actor-local read against the
+    /// in-memory `names` cache; callers that stamp the alias into
+    /// outgoing wire payloads (e.g. creator's `MemberProfile` at
+    /// group-create time) read this once at send time and don't
+    /// re-resolve later — a rename after the fact doesn't backfill
+    /// already-shipped state.
+    func currentIdentityName() -> String? {
+        guard let currentID else { return nil }
+        return names[currentID]
+    }
+
     /// Snapshot of every identity, ordered by insertion. View-safe
     /// (no secret material).
     func currentIdentities() -> [IdentitySummary] {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -113,6 +113,21 @@ struct OnymIOSApp: App {
         // and the Settings → Identities screen observe the same state.
         let identitiesFlow = IdentitiesFlow(repository: repository)
 
+        // Single shared JoinRequestApprover + ApproveRequestsFlow.
+        // The collector inside the approver subscribes to
+        // `IntroRequestStore` once and keeps a decoded snapshot in
+        // memory; the @Observable flow mirrors that snapshot so the
+        // toolbar badge on Chats and the modal request list see the
+        // same state without re-running decryption.
+        let joinRequestApprover = JoinRequestApprover(
+            identity: repository,
+            introKeyStore: introKeyStore,
+            introRequestStore: self.introRequestStore,
+            groupRepository: groupRepository,
+            inboxTransport: inboxTransport
+        )
+        let approveRequestsFlow = ApproveRequestsFlow(approver: joinRequestApprover)
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -162,7 +177,8 @@ struct OnymIOSApp: App {
             makeChatsFlow: { @MainActor in
                 ChatsFlow(repository: groupRepository)
             },
-            identitiesFlow: identitiesFlow
+            identitiesFlow: identitiesFlow,
+            approveRequestsFlow: approveRequestsFlow
         )
     }
 
@@ -178,6 +194,12 @@ struct OnymIOSApp: App {
                     // operation that needs identity will surface a clear
                     // error to the user.
                     _ = try? await identityRepository.bootstrap()
+                    // Start the approver collector eagerly so the
+                    // Chats toolbar badge reflects pending requests
+                    // from the moment the app is on screen, even
+                    // before the user opens the modal request list.
+                    // Idempotent — `ChatsView.task` calls it too.
+                    await dependencies.approveRequestsFlow.start()
                     // Kick off both GitHub Releases fetches as soon as the
                     // app is on screen. Failures are silent; the user can
                     // still enter a custom relayer URL / pick an older

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -29,6 +29,7 @@ struct RootView: View {
                     ChatsView(
                         flow: dependencies.makeChatsFlow(),
                         identitiesFlow: dependencies.identitiesFlow,
+                        approveRequestsFlow: dependencies.approveRequestsFlow,
                         makeCreateGroupFlow: dependencies.makeCreateGroupFlow,
                         makeShareInviteFlow: dependencies.makeShareInviteFlow
                     )

--- a/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
+++ b/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import OnymIOS
+
+@MainActor
+final class ApproveRequestsFlowTests: XCTestCase {
+
+    // MARK: - Stream propagation
+
+    func test_start_subscribesAndMirrorsApproverStream() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        await flow.start()
+
+        await stub.emit([Self.makeRequest(id: "req-1", alias: "alice")])
+        try await waitFor { flow.pending.map(\.id) == ["req-1"] }
+        XCTAssertEqual(flow.pending.first?.joinerDisplayLabel, "alice")
+    }
+
+    func test_start_isIdempotent_secondCallDoesNotDoubleSubscribe() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        await flow.start()
+        await flow.start()
+        let started = await stub.startCalls
+        XCTAssertEqual(started, 1, "start() must dedupe at the flow level")
+    }
+
+    // MARK: - Approve
+
+    func test_approve_routesToApproverAndClearsErrorOnSent() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        flow.lastError = "stale error"
+
+        await stub.setNextOutcome(.sent)
+        flow.approve("req-1")
+        try await waitFor { flow.lastError == nil }
+        let calls = await stub.approveCalls
+        XCTAssertEqual(calls, ["req-1"])
+    }
+
+    func test_approve_setsErrorOnTransportFailure() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+
+        await stub.setNextOutcome(.transportFailed("relay rejected"))
+        flow.approve("req-2")
+        try await waitFor { flow.lastError != nil }
+        XCTAssertTrue(flow.lastError?.contains("relay rejected") ?? false,
+                      "lastError = \(flow.lastError ?? "nil")")
+    }
+
+    func test_approve_setsErrorOnUnknownGroup() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+
+        await stub.setNextOutcome(.unknownGroup)
+        flow.approve("req-3")
+        try await waitFor { flow.lastError != nil }
+        XCTAssertEqual(
+            flow.lastError,
+            "This invite isn\u{2019}t for any group on this device."
+        )
+    }
+
+    // MARK: - Decline
+
+    func test_decline_routesToApproverAndClearsError() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        flow.lastError = "leftover"
+
+        flow.decline("req-1")
+        try await waitFor { flow.lastError == nil }
+        let calls = await stub.declineCalls
+        XCTAssertEqual(calls, ["req-1"])
+    }
+
+    // MARK: - Misc
+
+    func test_dismissError_clearsLastError() {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        flow.lastError = "boom"
+        flow.dismissError()
+        XCTAssertNil(flow.lastError)
+    }
+
+    // MARK: - Helpers
+
+    private static func makeRequest(
+        id: String,
+        alias: String
+    ) -> JoinRequestApprover.PendingRequest {
+        JoinRequestApprover.PendingRequest(
+            id: id,
+            joinerInboxPublicKey: Data(repeating: 0xAA, count: 32),
+            joinerDisplayLabel: alias,
+            groupId: Data(repeating: 0xBB, count: 32),
+            groupName: "Family"
+        )
+    }
+
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        interval: TimeInterval = 0.02,
+        _ predicate: @MainActor @escaping () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("Timed out waiting for predicate", file: file, line: line)
+    }
+}
+
+// MARK: - Stub
+
+private actor StubApprover: JoinRequestApproving {
+    private var continuations: [UUID: AsyncStream<[JoinRequestApprover.PendingRequest]>.Continuation] = [:]
+    private var snapshot: [JoinRequestApprover.PendingRequest] = []
+
+    private(set) var approveCalls: [String] = []
+    private(set) var declineCalls: [String] = []
+    private(set) var startCalls: Int = 0
+    private var nextOutcome: JoinRequestApprover.ApproveOutcome = .sent
+
+    func emit(_ requests: [JoinRequestApprover.PendingRequest]) {
+        snapshot = requests
+        for c in continuations.values { c.yield(requests) }
+    }
+
+    func setNextOutcome(_ outcome: JoinRequestApprover.ApproveOutcome) {
+        nextOutcome = outcome
+    }
+
+    nonisolated var pending: AsyncStream<[JoinRequestApprover.PendingRequest]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    func start() async {
+        startCalls += 1
+    }
+
+    func approve(requestId: String) async -> JoinRequestApprover.ApproveOutcome {
+        approveCalls.append(requestId)
+        return nextOutcome
+    }
+
+    func decline(requestId: String) async {
+        declineCalls.append(requestId)
+    }
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<[JoinRequestApprover.PendingRequest]>.Continuation
+    ) {
+        continuations[id] = continuation
+        continuation.yield(snapshot)
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+}

--- a/Tests/OnymIOSTests/ChatGroupTests.swift
+++ b/Tests/OnymIOSTests/ChatGroupTests.swift
@@ -29,6 +29,7 @@ final class ChatGroupTests: XCTestCase {
             groupSecret: Data(repeating: 0, count: 32),
             createdAt: Date(timeIntervalSince1970: 0),
             members: [],
+            memberProfiles: [:],
             epoch: 0,
             salt: Data(repeating: 0, count: 32),
             commitment: nil,

--- a/Tests/OnymIOSTests/GroupRepositoryTests.swift
+++ b/Tests/OnymIOSTests/GroupRepositoryTests.swift
@@ -150,6 +150,7 @@ final class GroupRepositoryTests: XCTestCase {
             groupSecret: Data(repeating: 0x33, count: 32),
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
             members: [],
+            memberProfiles: [:],
             epoch: 0,
             salt: Data(repeating: 0x44, count: 32),
             commitment: nil,

--- a/Tests/OnymIOSTests/JoinFlowTests.swift
+++ b/Tests/OnymIOSTests/JoinFlowTests.swift
@@ -132,6 +132,7 @@ final class JoinFlowTests: XCTestCase {
             groupSecret: Data(repeating: 0x55, count: 32),
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
             members: [],
+            memberProfiles: [:],
             epoch: 0,
             salt: Data(repeating: 0x66, count: 32),
             commitment: nil,

--- a/Tests/OnymIOSTests/MemberAnnouncementPayloadTests.swift
+++ b/Tests/OnymIOSTests/MemberAnnouncementPayloadTests.swift
@@ -13,7 +13,6 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
     func test_roundtrip_preservesAllFields() throws {
         let member = try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0x11, count: 48),
-            leafHash: Data(repeating: 0x22, count: 32),
             inboxPub: Data(repeating: 0x33, count: 32),
             alias: "Bob"
         )
@@ -36,7 +35,6 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
     func test_snake_case_keys_match_android_parity() throws {
         let member = try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 48),
-            leafHash: Data(repeating: 0, count: 32),
             inboxPub: Data(repeating: 0, count: 32),
             alias: "Bob"
         )
@@ -55,9 +53,10 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
         XCTAssertEqual(obj?["admin_alias"] as? String, "Alice")
         let memberObj = obj?["new_member"] as? [String: Any]
         XCTAssertNotNil(memberObj?["bls_pub"])
-        XCTAssertNotNil(memberObj?["leaf_hash"])
         XCTAssertNotNil(memberObj?["inbox_pub"])
         XCTAssertNotNil(memberObj?["alias"])
+        XCTAssertNil(memberObj?["leaf_hash"],
+                     "leaf_hash is intentionally absent in v1")
         XCTAssertEqual(memberObj?["alias"] as? String, "Bob")
     }
 
@@ -66,7 +65,6 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
     func test_constructor_rejectsWrongSizedGroupId() {
         let member = try! MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 48),
-            leafHash: Data(repeating: 0, count: 32),
             inboxPub: Data(repeating: 0, count: 32),
             alias: "x"
         )
@@ -83,18 +81,6 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
     func test_announcedMember_constructor_rejectsWrongSizedBlsPub() {
         XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 47),
-            leafHash: Data(repeating: 0, count: 32),
-            inboxPub: Data(repeating: 0, count: 32),
-            alias: "x"
-        )) { error in
-            XCTAssertTrue(error is MemberAnnouncementPayloadError)
-        }
-    }
-
-    func test_announcedMember_constructor_rejectsWrongSizedLeafHash() {
-        XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
-            blsPub: Data(repeating: 0, count: 48),
-            leafHash: Data(repeating: 0, count: 31),
             inboxPub: Data(repeating: 0, count: 32),
             alias: "x"
         )) { error in
@@ -105,7 +91,6 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
     func test_announcedMember_constructor_rejectsWrongSizedInboxPub() {
         XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 48),
-            leafHash: Data(repeating: 0, count: 32),
             inboxPub: Data(repeating: 0, count: 31),
             alias: "x"
         )) { error in
@@ -117,7 +102,7 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
 
     func test_decoder_rejectsWrongSizedGroupId() {
         let bad = #"""
-        {"version":1,"group_id":"AAA=","new_member":{"bls_pub":"\#(base64Zeros(48))","leaf_hash":"\#(base64Zeros(32))","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
+        {"version":1,"group_id":"AAA=","new_member":{"bls_pub":"\#(base64Zeros(48))","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
         """#
         let bytes = bad.data(using: .utf8)!
         XCTAssertThrowsError(
@@ -129,7 +114,7 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
 
     func test_decoder_rejectsWrongSizedBlsPub() {
         let bad = #"""
-        {"version":1,"group_id":"\#(base64Zeros(32))","new_member":{"bls_pub":"AAA=","leaf_hash":"\#(base64Zeros(32))","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
+        {"version":1,"group_id":"\#(base64Zeros(32))","new_member":{"bls_pub":"AAA=","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
         """#
         let bytes = bad.data(using: .utf8)!
         XCTAssertThrowsError(
@@ -137,6 +122,21 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
         ) { error in
             XCTAssertTrue(error is MemberAnnouncementPayloadError)
         }
+    }
+
+    func test_decoder_ignoresUnknownLeafHashField_forForwardCompat() throws {
+        // V2 receivers may add `leaf_hash`; V1 receivers MUST decode
+        // payloads carrying it, ignoring the unknown field.
+        let v2Shape = #"""
+        {"version":2,"group_id":"\#(base64Zeros(32))","new_member":{"bls_pub":"\#(base64Zeros(48))","leaf_hash":"\#(base64Zeros(32))","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
+        """#
+        let bytes = v2Shape.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(
+            MemberAnnouncementPayload.self,
+            from: bytes
+        )
+        XCTAssertEqual(decoded.version, 2)
+        XCTAssertEqual(decoded.newMember.alias, "x")
     }
 
     // MARK: - Helpers

--- a/Tests/OnymIOSTests/MemberAnnouncementPayloadTests.swift
+++ b/Tests/OnymIOSTests/MemberAnnouncementPayloadTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import OnymIOS
+
+/// Wire-format pin for `MemberAnnouncementPayload`. Authored on iOS
+/// first; onym-android will mirror. Cross-platform parity is checked
+/// via the snake_case key spelling assertions — Swift `JSONEncoder`
+/// + Kotlin `kotlinx.serialization.Json` both serialize `Data` /
+/// `ByteArray` to standard base64 with padding by default.
+final class MemberAnnouncementPayloadTests: XCTestCase {
+
+    // MARK: - Round-trip
+
+    func test_roundtrip_preservesAllFields() throws {
+        let member = try MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: Data(repeating: 0x11, count: 48),
+            leafHash: Data(repeating: 0x22, count: 32),
+            inboxPub: Data(repeating: 0x33, count: 32),
+            alias: "Bob"
+        )
+        let original = try MemberAnnouncementPayload(
+            version: 1,
+            groupId: Data(repeating: 0x42, count: 32),
+            newMember: member,
+            adminAlias: "Alice"
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            MemberAnnouncementPayload.self,
+            from: encoded
+        )
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - Wire shape
+
+    func test_snake_case_keys_match_android_parity() throws {
+        let member = try MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: Data(repeating: 0, count: 48),
+            leafHash: Data(repeating: 0, count: 32),
+            inboxPub: Data(repeating: 0, count: 32),
+            alias: "Bob"
+        )
+        let payload = try MemberAnnouncementPayload(
+            version: 1,
+            groupId: Data(repeating: 0, count: 32),
+            newMember: member,
+            adminAlias: "Alice"
+        )
+        let encoded = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNotNil(obj?["version"])
+        XCTAssertNotNil(obj?["group_id"])
+        XCTAssertNotNil(obj?["new_member"])
+        XCTAssertNotNil(obj?["admin_alias"])
+        XCTAssertEqual(obj?["admin_alias"] as? String, "Alice")
+        let memberObj = obj?["new_member"] as? [String: Any]
+        XCTAssertNotNil(memberObj?["bls_pub"])
+        XCTAssertNotNil(memberObj?["leaf_hash"])
+        XCTAssertNotNil(memberObj?["inbox_pub"])
+        XCTAssertNotNil(memberObj?["alias"])
+        XCTAssertEqual(memberObj?["alias"] as? String, "Bob")
+    }
+
+    // MARK: - Constructor validation
+
+    func test_constructor_rejectsWrongSizedGroupId() {
+        let member = try! MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: Data(repeating: 0, count: 48),
+            leafHash: Data(repeating: 0, count: 32),
+            inboxPub: Data(repeating: 0, count: 32),
+            alias: "x"
+        )
+        XCTAssertThrowsError(try MemberAnnouncementPayload(
+            version: 1,
+            groupId: Data(repeating: 0, count: 31),
+            newMember: member,
+            adminAlias: "y"
+        )) { error in
+            XCTAssertTrue(error is MemberAnnouncementPayloadError)
+        }
+    }
+
+    func test_announcedMember_constructor_rejectsWrongSizedBlsPub() {
+        XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: Data(repeating: 0, count: 47),
+            leafHash: Data(repeating: 0, count: 32),
+            inboxPub: Data(repeating: 0, count: 32),
+            alias: "x"
+        )) { error in
+            XCTAssertTrue(error is MemberAnnouncementPayloadError)
+        }
+    }
+
+    func test_announcedMember_constructor_rejectsWrongSizedLeafHash() {
+        XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: Data(repeating: 0, count: 48),
+            leafHash: Data(repeating: 0, count: 31),
+            inboxPub: Data(repeating: 0, count: 32),
+            alias: "x"
+        )) { error in
+            XCTAssertTrue(error is MemberAnnouncementPayloadError)
+        }
+    }
+
+    func test_announcedMember_constructor_rejectsWrongSizedInboxPub() {
+        XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: Data(repeating: 0, count: 48),
+            leafHash: Data(repeating: 0, count: 32),
+            inboxPub: Data(repeating: 0, count: 31),
+            alias: "x"
+        )) { error in
+            XCTAssertTrue(error is MemberAnnouncementPayloadError)
+        }
+    }
+
+    // MARK: - Decoder validation
+
+    func test_decoder_rejectsWrongSizedGroupId() {
+        let bad = #"""
+        {"version":1,"group_id":"AAA=","new_member":{"bls_pub":"\#(base64Zeros(48))","leaf_hash":"\#(base64Zeros(32))","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
+        """#
+        let bytes = bad.data(using: .utf8)!
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(MemberAnnouncementPayload.self, from: bytes)
+        ) { error in
+            XCTAssertTrue(error is MemberAnnouncementPayloadError)
+        }
+    }
+
+    func test_decoder_rejectsWrongSizedBlsPub() {
+        let bad = #"""
+        {"version":1,"group_id":"\#(base64Zeros(32))","new_member":{"bls_pub":"AAA=","leaf_hash":"\#(base64Zeros(32))","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
+        """#
+        let bytes = bad.data(using: .utf8)!
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(MemberAnnouncementPayload.self, from: bytes)
+        ) { error in
+            XCTAssertTrue(error is MemberAnnouncementPayloadError)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func base64Zeros(_ count: Int) -> String {
+        Data(repeating: 0, count: count).base64EncodedString()
+    }
+}

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -157,6 +157,7 @@ final class ShareInviteFlowTests: XCTestCase {
             groupSecret: Data(repeating: 0x33, count: 32),
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
             members: [],
+            memberProfiles: [:],
             epoch: 0,
             salt: Data(repeating: 0x44, count: 32),
             commitment: nil,

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -48,6 +48,42 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         XCTAssertEqual(first.members.count, group.members.count)
         XCTAssertEqual(first.members.first?.publicKeyCompressed,
                        group.members.first?.publicKeyCompressed)
+        XCTAssertEqual(first.memberProfiles, group.memberProfiles)
+    }
+
+    // MARK: - Member profiles
+
+    func test_insertOrUpdate_persistsMemberProfiles() async {
+        let aliceHex = "11".repeated(48)
+        let bobHex = "22".repeated(48)
+        let profiles: [String: MemberProfile] = [
+            aliceHex: MemberProfile(
+                alias: "alice",
+                inboxPublicKey: Data(repeating: 0xAA, count: 32)
+            ),
+            bobHex: MemberProfile(
+                alias: "bob",
+                inboxPublicKey: Data(repeating: 0xBB, count: 32)
+            ),
+        ]
+        let group = makeGroup(
+            id: "ab".repeated(32),
+            name: "Profiled",
+            memberProfiles: profiles
+        )
+        _ = await store.insertOrUpdate(group)
+
+        let listed = await store.list()
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed[0].memberProfiles, profiles)
+    }
+
+    func test_insertOrUpdate_emptyProfilesRoundtripAsEmptyDict() async {
+        let group = makeGroup(id: "cd".repeated(32), name: "No profiles")
+        _ = await store.insertOrUpdate(group)
+
+        let listed = await store.list()
+        XCTAssertEqual(listed[0].memberProfiles, [:])
     }
 
     // MARK: - Idempotence
@@ -128,7 +164,8 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         name: String,
         adminPubkeyHex: String? = nil,
         createdAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
-        ownerIdentityID: IdentityID = IdentityID()
+        ownerIdentityID: IdentityID = IdentityID(),
+        memberProfiles: [String: MemberProfile] = [:]
     ) -> ChatGroup {
         let member = GovernanceMember(
             publicKeyCompressed: Data(repeating: 0x11, count: 48),
@@ -141,6 +178,7 @@ final class SwiftDataGroupStoreTests: XCTestCase {
             groupSecret: Data(repeating: 0x33, count: 32),
             createdAt: createdAt,
             members: [member],
+            memberProfiles: memberProfiles,
             epoch: 0,
             salt: Data(repeating: 0x44, count: 32),
             commitment: Data(repeating: 0x55, count: 32),


### PR DESCRIPTION
## Summary

PR 3 of the new-member announcement stack. Stacked on #76 (approver UI).

Defines the plaintext payload an admin seals + ships to every existing member's inbox after they tap Approve. Tells receivers \"this person joined — extend your local roster\". No producers or consumers yet — those land in PRs 4 and 5.

### Why a separate payload type

`GroupInvitationPayload` is full state for a fresh joiner: name, secret, full member list, salt, commitment, governance type, etc. — everything needed to render the group from zero.

`MemberAnnouncementPayload` is incremental: existing members already have all that state and just need to learn about one new entry in the roster.

Forcing both into one type would either bloat announcements with redundant data or sprinkle nullability across `GroupInvitationPayload`. Two types stays clean.

### Wire shape

```json
{
  \"version\": 1,
  \"group_id\": \"<base64 32 bytes>\",
  \"new_member\": {
    \"bls_pub\": \"<base64 48>\",
    \"leaf_hash\": \"<base64 32>\",
    \"inbox_pub\": \"<base64 32>\",
    \"alias\": \"<self-asserted string>\"
  },
  \"admin_alias\": \"<admin's alias at send time>\"
}
```

Authored on iOS first; onym-android will mirror. Snake_case keys + base64 `Data` match Swift `JSONEncoder` + Kotlin's default Base64 encoder — same interop pattern as `JoinRequestPayload` / `GroupInvitationPayload`.

### Trust framing

Aliases are joiner/admin self-asserted — never load-bearing. The outer `SealedEnvelope`'s Ed25519 signature is the load-bearing authenticator. The receiver-side dispatcher (PR 5) MUST verify `senderEd25519PublicKey` against the group's stored `adminPubkeyHex` before mutating local state. This type is a pure value carrier.

### Out of scope (later PRs)

- PR 4 — `JoinRequestApprover.approve()` builds + ships the announcement to every existing member; also appends joiner's `GovernanceMember` + profile to local roster.
- PR 5 — Inbox dispatcher branches on payload type; verifies admin sig; merges into `ChatGroup.memberProfiles`.
- PR 6 — UI: \"X joined\" event + member roster screen.

### Test plan

- [x] 8 new `MemberAnnouncementPayloadTests` covering: round-trip, snake_case key spelling for cross-platform parity, constructor validation for groupId / blsPub / leafHash / inboxPub, decoder validation for groupId / blsPub.
- [x] Full unit suite — 459/459 pass (3 skipped, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)