### PR TITLE
feat(create-group): scan QR on Invite by Inbox Key (closes #115)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -33,6 +33,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Onym uses the camera to scan invite-key QR codes when you add someone to a group.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -202,6 +202,49 @@ final class CreateGroupFlow {
         route = .step2
     }
 
+    /// Drop a scanned QR payload into `inviteeInput`. Strips known URL
+    /// wrappers so the user sees the raw 64-char hex (or whatever the
+    /// payload canonicalises to) and can review before tapping
+    /// "Add to group". Validation is left to the existing pipeline —
+    /// a malformed scan surfaces the same inline error as a malformed
+    /// paste.
+    func tappedScannedKey(_ raw: String) {
+        inviteeInput = Self.canonicalizeInviteKey(raw)
+        inviteeError = nil
+    }
+
+    /// Pull a candidate inbox key out of a raw scanned/pasted string.
+    /// Recognises:
+    ///  - bare hex (returned unchanged, lowercased)
+    ///  - `https://onym.chat?payload=<hex>` (legacy iOS settings QR)
+    ///  - `https://onym.chat/i?k=<urlsafe-base64>` (Android identity
+    ///    invite — `IdentityInviteUrl.kt`)
+    /// Falls back to the trimmed raw input otherwise so the existing
+    /// validation surfaces a meaningful error.
+    static func canonicalizeInviteKey(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let comps = URLComponents(string: trimmed),
+           let items = comps.queryItems {
+            if let payload = items.first(where: { $0.name == "payload" })?.value,
+               !payload.isEmpty {
+                return payload.lowercased()
+            }
+            if let k = items.first(where: { $0.name == "k" })?.value,
+               let bytes = urlSafeBase64Decode(k) {
+                return bytes.map { String(format: "%02x", $0) }.joined()
+            }
+        }
+        return trimmed
+    }
+
+    private static func urlSafeBase64Decode(_ s: String) -> Data? {
+        var t = s.replacingOccurrences(of: "-", with: "+")
+        t = t.replacingOccurrences(of: "_", with: "/")
+        let pad = (4 - t.count % 4) % 4
+        t.append(String(repeating: "=", count: pad))
+        return Data(base64Encoded: t)
+    }
+
     /// Live char count for the InviteByKey field — matches the
     /// design's `(43/64)` chip.
     var inviteeInputCleanedLength: Int {

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -9,8 +9,10 @@ import SwiftUI
 ///   pill — they ship in a follow-up slice.
 /// - The "Add People" screen replaces the design's Contacts list with
 ///   a paste-only invitee list (Contacts framework is out of scope).
-/// - The "Invite by Inbox Key" screen drops the Scan QR button (no
-///   camera entitlement in the MVP).
+/// - The "Invite by Inbox Key" screen offers Paste from clipboard and
+///   Scan QR code. Scanning resolves Onym invite-key URLs (legacy
+///   `?payload=…` and the cross-platform `/i?k=…` shape) into a 64-
+///   char hex inbox key, then runs the same validation as paste.
 /// - The Creating screen wires its step list to real
 ///   `CreateGroupProgress` events from the interactor.
 /// - The Success screen replaces "Open" + "Invite more" with a single
@@ -593,7 +595,7 @@ private struct CreateGroupStep2View: View {
                             Text("Invite by inbox key")
                                 .font(.system(size: 13.5, weight: .semibold))
                                 .foregroundStyle(OnymTokens.text)
-                            Text("Paste a 64-char key")
+                            Text("Paste or scan a QR")
                                 .font(.system(size: 11.5))
                                 .foregroundStyle(OnymTokens.text2)
                         }
@@ -635,6 +637,7 @@ private struct CreateGroupStep2View: View {
 private struct CreateGroupInviteByKeyView: View {
     @Bindable var flow: CreateGroupFlow
     @FocusState private var fieldFocused: Bool
+    @State private var showScanner = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -649,7 +652,11 @@ private struct CreateGroupInviteByKeyView: View {
                     if let err = flow.inviteeError {
                         errorPill(err)
                     }
-                    pasteButton
+                    HStack(spacing: 10) {
+                        pasteButton
+                        scanButton
+                    }
+                    .padding(.top, 12)
                     helper
                 }
                 .padding(.horizontal, 16)
@@ -658,6 +665,16 @@ private struct CreateGroupInviteByKeyView: View {
             footer
         }
         .onAppear { fieldFocused = true }
+        .fullScreenCover(isPresented: $showScanner) {
+            QRCodeScannerView(
+                onScanned: { value in
+                    flow.tappedScannedKey(value)
+                    showScanner = false
+                    fieldFocused = false
+                },
+                onCancel: { showScanner = false }
+            )
+        }
     }
 
     private var accentColor: Color { flow.accent.color }
@@ -763,7 +780,7 @@ private struct CreateGroupInviteByKeyView: View {
             HStack(spacing: 8) {
                 Image(systemName: "doc.on.clipboard")
                     .font(.system(size: 13, weight: .semibold))
-                Text("Paste from clipboard")
+                Text("Paste")
                     .font(.system(size: 14.5, weight: .semibold))
             }
             .frame(maxWidth: .infinity, minHeight: 46)
@@ -775,7 +792,29 @@ private struct CreateGroupInviteByKeyView: View {
             .clipShape(RoundedRectangle(cornerRadius: 14))
         }
         .buttonStyle(.plain)
-        .padding(.top, 12)
+        .accessibilityIdentifier("invite_by_key.paste_button")
+    }
+
+    private var scanButton: some View {
+        Button {
+            showScanner = true
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "qrcode.viewfinder")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Scan QR")
+                    .font(.system(size: 14.5, weight: .semibold))
+            }
+            .frame(maxWidth: .infinity, minHeight: 46)
+            .foregroundStyle(accentColor)
+            .background(OnymTokens.surface2)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14).stroke(OnymTokens.hairlineStrong, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("invite_by_key.scan_button")
     }
 
     private var helper: some View {

--- a/Sources/OnymIOS/Group/QRCodeScannerView.swift
+++ b/Sources/OnymIOS/Group/QRCodeScannerView.swift
@@ -1,0 +1,228 @@
+import AVFoundation
+import SwiftUI
+
+/// Sheet-presented camera surface that scans QR codes and reports the
+/// decoded payload via `onScanned`. Wraps an `AVCaptureSession` with a
+/// `AVCaptureMetadataOutput` filtered to QR codes.
+///
+/// The scanner is intentionally generic — it doesn't know what the
+/// payload means. Callers (today, `CreateGroupInviteByKeyView`) parse
+/// the scanned string into an inbox key via
+/// `CreateGroupFlow.canonicalizeInviteKey(_:)`. Keeping the parser out
+/// of the scanner lets the same view scan future payload shapes
+/// without round-tripping through the camera surface.
+struct QRCodeScannerView: View {
+    let onScanned: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var failure: String?
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            if let failure {
+                VStack(spacing: 14) {
+                    Image(systemName: "video.slash.fill")
+                        .font(.system(size: 36))
+                        .foregroundStyle(.white.opacity(0.85))
+                    Text(failure)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                }
+                .accessibilityIdentifier("qr_scanner.error")
+            } else {
+                QRScannerRepresentable(
+                    onScanned: onScanned,
+                    onError: { failure = $0 }
+                )
+                .ignoresSafeArea()
+                .accessibilityIdentifier("qr_scanner.preview")
+
+                viewfinder
+            }
+
+            VStack {
+                HStack {
+                    Spacer()
+                    Button(action: onCancel) {
+                        Image(systemName: "xmark.circle.fill")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, .black.opacity(0.45))
+                            .font(.system(size: 32))
+                            .padding(20)
+                    }
+                    .accessibilityIdentifier("qr_scanner.cancel_button")
+                    .accessibilityLabel(Text("Cancel"))
+                }
+                Spacer()
+                Text("Point your camera at an Onym invite QR code.")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 40)
+            }
+        }
+    }
+
+    private var viewfinder: some View {
+        GeometryReader { geo in
+            let side = min(geo.size.width, geo.size.height) * 0.65
+            ZStack {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.white.opacity(0.85), lineWidth: 2)
+                    .frame(width: side, height: side)
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+private struct QRScannerRepresentable: UIViewControllerRepresentable {
+    let onScanned: (String) -> Void
+    let onError: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScanned: onScanned)
+    }
+
+    func makeUIViewController(context: Context) -> QRScannerViewController {
+        let vc = QRScannerViewController()
+        vc.metadataDelegate = context.coordinator
+        vc.onError = onError
+        return vc
+    }
+
+    func updateUIViewController(_ vc: QRScannerViewController, context: Context) {}
+
+    /// Owns the dedup latch — without it, AVFoundation can fire the
+    /// callback for the same QR several times per second, double-
+    /// invoking `onScanned`.
+    final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+        let onScanned: (String) -> Void
+        private var consumed = false
+
+        init(onScanned: @escaping (String) -> Void) {
+            self.onScanned = onScanned
+        }
+
+        func metadataOutput(
+            _ output: AVCaptureMetadataOutput,
+            didOutput metadataObjects: [AVMetadataObject],
+            from connection: AVCaptureConnection
+        ) {
+            guard !consumed else { return }
+            for object in metadataObjects {
+                if let m = object as? AVMetadataMachineReadableCodeObject,
+                   m.type == .qr,
+                   let value = m.stringValue,
+                   !value.isEmpty {
+                    consumed = true
+                    onScanned(value)
+                    return
+                }
+            }
+        }
+    }
+}
+
+private final class QRScannerViewController: UIViewController {
+    weak var metadataDelegate: QRScannerRepresentable.Coordinator?
+    var onError: ((String) -> Void)?
+
+    private let session = AVCaptureSession()
+    private let sessionQueue = DispatchQueue(label: "chat.onym.qrscanner.session")
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Task { await self.ensureAuthorizedAndStart() }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.layer.bounds
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        sessionQueue.async { [session] in
+            if session.isRunning { session.stopRunning() }
+        }
+    }
+
+    private func ensureAuthorizedAndStart() async {
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        let granted: Bool
+        switch status {
+        case .authorized:
+            granted = true
+        case .notDetermined:
+            granted = await AVCaptureDevice.requestAccess(for: .video)
+        default:
+            granted = false
+        }
+        if granted {
+            await MainActor.run { self.configureAndStart() }
+        } else {
+            await MainActor.run {
+                self.onError?(
+                    "Camera access is off. Enable it in Settings → Onym → Camera, then come back."
+                )
+            }
+        }
+    }
+
+    private func configureAndStart() {
+        guard let device = AVCaptureDevice.default(for: .video) else {
+            onError?("No camera available on this device.")
+            return
+        }
+
+        let input: AVCaptureDeviceInput
+        do {
+            input = try AVCaptureDeviceInput(device: device)
+        } catch {
+            onError?("Couldn't open the camera: \(error.localizedDescription)")
+            return
+        }
+
+        session.beginConfiguration()
+        guard session.canAddInput(input) else {
+            session.commitConfiguration()
+            onError?("Couldn't attach the camera input.")
+            return
+        }
+        session.addInput(input)
+
+        let output = AVCaptureMetadataOutput()
+        guard session.canAddOutput(output) else {
+            session.commitConfiguration()
+            onError?("Couldn't attach the QR decoder.")
+            return
+        }
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(metadataDelegate, queue: .main)
+        output.metadataObjectTypes = [.qr]
+        session.commitConfiguration()
+
+        let layer = AVCaptureVideoPreviewLayer(session: session)
+        layer.videoGravity = .resizeAspectFill
+        layer.frame = view.layer.bounds
+        view.layer.addSublayer(layer)
+        previewLayer = layer
+
+        sessionQueue.async { [session] in
+            if !session.isRunning { session.startRunning() }
+        }
+    }
+}

