### PR TITLE
fix(release): clear stale /tmp xcresult dirs before download-artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,6 +621,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clear stale xcresult download dirs
+        # /tmp persists across runs on the self-hosted runner, and
+        # `actions/download-artifact@v4` extracts INTO the destination
+        # path without first cleaning it. Leftover blobs from a prior
+        # run (or an entire stale `.xcresult` subdirectory) can sit
+        # alongside the fresh download, so `xcresulttool` surfaces an
+        # older test-suite payload — confirmed in run 25623336567 where
+        # `parse_xcresult.py` reported failures for `test_drilldown_…`,
+        # a test deleted in #119, even though the freshly-uploaded
+        # artifact only contained passing test names. Wipe both before
+        # the downloads so each run sees only its own bundles.
+        run: rm -rf /tmp/unit-xcresult /tmp/ui-xcresult
+
       - name: Download unit-tests xcresult
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Issue #125 (release `v0.0.43`) shipped cleanly — xcodebuild logged `Executed 13 tests, with 0 failures (0 unexpected) … ** TEST SUCCEEDED **`, build job uploaded the IPA, GitHub Release was created. But `report-to-issue` then posted [a failure comment](https://github.com/onymchat/onym-ios/issues/125#issuecomment-4414787458) about `test_drilldown_pickVersion_thenResetToDefault()` — a test that was **deleted in #119**.

I downloaded the run's `ui-tests-xcresult` artifact (id `6902127667`, SHA256 matches the upload log) and ran `parse_xcresult.py` against it locally: `62 passed, 0 failed`. Same script, same artifact, different result on CI.

## Root cause

`report-to-issue` runs on the self-hosted macOS runner where `/tmp` persists across workflow runs. `actions/download-artifact@v4` extracts into the destination path **without first cleaning it**, so blobs from a prior run — or an entire stale `.xcresult` subdirectory — can sit alongside the fresh download. `xcresulttool get test-results tests` then surfaces the older test-suite payload (still containing the deleted `test_drilldown_…` method) and `parse_xcresult.py` reports it as a failure.

## Fix

One step prepended to the `report-to-issue` job:

```yaml
- name: Clear stale xcresult download dirs
  run: rm -rf /tmp/unit-xcresult /tmp/ui-xcresult
```

…ahead of both `download-artifact` calls so each run starts with empty extraction targets.

This is a **reporting-pipeline bug only** — the release itself shipped correctly; testers were not affected.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` parses the workflow cleanly.
- [ ] Reviewer files a release issue (auto-bump or explicit tag) and confirms the post-run comment now matches the xcodebuild "Executed X tests, with Y failures" line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
