### PR TITLE
feat(release-issue): describe each UI test in the release checklist

### DIFF
--- a/.github/workflows/apply_results.py
+++ b/.github/workflows/apply_results.py
@@ -28,8 +28,12 @@ import sys
 START = "<!-- UI_TESTS_START -->"
 END = "<!-- UI_TESTS_END -->"
 
-# Match `- [ ] <FQN>` or `- [x] <FQN>` and capture the box state + FQN.
-LINE_RE = re.compile(r"^(?P<prefix>\s*-\s*\[)(?P<box>[ xX])(?P<mid>\]\s+)(?P<fqn>\S+)\s*$")
+# Match `- [ ] <FQN>` (with optional trailing ` — <description>` that
+# `discover_tests.py` may append). Capture box + FQN; preserve `rest`
+# verbatim on rewrite so the description survives box-flipping.
+LINE_RE = re.compile(
+    r"^(?P<prefix>\s*-\s*\[)(?P<box>[ xX])(?P<mid>\]\s+)(?P<fqn>\S+)(?P<rest>.*)$"
+)
 
 
 def rewrite_section(section: str, results: dict[str, str]) -> str:
@@ -47,7 +51,7 @@ def rewrite_section(section: str, results: dict[str, str]) -> str:
             box = " "
         else:
             box = m.group("box")  # leave as-is
-        out_lines.append(f"{m.group('prefix')}{box}{m.group('mid')}{fqn}")
+        out_lines.append(f"{m.group('prefix')}{box}{m.group('mid')}{fqn}{m.group('rest')}")
     return "\n".join(out_lines) + ("\n" if section.endswith("\n") else "")
 
 

--- a/.github/workflows/discover_tests.py
+++ b/.github/workflows/discover_tests.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Discover XCTestCase classes + their `test_*` methods, extract the
+`///` doc comments preceding each, and emit a markdown checklist for
+the release-issue body.
+
+Output shape:
+    - [ ] OnymIOSUITests.<Class> — <first sentence of class doc>
+      - <first sentence of test doc>
+      - ...
+
+Per-class lines stay tickable (the same `apply_results.py` flips them
+to `[x]`). Per-test bullets are nested non-checkbox items, emitted only
+when the test method has an authored `///` doc — keeps unit tests
+listed by class without exploding the issue body with humanized
+method names.
+
+Usage:
+    discover_tests.py --root <repo> --out <md>
+
+The script prints the discovered class count to stdout for the
+workflow's summary step.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+DOC_RE   = re.compile(r"^\s*///\s?(.*)$")
+CLASS_RE = re.compile(r"^\s*(?:final\s+)?class\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*XCTestCase")
+FUNC_RE  = re.compile(r"^\s*func\s+(test_[A-Za-z_0-9]+)\s*\(")
+SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
+
+
+def first_sentence(lines: list[str]) -> str:
+    """Collapse the first contiguous paragraph (up to the first blank
+    `///` separator) into one line, then trim to the first sentence."""
+    para: list[str] = []
+    for line in lines:
+        if line.strip() == "":
+            if para:
+                break
+            continue
+        para.append(line.strip())
+    flat = " ".join(para).strip()
+    if not flat:
+        return ""
+    return SENTENCE_END.split(flat, maxsplit=1)[0]
+
+
+def parse_file(path: pathlib.Path) -> list[dict]:
+    """Return [{name, doc, tests:[{name, doc}]}] for classes in this file."""
+    classes: list[dict] = []
+    pending: list[str] = []
+    current: dict | None = None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        m = DOC_RE.match(raw)
+        if m:
+            pending.append(m.group(1).rstrip())
+            continue
+        # Blank lines and `// MARK: ...` style non-doc comments don't
+        # break the doc-block → declaration association.
+        if not raw.strip() or raw.lstrip().startswith("//"):
+            continue
+        cls = CLASS_RE.match(raw)
+        if cls:
+            current = {"name": cls.group(1), "doc": first_sentence(pending), "tests": []}
+            classes.append(current)
+            pending = []
+            continue
+        fn = FUNC_RE.match(raw)
+        if fn and current is not None:
+            current["tests"].append({"name": fn.group(1), "doc": first_sentence(pending)})
+            pending = []
+            continue
+        # Unrelated code line — drop pending docs.
+        pending = []
+    return classes
+
+
+def render(targets: dict[str, list[pathlib.Path]]) -> tuple[str, int]:
+    lines: list[str] = []
+    class_count = 0
+    for target_name, files in targets.items():
+        for f in files:
+            for cls in parse_file(f):
+                class_count += 1
+                fqn = f"{target_name}.{cls['name']}"
+                head = f"- [ ] {fqn}"
+                if cls["doc"]:
+                    head += f" — {cls['doc']}"
+                lines.append(head)
+                for t in cls["tests"]:
+                    if t["doc"]:
+                        lines.append(f"  - {t['doc']}")
+    return "\n".join(lines), class_count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", required=True, help="Repository root.")
+    parser.add_argument("--out", required=True, help="Markdown output path.")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.root)
+    targets = {
+        "OnymIOSTests":   sorted((root / "Tests" / "OnymIOSTests").rglob("*.swift")),
+        "OnymIOSUITests": sorted((root / "Tests" / "OnymIOSUITests").rglob("*.swift")),
+    }
+    md, count = render(targets)
+    pathlib.Path(args.out).write_text(md + "\n", encoding="utf-8")
+    print(count)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release-from-issue.yml
+++ b/.github/workflows/release-from-issue.yml
@@ -63,50 +63,44 @@ jobs:
         # gh needs both vars at the failure-comment step
         # (set here so the env propagates to the failure path too).
 
