### PR TITLE
feat(chats): share invite link from chat-members view

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,22 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    " — they can find it in " : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " — they can find it in "
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " — они смогут её найти в "
+          }
+        }
+      }
+    },
     " · published on Stellar so anyone can verify it’s real." : {
       "localizations" : {
         "en" : {
@@ -17,18 +33,50 @@
         }
       }
     },
-    " — they can find it in " : {
+    "—" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : " — they can find it in "
+            "value" : "—"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : " — они смогут её найти в "
+            "value" : "—"
+          }
+        }
+      }
+    },
+    ", or share a QR code from there." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", or share a QR code from there."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", или поделитесь QR-кодом оттуда."
+          }
+        }
+      }
+    },
+    "·" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "·"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "·"
           }
         }
       }
@@ -49,6 +97,22 @@
         }
       }
     },
+    "(you)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(you)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(вы)"
+          }
+        }
+      }
+    },
     "%@" : {
       "localizations" : {
         "en" : {
@@ -61,54 +125,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"
-          }
-        }
-      }
-    },
-    "%@ %@ so far" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ %2$@ so far"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "пока %1$@ %2$@"
-          }
-        }
-      }
-    },
-    "%@ (%@)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ (%2$@)"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ (%2$@)"
-          }
-        }
-      }
-    },
-    "%@ is live" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is live"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ работает"
           }
         }
       }
@@ -129,18 +145,66 @@
         }
       }
     },
-    "%@%%" : {
+    "%@ (%@)" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@%%"
+            "state" : "new",
+            "value" : "%1$@ (%2$@)"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@%%"
+            "value" : "%1$@ (%2$@)"
+          }
+        }
+      }
+    },
+    "%@ %@ so far" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@ so far"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "пока %1$@ %2$@"
+          }
+        }
+      }
+    },
+    "%@ is live" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is live"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ работает"
+          }
+        }
+      }
+    },
+    "%@ member%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ member%2$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ участник%2$@"
           }
         }
       }
@@ -177,34 +241,98 @@
         }
       }
     },
-    ", or share a QR code from there." : {
+    "%@%%" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : ", or share a QR code from there."
+            "value" : "%@%%"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : ", или поделитесь QR-кодом оттуда."
+            "value" : "%@%%"
           }
         }
       }
     },
-    "ACTIVE IDENTITY" : {
+    "© 2026 · Onym Foundation" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ACTIVE IDENTITY"
+            "value" : "© 2026 · Onym Foundation"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "АКТИВНАЯ ЛИЧНОСТЬ"
+            "value" : "© 2026 · Onym Foundation"
+          }
+        }
+      }
+    },
+    "▲" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "▲"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "▲"
+          }
+        }
+      }
+    },
+    "✈" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "✈"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "✈"
+          }
+        }
+      }
+    },
+    "🎉 Hello, builder. Want to contribute?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🎉 Hello, builder. Want to contribute?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🎉 Привет, разработчик. Хотите помочь проекту?"
+          }
+        }
+      }
+    },
+    "🐳" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🐳"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🐳"
           }
         }
       }
@@ -241,6 +369,22 @@
         }
       }
     },
+    "ACTIVE IDENTITY" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ACTIVE IDENTITY"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "АКТИВНАЯ ЛИЧНОСТЬ"
+          }
+        }
+      }
+    },
     "Add Custom URL" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -258,22 +402,6 @@
         }
       }
     },
-    "Add Identity" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Identity"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить личность"
-          }
-        }
-      }
-    },
     "Add from Published List" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -287,6 +415,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Добавить из опубликованного списка"
+          }
+        }
+      }
+    },
+    "Add Identity" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Identity"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить личность"
           }
         }
       }
@@ -407,6 +551,22 @@
         }
       }
     },
+    "Approve" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approve"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Принять"
+          }
+        }
+      }
+    },
     "Ask for their " : {
       "localizations" : {
         "en" : {
@@ -453,54 +613,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не удалось аутентифицироваться"
-          }
-        }
-      }
-    },
-    "BLS" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BLS"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BLS"
-          }
-        }
-      }
-    },
-    "BLS %@…" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BLS %@…"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BLS %@…"
-          }
-        }
-      }
-    },
-    "BLS12-381" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BLS12-381"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BLS12-381"
           }
         }
       }
@@ -605,6 +717,54 @@
         }
       }
     },
+    "BLS" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BLS"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BLS"
+          }
+        }
+      }
+    },
+    "BLS %@…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BLS %@…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BLS %@…"
+          }
+        }
+      }
+    },
+    "BLS12-381" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BLS12-381"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BLS12-381"
+          }
+        }
+      }
+    },
     "Bring your own contract" : {
       "localizations" : {
         "en" : {
@@ -665,22 +825,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Создано людьми, которые считают приватность правом.\nВыпущено под лицензией MIT."
-          }
-        }
-      }
-    },
-    "CONTRACT · %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CONTRACT · %@"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "КОНТРАКТ · %@"
           }
         }
       }
