### PR TITLE
feat(group): GroupInvitationPayload carries member_profiles

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -260,7 +260,8 @@ struct CreateGroupInteractor: Sendable {
                 commitment: proof.commitment,
                 tierRaw: tier.rawValue,
                 groupTypeRaw: SEPGroupType.tyranny.rawValue,
-                adminPubkeyHex: adminPubkeyHex
+                adminPubkeyHex: adminPubkeyHex,
+                memberProfiles: creatorProfiles
             )
             try await sendInvitations(invitePayload, to: invitees)
         }
@@ -445,7 +446,8 @@ struct CreateGroupInteractor: Sendable {
             tierRaw: SEPTier.small.rawValue,
             groupTypeRaw: SEPGroupType.oneOnOne.rawValue,
             adminPubkeyHex: nil,
-            peerBlsSecret: peerBlsSecret
+            peerBlsSecret: peerBlsSecret,
+            memberProfiles: creatorProfiles
         )
         try await sendInvitations(invitePayload, to: [peerInboxKey])
 
@@ -626,7 +628,8 @@ struct CreateGroupInteractor: Sendable {
                 commitment: proof.commitment,
                 tierRaw: tier.rawValue,
                 groupTypeRaw: SEPGroupType.anarchy.rawValue,
-                adminPubkeyHex: nil
+                adminPubkeyHex: nil,
+                memberProfiles: creatorProfiles
             )
             try await sendInvitations(invitePayload, to: invitees)
         }

--- a/Sources/OnymIOS/Group/GroupInvitationPayload.swift
+++ b/Sources/OnymIOS/Group/GroupInvitationPayload.swift
@@ -44,6 +44,19 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
     /// Decoded via `decodeIfPresent` so older invitations (and other
     /// group types that never set this field) round-trip cleanly.
     let peerBlsSecret: Data?
