### PR TITLE
fix(join): prefill display name from active identity (closes #74)

### DIFF
--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -176,14 +176,23 @@ struct OnymIOSApp: App {
                     groupRepository: groupRepository
                 )
             },
-            makeJoinFlow: { @MainActor capability in
+            makeJoinFlow: { @MainActor [identitiesFlow] capability in
                 let sender = JoinRequestSender(
                     identity: repository,
                     inboxTransport: inboxTransport
                 )
+                // Pre-fill with the active identity's alias so the
+                // joiner sees a sensible default. Empty string when
+                // `identitiesFlow` hasn't populated yet (cold-start
+                // race) — JoinView's TextField placeholder + the
+                // disabled Send button prompt the user to type
+                // something in.
+                let activeName = identitiesFlow.identities
+                    .first { $0.id == identitiesFlow.currentID }?
+                    .name ?? ""
                 return JoinFlow(
                     capability: capability,
-                    suggestedDisplayLabel: "alice",  // PR-7+: derive from active identity
+                    suggestedDisplayLabel: activeName,
                     submitRequest: { cap, label in
                         await sender.send(
                             capability: cap,
@@ -213,6 +222,12 @@ struct OnymIOSApp: App {
                     // operation that needs identity will surface a clear
                     // error to the user.
                     _ = try? await identityRepository.bootstrap()
+                    // Eagerly populate the shared identities flow so a
+                    // cold-start deeplink (which constructs JoinFlow
+                    // before any tab's `.task` has fired) can read the
+                    // active identity's alias for `suggestedDisplayLabel`.
+                    // Idempotent — Chats / Settings tabs call this too.
+                    await dependencies.identitiesFlow.start()
                     // Start the approver collector eagerly so the
                     // Chats toolbar badge reflects pending requests
                     // from the moment the app is on screen, even


### PR DESCRIPTION
## Summary

Stacked on #91. Closes #74.

**Bug** (reported live): when Bob taps an invite deeplink, the display-name field defaults to the literal `"alice"` — a hardcoded placeholder left over from PR-7's stub data. Bob has to manually clear it and retype his alias on every join.

### Fix

`makeJoinFlow` reads the active identity's alias from the shared `identitiesFlow` at `JoinFlow` construction time:

```swift
let activeName = identitiesFlow.identities
    .first { $0.id == identitiesFlow.currentID }?
    .name ?? \"\"
```

Falls back to empty string when nothing's resolved yet (e.g., cold-start race). `JoinView`'s TextField placeholder + the disabled Send button already prompt the user to type a name in that case, so no silent broken state.

### Cold-start race fix

The WindowGroup `.task` now eagerly calls `identitiesFlow.start()` right after `identityRepository.bootstrap()`. Without it, a cold-start deeplink could construct `JoinFlow` before the Chats / Settings tab tasks fire, and `identitiesFlow.identities` would be empty → fallback to `\"\"`. Eager `start()` is idempotent (it guards on `streamingTask == nil`), so the per-tab `.task { await identitiesFlow.start() }` calls in `ChatsView` / `SettingsView` continue to work the same way.

### Test plan

- [x] All `JoinFlowTests` still pass (6/6) — they construct `JoinFlow` directly with a stubbed `submitRequest`, unaffected by the wiring change.
- [x] Full suite: **508/508 pass** (3 skipped, pre-existing).
- [ ] Manual: cold-launch the joiner sim, tap an invite deeplink → display-name field should be prefilled with the active identity's alias (not \"alice\").
- [ ] Manual: warm-launch (app already running), tap deeplink → same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)