### PR TITLE
fix(inbox): wrong commitment recompute in PR 13b verifier

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -533,6 +533,23 @@
         }
       }
     },
+    "Anchoring on chain…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anchoring on chain…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Якорим в блокчейне…"
+          }
+        }
+      }
+    },
     "Anchors" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -580,6 +597,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Принять"
+          }
+        }
+      }
+    },
+    "Approved on chain" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approved on chain"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закреплено в блокчейне"
           }
         }
       }
@@ -1377,22 +1410,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Генерируется доказательство и обновляется обязательство в блокчейне. Обычно занимает несколько секунд."
-          }
-        }
-      }
-    },
-    "Anchoring on chain…" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anchoring on chain…"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Якорим в блокчейне…"
           }
         }
       }

--- a/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
@@ -19,6 +19,12 @@ final class ApproveRequestsFlow {
     /// Last failed-approve reason, or nil. Cleared on the next
     /// successful Approve / Decline / dismiss.
     var lastError: String?
+    /// Brief success banner copy after a `.sent` approval. Auto-
+    /// dismisses ~3s after being set so the admin gets a positive
+    /// confirmation without having to manually clear it. The row
+    /// disappearing is also feedback, but explicit "Approved on
+    /// chain" makes the on-chain step visible.
+    var lastSuccessMessage: String?
     /// Request IDs whose Approve / Decline call is currently in
     /// flight. Drives the per-row spinner + disabled-buttons state
     /// in `ApproveRequestsView`. Necessary because PR 13a turned
@@ -72,10 +78,40 @@ final class ApproveRequestsFlow {
         guard !inFlightRequestIDs.contains(id) else { return }
         inFlightRequestIDs.insert(id)
         let approver = self.approver
+        // Capture joiner alias before firing — used for the success
+        // banner. Falls back to "this person" if the row was already
+        // removed somehow.
+        let joinerAlias = pending.first { $0.id == id }?.joinerDisplayLabel
         Task { @MainActor [weak self] in
             let outcome = await approver.approve(requestId: id)
-            self?.inFlightRequestIDs.remove(id)
-            self?.lastError = Self.failureReason(for: outcome)
+            guard let self else { return }
+            self.inFlightRequestIDs.remove(id)
+            switch outcome {
+            case .sent:
+                self.lastError = nil
+                let alias = joinerAlias?.trimmingCharacters(in: .whitespacesAndNewlines)
+                let label = (alias?.isEmpty ?? true) ? "this person" : alias!
+                self.lastSuccessMessage = "\(label) is now in the group."
+                self.scheduleSuccessDismiss()
+            default:
+                self.lastSuccessMessage = nil
+                self.lastError = Self.failureReason(for: outcome)
+            }
+        }
+    }
+
+    /// Auto-clear the success banner after ~3s. Cancelled implicitly
+    /// when a fresh approval overwrites `lastSuccessMessage` — the
+    /// detached Task only zeroes the field if it's still the same
+    /// content it set.
+    private func scheduleSuccessDismiss() {
+        let snapshot = lastSuccessMessage
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard let self else { return }
+            if self.lastSuccessMessage == snapshot {
+                self.lastSuccessMessage = nil
+            }
         }
     }
 

