### PR TITLE
chain(anarchy): publish "not tracked" sentinel for member_count at create

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -550,11 +550,17 @@ struct CreateGroupInteractor: Sendable {
             network: activeNetwork.sepNetwork,
             transport: transport
         )
+        // `member_count` is informational and the contract accepts `0`
+        // as the documented "not tracked" sentinel (per `sep-anarchy`'s
+        // `create_group` doc — "Operators who don't want to publish a
+        // count pass `0`"). Pass the sentinel so chain observers see
+        // only the tier, not the exact roster size at create time.
+        // The accurate count lives in the local model.
         let payload = AnarchyCreateGroupPayload(
             groupID: groupID,
             commitment: proof.commitment,
             tier: tier.rawValue,
-            memberCount: members.count,
+            memberCount: 0,
             proof: proof.proof,
             publicInputs: proof.publicInputs
         )

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -274,7 +274,8 @@ final class CreateGroupInteractorTests: XCTestCase {
         let payload = try XCTUnwrap(body["payload"] as? [String: Any])
         XCTAssertNil(payload["admin_pubkey_commitment"], "no admin field on Anarchy wire")
         XCTAssertEqual((payload["tier"] as? NSNumber)?.intValue, 0, "tier=small=0")
-        XCTAssertEqual((payload["member_count"] as? NSNumber)?.intValue, 1)
+        XCTAssertEqual((payload["member_count"] as? NSNumber)?.intValue, 0,
+                       "Anarchy create publishes the documented \"not tracked\" sentinel; the chain learns tier, never the exact roster size at create.")
         let publicInputs = try XCTUnwrap(payload["publicInputs"] as? [String])
         XCTAssertEqual(publicInputs.count, 2, "Anarchy ships [commitment, Fr(0)]")
 


### PR DESCRIPTION
## Summary

- `sep-anarchy`'s `create_group` accepts `member_count: 0` as the documented "not tracked" sentinel. The contract treats `member_count` as informational, never mutates it, and the test-vector pin (`anarchy/v1 sep-xxxx`) reserves `0` for the "not tracked" case.
- Production was passing `members.count` — always `1` at create, since the founding roster is creator-only. That published a small but permanent piece of group structure (`tier=Small, member_count=1`) into the on-chain `GroupCreated` event for every Anarchy group ever created via the iOS app.
- Switch to the sentinel. Chain observers now learn only the size class (`tier`), not the exact roster size at create. Accurate counts still live in the local model and the UI — only the wire value sent to the relayer changes.

This is the iOS half of a coordinated change with `onymchat/onym-android` (matching branch / PR title). Web copy on `/humans` and `/threat-model` will be tightened in a follow-up to take advantage of the narrower on-chain footprint.

## Test plan

- [ ] `swift test` — `CreateGroupInteractorTests.test_create_anarchy_*` should pass; the assertion now reads `0` with a comment explaining why.
- [ ] `SEPContractClientTests` is unchanged — that test instantiates `AnarchyCreateGroupPayload(memberCount: 1, …)` directly to verify the encoder serializes a non-zero `u32` correctly. After this PR it still does.
- [ ] Manual: create an Anarchy group on testnet and inspect the `GroupCreated` event payload — `member_count` should be `0`.
- [ ] Confirm the local UI still shows the correct count (`group.members.count`); the on-chain value isn't read back into the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)