### PR TITLE
fix(chats): drive Share Invite sheet off the flow itself (closes #107)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatMembersView.swift
+++ b/Sources/OnymIOS/Chats/ChatMembersView.swift
@@ -23,7 +23,6 @@ struct ChatMembersView: View {
     @Bindable var identitiesFlow: IdentitiesFlow
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
-    @State private var showShareInvite = false
     @State private var shareInviteFlow: ShareInviteFlow?
 
     var body: some View {
@@ -55,7 +54,6 @@ struct ChatMembersView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         shareInviteFlow = makeShareInviteFlow()
-                        showShareInvite = true
                     } label: {
                         Image(systemName: "person.crop.circle.badge.plus")
                     }
@@ -64,17 +62,12 @@ struct ChatMembersView: View {
                 }
             }
         }
-        .sheet(isPresented: $showShareInvite) {
-            if let flow = shareInviteFlow {
-                ShareInviteView(
-                    groupID: groupID,
-                    flow: flow,
-                    onDone: {
-                        showShareInvite = false
-                        shareInviteFlow = nil
-                    }
-                )
-            }
+        .sheet(item: $shareInviteFlow) { flow in
+            ShareInviteView(
+                groupID: groupID,
+                flow: flow,
+                onDone: { shareInviteFlow = nil }
+            )
         }
     }
 

--- a/Sources/OnymIOS/Group/ShareInviteFlow.swift
+++ b/Sources/OnymIOS/Group/ShareInviteFlow.swift
@@ -15,13 +15,19 @@ import Observation
 /// Mirrors onym-android's `ShareInviteViewModel.kt`.
 @MainActor
 @Observable
-final class ShareInviteFlow {
+final class ShareInviteFlow: Identifiable {
     enum State: Equatable, Sendable {
         case idle
         case minting
         case ready(link: String, groupName: String?)
         case failed(reason: String)
     }
+
+    /// Drives `.sheet(item:)` from a single source of truth.
+    /// `.sheet(isPresented:)` paired with a separate optional-flow
+    /// `@State` raced on first present — the content closure read
+    /// `nil` and rendered an empty sheet (#107).
+    nonisolated var id: ObjectIdentifier { ObjectIdentifier(self) }
 
     private(set) var state: State = .idle
 


### PR DESCRIPTION
ChatMembersView paired `.sheet(isPresented:)` with a separate optional
`shareInviteFlow` @State. On first tap right after group creation, the
sheet content closure read the stale `nil` flow and rendered an empty
sheet — the user had to dismiss and re-tap to see the invite.

Switch to `.sheet(item:)` with a single source of truth: setting the
flow presents the sheet, dismissal clears it. Add `Identifiable`
conformance to `ShareInviteFlow` (per-instance `ObjectIdentifier`) so
it can drive the item binding.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
