### PR TITLE
feat(group): admin anchors update_commitment on approve (PR 13a)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -385,6 +385,22 @@
         }
       }
     },
+    "Add" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить"
+          }
+        }
+      }
+    },
     "Add Custom URL" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1154,6 +1170,22 @@
         }
       }
     },
+    "DEFAULT" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEFAULT"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ПО УМОЛЧАНИЮ"
+          }
+        }
+      }
+    },
     "Democracy" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1769,6 +1801,22 @@
         }
       }
     },
+    "No relays configured. Inbox transport is offline." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No relays configured. Inbox transport is offline."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет настроенных релеев. Транспорт входящих сообщений отключён."
+          }
+        }
+      }
+    },
     "Nostr (npub)" : {
       "localizations" : {
         "en" : {
@@ -2096,6 +2144,22 @@
         }
       }
     },
+    "Re-install Onym Official as the only relay." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Re-install Onym Official as the only relay."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Восстановить Onym Official как единственный релей."
+          }
+        }
+      }
+    },
     "Read the docs" : {
       "localizations" : {
         "en" : {
@@ -2256,6 +2320,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сбросить к значению по умолчанию (последняя версия)"
+          }
+        }
+      }
+    },
+    "Restore default" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore default"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить к умолчаниям"
           }
         }
       }
@@ -2613,6 +2693,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нажмите, чтобы показать"
+          }
+        }
+      }
+    },
+    "TBA" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TBA"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "СКОРО"
           }
         }
       }

--- a/Sources/OnymIOS/Chain/GroupProofGenerator.swift
+++ b/Sources/OnymIOS/Chain/GroupProofGenerator.swift
@@ -30,11 +30,67 @@ struct GroupCreateProof: Equatable, Sendable {
 
 /// PR-B's chain seam for proof generation. Switches on `groupType` so
 /// that PR-C's interactor doesn't need to import OnymSDK directly. Only
-/// `.tyranny` is wired in this slice — the other governance types
-/// throw `notYetSupported`, which the UI surfaces as a clear "TBD"
-/// message rather than a silent fallback.
+/// `.tyranny` is wired for `proveUpdate` (PR 13a) — joiner admission
+/// is admin-only by contract design.
 protocol GroupProofGenerator: Sendable {
     func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof
+    /// Generate a Tyranny `update_commitment` proof for adding one
+    /// member to an existing group's tree. Wraps
+    /// `Tyranny.proveUpdate(...)` with the iOS calling convention.
+    /// Throws `notYetSupported` for non-Tyranny group types.
+    func proveUpdate(_ input: GroupProofUpdateInput) throws -> GroupUpdateProof
+}
+
+/// Output of `GroupProofGenerator.proveUpdate`. Same wire-shape
+/// invariant as `GroupCreateProof`: relayer expects the raw
+/// 1601-byte PLONK proof + the SDK's full PI bundle split into
+/// 32-byte chunks. Tyranny update returns 5 chunks
+/// (`c_old || epoch_old_be || c_new || admin_pubkey_commitment ||
+/// group_id_fr`).
+struct GroupUpdateProof: Equatable, Sendable {
+    let proof: Data
+    let publicInputs: [Data]
+
+    /// Bytes 64..96 of the PI bundle — the new commitment the
+    /// contract will store after verifying.
+    var commitmentNew: Data { publicInputs[2] }
+    /// `epoch_old + 1` — the epoch the contract advances to. The
+    /// proof binds `epoch_old` (PI[1]); the new epoch is implicit
+    /// in the contract's `update_commitment` arm.
+    func epochNew(epochOld: UInt64) -> UInt64 { epochOld + 1 }
+}
+
+/// Inputs for a Tyranny update-commitment proof. Mirrors
+/// `Tyranny.proveUpdate(...)`'s SDK shape.
+///
+/// - `oldMembers`: roster as it stands before the join (lex-sorted
+///   by `publicKeyCompressed`). Admin's position determined from
+///   this list.
+/// - `adminBlsSecretKey`: 32-byte BE BLS Fr scalar.
+/// - `adminIndexOld`: position of the admin's leaf in the OLD sorted
+///   roster (the proof witnesses admin membership at that index).
+/// - `epochOld`: current on-chain epoch.
+/// - `memberRootNew`: 32-byte Poseidon root of the NEW tree
+///   (post-join). Computed externally by the caller via
+///   `Common.merkleRoot(...)`.
+/// - `groupID`: 32-byte raw group ID (`group_id_fr` binding).
+/// - `tier`: depth selector — must match the depth used at create
+///   time + at every prior update for the proof to verify against
+///   the correct VK.
+/// - `saltOld` / `saltNew`: 32-byte fresh salts. `saltOld` was used
+///   for the previous commitment; `saltNew` is freshly minted by
+///   the admin per update to bind the new root.
+struct GroupProofUpdateInput: Sendable {
+    let groupType: SEPGroupType
+    let tier: SEPTier
+    let oldMembers: [GovernanceMember]
+    let adminBlsSecretKey: Data
+    let adminIndexOld: Int
+    let epochOld: UInt64
+    let memberRootNew: Data
+    let groupID: Data
+    let saltOld: Data
+    let saltNew: Data
 }
 
 /// Inputs for a create-group proof. Per-type field requirements:
@@ -94,6 +150,64 @@ struct OnymGroupProofGenerator: GroupProofGenerator {
         case .democracy, .oligarchy:
             throw GroupProofGeneratorError.notYetSupported(input.groupType)
         }
+    }
+
+    func proveUpdate(_ input: GroupProofUpdateInput) throws -> GroupUpdateProof {
+        switch input.groupType {
+        case .tyranny:
+            return try proveTyrannyUpdate(input)
+        case .oneOnOne, .anarchy, .democracy, .oligarchy:
+            // Only Tyranny supports admin-driven updates in this
+            // PR. Anarchy will need its own arm later (any-member
+            // update); OneOnOne is fixed 2-party.
+            throw GroupProofGeneratorError.notYetSupported(input.groupType)
+        }
+    }
+
+    private func proveTyrannyUpdate(_ input: GroupProofUpdateInput) throws -> GroupUpdateProof {
+        guard input.adminIndexOld >= 0, input.adminIndexOld < input.oldMembers.count else {
+            throw GroupProofGeneratorError.adminIndexOutOfRange(
+                index: input.adminIndexOld,
+                count: input.oldMembers.count
+            )
+        }
+        var packedOld = Data(capacity: input.oldMembers.count * 32)
+        for member in input.oldMembers {
+            packedOld.append(member.leafHash)
+        }
+
+        let result: Tyranny.UpdateProof
+        do {
+            result = try Tyranny.proveUpdate(
+                depth: input.tier.depth,
+                memberLeafHashesOld: packedOld,
+                adminSecretKey: input.adminBlsSecretKey,
+                adminIndexOld: input.adminIndexOld,
+                epochOld: input.epochOld,
+                memberRootNew: input.memberRootNew,
+                groupIdFr: input.groupID,
+                saltOld: input.saltOld,
+                saltNew: input.saltNew
+            )
+        } catch {
+            throw GroupProofGeneratorError.sdkFailure(String(describing: error))
+        }
+
+        // PI bundle layout (`Tyranny.UpdateProof.publicInputs`, 160 B):
+        //   c_old(32) || epoch_old_be(32) || c_new(32) ||
+        //   admin_pubkey_commitment(32) || group_id_fr(32)
+        // Each 32-byte chunk maps to one `BytesN<32>` in the contract's
+        // 5-element `Vec<BytesN<32>>` public-inputs argument.
+        let bundle = result.publicInputs
+        guard bundle.count == 160 else {
+            throw GroupProofGeneratorError.sdkFailure(
+                "expected 160-byte update PI bundle, got \(bundle.count)"
+            )
+        }
+        let chunks: [Data] = stride(from: 0, to: bundle.count, by: 32).map { offset in
+            Data(bundle[offset..<(offset + 32)])
+        }
+        return GroupUpdateProof(proof: result.proof, publicInputs: chunks)
     }
 
     /// Anarchy create: there's no dedicated `proveCreate` SDK call —