-      - name: Discover XCTestCase classes
+      - name: Discover XCTestCase classes + tests
         id: discover
         run: |
-          # Grep both test targets for `final class X: XCTestCase` and
-          # the bare `class X: XCTestCase` form. Emit `<Target>.<Class>`
-          # so the in-issue checklist is unambiguous when unit + UI
-          # targets ever share a class name.
+          # `discover_tests.py` walks both test targets, finds every
+          # XCTestCase subclass + its `test_*` methods, extracts `///`
+          # doc comments, and emits the markdown checklist:
+          #   - [ ] <Target>.<Class> — <first sentence of class doc>
+          #     - <first sentence of test doc>   (only when authored)
           #
           # Swift Testing (`@Test`) is intentionally NOT discovered —
           # the test targets are XCTest-only as of v0.0.9. When/if Swift
-          # Testing lands, extend this grep.
-          discover() {
-            local dir="$1" target="$2"
-            grep -rhE '^[[:space:]]*(final[[:space:]]+)?class[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*XCTestCase' "$dir" \
-              | sed -E "s/^[[:space:]]*(final[[:space:]]+)?class[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*/${target}.\2/" \
-              | sort -u
-          }
-          {
-            discover Tests/OnymIOSTests   OnymIOSTests
-            discover Tests/OnymIOSUITests OnymIOSUITests
-          } > /tmp/classes.txt
-          COUNT=$(wc -l < /tmp/classes.txt | tr -d ' ')
-          if [ "$COUNT" -eq 0 ]; then
+          # Testing lands, extend the script.
+          COUNT=$(python3 .github/workflows/discover_tests.py \
+                    --root . \
+                    --out /tmp/classes_section.md)
+          if [ -z "$COUNT" ] || [ "$COUNT" -eq 0 ]; then
             echo "::error::No XCTestCase classes found — discovery regex broke?"
             exit 1
           fi
           echo "Discovered $COUNT classes"
-          cat /tmp/classes.txt
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          cat /tmp/classes_section.md
 
       - name: Hydrate UI_TESTS section in issue body
         env:
           BODY: ${{ github.event.issue.body }}
           ISSUE: ${{ github.event.issue.number }}
