### PR TITLE
feat(inbox): receive-side dispatcher for member announcements

### DIFF
--- a/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
+++ b/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
@@ -16,7 +16,7 @@ import Foundation
 struct InboxFanoutInteractor: Sendable {
     let inboxTransport: any InboxTransport
     let identityRepository: IdentityRepository
-    let repository: IncomingInvitationsRepository
+    let dispatcher: IncomingMessageDispatcher
     /// Coalescing window — multiple identity changes within this many
     /// milliseconds collapse into one re-subscribe.
     let debounceMilliseconds: UInt64
@@ -24,12 +24,12 @@ struct InboxFanoutInteractor: Sendable {
     init(
         inboxTransport: any InboxTransport,
         identityRepository: IdentityRepository,
-        repository: IncomingInvitationsRepository,
+        dispatcher: IncomingMessageDispatcher,
         debounceMilliseconds: UInt64 = 250
     ) {
         self.inboxTransport = inboxTransport
         self.identityRepository = identityRepository
-        self.repository = repository
+        self.dispatcher = dispatcher
         self.debounceMilliseconds = debounceMilliseconds
     }
 
@@ -38,7 +38,7 @@ struct InboxFanoutInteractor: Sendable {
     func run() async {
         let subscriptions = ActiveSubscriptions(
             inboxTransport: inboxTransport,
-            repository: repository
+            dispatcher: dispatcher
         )
 
         // Apply the current identity set immediately on launch (the
@@ -106,12 +106,12 @@ struct InboxFanoutInteractor: Sendable {
 /// ones, no-ops the rest.
 private actor ActiveSubscriptions {
     private let inboxTransport: any InboxTransport
-    private let repository: IncomingInvitationsRepository
+    private let dispatcher: IncomingMessageDispatcher
     private var live: [IdentityID: (tag: TransportInboxID, task: Task<Void, Never>)] = [:]
 
-    init(inboxTransport: any InboxTransport, repository: IncomingInvitationsRepository) {
+    init(inboxTransport: any InboxTransport, dispatcher: IncomingMessageDispatcher) {
         self.inboxTransport = inboxTransport
-        self.repository = repository
+        self.dispatcher = dispatcher
     }
 
     func apply(_ wanted: Set<IdentityID>, tagsByID: [IdentityID: TransportInboxID]) async {
@@ -126,15 +126,15 @@ private actor ActiveSubscriptions {
             guard let tag = tagsByID[id], live[id] == nil else { continue }
             let stream = inboxTransport.subscribe(inbox: tag)
             // Capture the per-subscription identity ID into the Task —
-            // the persisted record stamps `ownerIdentityID = id` so
-            // `decryptInvitation(asIdentity:)` can later route the
-            // envelope to the right per-identity X25519 key, even if
+            // the dispatcher hands `ownerIdentityID = id` to
+            // `InvitationEnvelopeDecrypting` so cross-identity envelopes
+            // decrypt under the right per-identity X25519 key, even if
             // the user has switched to a different identity.
-            let task = Task { [repository, id] in
+            let task = Task { [dispatcher, id] in
                 for await message in stream {
                     if Task.isCancelled { break }
-                    await repository.recordIncoming(
-                        id: message.messageID,
+                    await dispatcher.dispatch(
+                        messageID: message.messageID,
                         ownerIdentityID: id,
                         payload: message.payload,
                         receivedAt: message.receivedAt

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Receive-side fan-out target for the inbox pump. Inspects every
+/// inbound message after decryption and routes it to the right
+/// destination:
+///
+///   - `MemberAnnouncementPayload` → applied directly to the
+///     matching local `ChatGroup.memberProfiles`. Never lands in the
+///     invitations queue; existing members just need their roster
+///     directory updated.
+///   - Anything else (current build: `GroupInvitationPayload` or
+///     unknown / undecryptable) → persisted as an opaque
+///     `IncomingInvitation` for later display via
+///     `InvitationDecryptor`. This preserves today's behavior for
+///     true invitations and for ciphertext we can't open at receive
+///     time (wrong recipient, corrupted envelope, etc.).
+///
+/// ## V1 trust model
+///
+/// The outer `SealedEnvelope`'s Ed25519 signature is verified by
+/// `decryptInvitation` (when `senderEd25519PublicKey` is present).
+/// We do **not** yet cross-check the signer against the group's
+/// admin Ed25519 pubkey because the receiver-side group
+/// materialization isn't wired — joiners process announcements as
+/// no-ops (no local `ChatGroup`) and the admin already knows about
+/// the join (no spoofing risk inside their own loop). When
+/// joiner-side group materialization lands, this dispatcher should
+/// gain an `assert senderEd25519 == storedAdminEd25519` check.
+///
+/// ## Cost
+///
+/// Every inbound message is decrypted at receive time (one extra
+/// X25519/AES-GCM op per message). For the low-volume Onym inbox
+/// this is negligible; the simplification gain — never leaking an
+/// announcement into the invitation list — is worth it.
+struct IncomingMessageDispatcher: Sendable {
+    let envelopeDecrypter: any InvitationEnvelopeDecrypting
+    let groupRepository: GroupRepository
+    let invitationsRepository: IncomingInvitationsRepository
+
+    func dispatch(
+        messageID: String,
+        ownerIdentityID: IdentityID,
+        payload: Data,
+        receivedAt: Date
+    ) async {
+        // Fast path: try to interpret as a `MemberAnnouncementPayload`.
+        // A successful decode + group-match consumes the message and
+        // skips the invitation store. Anything else falls through.
+        if let plaintext = try? await envelopeDecrypter.decryptInvitation(
+            envelopeBytes: payload,
+            asIdentity: ownerIdentityID
+        ),
+           let announcement = try? JSONDecoder().decode(
+               MemberAnnouncementPayload.self,
+               from: plaintext
+           ) {
+            await applyAnnouncement(announcement)
+            return
+        }
+        // Fall-through: store opaque ciphertext for the invitations
+        // pipeline to handle (matches pre-PR-6 behavior).
+        await invitationsRepository.recordIncoming(
+            id: messageID,
+            ownerIdentityID: ownerIdentityID,
+            payload: payload,
+            receivedAt: receivedAt
+        )
+    }
+
+    /// Idempotent merge of one announced member into the matching
+    /// local group's `memberProfiles`. No-op when:
+    ///
+    ///   - The group isn't on this device (joiner whose local
+    ///     materialization hasn't shipped, or stale announcement
+    ///     for an unrelated group).
+    ///   - The member is already known under the same BLS pubkey
+    ///     hex key (re-delivery, or the admin's own approve loop
+    ///     re-broadcasting).
+    ///
+    /// Dedup key is BLS pubkey hex, mirroring the producer-side
+    /// dictionary key in `JoinRequestApprover.recordJoiner`.
+    private func applyAnnouncement(_ payload: MemberAnnouncementPayload) async {
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.groupIDData == payload.groupId }) else {
+            return
+        }
+        let key = payload.newMember.blsPub
+            .map { String(format: "%02x", $0) }.joined()
+        if group.memberProfiles[key] != nil { return }
+        var updated = group
+        updated.memberProfiles[key] = MemberProfile(
+            alias: payload.newMember.alias,
+            inboxPublicKey: payload.newMember.inboxPub
+        )
+        await groupRepository.insert(updated)
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -244,10 +244,21 @@ struct OnymIOSApp: App {
                     // PR-4: subscribe to every identity's inbox
                     // concurrently. Without this, messages addressed
                     // to a non-current identity drop on the floor.
+                    //
+                    // Each inbound message is decrypted at receive
+                    // time by the dispatcher; member-roster
+                    // announcements apply directly to
+                    // `GroupRepository.memberProfiles`, everything
+                    // else falls through to the invitations queue.
+                    let dispatcher = IncomingMessageDispatcher(
+                        envelopeDecrypter: identityRepository,
+                        groupRepository: groupRepository,
+                        invitationsRepository: incomingInvitations
+                    )
                     let fanout = InboxFanoutInteractor(
                         inboxTransport: inboxTransport,
                         identityRepository: identityRepository,
-                        repository: incomingInvitations
+                        dispatcher: dispatcher
                     )
                     await fanout.run()
                 }

--- a/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
+++ b/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
@@ -12,6 +12,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
     private var identity: IdentityRepository!
     private var invitationsStore: FanoutInvitationStore!
     private var invitations: IncomingInvitationsRepository!
+    private var groups: GroupRepository!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -22,6 +23,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
         )
         invitationsStore = FanoutInvitationStore()
         invitations = IncomingInvitationsRepository(store: invitationsStore)
+        groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
     }
 
     override func tearDown() async throws {
@@ -30,7 +32,16 @@ final class InboxFanoutInteractorTests: XCTestCase {
         identity = nil
         invitationsStore = nil
         invitations = nil
+        groups = nil
         try await super.tearDown()
+    }
+
+    private func makeDispatcher() -> IncomingMessageDispatcher {
+        IncomingMessageDispatcher(
+            envelopeDecrypter: identity,
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
     }
 
     // MARK: - Initial subscription set
@@ -46,7 +57,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
         let fanout = InboxFanoutInteractor(
             inboxTransport: transport,
             identityRepository: identity,
-            repository: invitations,
+            dispatcher: makeDispatcher(),
             debounceMilliseconds: 1   // tight for tests
         )
         let runTask = Task { await fanout.run() }
@@ -70,7 +81,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
         let fanout = InboxFanoutInteractor(
             inboxTransport: transport,
             identityRepository: identity,
-            repository: invitations,
+            dispatcher: makeDispatcher(),
             debounceMilliseconds: 1
         )
         let runTask = Task { await fanout.run() }
@@ -96,7 +107,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
         let fanout = InboxFanoutInteractor(
             inboxTransport: transport,
             identityRepository: identity,
-            repository: invitations,
+            dispatcher: makeDispatcher(),
             debounceMilliseconds: 1
         )
         let runTask = Task { await fanout.run() }
@@ -128,7 +139,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
         let fanout = InboxFanoutInteractor(
             inboxTransport: transport,
             identityRepository: identity,
-            repository: invitations,
+            dispatcher: makeDispatcher(),
             debounceMilliseconds: 1
         )
         let runTask = Task { await fanout.run() }

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for `IncomingMessageDispatcher` — the receive-side
+/// fan-out target that decides whether an inbound inbox message is a
+/// member-roster announcement (apply directly to memberProfiles) or a
+/// regular invitation (store opaque for later display).
+@MainActor
+final class IncomingMessageDispatcherTests: XCTestCase {
+
+    private var groups: GroupRepository!
+    private var invitationsStore: DispatcherInvitationStore!
+    private var invitations: IncomingInvitationsRepository!
+    private var owner: IdentityID!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        invitationsStore = DispatcherInvitationStore()
+        invitations = IncomingInvitationsRepository(store: invitationsStore)
+        owner = IdentityID()
+        await groups.setCurrentIdentity(owner)
+    }
+
+    override func tearDown() async throws {
+        groups = nil
+        invitations = nil
+        invitationsStore = nil
+        owner = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Announcement path
+
+    func test_announcement_forKnownGroup_appendsToMemberProfiles() async throws {
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let creator = MemberProfile(
+            alias: "Alice",
+            inboxPublicKey: Data(repeating: 0x10, count: 32)
+        )
+        let creatorBlsHex = "aa".repeated(48)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [creatorBlsHex: creator]
+        )
+
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: "bb".repeated(48),
+            joinerInboxByte: 0x33,
+            joinerAlias: "Bob",
+            adminAlias: "Alice"
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        let updated = try XCTUnwrap(after.first { $0.groupIDData == groupID })
+        XCTAssertEqual(updated.memberProfiles.count, 2,
+                       "creator + new joiner")
+        XCTAssertEqual(updated.memberProfiles["bb".repeated(48)]?.alias, "Bob")
+        let storedCount = await invitationsStore.count
+        XCTAssertEqual(storedCount, 0,
+                       "announcements must NOT land in the invitations queue")
+    }
+
+    func test_announcement_forUnknownGroup_isNoOp() async throws {
+        // Group repository is empty.
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: Data(repeating: 0xCD, count: 32),
+            joinerBlsHex: "ee".repeated(48),
+            joinerInboxByte: 0x77,
+            joinerAlias: "stranger",
+            adminAlias: "unknown admin"
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-2",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        XCTAssertTrue(after.isEmpty)
+        let storedCount = await invitationsStore.count
+        XCTAssertEqual(storedCount, 0,
+                       "unknown-group announcement is dropped, not stored as invitation")
+    }
+
+    func test_announcement_forKnownMember_isIdempotentNoOp() async throws {
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let bobBlsHex = "bb".repeated(48)
+        let bob = MemberProfile(
+            alias: "Bob (original)",
+            inboxPublicKey: Data(repeating: 0x33, count: 32)
+        )
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [bobBlsHex: bob]
+        )
+
+        // Re-announce Bob (e.g. relay redelivery) with a fresh alias —
+        // dispatcher must dedupe by BLS pubkey hex and NOT overwrite.
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: bobBlsHex,
+            joinerInboxByte: 0x33,
+            joinerAlias: "Bob (renamed)",
+            adminAlias: "admin"
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-3",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        let updated = try XCTUnwrap(after.first { $0.groupIDData == groupID })
+        XCTAssertEqual(updated.memberProfiles[bobBlsHex]?.alias, "Bob (original)",
+                       "redelivery must NOT overwrite an existing profile")
+    }
+
+    // MARK: - Fall-through path
+
+    func test_undecodableJSON_fallsThroughToInvitations() async throws {
+        // Decryption succeeds but plaintext isn't a MemberAnnouncementPayload.
+        let plaintext = Data("not an announcement".utf8)
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-4",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let storedCount = await invitationsStore.count
+        XCTAssertEqual(storedCount, 1,
+                       "non-announcement plaintext falls through to invitations queue")
+    }
+
+    func test_decryptFailure_fallsThroughToInvitations() async throws {
+        // Decryption fails entirely (corrupted envelope, wrong recipient, etc.).
+        // Today's behavior is to store opaque ciphertext for later
+        // hand-off to the invitations pipeline; the dispatcher must
+        // preserve that.
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .failing(.signatureVerificationFailed)
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-5",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let storedCount = await invitationsStore.count
+        XCTAssertEqual(storedCount, 1,
+                       "decrypt failure falls through (ciphertext kept for later pipeline)")
+    }
+
+    // MARK: - Helpers
+
+    private func seedGroup(
+        groupID: Data,
+        memberProfiles: [String: MemberProfile]
+    ) async {
+        let group = ChatGroup(
+            id: groupID.map { String(format: "%02x", $0) }.joined(),
+            ownerIdentityID: owner,
+            name: "Family",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [],
+            memberProfiles: memberProfiles,
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: nil,
+            isPublishedOnChain: true
+        )
+        _ = await groups.insert(group)
+    }
+
+    private static func makeAnnouncement(
+        groupID: Data,
+        joinerBlsHex: String,
+        joinerInboxByte: UInt8,
+        joinerAlias: String,
+        adminAlias: String
+    ) throws -> MemberAnnouncementPayload {
+        let blsPub = Data(joinerBlsHex.hexBytes)
+        let member = try MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: blsPub,
+            inboxPub: Data(repeating: joinerInboxByte, count: 32),
+            alias: joinerAlias
+        )
+        return try MemberAnnouncementPayload(
+            version: 1,
+            groupId: groupID,
+            newMember: member,
+            adminAlias: adminAlias
+        )
+    }
+
+    private static func encode(announcement: MemberAnnouncementPayload) throws -> Data {
+        try JSONEncoder().encode(announcement)
+    }
+}
+
+// MARK: - String / hex helpers (test scope)
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+
+    var hexBytes: [UInt8] {
+        var bytes: [UInt8] = []
+        var index = startIndex
+        while index < endIndex {
+            let next = self.index(index, offsetBy: 2, limitedBy: endIndex) ?? endIndex
+            if let byte = UInt8(self[index..<next], radix: 16) {
+                bytes.append(byte)
+            }
+            index = next
+        }
+        return bytes
+    }
+}
+
+// MARK: - Test double
+
+private actor DispatcherInvitationStore: InvitationStore {
+    private var rows: [String: IncomingInvitationRecord] = [:]
+
+    var count: Int { rows.count }
+
+    func list() -> [IncomingInvitationRecord] {
+        rows.values.sorted { $0.receivedAt > $1.receivedAt }
+    }
+
+    @discardableResult
+    func save(_ record: IncomingInvitationRecord) -> Bool {
+        guard rows[record.id] == nil else { return false }
+        rows[record.id] = record
+        return true
+    }
+
+    func updateStatus(id: String, status: IncomingInvitationStatus) {
+        guard let existing = rows[id] else { return }
+        rows[id] = IncomingInvitationRecord(
+            id: existing.id,
+            ownerIdentityID: existing.ownerIdentityID,
+            payload: existing.payload,
+            receivedAt: existing.receivedAt,
+            status: status
+        )
+    }
+
+    func delete(id: String) {
+        rows.removeValue(forKey: id)
+    }
+
+    func deleteOwner(_ ownerIDString: String) {
+        rows = rows.filter { $0.value.ownerIdentityID.rawValue.uuidString != ownerIDString }
+    }
+}


### PR DESCRIPTION
## Summary

PR 6 of the new-member announcement stack. Stacked on #79. Closes the loop on the receive side: existing members of a group now actually see joiners appear in their local `memberProfiles` when an admin's PR-5 fanout lands in their inbox.

### Architecture

- **New `IncomingMessageDispatcher`** inspects every inbound inbox message after decryption.
  - `MemberAnnouncementPayload` plaintexts apply directly to the matching local `ChatGroup.memberProfiles` (idempotent dedup by BLS pubkey hex).
  - Anything else (invitations + undecodable / wrong-recipient ciphertext) falls through to the existing `IncomingInvitationsRepository` — pre-PR-6 behavior is preserved verbatim for non-announcement traffic.
- **`InboxFanoutInteractor`'s per-identity Task** now hands messages to the dispatcher instead of the invitations repo directly. The signature change is a clean trade: the fanout is no longer coupled to the persistence target, only to the routing.
- **`OnymIOSApp`** wires the dispatcher into the fanout's long-lived inbox `.task`.

### V1 trust model

The outer `SealedEnvelope`'s Ed25519 signature is verified by `decryptInvitation`. We do **not** yet cross-check the signer against the group's admin Ed25519 pubkey because joiner-side group materialization isn't wired — joiners process announcements as no-ops (no local `ChatGroup`) and admins already know about their own loop.

This is documented in `IncomingMessageDispatcher` with a clear TODO for when joiner-side materialization lands. At that point, the dispatcher should gain `assert senderEd25519 == storedAdminEd25519` before the merge.

### Cost

Every inbound message is decrypted once at receive time (extra X25519/AES-GCM op per message). For Onym's low-volume inbox this is negligible; the simplification — never leaking an announcement into the invitations queue — is worth it.

### Out of scope (next PR)

- **PR 7** — UI surfaces: inline \"X joined\" event in the chat list, member roster screen.

### Test plan

- [x] **5 new** `IncomingMessageDispatcherTests` covering: known-group append, unknown-group no-op, idempotent dedup on redelivery, plaintext-not-an-announcement fall-through to invitations, decrypt-failure fall-through to invitations.
- [x] **Existing** `InboxFanoutInteractorTests` updated to construct via the dispatcher seam — 4/4 still pass; the post-decrypt dispatch shape is preserved end-to-end.
- [x] Full unit suite — 465/465 pass (3 skipped, pre-existing).
- [ ] **Manual smoke (across PRs 5+6):** three devices A (admin), B (joiner 1, already in group), C (joiner 2, just-tapped invite). C taps invite, A approves; B's local `memberProfiles` should update to include C without B opening any UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)