### PR TITLE
fix(release-issue): replace heredoc with here-string for YAML block scalar

### DIFF
--- a/.github/workflows/release-from-issue.yml
+++ b/.github/workflows/release-from-issue.yml
@@ -75,9 +75,11 @@ jobs:
               TAG="v0.0.1"
               echo "::notice::No existing v* tags; defaulting to $TAG"
             else
-              IFS='.' read -r MAJOR MINOR PATCH <<EOF
-${LATEST#v}
-EOF
+              # Here-string instead of a heredoc — a multi-line heredoc
+              # would force `EOF` to column 0, which breaks YAML's
+              # `run: |` block scalar indentation rules. `<<<` is a
+              # single-line construct safe at any column.
+              IFS='.' read -r MAJOR MINOR PATCH <<<"${LATEST#v}"
               TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
               echo "::notice::Tag field blank; auto-bumping ${LATEST} → ${TAG}"
             fi


### PR DESCRIPTION
## Summary

The auto-bump merge ([#123](https://github.com/onymchat/onym-ios/pull/123)) broke `.github/workflows/release-from-issue.yml`. Validation [run 25623174548](https://github.com/onymchat/onym-ios/actions/runs/25623174548) fails immediately with "This run likely failed because of a workflow file issue".

Root cause: the auto-bump step used a multi-line heredoc to feed `${LATEST#v}` into `read`:

```bash
IFS='.' read -r MAJOR MINOR PATCH <<EOF
${LATEST#v}
EOF
```

A bash heredoc without `<<-` requires its terminator at column 0. But this lives inside a `run: |` YAML literal block scalar, and YAML ends the block at the first line whose indentation drops below the established indent. The `${LATEST#v}` and `EOF` lines pulled the content out of the block, so GitHub's parser rejected the file with `ScannerError: while scanning a simple key … could not find expected ':'`.

## Fix

Replace with a here-string — single-line, safe at any indentation:

```bash
IFS='.' read -r MAJOR MINOR PATCH <<<"${LATEST#v}"
```

Same `read` semantics, no column-0 terminator.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` now parses the workflow cleanly (was: `ScannerError` at line 79 column 1).
- [x] Bump arithmetic locally: `LATEST=v0.0.40` → `MAJOR=0 MINOR=0 PATCH=40` → `TAG=v0.0.41`.
- [ ] Reviewer should file a release issue (or pre-fill an existing one) to confirm the workflow now triggers + auto-bumps + dispatches end-to-end.

The same bug would have shipped with onymchat/onym-android#127 — already corrected there in `7acb9c1` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
