### PR TITLE
feat(chats): ChatMessagePayload wire type (PR 1/10 chat stack)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatMessagePayload.swift
+++ b/Sources/OnymIOS/Chats/ChatMessagePayload.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Plaintext chat-message payload that gets sealed (X25519 + AES-GCM
+/// via `IdentityRepository.sealInvitation`) and dropped on
+/// `InboxTransport.send` for each group member — same envelope path
+/// as `GroupInvitationPayload`. One envelope per recipient inbox
+/// key; the encrypted bytes carry this struct verbatim.
+///
+/// `variant` is governance-keyed because each group flavour signs and
+/// routes messages differently down the road: Tyranny only needs the
+/// body, but a 1-on-1 dialog will carry per-message ratchet state and
+/// Anarchy will carry a per-member signature. Today only `.tyranny`
+/// ships — adding a new case is the entire surface-area cost of
+/// turning a new governance type on for chat.
+///
+/// Versioned for forward compat. `version = 1` is the only shape the
+/// receiver has to handle today; later versions can add fields with
+/// non-failing `decodeIfPresent` decoders.
+struct ChatMessagePayload: Codable, Equatable, Sendable {
+    /// Wire schema version. Bump on a breaking field change (rename,
+    /// removal, semantic shift). Adding optional fields does NOT
+    /// require a bump.
+    let version: Int
+
+    /// Stable per-message identifier used for receive-side dedup —
+    /// the same Nostr inbox event can be re-delivered, and a single
+    /// message fans out as N sealed envelopes (one per recipient),
+    /// so the inbox-event ID is not enough.
+    let messageID: UUID
+
+    /// The group this message belongs to. Receiver looks up the
+    /// `ChatGroup` by this ID and rejects the message if no such
+    /// group exists locally.
+    let groupID: Data
+
+    /// Lowercase BLS pubkey hex (96 chars) of the sender. Keying
+    /// matches `ChatGroup.memberProfiles` so the receiver can verify
+    /// the sender is a known member with one dictionary lookup.
+    /// Sender identity has to live *inside* the encrypted payload —
+    /// the sealed envelope's ephemeral key tells the receiver nothing
+    /// about who sent it.
+    let senderBlsPubkeyHex: String
+
+    /// Milliseconds since Unix epoch at send time. Int64 (not
+    /// `Date`) so the wire format is unambiguous and cross-platform.
+    let sentAtMillis: Int64
+
+    /// Governance-keyed payload body. See `ChatMessageVariant`.
+    let variant: ChatMessageVariant
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case messageID = "message_id"
+        case groupID = "group_id"
+        case senderBlsPubkeyHex = "sender_bls_pubkey_hex"
+        case sentAtMillis = "sent_at_millis"
+        case variant
+    }
+}
+
+/// Governance-keyed body. The discriminator string on the wire is
+/// `SEPGroupType.rawValue` so a single spelling identifies the
+/// flavour across iOS, Android, the relayer, and the Stellar
+/// contracts.
+///
+/// Today only `.tyranny` carries a real case. Unknown / unsupported
+/// kinds throw on decode — the dispatcher catches and drops, which
+/// is what we want: a 1-on-1 message arriving at a v1 receiver
+/// should be ignored, not silently shoehorned into a Tyranny shape.
+enum ChatMessageVariant: Equatable, Sendable {
+    case tyranny(body: String)
+
+    /// Plaintext message body. Every variant ships a body string;
+    /// future variants may carry additional fields alongside it.
+    var body: String {
+        switch self {
+        case .tyranny(let body): body
+        }
+    }
+}
+
+extension ChatMessageVariant: Codable {
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case body
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let kindRaw = try c.decode(String.self, forKey: .kind)
+        guard let kind = SEPGroupType(rawValue: kindRaw) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind,
+                in: c,
+                debugDescription: "Unknown chat-message kind '\(kindRaw)'"
+            )
+        }
+        switch kind {
+        case .tyranny:
+            let body = try c.decode(String.self, forKey: .body)
+            self = .tyranny(body: body)
+        case .oneOnOne, .anarchy, .democracy, .oligarchy:
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind,
+                in: c,
+                debugDescription: "Chat-message variant '\(kindRaw)' is not yet supported"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .tyranny(let body):
+            try c.encode(SEPGroupType.tyranny.rawValue, forKey: .kind)
+            try c.encode(body, forKey: .body)
+        }
+    }
+}

