### PR TITLE
feat(inbox): verify member announcements against group's admin Ed25519

### DIFF
--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -48,6 +48,21 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     /// Hex (lowercase, 96 chars) BLS pubkey of the single Tyranny admin.
     /// `nil` for `.anarchy` / `.oneOnOne` (no privileged member).
     var adminPubkeyHex: String?
+    /// Hex (lowercase, 64 chars) Ed25519 pubkey of the admin —
+    /// HKDF-derived from their nostr secret on the admin's device.
+    /// Captured at materialize time from the inviting envelope's
+    /// `senderEd25519PublicKey`, or stamped at create time from the
+    /// creator's own `Identity.stellarPublicKey`. Used by the
+    /// receive-side dispatcher to verify that an inbound
+    /// `MemberAnnouncementPayload` was actually signed by the
+    /// known admin (and not a peer who happens to know the
+    /// recipient's inbox pubkey).
+    ///
+    /// `nil` for `.anarchy` / `.oneOnOne` (no admin) or when a
+    /// pre-PR-9 group was materialized before the field existed —
+    /// announcements for such groups fall back to V1 best-effort
+    /// (decrypt-only verification).
+    var adminEd25519PubkeyHex: String?
     /// Flips to `true` once the relayer's `create_group_v2` returns
     /// `accepted = true`. Persisted-but-not-anchored groups can be
     /// retried.

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -223,6 +223,8 @@ struct CreateGroupInteractor: Sendable {
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
         let adminPubkeyHex = identitySnapshot.blsPublicKey
             .map { String(format: "%02x", $0) }.joined()
+        let adminEd25519PubkeyHex = identitySnapshot.stellarPublicKey
+            .map { String(format: "%02x", $0) }.joined()
         let creatorProfiles = await Self.creatorProfiles(
             from: identitySnapshot,
             identity: identity
@@ -241,6 +243,7 @@ struct CreateGroupInteractor: Sendable {
             tier: tier,
             groupType: .tyranny,
             adminPubkeyHex: adminPubkeyHex,
+            adminEd25519PubkeyHex: adminEd25519PubkeyHex,
             isPublishedOnChain: false
         )
         _ = await groups.insert(group)
@@ -427,6 +430,7 @@ struct CreateGroupInteractor: Sendable {
             tier: .small,
             groupType: .oneOnOne,
             adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
             isPublishedOnChain: false
         )
         _ = await groups.insert(group)
@@ -606,6 +610,7 @@ struct CreateGroupInteractor: Sendable {
             tier: tier,
             groupType: .anarchy,
             adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
             isPublishedOnChain: false
         )
         _ = await groups.insert(group)

--- a/Sources/OnymIOS/Group/PersistedGroup.swift
+++ b/Sources/OnymIOS/Group/PersistedGroup.swift
@@ -45,6 +45,10 @@ final class PersistedGroup {
     /// Optional so SwiftData's lightweight migration can land an extra
     /// column on existing rows without a wipe. `nil` decodes to `[:]`.
     var encryptedMemberProfilesJSON: Data?
+    /// Optional Ed25519 pubkey of the admin (PR 9). `nil` on rows
+    /// migrated from pre-PR-9 schema, or for governance models
+    /// without an admin.
+    var encryptedAdminEd25519PubkeyHex: Data?
 
     init(
         id: String,
@@ -60,7 +64,8 @@ final class PersistedGroup {
         encryptedSalt: Data,
         encryptedCommitment: Data?,
         encryptedAdminPubkeyHex: Data?,
-        encryptedMemberProfilesJSON: Data?
+        encryptedMemberProfilesJSON: Data?,
+        encryptedAdminEd25519PubkeyHex: Data?
     ) {
         self.id = id
         self.ownerIdentityIDString = ownerIdentityIDString
@@ -76,5 +81,6 @@ final class PersistedGroup {
         self.encryptedCommitment = encryptedCommitment
         self.encryptedAdminPubkeyHex = encryptedAdminPubkeyHex
         self.encryptedMemberProfilesJSON = encryptedMemberProfilesJSON
+        self.encryptedAdminEd25519PubkeyHex = encryptedAdminEd25519PubkeyHex
     }
 }

--- a/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
+++ b/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
@@ -92,6 +92,7 @@ actor SwiftDataGroupStore: GroupStore {
             existing.encryptedCommitment = encoded.encryptedCommitment
             existing.encryptedAdminPubkeyHex = encoded.encryptedAdminPubkeyHex
             existing.encryptedMemberProfilesJSON = encoded.encryptedMemberProfilesJSON
+            existing.encryptedAdminEd25519PubkeyHex = encoded.encryptedAdminEd25519PubkeyHex
             try? context.save()
             return false
         }
@@ -164,7 +165,8 @@ actor SwiftDataGroupStore: GroupStore {
             encryptedSalt: try StorageEncryption.encrypt(group.salt),
             encryptedCommitment: try group.commitment.map(StorageEncryption.encrypt),
             encryptedAdminPubkeyHex: try group.adminPubkeyHex.map(StorageEncryption.encrypt),
-            encryptedMemberProfilesJSON: encryptedProfilesJSON
+            encryptedMemberProfilesJSON: encryptedProfilesJSON,
+            encryptedAdminEd25519PubkeyHex: try group.adminEd25519PubkeyHex.map(StorageEncryption.encrypt)
         )
     }
 
@@ -183,6 +185,9 @@ actor SwiftDataGroupStore: GroupStore {
         }
         let commitment = row.encryptedCommitment.flatMap { try? StorageEncryption.decrypt($0) }
         let adminPubkeyHex = row.encryptedAdminPubkeyHex.flatMap {
+            try? StorageEncryption.decryptString($0)
+        }
+        let adminEd25519PubkeyHex = row.encryptedAdminEd25519PubkeyHex.flatMap {
             try? StorageEncryption.decryptString($0)
         }
         // Missing column / decode failure → empty directory. Profiles
@@ -206,6 +211,7 @@ actor SwiftDataGroupStore: GroupStore {
             tier: tier,
             groupType: groupType,
             adminPubkeyHex: adminPubkeyHex,
+            adminEd25519PubkeyHex: adminEd25519PubkeyHex,
             isPublishedOnChain: row.isPublishedOnChain
         )
     }

--- a/Sources/OnymIOS/Identity/DecryptedEnvelope.swift
+++ b/Sources/OnymIOS/Identity/DecryptedEnvelope.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Output of `InvitationEnvelopeDecrypting.decryptInvitationWithSender`.
+/// Bundles the inner plaintext with the Ed25519 pubkey that signed
+/// the outer `SealedEnvelope` — receivers that need to authenticate
+/// the sender (e.g. the admin-Ed25519 trust check on
+/// `MemberAnnouncementPayload`) read both at the same time without
+/// re-decoding the envelope.
+///
+/// `senderEd25519PublicKey` is `nil` when the envelope shipped
+/// without a `sender_ed25519_public_key` block. That's allowed by
+/// the wire format (the signature block is optional), so callers
+/// that require provenance MUST treat `nil` as "no proof of sender"
+/// and refuse to act on the plaintext as if it were authenticated.
+struct DecryptedEnvelope: Equatable, Sendable {
+    let plaintext: Data
+    /// 32-byte raw Ed25519 pubkey, or `nil` when the envelope
+    /// didn't include a signature block.
+    let senderEd25519PublicKey: Data?
+}

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -303,6 +303,36 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
         )
     }
 
