### PR TITLE
rebrand to app.onym.ios + fix Android↔iOS invitation decode

### DIFF
--- a/.github/workflows/qa-build.yml
+++ b/.github/workflows/qa-build.yml
@@ -192,7 +192,7 @@ jobs:
 
           # OTA manifest. iOS Safari hands this to the system installer
           # when the user taps the itms-services:// link. The IPA's
-          # Info.plist must carry the same bundle-identifier ("chat.onym.ios")
+          # Info.plist must carry the same bundle-identifier ("app.onym.ios")
           # that match's ad-hoc profile is provisioned for, otherwise
           # the install fails with "unable to install".
           cat > "dist/qa/ios/${VERSION}/manifest.plist" <<EOF
@@ -215,7 +215,7 @@ jobs:
                 <key>metadata</key>
                 <dict>
                   <key>bundle-identifier</key>
-                  <string>chat.onym.ios</string>
+                  <string>app.onym.ios</string>
                   <key>bundle-version</key>
                   <string>${MARKETING}</string>
                   <key>kind</key>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,7 +426,7 @@ jobs:
           # OTA manifest. iOS Safari hands this to the system installer
           # when the user taps the itms-services:// link. The IPA's
           # Info.plist must carry the same bundle-identifier
-          # ("chat.onym.ios") that match's ad-hoc profile is provisioned
+          # ("app.onym.ios") that match's ad-hoc profile is provisioned
           # for, otherwise the install fails with "unable to install".
           cat > "dist/qa/ios/${VERSION}/manifest.plist" <<EOF
           <?xml version="1.0" encoding="UTF-8"?>
@@ -448,7 +448,7 @@ jobs:
                 <key>metadata</key>
                 <dict>
                   <key>bundle-identifier</key>
-                  <string>chat.onym.ios</string>
+                  <string>app.onym.ios</string>
                   <key>bundle-version</key>
                   <string>${MARKETING}</string>
                   <key>kind</key>

--- a/Info.plist
+++ b/Info.plist
@@ -24,7 +24,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>chat.onym.ios.join</string>
+			<string>app.onym.ios.join</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>onym</string>
@@ -51,14 +51,7 @@
 		<key>UIImageName</key>
 		<string>LaunchLogo</string>
 	</dict>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~iphone</key>
+	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>

--- a/OnymIOS.entitlements
+++ b/OnymIOS.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:onym.chat</string>
+		<string>applinks:onym.app</string>
 	</array>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ identity-derived operations.
 └── README.md
 ```
 
-Bundle id is `chat.onym.ios` (production) — same as the reference
+Bundle id is `app.onym.ios` (production) — same as the reference
 impl currently shipping from `stellar-mls/clients/ios`. As long as
 both repos exist in parallel they'll fight over the same install
 slot on a device; coordinate the cutover when promoting onym-ios to
@@ -305,7 +305,7 @@ builds work without local config.
 ## Identity persistence
 
 One Keychain item (`kSecClassGenericPassword`, service
-`chat.onym.ios.identity`) holds a JSON-encoded `StoredSnapshot`:
+`app.onym.ios.identity`) holds a JSON-encoded `StoredSnapshot`:
 
 ```swift
 struct StoredSnapshot: Codable {
@@ -338,13 +338,13 @@ derived pairs stay inside the repository.
                 │  64-byte seed                       │
                 └────────┬────────────────┬───────────┘
                          │                │     HKDF-SHA256
-                         ▼                ▼     salt = "chat.onym.bip39"
+                         ▼                ▼     salt = "app.onym.bip39"
               ┌──────────────────┐ ┌──────────────────┐
               │ nostr secret     │ │ BLS secret       │
               │ (32B secp256k1)  │ │ (32B BLS Fr)     │
               └────┬─────────────┘ └────────┬─────────┘
                    │ HKDF-SHA256              │
-                   │ salt = "chat.onym.ios"   │
+                   │ salt = "app.onym.ios"   │
        ┌───────────┼───────────────┐          │
        ▼           ▼               ▼          │
   ┌─────────┐ ┌─────────────┐ ┌─────────────┐ │
@@ -370,10 +370,10 @@ generated there restores the same identity here, and vice versa.
 | Step | Input | Salt | Info | Algorithm |
 |---|---|---|---|---|
 | Seed                  | mnemonic       | `"mnemonic"+passphrase` | —                          | PBKDF2-HMAC-SHA512, 2048 iters |
-| Nostr secret          | seed           | `chat.onym.bip39`       | `nostr-secp256k1-v1`       | HKDF-SHA256, 32B |
-| BLS secret            | seed           | `chat.onym.bip39`       | `bls12-381-v1`             | HKDF-SHA256, 32B |
-| Stellar Ed25519 seed  | nostr secret   | `chat.onym.ios`         | `stellar-ed25519-v1`       | HKDF-SHA256, 32B |
-| X25519 seed (inbox)   | nostr secret   | `chat.onym.ios`         | `x25519-key-agreement-v1`  | HKDF-SHA256, 32B |
+| Nostr secret          | seed           | `app.onym.bip39`       | `nostr-secp256k1-v1`       | HKDF-SHA256, 32B |
+| BLS secret            | seed           | `app.onym.bip39`       | `bls12-381-v1`             | HKDF-SHA256, 32B |
+| Stellar Ed25519 seed  | nostr secret   | `app.onym.ios`         | `stellar-ed25519-v1`       | HKDF-SHA256, 32B |
+| X25519 seed (inbox)   | nostr secret   | `app.onym.ios`         | `x25519-key-agreement-v1`  | HKDF-SHA256, 32B |
 | Inbox tag             | X25519 pubkey  | —                       | prefix `sep-inbox-v1`      | SHA-256, hex(prefix(8)) |
 | Stellar account ID    | Ed25519 pubkey | —                       | version byte `6 << 3 = 48` | StrKey (CRC16-XMODEM + base32) |
 
@@ -533,7 +533,7 @@ shipped binary to take the test-mode branch.
 | `--mock-biometric`   | Swaps `LAContextAuthenticator` for `AlwaysAcceptAuthenticator` (DEBUG-only struct).   |
 
 UI tests use a separate Keychain service
-(`chat.onym.ios.identity.uitests`) that is never touched by
+(`app.onym.ios.identity.uitests`) that is never touched by
 production builds, so even a developer running tests on their own
 device cannot disturb their real identity.
 
@@ -729,7 +729,7 @@ inspected without re-running the workflow.
 The structure was lifted from
 `stellar-mls/.github/workflows/release.yml` — minus TestFlight
 upload, OTA droplet rsync, Android, and the NotificationService
-extension. Same Match repo / team / bundle id (`chat.onym.ios`) so
+extension. Same Match repo / team / bundle id (`app.onym.ios`) so
 no new Apple Developer setup is needed.
 
 ### Required repo secrets

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -18,6 +18,7 @@
       }
     },
     " · published on Stellar so anyone can verify it’s real." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2046,6 +2047,9 @@
         }
       }
     },