--- a/Tests/OnymIOSTests/ChatMessagePayloadTests.swift
+++ b/Tests/OnymIOSTests/ChatMessagePayloadTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import OnymIOS
+
+/// Wire-format pin for `ChatMessagePayload`. The struct is the
+/// plaintext that gets sealed in the same envelope as
+/// `GroupInvitationPayload`, so the wire format is part of the
+/// cross-platform contract — these tests lock the field spelling and
+/// the variant discriminator.
+final class ChatMessagePayloadTests: XCTestCase {
+
+    // MARK: - Round-trip
+
+    func test_roundtrip_tyranny_preservesAllFields() throws {
+        let original = makePayload(body: "hello, world")
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: encoded)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.variant.body, "hello, world")
+    }
+
+    func test_roundtrip_emptyBody_succeeds() throws {
+        // Empty body is a valid wire shape — validation lives at the
+        // send/receive boundary, not in the data type.
+        let original = makePayload(body: "")
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: encoded)
+        XCTAssertEqual(decoded.variant.body, "")
+    }
+
+    func test_roundtrip_unicodeBody_preservesBytes() throws {
+        // We don't render emoji in v1, but the payload is content-
+        // agnostic — locking this guards against accidentally
+        // stripping non-ASCII at the encoder layer.
+        let original = makePayload(body: "héllo 🌍 こんにちは")
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: encoded)
+        XCTAssertEqual(decoded.variant.body, "héllo 🌍 こんにちは")
+    }
+
+    // MARK: - Wire format
+
+    func test_wireFormat_snakeCaseKeys() throws {
+        let payload = makePayload(body: "hi")
+        let encoded = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNotNil(obj?["message_id"],
+                        "snake_case key 'message_id' must match Android parity")
+        XCTAssertNotNil(obj?["group_id"])
+        XCTAssertNotNil(obj?["sender_bls_pubkey_hex"])
+        XCTAssertNotNil(obj?["sent_at_millis"])
+        XCTAssertNotNil(obj?["variant"])
+    }
+
+    func test_wireFormat_variantDiscriminatorMatchesSEPGroupType() throws {
+        // The variant's `kind` field must be the same lowercase string
+        // the relayer + contracts use — `SEPGroupType.tyranny.rawValue`
+        // is the single source of truth.
+        let payload = makePayload(body: "hi")
+        let encoded = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let variant = obj?["variant"] as? [String: Any]
+        XCTAssertEqual(variant?["kind"] as? String, SEPGroupType.tyranny.rawValue)
+        XCTAssertEqual(variant?["body"] as? String, "hi")
+    }
+
+    // MARK: - Decode failures
+
+    func test_decode_unknownVariantKind_throws() throws {
+        let json = #"""
+        {
+          "version": 1,
+          "message_id": "11111111-1111-1111-1111-111111111111",
+          "group_id": "QkJC",
+          "sender_bls_pubkey_hex": "ab",
+          "sent_at_millis": 0,
+          "variant": { "kind": "martian", "body": "x" }
+        }
+        """#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(ChatMessagePayload.self, from: json))
+    }
+
+    func test_decode_unsupportedVariantKind_throws() throws {
+        // `oneonone` is a known SEPGroupType but chat doesn't support
+        // it yet — decoding must throw, not silently coerce.
+        let json = #"""
+        {
+          "version": 1,
+          "message_id": "11111111-1111-1111-1111-111111111111",
+          "group_id": "QkJC",
+          "sender_bls_pubkey_hex": "ab",
+          "sent_at_millis": 0,
+          "variant": { "kind": "oneonone", "body": "x" }
+        }
+        """#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(ChatMessagePayload.self, from: json))
+    }
+
+    func test_decode_missingRequiredField_throws() throws {
+        // `message_id` is required — drop it and decode must throw.
+        let json = #"""
+        {
+          "version": 1,
+          "group_id": "QkJC",
+          "sender_bls_pubkey_hex": "ab",
+          "sent_at_millis": 0,
+          "variant": { "kind": "tyranny", "body": "hi" }
+        }
+        """#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(ChatMessagePayload.self, from: json))
+    }
+
+    func test_decode_extraField_isIgnored() throws {
+        // Forward-compat: a v1 receiver decoding payload from a
+        // sender that added an optional field must succeed.
+        let json = #"""
+        {
+          "version": 1,
+          "message_id": "11111111-1111-1111-1111-111111111111",
+          "group_id": "QkJC",
+          "sender_bls_pubkey_hex": "ab",
+          "sent_at_millis": 0,
+          "variant": { "kind": "tyranny", "body": "hi" },
+          "future_field_for_v2": "ignored"
+        }
+        """#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: json)
+        XCTAssertEqual(decoded.variant.body, "hi")
+    }
+
+    // MARK: - Helpers
+
+    private func makePayload(body: String) -> ChatMessagePayload {
+        ChatMessagePayload(
+            version: 1,
+            messageID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            groupID: Data(repeating: 0x42, count: 32),
+            senderBlsPubkeyHex: String(repeating: "ab", count: 48),
+            sentAtMillis: 1_700_000_000_000,
+            variant: .tyranny(body: body)
+        )
+    }
+}


### PR DESCRIPTION
First PR in the 10-PR chat stack. Adds the plaintext wire-format payload that future PRs will encrypt + transmit. **No wiring yet** — pure data type plus tests.

## What's in here
- `ChatMessagePayload` (Codable, Equatable, Sendable): `version`, `messageID` (UUID for dedup), `groupID`, `senderBlsPubkeyHex` (matches `memberProfiles` keying), `sentAtMillis` (Int64 for cross-platform clarity), `variant`.
- `ChatMessageVariant` enum, governance-keyed:
  - Only `.tyranny(body:)` ships today.
  - Discriminator on the wire is `SEPGroupType.rawValue` (`"tyranny"`, `"oneonone"`, `"anarchy"`) — same spelling the relayer and Stellar contracts already use, so future kinds slot in with no rename.
  - Unknown / known-but-unsupported kinds throw on decode (so PR 3's dispatcher will catch+drop rather than silently coerce).
- 9 tests covering: round-trip (ASCII / empty / unicode), wire-format pinning (snake_case keys, discriminator string), decode failures (unknown kind, unsupported kind, missing required field), forward-compat (extra fields ignored).

## Why a governance-keyed variant in PR 1
1-on-1 will need per-message ratchet state and Anarchy will need a per-member signature. Baking the variant shape in now means turning a new governance type on for chat is just one new enum case — no schema migration.

## Test plan
- [x] `xcodebuild test -only-testing:OnymIOSTests/ChatMessagePayloadTests` — 9/9 pass
- [x] Full `OnymIOSTests` suite — 527/527 pass (3 pre-existing skips, 0 regressions)

## Plan context
This is PR 1 of a 10-PR chain that ends with two users in a Tyranny group exchanging plain text. Next PRs: persistence (`PersistedMessage` + `MessageRepository`), then incoming-dispatcher branch + `SendMessageInteractor`, then UIKit chat screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)