@@ -751,6 +895,22 @@
         }
       }
     },
+    "Close" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть"
+          }
+        }
+      }
+    },
     "Compile the %@ contract from source and deploy it to Stellar %@. Onym signs with a one-time deploy key." : {
       "localizations" : {
         "en" : {
@@ -796,6 +956,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Продолжить с Face ID"
+          }
+        }
+      }
+    },
+    "CONTRACT · %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CONTRACT · %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "КОНТРАКТ · %@"
           }
         }
       }
@@ -898,22 +1074,6 @@
         }
       }
     },
-    "Create Group" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Group"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать группу"
-          }
-        }
-      }
-    },
     "Create an end-to-end encrypted group anchored on Stellar." : {
       "localizations" : {
         "en" : {
@@ -926,6 +1086,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Создайте сквозно зашифрованную группу с якорем в Stellar."
+          }
+        }
+      }
+    },
+    "Create Group" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create Group"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать группу"
           }
         }
       }
@@ -958,6 +1134,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Создание %@"
+          }
+        }
+      }
+    },
+    "Decline" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отклонить"
           }
         }
       }
@@ -1027,22 +1219,6 @@
         }
       }
     },
-    "Done" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Готово"
-          }
-        }
-      }
-    },
     "Don’t have their key? " : {
       "localizations" : {
         "en" : {
@@ -1055,6 +1231,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нет их ключа? "
+          }
+        }
+      }
+    },
+    "Done" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
           }
         }
       }
@@ -1140,6 +1332,22 @@
         }
       }
     },
+    "Group not found" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Group not found"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Группа не найдена"
+          }
+        }
+      }
+    },
     "Have someone scan this code with Onym to open a private chat with %@." : {
       "localizations" : {
         "en" : {
@@ -1152,6 +1360,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Попросите отсканировать этот код в Onym, чтобы открыть приватный чат с %@."
+          }
+        }
+      }
+    },
+    "i" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "i"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "i"
           }
         }
       }
@@ -1188,22 +1412,6 @@
         }
       }
     },
-    "INVITE KEY" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "INVITE KEY"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "КЛЮЧ ПРИГЛАШЕНИЯ"
-          }
-        }
-      }
-    },
     "Inbox %@" : {
       "localizations" : {
         "en" : {
@@ -1216,6 +1424,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Входящие %@"
+          }
+        }
+      }
+    },
+    "inbox key" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "inbox key"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ключ входящих"
           }
         }
       }
@@ -1252,6 +1476,38 @@
         }
       }
     },
+    "INVITE KEY" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "INVITE KEY"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "КЛЮЧ ПРИГЛАШЕНИЯ"
+          }
+        }
+      }
+    },
+    "Invite people from the chat to see them here." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invite people from the chat to see them here."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пригласите людей в чат — они появятся здесь."
+          }
+        }
+      }
+    },
     "Join chat" : {
       "localizations" : {
         "en" : {
@@ -1264,6 +1520,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Войти в чат"
+          }
+        }
+      }
+    },
+    "Join requests" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Join requests"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запросы на вступление"
           }
         }
       }
@@ -1433,6 +1705,38 @@
         }
       }
     },
+    "No members yet" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No members yet"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пока нет участников"
+          }
+        }
+      }
+    },
+    "No pending requests" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No pending requests"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет ожидающих запросов"
+          }
+        }
+      }
+    },
     "No published relayers yet." : {
       "localizations" : {
         "en" : {
@@ -1493,6 +1797,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Это не то слово. Проверьте фразу и повторите попытку."
+          }
+        }
+      }
+    },
+    "npub" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "npub"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "npub"
           }
         }
       }
@@ -1564,6 +1884,70 @@
         }
       }
     },
+    "onym · open · anonymous · onchain" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "onym · open · anonymous · onchain"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "onym · открыто · анонимно · в блокчейне"
+          }
+        }
+      }
+    },
+    "onymchat/onym-contracts" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "onymchat/onym-contracts"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "onymchat/onym-contracts"
+          }
+        }
+      }
+    },
+    "onymchat/onym-relayer" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "onymchat/onym-relayer"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "onymchat/onym-relayer"
+          }
+        }
+      }
+    },
+    "open · anonymous · onchain" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "open · anonymous · onchain"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "открыто · анонимно · в блокчейне"
+          }
+        }
+      }
+    },
     "Paste 64-char inbox key" : {
       "localizations" : {
         "en" : {
@@ -1608,6 +1992,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вставить из буфера обмена"
+          }
+        }
+      }
+    },
+    "People who tap one of your invite links show up here." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "People who tap one of your invite links show up here."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Люди, нажавшие на одну из ваших ссылок-приглашений, появятся здесь."
           }
         }
       }
