### PR TITLE
ci: drop sudo xcode-select, use DEVELOPER_DIR

### DIFF
--- a/.github/workflows/qa-build.yml
+++ b/.github/workflows/qa-build.yml
@@ -80,7 +80,11 @@ jobs:
         run: git lfs pull
 
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        # Self-hosted runner runs as a standard user without sudo, so
+        # `xcode-select -s` (which mutates the system-wide DEVELOPER_DIR
+        # symlink) isn't available. Export DEVELOPER_DIR instead -- xcrun
+        # / xcodebuild honour it transparently and it stays job-scoped.
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_26.app/Contents/Developer" >> "$GITHUB_ENV"
 
       - name: Install xcodegen
         run: brew install xcodegen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,11 @@ jobs:
         run: git lfs pull
 
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        # Self-hosted runner runs as a standard user without sudo, so
+        # `xcode-select -s` (which mutates the system-wide DEVELOPER_DIR
+        # symlink) isn't available. Export DEVELOPER_DIR instead -- xcrun
+        # / xcodebuild honour it transparently and it stays job-scoped.
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_26.app/Contents/Developer" >> "$GITHUB_ENV"
 
       - name: Install xcodegen
         run: brew install xcodegen
@@ -207,7 +211,11 @@ jobs:
         run: git lfs pull
 
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        # Self-hosted runner runs as a standard user without sudo, so
+        # `xcode-select -s` (which mutates the system-wide DEVELOPER_DIR
+        # symlink) isn't available. Export DEVELOPER_DIR instead -- xcrun
+        # / xcodebuild honour it transparently and it stays job-scoped.
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_26.app/Contents/Developer" >> "$GITHUB_ENV"
 
       - name: Install xcodegen
         run: brew install xcodegen
@@ -295,7 +303,11 @@ jobs:
         run: git lfs pull
 
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        # Self-hosted runner runs as a standard user without sudo, so
+        # `xcode-select -s` (which mutates the system-wide DEVELOPER_DIR
+        # symlink) isn't available. Export DEVELOPER_DIR instead -- xcrun
+        # / xcodebuild honour it transparently and it stays job-scoped.
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_26.app/Contents/Developer" >> "$GITHUB_ENV"
 
       - name: Install xcodegen
         run: brew install xcodegen


### PR DESCRIPTION
## Summary
- Self-hosted macOS runner runs as a standard user — `sudo xcode-select -s /Applications/Xcode_26.app` was failing on every job.
- Replaced the four call sites in `release.yml` (lint/unit/UI/build) and `qa-build.yml` with `echo "DEVELOPER_DIR=/Applications/Xcode_26.app/Contents/Developer" >> "$GITHUB_ENV"`.
- `xcrun` / `xcodebuild` honour `DEVELOPER_DIR` transparently, and the selection is scoped to the job rather than mutating the runner-wide symlink — closer to least-privilege than the previous approach anyway.

## Test plan
- [ ] Re-run a tag-gated release workflow (lint + unit + UI + build) and confirm every job picks Xcode 26 without invoking sudo.
- [ ] Dispatch QA Build on a branch and confirm the IPA build succeeds with `DEVELOPER_DIR` exported.
- [ ] Spot-check the job logs to confirm `xcodebuild -version` reports Xcode 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)