+    /// Single-pass decrypt that surfaces the sender's Ed25519 pubkey
+    /// alongside the plaintext. Overrides the protocol's default
+    /// (which would re-decode the envelope twice) — at our volume
+    /// the savings are tiny but it's the right factoring.
+    func decryptInvitationWithSender(
+        envelopeBytes: Data,
+        asIdentity identityID: IdentityID
+    ) throws -> DecryptedEnvelope {
+        guard let snapshot = try keychain.read(identityID) else {
+            throw InvitationDecryptError.identityNotLoaded
+        }
+        let privateKey = try Self.inboxKeyAgreementPrivateKey(
+            fromNostrSecret: snapshot.nostrSecretKey
+        )
+        let envelope: SealedEnvelope
+        do {
+            envelope = try JSONDecoder().decode(SealedEnvelope.self, from: envelopeBytes)
+        } catch {
+            throw InvitationDecryptError.malformedEnvelope
+        }
+        let plaintext = try Self.decryptSealedEnvelope(
+            envelope: envelope,
+            recipientX25519PrivateKey: privateKey
+        )
+        return DecryptedEnvelope(
+            plaintext: plaintext,
+            senderEd25519PublicKey: envelope.senderEd25519PublicKey
+        )
+    }
+
     /// Static decrypt for callers that already hold the X25519 private
     /// key — used by `JoinRequestApprover` to open envelopes sealed
     /// to a per-invite ephemeral introPub (where the matching privkey
