### PR TITLE
fix(approver): in-flight feedback for Approve / Decline (PR 14)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -568,6 +568,7 @@
       }
     },
     "Approve" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1360,6 +1361,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Загружаю список…"
+          }
+        }
+      }
+    },
+    "Generating proof and updating the on-chain commitment. This usually takes a few seconds." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generating proof and updating the on-chain commitment. This usually takes a few seconds."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Генерируется доказательство и обновляется обязательство в блокчейне. Обычно занимает несколько секунд."
+          }
+        }
+      }
+    },
+    "Anchoring on chain…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anchoring on chain…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Якорим в блокчейне…"
           }
         }
       }

--- a/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
@@ -19,12 +19,26 @@ final class ApproveRequestsFlow {
     /// Last failed-approve reason, or nil. Cleared on the next
     /// successful Approve / Decline / dismiss.
     var lastError: String?
+    /// Request IDs whose Approve / Decline call is currently in
+    /// flight. Drives the per-row spinner + disabled-buttons state
+    /// in `ApproveRequestsView`. Necessary because PR 13a turned
+    /// `approve` into a multi-second flow (PLONK prove +
+    /// `update_commitment` HTTP roundtrip + Stellar tx wait) — without
+    /// this signal the UI looks frozen while the proof generates.
+    var inFlightRequestIDs: Set<String> = []
 
     private let approver: any JoinRequestApproving
     private var streamingTask: Task<Void, Never>?
 
     init(approver: any JoinRequestApproving) {
         self.approver = approver
+    }
+
+    /// True when the row for `requestID` should render as
+    /// in-flight (spinner + disabled). Helper so views don't have
+    /// to reach into the `Set` directly.
+    func isInFlight(_ requestID: String) -> Bool {
+        inFlightRequestIDs.contains(requestID)
     }
 
     /// Start the underlying collector + mirror `pending` snapshots
@@ -50,17 +64,28 @@ final class ApproveRequestsFlow {
     }
 
     func approve(_ id: String) {
+        // Debounce: a second tap while the first call is in flight
+        // is a no-op. `approver.approve` is idempotent on requestID
+        // (already-consumed requests return `.unknownRequest`), but
+        // re-entering the proof+chain submission path twice is a
+        // waste of cycles + can confuse `lastError` ordering.
+        guard !inFlightRequestIDs.contains(id) else { return }
+        inFlightRequestIDs.insert(id)
         let approver = self.approver
         Task { @MainActor [weak self] in
             let outcome = await approver.approve(requestId: id)
+            self?.inFlightRequestIDs.remove(id)
             self?.lastError = Self.failureReason(for: outcome)
         }
     }
 
     func decline(_ id: String) {
+        guard !inFlightRequestIDs.contains(id) else { return }
+        inFlightRequestIDs.insert(id)
         let approver = self.approver
         Task { @MainActor [weak self] in
             await approver.decline(requestId: id)
+            self?.inFlightRequestIDs.remove(id)
             self?.lastError = nil
         }
     }

--- a/Sources/OnymIOS/Group/ApproveRequestsView.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsView.swift
@@ -123,7 +123,8 @@ struct ApproveRequestsView: View {
     }
 
     private func requestCard(_ request: JoinRequestApprover.PendingRequest) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        let inFlight = flow.isInFlight(request.id)
+        return VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 6) {
                 Text(displayAlias(request.joinerDisplayLabel))
                     .font(.system(size: 16, weight: .semibold))
@@ -146,22 +147,39 @@ struct ApproveRequestsView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
                 .accessibilityIdentifier("approve_requests.decline_button.\(request.id)")
-                .disabled(request.groupName == nil)
+                .disabled(request.groupName == nil || inFlight)
                 Button {
                     flow.approve(request.id)
                 } label: {
-                    Text("Approve")
-                        .font(.system(size: 14, weight: .semibold))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 11)
-                        .background(OnymAccent.blue.color)
-                        .foregroundStyle(OnymTokens.onAccent)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    HStack(spacing: 6) {
+                        if inFlight {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .tint(OnymTokens.onAccent)
+                                .scaleEffect(0.8)
+                        }
+                        Text(inFlight ? "Anchoring on chain\u{2026}" : "Approve")
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 11)
+                    .background(OnymAccent.blue.color.opacity(inFlight ? 0.7 : 1.0))
+                    .foregroundStyle(OnymTokens.onAccent)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
                 .accessibilityIdentifier("approve_requests.approve_button.\(request.id)")
-                .disabled(request.groupName == nil)
+                .disabled(request.groupName == nil || inFlight)
             }
