### PR TITLE
fix(identities): restore swipe-to-Remove via styled List

### DIFF
--- a/Sources/OnymIOS/Identity/IdentitiesView.swift
+++ b/Sources/OnymIOS/Identity/IdentitiesView.swift
@@ -16,51 +16,7 @@ struct IdentitiesView: View {
                 SettingsFootnote("Tap an identity to open it. Each identity has its own keys, chats, and recovery phrase.")
 
                 SettingsSectionLabel("YOUR IDENTITIES")
-                SettingsCard {
-                    let summaries = flow.identities
-                    ForEach(Array(summaries.enumerated()), id: \.element.id) { idx, summary in
-                        NavigationLink {
-                            IdentityDetailView(flow: flow, summary: summary)
-                        } label: {
-                            SettingsRow(
-                                title: LocalizedStringKey(summary.name),
-                                subtitle: "BLS \(flow.blsPrefix(of: summary))…",
-                                subtitleMono: true,
-                                inset: 68,
-                                last: idx == summaries.count - 1
-                            ) {
-                                IdentityRingTile(active: summary.id == flow.currentID, size: 40)
-                            } right: {
-                                if summary.id == flow.currentID {
-                                    Text("Active")
-                                        .font(.system(size: 11, weight: .semibold))
-                                        .padding(.horizontal, 8)
-                                        .padding(.vertical, 3)
-                                        .background(OnymTokens.green.opacity(0.18),
-                                                    in: Capsule())
-                                        .foregroundStyle(OnymTokens.green)
-                                        .accessibilityIdentifier("identities.active_badge.\(summary.id)")
-                                }
-                            }
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityIdentifier("identities.row.\(summary.id)")
-                        .swipeActions(edge: .trailing) {
-                            Button(role: .destructive) {
-                                flow.startRemoval(of: summary)
-                            } label: {
-                                Label("Remove", systemImage: "trash")
-                            }
-                        }
-                        .contextMenu {
-                            Button(role: .destructive) {
-                                flow.startRemoval(of: summary)
-                            } label: {
-                                Label("Remove", systemImage: "trash")
-                            }
-                        }
-                    }
-                }
+                identitiesList
 
                 Button {
                     showAddSheet = true
@@ -106,6 +62,74 @@ struct IdentitiesView: View {
                 RemoveIdentitySheet(flow: flow, summary: summary)
             }
         }
+    }
+
+    // MARK: - Identities list
+
+    /// SwiftUI `.swipeActions` is a List-only modifier — applying it to a
+    /// `VStack`/`SettingsCard` row is silently inert. We want both the
+    /// SettingsCard look (rounded card, custom hairlines) and native
+    /// swipe-to-Remove, so the rows live inside a `List` with system
+    /// chrome suppressed: `.listStyle(.plain)`, transparent
+    /// `scrollContentBackground`, hidden separators (we draw our own),
+    /// and `.scrollDisabled` + a measured frame so the outer
+    /// `ScrollView` still drives scrolling.
+    private var identitiesList: some View {
+        let summaries = flow.identities
+        let rowHeight: CGFloat = 64  // matches SettingsRow padding + dual-line label
+        return List {
+            ForEach(Array(summaries.enumerated()), id: \.element.id) { idx, summary in
+                NavigationLink {
+                    IdentityDetailView(flow: flow, summary: summary)
+                } label: {
+                    SettingsRow(
+                        title: LocalizedStringKey(summary.name),
+                        subtitle: "BLS \(flow.blsPrefix(of: summary))…",
+                        subtitleMono: true,
+                        inset: 68,
+                        last: idx == summaries.count - 1
+                    ) {
+                        IdentityRingTile(active: summary.id == flow.currentID, size: 40)
+                    } right: {
+                        if summary.id == flow.currentID {
+                            Text("Active")
+                                .font(.system(size: 11, weight: .semibold))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(OnymTokens.green.opacity(0.18),
+                                            in: Capsule())
+                                .foregroundStyle(OnymTokens.green)
+                                .accessibilityIdentifier("identities.active_badge.\(summary.id)")
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("identities.row.\(summary.id)")
+                .swipeActions(edge: .trailing) {
+                    Button(role: .destructive) {
+                        flow.startRemoval(of: summary)
+                    } label: {
+                        Label("Remove", systemImage: "trash")
+                    }
+                }
+                .contextMenu {
+                    Button(role: .destructive) {
+                        flow.startRemoval(of: summary)
+                    } label: {
+                        Label("Remove", systemImage: "trash")
+                    }
+                }
+                .listRowBackground(OnymTokens.surface2)
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .scrollDisabled(true)
+        .frame(height: max(rowHeight, CGFloat(summaries.count) * rowHeight))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .padding(.horizontal, 16)
     }
 }
 

--- a/Sources/OnymIOS/Identity/IdentitiesView.swift
+++ b/Sources/OnymIOS/Identity/IdentitiesView.swift
@@ -8,11 +8,11 @@ import SwiftUI
 struct IdentitiesView: View {
     @Bindable var flow: IdentitiesFlow
     @State private var showAddSheet = false
-    /// Sum of measured row heights, fed by `IdentityRowsHeightKey`.
-    /// Starts at 0; replaced by the actual rendered total on the first
-    /// layout pass — this is what lets the List grow with Dynamic Type
-    /// instead of clipping at a fixed row count × 64pt.
-    @State private var measuredRowsHeight: CGFloat = 0
+    /// Per-row height, scaled with Dynamic Type via `UIFontMetrics`.
+    /// 64 is the baseline at default size (matches `SettingsRow`'s
+    /// padding + dual-line label); AX1+/XL settings scale it up
+    /// automatically so the inner List frame grows in step.
+    @ScaledMetric private var rowHeight: CGFloat = 64
 
     var body: some View {
         ScrollView {
@@ -77,14 +77,9 @@ struct IdentitiesView: View {
     /// swipe-to-Remove, so the rows live inside a `List` with system
     /// chrome suppressed: `.listStyle(.plain)`, transparent
     /// `scrollContentBackground`, hidden separators (we draw our own),
-    /// and `.scrollDisabled` + a measured frame so the outer
-    /// `ScrollView` still drives scrolling.
-    ///
-    /// Row height is measured via `IdentityRowsHeightKey` (each row
-    /// publishes its rendered height through a hidden `GeometryReader`,
-    /// the parent sums them) so the frame grows with Dynamic Type /
-    /// AX1+ sizes — matching the natural growth `SettingsCard`'s VStack
-    /// would otherwise give.
+    /// and `.scrollDisabled` + a `rowHeight × count` frame so the outer
+    /// `ScrollView` still drives scrolling. `rowHeight` is `@ScaledMetric`
+    /// so the frame grows with Dynamic Type / AX1+ sizes.
     @ViewBuilder
     private var identitiesList: some View {
         let summaries = flow.identities
@@ -121,7 +116,6 @@ struct IdentitiesView: View {
                         }
                     }
                     .buttonStyle(.plain)
-                    .background(rowHeightProbe)
                     .accessibilityIdentifier("identities.row.\(summary.id)")
                     .swipeActions(edge: .trailing) {
                         Button(role: .destructive) {
@@ -145,47 +139,10 @@ struct IdentitiesView: View {
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .scrollDisabled(true)
-            // Two-floor frame: the per-count estimate is the baseline,
-            // so growing the list (e.g. Add Identity) gets enough room
-            // immediately even if the previous measurement reflected a
-            // smaller row count. The measured value only kicks in when
-            // it exceeds the estimate — i.e. at AX1+ where SettingsRow
-            // wraps to a taller layout. Cheaper than invalidating the
-            // measurement on count change and avoids a flicker.
-            .frame(height: max(CGFloat(summaries.count) * estimatedRowHeight,
-                               measuredRowsHeight))
-            .onPreferenceChange(IdentityRowsHeightKey.self) { measuredRowsHeight = $0 }
+            .frame(height: CGFloat(summaries.count) * rowHeight)
             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             .padding(.horizontal, 16)
         }
-    }
-
-    /// First-paint estimate before rows publish their measured height.
-    /// Tuned to the default Dynamic Type size; AX1+ rows are taller and
-    /// will trigger a single re-layout pass via `onPreferenceChange`.
-    private var estimatedRowHeight: CGFloat { 64 }
-
-    /// Hidden GeometryReader that publishes a row's rendered height
-    /// into `IdentityRowsHeightKey`. Stays as `.background` so it
-    /// participates in layout without affecting the row's intrinsic
-    /// size or hit-testing.
-    private var rowHeightProbe: some View {
-        GeometryReader { proxy in
-            Color.clear
-                .preference(key: IdentityRowsHeightKey.self,
-                            value: proxy.size.height)
-        }
-    }
-}
-
-/// Sum-reducing preference key: each identity row contributes its
-/// rendered height; the parent reads the total via
-/// `onPreferenceChange` and resizes the embedded List frame to match.
-/// Mirrors what `SettingsCard`'s VStack does intrinsically.
-private struct IdentityRowsHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value += nextValue()
     }
 }
 

--- a/Sources/OnymIOS/Identity/IdentitiesView.swift
+++ b/Sources/OnymIOS/Identity/IdentitiesView.swift
@@ -8,6 +8,11 @@ import SwiftUI
 struct IdentitiesView: View {
     @Bindable var flow: IdentitiesFlow
     @State private var showAddSheet = false
+    /// Sum of measured row heights, fed by `IdentityRowsHeightKey`.
+    /// Starts at 0; replaced by the actual rendered total on the first
+    /// layout pass — this is what lets the List grow with Dynamic Type
+    /// instead of clipping at a fixed row count × 64pt.
+    @State private var measuredRowsHeight: CGFloat = 0
 
     var body: some View {
         ScrollView {
@@ -74,62 +79,113 @@ struct IdentitiesView: View {
     /// `scrollContentBackground`, hidden separators (we draw our own),
     /// and `.scrollDisabled` + a measured frame so the outer
     /// `ScrollView` still drives scrolling.
+    ///
+    /// Row height is measured via `IdentityRowsHeightKey` (each row
+    /// publishes its rendered height through a hidden `GeometryReader`,
+    /// the parent sums them) so the frame grows with Dynamic Type /
+    /// AX1+ sizes — matching the natural growth `SettingsCard`'s VStack
+    /// would otherwise give.
+    @ViewBuilder
     private var identitiesList: some View {
         let summaries = flow.identities
-        let rowHeight: CGFloat = 64  // matches SettingsRow padding + dual-line label
-        return List {
-            ForEach(Array(summaries.enumerated()), id: \.element.id) { idx, summary in
-                NavigationLink {
-                    IdentityDetailView(flow: flow, summary: summary)
-                } label: {
-                    SettingsRow(
-                        title: LocalizedStringKey(summary.name),
-                        subtitle: "BLS \(flow.blsPrefix(of: summary))…",
-                        subtitleMono: true,
-                        inset: 68,
-                        last: idx == summaries.count - 1
-                    ) {
-                        IdentityRingTile(active: summary.id == flow.currentID, size: 40)
-                    } right: {
-                        if summary.id == flow.currentID {
-                            Text("Active")
-                                .font(.system(size: 11, weight: .semibold))
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 3)
-                                .background(OnymTokens.green.opacity(0.18),
-                                            in: Capsule())
-                                .foregroundStyle(OnymTokens.green)
-                                .accessibilityIdentifier("identities.active_badge.\(summary.id)")
+        if summaries.isEmpty {
+            // Avoid reserving a phantom row strip when the list is empty.
+            // Today bootstrapping guarantees ≥1 identity, but the empty
+            // branch keeps the layout honest if that ever loosens.
+            EmptyView()
+        } else {
+            List {
+                ForEach(Array(summaries.enumerated()), id: \.element.id) { idx, summary in
+                    NavigationLink {
+                        IdentityDetailView(flow: flow, summary: summary)
+                    } label: {
+                        SettingsRow(
+                            title: LocalizedStringKey(summary.name),
+                            subtitle: "BLS \(flow.blsPrefix(of: summary))…",
+                            subtitleMono: true,
+                            inset: 68,
+                            last: idx == summaries.count - 1
+                        ) {
+                            IdentityRingTile(active: summary.id == flow.currentID, size: 40)
+                        } right: {
+                            if summary.id == flow.currentID {
+                                Text("Active")
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 3)
+                                    .background(OnymTokens.green.opacity(0.18),
+                                                in: Capsule())
+                                    .foregroundStyle(OnymTokens.green)
+                                    .accessibilityIdentifier("identities.active_badge.\(summary.id)")
+                            }
                         }
                     }
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("identities.row.\(summary.id)")
-                .swipeActions(edge: .trailing) {
-                    Button(role: .destructive) {
-                        flow.startRemoval(of: summary)
-                    } label: {
-                        Label("Remove", systemImage: "trash")
+                    .buttonStyle(.plain)
+                    .background(rowHeightProbe)
+                    .accessibilityIdentifier("identities.row.\(summary.id)")
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            flow.startRemoval(of: summary)
+                        } label: {
+                            Label("Remove", systemImage: "trash")
+                        }
                     }
-                }
-                .contextMenu {
-                    Button(role: .destructive) {
-                        flow.startRemoval(of: summary)
-                    } label: {
-                        Label("Remove", systemImage: "trash")
+                    .contextMenu {
+                        Button(role: .destructive) {
+                            flow.startRemoval(of: summary)
+                        } label: {
+                            Label("Remove", systemImage: "trash")
+                        }
                     }
+                    .listRowBackground(OnymTokens.surface2)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
                 }
-                .listRowBackground(OnymTokens.surface2)
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .scrollDisabled(true)
+            // Two-floor frame: the per-count estimate is the baseline,
+            // so growing the list (e.g. Add Identity) gets enough room
+            // immediately even if the previous measurement reflected a
+            // smaller row count. The measured value only kicks in when
+            // it exceeds the estimate — i.e. at AX1+ where SettingsRow
+            // wraps to a taller layout. Cheaper than invalidating the
+            // measurement on count change and avoids a flicker.
+            .frame(height: max(CGFloat(summaries.count) * estimatedRowHeight,
+                               measuredRowsHeight))
+            .onPreferenceChange(IdentityRowsHeightKey.self) { measuredRowsHeight = $0 }
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .padding(.horizontal, 16)
         }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .scrollDisabled(true)
-        .frame(height: max(rowHeight, CGFloat(summaries.count) * rowHeight))
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-        .padding(.horizontal, 16)
+    }
+
+    /// First-paint estimate before rows publish their measured height.
+    /// Tuned to the default Dynamic Type size; AX1+ rows are taller and
+    /// will trigger a single re-layout pass via `onPreferenceChange`.
+    private var estimatedRowHeight: CGFloat { 64 }
+
+    /// Hidden GeometryReader that publishes a row's rendered height
+    /// into `IdentityRowsHeightKey`. Stays as `.background` so it
+    /// participates in layout without affecting the row's intrinsic
+    /// size or hit-testing.
+    private var rowHeightProbe: some View {
+        GeometryReader { proxy in
+            Color.clear
+                .preference(key: IdentityRowsHeightKey.self,
+                            value: proxy.size.height)
+        }
+    }
+}
+
+/// Sum-reducing preference key: each identity row contributes its
+/// rendered height; the parent reads the total via
+/// `onPreferenceChange` and resizes the embedded List frame to match.
+/// Mirrors what `SettingsCard`'s VStack does intrinsically.
+private struct IdentityRowsHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value += nextValue()
     }
 }
 


### PR DESCRIPTION
## Summary

`IdentityManagementUITests.test_removeIdentity_nameConfirmGate_blocksThenAllows` was the last red on Release run [25622030590](https://github.com/onymchat/onym-ios/actions/runs/25622030590). Root cause: `.swipeActions(edge: .trailing) { Remove }` was already declared on the identity row, but the Settings redesign moved the row into a custom `SettingsCard { VStack }` — and `.swipeActions` is a List-only modifier. SwiftUI silently dropped it, so swiping a row revealed nothing for users **and** the test.

## Fix

Wrap the row block in a `List` with system chrome suppressed so `.swipeActions` activates without changing the surrounding Identities chrome (title, intro footnote, Add button, closing footnote stay in the existing ScrollView/VStack):

- `.listStyle(.plain)` + `.scrollContentBackground(.hidden)` — kill the system List background
- `.listRowBackground(OnymTokens.surface2)` + `.listRowSeparator(.hidden)` + `.listRowInsets(EdgeInsets())` — recreate the SettingsCard row look; we draw our own hairlines via `SettingsRow`
- `.scrollDisabled(true)` + a measured `.frame(height: ...)` — the outer ScrollView still drives scrolling; the inner List just provides swipe behavior
- `.clipShape(RoundedRectangle(cornerRadius: 14))` + `.padding(.horizontal, 16)` — preserve the rounded-card shell

The `.contextMenu` block is kept so long-press → Remove still works as a parity affordance.

## Test plan

Verified locally on iPhone Air (iOS 26 simulator) — all four IdentityManagementUITests pass:

- [x] `test_identitiesList_showsBootstrappedIdentityAsActive` (9.5s)
- [x] `test_addIdentity_sheetSubmits_growsList` (18.8s)
- [x] `test_chatsPicker_switchesActiveIdentity_titleFlips` (25.6s)
- [x] `test_removeIdentity_nameConfirmGate_blocksThenAllows` (32.2s) — previously failing at IdentitiesScreen.swift:65 with "swipe Remove action never appeared"

The first three confirm that row identifiers + Active badge id + Add sheet survived the refactor.

Reviewer should:
- [ ] Visual sanity-check on a device — rounded card look should match the rest of the Settings tree.
- [ ] Confirm a swipe-Remove with multiple identities behaves correctly (list shrinks, no orphan swipe state).
- [ ] Re-run the Release workflow and confirm UI tests are green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)