### PR TITLE
fix(create-group): render generated name as placeholder, not real input (closes #112)

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -39,17 +39,10 @@ final class CreateGroupFlow {
     var invitees: [OnymInvitee] = []
 
     /// Friendly placeholder generated on init / reset (e.g. "Maple
-    /// Garden"). The TextField pre-fills with this so the user can
-    /// hit Create immediately without typing — first focus on the
-    /// field clears it (see `tappedNameFieldFocused`). Submit also
-    /// falls back to this if the user emptied the field and didn't
-    /// retype.
+    /// Garden"). Rendered as the TextField's `prompt` so it appears
+    /// in the muted placeholder style — never as real input. Submit
+    /// falls back to this when the user leaves the field empty.
     private(set) var generatedName: String
-
-    /// Goes true on the first focus event of the name field. Used to
-    /// distinguish "user accepted the placeholder" from "user wants
-    /// to type their own".
-    private var nameFieldHasBeenFocused = false
 
     /// Bound to the InviteByKey screen's TextField.
     var inviteeInput: String = ""
@@ -77,21 +70,8 @@ final class CreateGroupFlow {
 
     init(interactor: CreateGroupInteractor) {
         self.interactor = interactor
-        let generated = Self.generatePlaceholderName()
-        self.generatedName = generated
-        self.name = generated
-    }
-
-    /// Called by the Step1 view when the name TextField gets focus.
-    /// On the *first* focus we clear the field so the user can type a
-    /// fresh name without manually deleting the placeholder. After
-    /// that, focus is a no-op — the user is in charge of the field.
-    func tappedNameFieldFocused() {
-        guard !nameFieldHasBeenFocused else { return }
-        nameFieldHasBeenFocused = true
-        if name == generatedName {
-            name = ""
-        }
+        self.generatedName = Self.generatePlaceholderName()
+        self.name = ""
     }
 
     // MARK: - Step 1 → Step 2
@@ -336,10 +316,8 @@ final class CreateGroupFlow {
     }
 
     private func reset() {
-        let generated = Self.generatePlaceholderName()
-        generatedName = generated
-        name = generated
-        nameFieldHasBeenFocused = false
+        generatedName = Self.generatePlaceholderName()
+        name = ""
         accent = .blue
         governance = .tyranny
         invitees = []

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -245,9 +245,6 @@ private struct CreateGroupStep1View: View {
                 .autocorrectionDisabled()
                 .submitLabel(.done)
                 .focused($nameFocused)
-                .onChange(of: nameFocused) { _, isFocused in
-                    if isFocused { flow.tappedNameFieldFocused() }
-                }
                 .onChange(of: flow.name) { _, new in
                     // Strip any embedded newlines so paste from a
                     // multi-line source still resolves to a single

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -39,45 +39,22 @@ final class CreateGroupFlowTests: XCTestCase {
 
     // MARK: - Random placeholder name
 
-    func test_init_prePopulatesNameWithGeneratedPlaceholder() async throws {
+    func test_init_leavesNameEmpty_andGeneratesPlaceholder() async throws {
+        // The field starts empty so the TextField's `prompt` renders in
+        // the muted placeholder style. The generated name lives on the
+        // flow as a submit-time fallback only.
         let flow = await makeFlow()
-        XCTAssertFalse(flow.name.isEmpty,
-                       "init should pre-populate name with a friendly placeholder")
-        XCTAssertEqual(flow.name, flow.generatedName)
+        XCTAssertEqual(flow.name, "",
+                       "init must leave name empty so the prompt renders as a placeholder")
+        XCTAssertFalse(flow.generatedName.isEmpty,
+                       "init should still generate a placeholder for the prompt + submit fallback")
         XCTAssertTrue(flow.generatedName.contains(" "),
                       "placeholder should be 'Adjective Noun' shape")
-    }
-
-    func test_firstFocusOnNameField_clearsPlaceholder() async throws {
-        let flow = await makeFlow()
-        let original = flow.generatedName
-        XCTAssertEqual(flow.name, original)
-        flow.tappedNameFieldFocused()
-        XCTAssertEqual(flow.name, "", "first focus clears the placeholder")
-    }
-
-    func test_secondFocus_doesNotClearUserInput() async throws {
-        let flow = await makeFlow()
-        flow.tappedNameFieldFocused()  // clears placeholder
-        flow.name = "My Group"
-        flow.tappedNameFieldFocused()  // second focus — should be no-op
-        XCTAssertEqual(flow.name, "My Group")
-    }
-
-    func test_focusDoesNotClear_ifUserAlreadyEditedAwayFromPlaceholder() async throws {
-        // Edge case: programmatic name change before the field is
-        // ever focused. Focus should not stomp the user's value.
-        let flow = await makeFlow()
-        flow.name = "Manual"
-        flow.tappedNameFieldFocused()
-        XCTAssertEqual(flow.name, "Manual",
-                       "focus only clears when the field still holds the original placeholder")
     }
 
     func test_effectiveName_fallsBackToPlaceholder_whenEmpty() async throws {
         let flow = await makeFlow()
         let placeholder = flow.generatedName
-        flow.tappedNameFieldFocused()  // clears
         XCTAssertEqual(flow.effectiveName, placeholder,
                        "empty name should resolve to the auto-generated placeholder at submit")
         flow.name = "Family"
@@ -347,10 +324,10 @@ final class CreateGroupFlowTests: XCTestCase {
         flow.tappedDone()
         XCTAssertEqual(closedCount, 1)
         XCTAssertEqual(flow.route, .step1)
-        // Reset re-rolls the placeholder, so name == generatedName,
-        // not "".
-        XCTAssertEqual(flow.name, flow.generatedName)
-        XCTAssertFalse(flow.name.isEmpty)
+        XCTAssertEqual(flow.name, "",
+                       "reset should leave name empty so the prompt renders as a placeholder")
+        XCTAssertFalse(flow.generatedName.isEmpty,
+                       "reset should re-roll a fresh placeholder for the next flow run")
         XCTAssertTrue(flow.invitees.isEmpty)
     }
 


### PR DESCRIPTION
The Step 1 group-name field was seeded with the generated "Adjective
Noun" suggestion as the actual TextField value, so it rendered in the
full-opacity input color and looked indistinguishable from text the
user had typed. Users could miss that they were supposed to (or could)
change it, and unknowingly create groups called "Silver Atlas".

Leave `name` empty at init and reset so the TextField's `prompt` —
already styled with the muted `OnymTokens.text3` color — surfaces as a
proper iOS placeholder. The existing `effectiveName` fallback already
substitutes `generatedName` at submit when the user leaves the field
blank, so the "hit Create immediately" path still works.

The first-focus-clears-placeholder dance is no longer needed and is
removed along with its tests.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
