### PR TITLE
fix(release): fetch tags properly so auto-bump can find latest v*

### DIFF
--- a/.github/workflows/release-from-issue.yml
+++ b/.github/workflows/release-from-issue.yml
@@ -36,8 +36,15 @@ jobs:
         with:
           # Need the v* tag history so the auto-bump step can resolve
           # the latest patch version when the issue's Tag field is left
-          # blank. `fetch-tags` is lighter than `fetch-depth: 0`.
-          fetch-tags: true
+          # blank. `fetch-tags: true` alone (with default fetch-depth=1)
+          # does NOT actually populate refs/tags — the fetch refspec
+          # silently omits `+refs/tags/*` and `git tag` returns empty.
+          # That bit us once: auto-bump fell into the "fresh repo"
+          # branch and dispatched a duplicate v0.0.1 release, which
+          # softprops/action-gh-release happily overwrote the original
+          # v0.0.1 IPA with the HEAD build. Full clone is the only
+          # configuration that reliably ships tags here.
+          fetch-depth: 0
 
       - name: Resolve release tag
         id: tag
@@ -71,7 +78,23 @@ jobs:
                        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
                        | head -1)
             if [ -z "$LATEST" ]; then
-              # First-ever release on a fresh repo — start at v0.0.1.
+              # Safety net: a fetch glitch leaving the working tree
+              # tagless on a non-empty repo would otherwise silently
+              # default to v0.0.1 and overwrite the historical first
+              # release. Cross-check against the remote before falling
+              # through to the fresh-repo path.
+              REMOTE_LATEST=$(git ls-remote --tags origin 'refs/tags/v*' 2>/dev/null \
+                                | awk '{print $2}' \
+                                | sed 's|refs/tags/||' \
+                                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                                | sort -V \
+                                | tail -1)
+              if [ -n "$REMOTE_LATEST" ]; then
+                echo "::error::Local repo has no v* tags but remote has $REMOTE_LATEST. The checkout step likely failed to fetch tags — refusing to default to v0.0.1 and overwrite an existing release."
+                gh issue comment "$ISSUE" --body "❌ Local repo has no v* tags but remote has \`$REMOTE_LATEST\`. The release workflow's tag fetch is broken; refusing to dispatch to avoid overwriting an existing release. Re-trigger after the workflow is repaired."
+                exit 1
+              fi
+              # First-ever release on a genuinely fresh repo — start at v0.0.1.
               TAG="v0.0.1"
               echo "::notice::No existing v* tags; defaulting to $TAG"
             else


### PR DESCRIPTION
## Summary
Latest release run ([25954203601](https://github.com/onymchat/onym-ios/actions/runs/25954203601)) was dispatched with \`tag=v0.0.1\` instead of the expected \`v0.0.50\`, and \`softprops/action-gh-release@v2\` overwrote the original v0.0.1 IPA from 2026-05-02 with a fresh HEAD build at 05:57:59Z today.

**Root cause**: \`actions/checkout@v4\` with \`fetch-tags: true\` + default \`fetch-depth: 1\` silently does NOT populate \`refs/tags/*\`. The fetch refspec in the [release-from-issue run log](https://github.com/onymchat/onym-ios/actions/runs/25954200838) was:

\`\`\`
git fetch --depth=1 origin +<sha>:refs/remotes/origin/main
\`\`\`

No tag refspec, no second tag-only fetch. So \`git tag\` returned empty, the auto-bump script hit its "first-ever release on a fresh repo" branch, and dispatched \`v0.0.1\`. The collision check that's supposed to catch this couldn't fire because the existing v0.0.1 tag also wasn't visible locally.

## Changes
1. \`fetch-tags: true\` → \`fetch-depth: 0\` in the checkout step. Full clone is the only configuration that reliably lands tags here. Bandwidth cost on a release path that runs a few times a day is negligible.
2. Safety net in the auto-bump bash: when local \`git tag\` returns empty, cross-check \`git ls-remote --tags origin\`. If the remote has any v* tag the local repo can't see, the fetch is broken — bail with an issue comment instead of silently defaulting to v0.0.1.

## Manual cleanup outside this PR
The v0.0.1 GitHub release currently has the post-rebrand HEAD IPA attached, not the original 2026-05-02 asset. Restoring the original IPA (or just deleting + recreating the asset from the v0.0.1 git tag) is a manual step — this PR doesn't touch released artifacts.

## Test plan
- [ ] After merge, dispatch a release with the Tag field blank → auto-bump should resolve to \`v0.0.50\` (next after \`v0.0.49\`).
- [ ] If a future regression breaks the tag fetch again, the new safety net should fail the run with a clear error message instead of silently overwriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)