### PR TITLE
feat(transport): Nostr relays config + Settings → Transport section

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -9,6 +9,7 @@ import Foundation
 struct AppDependencies {
     let makeRecoveryPhraseBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
     let makeRelayerSettingsFlow: @MainActor () -> RelayerSettingsFlow
+    let makeNostrRelaySettingsFlow: @MainActor () -> NostrRelaySettingsFlow
     let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -8,6 +8,7 @@ struct OnymIOSApp: App {
     private let contractsRepository: ContractsRepository
     private let groupRepository: GroupRepository
     private let inboxTransport: any InboxTransport
+    private let nostrRelaysRepository: NostrRelaysRepository
     private let incomingInvitations: IncomingInvitationsRepository
     private let introKeyStore: any IntroKeyStore
     private let introRequestStore: any IntroRequestStore
@@ -85,12 +86,25 @@ struct OnymIOSApp: App {
         }
         self.groupRepository = groupRepository
 
-        // Inbox transport for invitation send. Connects on first use
-        // via `RootView.task`.
+        // Inbox transport for invitation send. The endpoint list comes
+        // from `NostrRelaysRepository` — read at app boot in the
+        // WindowGroup .task before the fanout interactor starts. The
+        // transport itself is just a Nostr-WebSocket client; nothing
+        // here picks the URL.
         let inboxTransport = NostrInboxTransport(
             signerProvider: OnymNostrSignerProvider()
         )
         self.inboxTransport = inboxTransport
+
+        // Nostr-relays config — drives the inbox transport's
+        // connections + the Settings → Transport → Nostr screen.
+        // First-launch path inside the actor seeds with the Onym
+        // Official relay; subsequent launches honor the user's
+        // persisted list.
+        let nostrRelaysRepository = NostrRelaysRepository(
+            store: UserDefaultsNostrRelaysSelectionStore()
+        )
+        self.nostrRelaysRepository = nostrRelaysRepository
 
         // Incoming invitations repository — falls back to in-memory if
         // the on-disk store can't open (same protection-class concerns
@@ -137,6 +151,9 @@ struct OnymIOSApp: App {
             },
             makeRelayerSettingsFlow: { @MainActor in
                 RelayerSettingsFlow(repository: relayerRepository)
+            },
+            makeNostrRelaySettingsFlow: { @MainActor in
+                NostrRelaySettingsFlow(repository: nostrRelaysRepository)
             },
             makeAnchorsPickerFlow: { @MainActor in
                 AnchorsPickerFlow(repository: contractsRepository)
@@ -241,6 +258,17 @@ struct OnymIOSApp: App {
                     }
                 }
                 .task {
+                    // Connect the Nostr inbox transport to every
+                    // configured relay BEFORE the fanout interactor
+                    // attempts to subscribe. Without this, both legs
+                    // of the inbox are silently dead: subscribe()
+                    // no-ops on an empty connections dict and send()
+                    // throws TransportError.notConnected.
+                    let endpoints = await nostrRelaysRepository
+                        .currentEndpoints()
+                        .map { TransportEndpoint(url: $0.url) }
+                    await inboxTransport.connect(to: endpoints)
+
                     // PR-4: subscribe to every identity's inbox
                     // concurrently. Without this, messages addressed
                     // to a non-current identity drop on the floor.

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -41,6 +41,7 @@ struct RootView: View {
                     SettingsView(
                         makeBackupFlow: dependencies.makeRecoveryPhraseBackupFlow,
                         makeRelayerSettingsFlow: dependencies.makeRelayerSettingsFlow,
+                        makeNostrRelaySettingsFlow: dependencies.makeNostrRelaySettingsFlow,
                         makeAnchorsPickerFlow: dependencies.makeAnchorsPickerFlow,
                         identitiesFlow: dependencies.identitiesFlow
                     )

--- a/Sources/OnymIOS/Settings/NostrRelaySettingsFlow.swift
+++ b/Sources/OnymIOS/Settings/NostrRelaySettingsFlow.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Observation
+
+/// `@Observable @MainActor` view-model for the Nostr-relays Settings
+/// screen. Drains `NostrRelaysRepository` snapshots into local
+/// `state.snapshot`; intents dispatch to the repository for
+/// configuration mutations.
+///
+/// Mirrors `RelayerSettingsFlow` shape but smaller: no published-list
+/// fetch (we ship a single hardcoded default in
+/// `NostrRelaysConfiguration.seed`), no primary/strategy concept
+/// (Nostr fanout-publishes to every configured relay).
+@MainActor
+@Observable
+final class NostrRelaySettingsFlow {
+    /// Combined snapshot from the repository plus the custom-URL
+    /// draft the user is currently typing. Draft is local-only
+    /// until they tap Add.
+    struct State: Equatable {
+        var snapshot: NostrRelaysConfiguration
+        var customDraft: String
+        var customDraftError: String?
+    }
+
+    private(set) var state: State
+
+    private let repository: NostrRelaysRepository
+    private var snapshotTask: Task<Void, Never>?
+
+    init(repository: NostrRelaysRepository) {
+        self.repository = repository
+        self.state = State(snapshot: .empty, customDraft: "", customDraftError: nil)
+    }
+
+    /// Begin draining repository snapshots. Idempotent.
+    func start() {
+        guard snapshotTask == nil else { return }
+        snapshotTask = Task { [weak self] in
+            guard let self else { return }
+            for await snapshot in self.repository.snapshots {
+                self.state.snapshot = snapshot
+            }
+        }
+    }
+
+    func stop() {
+        snapshotTask?.cancel()
+        snapshotTask = nil
+    }
+
+    // MARK: - Intents
+
+    func customDraftChanged(_ text: String) {
+        state.customDraft = text
+        state.customDraftError = nil
+    }
+
+    /// Tap the Add button next to the custom-URL field. Validates
+    /// `wss://` / `ws://` scheme + non-empty host.
+    func tappedAddCustom() {
+        let trimmed = state.customDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = Self.validate(trimmed) else {
+            state.customDraftError = String(localized: "Enter a valid wss:// URL")
+            return
+        }
+        let endpoint = NostrRelayEndpoint.custom(url: url)
+        state.customDraft = ""
+        Task { await repository.addEndpoint(endpoint) }
+    }
+
+    /// Swipe-to-delete on a configured row.
+    func tappedRemove(url: URL) {
+        Task { await repository.removeEndpoint(url: url) }
+    }
+
+    /// Restore default — re-installs the Onym Official seed and
+    /// clears the user-interaction flag so the seed sticks across
+    /// future relaunches.
+    func tappedResetToDefault() {
+        Task { await repository.resetToDefault() }
+    }
+
+    // MARK: - Private
+
+    /// Permissive WebSocket URL validation: must parse, must have
+    /// `wss` or `ws` scheme (the latter for local dev / loopback),
+    /// must have a non-empty host.
+    static func validate(_ raw: String) -> URL? {
+        guard let url = URL(string: raw),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "wss" || scheme == "ws",
+              let host = url.host(), !host.isEmpty
+        else { return nil }
+        return url
+    }
+}

--- a/Sources/OnymIOS/Settings/NostrRelaySettingsView.swift
+++ b/Sources/OnymIOS/Settings/NostrRelaySettingsView.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+
+/// Settings → Transport → Nostr Relays. Lists configured Nostr
+/// WebSocket endpoints, lets the user add a custom URL or remove
+/// any entry, and surfaces a "Restore default" affordance that
+/// re-installs the Onym Official seed.
+///
+/// V1 limitation: changes apply on the next app launch — the inbox
+/// transport reads endpoints once at boot. A footnote at the bottom
+/// of the screen surfaces this. Live re-connect lands when WebSocket
+/// reconnect-on-config-change is wired in a follow-up.
+struct NostrRelaySettingsView: View {
+    @State private var flow: NostrRelaySettingsFlow
+
+    init(flow: NostrRelaySettingsFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SettingsLargeTitle("Nostr Relays")
+
+                SettingsSectionLabel(
+                    "CONFIGURED · \(flow.state.snapshot.endpoints.count)"
+                )
+                configuredCard
+
+                SettingsSectionLabel("ADD CUSTOM URL")
+                customURLCard
+                SettingsFootnote(
+                    "Use a private deployment, localhost, or any Nostr relay you trust. URLs must use the wss:// (or ws://) scheme."
+                )
+
+                resetCard
+                SettingsFootnote(
+                    "Changes apply on the next app launch. The inbox transport reads relays once at boot."
+                )
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .navigationTitle("Nostr Relays")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { flow.start() }
+    }
+
+    // MARK: - Configured list
+
+    @ViewBuilder
+    private var configuredCard: some View {
+        let endpoints = flow.state.snapshot.endpoints
+        SettingsCard {
+            if endpoints.isEmpty {
+                Text("No relays configured. Inbox transport is offline.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text3)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 16).padding(.vertical, 14)
+                    .accessibilityIdentifier("nostr.configured.empty")
+            } else {
+                ForEach(Array(endpoints.enumerated()), id: \.element.url) { idx, endpoint in
+                    HStack(spacing: 12) {
+                        SettingsIconTile(
+                            symbol: "antenna.radiowaves.left.and.right",
+                            bg: SettingsTile.indigo
+                        )
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 6) {
+                                Text(endpoint.name)
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .foregroundStyle(OnymTokens.text)
+                                if endpoint.isDefault {
+                                    Text("DEFAULT")
+                                        .font(.system(size: 10, weight: .bold))
+                                        .foregroundStyle(OnymTokens.text2)
+                                        .padding(.horizontal, 6)
+                                        .padding(.vertical, 2)
+                                        .background(
+                                            OnymTokens.surface3,
+                                            in: RoundedRectangle(cornerRadius: 4)
+                                        )
+                                }
+                            }
+                            Text(endpoint.url.absoluteString)
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundStyle(OnymTokens.text3)
+                                .lineLimit(1)
+                        }
+                        Spacer(minLength: 0)
+                        Button {
+                            flow.tappedRemove(url: endpoint.url)
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                                .font(.system(size: 22))
+                                .foregroundStyle(OnymTokens.red)
+                        }
+                        .accessibilityLabel("Remove \(endpoint.name)")
+                        .accessibilityIdentifier("nostr.configured.remove.\(endpoint.url.absoluteString)")
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    if idx != endpoints.count - 1 {
+                        Divider()
+                            .background(OnymTokens.hairline)
+                            .padding(.leading, 56)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Custom URL add
+
+    private var customURLCard: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    TextField(
+                        "wss://relay.example.com",
+                        text: Binding(
+                            get: { flow.state.customDraft },
+                            set: { flow.customDraftChanged($0) }
+                        )
+                    )
+                    .textFieldStyle(.plain)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundStyle(OnymTokens.text)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 10)
+                    .background(
+                        OnymTokens.surface3,
+                        in: RoundedRectangle(cornerRadius: 8)
+                    )
+                    .accessibilityIdentifier("nostr.add.custom_url_field")
+                    Button {
+                        flow.tappedAddCustom()
+                    } label: {
+                        Text("Add")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(OnymTokens.onAccent)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                            .background(
+                                OnymAccent.blue.color,
+                                in: RoundedRectangle(cornerRadius: 8)
+                            )
+                    }
+                    .accessibilityIdentifier("nostr.add.custom_button")
+                }
+                if let error = flow.state.customDraftError {
+                    Text(error)
+                        .font(.system(size: 12))
+                        .foregroundStyle(OnymTokens.red)
+                        .accessibilityIdentifier("nostr.add.custom_error")
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    // MARK: - Reset
+
+    private var resetCard: some View {
+        SettingsCard {
+            Button {
+                flow.tappedResetToDefault()
+            } label: {
+                HStack {
+                    SettingsIconTile(
+                        symbol: "arrow.counterclockwise",
+                        bg: SettingsTile.gray
+                    )
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Restore default")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text)
+                        Text("Re-install Onym Official as the only relay.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("nostr.reset_default")
+        }
+    }
+}

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct SettingsView: View {
     let makeBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
     let makeRelayerSettingsFlow: @MainActor () -> RelayerSettingsFlow
+    let makeNostrRelaySettingsFlow: @MainActor () -> NostrRelaySettingsFlow
     let makeAnchorsPickerFlow: @MainActor () -> AnchorsPickerFlow
     let identitiesFlow: IdentitiesFlow
 
@@ -110,6 +111,48 @@ struct SettingsView: View {
                             .tint(OnymTokens.green)
                             .accessibilityIdentifier("settings.use_mainnet_toggle")
                     }
+                }
+
+                SettingsSectionLabel("TRANSPORT")
+                SettingsCard {
+                    NavigationLink {
+                        NostrRelaySettingsView(flow: makeNostrRelaySettingsFlow())
+                    } label: {
+                        SettingsRow(
+                            title: "Nostr Relays",
+                            subtitle: "Inbox + invitation transport"
+                        ) {
+                            SettingsIconTile(
+                                symbol: "antenna.radiowaves.left.and.right.circle.fill",
+                                bg: SettingsTile.indigo
+                            )
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("settings.nostr_relays_row")
+
+                    SettingsRow(
+                        title: "Tor (Hidden Service)",
+                        subtitle: "Coming soon",
+                        hasChevron: false,
+                        last: true
+                    ) {
+                        SettingsIconTile(
+                            symbol: "shield.lefthalf.filled",
+                            bg: SettingsTile.gray
+                        )
+                    } right: {
+                        Text("TBA")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundStyle(OnymTokens.text3)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                OnymTokens.surface3,
+                                in: RoundedRectangle(cornerRadius: 4)
+                            )
+                    }
+                    .accessibilityIdentifier("settings.tor_row")
                 }
 
                 SettingsSectionLabel("APP")

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayEndpoint.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayEndpoint.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// One Nostr-relay entry the inbox transport connects to. Pure value
+/// type — no behaviour, just the wire shape persisted in UserDefaults.
+///
+/// Distinct from the chain-side `RelayerEndpoint` because the two
+/// transports talk to completely different services:
+///   - `RelayerEndpoint` → HTTPS Soroban contract proxy
+///     (`POST https://relayer.onym.chat/`).
+///   - `NostrRelayEndpoint` → Nostr WebSocket relay (strfry behind
+///     nginx at `wss://nostr.onym.chat`).
+///
+/// Sharing the type would couple two unrelated concerns and force
+/// the manifest schema to track both — cleaner to keep them apart.
+struct NostrRelayEndpoint: Codable, Equatable, Hashable, Identifiable, Sendable {
+    /// Display label. Defaults to the URL's host for user-added
+    /// entries; the app-shipped seed carries a friendlier name.
+    let name: String
+    /// `wss://` (or `ws://` for local dev) URL of the relay.
+    let url: URL
+    /// `true` for the app-shipped default seed, `false` for entries
+    /// the user added in Settings. UI uses this to render a small
+    /// "Default" badge so the user can distinguish their own
+    /// additions from what shipped with the app.
+    let isDefault: Bool
+
+    /// Stable id for SwiftUI list diffing — URL is the natural key.
+    var id: URL { url }
+
+    /// Convenience for synthesising an entry from a custom URL the
+    /// user typed. Name defaults to the URL's host so the row is
+    /// recognisable even before the user gives it a friendlier label.
+    static func custom(url: URL) -> NostrRelayEndpoint {
+        NostrRelayEndpoint(
+            name: url.host() ?? url.absoluteString,
+            url: url,
+            isDefault: false
+        )
+    }
+}

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelaysConfiguration.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelaysConfiguration.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Persisted Nostr-relay configuration. Single field — the list of
+/// relays the inbox transport should connect to — plus a sticky
+/// "user has interacted" flag so the next app boot doesn't re-seed
+/// the default if the user explicitly cleared the list.
+///
+/// V1 connects to **every** configured endpoint at the same time;
+/// there's no primary/strategy concept like the chain relayer has.
+/// Nostr fanout is by design: clients publish to and listen on all
+/// configured relays so a single relay outage doesn't drop traffic.
+struct NostrRelaysConfiguration: Codable, Equatable, Sendable {
+    var endpoints: [NostrRelayEndpoint]
+    /// Flips to `true` after the first user mutation (add / remove).
+    /// Sticky — once set, the seed-on-empty logic in
+    /// `NostrRelaysRepository.init` never re-fires, so a user who
+    /// clears the list keeps an empty list across launches.
+    var hasUserInteracted: Bool
+
+    static let empty = NostrRelaysConfiguration(
+        endpoints: [],
+        hasUserInteracted: false
+    )
+
+    /// App-shipped default — single Onym-operated relay. Used at
+    /// first launch (or any launch where the persisted config is
+    /// empty AND `hasUserInteracted` is false).
+    static let seed = NostrRelaysConfiguration(
+        endpoints: [
+            NostrRelayEndpoint(
+                name: "Onym Official",
+                url: URL(string: "wss://nostr.onym.chat")!,
+                isDefault: true
+            )
+        ],
+        hasUserInteracted: false
+    )
+}

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelaysRepository.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelaysRepository.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Owns the user's Nostr-relay configuration. Mirrors
+/// `RelayerRepository` shape: `actor` with snapshot replay on
+/// subscribe + a fresh push after every mutation.
+///
+/// Lifecycle:
+///   1. `OnymIOSApp.init` constructs the repository with the
+///      UserDefaults-backed store.
+///   2. On init, if the persisted config is empty and the user
+///      hasn't interacted yet, seed with `.seed` (Onym's official
+///      relay). This is the "first launch" path; subsequent launches
+///      restore the user's actual list (which may be empty if they
+///      removed every entry — `hasUserInteracted = true` keeps it
+///      that way).
+///   3. App `.task` reads `currentEndpoints()` once at boot and
+///      passes them to `NostrInboxTransport.connect(to:)`.
+///   4. Settings → Transport → Nostr drives `addEndpoint` /
+///      `removeEndpoint`. Changes apply on the next app launch
+///      (V1 doesn't reactively reconnect — Settings shows a banner).
+actor NostrRelaysRepository {
+    private let store: any NostrRelaysSelectionStore
+
+    private var cached: NostrRelaysConfiguration
+    private var continuations: [UUID: AsyncStream<NostrRelaysConfiguration>.Continuation] = [:]
+
+    init(store: any NostrRelaysSelectionStore) {
+        self.store = store
+        let loaded = store.load()
+        // First-launch seed: empty config + no prior user interaction
+        // → install the app's default relay. Sticky once the user
+        // touches the list (mutations flip `hasUserInteracted`).
+        if loaded.endpoints.isEmpty && !loaded.hasUserInteracted {
+            self.cached = .seed
+            store.save(.seed)
+        } else {
+            self.cached = loaded
+        }
+    }
+
+    // MARK: - Read
+
+    /// Snapshot of the configured endpoints. Used at app boot to
+    /// pass into `NostrInboxTransport.connect(to:)`.
+    func currentEndpoints() -> [NostrRelayEndpoint] {
+        cached.endpoints
+    }
+
+    func currentConfiguration() -> NostrRelaysConfiguration {
+        cached
+    }
+
+    // MARK: - Mutations
+
+    /// Idempotent on URL — re-adding an existing URL replaces its
+    /// metadata (display name) but doesn't duplicate the row.
+    /// Returns true on insert, false on update.
+    @discardableResult
+    func addEndpoint(_ endpoint: NostrRelayEndpoint) -> Bool {
+        var endpoints = cached.endpoints
+        let inserted: Bool
+        if let index = endpoints.firstIndex(where: { $0.url == endpoint.url }) {
+            endpoints[index] = endpoint
+            inserted = false
+        } else {
+            endpoints.append(endpoint)
+            inserted = true
+        }
+        applyConfiguration(NostrRelaysConfiguration(
+            endpoints: endpoints,
+            hasUserInteracted: true
+        ))
+        return inserted
+    }
+
+    func removeEndpoint(url: URL) {
+        let endpoints = cached.endpoints.filter { $0.url != url }
+        applyConfiguration(NostrRelaysConfiguration(
+            endpoints: endpoints,
+            hasUserInteracted: true
+        ))
+    }
+
+    /// Drop every entry. Sets `hasUserInteracted = true` so the next
+    /// launch doesn't re-seed.
+    func clearAll() {
+        applyConfiguration(NostrRelaysConfiguration(
+            endpoints: [],
+            hasUserInteracted: true
+        ))
+    }
+
+    /// Reset to the app-shipped default. Useful as a "restore
+    /// defaults" affordance in Settings; resets
+    /// `hasUserInteracted = false` so the seed sticks even if the
+    /// user later clears + relaunches.
+    func resetToDefault() {
+        applyConfiguration(.seed)
+    }
+
+    // MARK: - Subscriptions
+
+    nonisolated var snapshots: AsyncStream<NostrRelaysConfiguration> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func applyConfiguration(_ configuration: NostrRelaysConfiguration) {
+        store.save(configuration)
+        cached = configuration
+        publish()
+    }
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<NostrRelaysConfiguration>.Continuation
+    ) {
+        continuations[id] = continuation
+        continuation.yield(cached)
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func publish() {
+        for continuation in continuations.values {
+            continuation.yield(cached)
+        }
+    }
+}

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelaysSelectionStore.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelaysSelectionStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Persistence seam for the Nostr-relays configuration. Mirrors
+/// `RelayerSelectionStore`'s shape — UserDefaults-backed, no
+/// secrets so Keychain would be over-rotation, isolated key prefix
+/// (`chat.onym.ios.nostr.*`) so other consumers can't collide.
+protocol NostrRelaysSelectionStore: Sendable {
+    func load() -> NostrRelaysConfiguration
+    func save(_ configuration: NostrRelaysConfiguration)
+}
+
+/// Production store. UserDefaults-backed; defaults to `.standard` but
+/// injectable so tests get an isolated suite.
+struct UserDefaultsNostrRelaysSelectionStore: NostrRelaysSelectionStore, @unchecked Sendable {
+    private static let configurationKey = "chat.onym.ios.nostr.configuration"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load() -> NostrRelaysConfiguration {
+        guard let data = defaults.data(forKey: Self.configurationKey),
+              let config = try? JSONDecoder().decode(
+                NostrRelaysConfiguration.self,
+                from: data
+              )
+        else {
+            return .empty
+        }
+        return config
+    }
+
+    func save(_ configuration: NostrRelaysConfiguration) {
+        if let data = try? JSONEncoder().encode(configuration) {
+            defaults.set(data, forKey: Self.configurationKey)
+        }
+    }
+}
+
+/// Test-only in-memory store. Lets unit tests assert add/remove
+/// behavior without touching the real UserDefaults database.
+final class InMemoryNostrRelaysSelectionStore: NostrRelaysSelectionStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: NostrRelaysConfiguration
+
+    init(initial: NostrRelaysConfiguration = .empty) {
+        self.stored = initial
+    }
+
+    func load() -> NostrRelaysConfiguration {
+        lock.withLock { stored }
+    }
+
+    func save(_ configuration: NostrRelaysConfiguration) {
+        lock.withLock { stored = configuration }
+    }
+}

--- a/Tests/OnymIOSTests/NostrRelaySettingsFlowTests.swift
+++ b/Tests/OnymIOSTests/NostrRelaySettingsFlowTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import OnymIOS
+
+@MainActor
+final class NostrRelaySettingsFlowTests: XCTestCase {
+
+    func test_validate_acceptsWssAndWs() {
+        XCTAssertNotNil(NostrRelaySettingsFlow.validate("wss://relay.example.com"))
+        XCTAssertNotNil(NostrRelaySettingsFlow.validate("ws://localhost:7777"))
+    }
+
+    func test_validate_rejectsHttpAndBareString() {
+        XCTAssertNil(NostrRelaySettingsFlow.validate("https://relay.example.com"),
+                     "https not accepted — Nostr is WebSocket-only")
+        XCTAssertNil(NostrRelaySettingsFlow.validate("relay.example.com"),
+                     "no scheme not accepted")
+        XCTAssertNil(NostrRelaySettingsFlow.validate(""))
+        XCTAssertNil(NostrRelaySettingsFlow.validate("wss://"),
+                     "missing host not accepted")
+    }
+
+    func test_tappedAddCustom_invalidURL_setsErrorAndKeepsDraft() async throws {
+        let store = InMemoryNostrRelaysSelectionStore(initial: .empty)
+        let repo = NostrRelaysRepository(store: store)
+        let flow = NostrRelaySettingsFlow(repository: repo)
+        flow.customDraftChanged("https://wrong-scheme")
+        flow.tappedAddCustom()
+        XCTAssertNotNil(flow.state.customDraftError)
+        XCTAssertEqual(flow.state.customDraft, "https://wrong-scheme",
+                       "draft must be kept so the user can edit")
+    }
+
+    func test_tappedAddCustom_validURL_clearsDraftAndAdds() async throws {
+        let store = InMemoryNostrRelaysSelectionStore(initial: .empty)
+        let repo = NostrRelaysRepository(store: store)
+        let flow = NostrRelaySettingsFlow(repository: repo)
+        flow.customDraftChanged("wss://relay.example.com")
+        flow.tappedAddCustom()
+        // Draft cleared synchronously on success.
+        XCTAssertEqual(flow.state.customDraft, "")
+        XCTAssertNil(flow.state.customDraftError)
+        // Repo mutation goes through Task — wait briefly.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertTrue(endpoints.contains { $0.url.absoluteString == "wss://relay.example.com" })
+    }
+
+    func test_start_drainsRepositorySnapshotsIntoState() async throws {
+        let store = InMemoryNostrRelaysSelectionStore(initial: .empty)
+        let repo = NostrRelaysRepository(store: store)
+        let flow = NostrRelaySettingsFlow(repository: repo)
+        flow.start()
+        try await waitFor { flow.state.snapshot.endpoints.count == 1 }
+    }
+
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        _ predicate: @MainActor @escaping () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTFail("Timed out", file: file, line: line)
+    }
+}

--- a/Tests/OnymIOSTests/NostrRelaysRepositoryTests.swift
+++ b/Tests/OnymIOSTests/NostrRelaysRepositoryTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for `NostrRelaysRepository` covering the
+/// first-launch seed, mutation idempotency, and reset-to-default.
+final class NostrRelaysRepositoryTests: XCTestCase {
+
+    // MARK: - First-launch seed
+
+    func test_init_emptyStore_seedsWithOnymOfficial() async {
+        let store = InMemoryNostrRelaysSelectionStore(initial: .empty)
+        let repo = NostrRelaysRepository(store: store)
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.count, 1)
+        XCTAssertEqual(endpoints.first?.url.absoluteString, "wss://nostr.onym.chat")
+        XCTAssertTrue(endpoints.first?.isDefault ?? false,
+                      "seeded entry must carry isDefault = true")
+    }
+
+    func test_init_userInteractedEmpty_doesNotReseed() async {
+        // User explicitly cleared the list on a prior launch — the
+        // sticky `hasUserInteracted` flag must keep the list empty.
+        let store = InMemoryNostrRelaysSelectionStore(
+            initial: NostrRelaysConfiguration(endpoints: [], hasUserInteracted: true)
+        )
+        let repo = NostrRelaysRepository(store: store)
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertTrue(endpoints.isEmpty,
+                      "post-clear empty config must NOT re-seed")
+    }
+
+    func test_init_userInteractedNonEmpty_preservesUserList() async {
+        let custom = NostrRelayEndpoint(
+            name: "my relay",
+            url: URL(string: "wss://relay.example.com")!,
+            isDefault: false
+        )
+        let store = InMemoryNostrRelaysSelectionStore(
+            initial: NostrRelaysConfiguration(
+                endpoints: [custom],
+                hasUserInteracted: true
+            )
+        )
+        let repo = NostrRelaysRepository(store: store)
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints, [custom])
+    }
+
+    // MARK: - addEndpoint
+
+    func test_addEndpoint_inserts_andFlipsUserInteracted() async {
+        let store = InMemoryNostrRelaysSelectionStore(initial: .empty)
+        let repo = NostrRelaysRepository(store: store)
+        // Init seeded → 1 entry.
+        let custom = NostrRelayEndpoint.custom(url: URL(string: "wss://relay.example.com")!)
+        let inserted = await repo.addEndpoint(custom)
+        XCTAssertTrue(inserted)
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.count, 2)
+        // Persisted with hasUserInteracted = true.
+        XCTAssertTrue(store.load().hasUserInteracted)
+    }
+
+    func test_addEndpoint_dedupesOnURL() async {
+        let store = InMemoryNostrRelaysSelectionStore(initial: .empty)
+        let repo = NostrRelaysRepository(store: store)
+        let custom = NostrRelayEndpoint.custom(url: URL(string: "wss://x.com")!)
+        _ = await repo.addEndpoint(custom)
+        let inserted = await repo.addEndpoint(custom)
+        XCTAssertFalse(inserted, "duplicate URL must not insert again")
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.filter { $0.url == custom.url }.count, 1)
+    }
+
+    // MARK: - removeEndpoint
+
+    func test_removeEndpoint_dropsTheRow_andFlipsUserInteracted() async {
+        let store = InMemoryNostrRelaysSelectionStore(initial: .empty)
+        let repo = NostrRelaysRepository(store: store)
+        let seedURL = URL(string: "wss://nostr.onym.chat")!
+        await repo.removeEndpoint(url: seedURL)
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertTrue(endpoints.isEmpty)
+        XCTAssertTrue(store.load().hasUserInteracted)
+    }
+
+    // MARK: - resetToDefault
+
+    func test_resetToDefault_reinstallsSeed_andClearsInteractionFlag() async {
+        let store = InMemoryNostrRelaysSelectionStore(
+            initial: NostrRelaysConfiguration(endpoints: [], hasUserInteracted: true)
+        )
+        let repo = NostrRelaysRepository(store: store)
+        // Pre-condition: empty + sticky.
+        let preEndpoints = await repo.currentEndpoints()
+        XCTAssertTrue(preEndpoints.isEmpty)
+
+        await repo.resetToDefault()
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.count, 1)
+        XCTAssertEqual(endpoints.first?.isDefault, true)
+        XCTAssertFalse(store.load().hasUserInteracted,
+                       "resetToDefault must clear hasUserInteracted so the seed sticks")
+    }
+
+    // MARK: - snapshots stream
+
+    func test_snapshots_emitsOnEveryMutation() async throws {
+        let store = InMemoryNostrRelaysSelectionStore(initial: .empty)
+        let repo = NostrRelaysRepository(store: store)
+        let stream = repo.snapshots
+        var iterator = stream.makeAsyncIterator()
+
+        // Initial snapshot (replay of seed).
+        let s0 = await iterator.next()
+        XCTAssertEqual(s0?.endpoints.count, 1)
+
+        await repo.addEndpoint(NostrRelayEndpoint.custom(url: URL(string: "wss://a.example")!))
+        let s1 = await iterator.next()
+        XCTAssertEqual(s1?.endpoints.count, 2)
+
+        await repo.removeEndpoint(url: URL(string: "wss://a.example")!)
+        let s2 = await iterator.next()
+        XCTAssertEqual(s2?.endpoints.count, 1)
+    }
+}


### PR DESCRIPTION
## Summary

PR 12 of the new-member announcement stack. Stacked on #86. **Closes the \"Couldn't send: not connected\" runtime failure** by giving the inbox transport actual relays to connect to and surfacing config in Settings.

The original gap: nothing in the app was calling `NostrInboxTransport.connect(to:)`. `send` threw `TransportError.notConnected` and `subscribe` silently no-op'd because `connections` was empty. Both legs of the inbox were dead from boot.

### What changes

**Data layer** (mirrors `RelayerRepository` shape, simpler — no fetch, no primary, no strategy):

- `NostrRelayEndpoint` — value type, `wss://` URL + display name + `isDefault` flag for UI badging. Distinct from `RelayerEndpoint` (chain relayer at `relayer.onym.chat`); Nostr relay is a separate service at `nostr.onym.chat` (strfry behind nginx).
- `NostrRelaysConfiguration` — `{ endpoints, hasUserInteracted }`. Sticky interaction flag prevents re-seeding after the user clears the list.
- `NostrRelaysSelectionStore` protocol + `UserDefaultsNostrRelaysSelectionStore` (production) + `InMemoryNostrRelaysSelectionStore` (tests).
- `NostrRelaysRepository` actor — first-launch seed with the Onym Official relay (`wss://nostr.onym.chat`); add / remove / clear / reset intents; `snapshots` stream.

**Wiring**:

- `OnymIOSApp` constructs the repo and reads `currentEndpoints()` in the WindowGroup `.task` **before** `InboxFanoutInteractor.run()`. The single missing call.
- `AppDependencies` + `RootView` + `SettingsView` pass through a `makeNostrRelaySettingsFlow` factory.

**UI**:

- `NostrRelaySettingsFlow` `@Observable` view-model (add / remove / reset).
- `NostrRelaySettingsView` — list with `DEFAULT` badge on app-shipped entries, custom-URL field with inline `wss://`/`ws://` validation, \"Restore default\" affordance.
- New **TRANSPORT** section in Settings between NETWORK and APP:
  - **Nostr Relays** (working) → drills into the new screen.
  - **Tor (Hidden Service)** — TBA placeholder row, disabled, \"Coming soon\" subtitle.

### V1 limitation

Changes apply on **next app launch** only — the inbox transport reads endpoints once at boot. Footnote on the screen calls this out. Live re-connect on config change lands in a follow-up alongside WebSocket reconnect-on-graph-change.

### Test plan

- [x] 13 new tests:
  - 8 `NostrRelaysRepositoryTests` — first-launch seed, sticky interaction flag, idempotent add, remove, reset, snapshots stream.
  - 5 `NostrRelaySettingsFlowTests` — `wss`/`ws` accept, `http`/bare reject, invalid-URL keeps draft + sets error, valid-URL clears + dispatches, snapshots drain into `state`.
- [x] Build green; full unit suite — 496/496 pass (3 skipped, pre-existing).
- [ ] **Manual smoke** (the original problem): with this PR installed, run the original Phase 2 of the smoke plan again — joiner taps invite link, taps Send, no \"not connected\" error, sheet flips to \"Waiting for the host to approve\". Admin sees the request, taps Approve, joiner gets \"You're in!\".
- [ ] Manual: open Settings → Transport → Nostr Relays. Verify Onym Official appears with DEFAULT badge. Add a custom relay (e.g. `wss://relay.damus.io`), confirm it lands. Remove it. Tap Restore default to confirm reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)