### PR TITLE
fix(chats): hide Share Invite for non-admins on Tyranny groups

### DIFF
--- a/Sources/OnymIOS/Chats/ChatMembersView.swift
+++ b/Sources/OnymIOS/Chats/ChatMembersView.swift
@@ -42,13 +42,16 @@ struct ChatMembersView: View {
         .navigationBarTitleDisplayMode(.inline)
         .background(OnymTokens.bg)
         .toolbar {
-            // Only the local owner of the group can mint a useful
-            // invite link — joiners' invites would point requests at
-            // their own intro inbox, where they can't actually admit
-            // anyone (admin approval is what materializes the group
-            // for the new joiner). Showing the entry-point only on
-            // owner-side groups removes a footgun.
-            if isLocalOwner {
+            // Only the cryptographic admin can mint a useful invite
+            // link — non-admin members minting invites would surface
+            // join requests in their own intro inbox, but the
+            // approver's PR-13 anchor flow would short-circuit with
+            // `.notAdminOfThisGroup` because they don't hold the
+            // admin BLS secret. Hiding the entry-point removes the
+            // footgun + matches the cryptographic constraint
+            // already enforced on chain (sep-tyranny rejects
+            // `update_commitment` proofs from non-admins).
+            if canShareInvite {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         shareInviteFlow = makeShareInviteFlow()
@@ -81,17 +84,32 @@ struct ChatMembersView: View {
         chatsFlow.groups.first { $0.id == groupID }
     }
 
-    /// True iff the active identity owns this group locally — i.e.
-    /// they're the device that created it. Used to gate the
-    /// "Share invite" entry-point: only the owner's intro inbox can
-    /// usefully receive join requests, since approval requires the
-    /// admin's keys.
-    private var isLocalOwner: Bool {
+    /// True iff the active identity is the cryptographic admin of
+    /// this group — i.e. their BLS pubkey hex matches
+    /// `group.adminPubkeyHex`. Gates the "Share invite" toolbar
+    /// entry-point.
+    ///
+    /// Why not `group.ownerIdentityID == activeID`? `ownerIdentityID`
+    /// is per-device; for a joiner-side group materialized from an
+    /// invitation, it gets stamped as the joiner's local identity
+    /// (so the chats-list filter routes it to the right tab). That
+    /// would falsely report "you own this" for every joiner — the
+    /// stronger BLS-pubkey-matches-stored-admin check is the right
+    /// one. For Anarchy / OneOnOne we hide regardless: anarchy
+    /// admit ceremonies aren't wired in V1, OneOnOne is fixed
+    /// 2-party.
+    private var canShareInvite: Bool {
         guard
             let group = currentGroup,
-            let activeID = identitiesFlow.currentID
+            group.groupType == .tyranny,
+            let storedAdminHex = group.adminPubkeyHex?.lowercased(),
+            let activeID = identitiesFlow.currentID,
+            let activeSummary = identitiesFlow.identities.first(where: { $0.id == activeID })
         else { return false }
-        return group.ownerIdentityID == activeID
+        let activeHex = activeSummary.blsPublicKey
+            .map { String(format: "%02x", $0) }.joined()
+            .lowercased()
+        return activeHex == storedAdminHex
     }
 
     private var activeBlsHex: String? {


### PR DESCRIPTION
## Summary

Stacked on #93.

PR 11's `isLocalOwner` check used `group.ownerIdentityID == activeID` — but that's a per-device field. The materializer stamps it as the joiner's local identity (so the chats-list filter routes the row to the right identity tab), which means **every joiner sees \"you own this\"** and the Share Invite button stays visible on their copy of someone else's group.

Functionally it's already locked down: Bob hitting Share Invite would generate an `IntroCapability` pointing at Bob's intro inbox. A stranger tapping it would land a join request on Bob, where his approver's PR-13 anchor flow short-circuits with `.notAdminOfThisGroup` (the cryptographic gate added in #93). But the visible UI affordance is misleading.

### Fix

`canShareInvite` replaces `isLocalOwner`:

```swift
guard
    let group = currentGroup,
    group.groupType == .tyranny,
    let storedAdminHex = group.adminPubkeyHex?.lowercased(),
    let activeID = identitiesFlow.currentID,
    let activeSummary = identitiesFlow.identities.first(where: { $0.id == activeID })
else { return false }
let activeHex = activeSummary.blsPublicKey
    .map { String(format: \"%02x\", $0) }.joined()
    .lowercased()
return activeHex == storedAdminHex
```

Tyranny-only — Anarchy and OneOnOne hide regardless (Anarchy admit ceremonies aren't wired in V1; OneOnOne is fixed 2-party).

### Test plan

- [x] All tests still pass — 509/509 (3 skipped, pre-existing). Pure view-state change, covered indirectly.
- [ ] Manual: Bob's copy of Alice's group → Share Invite button **hidden**.
- [ ] Manual: Alice's same group on her own device → button **visible**.
- [ ] Manual: Bob creates his own Tyranny group → button **visible** on Bob's copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)