-            if request.groupName == nil {
+            if inFlight {
+                // The on-chain admit ceremony is multi-second
+                // (PLONK proving + relayer roundtrip + Stellar tx
+                // confirmation) — surface that explicitly so the
+                // admin doesn't think the tap was lost.
+                Text("Generating proof and updating the on-chain commitment. This usually takes a few seconds.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+                    .accessibilityIdentifier("approve_requests.in_flight_hint.\(request.id)")
+            } else if request.groupName == nil {
                 Text("This request is for a group that isn\u{2019}t on this device. Decline to clear it.")
                     .font(.system(size: 12))
                     .foregroundStyle(OnymTokens.text2)

--- a/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
+++ b/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
@@ -76,6 +76,71 @@ final class ApproveRequestsFlowTests: XCTestCase {
         XCTAssertEqual(calls, ["req-1"])
     }
 
+    // MARK: - PR 14 in-flight state
+
+    func test_approve_marksInFlight_thenClearsOnCompletion() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        await stub.setHoldApprove(true)
+        await stub.setNextOutcome(.sent)
+
+        flow.approve("req-flight")
+        // Synchronously after the intent fires, the ID should be
+        // recorded as in-flight (the .insert happens on the @MainActor
+        // before the Task hits any suspension point).
+        try await waitFor { flow.isInFlight("req-flight") }
+
+        await stub.releaseApprove()
+        try await waitFor { !flow.isInFlight("req-flight") }
+        XCTAssertNil(flow.lastError, ".sent outcome must clear lastError")
+    }
+
+    func test_approve_secondTapWhileInFlight_isNoop() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        await stub.setHoldApprove(true)
+
+        flow.approve("req-debounce")
+        try await waitFor { flow.isInFlight("req-debounce") }
+        // Second tap during in-flight is debounced — must not call
+        // `approver.approve` again.
+        flow.approve("req-debounce")
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let calls = await stub.approveCalls
+        XCTAssertEqual(calls, ["req-debounce"],
+                       "second tap during in-flight must be a no-op")
+
+        await stub.releaseApprove()
+        try await waitFor { !flow.isInFlight("req-debounce") }
+    }
+
+    func test_approve_clearsInFlight_evenOnFailure() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        await stub.setHoldApprove(true)
+        await stub.setNextOutcome(.anchorRejected("test reject"))
+
+        flow.approve("req-fail")
+        try await waitFor { flow.isInFlight("req-fail") }
+
+        await stub.releaseApprove()
+        try await waitFor { !flow.isInFlight("req-fail") }
+        XCTAssertNotNil(flow.lastError,
+                        "failure must populate lastError so the banner shows")
+    }
+
+    func test_decline_marksInFlight_thenClears() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        await stub.setHoldDecline(true)
+
+        flow.decline("req-dec")
+        try await waitFor { flow.isInFlight("req-dec") }
+
+        await stub.releaseDecline()
+        try await waitFor { !flow.isInFlight("req-dec") }
+    }
+
     // MARK: - Misc
 
     func test_dismissError_clearsLastError() {
@@ -130,6 +195,21 @@ private actor StubApprover: JoinRequestApproving {
     private(set) var startCalls: Int = 0
     private var nextOutcome: JoinRequestApprover.ApproveOutcome = .sent
 
+    /// PR 14: optional gate so tests can hold `approve` / `decline`
+    /// in flight to assert the flow's `inFlightRequestIDs` state.
+    /// Default is "complete immediately" (matches PR 13's fast-path
+    /// tests). Polling-based instead of continuation-based to avoid
+    /// the test/stub setup race where `release` could fire before
+    /// the held call had stored its continuation.
+    private var holdApprove: Bool = false
+    private var holdDecline: Bool = false
+
+    func setHoldApprove(_ hold: Bool) { holdApprove = hold }
+    func setHoldDecline(_ hold: Bool) { holdDecline = hold }
+
+    func releaseApprove() { holdApprove = false }
+    func releaseDecline() { holdDecline = false }
+
     func emit(_ requests: [JoinRequestApprover.PendingRequest]) {
         snapshot = requests
         for c in continuations.values { c.yield(requests) }
@@ -155,11 +235,17 @@ private actor StubApprover: JoinRequestApproving {
 
     func approve(requestId: String) async -> JoinRequestApprover.ApproveOutcome {
         approveCalls.append(requestId)
+        while holdApprove {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
         return nextOutcome
     }
 
     func decline(requestId: String) async {
         declineCalls.append(requestId)
+        while holdDecline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
     }
 
     private func subscribe(


### PR DESCRIPTION
## Summary

Stacked on #89.

**Bug** (reported live during smoke testing): PR 13a turned `JoinRequestApprover.approve` into a multi-second flow (PLONK proving ~3-5s + relayer roundtrip + Stellar tx wait). The UI gave zero feedback during that window — Alice taps Approve, nothing visible changes for 5-15s, looks frozen.

**Fix:**

- `ApproveRequestsFlow` gains `inFlightRequestIDs: Set<String>` tracking per-request in-flight state. Updated synchronously when the intent fires (so SwiftUI re-renders immediately) and cleared in the completion handler.
- `approve` / `decline` debounce: a second tap during in-flight is a no-op so the user can't accidentally fire two proof+chain submissions.
- `ApproveRequestsView` request card renders a `ProgressView` + \"Anchoring on chain…\" label on the Approve button while in-flight, dims the button background, disables both buttons, and shows an inline hint:

  > Generating proof and updating the on-chain commitment. This usually takes a few seconds.

  Decline buttons are also disabled during in-flight to prevent state-machine confusion (admin can't undo Approve mid-anchor).

### Test coverage

4 new `ApproveRequestsFlowTests`:
- `approve_marksInFlight_thenClearsOnCompletion`
- `approve_secondTapWhileInFlight_isNoop` (debounce)
- `approve_clearsInFlight_evenOnFailure` (error path)
- `decline_marksInFlight_thenClears`

Stub gate refactored from `CheckedContinuation` to a polling `Bool` flag — eliminates a test/stub setup race where `release` could fire before the held call had stored its continuation.

Full suite: **506/506 pass** (3 skipped, pre-existing).

Localization: filled en+ru for the two new strings (`Anchoring on chain…`, `Generating proof and updating the on-chain commitment. This usually takes a few seconds.`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)