@@ -322,6 +352,20 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
         } catch {
             throw InvitationDecryptError.malformedEnvelope
         }
+        return try decryptSealedEnvelope(
+            envelope: envelope,
+            recipientX25519PrivateKey: recipientX25519PrivateKey
+        )
+    }
+
+    /// Same as `decryptSealedEnvelope(envelopeBytes:...)` but operates
+    /// on a pre-decoded envelope. Lets the caller fish out fields like
+    /// `senderEd25519PublicKey` without paying for a second JSON
+    /// decode of the same bytes.
+    static func decryptSealedEnvelope(
+        envelope: SealedEnvelope,
+        recipientX25519PrivateKey: Curve25519.KeyAgreement.PrivateKey
+    ) throws -> Data {
         guard envelope.scheme == "x25519-aes-256-gcm-v1" else {
             throw InvitationDecryptError.unsupportedScheme(envelope.scheme)
         }

--- a/Sources/OnymIOS/Identity/InvitationEnvelopeDecrypting.swift
+++ b/Sources/OnymIOS/Identity/InvitationEnvelopeDecrypting.swift
@@ -16,6 +16,42 @@ protocol InvitationEnvelopeDecrypting: Sendable {
     /// the keychain, invalid signature on the ephemeral key (when
     /// present), or AES-GCM tag mismatch.
     func decryptInvitation(envelopeBytes: Data, asIdentity identityID: IdentityID) async throws -> Data
+
+    /// Same as `decryptInvitation` but additionally surfaces the
+    /// sender's Ed25519 pubkey from the outer envelope. Used by
+    /// receivers that need to authenticate the sender (e.g. verify a
+    /// `MemberAnnouncementPayload` came from the group's known admin)
+    /// without doing a second envelope decode. The default
+    /// implementation re-decodes the envelope just to extract the
+    /// sender pubkey — production conformers (`IdentityRepository`)
+    /// override with a single-pass implementation that decodes once.
+    func decryptInvitationWithSender(
+        envelopeBytes: Data,
+        asIdentity identityID: IdentityID
+    ) async throws -> DecryptedEnvelope
+}
+
+extension InvitationEnvelopeDecrypting {
+    /// Default fallback: decrypt via the existing API + decode the
+    /// envelope a second time to fish out the sender pubkey. Test
+    /// stubs that don't care about provenance get this for free.
+    func decryptInvitationWithSender(
+        envelopeBytes: Data,
+        asIdentity identityID: IdentityID
+    ) async throws -> DecryptedEnvelope {
+        let plaintext = try await decryptInvitation(
+            envelopeBytes: envelopeBytes,
+            asIdentity: identityID
+        )
+        let envelope = try? JSONDecoder().decode(
+            SealedEnvelope.self,
+            from: envelopeBytes
+        )
+        return DecryptedEnvelope(
+            plaintext: plaintext,
+            senderEd25519PublicKey: envelope?.senderEd25519PublicKey
+        )
+    }
 }
 
 enum InvitationDecryptError: Error, Equatable, Sendable {

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -47,10 +47,12 @@ struct IncomingMessageDispatcher: Sendable {
         payload: Data,
         receivedAt: Date
     ) async {
-        // Decrypt once at receive time — both fast paths below need
-        // the plaintext; the safety-net path only needs to know
-        // decryption failed.
-        guard let plaintext = try? await envelopeDecrypter.decryptInvitation(
+        // Decrypt once at receive time and grab the sender's Ed25519
+        // pubkey at the same hop — both fast paths use it for
+        // provenance (announcement: verify against stored admin;
+        // invitation: stamp into the materialized group). The
+        // safety-net path only needs to know decryption failed.
+        guard let envelope = try? await envelopeDecrypter.decryptInvitationWithSender(
             envelopeBytes: payload,
             asIdentity: ownerIdentityID
         ) else {
@@ -67,9 +69,12 @@ struct IncomingMessageDispatcher: Sendable {
         // delta for an existing local group.
         if let announcement = try? JSONDecoder().decode(
             MemberAnnouncementPayload.self,
-            from: plaintext
+            from: envelope.plaintext
         ) {
-            await applyAnnouncement(announcement)
+            await applyAnnouncement(
+                announcement,
+                senderEd25519PublicKey: envelope.senderEd25519PublicKey
+            )
             return
         }
 
@@ -78,9 +83,13 @@ struct IncomingMessageDispatcher: Sendable {
         // because the group is now visible in the chat list.
         if let invitation = try? JSONDecoder().decode(
             GroupInvitationPayload.self,
-            from: plaintext
+            from: envelope.plaintext
         ) {
-            await materializeGroup(invitation, ownerIdentityID: ownerIdentityID)
+            await materializeGroup(
+                invitation,
+                ownerIdentityID: ownerIdentityID,
+                senderEd25519PublicKey: envelope.senderEd25519PublicKey
+            )
             return
         }
 
@@ -125,7 +134,8 @@ struct IncomingMessageDispatcher: Sendable {
     /// materialize a partial group.
     private func materializeGroup(
         _ invitation: GroupInvitationPayload,
-        ownerIdentityID: IdentityID
+        ownerIdentityID: IdentityID,
+        senderEd25519PublicKey: Data?
     ) async {
         guard let tier = SEPTier(rawValue: invitation.tierRaw),
               let groupType = SEPGroupType(rawValue: invitation.groupTypeRaw)
@@ -139,6 +149,21 @@ struct IncomingMessageDispatcher: Sendable {
         var profiles = invitation.memberProfiles ?? [:]
         if let selfEntry = await selfMemberProfileEntry(for: ownerIdentityID) {
             profiles[selfEntry.key] = selfEntry.value
+        }
+
+        // Stamp the inviting envelope's Ed25519 pubkey as the
+        // group's admin signing key. PR 9 uses this on every
+        // subsequent MemberAnnouncementPayload to verify the sender
+        // is the same admin we received the invitation from. Empty
+        // for `.anarchy` / `.oneOnOne` (no admin), and `nil` when
+        // the envelope shipped without a signature block.
+        let adminEd25519PubkeyHex: String?
+        switch groupType {
+        case .anarchy, .oneOnOne:
+            adminEd25519PubkeyHex = nil
+        default:
+            adminEd25519PubkeyHex = senderEd25519PublicKey
+                .map { $0.map { String(format: "%02x", $0) }.joined() }
         }
 
         let groupIDHex = invitation.groupID
@@ -157,6 +182,7 @@ struct IncomingMessageDispatcher: Sendable {
             tier: tier,
             groupType: groupType,
             adminPubkeyHex: invitation.adminPubkeyHex,
+            adminEd25519PubkeyHex: adminEd25519PubkeyHex,
             // Sender already anchored before sending the invite, so
             // by the time it lands the group is on chain.
             isPublishedOnChain: true
@@ -190,17 +216,41 @@ struct IncomingMessageDispatcher: Sendable {
     ///   - The group isn't on this device (joiner whose local
     ///     materialization hasn't shipped, or stale announcement
     ///     for an unrelated group).
+    ///   - The sender's Ed25519 pubkey doesn't match the group's
+    ///     stored `adminEd25519PubkeyHex` (forged announcement, or
+    ///     announcement for a Tyranny group from a non-admin
+    ///     member). PR 9 trust check.
     ///   - The member is already known under the same BLS pubkey
     ///     hex key (re-delivery, or the admin's own approve loop
     ///     re-broadcasting).
     ///
     /// Dedup key is BLS pubkey hex, mirroring the producer-side
     /// dictionary key in `JoinRequestApprover.recordJoiner`.
-    private func applyAnnouncement(_ payload: MemberAnnouncementPayload) async {
+    private func applyAnnouncement(
+        _ payload: MemberAnnouncementPayload,
+        senderEd25519PublicKey: Data?
+    ) async {
         let groups = await groupRepository.currentGroups()
         guard let group = groups.first(where: { $0.groupIDData == payload.groupId }) else {
             return
         }
+
+        // Trust check: announcement must be signed by the group's
+        // known admin. Skipped (V1 best-effort) when the group has
+        // no stored admin Ed25519 — happens for governance models
+        // without an admin (anarchy / oneOnOne) or pre-PR-9 rows
+        // that materialized before the field existed. We DO require
+        // the envelope to carry SOME sender pubkey though; an
+        // unsigned announcement is rejected outright when the group
+        // has an admin to verify against.
+        if let storedAdmin = group.adminEd25519PubkeyHex {
+            guard let senderEd25519PublicKey else { return }
+            let senderHex = senderEd25519PublicKey
+                .map { String(format: "%02x", $0) }.joined()
+                .lowercased()
+            guard senderHex == storedAdmin.lowercased() else { return }
+        }
+
         let key = payload.newMember.blsPub
             .map { String(format: "%02x", $0) }.joined()
         if group.memberProfiles[key] != nil { return }

--- a/Tests/OnymIOSTests/ChatGroupTests.swift
+++ b/Tests/OnymIOSTests/ChatGroupTests.swift
@@ -36,6 +36,7 @@ final class ChatGroupTests: XCTestCase {
             tier: .small,
             groupType: .tyranny,
             adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
             isPublishedOnChain: false
         )
     }

--- a/Tests/OnymIOSTests/GroupRepositoryTests.swift
+++ b/Tests/OnymIOSTests/GroupRepositoryTests.swift
@@ -157,6 +157,7 @@ final class GroupRepositoryTests: XCTestCase {
             tier: .small,
             groupType: .tyranny,
             adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
             isPublishedOnChain: false
         )
     }

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -149,6 +149,196 @@ final class IncomingMessageDispatcherTests: XCTestCase {
                        "redelivery must NOT overwrite an existing profile")
     }
 
+    // MARK: - PR 9: admin Ed25519 trust check
+
+    func test_announcement_acceptedWhenSenderMatchesStoredAdminEd25519() async throws {
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let adminEd25519 = Data(repeating: 0xED, count: 32)
+        let adminEd25519Hex = "ed".repeated(32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [:],
+            adminEd25519PubkeyHex: adminEd25519Hex
+        )
+
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: "bb".repeated(48),
+            joinerInboxByte: 0x33,
+            joinerAlias: "Bob",
+            adminAlias: "Alice"
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: adminEd25519
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-trust-ok",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        let updated = try XCTUnwrap(after.first { $0.groupIDData == groupID })
+        XCTAssertEqual(updated.memberProfiles["bb".repeated(48)]?.alias, "Bob",
+                       "matched-admin announcement is accepted")
+    }
+
+    func test_announcement_rejectedWhenSenderDoesNotMatchStoredAdmin() async throws {
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let adminEd25519Hex = "ed".repeated(32)
+        let imposterEd25519 = Data(repeating: 0xBA, count: 32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [:],
+            adminEd25519PubkeyHex: adminEd25519Hex
+        )
+
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: "ff".repeated(48),
+            joinerInboxByte: 0x99,
+            joinerAlias: "Mallory",
+            adminAlias: "imposter"
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: imposterEd25519
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-trust-bad",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        let updated = try XCTUnwrap(after.first { $0.groupIDData == groupID })
+        XCTAssertNil(updated.memberProfiles["ff".repeated(48)],
+                     "imposter announcement must NOT mutate memberProfiles")
+    }
+
+    func test_announcement_rejectedWhenAdminKnownButEnvelopeUnsigned() async throws {
+        // Group has a stored admin but the envelope didn't carry a
+        // sender pubkey (no signature block). PR 9 rule: when we know
+        // who the admin should be, an unsigned announcement is
+        // dropped — best-effort acceptance only applies to legacy
+        // groups with no stored admin Ed25519.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [:],
+            adminEd25519PubkeyHex: "ed".repeated(32)
+        )
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: "bb".repeated(48),
+            joinerInboxByte: 0x33,
+            joinerAlias: "Bob",
+            adminAlias: "Alice"
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: nil
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-unsigned",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let after = await groups.currentGroups()
+        XCTAssertNil(after.first?.memberProfiles["bb".repeated(48)],
+                     "unsigned announcement is dropped when the group has a stored admin")
+    }
+
+    func test_announcement_acceptedForGroupWithoutStoredAdmin_legacyFallback() async throws {
+        // Legacy / pre-PR-9 group materialized without a stored
+        // adminEd25519PubkeyHex. Best-effort acceptance: any
+        // announcement that decrypts cleanly + names the group is
+        // accepted, matching pre-PR-9 behavior.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        await seedGroup(groupID: groupID, memberProfiles: [:], adminEd25519PubkeyHex: nil)
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: "bb".repeated(48),
+            joinerInboxByte: 0x33,
+            joinerAlias: "Bob",
+            adminAlias: "Alice"
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: Data(repeating: 0xAA, count: 32)
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-legacy-fallback",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let after = await groups.currentGroups()
+        XCTAssertEqual(after.first?.memberProfiles["bb".repeated(48)]?.alias, "Bob",
+                       "legacy group accepts announcements (best-effort)")
+    }
+
+    func test_invitation_capturesSenderEd25519AsAdmin() async throws {
+        // PR 9: the materializer stamps the inviting envelope's
+        // senderEd25519PublicKey as the group's adminEd25519PubkeyHex
+        // for Tyranny groups, so subsequent announcements can be
+        // verified against it.
+        let payload = makeInvitationPayload(
+            groupID: Data(repeating: 0x42, count: 32),
+            name: "Family",
+            memberProfiles: nil
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let admin = Data(repeating: 0xED, count: 32)
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: admin
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-cap",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let after = await groups.currentGroups()
+        XCTAssertEqual(after.first?.adminEd25519PubkeyHex, "ed".repeated(32),
+                       "materializer stamps sender Ed25519 hex on the new group")
+    }
+
     // MARK: - Invitation materialization path
 
     func test_invitation_materializesLocalGroup_withSelfEntry() async throws {
@@ -334,7 +524,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
 
     private func seedGroup(
         groupID: Data,
-        memberProfiles: [String: MemberProfile]
+        memberProfiles: [String: MemberProfile],
+        adminEd25519PubkeyHex: String? = nil
     ) async {
         let group = ChatGroup(
             id: groupID.map { String(format: "%02x", $0) }.joined(),
@@ -350,6 +541,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             tier: .small,
             groupType: .tyranny,
             adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: adminEd25519PubkeyHex,
             isPublishedOnChain: true
         )
         _ = await groups.insert(group)

--- a/Tests/OnymIOSTests/JoinFlowTests.swift
+++ b/Tests/OnymIOSTests/JoinFlowTests.swift
@@ -139,6 +139,7 @@ final class JoinFlowTests: XCTestCase {
             tier: .small,
             groupType: .tyranny,
             adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
             isPublishedOnChain: false
         )
     }

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -164,6 +164,7 @@ final class ShareInviteFlowTests: XCTestCase {
             tier: .small,
             groupType: .tyranny,
             adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
             isPublishedOnChain: false
         )
     }

--- a/Tests/OnymIOSTests/Support/FakeInvitationEnvelopeDecrypter.swift
+++ b/Tests/OnymIOSTests/Support/FakeInvitationEnvelopeDecrypter.swift
@@ -21,10 +21,16 @@ actor FakeInvitationEnvelopeDecrypter: InvitationEnvelopeDecrypting {
     }
 
     private let mode: Mode
+    /// Optional Ed25519 sender pubkey returned alongside the
+    /// plaintext from `decryptInvitationWithSender`. Tests asserting
+    /// PR-9 trust-check behavior set this; the default `nil` matches
+    /// pre-PR-9 envelopes that didn't carry a signature block.
+    private let senderEd25519PublicKey: Data?
     private(set) var decryptCalls: [(envelopeBytes: Data, identityID: IdentityID)] = []
 
-    init(mode: Mode) {
+    init(mode: Mode, senderEd25519PublicKey: Data? = nil) {
         self.mode = mode
+        self.senderEd25519PublicKey = senderEd25519PublicKey
     }
 
     func decryptInvitation(envelopeBytes: Data, asIdentity identityID: IdentityID) throws -> Data {
@@ -40,5 +46,19 @@ actor FakeInvitationEnvelopeDecrypter: InvitationEnvelopeDecrypting {
         case .failing(let error):
             throw error
         }
+    }
+
+    func decryptInvitationWithSender(
+        envelopeBytes: Data,
+        asIdentity identityID: IdentityID
+    ) throws -> DecryptedEnvelope {
+        let plaintext = try decryptInvitation(
+            envelopeBytes: envelopeBytes,
+            asIdentity: identityID
+        )
+        return DecryptedEnvelope(
+            plaintext: plaintext,
+            senderEd25519PublicKey: senderEd25519PublicKey
+        )
     }
 }

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -185,6 +185,7 @@ final class SwiftDataGroupStoreTests: XCTestCase {
             tier: .small,
             groupType: .tyranny,
             adminPubkeyHex: adminPubkeyHex,
+            adminEd25519PubkeyHex: nil,
             isPublishedOnChain: false
         )
     }


### PR DESCRIPTION
## Summary

PR 9 of the new-member announcement stack. Stacked on #83. **Closes the receive-side trust-model TODO** from PR 6: existing members now refuse `MemberAnnouncementPayload`s that aren't signed by the group's known admin, instead of accepting any announcement that decrypts cleanly.

### Wire / data model

- **New `DecryptedEnvelope`** value type bundles plaintext + `senderEd25519PublicKey` from the outer `SealedEnvelope`.
- **`InvitationEnvelopeDecrypting`** gains `decryptInvitationWithSender` with a default impl that re-decodes the envelope; `IdentityRepository` overrides with a single-pass version. `decryptSealedEnvelope` factored to accept either bytes or a pre-decoded envelope.
- **`ChatGroup`** gains optional `adminEd25519PubkeyHex` (HKDF-derived Ed25519 pubkey of the admin). Persisted via `PersistedGroup`'s new encrypted column (optional for SwiftData lightweight migration).

### Producers

- **`CreateGroupInteractor.createTyranny`** stamps the creator's own `Identity.stellarPublicKey` at create time. Anarchy / OneOnOne leave it nil (no admin role).
- **`IncomingMessageDispatcher.materializeGroup`** captures the inviting envelope's `senderEd25519PublicKey` for Tyranny groups; nil for governance models without admins.

### Trust check

`IncomingMessageDispatcher.applyAnnouncement` now compares the envelope's sender Ed25519 hex against the group's stored admin:

- **Match** → apply the roster delta as before.
- **Mismatch** → drop silently.
- **Unsigned envelope but group has stored admin** → drop silently. Tightening — V1's \"best-effort\" only applies to legacy / pre-PR-9 groups whose `adminEd25519PubkeyHex` is `nil`.

### Test plan

- [x] **5 new** `IncomingMessageDispatcherTests`: matched-admin acceptance, mismatch rejection, unsigned-envelope rejection when admin known, legacy fallback (nil stored admin), invitation materialization captures sender Ed25519.
- [x] `FakeInvitationEnvelopeDecrypter` takes an optional `senderEd25519PublicKey` so tests can drive the trust path.
- [x] All 5 `ChatGroup()` construction tests updated for the new field.
- [x] Full unit suite — 477/477 pass (3 skipped, pre-existing).

### Known follow-ups

- The admin's *own* Ed25519 doesn't need verification (they originated the announcement) — `JoinRequestApprover.broadcastJoin` skips the admin's own inbox in fanout, so this isn't an issue.
- For groups created on this device, `adminEd25519PubkeyHex` matches the active identity's stellar pubkey at create time. If the user *renames* their identity, that's just an alias change — the Ed25519 key is recovery-phrase-derived and stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)