### PR TITLE
feat(qa): comments link to /qa/build/ details page, embed issue body

### DIFF
--- a/.github/workflows/qa-build.yml
+++ b/.github/workflows/qa-build.yml
@@ -246,14 +246,19 @@ jobs:
           set -eu
           BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          # Resolve issue title (best-effort; gh failure -> empty title)
+          # Resolve issue title + body (best-effort; gh failure -> empty
+          # strings). `body` powers the Test Plan section on the build
+          # details page (public/qa/build/ in onym-website) without the
+          # page having to hit the GitHub API at view time.
           ISSUE_OBJ='null'
           if [ -n "$ISSUE" ]; then
-            TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title -q .title 2>/dev/null || echo "")
+            ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" --json title,body 2>/dev/null || echo '{}')
+            TITLE=$(printf '%s' "$ISSUE_JSON" | jq -r '.title // ""')
+            BODY=$(printf  '%s' "$ISSUE_JSON" | jq -r '.body  // ""')
             ISSUE_OBJ=$(jq -n \
-              --arg n "$ISSUE" --arg t "$TITLE" \
+              --arg n "$ISSUE" --arg t "$TITLE" --arg b "$BODY" \
               --arg url "https://github.com/$REPO/issues/$ISSUE" \
-              '{number: ($n|tonumber), title: $t, url: $url}')
+              '{number: ($n|tonumber), title: $t, url: $url, body: $b}')
           fi
 
           # Schema -- see public/qa/index.html in onym-website. Keep
@@ -358,6 +363,7 @@ jobs:
             echo "| IPA | https://${HOST}/qa/ios/${VERSION}/OnymIOS.ipa |"
             echo "| Manifest | https://${HOST}/qa/ios/${VERSION}/manifest.plist |"
             echo "| Install | \`itms-services://?action=download-manifest&url=https://${HOST}/qa/ios/${VERSION}/manifest.plist\` |"
+            echo "| Build details | https://${HOST}/qa/build/?platform=ios&version=${VERSION} |"
             echo "| Dashboard | https://${HOST}/qa/?platform=ios |"
             echo
             echo "Tester device must be UDID-registered to the team ad-hoc provisioning profile -- otherwise install fails."
@@ -414,7 +420,7 @@ jobs:
           QA build \`${VERSION}\` published.
 
           - Install on a UDID-registered iPhone: \`${INSTALL_URL}\`
-          - Dashboard: https://${HOST}/qa/?platform=ios
+          - Build details (test plan, install, metadata): https://${HOST}/qa/build/?platform=ios&version=${VERSION}
           - IPA: https://${HOST}/qa/ios/${VERSION}/OnymIOS.ipa
           MSG
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,17 +468,22 @@ jobs:
           BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           COMMIT_SHORT=$(printf '%s' "$COMMIT" | cut -c1-5)
 
-          # Resolve the originating release issue's title (best-effort;
-          # gh failure -> empty title). Issue number is plumbed in by
-          # release-from-issue.yml; manual `gh workflow run Release`
-          # dispatches without it leave the field null.
+          # Resolve the originating release issue's title + body
+          # (best-effort; gh failure -> empty strings). Issue number is
+          # plumbed in by release-from-issue.yml; manual `gh workflow run
+          # Release` dispatches without it leave the field null. `body`
+          # powers the Test Plan section on the build details page
+          # (public/qa/build/ in onym-website) without the page having
+          # to hit the GitHub API at view time.
           ISSUE_OBJ='null'
           if [ -n "$ISSUE" ]; then
-            TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title -q .title 2>/dev/null || echo "")
+            ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" --json title,body 2>/dev/null || echo '{}')
+            TITLE=$(printf '%s' "$ISSUE_JSON" | jq -r '.title // ""')
+            BODY=$(printf  '%s' "$ISSUE_JSON" | jq -r '.body  // ""')
             ISSUE_OBJ=$(jq -n \
-              --arg n "$ISSUE" --arg t "$TITLE" \
+              --arg n "$ISSUE" --arg t "$TITLE" --arg b "$BODY" \
               --arg url "https://github.com/$REPO/issues/$ISSUE" \
-              '{number: ($n|tonumber), title: $t, url: $url}')
+              '{number: ($n|tonumber), title: $t, url: $url, body: $b}')
           fi
 
           # Schema must match `qa-build.yml`'s entry shape — the
@@ -578,6 +583,7 @@ jobs:
             echo "| IPA | https://${HOST}/qa/ios/${VERSION}/OnymIOS.ipa |"
             echo "| Manifest | https://${HOST}/qa/ios/${VERSION}/manifest.plist |"
             echo "| Install (UDID-registered iPhone) | \`itms-services://?action=download-manifest&url=https://${HOST}/qa/ios/${VERSION}/manifest.plist\` |"
+            echo "| Build details | https://${HOST}/qa/build/?platform=ios&version=${VERSION} |"
             echo "| Dashboard | https://${HOST}/qa/?platform=ios |"
             echo
             echo "Tester device must be UDID-registered to the team ad-hoc provisioning profile -- otherwise install fails."
@@ -598,7 +604,7 @@ jobs:
           QA build \`${VERSION}\` published to the dashboard.
 
           - Install on a UDID-registered iPhone: \`itms-services://?action=download-manifest&url=https://${HOST}/qa/ios/${VERSION}/manifest.plist\`
-          - Dashboard: https://${HOST}/qa/?platform=ios
+          - Build details (test plan, install, metadata): https://${HOST}/qa/build/?platform=ios&version=${VERSION}
           - IPA: https://${HOST}/qa/ios/${VERSION}/OnymIOS.ipa
           MSG
           if ! gh issue comment "$ISSUE" --repo "$REPO" --body-file "$BODY_FILE"; then


### PR DESCRIPTION
## Summary
- The QA-publish comment posted on the linked PR (qa-build) and on the linked release issue (release) now links to the per-build details page on onym.app instead of the dashboard.
- Build entry written to `qa/builds.json` now carries `issue.body` alongside `title` so the details page can render the Test Plan section without hitting the GitHub API per visitor.
- Adds a "Build details" row to the GH Actions step-summary tables for parity with the comment.

## Why
Pairs with onymchat/onym-website#1, which adds `/qa/build/?platform=ios&version=...`. The detail page extracts the `## Test plan` section from `issue.body`. Embedding the body in the dashboard JSON keeps the page snappy and dodges GitHub API rate limits when several testers open the link at once.

## Test plan
- [ ] Dispatch `qa-build.yml` against a branch with a linked PR that has a `## Test plan` section -> PR comment posts and links to `https://onym.app/qa/build/?platform=ios&version=...`; opening the link shows the Test Plan rendered without a GitHub API spinner
- [ ] Run `release.yml` from `release-from-issue.yml` against a release issue with a `## Test plan` section -> issue comment posts the new URL; details page renders the test plan
- [ ] Manual `gh workflow run Release -f tag=...` (no `issue_number`) -> `issue` field stays `null` in builds.json, no comment, build entry still publishes
- [ ] Issue body containing markdown special chars (backticks, dollar signs, code fences) survives the `--arg b "$BODY"` round-trip and renders correctly on the details page
- [ ] GH Actions summary table shows both "Build details" and "Dashboard" rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)