### PR TITLE
fix(settings): hide nav bar to remove duplicate "Settings" title (closes #109)

### DIFF
--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -192,8 +192,7 @@ struct SettingsView: View {
             .padding(.bottom, 32)
         }
         .background(OnymTokens.surface.ignoresSafeArea())
-        .navigationTitle("Settings")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .task { await identitiesFlow.start() }
         .sheet(isPresented: $showRecoveryPhrase) {
             RecoveryPhraseBackupView(flow: makeBackupFlow())


### PR DESCRIPTION
The Settings tab rendered "Settings" twice — once via the in-content
`SettingsLargeTitle` and once via `.navigationTitle` on the inline nav bar.
Hide the nav bar at the tab root so the in-content large title (which the
design treats as the canonical heading) is the only one shown.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