--- a/Sources/OnymIOS/Settings/SettingsQRCode.swift
+++ b/Sources/OnymIOS/Settings/SettingsQRCode.swift
@@ -45,12 +45,17 @@ struct SettingsQRCode: View {
     }
 }
 
-/// Build the deeplink-style invite URL for an identity's BLS public
-/// key. Mirrors the format the design uses — `https://onym.chat?payload=…`
-/// with the truncated key as the payload prefix. Real production
-/// invitee links live in the Group flow's `IntroCapability` — this is
-/// the per-identity equivalent surfaced from Settings.
+/// Build the deeplink-style invite URL for an identity's 32-byte X25519
+/// inbox public key. Mirrors the format the design uses —
+/// `https://onym.chat?payload=<64-hex>` with the **full** key as the
+/// payload. Truncating would leave the QR purely decorative:
+/// `CreateGroupFlow.canonicalizeInviteKey` extracts the `payload`
+/// query value verbatim and the InviteByKey paste validator requires
+/// 64 hex chars (32-byte X25519 key), so a shorter prefix would never
+/// pass validation on the scanning device. Real production invitee
+/// links live in the Group flow's `IntroCapability` — this is the
+/// per-identity equivalent surfaced from Settings.
 func settingsInviteURL(blsPublicKey: Data) -> String {
-    let hex = blsPublicKey.prefix(22).map { String(format: "%02x", $0) }.joined()
+    let hex = blsPublicKey.map { String(format: "%02x", $0) }.joined()
     return "https://onym.chat?payload=\(hex)"
 }

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -136,6 +136,66 @@ final class CreateGroupFlowTests: XCTestCase {
         XCTAssertEqual(flow.invitees.count, 1)
     }
 
