### PR TITLE
feat(inbox): joiner-side group materialization from invitation

### DIFF
--- a/Sources/OnymIOS/Identity/IdentitiesProviding.swift
+++ b/Sources/OnymIOS/Identity/IdentitiesProviding.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Narrow seam over `IdentityRepository.currentIdentities()` used by
+/// inbox-side interactors that need to look up an identity's
+/// view-facing summary (BLS + inbox public keys, display alias)
+/// without taking a dependency on the whole repository. Mirrors the
+/// `InvitationEnvelopeDecrypting` pattern: tests substitute a canned
+/// list, production conforms `IdentityRepository` directly.
+protocol IdentitiesProviding: Sendable {
+    func currentIdentities() async -> [IdentitySummary]
+}

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -23,7 +23,7 @@ import OnymSDK
 /// Single actor — every mutation is serialised on its executor. Keychain
 /// reads/writes, PBKDF2, HKDF, and FFI calls into OnymSDK all run here.
 /// Views interact via `await` from a `Task` (typically a SwiftUI `.task`).
-actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealing {
+actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealing, IdentitiesProviding {
     static let shared = IdentityRepository()
 
     private let keychain: IdentityKeychainStore

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -6,35 +6,38 @@ import Foundation
 ///
 ///   - `MemberAnnouncementPayload` → applied directly to the
 ///     matching local `ChatGroup.memberProfiles`. Never lands in the
-///     invitations queue; existing members just need their roster
-///     directory updated.
-///   - Anything else (current build: `GroupInvitationPayload` or
-///     unknown / undecryptable) → persisted as an opaque
-///     `IncomingInvitation` for later display via
-///     `InvitationDecryptor`. This preserves today's behavior for
-///     true invitations and for ciphertext we can't open at receive
-///     time (wrong recipient, corrupted envelope, etc.).
+///     invitations queue.
+///   - `GroupInvitationPayload` → materializes a local `ChatGroup`
+///     under the recipient identity, populating `memberProfiles`
+///     from the wire payload (PR 8a) and adding the receiver's own
+///     entry. The invitation is consumed at this point — no need to
+///     also queue it for manual acceptance.
+///   - Anything else (unknown / undecryptable plaintext) → persisted
+///     as an opaque `IncomingInvitation` for the legacy display
+///     pipeline. This is the safety-net: ciphertext we can't open
+///     at receive time (wrong recipient, corrupted envelope) still
+///     gets a chance via `InvitationDecryptor` later.
 ///
 /// ## V1 trust model
 ///
 /// The outer `SealedEnvelope`'s Ed25519 signature is verified by
 /// `decryptInvitation` (when `senderEd25519PublicKey` is present).
 /// We do **not** yet cross-check the signer against the group's
-/// admin Ed25519 pubkey because the receiver-side group
-/// materialization isn't wired — joiners process announcements as
-/// no-ops (no local `ChatGroup`) and the admin already knows about
-/// the join (no spoofing risk inside their own loop). When
-/// joiner-side group materialization lands, this dispatcher should
-/// gain an `assert senderEd25519 == storedAdminEd25519` check.
+/// admin Ed25519 pubkey because the joiner-side path doesn't have
+/// a stored admin Ed25519 to compare against (the wire only carries
+/// `admin_pubkey_hex`, which is the BLS pub). A future PR can wire
+/// the SealedEnvelope's `senderEd25519PublicKey` through to the
+/// materialized `ChatGroup` and use it on subsequent announcements.
 ///
 /// ## Cost
 ///
 /// Every inbound message is decrypted at receive time (one extra
 /// X25519/AES-GCM op per message). For the low-volume Onym inbox
 /// this is negligible; the simplification gain — never leaking an
-/// announcement into the invitation list — is worth it.
+/// announcement or a stale invitation into the queue — is worth it.
 struct IncomingMessageDispatcher: Sendable {
     let envelopeDecrypter: any InvitationEnvelopeDecrypting
+    let identities: any IdentitiesProviding
     let groupRepository: GroupRepository
     let invitationsRepository: IncomingInvitationsRepository
 
@@ -44,28 +47,141 @@ struct IncomingMessageDispatcher: Sendable {
         payload: Data,
         receivedAt: Date
     ) async {
-        // Fast path: try to interpret as a `MemberAnnouncementPayload`.
-        // A successful decode + group-match consumes the message and
-        // skips the invitation store. Anything else falls through.
-        if let plaintext = try? await envelopeDecrypter.decryptInvitation(
+        // Decrypt once at receive time — both fast paths below need
+        // the plaintext; the safety-net path only needs to know
+        // decryption failed.
+        guard let plaintext = try? await envelopeDecrypter.decryptInvitation(
             envelopeBytes: payload,
             asIdentity: ownerIdentityID
-        ),
-           let announcement = try? JSONDecoder().decode(
-               MemberAnnouncementPayload.self,
-               from: plaintext
-           ) {
+        ) else {
+            await fallThrough(
+                messageID: messageID,
+                ownerIdentityID: ownerIdentityID,
+                payload: payload,
+                receivedAt: receivedAt
+            )
+            return
+        }
+
+        // Fast path 1: MemberAnnouncementPayload — incremental roster
+        // delta for an existing local group.
+        if let announcement = try? JSONDecoder().decode(
+            MemberAnnouncementPayload.self,
+            from: plaintext
+        ) {
             await applyAnnouncement(announcement)
             return
         }
-        // Fall-through: store opaque ciphertext for the invitations
-        // pipeline to handle (matches pre-PR-6 behavior).
+
+        // Fast path 2: GroupInvitationPayload — materialize a local
+        // group under `ownerIdentityID`. Skips the invitations queue
+        // because the group is now visible in the chat list.
+        if let invitation = try? JSONDecoder().decode(
+            GroupInvitationPayload.self,
+            from: plaintext
+        ) {
+            await materializeGroup(invitation, ownerIdentityID: ownerIdentityID)
+            return
+        }
+
+        // Plaintext didn't match any known payload — fall through.
+        await fallThrough(
+            messageID: messageID,
+            ownerIdentityID: ownerIdentityID,
+            payload: payload,
+            receivedAt: receivedAt
+        )
+    }
+
+    private func fallThrough(
+        messageID: String,
+        ownerIdentityID: IdentityID,
+        payload: Data,
+        receivedAt: Date
+    ) async {
         await invitationsRepository.recordIncoming(
             id: messageID,
             ownerIdentityID: ownerIdentityID,
             payload: payload,
             receivedAt: receivedAt
         )
+    }
+
+    /// Materialize a local `ChatGroup` from an inbound
+    /// `GroupInvitationPayload`. Idempotent on `groupID` —
+    /// `GroupRepository.insert` delegates to `insertOrUpdate`, so a
+    /// re-delivery of the same invitation overwrites in place rather
+    /// than minting a duplicate row.
+    ///
+    /// The `memberProfiles` directory is the union of:
+    ///   - whatever the sender shipped on the wire (PR 8a)
+    ///   - the receiver's own profile, looked up from
+    ///     `IdentitiesProviding`. We add this locally because the
+    ///     sender doesn't know us by alias yet — the producer-side
+    ///     `recordJoiner` runs after the invite ships.
+    ///
+    /// Skipped when `tier_raw` / `group_type_raw` don't decode (older
+    /// or future wire versions) — better to drop the message than
+    /// materialize a partial group.
+    private func materializeGroup(
+        _ invitation: GroupInvitationPayload,
+        ownerIdentityID: IdentityID
+    ) async {
+        guard let tier = SEPTier(rawValue: invitation.tierRaw),
+              let groupType = SEPGroupType(rawValue: invitation.groupTypeRaw)
+        else { return }
+
+        // Build the directory: wire-shipped profiles first, then add
+        // self if we can resolve our own identity. The "wire first"
+        // ordering means a sender that mistakenly includes us under
+        // our own BLS key gets overwritten by our locally-trusted
+        // alias + inbox pub — the receiver's view of itself wins.
+        var profiles = invitation.memberProfiles ?? [:]
+        if let selfEntry = await selfMemberProfileEntry(for: ownerIdentityID) {
+            profiles[selfEntry.key] = selfEntry.value
+        }
+
+        let groupIDHex = invitation.groupID
+            .map { String(format: "%02x", $0) }.joined()
+        let group = ChatGroup(
+            id: groupIDHex,
+            ownerIdentityID: ownerIdentityID,
+            name: invitation.name,
+            groupSecret: invitation.groupSecret,
+            createdAt: Date(),
+            members: invitation.members,
+            memberProfiles: profiles,
+            epoch: invitation.epoch,
+            salt: invitation.salt,
+            commitment: invitation.commitment,
+            tier: tier,
+            groupType: groupType,
+            adminPubkeyHex: invitation.adminPubkeyHex,
+            // Sender already anchored before sending the invite, so
+            // by the time it lands the group is on chain.
+            isPublishedOnChain: true
+        )
+        await groupRepository.insert(group)
+    }
+
+    /// Look up the receiver's own `MemberProfile` entry keyed by
+    /// their BLS pubkey hex. Returns `nil` when the identity can't
+    /// be resolved (race during identity removal, test stub returns
+    /// empty, etc.) — caller leaves the directory wire-only.
+    private func selfMemberProfileEntry(
+        for identityID: IdentityID
+    ) async -> (key: String, value: MemberProfile)? {
+        let summaries = await identities.currentIdentities()
+        guard let me = summaries.first(where: { $0.id == identityID }) else {
+            return nil
+        }
+        let key = me.blsPublicKey
+            .map { String(format: "%02x", $0) }.joined()
+        let profile = MemberProfile(
+            alias: me.name,
+            inboxPublicKey: me.inboxPublicKey
+        )
+        return (key, profile)
     }
 
     /// Idempotent merge of one announced member into the matching

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -252,6 +252,7 @@ struct OnymIOSApp: App {
                     // else falls through to the invitations queue.
                     let dispatcher = IncomingMessageDispatcher(
                         envelopeDecrypter: identityRepository,
+                        identities: identityRepository,
                         groupRepository: groupRepository,
                         invitationsRepository: incomingInvitations
                     )

--- a/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
+++ b/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
@@ -39,6 +39,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
     private func makeDispatcher() -> IncomingMessageDispatcher {
         IncomingMessageDispatcher(
             envelopeDecrypter: identity,
+            identities: identity,
             groupRepository: groups,
             invitationsRepository: invitations
         )

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -54,6 +54,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations
         )
@@ -87,6 +88,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations
         )
@@ -129,6 +131,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations
         )
@@ -146,6 +149,135 @@ final class IncomingMessageDispatcherTests: XCTestCase {
                        "redelivery must NOT overwrite an existing profile")
     }
 
+    // MARK: - Invitation materialization path
+
+    func test_invitation_materializesLocalGroup_withSelfEntry() async throws {
+        // Joiner-side: receive a fresh invitation for a group that
+        // doesn't exist locally. Dispatcher materializes a ChatGroup
+        // and adds the receiver's own profile to memberProfiles.
+        let creatorBlsHex = "11".repeated(48)
+        let creatorProfile = MemberProfile(
+            alias: "Alice",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32)
+        )
+        let payload = makeInvitationPayload(
+            groupID: Data(repeating: 0x42, count: 32),
+            name: "Family",
+            memberProfiles: [creatorBlsHex: creatorProfile]
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+
+        // Self has a different BLS pubkey from the creator — receiver
+        // is the joiner, not the admin.
+        let selfBlsHex = "22".repeated(48)
+        let selfSummary = IdentitySummary(
+            id: owner,
+            name: "Bob",
+            blsPublicKey: Data(repeating: 0x22, count: 48),
+            inboxPublicKey: Data(repeating: 0xBB, count: 32)
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: [selfSummary]),
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-mat",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        let materialized = try XCTUnwrap(after.first)
+        XCTAssertEqual(materialized.name, "Family")
+        XCTAssertEqual(materialized.ownerIdentityID, owner)
+        XCTAssertEqual(materialized.memberProfiles.count, 2,
+                       "creator (from wire) + self (from identity provider)")
+        XCTAssertEqual(materialized.memberProfiles[creatorBlsHex]?.alias, "Alice")
+        XCTAssertEqual(materialized.memberProfiles[selfBlsHex]?.alias, "Bob")
+        XCTAssertTrue(materialized.isPublishedOnChain,
+                      "sender already anchored before sending the invite")
+        let storedCount = await invitationsStore.count
+        XCTAssertEqual(storedCount, 0,
+                       "materialized invitations must NOT also queue as pending")
+    }
+
+    func test_invitation_withoutMemberProfiles_materializesWithSelfOnly() async throws {
+        // Legacy / pre-PR-8a sender — no member_profiles on the wire.
+        // Receiver still materializes; directory carries just self.
+        let payload = makeInvitationPayload(
+            groupID: Data(repeating: 0x99, count: 32),
+            name: "Legacy",
+            memberProfiles: nil
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+
+        let selfSummary = IdentitySummary(
+            id: owner,
+            name: "Carol",
+            blsPublicKey: Data(repeating: 0x33, count: 48),
+            inboxPublicKey: Data(repeating: 0xCC, count: 32)
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: [selfSummary]),
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-legacy",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        XCTAssertEqual(after.first?.memberProfiles.count, 1,
+                       "wire didn't carry profiles, but self entry still gets added")
+        XCTAssertEqual(after.first?.memberProfiles["33".repeated(48)]?.alias, "Carol")
+    }
+
+    func test_invitation_unresolvableSelf_materializesWithoutSelfEntry() async throws {
+        // Identity provider returns an empty list (race during
+        // identity removal, fresh wipe, etc.). Materializer must not
+        // crash and must still create the group with the wire-shipped
+        // directory only.
+        let creatorBlsHex = "44".repeated(48)
+        let payload = makeInvitationPayload(
+            groupID: Data(repeating: 0xEE, count: 32),
+            name: "Race",
+            memberProfiles: [creatorBlsHex: MemberProfile(
+                alias: "Alice",
+                inboxPublicKey: Data(repeating: 0x44, count: 32)
+            )]
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-race",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        XCTAssertEqual(after.first?.memberProfiles.count, 1,
+                       "wire-shipped directory survives even without self resolution")
+    }
+
     // MARK: - Fall-through path
 
     func test_undecodableJSON_fallsThroughToInvitations() async throws {
@@ -154,6 +286,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations
         )
@@ -180,6 +313,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         )
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations
         )
