### PR TITLE
fix(create-group): disable 1-on-1 and Anarchy governance cards

### DIFF
--- a/Sources/OnymIOS/Group/OnymBrand.swift
+++ b/Sources/OnymIOS/Group/OnymBrand.swift
@@ -178,12 +178,13 @@ enum OnymUIGovernance: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    /// True when this governance type is wired through the chain
-    /// layer end-to-end. All three currently surfaced types
-    /// (Tyranny, 1-on-1, Anarchy) are live.
+    /// True when this governance type is selectable in the Create
+    /// Group flow. Only Tyranny ships today — 1-on-1 and Anarchy
+    /// render with a "Soon" label and aren't selectable.
     var isAvailable: Bool {
         switch self {
-        case .tyranny, .oneOnOne, .anarchy: true
+        case .tyranny: true
+        case .oneOnOne, .anarchy: false
         }
     }
 

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -233,11 +233,12 @@ final class CreateGroupFlowTests: XCTestCase {
 
     // MARK: - OneOnOne governance gates
 
-    func test_oneOnOne_isNowAvailable() async throws {
-        // PR-3 flips the gate — Step1 should advance with .oneOnOne.
+    func test_oneOnOne_isDisabled() async throws {
+        // 1-on-1 is gated off in the Create Group flow — Step1 must
+        // not advance when it's selected.
         let flow = await makeFlow()
         flow.governance = .oneOnOne
-        XCTAssertTrue(flow.canAdvanceToStep2)
+        XCTAssertFalse(flow.canAdvanceToStep2)
     }
 
     func test_oneOnOne_canCreate_requiresExactlyOneInvitee() async throws {
@@ -298,11 +299,12 @@ final class CreateGroupFlowTests: XCTestCase {
 
     // MARK: - Anarchy governance gates
 
-    func test_anarchy_isNowAvailable() async throws {
-        // PR-3 of Anarchy flips the gate — Step1 should advance with .anarchy.
+    func test_anarchy_isDisabled() async throws {
+        // Anarchy is gated off in the Create Group flow — Step1 must
+        // not advance when it's selected.
         let flow = await makeFlow()
         flow.governance = .anarchy
-        XCTAssertTrue(flow.canAdvanceToStep2)
+        XCTAssertFalse(flow.canAdvanceToStep2)
     }
 
     func test_anarchy_canCreate_alwaysTrue() async throws {


### PR DESCRIPTION
## Summary
- 1-on-1 and Anarchy aren't supported end-to-end yet, so they shouldn't be selectable in the Create Group flow.
- Flips `OnymUIGovernance.isAvailable` to return `true` only for `.tyranny`. This re-routes both cards through `CreateGroupView`'s existing unavailable-card path: dimmed (opacity 0.55), non-tappable, with a "Soon" pill overlay. Step 1's Next button stays disabled until Tyranny is picked.
- Updated the two flow tests that previously asserted Step 1 advances with 1-on-1 / Anarchy — they now assert `canAdvanceToStep2 == false` for both.

## Test plan
- [x] `xcodebuild test -only-testing:OnymIOSTests/CreateGroupFlowTests` — 35/35 pass, including new `test_oneOnOne_isDisabled` / `test_anarchy_isDisabled`.
- [ ] Manual: open Create Group, verify the 1-on-1 and Anarchy cards show the "Soon" pill, are dimmed, and don't respond to taps; Tyranny remains selectable and advances Step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)