### PR TITLE
fix(approver): pre-flight admin-identity check before proof generation

### DIFF
--- a/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
@@ -147,6 +147,8 @@ final class ApproveRequestsFlow {
             return "No chain relayer configured. Set one in Settings \u{2192} Network \u{2192} Relayer."
         case .noContractBinding:
             return "No Tyranny contract selected for this network. Pick one in Settings \u{2192} Network \u{2192} Anchors."
+        case .notAdminOfThisGroup:
+            return "The active identity isn\u{2019}t this group\u{2019}s admin. Switch to the identity that created the group, then try again."
         case .proofFailed(let reason):
             return "Couldn\u{2019}t generate proof: \(reason)"
         case .anchorRejected(let reason):

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -79,6 +79,14 @@ actor JoinRequestApprover: JoinRequestApproving {
         /// user hasn't picked a deployed Tyranny contract for the
         /// active network in Settings → Anchors.
         case noContractBinding
+        /// The active identity isn't this group's admin: the BLS
+        /// pubkey derived from the keychain's secret doesn't match
+        /// the admin pubkey baked into the local group state. Most
+        /// common cause: user switched to a different identity
+        /// between group create-time and approve-time, or restored
+        /// from a different recovery phrase. Catches cleanly what
+        /// would otherwise surface as a cryptic SDK proof failure.
+        case notAdminOfThisGroup
         /// `Tyranny.proveUpdate` failed — usually means a corrupted
         /// roster, wrong tier depth, or SDK FFI error. Diagnostic
         /// detail in the associated string.
@@ -377,6 +385,26 @@ actor JoinRequestApprover: JoinRequestApproving {
             blsSecret = try await identity.blsSecretKey()
         } catch {
             return .failed(.transportFailed("bls_secret: \(error)"))
+        }
+
+        // Pre-flight: confirm the active identity actually IS the
+        // admin of this group before handing the secret to the
+        // prover. Catches the common "Alice has switched identities,
+        // her current keychain secret doesn't match the group's
+        // stored admin BLS pubkey" case cleanly — without this check
+        // the SDK would surface the same problem as a cryptic
+        // `Poseidon(admin_secret_key) ≠ supplied leaf hash` error
+        // ~3-5s later (after the prover's pre-witness checks fail).
+        let activePubFromSecret: Data
+        do {
+            activePubFromSecret = try GroupCommitmentBuilder.computePublicKey(
+                secretKey: blsSecret
+            )
+        } catch {
+            return .failed(.transportFailed("derive_pub: \(error)"))
+        }
+        guard activePubFromSecret == group.members[adminIndexOld].publicKeyCompressed else {
+            return .failed(.notAdminOfThisGroup)
         }
         let proofInput = GroupProofUpdateInput(
             groupType: .tyranny,

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -241,6 +241,40 @@ final class JoinRequestApproverTests: XCTestCase {
                        "epoch must NOT advance when anchor is rejected")
     }
 
+    func test_approve_notAdminOfThisGroup_whenStoredAdminPubkeyDoesntMatchActiveIdentity() async throws {
+        // Simulate the "Alice switched to a different identity, but
+        // the group was created by the original Alice" case. The
+        // approver's pre-flight should catch this before the SDK
+        // proof attempt, surfacing as `.notAdminOfThisGroup` (the
+        // user-meaningful error) rather than `.proofFailed` with the
+        // cryptic `Poseidon(admin_secret_key) ≠ supplied leaf hash`
+        // message.
+        let env = try await seedEnvironment()
+        // Mutate the persisted group so its first member's BLS
+        // pubkey is NOT what the active identity's secret hashes to.
+        var groups = await groups.currentGroups()
+        guard var group = groups.first(where: { $0.id == env.groupID.map { String(format: "%02x", $0) }.joined() }) else {
+            XCTFail("test fixture didn't insert the group"); return
+        }
+        let bogusAdminMember = GovernanceMember(
+            publicKeyCompressed: Data(repeating: 0xEE, count: 48),
+            leafHash: Data(repeating: 0xFF, count: 32)
+        )
+        group.members = [bogusAdminMember]
+        group.adminPubkeyHex = bogusAdminMember.publicKeyCompressed
+            .map { String(format: "%02x", $0) }.joined()
+        _ = await self.groups.insert(group)
+
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .notAdminOfThisGroup,
+                       "pre-flight must catch identity mismatch before invoking the prover")
+
+        let sends = await transport.sends
+        XCTAssertTrue(sends.isEmpty,
+                      "no envelopes shipped when admin pre-flight fails")
+    }
+
     // MARK: - decline
 
     func test_decline_dropsRequestAndRevokesKey() async throws {


### PR DESCRIPTION
## Re: \"are we sending secret keys via transport?\"

**No long-term identity secrets ever leave the keychain.** We ship two kinds of symmetric/per-dialog secret material, both **only inside sealed X25519+AES-GCM envelopes**:

| Field | What it is | Where |
|------|-----------|-------|
| `groupSecret` | 32-byte symmetric key for future message-key HKDF | Sealed inside `GroupInvitationPayload`, recipient = each invitee's inbox pubkey |
| `peerBlsSecret` (OneOnOne only) | Fresh BLS Fr scalar minted by creator for the peer party | Same envelope; OneOnOne SDK requires both secrets at create time, creator gifts one |

Everything else on the wire is public material — pubkeys, hashes, commitments. `joinerLeafHash` for example is `Poseidon(BLS_Fr)`, not the secret itself; Poseidon is one-way.

So: yes, some secrets are transported, but always inside encrypted envelopes addressed to a specific recipient's inbox. A relayer / on-path attacker sees ciphertext.

---

## Bug fix in this PR — the cryptic SDK error you screenshotted

`Poseidon(admin_secret_key) ≠ supplied leaf hash` is the prover's pre-witness check failing. It says: *the secret I was handed doesn't hash to the leaf the caller said is at `adminIndexOld`*.

Most common cause when testing: **Alice's active identity isn't actually the group's admin**. Either she switched identities post-create, or restored from a different recovery phrase, or a multi-identity test setup got mixed up. Either way, the secret pulled from the keychain doesn't match the BLS pubkey baked into the group's `members[adminIndexOld]`.

### Fix

Pre-flight check in `JoinRequestApprover.anchorTyrannyJoin` — before handing the secret to the prover:

```swift
let activePubFromSecret = try GroupCommitmentBuilder.computePublicKey(secretKey: blsSecret)
guard activePubFromSecret == group.members[adminIndexOld].publicKeyCompressed else {
    return .failed(.notAdminOfThisGroup)
}
```

New `ApproveOutcome.notAdminOfThisGroup` case with user-meaningful banner copy:
> *The active identity isn't this group's admin. Switch to the identity that created the group, then try again.*

Catches the mismatch in milliseconds instead of letting the prover spend 3-5s on a doomed witness, and gives Alice a clear next step.

### Test plan

- [x] New `test_approve_notAdminOfThisGroup_whenStoredAdminPubkeyDoesntMatchActiveIdentity` — mutates the group's members to a bogus admin pubkey, asserts pre-flight returns `.notAdminOfThisGroup` without invoking the prover or shipping any envelope.
- [x] All previous approver tests pass (9/9).
- [x] Full suite **509/509 pass** (3 skipped, pre-existing).
- [ ] Manual: switch identities mid-test, tap Approve — should see the new banner instead of the SDK error.
- [ ] Manual (the actual scenario reported): create a group as Alice, do NOT switch identities, approve Bob's request — should NOT trip this check; should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)