+          COUNT: ${{ steps.discover.outputs.count }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Build the new section: one `- [ ] <FQN>` per class. The
-          # report-to-issue job in `Release` flips boxes to `[x]` after
-          # xcodebuild finishes.
+          # Prepend a one-line summary to the discovered checklist. The
+          # report-to-issue job in `Release` flips per-class boxes to
+          # `[x]` after xcodebuild finishes; `apply_results.py`
+          # preserves the trailing ` — <description>` verbatim.
           {
-            echo "_Discovered $(wc -l < /tmp/classes.txt | tr -d ' ') XCTestCase classes — boxes flip to \`[x]\` once \`Release\` finishes._"
+            echo "_Discovered ${COUNT} XCTestCase classes — boxes flip to \`[x]\` once \`Release\` finishes._"
             echo ""
-            while IFS= read -r CLASS; do
-              echo "- [ ] $CLASS"
-            done < /tmp/classes.txt
+            cat /tmp/classes_section.md
           } > /tmp/ui_tests_section.md
 
           # Sed-friendly extraction: replace everything between the two

--- a/Tests/OnymIOSUITests/AnchorsUITests.swift
+++ b/Tests/OnymIOSUITests/AnchorsUITests.swift
@@ -6,6 +6,8 @@ import XCTest
 /// and Testnet drilling-down works for every governance type.
 final class AnchorsUITests: XCTestCase {
 
+    /// When the manifest publishes no Mainnet contracts, the Mainnet row
+    /// renders disabled (no NavigationLink) while Testnet stays tappable.
     func test_mainnet_isDisabled_whenNoContractsPublished() throws {
         let app = AppLauncher.launchFresh()
         let settings = SettingsScreen(app: app)

--- a/Tests/OnymIOSUITests/RecoveryPhraseBackupUITests.swift
+++ b/Tests/OnymIOSUITests/RecoveryPhraseBackupUITests.swift
@@ -28,6 +28,9 @@ final class RecoveryPhraseBackupUITests: XCTestCase {
 
     // MARK: - Happy path
 
+    /// Full happy path: open Backup → tap Reveal → see a 12-word phrase →
+    /// answer all three verification rounds correctly → land on the Done
+    /// screen.
     func test_happyPath_endToEnd() {
         let app = AppLauncher.launchFresh(language: "en")
         defer { app.terminate() }
@@ -63,6 +66,9 @@ final class RecoveryPhraseBackupUITests: XCTestCase {
 
     // MARK: - Wrong word
 
+    /// Picking a wrong word during verification keeps the user on the
+    /// same round and surfaces the inline error message — no silent
+    /// advance, no false-positive completion.
     func test_wrongWordPicked_keepsRound_andShowsError() {
         let app = AppLauncher.launchFresh(language: "en")
         defer { app.terminate() }
@@ -88,6 +94,9 @@ final class RecoveryPhraseBackupUITests: XCTestCase {
 
     // MARK: - Russian locale
 
+    /// Launching with `language: "ru"` renders Russian copy on Settings
+    /// (nav title + Backup row) and on the recovery-phrase Intro screen —
+    /// confirms the localized catalog wires through end to end.
     func test_russianLocale_rendersRussianStrings() {
         let app = AppLauncher.launchFresh(language: "ru")
         defer { app.terminate() }
@@ -117,6 +126,9 @@ final class RecoveryPhraseBackupUITests: XCTestCase {
 
     // MARK: - Fresh launch
 
+    /// A fresh-keychain launch generates a valid 12-word phrase: every
+    /// word is non-empty, all-lowercase letters, and the phrase has at
+    /// least 6 unique words (a sanity guard against a stuck/zeroed seed).
     func test_freshLaunch_generates12WordPhrase() {
         let app = AppLauncher.launchFresh(language: "en")
         defer { app.terminate() }

--- a/Tests/OnymIOSUITests/RelayerSettingsUITests.swift
+++ b/Tests/OnymIOSUITests/RelayerSettingsUITests.swift
@@ -19,6 +19,9 @@ final class RelayerSettingsUITests: XCTestCase {
 
     // MARK: - first launch
 
+    /// On a clean first launch, the Configured-relayers list pre-populates
+    /// from the published manifest fixture (testnet + mainnet rows visible
+    /// without any user action).
     func test_firstLaunch_configuredListAutoPopulatedFromManifest() throws {
         let app = AppLauncher.launchFresh()
         let settings = SettingsScreen(app: app)
@@ -34,6 +37,8 @@ final class RelayerSettingsUITests: XCTestCase {
                       "first launch should auto-populate the mainnet fixture too")
     }
 
+    /// On a clean first launch, the relayer-selection strategy defaults to
+    /// Random — the segmented control's "Random" segment is the selected one.
     func test_firstLaunch_strategyDefaultsToRandom() throws {
         let app = AppLauncher.launchFresh()
         let settings = SettingsScreen(app: app)
@@ -50,6 +55,9 @@ final class RelayerSettingsUITests: XCTestCase {
 
     // MARK: - mutators
 
+    /// Tapping a row's star to mark it primary, then switching the strategy
+    /// segment from Random to Primary, persists through the UI: the Primary
+    /// segment is the selected one when the dust settles.
     func test_setPrimary_thenSwitchToPrimary_persistsViaUI() throws {
         let app = AppLauncher.launchFresh()
         let settings = SettingsScreen(app: app)
@@ -71,6 +79,8 @@ final class RelayerSettingsUITests: XCTestCase {
         XCTAssertTrue(relayer.primarySegment.isSelected)
     }
 
+    /// Typing a URL into the custom-relayer field and tapping Add makes
+    /// the new row appear in the Configured list.
     func test_addCustomURL_appearsInConfigured() throws {
         let app = AppLauncher.launchFresh()
         let settings = SettingsScreen(app: app)


### PR DESCRIPTION
## Summary

Reviewers tracking a release through the auto-generated GitHub issue used to see one opaque checkbox per `XCTestCase` subclass — e.g. `- [ ] OnymIOSUITests.RelayerSettingsUITests` — and had to read source to understand what was actually being verified. This PR makes the checklist self-explanatory by extracting `///` doc comments and writing per-test descriptions into the issue body.

## What changed

- **UI test methods carry plain-English `///` docs.** One short sentence each, in `AnchorsUITests`, `RecoveryPhraseBackupUITests`, `RelayerSettingsUITests` (and `IdentityManagementUITests` already had them). Class-level docs already existed.
- **New `.github/workflows/discover_tests.py`** walks both test targets, extracts the first sentence of each `///` doc, and emits a nested markdown checklist. Per-class lines stay tickable; per-test bullets are non-checkbox sub-items (xcresulttool reports per-class, so there's nothing to flip at method level). Unit-test classes without authored docs render as plain `- [ ] OnymIOSTests.<Class>` so we don't explode the checklist with humanized names for 50+ unit suites.
- **`release-from-issue.yml`** now invokes `discover_tests.py` instead of the old grep + sed loop.
- **`apply_results.py`** loosened its line regex to allow an optional trailing ` — <description>` after the FQN, preserving it verbatim when flipping `[ ]` ↔ `[x]`. Verified idempotent.

Sample of what the issue will now contain:

```
- [ ] OnymIOSUITests.RelayerSettingsUITests — End-to-end UI tests for Settings → Relayer.
  - On a clean first launch, the Configured-relayers list pre-populates from the published manifest fixture (testnet + mainnet rows visible without any user action).
  - On a clean first launch, the relayer-selection strategy defaults to Random — the segmented control's "Random" segment is the selected one.
  - Tapping a row's star to mark it primary, then switching the strategy segment from Random to Primary, persists through the UI: the Primary segment is the selected one when the dust settles.
  - Typing a URL into the custom-relayer field and tapping Add makes the new row appear in the Configured list.
- [ ] OnymIOSTests.SmokeTests
- [ ] OnymIOSTests.SealedEnvelopeTests
…
```

## Test plan

- [x] `discover_tests.py` run locally against the working tree — emits 62 class lines, with rich nested bullets for the 4 UI test classes.
- [x] `apply_results.py` round-trip on a synthetic body: classes with descriptions flip `[ ]` → `[x]` with the description intact; classes without descriptions still flip cleanly; running twice is idempotent.
- [x] `xcodebuild build-for-testing` succeeds — doc-comment additions don't break compilation.
- [ ] Reviewer should open a fresh release issue (or trigger via `gh issue create`) and confirm the auto-hydrated body has the new nested-bullet shape.
- [ ] Reviewer should re-run an existing failed Release workflow and confirm `apply_results.py` still ticks boxes correctly with the new line shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)