@@ -245,6 +379,40 @@ final class IncomingMessageDispatcherTests: XCTestCase {
     private static func encode(announcement: MemberAnnouncementPayload) throws -> Data {
         try JSONEncoder().encode(announcement)
     }
+
+    private func makeInvitationPayload(
+        groupID: Data,
+        name: String,
+        memberProfiles: [String: MemberProfile]?
+    ) -> GroupInvitationPayload {
+        GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),
+            name: name,
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: Data(repeating: 0x77, count: 32),
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.tyranny.rawValue,
+            adminPubkeyHex: nil,
+            peerBlsSecret: nil,
+            memberProfiles: memberProfiles
+        )
+    }
+}
+
+// MARK: - Stub identity provider
+
+private actor StubIdentities: IdentitiesProviding {
+    private let summaries: [IdentitySummary]
+
+    init(summaries: [IdentitySummary]) {
+        self.summaries = summaries
+    }
+
+    func currentIdentities() -> [IdentitySummary] { summaries }
 }
 
 // MARK: - String / hex helpers (test scope)


### PR DESCRIPTION
## Summary

PR 8b of the new-member announcement stack. Stacked on #82. **Closes the round-trip**: joiners receiving a sealed `GroupInvitationPayload` now materialize a local `ChatGroup` automatically, populated with both the sender's shipped `memberProfiles` (PR 8a) and the receiver's own profile.