@@ -1892,22 +2292,6 @@
         }
       }
     },
-    "SX" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SX"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SX"
-          }
-        }
-      }
-    },
     "Scan with Onym on another device to open a private chat with this identity." : {
       "localizations" : {
         "en" : {
@@ -2185,18 +2569,18 @@
         }
       }
     },
-    "Tap to reveal" : {
+    "SX" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tap to reveal"
+            "value" : "SX"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Нажмите, чтобы показать"
+            "value" : "SX"
           }
         }
       }
@@ -2213,6 +2597,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нажмите «Использовать этот контракт», чтобы привязывать новые чаты %@ здесь. Существующие чаты сохранят свой текущий контракт."
+          }
+        }
+      }
+    },
+    "Tap to reveal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to reveal"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нажмите, чтобы показать"
           }
         }
       }
@@ -2250,6 +2650,22 @@
         }
       }
     },
+    "This request is for a group that isn’t on this device. Decline to clear it." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This request is for a group that isn’t on this device. Decline to clear it."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот запрос относится к группе, которой нет на этом устройстве. Отклоните, чтобы убрать."
+          }
+        }
+      }
+    },
     "This usually takes a few seconds. It’s safe to close this — we’ll finish in the background." : {
       "localizations" : {
         "en" : {
@@ -2266,13 +2682,12 @@
         }
       }
     },
-    "Try Again" : {
-      "extractionState" : "stale",
+    "Try again" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Try Again"
+            "value" : "Try again"
           }
         },
         "ru" : {
@@ -2283,12 +2698,13 @@
         }
       }
     },
-    "Try again" : {
+    "Try Again" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Try again"
+            "value" : "Try Again"
           }
         },
         "ru" : {
@@ -2443,6 +2859,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ждём одобрения от хоста…"
+          }
+        }
+      }
+    },
+    "wants to join “%@”" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wants to join “%@”"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "хочет вступить в «%@»"
           }
         }
       }
@@ -2624,230 +3056,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваш релеер — ваши правила"
-          }
-        }
-      }
-    },
-    "i" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "i"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "i"
-          }
-        }
-      }
-    },
-    "inbox key" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "inbox key"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ключ входящих"
-          }
-        }
-      }
-    },
-    "npub" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "npub"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "npub"
-          }
-        }
-      }
-    },
-    "onym · open · anonymous · onchain" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "onym · open · anonymous · onchain"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "onym · открыто · анонимно · в блокчейне"
-          }
-        }
-      }
-    },
-    "onymchat/onym-contracts" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "onymchat/onym-contracts"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "onymchat/onym-contracts"
-          }
-        }
-      }
-    },
-    "onymchat/onym-relayer" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "onymchat/onym-relayer"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "onymchat/onym-relayer"
-          }
-        }
-      }
-    },
-    "open · anonymous · onchain" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "open · anonymous · onchain"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "открыто · анонимно · в блокчейне"
-          }
-        }
-      }
-    },
-    "© 2026 · Onym Foundation" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "© 2026 · Onym Foundation"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "© 2026 · Onym Foundation"
-          }
-        }
-      }
-    },
-    "·" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "·"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "·"
-          }
-        }
-      }
-    },
-    "—" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "—"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "—"
-          }
-        }
-      }
-    },
-    "▲" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "▲"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "▲"
-          }
-        }
-      }
-    },
-    "✈" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "✈"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "✈"
-          }
-        }
-      }
-    },
-    "🎉 Hello, builder. Want to contribute?" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "🎉 Hello, builder. Want to contribute?"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "🎉 Привет, разработчик. Хотите помочь проекту?"
-          }
-        }
-      }
-    },
-    "🐳" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "🐳"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "🐳"
           }
         }
       }