+    /// Snapshot of the sender's `ChatGroup.memberProfiles` at the
+    /// moment the invitation was sealed — keyed by lowercase BLS
+    /// pubkey hex, value carries `alias` + `inboxPublicKey`. Lets a
+    /// joiner-side materializer populate the local directory at the
+    /// same time the group lands locally, so existing members appear
+    /// by name without waiting for a follow-up announcement.
+    ///
+    /// Optional + decoded via `decodeIfPresent` so older senders
+    /// without the field still round-trip cleanly. Empty / missing
+    /// at receive time means the receiver renders the roster by
+    /// fingerprint until a future `MemberAnnouncementPayload` fills
+    /// in the aliases.
+    let memberProfiles: [String: MemberProfile]?
 
     enum CodingKeys: String, CodingKey {
         case version
@@ -58,6 +71,7 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         case groupTypeRaw = "group_type_raw"
         case adminPubkeyHex = "admin_pubkey_hex"
         case peerBlsSecret = "peer_bls_secret"
+        case memberProfiles = "member_profiles"
     }
 
     init(
@@ -72,7 +86,8 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         tierRaw: Int,
         groupTypeRaw: String,
         adminPubkeyHex: String?,
-        peerBlsSecret: Data? = nil
+        peerBlsSecret: Data? = nil,
+        memberProfiles: [String: MemberProfile]? = nil
     ) {
         self.version = version
         self.groupID = groupID
@@ -86,6 +101,7 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         self.groupTypeRaw = groupTypeRaw
         self.adminPubkeyHex = adminPubkeyHex
         self.peerBlsSecret = peerBlsSecret
+        self.memberProfiles = memberProfiles
     }
 
     init(from decoder: Decoder) throws {
@@ -102,5 +118,9 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         groupTypeRaw = try c.decode(String.self, forKey: .groupTypeRaw)
         adminPubkeyHex = try c.decodeIfPresent(String.self, forKey: .adminPubkeyHex)
         peerBlsSecret = try c.decodeIfPresent(Data.self, forKey: .peerBlsSecret)
+        memberProfiles = try c.decodeIfPresent(
+            [String: MemberProfile].self,
+            forKey: .memberProfiles
+        )
     }
 }

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -157,7 +157,14 @@ actor JoinRequestApprover: JoinRequestApproving {
             commitment: group.commitment,
             tierRaw: group.tier.rawValue,
             groupTypeRaw: group.groupType.rawValue,
-            adminPubkeyHex: group.adminPubkeyHex
+            adminPubkeyHex: group.adminPubkeyHex,
+            // Ship the directory-as-known so the joiner sees existing
+            // peers + admin by name from the moment they land. The
+            // joiner won't see themselves here — recordJoiner runs
+            // after the invite ships — and that's fine: the joiner-
+            // side materializer can backfill self from the active
+            // identity.
+            memberProfiles: group.memberProfiles.isEmpty ? nil : group.memberProfiles
         )
         let payloadBytes: Data
         do {

--- a/Tests/OnymIOSTests/GroupInvitationPayloadTests.swift
+++ b/Tests/OnymIOSTests/GroupInvitationPayloadTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import OnymIOS
+
+/// Wire-format pin for `GroupInvitationPayload`. Focused on the
+/// `member_profiles` field added in PR 8a; the rest of the wire
+/// format has been stable since group-create v1 and is exercised
+/// indirectly via `CreateGroupInteractorTests` /
+/// `JoinRequestApproverTests` (when those land).
+final class GroupInvitationPayloadTests: XCTestCase {
+
+    // MARK: - Round-trip
+
+    func test_roundtrip_withMemberProfiles_preservesDirectory() throws {
+        let aliceHex = "11".repeated(48)
+        let profiles: [String: MemberProfile] = [
+            aliceHex: MemberProfile(
+                alias: "Alice",
+                inboxPublicKey: Data(repeating: 0xAA, count: 32)
+            )
+        ]
+        let original = makePayload(memberProfiles: profiles)
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GroupInvitationPayload.self, from: encoded)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.memberProfiles?[aliceHex]?.alias, "Alice")
+    }
+
+    func test_roundtrip_withoutMemberProfiles_decodesAsNil() throws {
+        let original = makePayload(memberProfiles: nil)
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GroupInvitationPayload.self, from: encoded)
+        XCTAssertNil(decoded.memberProfiles)
+    }
+
+    // MARK: - Forward-compat
+
+    func test_decoder_acceptsLegacyPayloadWithoutMemberProfiles() throws {
+        // Older onym-android / pre-PR-8a builds ship invitations
+        // without member_profiles. The wire format must round-trip
+        // those into a payload with `memberProfiles == nil` so the
+        // joiner-side materializer falls back to "no aliases yet"
+        // rather than failing decode.
+        let gid = Data(repeating: 0, count: 32).base64EncodedString()
+        let secret = Data(repeating: 0, count: 32).base64EncodedString()
+        let salt = Data(repeating: 0, count: 32).base64EncodedString()
+        let legacy = #"""
+        {"version":1,"group_id":"\#(gid)","group_secret":"\#(secret)","name":"Family","members":[],"epoch":0,"salt":"\#(salt)","tier_raw":1,"group_type_raw":"tyranny"}
+        """#
+        let bytes = legacy.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(GroupInvitationPayload.self, from: bytes)
+        XCTAssertNil(decoded.memberProfiles)
+        XCTAssertEqual(decoded.name, "Family")
+    }
+
+    // MARK: - Wire shape
+
+    func test_member_profiles_keySpelling_matches_android_parity() throws {
+        let payload = makePayload(memberProfiles: [
+            "ab".repeated(48): MemberProfile(
+                alias: "x",
+                inboxPublicKey: Data(repeating: 0, count: 32)
+            )
+        ])
+        let encoded = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNotNil(obj?["member_profiles"],
+                        "snake_case key 'member_profiles' must match Android parity")
+    }
+
+    // MARK: - Helpers
+
+    private func makePayload(
+        memberProfiles: [String: MemberProfile]?
+    ) -> GroupInvitationPayload {
+        GroupInvitationPayload(
+            version: 1,
+            groupID: Data(repeating: 0x42, count: 32),
+            groupSecret: Data(repeating: 0x33, count: 32),
+            name: "Family",
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x44, count: 32),
+            commitment: nil,
+            tierRaw: 1,
+            groupTypeRaw: "tyranny",
+            adminPubkeyHex: nil,
+            peerBlsSecret: nil,
+            memberProfiles: memberProfiles
+        )
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}


### PR DESCRIPTION
## Summary

PR 8a of the new-member announcement stack. Stacked on #81. **Wire change only** — no joiner-side consumer yet (PR 8b).

When PR 8b lands, joiners will be able to populate their local `memberProfiles` directly from the invitation, so existing peers + admin show by name from first mount instead of waiting for a follow-up `MemberAnnouncementPayload`. Today (without 8b), the field is shipped by senders but ignored by receivers.

### Wire shape

Optional `member_profiles: {bls_hex: MemberProfile}` on `GroupInvitationPayload`. Snake_case + `decodeIfPresent` so older senders + onym-android builds round-trip cleanly.

### Producers

- `JoinRequestApprover.approve()` includes `group.memberProfiles` in the sealed invite. The joiner won't see themselves there because `recordJoiner` runs after the invite ships — that's by design; PR 8b's materializer can backfill self from the active identity.
- `CreateGroupInteractor.{createTyranny, createOneOnOne, createAnarchy}` send the creator's own profile (from PR 1's `creatorProfiles`) inside their initial invitations.

### Out of scope (PR 8b)

Joiner-side materializer that reads `member_profiles` + populates the local `ChatGroup`. Until that lands, this PR is producer-only; receivers ignore the field.

### Test plan

- [x] **4 new** `GroupInvitationPayloadTests`: round-trip with profiles, round-trip without (nil), forward-compat decode of legacy payload missing the field, snake_case key spelling pin for cross-platform parity.
- [x] Full unit suite — 469/469 pass (3 skipped, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)