After this PR, the original feature ask works end-to-end on both sides:

- Existing members see new joiners' aliases via PR 5/6 fanout.
- **New joiners see existing members' aliases at first mount**, without waiting for a follow-up announcement.

### Architecture

- **New `IdentitiesProviding` protocol** — narrow seam over `IdentityRepository.currentIdentities()` so the dispatcher can look up the receiver's own `MemberProfile` (alias + inbox pub + BLS hex key) without taking a dependency on the whole repo. `IdentityRepository` conforms directly; tests inject a stub.
- **`IncomingMessageDispatcher` gains a third decode branch**:
  1. `MemberAnnouncementPayload` → apply roster delta (PR 6).
  2. `GroupInvitationPayload` → materialize `ChatGroup`, skip the invitations queue (**NEW**).
  3. unknown / undecryptable → fall through to invitations queue for the legacy display path.
  Decryption is now hoisted out of the announcement-only branch and shared across both fast paths.
- **Materializer builds the directory as** `wire-shipped profiles ∪ {receiver self}`. Wire-shipped self (if a sender mistakenly includes it) gets overwritten by the locally-trusted entry — the receiver's view of itself wins.
- `isPublishedOnChain = true` on materialization (sender already anchored before sending the invite).
- **Idempotent**: `GroupRepository.insert` delegates to `insertOrUpdate`, so re-delivery of the same invitation overwrites in place.

### Trust model (unchanged)

Outer `SealedEnvelope`'s Ed25519 signature is verified by `decryptInvitation`, but no admin-Ed25519 cross-check yet (the wire only carries admin BLS pubkey hex). When that's wired, it'll plug into the same materializer here.

### Test plan

- [x] **3 new** `IncomingMessageDispatcherTests`: full materialization with self-entry from identity provider, legacy invitation without `member_profiles` materializes with self-only, unresolvable self materializes with wire-shipped directory only.
- [x] All previous dispatcher tests still pass — 8/8.
- [x] Existing `InboxFanoutInteractorTests` updated for the new constructor signature — 4/4 still pass.
- [x] Full unit suite — 472/472 pass (3 skipped, pre-existing).

### Known follow-ups

- The materialized group will trigger `JoinFlow.startWatcher`'s `groupRepository.snapshots` watcher → `JoinFlow` finally flips to `.approved` for joiners that taped a deeplink. End-to-end \"you're in!\" UX should work for the first time after PRs 1-8b ship.
- Manual smoke recommended across two devices: A creates a group + invites B, B taps invite, A approves, B's chat list populates with the group + member roster shows both A and B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)