+    // MARK: - Scanned QR payload canonicalisation
+
+    func test_canonicalizeInviteKey_bareHex_returnsUnchanged() {
+        let hex = String(repeating: "ab", count: 32)
+        XCTAssertEqual(CreateGroupFlow.canonicalizeInviteKey(hex), hex)
+    }
+
+    func test_canonicalizeInviteKey_trimsSurroundingWhitespace() {
+        let hex = String(repeating: "ab", count: 32)
+        XCTAssertEqual(
+            CreateGroupFlow.canonicalizeInviteKey("  \n\(hex)\t "),
+            hex
+        )
+    }
+
+    func test_canonicalizeInviteKey_legacyPayloadURL_extractsHex() {
+        let hex = String(repeating: "ab", count: 32)
+        let url = "https://onym.chat?payload=\(hex)"
+        XCTAssertEqual(CreateGroupFlow.canonicalizeInviteKey(url), hex)
+    }
+
+    func test_canonicalizeInviteKey_androidIdentityURL_decodesBase64ToHex() {
+        // Mirrors `IdentityInviteUrl.kt` — URL-safe base64 of a 32-byte
+        // X25519 pubkey, no padding.
+        let bytes = Data((0..<32).map { UInt8($0) })
+        let expectedHex = bytes.map { String(format: "%02x", $0) }.joined()
+        var b64 = bytes.base64EncodedString()
+        b64 = b64.replacingOccurrences(of: "+", with: "-")
+        b64 = b64.replacingOccurrences(of: "/", with: "_")
+        while b64.hasSuffix("=") { b64.removeLast() }
+        let url = "https://onym.chat/i?k=\(b64)"
+        XCTAssertEqual(CreateGroupFlow.canonicalizeInviteKey(url), expectedHex)
+    }
+
+    func test_canonicalizeInviteKey_unknownPayload_returnsTrimmedRaw() {
+        // Garbage in → garbage out (trimmed). Validation downstream
+        // surfaces the inline "doesn't look like a valid inbox key"
+        // error so the user sees what was scanned.
+        XCTAssertEqual(CreateGroupFlow.canonicalizeInviteKey(" hello world "), "hello world")
+    }
+
+    func test_tappedScannedKey_validURL_endToEnd_addsInvitee() async throws {
+        let flow = await makeFlow()
+        flow.route = .inviteByKey
+        let hex = String(repeating: "cd", count: 32)
+        flow.tappedScannedKey("https://onym.chat?payload=\(hex)")
+        XCTAssertEqual(flow.inviteeInput, hex)
+        XCTAssertNil(flow.inviteeError)
+        flow.tappedAddInvitee()
+        XCTAssertEqual(flow.invitees.count, 1)
+        XCTAssertEqual(flow.invitees[0].inboxPublicKey, Data(repeating: 0xCD, count: 32))
+    }
+
+    func test_tappedScannedKey_clearsStaleInviteeError() async throws {
+        let flow = await makeFlow()
+        flow.inviteeError = "stale"
+        flow.tappedScannedKey("anything")
+        XCTAssertNil(flow.inviteeError)
+    }
+
     func test_removeInvitee_removesByIndex() async throws {
         let flow = await makeFlow()
         flow.inviteeInput = String(repeating: "aa", count: 32)

--- a/Tests/OnymIOSTests/SettingsQRCodeTests.swift
+++ b/Tests/OnymIOSTests/SettingsQRCodeTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import OnymIOS
+
+/// Producer-side checks for the inbox-key invite URL emitted by
+/// Settings → Invite Key. The consumer side
+/// (`CreateGroupFlow.canonicalizeInviteKey`) lives in
+/// `CreateGroupFlowTests`; the round-trip case here is the
+/// load-bearing assertion that the QR is actually scannable —
+/// without it the producer can drift to an encoding the consumer
+/// silently rejects.
+final class SettingsQRCodeTests: XCTestCase {
+
+    func test_settingsInviteURL_encodesFullKey() {
+        // Truncating the key would mean the scanning device couldn't
+        // reconstruct the 32-byte inbox handle the InviteByKey paste
+        // field expects (validator requires 64 hex chars). 32 bytes
+        // → 64 hex chars; anything shorter is decorative.
+        let key = Data((0..<32).map { UInt8($0) })
+        let url = settingsInviteURL(blsPublicKey: key)
+        XCTAssertTrue(url.hasPrefix("https://onym.chat?payload="))
+        let payload = url.replacingOccurrences(of: "https://onym.chat?payload=", with: "")
+        XCTAssertEqual(payload.count, 64, "32 bytes should serialise to 64 hex chars")
+        XCTAssertEqual(payload, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+    }
+
+    @MainActor
+    func test_settingsInviteURL_roundTripsThroughCanonicalize() {
+        // Producer ↔ consumer contract: a URL emitted by
+        // `settingsInviteURL` must canonicalize back to the original
+        // 64-char hex on the scanning device. If this fails, the QR
+        // scans but the InviteByKey validator rejects it as
+        // "doesn't look like a valid inbox key" — the symptom that
+        // the truncated `prefix(22)` regression produced before this
+        // change.
+        let key = Data((0..<32).map { UInt8($0 ^ 0x5A) })
+        let expectedHex = key.map { String(format: "%02x", $0) }.joined()
+        let url = settingsInviteURL(blsPublicKey: key)
+        XCTAssertEqual(CreateGroupFlow.canonicalizeInviteKey(url), expectedHex)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -83,6 +83,12 @@ targets:
             CFBundleURLName: chat.onym.ios.join
             CFBundleURLSchemes:
               - onym
+        # Camera access is requested only when the user taps "Scan QR"
+        # on the Create Group → Invite by Inbox Key screen
+        # (`QRCodeScannerView`). The camera frame is decoded on-device
+        # via AVFoundation's QR metadata output and never leaves the
+        # process; we only consume the decoded string payload.
+        NSCameraUsageDescription: Onym uses the camera to scan invite-key QR codes when you add someone to a group.
     entitlements:
       path: OnymIOS.entitlements
       properties:


### PR DESCRIPTION
## Summary

- Add a **Scan QR** button next to **Paste** on the Create Group → *Invite by Inbox Key* screen so the inviter can capture an invitee's inbox key with the camera instead of typing 64 hex chars by hand.
- New `QRCodeScannerView` wraps an `AVCaptureSession` with QR-only metadata output, requests camera permission on first use, and surfaces a friendly inline message on denial / unavailable hardware.
- New `CreateGroupFlow.canonicalizeInviteKey(_:)` parses scan payloads — bare hex, the legacy iOS `?payload=<hex>` URL, and the cross-platform Android `/i?k=<urlsafe-b64>` shape — into the same 64-char hex string the existing paste path validates.
- `settingsInviteURL` now emits the **full** 32-byte X25519 inbox key (was truncated to 22 bytes / 44 hex chars), so the Settings → Invite Key QR actually round-trips through the new scanner.
- `NSCameraUsageDescription` added to `Info.plist` + `project.yml`.

## Test plan

- [ ] Unit: `CreateGroupFlowTests` — canonicalisation of bare hex, `payload=` URL, and Android `/i?k=` URL; garbage falls through unchanged.
- [ ] Unit: `SettingsQRCodeTests` — generated URL contains all 64 hex chars and round-trips through `canonicalizeInviteKey`.
- [ ] Manual (device): Settings → Invite Key shows QR; on a second device, Create Group → Add People → Invite by Inbox Key → Scan QR → permission prompt → scan → inbox key prefilled in the field → Add to group succeeds.
- [ ] Manual (denied path): Deny camera in iOS Settings → reopen scanner → inline "Open Settings" affordance shown, no crash.
- [ ] Manual (simulator): Scanner falls back to "Camera unavailable" message instead of hanging on a black preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)