--- a/Sources/OnymIOS/Chats/ChatMembersView.swift
+++ b/Sources/OnymIOS/Chats/ChatMembersView.swift
@@ -21,6 +21,10 @@ struct ChatMembersView: View {
     let groupID: String
     @Bindable var chatsFlow: ChatsFlow
     @Bindable var identitiesFlow: IdentitiesFlow
+    let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
+
+    @State private var showShareInvite = false
+    @State private var shareInviteFlow: ShareInviteFlow?
 
     var body: some View {
         Group {
@@ -37,12 +41,57 @@ struct ChatMembersView: View {
         .navigationTitle(currentGroup?.name ?? "Members")
         .navigationBarTitleDisplayMode(.inline)
         .background(OnymTokens.bg)
+        .toolbar {
+            // Only the local owner of the group can mint a useful
+            // invite link — joiners' invites would point requests at
+            // their own intro inbox, where they can't actually admit
+            // anyone (admin approval is what materializes the group
+            // for the new joiner). Showing the entry-point only on
+            // owner-side groups removes a footgun.
+            if isLocalOwner {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        shareInviteFlow = makeShareInviteFlow()
+                        showShareInvite = true
+                    } label: {
+                        Image(systemName: "person.crop.circle.badge.plus")
+                    }
+                    .accessibilityLabel("Share invite link")
+                    .accessibilityIdentifier("members.share_invite_button")
+                }
+            }
+        }
+        .sheet(isPresented: $showShareInvite) {
+            if let flow = shareInviteFlow {
+                ShareInviteView(
+                    groupID: groupID,
+                    flow: flow,
+                    onDone: {
+                        showShareInvite = false
+                        shareInviteFlow = nil
+                    }
+                )
+            }
+        }
     }
 
     // MARK: - State
 
     private var currentGroup: ChatGroup? {
         chatsFlow.groups.first { $0.id == groupID }
+    }
+
+    /// True iff the active identity owns this group locally — i.e.
+    /// they're the device that created it. Used to gate the
+    /// "Share invite" entry-point: only the owner's intro inbox can
+    /// usefully receive join requests, since approval requires the
+    /// admin's keys.
+    private var isLocalOwner: Bool {
+        guard
+            let group = currentGroup,
+            let activeID = identitiesFlow.currentID
+        else { return false }
+        return group.ownerIdentityID == activeID
     }
 
     private var activeBlsHex: String? {

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -124,7 +124,8 @@ struct ChatsView: View {
             ChatMembersView(
                 groupID: groupID,
                 chatsFlow: flow,
-                identitiesFlow: identitiesFlow
+                identitiesFlow: identitiesFlow,
+                makeShareInviteFlow: makeShareInviteFlow
             )
         }
     }


### PR DESCRIPTION
## Summary

PR 11 of the new-member announcement stack. Stacked on #85. **Closes the discoverability gap reported during smoke testing**: previously the only entry-point to the share-link UI was the post-create flow, which made it impossible to invite a second person to an already-created group.

### What changes

- **`ChatMembersView` toolbar**: new \"Share invite\" button (`person.crop.circle.badge.plus`) in the navigation bar's trailing slot. Tap mints a fresh `IntroCapability` via the existing `ShareInviteFlow` and presents the standard `ShareInviteView` modally — same component that fires post-create.
- **Visibility gate**: button only shown when `group.ownerIdentityID == identitiesFlow.currentID`. Joiner-side groups hide the entry-point because the joiner can't usefully approve requests sent to their own intro inbox — mismatched admin Ed25519 would make subsequent announcements fail PR 9's verification on every existing member's device.
- **Plumbing**: `ChatMembersView` gains a `makeShareInviteFlow` factory parameter; the factory is already in `AppDependencies` (used by `CreateGroupViewHost`) so no app-shell rewiring. `ChatsView.navigationDestination` passes it through.

### Bundled fix: localization catalog

Filling 13 missing `en` + `ru` entries in `Localizable.xcstrings`. These are strings introduced by **PRs 2 + 7** that `LocalizationCatalogTests` finally caught after Xcode's auto-extraction populated empty catalog entries on this build (the test passed earlier because the empty entries hadn't been written yet).

Strings localized: `Approve`, `Decline`, `Close`, `(you)`, `Group not found`, `Invite people from the chat to see them here.`, `Join requests`, `No members yet`, `No pending requests`, `People who tap one of your invite links show up here.`, `This request is for a group that isn't on this device. Decline to clear it.`, `wants to join \"%@\"`, `%@ member%@`.

Russian translations are best-effort — flagged for native-speaker review in a follow-up.

### Test plan

- [x] Build green, no test regressions — 483/483 pass (3 skipped, pre-existing).
- [x] `LocalizationCatalogTests.test_localizable_xcstrings_everyKey_hasEnAndRu` now green (was failing on this branch before the catalog fix).
- [ ] **Manual smoke** (the original problem reported): create a group, tap into chat-members view, tap toolbar share button, copy the resulting `https://onym.chat/join?c=…` link, paste into another simulator's `xcrun simctl openurl …` — joiner's app should open into JoinView with the alias prefilled.
- [ ] Manual smoke: switch to a joiner-side group (one materialized from another device's invitation), confirm the share button is **hidden** (only owner sees it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)