+    "Paste" : {
+
+    },
     "Paste 64-char inbox key" : {
       "localizations" : {
         "en" : {
@@ -2063,6 +2067,7 @@
       }
     },
     "Paste a 64-char key" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2079,6 +2084,7 @@
       }
     },
     "Paste from clipboard" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2093,6 +2099,9 @@
           }
         }
       }
+    },
+    "Paste or scan a QR" : {
+
     },
     "People who tap one of your invite links show up here." : {
       "localizations" : {
@@ -2126,6 +2135,9 @@
           }
         }
       }
+    },
+    "Point your camera at an Onym invite QR code." : {
+
     },
     "Primary" : {
       "extractionState" : "stale",
@@ -2421,6 +2433,9 @@
           }
         }
       }
+    },
+    "Scan QR" : {
+
     },
     "Scan with Onym on another device to open a private chat with this identity." : {
       "localizations" : {

--- a/Sources/OnymIOS/Chain/AnchorSelectionStore.swift
+++ b/Sources/OnymIOS/Chain/AnchorSelectionStore.swift
@@ -18,8 +18,8 @@ protocol AnchorSelectionStore: Sendable {
 /// Production `AnchorSelectionStore`. UserDefaults-backed (no secret
 /// material). Suite-name injectable for per-test isolation.
 struct UserDefaultsAnchorSelectionStore: AnchorSelectionStore, @unchecked Sendable {
-    private static let selectionsKey = "chat.onym.ios.anchors.selections"
-    private static let manifestKey = "chat.onym.ios.anchors.cachedManifest"
+    private static let selectionsKey = "app.onym.ios.anchors.selections"
+    private static let manifestKey = "app.onym.ios.anchors.cachedManifest"
 
     private let defaults: UserDefaults
 

--- a/Sources/OnymIOS/Chain/RelayerSelectionStore.swift
+++ b/Sources/OnymIOS/Chain/RelayerSelectionStore.swift
@@ -20,7 +20,7 @@ protocol RelayerSelectionStore: Sendable {
 }
 
 /// Production `RelayerSelectionStore`. Keys are scoped under
-/// `chat.onym.ios.relayer.*` so other UserDefaults consumers can't
+/// `app.onym.ios.relayer.*` so other UserDefaults consumers can't
 /// collide. Suite name is injectable so each test gets its own
 /// isolated suite (mirrors the per-test Keychain service pattern in
 /// `IdentityRepositoryTests`).
@@ -29,10 +29,10 @@ protocol RelayerSelectionStore: Sendable {
 /// thread-safe (its set / remove / data(forKey:) APIs serialise
 /// internally) but isn't formally `Sendable` in the standard library.
 struct UserDefaultsRelayerSelectionStore: RelayerSelectionStore, @unchecked Sendable {
-    private static let configurationKey = "chat.onym.ios.relayer.configuration"
-    private static let cachedListKey = "chat.onym.ios.relayer.cachedKnownList"
+    private static let configurationKey = "app.onym.ios.relayer.configuration"
+    private static let cachedListKey = "app.onym.ios.relayer.cachedKnownList"
     /// PR #18 key — read once for migration, then deleted.
-    private static let legacySelectionKey = "chat.onym.ios.relayer.selection"
+    private static let legacySelectionKey = "app.onym.ios.relayer.selection"
 
     private let defaults: UserDefaults
 

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -216,8 +216,8 @@ final class CreateGroupFlow {
     /// Pull a candidate inbox key out of a raw scanned/pasted string.
     /// Recognises:
     ///  - bare hex (returned unchanged, lowercased)
-    ///  - `https://onym.chat?payload=<hex>` (legacy iOS settings QR)
-    ///  - `https://onym.chat/i?k=<urlsafe-base64>` (Android identity
+    ///  - `https://onym.app?payload=<hex>` (legacy iOS settings QR)
+    ///  - `https://onym.app/i?k=<urlsafe-base64>` (Android identity
     ///    invite — `IdentityInviteUrl.kt`)
     /// Falls back to the trimmed raw input otherwise so the existing
     /// validation surfaces a meaningful error.

--- a/Sources/OnymIOS/Group/GovernanceMember.swift
+++ b/Sources/OnymIOS/Group/GovernanceMember.swift
@@ -13,4 +13,9 @@ import Foundation
 struct GovernanceMember: Codable, Equatable, Sendable {
     let publicKeyCompressed: Data
     let leafHash: Data
+
+    enum CodingKeys: String, CodingKey {
+        case publicKeyCompressed = "public_key_compressed"
+        case leafHash = "leaf_hash"
+    }
 }

--- a/Sources/OnymIOS/Group/IntroCapability.swift
+++ b/Sources/OnymIOS/Group/IntroCapability.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// Encoded as `Base64(JSON)` and ferried via either:
 ///
-///  - `https://onym.chat/join?c=<base64>` — the Universal Link form;
+///  - `https://onym.app/join?c=<base64>` — the Universal Link form;
 ///    the OS routes it straight to the app on devices that have
 ///    fetched the AASA file.
 ///  - `onym://join?c=<base64>` — custom-scheme fallback for clients
@@ -73,7 +73,7 @@ struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
     /// Optional display name. Public — see type doc.
     let groupName: String?
 
-    static let appLinkBase = "https://onym.chat/join?c="
+    static let appLinkBase = "https://onym.app/join?c="
     static let customSchemeBase = "onym://join?c="
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -18,7 +18,7 @@ import Security
 actor KeychainIntroKeyStore: IntroKeyStore {
 
     /// Keychain service — one fixed item across the device.
-    static let serviceDefault = "chat.onym.ios.intro_keys"
+    static let serviceDefault = "app.onym.ios.intro_keys"
     static let account = "blob"
 
     private let service: String

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -24,4 +24,9 @@ import Foundation
 struct MemberProfile: Codable, Equatable, Hashable, Sendable {
     let alias: String
     let inboxPublicKey: Data
+
+    enum CodingKeys: String, CodingKey {
+        case alias
+        case inboxPublicKey = "inbox_public_key"
+    }
 }

--- a/Sources/OnymIOS/Group/QRCodeScannerView.swift
+++ b/Sources/OnymIOS/Group/QRCodeScannerView.swift
@@ -135,7 +135,7 @@ private final class QRScannerViewController: UIViewController {
     var onError: ((String) -> Void)?
 
     private let session = AVCaptureSession()
-    private let sessionQueue = DispatchQueue(label: "chat.onym.qrscanner.session")
+    private let sessionQueue = DispatchQueue(label: "app.onym.qrscanner.session")
     private var previewLayer: AVCaptureVideoPreviewLayer?
 
     override func viewDidLoad() {

--- a/Sources/OnymIOS/Identity/Bip39.swift
+++ b/Sources/OnymIOS/Identity/Bip39.swift
@@ -2195,7 +2195,7 @@ enum Bip39 {
     static func deriveNostrKey(from seed: Data) -> Data {
         let derived = HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: seed),
-            salt: Data("chat.onym.bip39".utf8),
+            salt: Data("app.onym.bip39".utf8),
             info: Data("nostr-secp256k1-v1".utf8),
             outputByteCount: 32
         )
@@ -2206,7 +2206,7 @@ enum Bip39 {
     static func deriveBlsKey(from seed: Data) -> Data {
         let derived = HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: seed),
-            salt: Data("chat.onym.bip39".utf8),
+            salt: Data("app.onym.bip39".utf8),
             info: Data("bls12-381-v1".utf8),
             outputByteCount: 32
         )

--- a/Sources/OnymIOS/Identity/IdentityID.swift
+++ b/Sources/OnymIOS/Identity/IdentityID.swift
@@ -7,7 +7,7 @@ import Foundation
 /// `OnymInvitee.id`) anywhere an identity is expected.
 ///
 /// Persisted via the keychain `kSecAttrService` suffix
-/// (`chat.onym.ios.identity.<uuidString>`) and inside `ChatGroup` rows
+/// (`app.onym.ios.identity.<uuidString>`) and inside `ChatGroup` rows
 /// (post-PR-3) so any group can be traced back to the identity that
 /// owns it without a separate join table.
 struct IdentityID: Hashable, Codable, Sendable, CustomStringConvertible {

--- a/Sources/OnymIOS/Identity/IdentityKeychainStore.swift
+++ b/Sources/OnymIOS/Identity/IdentityKeychainStore.swift
@@ -28,7 +28,7 @@ struct StoredSnapshot: Codable, Sendable, Equatable {
 
 /// Per-identity Keychain store. Each identity gets its own
 /// `kSecClassGenericPassword` item under the service name
-/// `chat.onym.ios.identity.<uuid>`. Listing identities is a single
+/// `app.onym.ios.identity.<uuid>`. Listing identities is a single
 /// `SecItemCopyMatching` over that service-name prefix.
 ///
 /// Same `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` policy as
@@ -41,7 +41,7 @@ struct StoredSnapshot: Codable, Sendable, Equatable {
 struct IdentityKeychainStore: Sendable {
     /// Service-name prefix shared by every per-identity item. Listing
     /// identities walks every item whose service starts with this.
-    static let servicePrefix = "chat.onym.ios.identity."
+    static let servicePrefix = "app.onym.ios.identity."
 
     /// Stable account string used for every item. The discriminator is
     /// the per-identity service suffix; account is constant so reading

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -673,7 +673,7 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     ) throws -> Curve25519.Signing.PrivateKey {
         let derived = HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: nostrSecret),
-            salt: Data("chat.onym.ios".utf8),
+            salt: Data("app.onym.ios".utf8),
             info: Data("stellar-ed25519-v1".utf8),
             outputByteCount: 32
         )
@@ -691,7 +691,7 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     ) throws -> Curve25519.KeyAgreement.PrivateKey {
         let derived = HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: nostrSecret),
-            salt: Data("chat.onym.ios".utf8),
+            salt: Data("app.onym.ios".utf8),
             info: Data("x25519-key-agreement-v1".utf8),
             outputByteCount: 32
         )
@@ -731,7 +731,7 @@ struct SelectedIdentityStore: Sendable {
     let save: @Sendable (IdentityID?) -> Void
 
     static let userDefaults: SelectedIdentityStore = {
-        let key = "chat.onym.ios.identity.selectedID"
+        let key = "app.onym.ios.identity.selectedID"
         return SelectedIdentityStore(
             load: {
                 guard let raw = UserDefaults.standard.string(forKey: key) else { return nil }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -14,7 +14,7 @@ struct OnymIOSApp: App {
     private let introRequestStore: any IntroRequestStore
 
     /// Captured intro capability from a Universal Link or custom-
-    /// scheme deeplink (`https://onym.chat/join?c=…` /
+    /// scheme deeplink (`https://onym.app/join?c=…` /
     /// `onym://join?c=…`). Drives a `.sheet(item:)` over RootView —
     /// PR-6 surfaces a placeholder; PR-7 will replace it with the
     /// real `JoinView` + `JoinFlow`.
@@ -391,7 +391,7 @@ extension OnymIOSApp {
     ///                         (the simulator can't pass one).
     ///
     /// All UI-test runs use a separate Keychain service
-    /// (`chat.onym.ios.identity.uitests`) so they never touch the user's
+    /// (`app.onym.ios.identity.uitests`) so they never touch the user's
     /// real identity even on a developer machine.
     fileprivate static func resolveTestMode(
         args: [String]
@@ -402,7 +402,7 @@ extension OnymIOSApp {
             try? keychain.wipeAll()
             // Also clear the "selected identity" UserDefault so each
             // UI test boots into the same first-launch shape.
-            UserDefaults.standard.removeObject(forKey: "chat.onym.ios.identity.selectedID")
+            UserDefaults.standard.removeObject(forKey: "app.onym.ios.identity.selectedID")
         }
         let repo = IdentityRepository(keychain: keychain)
         let auth: BiometricAuthenticator = args.contains("--mock-biometric")

--- a/Sources/OnymIOS/Persistence/StorageEncryption.swift
+++ b/Sources/OnymIOS/Persistence/StorageEncryption.swift
@@ -14,7 +14,7 @@ import Security
 /// Persistence seam can encrypt/decrypt without taking a dependency on
 /// identity.
 enum StorageEncryption {
-    private static let keychainAccount = "chat.onym.ios.storageRootKey"
+    private static let keychainAccount = "app.onym.ios.storageRootKey"
 
     /// Memoised so repeated `encrypt` / `decrypt` calls don't round-trip
     /// to the Keychain. The seed itself never changes for the lifetime
@@ -27,7 +27,7 @@ enum StorageEncryption {
     static var storageKey: SymmetricKey {
         HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: cachedRootSecret),
-            salt: Data("chat.onym.ios.storage".utf8),
+            salt: Data("app.onym.ios.storage".utf8),
             info: Data("local-storage-v1".utf8),
             outputByteCount: 32
         )

--- a/Sources/OnymIOS/Settings/AboutView.swift
+++ b/Sources/OnymIOS/Settings/AboutView.swift
@@ -7,8 +7,8 @@ struct AboutView: View {
     @State private var taps = 0
 
     private static let sourceURL  = URL(string: "https://github.com/onymchat/onym-ios")!
-    private static let docsURL    = URL(string: "https://docs.onym.chat")!
-    private static let supportURL = URL(string: "mailto:hello@onym.chat")!
+    private static let docsURL    = URL(string: "https://docs.onym.app")!
+    private static let supportURL = URL(string: "mailto:hello@onym.app")!
 
     private var version: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
@@ -64,7 +64,7 @@ struct AboutView: View {
 
                     SettingsRow(
                         title: "Documentation",
-                        subtitle: "docs.onym.chat",
+                        subtitle: "docs.onym.app",
                         hasChevron: false,
                         onTap: { open(Self.docsURL.absoluteString) }
                     ) {
@@ -78,7 +78,7 @@ struct AboutView: View {
                         title: "Whitepaper",
                         subtitle: "The Onym protocol",
                         hasChevron: false,
-                        onTap: { open("https://onym.chat/whitepaper") }
+                        onTap: { open("https://onym.app/whitepaper") }
                     ) {
                         SettingsIconTile(symbol: "sparkles", bg: SettingsTile.green)
                     } right: {
@@ -113,7 +113,7 @@ struct AboutView: View {
                         title: "Community chat",
                         subtitle: "Join the dev group on Onym",
                         hasChevron: false,
-                        onTap: { open("https://onym.chat/community") }
+                        onTap: { open("https://onym.app/community") }
                     ) {
                         SettingsIconTile(symbol: "bubble.left.fill", bg: SettingsTile.green)
                     } right: {
@@ -122,7 +122,7 @@ struct AboutView: View {
                     }
                     SettingsRow(
                         title: "Contact support",
-                        subtitle: "hello@onym.chat",
+                        subtitle: "hello@onym.app",
                         hasChevron: false,
                         last: true,
                         onTap: { open(Self.supportURL.absoluteString) }
@@ -138,7 +138,7 @@ struct AboutView: View {
                 SettingsCard {
                     SettingsRow(title: "Privacy policy",
                                 hasChevron: false, inset: 16,
-                                onTap: { open("https://onym.chat/privacy") }) {
+                                onTap: { open("https://onym.app/privacy") }) {
                         EmptyView()
                     } right: {
                         Image(systemName: "arrow.up.right.square")
@@ -146,7 +146,7 @@ struct AboutView: View {
                     }
                     SettingsRow(title: "Terms of service",
                                 hasChevron: false, inset: 16,
-                                onTap: { open("https://onym.chat/terms") }) {
+                                onTap: { open("https://onym.app/terms") }) {
                         EmptyView()
                     } right: {
                         Image(systemName: "arrow.up.right.square")

--- a/Sources/OnymIOS/Settings/RunYourOwnRelayerView.swift
+++ b/Sources/OnymIOS/Settings/RunYourOwnRelayerView.swift
@@ -7,7 +7,7 @@ struct RunYourOwnRelayerView: View {
     @State private var copied: String?
 
     private static let repoURL = URL(string: "https://github.com/onymchat/onym-relayer")!
-    private static let docsURL = URL(string: "https://onym.chat/docs/relayer")!
+    private static let docsURL = URL(string: "https://onym.app/docs/relayer")!
 
     private struct Step: Identifiable {
         let id = UUID()

--- a/Sources/OnymIOS/Settings/SettingsQRCode.swift
+++ b/Sources/OnymIOS/Settings/SettingsQRCode.swift
@@ -47,7 +47,7 @@ struct SettingsQRCode: View {
 
 /// Build the deeplink-style invite URL for an identity's 32-byte X25519
 /// inbox public key. Mirrors the format the design uses —
-/// `https://onym.chat?payload=<64-hex>` with the **full** key as the
+/// `https://onym.app?payload=<64-hex>` with the **full** key as the
 /// payload. Truncating would leave the QR purely decorative:
 /// `CreateGroupFlow.canonicalizeInviteKey` extracts the `payload`
 /// query value verbatim and the InviteByKey paste validator requires
@@ -57,5 +57,5 @@ struct SettingsQRCode: View {
 /// per-identity equivalent surfaced from Settings.
 func settingsInviteURL(blsPublicKey: Data) -> String {
     let hex = blsPublicKey.map { String(format: "%02x", $0) }.joined()
-    return "https://onym.chat?payload=\(hex)"
+    return "https://onym.app?payload=\(hex)"
 }

--- a/Sources/OnymIOS/Transport/DeeplinkCapture.swift
+++ b/Sources/OnymIOS/Transport/DeeplinkCapture.swift
@@ -11,7 +11,7 @@ import Foundation
 ///    `IntroCapability?` out) and unit-testable. Holds the
 ///    **scheme/host allowlist** — the Info.plist `CFBundleURLTypes`
 ///    + Universal Links AASA already gate inbound URLs to
-///    `https://onym.chat/join*` and `onym://join`, but a
+///    `https://onym.app/join*` and `onym://join`, but a
 ///    misconfigured share target could still surface other URLs
 ///    to `.onOpenURL`. We re-check here as defense in depth and
 ///    so the pre-flight reasoning lives in code, not in
@@ -25,10 +25,10 @@ enum DeeplinkCapture {
 
     /// Allowlist of `(scheme, host)` pairs that may carry an
     /// `IntroCapability`. Mirrors the URL-types in `Info.plist`
-    /// + the `applinks:onym.chat` entitlement; keep them in
+    /// + the `applinks:onym.app` entitlement; keep them in
     /// lockstep.
     private static let allowed: Set<Pair> = [
-        Pair(scheme: "https", host: "onym.chat"),
+        Pair(scheme: "https", host: "onym.app"),
         Pair(scheme: "onym", host: "join"),
     ]
 

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -226,7 +226,7 @@ actor NostrRelayConnection {
     /// Reject incoming frames over 1 MB so a malicious relay can't
     /// exhaust memory.
     private static let maxMessageSize = 1_048_576
-    private static let securityLogger = Logger(subsystem: "chat.onym.ios", category: "Transport")
+    private static let securityLogger = Logger(subsystem: "app.onym.ios", category: "Transport")
 
     private func handleMessage(_ text: String) {
         guard text.utf8.count <= Self.maxMessageSize else {

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelaysSelectionStore.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelaysSelectionStore.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Persistence seam for the Nostr-relays configuration. Mirrors
 /// `RelayerSelectionStore`'s shape — UserDefaults-backed, no
 /// secrets so Keychain would be over-rotation, isolated key prefix
-/// (`chat.onym.ios.nostr.*`) so other consumers can't collide.
+/// (`app.onym.ios.nostr.*`) so other consumers can't collide.
 protocol NostrRelaysSelectionStore: Sendable {
     func load() -> NostrRelaysConfiguration
     func save(_ configuration: NostrRelaysConfiguration)
@@ -12,7 +12,7 @@ protocol NostrRelaysSelectionStore: Sendable {
 /// Production store. UserDefaults-backed; defaults to `.standard` but
 /// injectable so tests get an isolated suite.
 struct UserDefaultsNostrRelaysSelectionStore: NostrRelaysSelectionStore, @unchecked Sendable {
-    private static let configurationKey = "chat.onym.ios.nostr.configuration"
+    private static let configurationKey = "app.onym.ios.nostr.configuration"
 
     private let defaults: UserDefaults
 

--- a/Tests/OnymIOSTests/AnchorSelectionStoreTests.swift
+++ b/Tests/OnymIOSTests/AnchorSelectionStoreTests.swift
@@ -10,7 +10,7 @@ final class AnchorSelectionStoreTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        suiteName = "chat.onym.ios.anchors.tests.\(UUID().uuidString)"
+        suiteName = "app.onym.ios.anchors.tests.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: suiteName)
         store = UserDefaultsAnchorSelectionStore(defaults: defaults)
     }

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -153,7 +153,7 @@ final class CreateGroupFlowTests: XCTestCase {
 
     func test_canonicalizeInviteKey_legacyPayloadURL_extractsHex() {
         let hex = String(repeating: "ab", count: 32)
-        let url = "https://onym.chat?payload=\(hex)"
+        let url = "https://onym.app?payload=\(hex)"
         XCTAssertEqual(CreateGroupFlow.canonicalizeInviteKey(url), hex)
     }
 
@@ -166,7 +166,7 @@ final class CreateGroupFlowTests: XCTestCase {
         b64 = b64.replacingOccurrences(of: "+", with: "-")
         b64 = b64.replacingOccurrences(of: "/", with: "_")
         while b64.hasSuffix("=") { b64.removeLast() }
-        let url = "https://onym.chat/i?k=\(b64)"
+        let url = "https://onym.app/i?k=\(b64)"
         XCTAssertEqual(CreateGroupFlow.canonicalizeInviteKey(url), expectedHex)
     }
 
@@ -181,7 +181,7 @@ final class CreateGroupFlowTests: XCTestCase {
         let flow = await makeFlow()
         flow.route = .inviteByKey
         let hex = String(repeating: "cd", count: 32)
-        flow.tappedScannedKey("https://onym.chat?payload=\(hex)")
+        flow.tappedScannedKey("https://onym.app?payload=\(hex)")
         XCTAssertEqual(flow.inviteeInput, hex)
         XCTAssertNil(flow.inviteeError)
         flow.tappedAddInvitee()

--- a/Tests/OnymIOSTests/DeeplinkCaptureTests.swift
+++ b/Tests/OnymIOSTests/DeeplinkCaptureTests.swift
@@ -8,7 +8,7 @@ import XCTest
 ///
 /// Mirrors `DeeplinkCaptureTest.kt` test-for-test. Pin the allowlist
 /// semantics:
-///  - `https://onym.chat/join?c=…` → decoded
+///  - `https://onym.app/join?c=…` → decoded
 ///  - `onym://join?c=…` → decoded
 ///  - any other scheme/host → nil (Info.plist + entitlements are
 ///    the primary gate; this is defense in depth)
@@ -56,7 +56,7 @@ final class DeeplinkCaptureTests: XCTestCase {
 
     func test_foreignScheme_returnsNil() throws {
         let good = try fixture().encode()
-        let link = "ftp://onym.chat/join?c=\(good)"
+        let link = "ftp://onym.app/join?c=\(good)"
         XCTAssertNil(DeeplinkCapture.introCapability(fromString: link))
     }
 
@@ -75,7 +75,7 @@ final class DeeplinkCaptureTests: XCTestCase {
     }
 
     func test_knownHostMissingC_returnsNil() {
-        XCTAssertNil(DeeplinkCapture.introCapability(fromString: "https://onym.chat/join"))
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: "https://onym.app/join"))
         XCTAssertNil(DeeplinkCapture.introCapability(fromString: "onym://join"))
     }
 
@@ -83,14 +83,14 @@ final class DeeplinkCaptureTests: XCTestCase {
         // Allowed scheme/host, but the `c` value is not valid
         // base64 + the JSON payload doesn't decode. `fromLink`
         // returns nil; we propagate that → callers no-op.
-        XCTAssertNil(DeeplinkCapture.introCapability(fromString: "https://onym.chat/join?c=not-base64!!!"))
+        XCTAssertNil(DeeplinkCapture.introCapability(fromString: "https://onym.app/join?c=not-base64!!!"))
     }
 
     func test_caseInsensitiveSchemeAndHost_decodes() throws {
         // RFC 3986: scheme + host are case-insensitive. Build a
         // deliberately mixed-case form to pin the normalization.
         let good = try fixture().encode()
-        let link = "HTTPS://Onym.Chat/join?c=\(good)"
+        let link = "HTTPS://Onym.App/join?c=\(good)"
         XCTAssertNotNil(DeeplinkCapture.introCapability(fromString: link))
     }
 

--- a/Tests/OnymIOSTests/IdentityRepositoryTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryTests.swift
@@ -53,44 +53,43 @@ final class IdentityRepositoryTests: XCTestCase {
         XCTAssertEqual(stored?.blsSecretKey.count, 32)
     }
 
-    /// **Cross-platform interop fixture.** Locks in derivation against the
-    /// canonical BIP39 test mnemonic so any change to a salt / info string
-    /// (HKDF for nostr, BLS, Stellar Ed25519, X25519, or the `sep-inbox-v1`
-    /// SHA-256 tag) breaks this test loudly.
+    /// **Derivation fixture.** Locks in derivation against the canonical BIP39
+    /// test mnemonic so any change to a salt / info string (HKDF for nostr,
+    /// BLS, Stellar Ed25519, X25519, or the `sep-inbox-v1` SHA-256 tag)
+    /// breaks this test loudly.
     ///
-    /// All four pubkeys + the inbox tag MUST match `KeyManager` /
-    /// `GroupCrypto.hiddenInboxTag` in `stellar-mls/clients/ios/StellarChat`
-    /// — and, when it lands, the same fixture in onym-android. A user who
-    /// restores `abandon × 11 + about` on any platform must land on the same
-    /// `G…` account and the same inbox tag, otherwise their groups become
-    /// unreachable.
+    /// Salts: `app.onym.bip39` (root entropy → secrets) and `app.onym.ios`
+    /// (nostr secret → Stellar/X25519 seeds). The `chat.onym.*` rebrand
+    /// changed these, so the values below diverge from the historical
+    /// `stellar-mls` / onym-android fixtures — cross-platform interop is
+    /// broken until the other platforms adopt the same salts.
     func test_derivation_matchesCrossPlatformFixture() async throws {
         let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
         let identity = try await repo.restore(mnemonic: mnemonic)
 
         XCTAssertEqual(
             identity.nostrPublicKey.hex,
-            "1ee9632e948a11ff2b00fd0acf11f642fadcf14cd14d1f15b3bb6c072a268894"
+            "d8631b8e96d3d3d6d42cdadd07bc6db04108367dc2ce2d5e9b9a524123dc0821"
         )
         XCTAssertEqual(
             identity.blsPublicKey.hex,
-            "93c738ad5a4ff1be5692bd9b9eebb168c23710b7926b105fce3ee82fdf94debd17fef8ab2950622704438a2f16dbe3d6"
+            "a5859e962056987df69617fa41318641def18a1f78959951d1cf07bd164a6dcb50962786c8ead48c4e6aab5db6ce8f10"
         )
         XCTAssertEqual(
             identity.stellarPublicKey.hex,
-            "2d26005ffeaf78d38581e0c1c1cea3a7ae5d9510b0215a122c2b8c7ea24c6118"
+            "7a33c09cdb7f51fe723a4003d2f28272cddc8fa2cf3d74a374a5f2ee6fb1fcdc"
         )
         XCTAssertEqual(
             identity.stellarAccountID,
-            "GAWSMAC772XXRU4FQHQMDQOOUOT24XMVCCYCCWQSFQVYY7VCJRQRRF2K"
+            "GB5DHQE43N7VD7TSHJAAHUXSQJZM3XEPULHT25FDOSS7F3TPWH6NYJ7A"
         )
         XCTAssertEqual(
             identity.inboxPublicKey.hex,
-            "677244099e153cd18331aa2b44132d82b2a7f385f339b05184ac92df77e79d50"
+            "66ac34309b3b73163b628c2c40174ea76d58d4eb769172611e5c42f9a0cefe5f"
         )
         XCTAssertEqual(
             identity.inboxTag,
-            "2257fa71222dcc05"
+            "f462ae97384bd242"
         )
     }
 

--- a/Tests/OnymIOSTests/IntroCapabilityTests.swift
+++ b/Tests/OnymIOSTests/IntroCapabilityTests.swift
@@ -49,12 +49,12 @@ final class IntroCapabilityTests: XCTestCase {
 
     // MARK: - link forms
 
-    func test_toAppLink_isOnymChatJoinPath() throws {
+    func test_toAppLink_isOnymAppJoinPath() throws {
         let cap = try IntroCapability(
             introPublicKey: sampleIntroPub,
             groupId: sampleGroupId
         )
-        XCTAssertTrue(cap.toAppLink().hasPrefix("https://onym.chat/join?c="))
+        XCTAssertTrue(cap.toAppLink().hasPrefix("https://onym.app/join?c="))
     }
 
     func test_toCustomSchemeLink_isOnymJoinScheme() throws {
@@ -104,8 +104,8 @@ final class IntroCapabilityTests: XCTestCase {
     }
 
     func test_fromLink_missingCapabilityParam_returnsNull() {
-        XCTAssertNil(IntroCapability.fromLink("https://onym.chat/join"))
-        XCTAssertNil(IntroCapability.fromLink("https://onym.chat/join?other=value"))
+        XCTAssertNil(IntroCapability.fromLink("https://onym.app/join"))
+        XCTAssertNil(IntroCapability.fromLink("https://onym.app/join?other=value"))
     }
 
     func test_fromLink_malformedUri_returnsNull() {
@@ -173,7 +173,7 @@ final class IntroCapabilityTests: XCTestCase {
         )
         let text = IntroCapability.shareText(link: cap.toAppLink(), groupName: cap.groupName)
         XCTAssertTrue(text.contains("\"Friends\""))
-        XCTAssertTrue(text.contains("https://onym.chat/join?c="))
+        XCTAssertTrue(text.contains("https://onym.app/join?c="))
     }
 
     func test_shareText_omitsGroupName_whenBlankOrNull() throws {

--- a/Tests/OnymIOSTests/RelayerSelectionStoreTests.swift
+++ b/Tests/OnymIOSTests/RelayerSelectionStoreTests.swift
@@ -6,7 +6,7 @@ import XCTest
 /// `IdentityRepositoryTests`.
 ///
 /// Also exercises the one-time migration from PR #18's
-/// single-selection format — the legacy `chat.onym.ios.relayer.selection`
+/// single-selection format — the legacy `app.onym.ios.relayer.selection`
 /// blob (`RelayerSelection` enum with `.known`/`.custom` cases) projects
 /// onto a one-endpoint `RelayerConfiguration` with that endpoint as
 /// primary, strategy `.primary`. After successful migration the legacy
@@ -18,7 +18,7 @@ final class RelayerSelectionStoreTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        suiteName = "chat.onym.ios.relayer.tests.\(UUID().uuidString)"
+        suiteName = "app.onym.ios.relayer.tests.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: suiteName)
         store = UserDefaultsRelayerSelectionStore(defaults: defaults)
     }
@@ -90,7 +90,7 @@ final class RelayerSelectionStoreTests: XCTestCase {
             networks: ["testnet"]
         )
         let legacyJSON = #"{ "known": { "name": "Legacy", "url": "https://legacy.example", "network": "testnet" } }"#
-        defaults.set(Data(legacyJSON.utf8), forKey: "chat.onym.ios.relayer.selection")
+        defaults.set(Data(legacyJSON.utf8), forKey: "app.onym.ios.relayer.selection")
 
         let migrated = store.loadConfiguration()
         XCTAssertEqual(migrated.endpoints, [endpoint])
@@ -101,7 +101,7 @@ final class RelayerSelectionStoreTests: XCTestCase {
     func test_migration_legacyCustomSelection_yieldsSingleEndpointConfig() throws {
         // Legacy `.custom(url)` synthesises a custom-network endpoint.
         let legacyJSON = #"{ "custom": { "_0": "https://custom.example" } }"#
-        defaults.set(Data(legacyJSON.utf8), forKey: "chat.onym.ios.relayer.selection")
+        defaults.set(Data(legacyJSON.utf8), forKey: "app.onym.ios.relayer.selection")
 
         let migrated = store.loadConfiguration()
         XCTAssertEqual(migrated.endpoints.count, 1)
@@ -113,14 +113,14 @@ final class RelayerSelectionStoreTests: XCTestCase {
 
     func test_migration_runsOnlyOnce_legacyKeyRemovedAfterMigration() throws {
         let legacyJSON = #"{ "known": { "name": "Legacy", "url": "https://legacy.example", "network": "testnet" } }"#
-        defaults.set(Data(legacyJSON.utf8), forKey: "chat.onym.ios.relayer.selection")
+        defaults.set(Data(legacyJSON.utf8), forKey: "app.onym.ios.relayer.selection")
 
         // First load triggers migration.
         _ = store.loadConfiguration()
 
         // Legacy key must be gone, replaced by the new configuration key.
-        XCTAssertNil(defaults.data(forKey: "chat.onym.ios.relayer.selection"))
-        XCTAssertNotNil(defaults.data(forKey: "chat.onym.ios.relayer.configuration"))
+        XCTAssertNil(defaults.data(forKey: "app.onym.ios.relayer.selection"))
+        XCTAssertNotNil(defaults.data(forKey: "app.onym.ios.relayer.configuration"))
 
         // Second load returns the migrated value without retriggering migration.
         let second = store.loadConfiguration()
@@ -128,10 +128,10 @@ final class RelayerSelectionStoreTests: XCTestCase {
     }
 
     func test_migration_unreadableLegacyBlob_dropsItAndReturnsEmpty() throws {
-        defaults.set(Data("garbage".utf8), forKey: "chat.onym.ios.relayer.selection")
+        defaults.set(Data("garbage".utf8), forKey: "app.onym.ios.relayer.selection")
         let migrated = store.loadConfiguration()
         XCTAssertEqual(migrated, .empty)
-        XCTAssertNil(defaults.data(forKey: "chat.onym.ios.relayer.selection"),
+        XCTAssertNil(defaults.data(forKey: "app.onym.ios.relayer.selection"),
                      "unreadable legacy blob must be dropped, not left lingering")
     }
 
@@ -141,6 +141,6 @@ final class RelayerSelectionStoreTests: XCTestCase {
         // UserDefaults writes on every cold launch).
         let result = store.loadConfiguration()
         XCTAssertEqual(result, .empty)
-        XCTAssertNil(defaults.data(forKey: "chat.onym.ios.relayer.configuration"))
+        XCTAssertNil(defaults.data(forKey: "app.onym.ios.relayer.configuration"))
     }
 }

--- a/Tests/OnymIOSTests/SettingsQRCodeTests.swift
+++ b/Tests/OnymIOSTests/SettingsQRCodeTests.swift
@@ -17,8 +17,8 @@ final class SettingsQRCodeTests: XCTestCase {
         // → 64 hex chars; anything shorter is decorative.
         let key = Data((0..<32).map { UInt8($0) })
         let url = settingsInviteURL(blsPublicKey: key)
-        XCTAssertTrue(url.hasPrefix("https://onym.chat?payload="))
-        let payload = url.replacingOccurrences(of: "https://onym.chat?payload=", with: "")
+        XCTAssertTrue(url.hasPrefix("https://onym.app?payload="))
+        let payload = url.replacingOccurrences(of: "https://onym.app?payload=", with: "")
         XCTAssertEqual(payload.count, 64, "32 bytes should serialise to 64 hex chars")
         XCTAssertEqual(payload, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
     }

--- a/Tests/OnymIOSUITests/Support/AppLauncher.swift
+++ b/Tests/OnymIOSUITests/Support/AppLauncher.swift
@@ -6,7 +6,7 @@ import XCTest
 ///
 /// Launch arguments honoured by the app under `#if DEBUG`:
 ///   `--ui-testing`      Required to flip the App into test wiring.
-///   `--reset-keychain`  Wipe the test-isolated `chat.onym.ios.identity.uitests`
+///   `--reset-keychain`  Wipe the test-isolated `app.onym.ios.identity.uitests`
 ///                       keychain item before bootstrap.
 ///   `--mock-biometric`  Swap `LAContextAuthenticator` for a stub that returns
 ///                       success immediately without prompting.

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,2 @@
-app_identifier("chat.onym.ios")
+app_identifier("app.onym.ios")
 team_id(ENV['MATCH_TEAM_ID'])

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,7 +7,7 @@ platform :ios do
 
     match(
       type: "adhoc",
-      app_identifier: ["chat.onym.ios"],
+      app_identifier: ["app.onym.ios"],
       readonly: true
     )
 
@@ -17,7 +17,7 @@ platform :ios do
       team_id: ENV['MATCH_TEAM_ID'],
       code_sign_identity: "Apple Distribution",
       targets: ["OnymIOS"],
-      profile_name: "match AdHoc chat.onym.ios"
+      profile_name: "match AdHoc app.onym.ios"
     )
 
     gym(
@@ -31,7 +31,7 @@ platform :ios do
         signingStyle: "manual",
         teamID: ENV['MATCH_TEAM_ID'],
         provisioningProfiles: {
-          "chat.onym.ios" => "match AdHoc chat.onym.ios"
+          "app.onym.ios" => "match AdHoc app.onym.ios"
         }
       },
       xcargs: "COMPILER_INDEX_STORE_ENABLE=NO DEVELOPMENT_TEAM='#{ENV['MATCH_TEAM_ID']}'",

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,7 +1,7 @@
 git_url(ENV['MATCH_GIT_URL'])
 storage_mode('git')
 
-app_identifier(["chat.onym.ios"])
+app_identifier(["app.onym.ios"])
 team_id(ENV['MATCH_TEAM_ID'])
 
 readonly(true)

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 name: OnymIOS
 options:
-  bundleIdPrefix: chat.onym
+  bundleIdPrefix: app.onym
   deploymentTarget:
     iOS: "18.0"
   xcodeVersion: "26.0"
@@ -63,13 +63,8 @@ targets:
         UILaunchScreen:
           UIColorName: LaunchBackground
           UIImageName: LaunchLogo
-        UISupportedInterfaceOrientations~iphone:
+        UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
-          - UIInterfaceOrientationLandscapeLeft
-          - UIInterfaceOrientationLandscapeRight
-        UISupportedInterfaceOrientations~ipad:
-          - UIInterfaceOrientationPortrait
-          - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         # PR-6: custom URL scheme for the Level-2 deeplink invite
@@ -80,7 +75,7 @@ targets:
         # works on both platforms.
         CFBundleURLTypes:
           - CFBundleTypeRole: Editor
-            CFBundleURLName: chat.onym.ios.join
+            CFBundleURLName: app.onym.ios.join
             CFBundleURLSchemes:
               - onym
         # Camera access is requested only when the user taps "Scan QR"
@@ -92,18 +87,18 @@ targets:
     entitlements:
       path: OnymIOS.entitlements
       properties:
-        # PR-6: Universal Links for `https://onym.chat/join*` and
-        # `https://onym.chat/onboard*`. The matching AASA file at
-        # `https://onym.chat/.well-known/apple-app-site-association`
-        # must list the team-prefixed app id (5V5EUT3ZXJ.chat.onym.ios)
+        # PR-6: Universal Links for `https://onym.app/join*` and
+        # `https://onym.app/onboard*`. The matching AASA file at
+        # `https://onym.app/.well-known/apple-app-site-association`
+        # must list the team-prefixed app id (7C7LXXWRMG.app.onym.ios)
         # against `appIDs`. Without the AASA file the OS still
         # routes the URL through the browser; the app only takes
         # over once Apple's CDN has fetched + validated the file.
         com.apple.developer.associated-domains:
-          - applinks:onym.chat
+          - applinks:onym.app
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios
+        PRODUCT_BUNDLE_IDENTIFIER: app.onym.ios
         # Single source of truth: the GitHub release tag. xcodegen
         # interpolates `${MARKETING_VERSION}` / `${CURRENT_PROJECT_VERSION}`
         # from the env at generate time; `generate-xcodeproj.sh` always
@@ -118,7 +113,7 @@ targets:
         # loud at build time instead of silently producing an unbranded
         # icon.
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        TARGETED_DEVICE_FAMILY: "1,2"
+        TARGETED_DEVICE_FAMILY: "1"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
         CODE_SIGN_ENTITLEMENTS: OnymIOS.entitlements
@@ -130,11 +125,12 @@ targets:
       - Tests/OnymIOSTests
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios.tests
+        PRODUCT_BUNDLE_IDENTIFIER: app.onym.ios.tests
         SWIFT_VERSION: "5.0"
         GENERATE_INFOPLIST_FILE: YES
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
+        TARGETED_DEVICE_FAMILY: "1"
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/OnymIOS.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/OnymIOS"
         BUNDLE_LOADER: "$(TEST_HOST)"
     dependencies:
@@ -148,11 +144,12 @@ targets:
       - Tests/OnymIOSUITests
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: chat.onym.ios.uitests
+        PRODUCT_BUNDLE_IDENTIFIER: app.onym.ios.uitests
         SWIFT_VERSION: "5.0"
         GENERATE_INFOPLIST_FILE: YES
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
+        TARGETED_DEVICE_FAMILY: "1"
         TEST_TARGET_NAME: OnymIOS
     dependencies:
       - target: OnymIOS


### PR DESCRIPTION
## Summary
Three independent rebrands bundled with one cross-platform decode fix the rebrand surfaced. Pairs with [onymchat/onym-android#TODO](https://github.com/onymchat/onym-android/pulls).

- **Universal Link domain**: \`onym.chat\` → \`onym.app\` (entitlement, DeeplinkCapture host allowlist, IntroCapability appLinkBase, SettingsQRCode invite URL prefix, AboutView/RunYourOwnRelayer website URLs). Relayer/nostr infrastructure URLs left on \`onym.chat\`.
- **iPhone-only**: \`TARGETED_DEVICE_FAMILY\` \`1,2\` → \`1\` on app + both test targets; collapsed the dual orientation blocks into a single iPhone-only one.
- **Bundle id**: \`chat.onym.ios\` → \`app.onym.ios\` everywhere (PRODUCT_BUNDLE_IDENTIFIER, CFBundleURLName, fastlane Appfile/Fastfile/Matchfile, both GitHub workflow YAMLs, internal Keychain/UserDefaults/OSLog prefixes, and HKDF salts in Bip39.swift + IdentityRepository.swift). \`test_derivation_matchesCrossPlatformFixture\` rebaselined to the post-rebrand expected hex values.
- **Cross-platform decode fix**: \`GovernanceMember\` and \`MemberProfile\` had no \`CodingKeys\`, so Swift defaulted to camelCase. Android emits snake_case per the wire spec — every Android-emitted \`GroupInvitationPayload\` got rejected with \`keyNotFound("publicKeyCompressed")\`, dropping silently to fallthrough so \`JoinFlow\` stayed in \`awaitingApproval\` forever after Android approved a join. Adding the snake_case \`CodingKeys\` closes the loop.

## Out of scope / pre-existing
- \`Resources/Localizable.xcstrings\` was already modified at session start with new QR-scan strings missing en/ru translations; rides along but isn't from this work.
- AASA file at \`https://onym.app/.well-known/apple-app-site-association\` already deployed and validated against Apple's CDN — Universal Links route to the app once the user reinstalls.
- Existing iOS users will lose their on-device identity (keychain prefix changed) and need to restore from recovery phrase. Cross-platform with onym-android requires the companion salt rebrand PR over there to also land before iOS↔Android invites round-trip again.

## Test plan
- [ ] \`./generate-xcodeproj.sh && xcodebuild -scheme OnymIOS -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:OnymIOSTests test\` — passes (one pre-existing unrelated failure: \`LocalizationCatalogTests.test_localizable_xcstrings_everyKey_hasEnAndRu\` from the rider xcstrings change)
- [ ] On a real device: tap an invite link issued by Android (with the companion PR merged + Android app reinstalled) → iOS \`JoinFlow\` advances from \`awaitingApproval\` → \`approved\`.
- [ ] Universal Links open the app instead of bouncing through Safari (requires reinstall so iOS re-fetches the AASA on app install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)