--- a/Sources/OnymIOS/Group/ApproveRequestsView.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsView.swift
@@ -17,6 +17,9 @@ struct ApproveRequestsView: View {
     var body: some View {
         VStack(spacing: 0) {
             topBar
+            if let success = flow.lastSuccessMessage {
+                successBanner(success)
+            }
             if let error = flow.lastError {
                 errorBanner(error)
             }
@@ -27,6 +30,34 @@ struct ApproveRequestsView: View {
             }
         }
         .background(OnymTokens.bg)
+    }
+
+    // MARK: - Success
+
+    private func successBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(OnymTokens.green)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Approved on chain")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text(message)
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(12)
+        .background(OnymTokens.surface2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(OnymTokens.green.opacity(0.4), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+        .accessibilityIdentifier("approve_requests.success_banner")
     }
 
     // MARK: - Top bar

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -212,20 +212,28 @@ struct IncomingMessageDispatcher: Sendable {
     }
 
     /// PR 13b: validate a Tyranny invitation's commitment against
-    /// both the wire-shipped members list (recomputed Poseidon root)
+    /// both the wire-shipped state (recomputed Poseidon commitment)
     /// and the on-chain state (`SEPContractClient.getCommitment`).
+    ///
+    /// The commitment is `Poseidon(Poseidon(merkle_root, epoch), salt)`
+    /// — NOT just the merkle root. The original PR 13b verifier got
+    /// this wrong and rejected every legitimate invitation because
+    /// `merkle_root != commitment`. Bug fix landed here.
     ///
     /// Three failure modes — all return `false`:
     ///   - Payload omits `commitment` (pre-PR-13a sender, can't
     ///     verify, refuse).
-    ///   - `Common.merkleRoot(payload.members)` ≠ `payload.commitment`
-    ///     (internally inconsistent — can't be a valid post-update
-    ///     state for the claimed roster).
+    ///   - Recomputed `Poseidon(Poseidon(merkle_root(members),
+    ///     epoch), salt)` ≠ `payload.commitment` (internally
+    ///     inconsistent — sender can't have run a valid
+    ///     `update_commitment` for the claimed `(members, epoch,
+    ///     salt)` triple, OR they fabricated `members` while
+    ///     copying a real on-chain commitment).
     ///   - On-chain `commitment` ≠ `payload.commitment` OR on-chain
-    ///     `epoch` ≠ `payload.epoch` (forged by someone who isn't
-    ///     the admin — chain rejected their proof, but they may
-    ///     still try to ship a fake invitation; receiver catches it
-    ///     here).
+    ///     `epoch` ≠ `payload.epoch` (forged commitment that
+    ///     doesn't match what's anchored — chain rejected the
+    ///     sender's proof, they may still try to ship a fake
+    ///     invitation; receiver catches it here).
     ///
     /// Throws on chain-read transport failures are also treated as
     /// "couldn't verify, reject" — the safe default. Operators
@@ -238,17 +246,28 @@ struct IncomingMessageDispatcher: Sendable {
         guard let claimedCommitment = invitation.commitment else {
             return false
         }
-        // Internal consistency: recompute root from wire members.
-        let recomputedRoot: Data
+        // Internal consistency: recompute the FULL Poseidon
+        // commitment from (members, epoch, salt) and compare. The
+        // commitment is the Poseidon hash of (root, epoch, salt) —
+        // not just the root. Both sides of this check land on the
+        // same byte string only when the sender ran a valid
+        // `update_commitment` (or `create_group`) for these exact
+        // inputs.
+        let recomputed: Data
         do {
-            recomputedRoot = try GroupCommitmentBuilder.computeMerkleRoot(
+            let root = try GroupCommitmentBuilder.computeMerkleRoot(
                 members: invitation.members,
                 tier: tier
+            )
+            recomputed = try GroupCommitmentBuilder.computePoseidonCommitment(
+                poseidonRoot: root,
+                epoch: invitation.epoch,
+                salt: invitation.salt
             )
         } catch {
             return false
         }
-        guard recomputedRoot == claimedCommitment else { return false }
+        guard recomputed == claimedCommitment else { return false }
         // External anchor: matches what's on chain.
         let onchain: SEPCommitmentEntry
         do {

--- a/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
+++ b/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
@@ -83,6 +83,9 @@ final class ApproveRequestsFlowTests: XCTestCase {
         let flow = ApproveRequestsFlow(approver: stub)
         await stub.setHoldApprove(true)
         await stub.setNextOutcome(.sent)
+        await stub.emit([Self.makeRequest(id: "req-flight", alias: "Bob")])
+        await flow.start()
+        try await waitFor { flow.pending.map(\.id).contains("req-flight") }
 
         flow.approve("req-flight")
         // Synchronously after the intent fires, the ID should be
@@ -93,6 +96,39 @@ final class ApproveRequestsFlowTests: XCTestCase {
         await stub.releaseApprove()
         try await waitFor { !flow.isInFlight("req-flight") }
         XCTAssertNil(flow.lastError, ".sent outcome must clear lastError")
+        // PR 15: success banner shows the joiner's alias.
+        XCTAssertEqual(flow.lastSuccessMessage, "Bob is now in the group.")
+    }
+
+    func test_approve_successBanner_autoDismissesAfter3s() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        await stub.setNextOutcome(.sent)
+        await stub.emit([Self.makeRequest(id: "req-toast", alias: "Bob")])
+        await flow.start()
+        try await waitFor { flow.pending.map(\.id).contains("req-toast") }
+
+        flow.approve("req-toast")
+        try await waitFor { flow.lastSuccessMessage != nil }
+        // Wait a touch over 3s for the auto-dismiss task.
+        try await Task.sleep(nanoseconds: 3_200_000_000)
+        XCTAssertNil(flow.lastSuccessMessage,
+                     "success banner must auto-dismiss after ~3s")
+    }
+
+    func test_approve_failureClearsAnyPriorSuccessBanner() async throws {
+        let stub = StubApprover()
+        let flow = ApproveRequestsFlow(approver: stub)
+        flow.lastSuccessMessage = "stale success"
+        await stub.emit([Self.makeRequest(id: "req-fail-bus", alias: "Bob")])
+        await flow.start()
+        try await waitFor { flow.pending.map(\.id).contains("req-fail-bus") }
+        await stub.setNextOutcome(.anchorRejected("test"))
+
+        flow.approve("req-fail-bus")
+        try await waitFor { flow.lastError != nil }
+        XCTAssertNil(flow.lastSuccessMessage,
+                     "failure must clear any leftover success banner")
     }
 
     func test_approve_secondTapWhileInFlight_isNoop() async throws {

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -322,22 +322,26 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         // for Tyranny groups, so subsequent announcements can be
         // verified against it.
         //
-        // PR 13b: Tyranny invitations now also require the wire
-        // `commitment` to match `Common.merkleRoot(members)` AND
-        // the on-chain commitment. Compute the real root from the
-        // (empty) test member list, seed the chain stub to match.
+        // PR 13b (post-fix): Tyranny invitations require the wire
+        // `commitment` to match Poseidon(Poseidon(merkle_root, epoch),
+        // salt) AND the on-chain commitment. Compute the real
+        // commitment from the (empty) test member list + the salt
+        // that makeInvitationPayload uses, seed the chain stub.
         let groupID = Data(repeating: 0x42, count: 32)
-        let realRoot = try GroupCommitmentBuilder.computeMerkleRoot(
+        let salt = Data(repeating: 0x66, count: 32)  // matches makeInvitationPayload
+        let realCommitment = try Self.makeRealTyrannyCommitment(
             members: [],
+            epoch: 0,
+            salt: salt,
             tier: .small
         )
-        chainState.setNext(commitment: realRoot, epoch: 0)
+        chainState.setNext(commitment: realCommitment, epoch: 0)
         let payload = makeInvitationPayload(
             groupID: groupID,
             name: "Family",
             memberProfiles: nil,
             groupType: .tyranny,
-            commitment: realRoot
+            commitment: realCommitment
         )
         let plaintext = try JSONEncoder().encode(payload)
         let admin = Data(repeating: 0xED, count: 32)
@@ -398,24 +402,28 @@ final class IncomingMessageDispatcherTests: XCTestCase {
     }
 
     func test_invitation_tyranny_rejectsWhenOnchainCommitmentMismatch() async throws {
-        // The dispatcher recomputes the Poseidon root from the wire
-        // members and verifies the resulting root matches BOTH the
+        // The dispatcher recomputes Poseidon(Poseidon(root, epoch),
+        // salt) from the wire and verifies it matches BOTH the
         // payload's commitment AND the on-chain state. If on-chain
-        // disagrees (because the sender forged a fake commitment),
-        // reject the invitation.
+        // disagrees (the sender forged a fake commitment that
+        // happens to be self-consistent), reject the invitation.
         let groupID = Data(repeating: 0x42, count: 32)
-        let internallyConsistentRoot = try GroupCommitmentBuilder.computeMerkleRoot(
+        let salt = Data(repeating: 0x66, count: 32)
+        let internallyConsistent = try Self.makeRealTyrannyCommitment(
             members: [],
+            epoch: 0,
+            salt: salt,
             tier: .small
         )
-        // Payload claims this root; chain says something different.
+        // Payload's commitment is internally consistent; chain
+        // says something different.
         chainState.setNext(commitment: Data(repeating: 0xFF, count: 32), epoch: 0)
         let payload = makeInvitationPayload(
             groupID: groupID,
             name: "Family",
             memberProfiles: nil,
             groupType: .tyranny,
-            commitment: internallyConsistentRoot
+            commitment: internallyConsistent
         )
         let plaintext = try JSONEncoder().encode(payload)
         let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
@@ -767,6 +775,27 @@ final class IncomingMessageDispatcherTests: XCTestCase {
 
     private static func encode(announcement: MemberAnnouncementPayload) throws -> Data {
         try JSONEncoder().encode(announcement)
+    }
+
+    /// Compute the real Tyranny commitment for a given (members,
+    /// epoch, salt) — i.e. `Poseidon(Poseidon(merkle_root, epoch),
+    /// salt)`. Tests that exercise PR 13b's verifier need this so
+    /// the dispatcher's recompute matches the wire-shipped value.
+    static func makeRealTyrannyCommitment(
+        members: [GovernanceMember],
+        epoch: UInt64,
+        salt: Data,
+        tier: SEPTier
+    ) throws -> Data {
+        let root = try GroupCommitmentBuilder.computeMerkleRoot(
+            members: members,
+            tier: tier
+        )
+        return try GroupCommitmentBuilder.computePoseidonCommitment(
+            poseidonRoot: root,
+            epoch: epoch,
+            salt: salt
+        )
     }
 
     private func makeInvitationPayload(


### PR DESCRIPTION
## Summary

Stacked on #90.

**Critical bug.** PR 13b's `verifyTyrannyInvitation` compared `Common.merkleRoot(members)` (the Poseidon root over the leaves) to `payload.commitment`. But the commitment isn't the root — it's `Poseidon(Poseidon(merkle_root, epoch), salt)`. So the verifier rejected **every legitimate Tyranny invitation**.

**Symptom** (reported live): admin approves on Alice's device → anchor succeeds on chain → sealed invitation arrives in Bob's inbox → dispatcher's internal-recompute check fails → message silently dropped → Bob's `JoinFlow` stays on \"Waiting for the host to approve…\" forever.

### Fix

- `verifyTyrannyInvitation` now computes the **full** Poseidon commitment via `GroupCommitmentBuilder.computePoseidonCommitment` before comparing. This matches the shape that both production proofs (`CreateProof.PI[0]`, `UpdateProof.PI[2]`) emit and that the contract stores.
- Tests gain a `makeRealTyrannyCommitment` helper that computes the legit value from `(members, epoch, salt, tier)` so dispatcher tests can exercise the verifier with realistic inputs.

### Bundled UX fix

For the second half of the report (\"no visual feedback if anchoring was successful or not\"):

- `ApproveRequestsFlow` gains `lastSuccessMessage` with auto-dismiss ~3s after a `.sent` outcome. Falls back to \"this person\" if the joiner row was already removed.
- `ApproveRequestsView` shows a green **\"Approved on chain · Bob is now in the group.\"** banner above the request list. Mirrors the existing red error banner shape for consistency.

### Test plan

- [x] **3 new `ApproveRequestsFlowTests`** — `lastSuccessMessage` populated on `.sent`, auto-dismisses after 3s, failure clears any leftover success banner.
- [x] **Updated 2 `IncomingMessageDispatcherTests`** — `test_invitation_capturesSenderEd25519AsAdmin` and `test_invitation_tyranny_rejectsWhenOnchainCommitmentMismatch` now seed the chain stub with the real Poseidon commitment.
- [x] All previously-passing tests still pass — **508/508 (3 skipped, pre-existing)**.
- [ ] **Manual smoke** (the original failure scenario):
  1. Bob taps invite, sends join request.
  2. Alice approves — green banner: \"Approved on chain · Bob is now in the group.\"
  3. Bob's join sheet flips to \"You're in!\" within ~5s.
  4. Bob's chat list shows the new group with both Alice + Bob in the roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)