--- a/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
@@ -80,6 +80,16 @@ final class ApproveRequestsFlow {
             return "Sign in first."
         case .transportFailed(let reason):
             return "Couldn\u{2019}t send: \(reason)"
+        case .outdatedJoinerClient:
+            return "Joiner is on an outdated app. Ask them to update."
+        case .noActiveRelayer:
+            return "No chain relayer configured. Set one in Settings \u{2192} Network \u{2192} Relayer."
+        case .noContractBinding:
+            return "No Tyranny contract selected for this network. Pick one in Settings \u{2192} Network \u{2192} Anchors."
+        case .proofFailed(let reason):
+            return "Couldn\u{2019}t generate proof: \(reason)"
+        case .anchorRejected(let reason):
+            return "Chain rejected the proof: \(reason)"
         }
     }
 }

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -45,6 +45,13 @@ actor JoinRequestApprover: JoinRequestApproving {
         /// back, but skips the local roster update because there's
         /// no stable cross-device key to record under.
         let joinerBlsPublicKey: Data?
+        /// 32-byte Poseidon leaf hash. Required for Tyranny approve:
+        /// the admin can't generate the on-chain `update_commitment`
+        /// proof without it (it's the joiner's leaf in the new tree).
+        /// `nil` when the joiner shipped a pre-PR-13 request — those
+        /// requests can't be approved on-chain and surface as
+        /// `.outdatedJoinerClient`.
+        let joinerLeafHash: Data?
         let joinerDisplayLabel: String
         let groupId: Data
         /// Looked up from the local `GroupRepository`. nil if the
@@ -60,6 +67,25 @@ actor JoinRequestApprover: JoinRequestApproving {
         case unknownRequest
         case noIdentityLoaded
         case transportFailed(String)
+        /// Joiner shipped a pre-PR-13 request without `joiner_leaf_hash`.
+        /// Admin can't extend the on-chain tree without it; user must
+        /// ask the joiner to upgrade their client.
+        case outdatedJoinerClient
+        /// `RelayerRepository.selectURL()` returned nil — the user has
+        /// no chain relayer configured. Different from the Nostr-relays
+        /// path; admin-anchoring needs the HTTPS contract relayer.
+        case noActiveRelayer
+        /// `ContractsRepository.binding(for:)` returned nil — the
+        /// user hasn't picked a deployed Tyranny contract for the
+        /// active network in Settings → Anchors.
+        case noContractBinding
+        /// `Tyranny.proveUpdate` failed — usually means a corrupted
+        /// roster, wrong tier depth, or SDK FFI error. Diagnostic
+        /// detail in the associated string.
+        case proofFailed(String)
+        /// Relayer accepted the POST but the contract rejected the
+        /// proof (admin pubkey mismatch, replay, etc.).
+        case anchorRejected(String)
     }
 
     private let identity: IdentityRepository
@@ -67,6 +93,11 @@ actor JoinRequestApprover: JoinRequestApproving {
     private let introRequestStore: any IntroRequestStore
     private let groupRepository: GroupRepository
     private let inboxTransport: any InboxTransport
+    private let relayers: RelayerRepository
+    private let contracts: ContractsRepository
+    private let networkPreference: any NetworkPreferenceProviding
+    private let proofGenerator: any GroupProofGenerator
+    private let makeContractTransport: @Sendable (URL) -> any SEPContractTransport
 
     private var pendingValue: [PendingRequest] = []
     private var pendingContinuations: [UUID: AsyncStream<[PendingRequest]>.Continuation] = [:]
@@ -78,13 +109,28 @@ actor JoinRequestApprover: JoinRequestApproving {
         introKeyStore: any IntroKeyStore,
         introRequestStore: any IntroRequestStore,
         groupRepository: GroupRepository,
-        inboxTransport: any InboxTransport
+        inboxTransport: any InboxTransport,
+        relayers: RelayerRepository,
+        contracts: ContractsRepository,
+        networkPreference: any NetworkPreferenceProviding = UserDefaultsNetworkPreference(),
+        proofGenerator: any GroupProofGenerator = OnymGroupProofGenerator(),
+        makeContractTransport: @escaping @Sendable (URL) -> any SEPContractTransport = { url in
+            URLSessionSEPContractTransport(
+                endpoint: url,
+                authToken: RelayerSecrets.authToken
+            )
+        }
     ) {
         self.identity = identity
         self.introKeyStore = introKeyStore
         self.introRequestStore = introRequestStore
         self.groupRepository = groupRepository
         self.inboxTransport = inboxTransport
+        self.relayers = relayers
+        self.contracts = contracts
+        self.networkPreference = networkPreference
+        self.proofGenerator = proofGenerator
+        self.makeContractTransport = makeContractTransport
     }
 
     /// Hot stream of decoded pending requests. Replays the current
@@ -131,40 +177,80 @@ actor JoinRequestApprover: JoinRequestApproving {
         await refresh(from: raw)
     }
 
-    /// Approve a pending request: build the `GroupInvitationPayload`
-    /// from the local group state, seal to the joiner's inbox key,
-    /// ship via Nostr, then revoke the intro slot + drop the
-    /// pending entry.
+    /// Approve a pending request. Tyranny-only on-chain anchor flow:
+    ///
+    ///   1. Verify joiner shipped both `bls_pub` + `leaf_hash`.
+    ///   2. Build new sorted member list = current ∪ joiner.
+    ///   3. Compute new Poseidon root via `Common.merkleRoot`.
+    ///   4. Mint a fresh `salt_new`.
+    ///   5. Generate `Tyranny.proveUpdate` with admin's BLS secret.
+    ///   6. POST `update_commitment` to the chain relayer.
+    ///   7. Only on `accepted == true`: update local `ChatGroup`
+    ///      (members, commitment, epoch, salt), seal + ship the
+    ///      `GroupInvitationPayload` (with new state) to the joiner,
+    ///      fanout `MemberAnnouncementPayload` (also with new state)
+    ///      to existing members, revoke intro key + consume request.
+    ///
+    /// Failures at the proof / anchor steps return without mutating
+    /// any local state or consuming the request, so the admin can
+    /// retry. Failures at seal+ship after a successful anchor leave
+    /// the on-chain state advanced but the joiner uninformed —
+    /// out-of-band recovery is required (rare in practice).
+    ///
+    /// Non-Tyranny groups fall back to the pre-PR-13 ship-only flow
+    /// (no chain anchor) because there's no admin-driven update path
+    /// in `OneOnOne` / `Anarchy`. PR-13b's receiver verification
+    /// gates announcements to Tyranny groups specifically; other
+    /// types stay best-effort.
     func approve(requestId: String) async -> ApproveOutcome {
         guard let req = pendingValue.first(where: { $0.id == requestId }) else {
             return .unknownRequest
         }
-        guard await identity.currentIdentity() != nil else {
+        guard let activeIdentity = await identity.currentIdentity() else {
             return .noIdentityLoaded
         }
         let groups = await groupRepository.currentGroups()
         guard let group = groups.first(where: { $0.groupIDData == req.groupId }) else {
             return .unknownGroup
         }
+
+        // PR-13a admin-anchor path is Tyranny-only. Other types fall
+        // through to the pre-PR-13 ship-only flow at the bottom.
+        var anchored = group
+        if group.groupType == .tyranny {
+            switch await anchorTyrannyJoin(
+                req: req,
+                group: group,
+                activeIdentity: activeIdentity
+            ) {
+            case .failed(let outcome):
+                return outcome
+            case .ok(let updated):
+                anchored = updated
+                // Persist the advanced state immediately so a
+                // subsequent crash before seal+ship doesn't lose the
+                // chain transition.
+                await groupRepository.insert(anchored)
+            }
+        }
+
         let invite = GroupInvitationPayload(
             version: 1,
-            groupID: group.groupIDData,
-            groupSecret: group.groupSecret,
-            name: group.name,
-            members: group.members,
-            epoch: group.epoch,
-            salt: group.salt,
-            commitment: group.commitment,
-            tierRaw: group.tier.rawValue,
-            groupTypeRaw: group.groupType.rawValue,
-            adminPubkeyHex: group.adminPubkeyHex,
+            groupID: anchored.groupIDData,
+            groupSecret: anchored.groupSecret,
+            name: anchored.name,
+            members: anchored.members,
+            epoch: anchored.epoch,
+            salt: anchored.salt,
+            commitment: anchored.commitment,
+            tierRaw: anchored.tier.rawValue,
+            groupTypeRaw: anchored.groupType.rawValue,
+            adminPubkeyHex: anchored.adminPubkeyHex,
             // Ship the directory-as-known so the joiner sees existing
             // peers + admin by name from the moment they land. The
-            // joiner won't see themselves here — recordJoiner runs
-            // after the invite ships — and that's fine: the joiner-
-            // side materializer can backfill self from the active
-            // identity.
-            memberProfiles: group.memberProfiles.isEmpty ? nil : group.memberProfiles
+            // joiner's own profile gets backfilled by the receiver's
+            // materializer from their active identity.
+            memberProfiles: anchored.memberProfiles.isEmpty ? nil : anchored.memberProfiles
         )
         let payloadBytes: Data
         do {
@@ -194,34 +280,158 @@ actor JoinRequestApprover: JoinRequestApproving {
             return .transportFailed("no relay accepted the invitation")
         }
         // Record the joiner in the local group's view-facing roster
-        // so the admin sees their alias in the UI, then announce the
-        // join to every other member's inbox. Both side-effects only
-        // run when the joiner shipped a BLS pubkey (pre-PR-4 builds
-        // skip these — no stable cross-device key, no fanout
-        // possible). The sealed invite already shipped above, so any
-        // failure here is non-fatal; the joiner is still admitted.
+        // (alias / inbox-pub) so the admin sees their alias in the
+        // UI. The cryptographic roster (`anchored.members`) was
+        // already updated by the anchor step. Both side-effects only
+        // run when the joiner shipped a BLS pubkey.
         if let blsPub = req.joinerBlsPublicKey {
             await recordJoiner(
-                in: group,
+                in: anchored,
                 blsPub: blsPub,
                 inboxPub: req.joinerInboxPublicKey,
                 alias: req.joinerDisplayLabel
             )
             await broadcastJoin(
-                in: group,
+                in: anchored,
                 joinerBlsPub: blsPub,
                 joinerInboxPub: req.joinerInboxPublicKey,
                 joinerAlias: req.joinerDisplayLabel
             )
         }
-        // Best-effort cleanup. Both calls run regardless of failures
-        // because the request is conceptually consumed at this point;
-        // a leaked intro key is benign.
+        // Best-effort cleanup.
         if let introPub = await findIntroPub(forRequestID: requestId) {
             await introKeyStore.revoke(introPublicKey: introPub)
         }
         await introRequestStore.consume(id: requestId)
         return .sent
+    }
+
+    /// Outcome shape for the anchor helper. `Result` is unergonomic
+    /// here because `ApproveOutcome` doesn't conform to `Error`.
+    private enum AnchorOutcome {
+        case ok(ChatGroup)
+        case failed(ApproveOutcome)
+    }
+
+    /// On-chain anchor leg of `approve` — Tyranny only. Returns the
+    /// updated `ChatGroup` (post-anchor) on success, or an
+    /// `ApproveOutcome` describing the failure on any short-circuit.
+    /// Pure: never mutates local state. Caller persists.
+    private func anchorTyrannyJoin(
+        req: PendingRequest,
+        group: ChatGroup,
+        activeIdentity: Identity
+    ) async -> AnchorOutcome {
+        guard let joinerBlsPub = req.joinerBlsPublicKey,
+              let joinerLeafHash = req.joinerLeafHash
+        else {
+            return .failed(.outdatedJoinerClient)
+        }
+        guard let adminPubkeyHex = group.adminPubkeyHex else {
+            // Tyranny group without a stored admin pubkey shouldn't
+            // exist (CreateGroupInteractor stamps it at create time).
+            // Reject defensively.
+            return .failed(.transportFailed("group missing adminPubkeyHex"))
+        }
+        guard let relayerURL = await relayers.selectURL() else {
+            return .failed(.noActiveRelayer)
+        }
+        let activeNetwork = networkPreference.current()
+        let key = AnchorSelectionKey(network: activeNetwork.contractNetwork, type: .tyranny)
+        guard let binding = await contracts.binding(for: key) else {
+            return .failed(.noContractBinding)
+        }
+
+        // Resolve admin's index in the OLD member roster.
+        let adminBytes = ChatGroup.bytes(fromHex: adminPubkeyHex)
+        guard let adminIndexOld = group.members.firstIndex(
+            where: { $0.publicKeyCompressed == adminBytes }
+        ) else {
+            return .failed(.transportFailed("admin not in members roster"))
+        }
+
+        // Build new sorted member list including the joiner. Compute
+        // the new Poseidon root over the new tree.
+        let joinerMember = GovernanceMember(
+            publicKeyCompressed: joinerBlsPub,
+            leafHash: joinerLeafHash
+        )
+        let newMembers = (group.members + [joinerMember]).sorted { lhs, rhs in
+            lhs.publicKeyCompressed.lexicographicallyPrecedes(rhs.publicKeyCompressed)
+        }
+        let memberRootNew: Data
+        do {
+            memberRootNew = try GroupCommitmentBuilder.computeMerkleRoot(
+                members: newMembers,
+                tier: group.tier
+            )
+        } catch {
+            return .failed(.proofFailed("merkle_root: \(error)"))
+        }
+        let saltNew = GroupCommitmentBuilder.generateSalt()
+
+        // Generate the update proof.
+        let blsSecret: Data
+        do {
+            // onym:allow-secret-read
+            blsSecret = try await identity.blsSecretKey()
+        } catch {
+            return .failed(.transportFailed("bls_secret: \(error)"))
+        }
+        let proofInput = GroupProofUpdateInput(
+            groupType: .tyranny,
+            tier: group.tier,
+            oldMembers: group.members,
+            adminBlsSecretKey: blsSecret,
+            adminIndexOld: adminIndexOld,
+            epochOld: group.epoch,
+            memberRootNew: memberRootNew,
+            groupID: group.groupIDData,
+            saltOld: group.salt,
+            saltNew: saltNew
+        )
+        let proof: GroupUpdateProof
+        do {
+            proof = try proofGenerator.proveUpdate(proofInput)
+        } catch let err as GroupProofGeneratorError {
+            return .failed(.proofFailed(err.localizedDescription))
+        } catch {
+            return .failed(.proofFailed(String(describing: error)))
+        }
+
+        // Submit to chain.
+        let transport = makeContractTransport(relayerURL)
+        let client = SEPContractClient(
+            contractID: binding.contractID,
+            contractType: .tyranny,
+            network: activeNetwork.sepNetwork,
+            transport: transport
+        )
+        let payload = TyrannyUpdateCommitmentPayload(
+            groupID: group.groupIDData,
+            proof: proof.proof,
+            publicInputs: proof.publicInputs
+        )
+        let response: SEPSubmissionResponse
+        do {
+            response = try await client.updateCommitmentTyranny(payload)
+        } catch {
+            return .failed(.transportFailed("anchor: \(error)"))
+        }
+        guard response.accepted else {
+            return .failed(.anchorRejected(response.message ?? "(no message)"))
+        }
+
+        // Build the updated local ChatGroup. `commitment` becomes
+        // the proof's c_new (PI[2]); `epoch` advances by 1; `salt`
+        // becomes saltNew; `members` becomes newMembers.
+        let newEpoch = group.epoch + 1
+        var updated = group
+        updated.members = newMembers
+        updated.commitment = proof.commitmentNew
+        updated.epoch = newEpoch
+        updated.salt = saltNew
+        return .ok(updated)
     }
 
     /// Insert/update the joiner's `MemberProfile` on the local
@@ -284,7 +494,15 @@ actor JoinRequestApprover: JoinRequestApproving {
                 version: 1,
                 groupId: group.groupIDData,
                 newMember: announced,
-                adminAlias: adminAlias
+                adminAlias: adminAlias,
+                // PR-13a: ship the post-anchor commitment + epoch
+                // so PR-13b's receivers can verify against
+                // `SEPContractClient.getCommitment`. nil only when
+                // the calling group hasn't been anchored (legacy
+                // / non-Tyranny path) — receivers fall back to
+                // best-effort acceptance in that case.
+                commitment: group.commitment,
+                epoch: group.epoch
             )
         } catch {
             return
@@ -404,6 +622,7 @@ actor JoinRequestApprover: JoinRequestApproving {
             id: raw.id,
             joinerInboxPublicKey: payload.joinerInboxPublicKey,
             joinerBlsPublicKey: payload.joinerBlsPublicKey,
+            joinerLeafHash: payload.joinerLeafHash,
             joinerDisplayLabel: payload.joinerDisplayLabel,
             groupId: payload.groupId,
             groupName: groupName

--- a/Sources/OnymIOS/Group/JoinRequestPayload.swift
+++ b/Sources/OnymIOS/Group/JoinRequestPayload.swift
@@ -37,12 +37,25 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
     /// fallback key in `memberProfiles` rather than rejecting the
     /// request.
     let joinerBlsPublicKey: Data?
+    /// 32-byte Poseidon leaf hash — `Poseidon(joiner_bls_secret)`,
+    /// computed by the joiner via `Common.leafHash(secretKey:)`.
+    /// Required for the admin to extend the on-chain Merkle tree at
+    /// approve time (`Tyranny.proveUpdate` needs it as part of the
+    /// new packed leaf set).
+    ///
+    /// Optional on the wire — pre-PR-13 joiner builds shipped
+    /// requests without it. Admins running a PR-13+ build MUST
+    /// reject join requests missing this field for Tyranny groups,
+    /// because the on-chain `update_commitment` proof can't be
+    /// generated without it.
+    let joinerLeafHash: Data?
     let joinerDisplayLabel: String
     let groupId: Data
 
     enum CodingKeys: String, CodingKey {
         case joinerInboxPublicKey = "joiner_inbox_pub"
         case joinerBlsPublicKey = "joiner_bls_pub"
+        case joinerLeafHash = "joiner_leaf_hash"
         case joinerDisplayLabel = "joiner_display_label"
         case groupId = "group_id"
     }
@@ -50,6 +63,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
     init(
         joinerInboxPublicKey: Data,
         joinerBlsPublicKey: Data?,
+        joinerLeafHash: Data?,
         joinerDisplayLabel: String,
         groupId: Data
     ) throws {
@@ -63,6 +77,11 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
                 "joinerBlsPublicKey: expected 48 bytes, got \(bls.count)"
             )
         }
+        if let leaf = joinerLeafHash, leaf.count != 32 {
+            throw JoinRequestPayloadError.shape(
+                "joinerLeafHash: expected 32 bytes, got \(leaf.count)"
+            )
+        }
         guard groupId.count == 32 else {
             throw JoinRequestPayloadError.shape(
                 "groupId: expected 32 bytes, got \(groupId.count)"
@@ -70,6 +89,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         }
         self.joinerInboxPublicKey = joinerInboxPublicKey
         self.joinerBlsPublicKey = joinerBlsPublicKey
+        self.joinerLeafHash = joinerLeafHash
         self.joinerDisplayLabel = joinerDisplayLabel
         self.groupId = groupId
     }
@@ -78,6 +98,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         let pub = try c.decode(Data.self, forKey: .joinerInboxPublicKey)
         let bls = try c.decodeIfPresent(Data.self, forKey: .joinerBlsPublicKey)
+        let leaf = try c.decodeIfPresent(Data.self, forKey: .joinerLeafHash)
         let label = try c.decode(String.self, forKey: .joinerDisplayLabel)
         let gid = try c.decode(Data.self, forKey: .groupId)
         guard pub.count == 32 else {
@@ -90,6 +111,11 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
                 "joinerBlsPublicKey: expected 48 bytes, got \(blsBytes.count)"
             )
         }
+        if let leafBytes = leaf, leafBytes.count != 32 {
+            throw JoinRequestPayloadError.shape(
+                "joinerLeafHash: expected 32 bytes, got \(leafBytes.count)"
+            )
+        }
         guard gid.count == 32 else {
             throw JoinRequestPayloadError.shape(
                 "groupId: expected 32 bytes, got \(gid.count)"
@@ -97,6 +123,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         }
         self.joinerInboxPublicKey = pub
         self.joinerBlsPublicKey = bls
+        self.joinerLeafHash = leaf
         self.joinerDisplayLabel = label
         self.groupId = gid
     }

--- a/Sources/OnymIOS/Group/JoinRequestSender.swift
+++ b/Sources/OnymIOS/Group/JoinRequestSender.swift
@@ -42,11 +42,28 @@ actor JoinRequestSender {
         guard let active = await identity.currentIdentity() else {
             return .noIdentityLoaded
         }
+        // Compute leaf_hash = Poseidon(joiner_bls_secret) so the
+        // admin can extend the Merkle tree at approve time without
+        // ever seeing the joiner's BLS secret.
+        let blsSecret: Data
+        do {
+            // onym:allow-secret-read
+            blsSecret = try await identity.blsSecretKey()
+        } catch {
+            return .noIdentityLoaded
+        }
+        let leafHash: Data
+        do {
+            leafHash = try GroupCommitmentBuilder.computeLeafHash(secretKey: blsSecret)
+        } catch {
+            return .transportFailed("leaf_hash: \(error)")
+        }
         let payload: JoinRequestPayload
         do {
             payload = try JoinRequestPayload(
                 joinerInboxPublicKey: active.inboxPublicKey,
                 joinerBlsPublicKey: active.blsPublicKey,
+                joinerLeafHash: leafHash,
                 joinerDisplayLabel: joinerDisplayLabel,
                 groupId: capability.groupId
             )

--- a/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
+++ b/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
@@ -52,6 +52,23 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
     /// (which the receiver does have, but rendering becomes
     /// strictly local-state-free this way).
     let adminAlias: String
+    /// 32-byte Poseidon commitment of the new tree (post-admit).
+    /// PR-13a (admin side): admin runs `update_commitment` BEFORE
+    /// fanning out the announcement and stamps the new commitment
+    /// here. PR-13b (receiver side): the dispatcher fetches the
+    /// on-chain commitment via `SEPContractClient.getCommitment(...)`
+    /// and rejects announcements where these don't match.
+    ///
+    /// Optional on the wire — pre-PR-13 senders shipped
+    /// announcements without this field. Receivers running PR-13b+
+    /// MUST reject Tyranny announcements missing this field
+    /// (best-effort acceptance is no longer safe once the trust
+    /// model upgrades to on-chain anchoring).
+    let commitment: Data?
+    /// New epoch number after the on-chain `update_commitment`
+    /// (i.e. `epoch_old + 1`). Optional for the same reason as
+    /// `commitment`.
+    let epoch: UInt64?
 
     /// One member's directory entry. App-level only — the
     /// cryptographic Poseidon leaf hash is intentionally absent.
@@ -118,18 +135,34 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
         case groupId = "group_id"
         case newMember = "new_member"
         case adminAlias = "admin_alias"
+        case commitment
+        case epoch
     }
 
-    init(version: Int, groupId: Data, newMember: AnnouncedMember, adminAlias: String) throws {
+    init(
+        version: Int,
+        groupId: Data,
+        newMember: AnnouncedMember,
+        adminAlias: String,
+        commitment: Data? = nil,
+        epoch: UInt64? = nil
+    ) throws {
         guard groupId.count == 32 else {
             throw MemberAnnouncementPayloadError.shape(
                 "groupId: expected 32 bytes, got \(groupId.count)"
+            )
+        }
+        if let c = commitment, c.count != 32 {
+            throw MemberAnnouncementPayloadError.shape(
+                "commitment: expected 32 bytes, got \(c.count)"
             )
         }
         self.version = version
         self.groupId = groupId
         self.newMember = newMember
         self.adminAlias = adminAlias
+        self.commitment = commitment
+        self.epoch = epoch
     }
 
     init(from decoder: Decoder) throws {
@@ -141,10 +174,18 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
                 "groupId: expected 32 bytes, got \(gid.count)"
             )
         }
+        let commitment = try c.decodeIfPresent(Data.self, forKey: .commitment)
+        if let comm = commitment, comm.count != 32 {
+            throw MemberAnnouncementPayloadError.shape(
+                "commitment: expected 32 bytes, got \(comm.count)"
+            )
+        }
         self.version = v
         self.groupId = gid
         self.newMember = try c.decode(AnnouncedMember.self, forKey: .newMember)
         self.adminAlias = try c.decode(String.self, forKey: .adminAlias)
+        self.commitment = commitment
+        self.epoch = try c.decodeIfPresent(UInt64.self, forKey: .epoch)
     }
 }
 

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -138,7 +138,9 @@ struct OnymIOSApp: App {
             introKeyStore: introKeyStore,
             introRequestStore: self.introRequestStore,
             groupRepository: groupRepository,
-            inboxTransport: inboxTransport
+            inboxTransport: inboxTransport,
+            relayers: relayerRepository,
+            contracts: contractsRepository
         )
         let approveRequestsFlow = ApproveRequestsFlow(approver: joinRequestApprover)
 

--- a/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
+++ b/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
@@ -96,6 +96,7 @@ final class ApproveRequestsFlowTests: XCTestCase {
             id: id,
             joinerInboxPublicKey: Data(repeating: 0xAA, count: 32),
             joinerBlsPublicKey: Data(repeating: 0xCC, count: 48),
+            joinerLeafHash: Data(repeating: 0xDD, count: 32),
             joinerDisplayLabel: alias,
             groupId: Data(repeating: 0xBB, count: 32),
             groupName: "Family"

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -565,6 +565,15 @@ private struct StubGroupProofGenerator: GroupProofGenerator {
             throw GroupProofGeneratorError.notYetSupported(input.groupType)
         }
     }
+
+    /// PR 13a: not exercised in CreateGroupInteractor flows
+    /// (CreateGroupInteractor never calls `proveUpdate`), but the
+    /// protocol now requires it. Throws `notYetSupported` for every
+    /// type — the create-side stubs don't need to model the update
+    /// path.
+    func proveUpdate(_ input: GroupProofUpdateInput) throws -> GroupUpdateProof {
+        throw GroupProofGeneratorError.notYetSupported(input.groupType)
+    }
 }
 
 /// Recording inbox transport with a configurable acceptedBy count.

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -18,6 +18,11 @@ final class JoinRequestApproverTests: XCTestCase {
     private var introRequestStore: InMemoryIntroRequestStore!
     private var groups: GroupRepository!
     private var transport: ApproverRecordingInboxTransport!
+    // PR 13a: stubs for the on-chain anchor leg.
+    private var relayers: RelayerRepository!
+    private var contracts: ContractsRepository!
+    private var proofGenerator: ApproverStubProofGenerator!
+    private var contractTransport: ApproverStubContractTransport!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -27,6 +32,43 @@ final class JoinRequestApproverTests: XCTestCase {
         introRequestStore = InMemoryIntroRequestStore()
         groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
         transport = ApproverRecordingInboxTransport()
+
+        relayers = RelayerRepository(
+            fetcher: ApproverNoopRelayerFetcher(),
+            store: ApproverInMemoryRelayerStore()
+        )
+        _ = await relayers.addEndpoint(RelayerEndpoint(
+            name: "test",
+            url: URL(string: "https://relayer.test.example")!,
+            networks: ["testnet"]
+        ))
+        await relayers.setStrategy(.primary)
+        await relayers.setPrimary(url: URL(string: "https://relayer.test.example")!)
+
+        let manifest = ContractsManifest(
+            version: 1,
+            releases: [
+                ContractRelease(
+                    release: "v0.0.3",
+                    publishedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    contracts: [
+                        ContractEntry(
+                            network: .testnet,
+                            type: .tyranny,
+                            id: "CTYRANNYTEST00000000000000000000000000000000000000000000"
+                        )
+                    ]
+                )
+            ]
+        )
+        contracts = ContractsRepository(
+            fetcher: ApproverFakeContractsFetcher(manifest: manifest),
+            store: ApproverInMemoryContractsStore()
+        )
+        try? await contracts.refresh()
+
+        proofGenerator = ApproverStubProofGenerator()
+        contractTransport = ApproverStubContractTransport()
     }
 
     override func tearDown() async throws {
@@ -37,6 +79,10 @@ final class JoinRequestApproverTests: XCTestCase {
         introRequestStore = nil
         groups = nil
         transport = nil
+        relayers = nil
+        contracts = nil
+        proofGenerator = nil
+        contractTransport = nil
         try await super.tearDown()
     }
 
@@ -152,6 +198,49 @@ final class JoinRequestApproverTests: XCTestCase {
                        "joiner gets exactly one envelope (the invitation), not also a fanout copy")
     }
 
+    // MARK: - PR 13a anchor failure modes
+
+    func test_approve_outdatedJoinerClient_whenLeafHashMissing() async throws {
+        // Joiner shipped without joiner_leaf_hash (pre-PR-13 build).
+        // Admin can't anchor; should return .outdatedJoinerClient
+        // and NOT consume the request.
+        let env = try await seedEnvironment(omitJoinerLeafHash: true)
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .outdatedJoinerClient)
+        let remaining = await introRequestStore.current()
+        XCTAssertEqual(remaining.count, 1, "outdated request must NOT be consumed")
+        let sends = await transport.sends
+        XCTAssertTrue(sends.isEmpty, "no envelopes shipped on outdated-client failure")
+    }
+
+    func test_approve_anchorRejected_doesNotConsumeRequest() async throws {
+        // Chain returns accepted=false (e.g. proof verification
+        // failed on the contract side). Admin should NOT ship the
+        // invitation, NOT mutate local state, NOT consume the
+        // request. Admin can investigate + retry.
+        contractTransport.nextAccepted = false
+        let env = try await seedEnvironment()
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        if case .anchorRejected = outcome {
+            // expected
+        } else {
+            XCTFail("expected .anchorRejected, got \(outcome)")
+        }
+        let sends = await transport.sends
+        XCTAssertTrue(sends.isEmpty,
+                      "invitation must NOT ship when chain rejects the proof")
+        let remaining = await introRequestStore.current()
+        XCTAssertEqual(remaining.count, 1,
+                       "rejected request stays in store so admin can retry")
+        // Local group state stayed at the original (epoch unchanged,
+        // members not extended).
+        let after = await groups.currentGroups()
+        XCTAssertEqual(after.first?.epoch, 0,
+                       "epoch must NOT advance when anchor is rejected")
+    }
+
     // MARK: - decline
 
     func test_decline_dropsRequestAndRevokesKey() async throws {
@@ -196,10 +285,14 @@ final class JoinRequestApproverTests: XCTestCase {
     /// approver doesn't care; it operates on cryptographic shape.
     private func seedEnvironment(
         insertGroup: Bool = true,
-        extraMemberProfiles: [String: MemberProfile] = [:]
+        extraMemberProfiles: [String: MemberProfile] = [:],
+        omitJoinerLeafHash: Bool = false
     ) async throws -> Env {
         let active = try await identity.bootstrap()
         let ownerID = try await XCTUnwrapAsync(await identity.currentSelectedID())
+        // onym:allow-secret-read
+        let adminBlsSecret = try await identity.blsSecretKey()
+        let adminLeafHash = try GroupCommitmentBuilder.computeLeafHash(secretKey: adminBlsSecret)
 
         let groupID = Data(repeating: 0x42, count: 32)
         let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
@@ -217,13 +310,23 @@ final class JoinRequestApproverTests: XCTestCase {
         ))
 
         // Build JoinRequestPayload + seal to the intro pubkey using
-        // the admin's identity as the signer.
+        // the admin's identity as the signer. In production, joiner
+        // and admin are different identities; this single-identity
+        // collapse is fine because the approver only inspects
+        // cryptographic shape, not party relationship.
+        //
+        // Single-identity collapse means joiner.bls_pub == admin.bls_pub,
+        // which would cause the anchor flow to add a duplicate leaf.
+        // Use a synthetic joiner BLS pubkey here so the new tree is
+        // distinct from the seed.
         let joinerInboxPub = active.inboxPublicKey
-        let joinerBlsPub = active.blsPublicKey
+        let joinerBlsPub = Data(repeating: 0xCC, count: 48)
+        let joinerLeafHash = Data(repeating: 0xDD, count: 32)
         let joinerAlias = "Joiner Bob"
         let joinPayload = try JoinRequestPayload(
             joinerInboxPublicKey: joinerInboxPub,
             joinerBlsPublicKey: joinerBlsPub,
+            joinerLeafHash: omitJoinerLeafHash ? nil : joinerLeafHash,
             joinerDisplayLabel: joinerAlias,
             groupId: groupID
         )
@@ -252,13 +355,20 @@ final class JoinRequestApproverTests: XCTestCase {
                 alias: "Admin",
                 inboxPublicKey: active.inboxPublicKey
             )
+            // Admin must be in the cryptographic roster for the
+            // anchor path to find adminIndexOld. Real groups land
+            // here via CreateGroupInteractor.
+            let adminMember = GovernanceMember(
+                publicKeyCompressed: active.blsPublicKey,
+                leafHash: adminLeafHash
+            )
             let group = ChatGroup(
                 id: groupIDHex,
                 ownerIdentityID: ownerID,
                 name: "Family",
                 groupSecret: Data(repeating: 0x55, count: 32),
                 createdAt: Date(timeIntervalSince1970: 1_700_000_000),
-                members: [],
+                members: [adminMember],
                 memberProfiles: profiles,
                 epoch: 0,
                 salt: Data(repeating: 0x66, count: 32),
@@ -272,12 +382,19 @@ final class JoinRequestApproverTests: XCTestCase {
             _ = await groups.insert(group)
         }
 
+        // Capture the contractTransport for the closure capture.
+        let chainTransport = contractTransport!
         let approver = JoinRequestApprover(
             identity: identity,
             introKeyStore: introKeyStore,
             introRequestStore: introRequestStore,
             groupRepository: groups,
-            inboxTransport: transport
+            inboxTransport: transport,
+            relayers: relayers,
+            contracts: contracts,
+            networkPreference: ApproverStaticNetworkPreference(value: .testnet),
+            proofGenerator: proofGenerator,
+            makeContractTransport: { _ in chainTransport }
         )
 
         return Env(
@@ -355,3 +472,171 @@ private func XCTUnwrapAsync<T>(
 }
 
 private struct XCTUnwrapFailedError: Error {}
+
+// MARK: - PR 13a chain-anchor stubs
+
+/// Returns canned `Tyranny.UpdateProof`-shape outputs (160-byte PI
+/// bundle / 5 chunks) without invoking the real prover. Optional
+/// failure mode for the proof-fails test.
+private actor ApproverStubProofGenerator: GroupProofGenerator {
+    var nextProofShouldFail: Bool = false
+    private(set) var proveUpdateCalls: Int = 0
+
+    func setNextProofShouldFail(_ fail: Bool) { nextProofShouldFail = fail }
+
+    nonisolated func proveCreate(_ input: GroupProofCreateInput) throws -> GroupCreateProof {
+        // Not used in approver tests — return a deterministic create
+        // proof so the protocol conformance is satisfied.
+        let frZero = Data(repeating: 0, count: 32)
+        return GroupCreateProof(
+            proof: Data(repeating: 0xAB, count: 1601),
+            publicInputs: [
+                Data(repeating: 0xCD, count: 32),
+                frZero,
+                Data(repeating: 0xEF, count: 32),
+                input.groupID,
+            ]
+        )
+    }
+
+    nonisolated func proveUpdate(_ input: GroupProofUpdateInput) throws -> GroupUpdateProof {
+        // Synchronous bridge into the actor: read flags via an
+        // unsafe sync hop. For test purposes a tiny race here is
+        // fine — single-test-actor execution serializes calls.
+        return try _proveUpdateSync(input)
+    }
+
+    private nonisolated func _proveUpdateSync(_ input: GroupProofUpdateInput) throws -> GroupUpdateProof {
+        // Use a semaphore to read the flag synchronously. Fine for
+        // tests; the actor's serial executor enforces ordering.
+        let dispatch = DispatchSemaphore(value: 0)
+        var shouldFail = false
+        var calls = 0
+        Task { [self] in
+            shouldFail = await self.nextProofShouldFail
+            calls = await self.proveUpdateCalls
+            await self.bumpProveUpdateCalls()
+            dispatch.signal()
+        }
+        dispatch.wait()
+        _ = calls
+        if shouldFail {
+            throw GroupProofGeneratorError.sdkFailure("stub: forced failure")
+        }
+        // Synthetic 160-byte PI bundle — c_old || epoch_old_be ||
+        // c_new || admin_pubkey_commitment || group_id_fr.
+        var epochOldBe = Data(count: 32)
+        epochOldBe.withUnsafeMutableBytes { buf in
+            let bytes = buf.bindMemory(to: UInt8.self)
+            var v = input.epochOld.bigEndian
+            withUnsafeBytes(of: &v) { src in
+                for i in 0..<8 { bytes[24 + i] = src[i] }
+            }
+        }
+        return GroupUpdateProof(
+            proof: Data(repeating: 0xAB, count: 1601),
+            publicInputs: [
+                Data(repeating: 0xC0, count: 32),  // c_old (synthetic)
+                epochOldBe,
+                Data(repeating: 0xC1, count: 32),  // c_new (synthetic)
+                Data(repeating: 0xAD, count: 32),  // admin_pubkey_commitment
+                input.groupID,                      // group_id_fr
+            ]
+        )
+    }
+
+    private func bumpProveUpdateCalls() {
+        proveUpdateCalls += 1
+    }
+}
+
+/// Stub `SEPContractTransport` — records every invocation, returns
+/// `accepted = true` by default; tests can flip
+/// `nextAccepted` to drive the rejected path.
+private final class ApproverStubContractTransport: SEPContractTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _nextAccepted: Bool = true
+    private var _calls: [String] = []
+
+    var nextAccepted: Bool {
+        get { lock.withLock { _nextAccepted } }
+        set { lock.withLock { _nextAccepted = newValue } }
+    }
+    var calls: [String] {
+        lock.withLock { _calls }
+    }
+
+    func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ invocation: SEPContractInvocation<Payload>,
+        responseType: Response.Type
+    ) async throws -> Response {
+        lock.withLock { _calls.append(invocation.function) }
+        let response = SEPSubmissionResponse(
+            accepted: nextAccepted,
+            transactionHash: nextAccepted ? "0xstubhash" : nil,
+            message: nextAccepted ? nil : "stub rejected"
+        )
+        let data = try JSONEncoder().encode(response)
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+}
+
+/// Static `NetworkPreferenceProviding` for tests.
+private struct ApproverStaticNetworkPreference: NetworkPreferenceProviding, Sendable {
+    let value: AppNetwork
+    func current() -> AppNetwork { value }
+}
+
+/// In-memory `RelayerSelectionStore` so the test fixture can
+/// pre-load a configured endpoint without touching UserDefaults.
+private final class ApproverInMemoryRelayerStore: RelayerSelectionStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var configuration: RelayerConfiguration = .empty
+    private var cachedKnownList: [RelayerEndpoint] = []
+
+    func loadConfiguration() -> RelayerConfiguration {
+        lock.withLock { configuration }
+    }
+    func saveConfiguration(_ configuration: RelayerConfiguration) {
+        lock.withLock { self.configuration = configuration }
+    }
+    func loadCachedKnownList() -> [RelayerEndpoint] {
+        lock.withLock { cachedKnownList }
+    }
+    func saveCachedKnownList(_ list: [RelayerEndpoint]) {
+        lock.withLock { cachedKnownList = list }
+    }
+}
+
+/// No-op `KnownRelayersFetcher` — the test fixture pre-populates
+/// the configuration via `addEndpoint`, no network needed.
+private struct ApproverNoopRelayerFetcher: KnownRelayersFetcher {
+    func fetchLatest() async throws -> [RelayerEndpoint] { [] }
+}
+
+/// In-memory `AnchorSelectionStore` so the test fixture's
+/// `ContractsRepository` doesn't reach for UserDefaults.
+private final class ApproverInMemoryContractsStore: AnchorSelectionStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var manifest: ContractsManifest?
+    private var selections: [AnchorSelectionKey: String] = [:]
+
+    func loadSelections() -> [AnchorSelectionKey: String] {
+        lock.withLock { selections }
+    }
+    func saveSelections(_ selections: [AnchorSelectionKey: String]) {
+        lock.withLock { self.selections = selections }
+    }
+    func loadCachedManifest() -> ContractsManifest? {
+        lock.withLock { manifest }
+    }
+    func saveCachedManifest(_ manifest: ContractsManifest) {
+        lock.withLock { self.manifest = manifest }
+    }
+}
+
+/// Returns a fixed manifest from `fetchLatest`.
+private struct ApproverFakeContractsFetcher: ContractsManifestFetcher {
+    let manifest: ContractsManifest
+    func fetchLatest() async throws -> ContractsManifest { manifest }
+}

--- a/Tests/OnymIOSTests/JoinRequestPayloadTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestPayloadTests.swift
@@ -12,6 +12,7 @@ final class JoinRequestPayloadTests: XCTestCase {
         let original = try JoinRequestPayload(
             joinerInboxPublicKey: Data(repeating: 0xAA, count: 32),
             joinerBlsPublicKey: Data(repeating: 0xBB, count: 48),
+            joinerLeafHash: Data(repeating: 0xCC, count: 32),
             joinerDisplayLabel: "Bob",
             groupId: Data(repeating: 0x42, count: 32)
         )
@@ -27,6 +28,7 @@ final class JoinRequestPayloadTests: XCTestCase {
         let payload = try JoinRequestPayload(
             joinerInboxPublicKey: Data(repeating: 0, count: 32),
             joinerBlsPublicKey: Data(repeating: 0, count: 48),
+            joinerLeafHash: Data(repeating: 0, count: 32),
             joinerDisplayLabel: "Bob",
             groupId: Data(repeating: 0, count: 32)
         )
@@ -43,6 +45,7 @@ final class JoinRequestPayloadTests: XCTestCase {
         XCTAssertThrowsError(try JoinRequestPayload(
             joinerInboxPublicKey: Data(repeating: 0, count: 31),
             joinerBlsPublicKey: nil,
+            joinerLeafHash: nil,
             joinerDisplayLabel: "x",
             groupId: Data(repeating: 0, count: 32)
         )) { error in
@@ -51,6 +54,7 @@ final class JoinRequestPayloadTests: XCTestCase {
         XCTAssertThrowsError(try JoinRequestPayload(
             joinerInboxPublicKey: Data(repeating: 0, count: 32),
             joinerBlsPublicKey: nil,
+            joinerLeafHash: nil,
             joinerDisplayLabel: "x",
             groupId: Data(repeating: 0, count: 33)
         )) { error in
@@ -59,6 +63,17 @@ final class JoinRequestPayloadTests: XCTestCase {
         XCTAssertThrowsError(try JoinRequestPayload(
             joinerInboxPublicKey: Data(repeating: 0, count: 32),
             joinerBlsPublicKey: Data(repeating: 0, count: 47),
+            joinerLeafHash: nil,
+            joinerDisplayLabel: "x",
+            groupId: Data(repeating: 0, count: 32)
+        )) { error in
+            XCTAssertTrue(error is JoinRequestPayloadError)
+        }
+        // Wrong-sized leaf hash also rejected.
+        XCTAssertThrowsError(try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0, count: 32),
+            joinerBlsPublicKey: Data(repeating: 0, count: 48),
+            joinerLeafHash: Data(repeating: 0, count: 31),
             joinerDisplayLabel: "x",
             groupId: Data(repeating: 0, count: 32)
         )) { error in


### PR DESCRIPTION
## Summary

PR 13a — admin anchors. Stacked on #87.

Admin's `JoinRequestApprover.approve` now runs the full on-chain admit ceremony before shipping anything to the joiner:

1. Decode `joiner_leaf_hash` from the request.
2. Build new sorted member list = current ∪ joiner.
3. Compute new Poseidon root via `Common.merkleRoot`.
4. Mint a fresh `salt_new`.
5. Generate `Tyranny.proveUpdate` with admin's BLS secret.
6. POST `update_commitment` to the chain relayer.
7. **Only on `accepted == true`**: persist the advanced local state, seal+ship the `GroupInvitationPayload` (with new state) to the joiner, fanout `MemberAnnouncementPayload` (also with new state) to existing members.

Failures at proof / anchor steps return without mutating local state or consuming the request — admin can retry. Failures at seal+ship after a successful anchor leave on-chain state advanced but the joiner uninformed (rare; out-of-band recovery).

The cryptographic gate now matches what's already enforced on-chain (`sep-tyranny/src/lib.rs:379` — `update_commitment` verifies the admin holds the BLS secret matching `admin_pubkey_commitment`). Bob's spoofed approval fails contract verification.

### What this does NOT close yet

PR 13b is required for the security fix to be airtight: receivers must verify the payload's commitment against on-chain state before accepting. Today's receivers still trust whatever the sender ships. **Merge 13a + 13b together.**

### Wire changes

- `JoinRequestPayload.joiner_leaf_hash` (32 bytes, `decodeIfPresent`) — joiner ships their Poseidon leaf hash so admin can extend the tree without seeing the joiner's BLS secret.
- `MemberAnnouncementPayload.commitment` + `epoch` (both `decodeIfPresent`) — receivers in PR 13b verify these against on-chain state.

### Surface changes

- New `JoinRequestApprover.ApproveOutcome` cases: `outdatedJoinerClient`, `noActiveRelayer`, `noContractBinding`, `proofFailed`, `anchorRejected` — each mapped to user-facing error strings in `ApproveRequestsFlow`.
- `JoinRequestApprover` constructor gains `relayers` / `contracts` / `proofGenerator` / `makeContractTransport` deps. Wired through `OnymIOSApp`.

### Test plan

- [x] **6 prior `JoinRequestApproverTests`** now exercise the Tyranny anchor flow through stubbed proof generator + chain transport. Test fixture stands up an in-memory `RelayerRepository` + `ContractsRepository` pre-loaded with one endpoint + one Tyranny binding.
- [x] **2 new tests**:
  - `test_approve_outdatedJoinerClient_whenLeafHashMissing` — pre-PR-13 joiner with no `leaf_hash` returns `.outdatedJoinerClient`, request not consumed.
  - `test_approve_anchorRejected_doesNotConsumeRequest` — chain returns `accepted=false`, no envelopes shipped, request stays in store, local epoch unchanged.
- [x] Full unit suite — 498/498 pass (3 skipped, pre-existing).
- [ ] Manual smoke (multi-device): admin approves, observe `update_commitment` POST to relayer + on-chain epoch advance + joiner gets the new state.

### Bundled localization fix

Filled 6 leftover Russian translations from PR 12 (`Add`, `DEFAULT`, `TBA`, `Restore default`, `No relays configured…`, `Re-install Onym Official…`). Russian is best-effort, flagged for native-speaker review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)