### PR TITLE
fix(chats): surface Invite Key as a QR toolbar shortcut (closes #113)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -13,6 +13,7 @@ struct ChatsView: View {
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
     @State private var showCreateGroup = false
+    @State private var showShareKey = false
 
     var body: some View {
         Group {
@@ -34,6 +35,20 @@ struct ChatsView: View {
             // the badge only appears when `pending.count > 0`.
             ToolbarItem(placement: .topBarTrailing) {
                 ApproveRequestsToolbarButton(flow: approveRequestsFlow)
+            }
+            // Share invite-key shortcut — opens the same QR / link /
+            // copy-key sheet as Settings → Invite Key, so users can
+            // hand out their inbox key without leaving the main tab.
+            if activeSummary != nil {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showShareKey = true
+                    } label: {
+                        Image(systemName: "qrcode")
+                    }
+                    .accessibilityLabel("Share invite key")
+                    .accessibilityIdentifier("chats.share_key_toolbar")
+                }
             }
             // Plus button mirrors iOS Mail / Messages — useful once
             // the user already has at least one chat. Hidden in the
@@ -59,16 +74,27 @@ struct ChatsView: View {
                 onClose: { showCreateGroup = false }
             )
         }
+        .sheet(isPresented: $showShareKey) {
+            if let active = activeSummary {
+                NavigationStack {
+                    ShareKeyView(identity: active, blsPrefix: identitiesFlow.blsPrefix(of: active))
+                }
+            }
+        }
+    }
+
+    /// Active identity summary, or nil pre-bootstrap. Drives both the
+    /// nav title and whether the Share-Key toolbar shortcut is visible.
+    private var activeSummary: IdentitySummary? {
+        guard let id = identitiesFlow.currentID else { return nil }
+        return identitiesFlow.identities.first { $0.id == id }
     }
 
     /// "Chats" when no identity exists yet (pre-bootstrap), otherwise
     /// the active identity's display name. SwiftUI re-renders on every
     /// `currentID` change because `identitiesFlow` is `@Observable`.
     private var currentIdentityName: String {
-        guard let id = identitiesFlow.currentID,
-              let summary = identitiesFlow.identities.first(where: { $0.id == id })
-        else { return "Chats" }
-        return summary.name
+        activeSummary?.name ?? "Chats"
     }
 
     // MARK: - Empty state

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -683,9 +683,9 @@ private struct CreateGroupInviteByKeyView: View {
         (
             Text("Ask for their ").foregroundColor(OnymTokens.text2)
             + Text("inbox key").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
-            + Text(" \u{2014} they can find it in ").foregroundColor(OnymTokens.text2)
-            + Text("Settings \u{2192} Advanced").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
-            + Text(", or share a QR code from there.").foregroundColor(OnymTokens.text2)
+            + Text(" \u{2014} they can copy it from the ").foregroundColor(OnymTokens.text2)
+            + Text("QR icon on Chats").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
+            + Text(", or share their QR code from there.").foregroundColor(OnymTokens.text2)
         )
         .font(.system(size: 13))
         .lineSpacing(1.5)

--- a/Sources/OnymIOS/Identity/ShareKeyView.swift
+++ b/Sources/OnymIOS/Identity/ShareKeyView.swift
@@ -14,6 +14,12 @@ struct ShareKeyView: View {
         settingsInviteURL(blsPublicKey: identity.inboxPublicKey)
     }
 
+    /// 64-char hex of the X25519 inbox public key — the value the
+    /// "Invite by inbox key" paste field expects on the other device.
+    private var inboxKeyHex: String {
+        identity.inboxPublicKey.map { String(format: "%02x", $0) }.joined()
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -85,6 +91,26 @@ struct ShareKeyView: View {
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 14)
+
+                Button {
+                    UIPasteboard.general.string = inboxKeyHex
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "key.fill")
+                        Text("Copy inbox key")
+                            .font(.system(size: 15, weight: .semibold))
+                    }
+                    .foregroundStyle(OnymAccent.blue.color)
+                    .frame(maxWidth: .infinity, minHeight: 48)
+                    .background(OnymTokens.surface2,
+                                in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(OnymTokens.hairline, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("share_key.copy_inbox_key_button")
+                .padding(.horizontal, 16)
+                .padding(.top, 10)
 
                 SettingsFootnote("Anyone who scans this code with Onym can start a private, end-to-end encrypted chat with \(identity.name). The invite key contains your inbox X25519 public key only — no contact info.")
             }


### PR DESCRIPTION
## Summary

- Adds a QR-code button to the Chats top bar (between the join-requests bell and the create-group button) that opens the existing **Invite Key** sheet — so users can hand out their inbox key without diving into Settings.
- Adds a **Copy inbox key** action to that sheet alongside Copy link / Share. Copies the 64-char hex of the X25519 inbox public key — exactly what the *Invite by inbox key* paste field on the other device expects.
- Updates the *Invite by inbox key* hint on Step 2 of Create Group: it now points to the QR icon on Chats instead of the since-removed Settings → Advanced route, which was a dead end (Advanced shows the BLS public key, not the inbox key).

This is Option B from the issue thread — placing the entry point on the main Chats screen rather than burying it in Advanced. Settings → Invite Key still works exactly as before, just with the extra Copy inbox key button.

## Test plan

- [ ] On a fresh install, open the app → Chats. Verify a QR icon appears in the top bar next to the join-requests bell and the create-group button. Tap it.
- [ ] Confirm the sheet that opens shows the same QR / link / identity info as Settings → INVITE KEY, plus a new **Copy inbox key** button. Tap it and paste — should be 64 lowercase hex characters.
- [ ] Open Settings → INVITE KEY card → Invite Key sheet, verify the Copy inbox key button works there too.
- [ ] Start Create Group → Step 2 → Invite by inbox key. Verify the hint reads "they can copy it from the QR icon on Chats, or share their QR code from there." (no Settings → Advanced).
- [ ] Paste the copied inbox key into the Invite by inbox key field on a second device — should validate and accept (64/64, no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)