### PR TITLE
feat(chats): surface invite QR on Chats toolbar; fix dead-end hint (closes #137)

### DIFF
--- a/Sources/OnymIOS/Assembly.swift
+++ b/Sources/OnymIOS/Assembly.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Seam over the app's composition root. The production conformer is
+/// `OnymIOSApp` itself (whose `init` wires the live graph); UI-test and
+/// preview hosts can adopt this to vend a hand-built `AppDependencies`
+/// without dragging in the full `WindowGroup` lifecycle.
+@MainActor
+protocol Assembly {
+    func assemble() -> AppDependencies
+}

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -13,6 +13,7 @@ struct ChatsView: View {
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
     @State private var showCreateGroup = false
+    @State private var showShareKey = false
 
     var body: some View {
         Group {
@@ -34,6 +35,21 @@ struct ChatsView: View {
             // the badge only appears when `pending.count > 0`.
             ToolbarItem(placement: .topBarTrailing) {
                 ApproveRequestsToolbarButton(flow: approveRequestsFlow)
+            }
+            // Show invite QR — primary discovery point for the
+            // user's own invite key. Hidden pre-bootstrap (no active
+            // identity yet); shown in both empty and populated
+            // states because surfacing one's invite is at least as
+            // useful before the first chat exists.
+            if activeSummary != nil {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showShareKey = true
+                    } label: {
+                        Image(systemName: "qrcode")
+                    }
+                    .accessibilityIdentifier("chats.share_invite_qr")
+                }
             }
             // Plus button mirrors iOS Mail / Messages — useful once
             // the user already has at least one chat. Hidden in the
@@ -59,6 +75,21 @@ struct ChatsView: View {
                 onClose: { showCreateGroup = false }
             )
         }
+        .sheet(isPresented: $showShareKey) {
+            if let active = activeSummary {
+                NavigationStack {
+                    ShareKeyView(identity: active, blsPrefix: identitiesFlow.blsPrefix(of: active))
+                }
+            }
+        }
+    }
+
+    /// Active identity, mirroring `SettingsView.activeSummary` — used
+    /// both to gate the invite-QR toolbar item and to feed
+    /// `ShareKeyView` when the sheet presents.
+    private var activeSummary: IdentitySummary? {
+        guard let id = identitiesFlow.currentID else { return nil }
+        return identitiesFlow.identities.first { $0.id == id }
     }
 
     /// "Chats" when no identity exists yet (pre-bootstrap), otherwise

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -682,10 +682,10 @@ private struct CreateGroupInviteByKeyView: View {
     private var explanation: some View {
         (
             Text("Ask for their ").foregroundColor(OnymTokens.text2)
-            + Text("inbox key").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
-            + Text(" \u{2014} they can find it in ").foregroundColor(OnymTokens.text2)
-            + Text("Settings \u{2192} Advanced").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
-            + Text(", or share a QR code from there.").foregroundColor(OnymTokens.text2)
+            + Text("invite key").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
+            + Text(" \u{2014} they can tap the ").foregroundColor(OnymTokens.text2)
+            + Text("QR icon on their Chats screen").font(.system(size: 13, weight: .semibold)).foregroundColor(OnymTokens.text)
+            + Text(", then share the QR or copy the link.").foregroundColor(OnymTokens.text2)
         )
         .font(.system(size: 13))
         .lineSpacing(1.5)

--- a/Sources/OnymIOS/Identity/IdentityDetailView.swift
+++ b/Sources/OnymIOS/Identity/IdentityDetailView.swift
@@ -152,7 +152,7 @@ struct IdentityDetailView: View {
             SettingsCard {
                 VStack(spacing: 14) {
                     SettingsQRCode(
-                        value: settingsInviteURL(blsPublicKey: summary.inboxPublicKey),
+                        value: settingsInviteURL(inboxPublicKey: summary.inboxPublicKey),
                         size: 200
                     )
                     .padding(12)
@@ -168,7 +168,7 @@ struct IdentityDetailView: View {
                         .lineSpacing(2)
                         .frame(maxWidth: 280)
 
-                    Text(settingsInviteURL(blsPublicKey: summary.inboxPublicKey))
+                    Text(settingsInviteURL(inboxPublicKey: summary.inboxPublicKey))
                         .font(.system(size: 11.5, design: .monospaced))
                         .foregroundStyle(OnymTokens.text2)
                         .lineLimit(1).truncationMode(.middle)
@@ -190,13 +190,13 @@ struct IdentityDetailView: View {
                         foreground: OnymAccent.blue.color
                     ) {
                         UIPasteboard.general.string =
-                            settingsInviteURL(blsPublicKey: summary.inboxPublicKey)
+                            settingsInviteURL(inboxPublicKey: summary.inboxPublicKey)
                     }
                     .accessibilityIdentifier("identity.copy_link.\(summary.id)")
 
                     Rectangle().fill(OnymTokens.hairlineStrong).frame(width: 0.5)
 
-                    ShareLink(item: settingsInviteURL(blsPublicKey: summary.inboxPublicKey)) {
+                    ShareLink(item: settingsInviteURL(inboxPublicKey: summary.inboxPublicKey)) {
                         HStack(spacing: 6) {
                             Image(systemName: "square.and.arrow.up")
                             Text("Share").font(.system(size: 15, weight: .medium))

--- a/Sources/OnymIOS/Identity/ShareKeyView.swift
+++ b/Sources/OnymIOS/Identity/ShareKeyView.swift
@@ -11,7 +11,7 @@ struct ShareKeyView: View {
     @Environment(\.dismiss) private var dismiss
 
     private var inviteURL: String {
-        settingsInviteURL(blsPublicKey: identity.inboxPublicKey)
+        settingsInviteURL(inboxPublicKey: identity.inboxPublicKey)
     }
 
     var body: some View {

--- a/Sources/OnymIOS/Settings/SettingsQRCode.swift
+++ b/Sources/OnymIOS/Settings/SettingsQRCode.swift
@@ -55,7 +55,11 @@ struct SettingsQRCode: View {
 /// pass validation on the scanning device. Real production invitee
 /// links live in the Group flow's `IntroCapability` — this is the
 /// per-identity equivalent surfaced from Settings.
-func settingsInviteURL(blsPublicKey: Data) -> String {
-    let hex = blsPublicKey.map { String(format: "%02x", $0) }.joined()
+///
+/// Note: this is the X25519 **inbox** key, not the BLS12-381 governance
+/// key. See `IdentitySummary.swift:11-21` for the distinction — both are
+/// `Data`, so the type system doesn't catch a wrong-key call site.
+func settingsInviteURL(inboxPublicKey: Data) -> String {
+    let hex = inboxPublicKey.map { String(format: "%02x", $0) }.joined()
     return "https://onym.chat?payload=\(hex)"
 }

--- a/Sources/OnymIOS/Settings/SettingsView.swift
+++ b/Sources/OnymIOS/Settings/SettingsView.swift
@@ -277,7 +277,7 @@ struct SettingsView: View {
         } label: {
             HStack(spacing: 16) {
                 let payload = activeSummary?.inboxPublicKey ?? Data(count: 16)
-                SettingsQRCode(value: settingsInviteURL(blsPublicKey: payload), size: 92)
+                SettingsQRCode(value: settingsInviteURL(inboxPublicKey: payload), size: 92)
                     .padding(8)
                     .background(OnymTokens.surface2,
                                 in: RoundedRectangle(cornerRadius: 14, style: .continuous))

--- a/Tests/OnymIOSTests/SettingsQRCodeTests.swift
+++ b/Tests/OnymIOSTests/SettingsQRCodeTests.swift
@@ -16,7 +16,7 @@ final class SettingsQRCodeTests: XCTestCase {
         // field expects (validator requires 64 hex chars). 32 bytes
         // → 64 hex chars; anything shorter is decorative.
         let key = Data((0..<32).map { UInt8($0) })
-        let url = settingsInviteURL(blsPublicKey: key)
+        let url = settingsInviteURL(inboxPublicKey: key)
         XCTAssertTrue(url.hasPrefix("https://onym.chat?payload="))
         let payload = url.replacingOccurrences(of: "https://onym.chat?payload=", with: "")
         XCTAssertEqual(payload.count, 64, "32 bytes should serialise to 64 hex chars")
@@ -34,7 +34,7 @@ final class SettingsQRCodeTests: XCTestCase {
         // change.
         let key = Data((0..<32).map { UInt8($0 ^ 0x5A) })
         let expectedHex = key.map { String(format: "%02x", $0) }.joined()
-        let url = settingsInviteURL(blsPublicKey: key)
+        let url = settingsInviteURL(inboxPublicKey: key)
         XCTAssertEqual(CreateGroupFlow.canonicalizeInviteKey(url), expectedHex)
     }
 }


### PR DESCRIPTION
Adds a QR toolbar icon to the Chats tab that opens ShareKeyView, so users
can share their invite without drilling into Settings. Updates the Invite
by Key hint in Create Group to point at the new entry point instead of the
non-existent "Settings -> Advanced" path. Renames settingsInviteURL's
parameter from blsPublicKey: to inboxPublicKey: to match what it actually
carries (X25519 inbox key, not the BLS governance key) and adds a doc note
to keep the next contributor from re-introducing the drift.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
