### PR TITLE
feat(chats): message persistence layer (PR 2/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatMessage.swift
+++ b/Sources/OnymIOS/Chats/ChatMessage.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// One persisted chat message — what the UI renders and what the
+/// store hands back. Mirrors `ChatMessagePayload` but flattens the
+/// `variant` into a `body` + `groupType` pair because every variant
+/// has a body (today) and a single type column is enough for the
+/// store-level layer.
+///
+/// Stable across direction: incoming and outgoing messages share the
+/// same shape, distinguished by `direction` + `status`. Each row
+/// belongs to exactly one `ownerIdentityID` so cascade-delete on
+/// identity removal is a `WHERE owner = ?` over the messages table —
+/// same pattern as `ChatGroup`.
+struct ChatMessage: Equatable, Sendable, Identifiable {
+    /// Stable per-message UUID. Matches `ChatMessagePayload.messageID`
+    /// for incoming rows; minted locally at send time for outgoing.
+    /// Receive-side dedup is a uniqueness check on this ID.
+    let id: UUID
+
+    /// 64-char hex of the parent `ChatGroup.id`. Plain (queryable) on
+    /// disk so `list(groupID:)` is a single `#Predicate`.
+    let groupID: String
+
+    /// Identity that owns this row. Inherits from
+    /// `ChatGroup.ownerIdentityID` of the parent group at write time.
+    let ownerIdentityID: IdentityID
+
+    /// Lowercase BLS pubkey hex (96 chars) of the sender. Matches the
+    /// `memberProfiles` keying — the dispatcher will use this to look
+    /// up the sender's `sendingPubkey` for envelope-signature
+    /// verification in PR 4.
+    let senderBlsPubkeyHex: String
+
+    let body: String
+
+    /// Sender's claim of when they sent. For incoming, taken from
+    /// the payload's `sent_at_millis`. For outgoing, the local clock
+    /// at submit time. Drives chronological display order.
+    let sentAt: Date
+
+    let direction: MessageDirection
+
+    /// Mutable for outgoing (pending → sent / failed). For incoming,
+    /// always `.received` at insert and never changes.
+    let status: MessageStatus
+
+    /// Mirrors `ChatMessageVariant.kind`. Stored alongside the body so
+    /// migrating to multi-variant rendering later doesn't need to
+    /// re-fetch the group to learn the flavour.
+    let groupType: SEPGroupType
+}
+
+enum MessageDirection: String, Codable, Sendable {
+    case incoming
+    case outgoing
+}
+
+enum MessageStatus: String, Codable, Sendable {
+    /// Outgoing only — in flight to transport.
+    case pending
+    /// Outgoing only — transport accepted (per-envelope errors
+    /// resolved or tolerated).
+    case sent
+    /// Outgoing only — transport rejected. Retry via
+    /// `SendMessageInteractor` flips back to `.pending`.
+    case failed
+    /// Incoming only — payload decoded and persisted.
+    case received
+}

--- a/Sources/OnymIOS/Chats/MessageRepository.swift
+++ b/Sources/OnymIOS/Chats/MessageRepository.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Owns the `MessageStore` and exposes a per-group reactive snapshots
+/// stream. Mirrors `GroupRepository`: every successful mutation is
+/// followed by a fresh snapshot pushed to that group's subscribers;
+/// the current list is replayed on every new subscribe.
+///
+/// Keyed by groupID instead of by current identity because the chat
+/// screen subscribes to exactly one group at a time, and identity
+/// scope is already enforced upstream (only groups the active
+/// identity owns appear in the list, so only those will have a thread
+/// opened).
+actor MessageRepository {
+    private let store: any MessageStore
+
+    /// Per-group cache. Populated lazily on first subscribe or
+    /// mutation; one entry per group the UI has touched this session.
+    /// Kept narrow on purpose — the chat thread reads one group at a
+    /// time, so loading the entire messages table at startup would be
+    /// wasted I/O.
+    private var cached: [String: [ChatMessage]] = [:]
+
+    private var continuations: [String: [UUID: AsyncStream<[ChatMessage]>.Continuation]] = [:]
+
+    init(store: any MessageStore) {
+        self.store = store
+    }
+
+    // MARK: - Mutations
+
+    /// Idempotent on `message.id` (delegates to
+    /// `MessageStore.insertOrUpdate`). Receive-side replays and
+    /// outgoing status flips both flow through here.
+    @discardableResult
+    func insert(_ message: ChatMessage) async -> Bool {
+        let inserted = await store.insertOrUpdate(message)
+        await refresh(groupID: message.groupID)
+        return inserted
+    }
+
+    /// Flip an outgoing message's status (pending → sent / failed).
+    /// Hot path for the send pipeline so we don't round-trip the
+    /// whole row through the encryption boundary.
+    func updateStatus(
+        id: UUID,
+        status: MessageStatus,
+        groupID: String
+    ) async {
+        await store.updateStatus(id: id, status: status)
+        await refresh(groupID: groupID)
+    }
+
+    func delete(id: UUID, groupID: String) async {
+        await store.delete(id: id)
+        await refresh(groupID: groupID)
+    }
+
+    /// Drop every message for one group. Wired into the group-delete
+    /// path so removing a group wipes its thread.
+    func removeForGroup(_ groupID: String) async {
+        await store.deleteGroup(groupID: groupID)
+        cached[groupID] = []
+        publish(groupID: groupID)
+    }
+
+    /// Cascade delete on identity removal. The store drops rows whose
+    /// `ownerIdentityID` matches; rows in the same group owned by a
+    /// different identity stay put, so each cached group has to be
+    /// refreshed (not wiped) and re-published.
+    func removeForOwner(_ id: IdentityID) async {
+        await store.deleteOwner(id.rawValue.uuidString)
+        let groupIDs = Array(cached.keys)
+        for groupID in groupIDs {
+            await refresh(groupID: groupID)
+        }
+    }
+
+    // MARK: - Subscriptions
+
+    /// Reactive stream of messages for one group. Emits the current
+    /// snapshot on subscribe and on every mutation that touches this
+    /// group. Other groups' mutations are silent.
+    nonisolated func snapshots(groupID: String) -> AsyncStream<[ChatMessage]> {
+        AsyncStream { continuation in
+            let subscriberID = UUID()
+            Task {
+                await self.subscribe(
+                    groupID: groupID,
+                    subscriberID: subscriberID,
+                    continuation: continuation
+                )
+            }
+            continuation.onTermination = { _ in
+                Task { await self.unsubscribe(groupID: groupID, subscriberID: subscriberID) }
+            }
+        }
+    }
+
+    /// One-shot read. Useful for tests and for paths that need to
+    /// look at the current list without keeping a subscription.
+    func currentMessages(groupID: String) async -> [ChatMessage] {
+        if cached[groupID] == nil { await refresh(groupID: groupID) }
+        return cached[groupID] ?? []
+    }
+
+    // MARK: - Private
+
+    private func subscribe(
+        groupID: String,
+        subscriberID: UUID,
+        continuation: AsyncStream<[ChatMessage]>.Continuation
+    ) async {
+        if cached[groupID] == nil {
+            await refresh(groupID: groupID)
+        }
+        continuations[groupID, default: [:]][subscriberID] = continuation
+        continuation.yield(cached[groupID] ?? [])
+    }
+
+    private func unsubscribe(groupID: String, subscriberID: UUID) {
+        continuations[groupID]?.removeValue(forKey: subscriberID)
+        if continuations[groupID]?.isEmpty == true {
+            continuations.removeValue(forKey: groupID)
+        }
+    }
+
+    private func refresh(groupID: String) async {
+        cached[groupID] = await store.list(groupID: groupID)
+        publish(groupID: groupID)
+    }
+
+    private func publish(groupID: String) {
+        let view = cached[groupID] ?? []
+        guard let subscribers = continuations[groupID] else { return }
+        for continuation in subscribers.values {
+            continuation.yield(view)
+        }
+    }
+}

--- a/Sources/OnymIOS/Chats/MessageStore.swift
+++ b/Sources/OnymIOS/Chats/MessageStore.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Persistence seam for chat messages. Async surface mirrors
+/// `GroupStore` so a concrete implementation can serialise writes on
+/// its own queue without forcing callers onto a specific actor.
+///
+/// `ChatMessage` itself is the domain shape; the store is responsible
+/// for AES-GCM-wrapping the sensitive columns at the boundary.
+protocol MessageStore: Sendable {
+    /// All messages for one group, sorted by `sentAt` ascending —
+    /// chronological order is what the chat scroll renders.
+    func list(groupID: String) async -> [ChatMessage]
+
+    /// Idempotent on `message.id`. New row → insert. Same id → update
+    /// in place; used both for receive-side replays (no-op result on
+    /// the second insert) and outgoing status transitions (pending →
+    /// sent / failed). Returns `true` on insert, `false` on update.
+    @discardableResult
+    func insertOrUpdate(_ message: ChatMessage) async -> Bool
+
+    /// Flip just the status column. Convenience for the outgoing
+    /// pipeline so we don't have to round-trip the whole row through
+    /// the encryption boundary just to bump pending → sent. No-op if
+    /// the row is missing.
+    func updateStatus(id: UUID, status: MessageStatus) async
+
+    func delete(id: UUID) async
+
+    /// Drop every message for one group — wired into
+    /// `GroupRepository.delete` so removing a group wipes its
+    /// messages too.
+    func deleteGroup(groupID: String) async
+
+    /// Cascade delete for `IdentityRepository.identityRemoved`. Same
+    /// pattern as `GroupStore.deleteOwner`.
+    func deleteOwner(_ ownerIDString: String) async
+}

--- a/Sources/OnymIOS/Chats/PersistedMessage.swift
+++ b/Sources/OnymIOS/Chats/PersistedMessage.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SwiftData
+
+/// SwiftData row for one chat message on disk. Same plain-vs-encrypted
+/// split as `PersistedGroup`: anything we need to filter or sort on
+/// stays plain; sensitive content rides through `StorageEncryption`.
+///
+/// Plain:
+/// - `id` — UUID string. Drives receive-side dedup (`@Attribute(.unique)`).
+/// - `groupID` — 64-char hex of the parent group; predicate-filterable.
+/// - `ownerIdentityIDString` — identity that owns the row; cascade
+///   delete on identity removal needs a predicate over this.
+/// - `sentAt` — sort column for the chat scroll order.
+/// - `directionRaw`, `statusRaw`, `groupTypeRaw` — small enums.
+///
+/// Encrypted (`StorageEncryption.encrypt`):
+/// - `senderBlsPubkeyHex` — group-membership identifier; consistent
+///   with the encrypted `memberProfiles` column on `PersistedGroup`.
+/// - `body` — user-supplied message text.
+///
+/// Decryption boundary lives in `SwiftDataMessageStore`, not here —
+/// the @Model stays dumb so the macro doesn't have to reason about
+/// CryptoKit types.
+@Model
+final class PersistedMessage {
+    @Attribute(.unique) var id: String
+    var groupID: String
+    var ownerIdentityIDString: String
+    var sentAt: Date
+    var directionRaw: String
+    var statusRaw: String
+    var groupTypeRaw: String
+
+    var encryptedSenderBlsPubkeyHex: Data
+    var encryptedBody: Data
+
+    init(
+        id: String,
+        groupID: String,
+        ownerIdentityIDString: String,
+        sentAt: Date,
+        directionRaw: String,
+        statusRaw: String,
+        groupTypeRaw: String,
+        encryptedSenderBlsPubkeyHex: Data,
+        encryptedBody: Data
+    ) {
+        self.id = id
+        self.groupID = groupID
+        self.ownerIdentityIDString = ownerIdentityIDString
+        self.sentAt = sentAt
+        self.directionRaw = directionRaw
+        self.statusRaw = statusRaw
+        self.groupTypeRaw = groupTypeRaw
+        self.encryptedSenderBlsPubkeyHex = encryptedSenderBlsPubkeyHex
+        self.encryptedBody = encryptedBody
+    }
+}

--- a/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
+++ b/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
@@ -1,0 +1,186 @@
+import Foundation
+import SwiftData
+
+/// SwiftData-backed `MessageStore`. Owns one `ModelContainer` for the
+/// message schema; each call hops to this actor's executor so
+/// concurrent writes don't fight over `ModelContext`. Same shape as
+/// `SwiftDataGroupStore`.
+///
+/// Schema lives in a separate `.store` file from groups —
+/// `Messages.store` next to `Groups.store` under
+/// `Application Support/OnymIOS/`. Separate containers keep schema
+/// migrations for one domain from triggering a wipe of the other.
+actor SwiftDataMessageStore: MessageStore {
+    private let container: ModelContainer
+    private let context: ModelContext
+
+    /// Production initializer — on-disk SQLite under
+    /// `Application Support/OnymIOS/Messages.store`, with
+    /// `FileProtectionType.complete` on the directory.
+    ///
+    /// Schema-mismatch at `ModelContainer(...)` init wipes the
+    /// on-disk store and retries once. Pre-1.0 install base, no real
+    /// users to preserve — matches the policy on `SwiftDataGroupStore`.
+    init() throws {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        )[0]
+        let storeDir = appSupport.appendingPathComponent("OnymIOS", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: storeDir,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        let url = storeDir.appendingPathComponent("Messages.store")
+        let schema = Schema([PersistedMessage.self])
+        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        let container: ModelContainer
+        do {
+            container = try ModelContainer(for: schema, configurations: [config])
+        } catch {
+            for suffix in ["", "-shm", "-wal"] {
+                try? FileManager.default.removeItem(
+                    at: url.deletingPathExtension().appendingPathExtension("store\(suffix)")
+                )
+            }
+            try? FileManager.default.removeItem(at: url)
+            container = try ModelContainer(for: schema, configurations: [config])
+        }
+        self.container = container
+        self.context = ModelContext(container)
+    }
+
+    /// In-memory factory for tests.
+    static func inMemory() -> SwiftDataMessageStore {
+        let schema = Schema([PersistedMessage.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: [config])
+        return SwiftDataMessageStore(container: container)
+    }
+
+    private init(container: ModelContainer) {
+        self.container = container
+        self.context = ModelContext(container)
+    }
+
+    // MARK: - MessageStore
+
+    func list(groupID: String) -> [ChatMessage] {
+        let descriptor = FetchDescriptor<PersistedMessage>(
+            predicate: #Predicate { $0.groupID == groupID },
+            sortBy: [SortDescriptor(\.sentAt, order: .forward)]
+        )
+        guard let rows = try? context.fetch(descriptor) else { return [] }
+        return rows.compactMap(Self.decode)
+    }
+
+    @discardableResult
+    func insertOrUpdate(_ message: ChatMessage) -> Bool {
+        guard let encoded = try? Self.encode(message) else { return false }
+
+        let id = message.id.uuidString
+        let descriptor = FetchDescriptor<PersistedMessage>(
+            predicate: #Predicate { $0.id == id }
+        )
+        if let existing = try? context.fetch(descriptor).first {
+            // Receive-side replays land here as no-op overwrites; the
+            // outgoing pending → sent / failed flip uses the same path.
+            existing.groupID = encoded.groupID
+            existing.ownerIdentityIDString = encoded.ownerIdentityIDString
+            existing.sentAt = encoded.sentAt
+            existing.directionRaw = encoded.directionRaw
+            existing.statusRaw = encoded.statusRaw
+            existing.groupTypeRaw = encoded.groupTypeRaw
+            existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
+            existing.encryptedBody = encoded.encryptedBody
+            try? context.save()
+            return false
+        }
+
+        context.insert(encoded)
+        try? context.save()
+        return true
+    }
+
+    func updateStatus(id: UUID, status: MessageStatus) {
+        let key = id.uuidString
+        let descriptor = FetchDescriptor<PersistedMessage>(
+            predicate: #Predicate { $0.id == key }
+        )
+        guard let row = try? context.fetch(descriptor).first else { return }
+        row.statusRaw = status.rawValue
+        try? context.save()
+    }
+
+    func delete(id: UUID) {
+        let key = id.uuidString
+        let descriptor = FetchDescriptor<PersistedMessage>(
+            predicate: #Predicate { $0.id == key }
+        )
+        if let rows = try? context.fetch(descriptor) {
+            for row in rows { context.delete(row) }
+        }
+        try? context.save()
+    }
+
+    func deleteGroup(groupID: String) {
+        let descriptor = FetchDescriptor<PersistedMessage>(
+            predicate: #Predicate { $0.groupID == groupID }
+        )
+        if let rows = try? context.fetch(descriptor) {
+            for row in rows { context.delete(row) }
+        }
+        try? context.save()
+    }
+
+    func deleteOwner(_ ownerIDString: String) {
+        let descriptor = FetchDescriptor<PersistedMessage>(
+            predicate: #Predicate { $0.ownerIdentityIDString == ownerIDString }
+        )
+        if let rows = try? context.fetch(descriptor) {
+            for row in rows { context.delete(row) }
+        }
+        try? context.save()
+    }
+
+    // MARK: - Mapping
+
+    private static func encode(_ message: ChatMessage) throws -> PersistedMessage {
+        PersistedMessage(
+            id: message.id.uuidString,
+            groupID: message.groupID,
+            ownerIdentityIDString: message.ownerIdentityID.rawValue.uuidString,
+            sentAt: message.sentAt,
+            directionRaw: message.direction.rawValue,
+            statusRaw: message.status.rawValue,
+            groupTypeRaw: message.groupType.rawValue,
+            encryptedSenderBlsPubkeyHex: try StorageEncryption.encrypt(message.senderBlsPubkeyHex),
+            encryptedBody: try StorageEncryption.encrypt(message.body)
+        )
+    }
+
+    private static func decode(_ row: PersistedMessage) -> ChatMessage? {
+        guard
+            let id = UUID(uuidString: row.id),
+            let owner = IdentityID(row.ownerIdentityIDString),
+            let direction = MessageDirection(rawValue: row.directionRaw),
+            let status = MessageStatus(rawValue: row.statusRaw),
+            let groupType = SEPGroupType(rawValue: row.groupTypeRaw),
+            let senderHex = try? StorageEncryption.decryptString(row.encryptedSenderBlsPubkeyHex),
+            let body = try? StorageEncryption.decryptString(row.encryptedBody)
+        else {
+            return nil
+        }
+        return ChatMessage(
+            id: id,
+            groupID: row.groupID,
+            ownerIdentityID: owner,
+            senderBlsPubkeyHex: senderHex,
+            body: body,
+            sentAt: row.sentAt,
+            direction: direction,
+            status: status,
+            groupType: groupType
+        )
+    }
+}

--- a/Tests/OnymIOSTests/MessageRepositoryTests.swift
+++ b/Tests/OnymIOSTests/MessageRepositoryTests.swift
@@ -1,0 +1,259 @@
+import XCTest
+@testable import OnymIOS
+
+/// Reactive-surface tests for `MessageRepository`. Backed by an
+/// in-memory `MessageStore` fake — same pattern as
+/// `GroupRepositoryTests`.
+final class MessageRepositoryTests: XCTestCase {
+
+    private let groupA = "aa".repeated(32)
+    private let groupB = "bb".repeated(32)
+
+    // MARK: - snapshots emission
+
+    func test_snapshots_replaysCurrentOnSubscribe() async {
+        let store = InMemoryMessageStore()
+        let seeded = makeMessage(groupID: groupA, body: "earlier")
+        await store.preload([seeded])
+        let repo = MessageRepository(store: store)
+
+        var iterator = repo.snapshots(groupID: groupA).makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first?.count, 1)
+        XCTAssertEqual(first?.first?.body, "earlier")
+    }
+
+    func test_snapshots_emptyStream_yieldsEmptyArrayOnSubscribe() async {
+        let store = InMemoryMessageStore()
+        let repo = MessageRepository(store: store)
+
+        var iterator = repo.snapshots(groupID: groupA).makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first, [])
+    }
+
+    func test_insert_broadcastsNewSnapshot() async {
+        let store = InMemoryMessageStore()
+        let repo = MessageRepository(store: store)
+
+        var iterator = repo.snapshots(groupID: groupA).makeAsyncIterator()
+        _ = await iterator.next()  // initial empty
+
+        let msg = makeMessage(groupID: groupA, body: "hello")
+        let inserted = await repo.insert(msg)
+        XCTAssertTrue(inserted)
+
+        let next = await iterator.next()
+        XCTAssertEqual(next?.count, 1)
+        XCTAssertEqual(next?.first?.body, "hello")
+    }
+
+    func test_updateStatus_broadcastsStatusFlip() async {
+        let store = InMemoryMessageStore()
+        let msg = makeMessage(groupID: groupA, body: "wip", status: .pending)
+        await store.preload([msg])
+        let repo = MessageRepository(store: store)
+
+        var iterator = repo.snapshots(groupID: groupA).makeAsyncIterator()
+        _ = await iterator.next()  // initial: pending
+
+        await repo.updateStatus(id: msg.id, status: .sent, groupID: groupA)
+
+        let next = await iterator.next()
+        XCTAssertEqual(next?.first?.status, .sent)
+    }
+
+    func test_delete_emptiesSnapshot() async {
+        let store = InMemoryMessageStore()
+        let msg = makeMessage(groupID: groupA)
+        await store.preload([msg])
+        let repo = MessageRepository(store: store)
+
+        var iterator = repo.snapshots(groupID: groupA).makeAsyncIterator()
+        _ = await iterator.next()
+
+        await repo.delete(id: msg.id, groupID: groupA)
+        let next = await iterator.next()
+        XCTAssertEqual(next?.count, 0)
+    }
+
+    // MARK: - Per-group isolation
+
+    func test_snapshots_insertIntoOtherGroup_doesNotEmit() async {
+        let store = InMemoryMessageStore()
+        let repo = MessageRepository(store: store)
+
+        // Subscribe to group A.
+        let snapshots = repo.snapshots(groupID: groupA)
+        var iterator = snapshots.makeAsyncIterator()
+        _ = await iterator.next()  // initial empty for A
+
+        // Insert into group B — A's stream must not receive anything.
+        _ = await repo.insert(makeMessage(groupID: groupB, body: "in B"))
+
+        // Force an A-side mutation so the test has something to await
+        // (we can't directly assert "no emission" without a timeout,
+        // but back-to-back: A is silent through the B-insert and then
+        // emits exactly the A-insert's snapshot).
+        _ = await repo.insert(makeMessage(groupID: groupA, body: "in A"))
+        let next = await iterator.next()
+        XCTAssertEqual(next?.count, 1)
+        XCTAssertEqual(next?.first?.body, "in A",
+                       "group-A stream must skip the group-B insert and surface only the A-side row")
+    }
+
+    func test_snapshots_sortedBySentAtAscending() async {
+        let store = InMemoryMessageStore()
+        let older = makeMessage(
+            groupID: groupA,
+            body: "older",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let newer = makeMessage(
+            groupID: groupA,
+            body: "newer",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_500)
+        )
+        await store.preload([newer, older])  // out of order on disk
+        let repo = MessageRepository(store: store)
+
+        var iterator = repo.snapshots(groupID: groupA).makeAsyncIterator()
+        let snap = await iterator.next()
+        XCTAssertEqual(snap?.map(\.body), ["older", "newer"])
+    }
+
+    // MARK: - Cascades
+
+    func test_removeForGroup_clearsCacheAndEmitsEmpty() async {
+        let store = InMemoryMessageStore()
+        await store.preload([
+            makeMessage(groupID: groupA, body: "a1"),
+            makeMessage(groupID: groupA, body: "a2"),
+        ])
+        let repo = MessageRepository(store: store)
+
+        var iterator = repo.snapshots(groupID: groupA).makeAsyncIterator()
+        _ = await iterator.next()
+
+        await repo.removeForGroup(groupA)
+        let next = await iterator.next()
+        XCTAssertEqual(next, [])
+    }
+
+    func test_removeForOwner_emptiesAllCachedGroups() async {
+        let owner = IdentityID()
+        let other = IdentityID()
+        let store = InMemoryMessageStore()
+        await store.preload([
+            makeMessage(groupID: groupA, ownerIdentityID: owner, body: "a-owner"),
+            makeMessage(groupID: groupB, ownerIdentityID: owner, body: "b-owner"),
+            makeMessage(groupID: groupA, ownerIdentityID: other, body: "a-other"),
+        ])
+        let repo = MessageRepository(store: store)
+
+        // Touch both groups so they enter the cache.
+        var iterA = repo.snapshots(groupID: groupA).makeAsyncIterator()
+        var iterB = repo.snapshots(groupID: groupB).makeAsyncIterator()
+        _ = await iterA.next()
+        _ = await iterB.next()
+
+        await repo.removeForOwner(owner)
+
+        // A still has the "other" identity's row; B is fully empty.
+        let nextA = await iterA.next()
+        let nextB = await iterB.next()
+        XCTAssertEqual(nextA?.map(\.body), ["a-other"])
+        XCTAssertEqual(nextB, [])
+    }
+
+    // MARK: - One-shot read
+
+    func test_currentMessages_loadsFromStoreIfNotCached() async {
+        let store = InMemoryMessageStore()
+        await store.preload([makeMessage(groupID: groupA, body: "hello")])
+        let repo = MessageRepository(store: store)
+
+        let snap = await repo.currentMessages(groupID: groupA)
+        XCTAssertEqual(snap.map(\.body), ["hello"])
+    }
+
+    // MARK: - Helpers
+
+    private func makeMessage(
+        id: UUID = UUID(),
+        groupID: String,
+        ownerIdentityID: IdentityID = IdentityID(),
+        body: String = "hi",
+        sentAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        status: MessageStatus = .sent
+    ) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            groupID: groupID,
+            ownerIdentityID: ownerIdentityID,
+            senderBlsPubkeyHex: "11".repeated(48),
+            body: body,
+            sentAt: sentAt,
+            direction: .outgoing,
+            status: status,
+            groupType: .tyranny
+        )
+    }
+}
+
+/// Reusable in-memory fake. Mirrors `InMemoryGroupStore` from the
+/// `GroupRepositoryTests` file; kept private here so the two test
+/// files stay independent.
+private actor InMemoryMessageStore: MessageStore {
+    private var rows: [UUID: ChatMessage] = [:]
+
+    func preload(_ messages: [ChatMessage]) {
+        for msg in messages { rows[msg.id] = msg }
+    }
+
+    func list(groupID: String) -> [ChatMessage] {
+        rows.values
+            .filter { $0.groupID == groupID }
+            .sorted { $0.sentAt < $1.sentAt }
+    }
+
+    @discardableResult
+    func insertOrUpdate(_ message: ChatMessage) -> Bool {
+        let isNew = rows[message.id] == nil
+        rows[message.id] = message
+        return isNew
+    }
+
+    func updateStatus(id: UUID, status: MessageStatus) {
+        guard let existing = rows[id] else { return }
+        rows[id] = ChatMessage(
+            id: existing.id,
+            groupID: existing.groupID,
+            ownerIdentityID: existing.ownerIdentityID,
+            senderBlsPubkeyHex: existing.senderBlsPubkeyHex,
+            body: existing.body,
+            sentAt: existing.sentAt,
+            direction: existing.direction,
+            status: status,
+            groupType: existing.groupType
+        )
+    }
+
+    func delete(id: UUID) {
+        rows.removeValue(forKey: id)
+    }
+
+    func deleteGroup(groupID: String) {
+        rows = rows.filter { $0.value.groupID != groupID }
+    }
+
+    func deleteOwner(_ ownerIDString: String) {
+        rows = rows.filter { $0.value.ownerIdentityID.rawValue.uuidString != ownerIDString }
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import OnymIOS
+
+/// Round-trip tests for `SwiftDataMessageStore`. Uses
+/// `SwiftDataMessageStore.inMemory()` so the on-disk store under
+/// Application Support isn't touched. Encrypted columns go through
+/// the real `StorageEncryption` — same setup as
+/// `SwiftDataGroupStoreTests`.
+final class SwiftDataMessageStoreTests: XCTestCase {
+
+    private var store: SwiftDataMessageStore!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        store = SwiftDataMessageStore.inMemory()
+    }
+
+    override func tearDown() async throws {
+        store = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Round-trip
+
+    func test_insertOrUpdate_thenList_roundtripsAllFields() async {
+        let owner = IdentityID()
+        let groupID = "aa".repeated(32)
+        let msg = makeMessage(
+            groupID: groupID,
+            ownerIdentityID: owner,
+            senderHex: "11".repeated(48),
+            body: "hello",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            direction: .outgoing,
+            status: .pending
+        )
+
+        let inserted = await store.insertOrUpdate(msg)
+        XCTAssertTrue(inserted)
+
+        let listed = await store.list(groupID: groupID)
+        XCTAssertEqual(listed.count, 1)
+        let first = listed[0]
+        XCTAssertEqual(first.id, msg.id)
+        XCTAssertEqual(first.groupID, groupID)
+        XCTAssertEqual(first.ownerIdentityID, owner)
+        XCTAssertEqual(first.senderBlsPubkeyHex, "11".repeated(48))
+        XCTAssertEqual(first.body, "hello")
+        XCTAssertEqual(first.sentAt, msg.sentAt)
+        XCTAssertEqual(first.direction, .outgoing)
+        XCTAssertEqual(first.status, .pending)
+        XCTAssertEqual(first.groupType, .tyranny)
+    }
+
+    func test_insertOrUpdate_sameID_updatesInPlace() async {
+        let msg = makeMessage(body: "draft", status: .pending)
+        _ = await store.insertOrUpdate(msg)
+
+        // Same id, status flipped: should overwrite, not duplicate.
+        let updated = ChatMessage(
+            id: msg.id,
+            groupID: msg.groupID,
+            ownerIdentityID: msg.ownerIdentityID,
+            senderBlsPubkeyHex: msg.senderBlsPubkeyHex,
+            body: "draft",
+            sentAt: msg.sentAt,
+            direction: .outgoing,
+            status: .sent,
+            groupType: .tyranny
+        )
+        let inserted = await store.insertOrUpdate(updated)
+        XCTAssertFalse(inserted, "second insert on same id must report update, not insert")
+
+        let listed = await store.list(groupID: msg.groupID)
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed[0].status, .sent)
+    }
+
+    // MARK: - list
+
+    func test_list_filtersByGroupID() async {
+        let groupA = "aa".repeated(32)
+        let groupB = "bb".repeated(32)
+        _ = await store.insertOrUpdate(makeMessage(groupID: groupA, body: "in A"))
+        _ = await store.insertOrUpdate(makeMessage(groupID: groupB, body: "in B"))
+
+        let inA = await store.list(groupID: groupA)
+        let inB = await store.list(groupID: groupB)
+        XCTAssertEqual(inA.count, 1)
+        XCTAssertEqual(inB.count, 1)
+        XCTAssertEqual(inA[0].body, "in A")
+        XCTAssertEqual(inB[0].body, "in B")
+    }
+
+    func test_list_sortsBySentAtAscending() async {
+        let groupID = "cc".repeated(32)
+        let older = makeMessage(
+            groupID: groupID,
+            body: "older",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let newer = makeMessage(
+            groupID: groupID,
+            body: "newer",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_500)
+        )
+        // Insert out of order — sort must come from the store.
+        _ = await store.insertOrUpdate(newer)
+        _ = await store.insertOrUpdate(older)
+
+        let listed = await store.list(groupID: groupID)
+        XCTAssertEqual(listed.map(\.body), ["older", "newer"])
+    }
+
+    func test_list_unknownGroupID_returnsEmpty() async {
+        let listed = await store.list(groupID: "ff".repeated(32))
+        XCTAssertTrue(listed.isEmpty)
+    }
+
+    // MARK: - updateStatus
+
+    func test_updateStatus_flipsOnlyStatusColumn() async {
+        let msg = makeMessage(body: "in flight", status: .pending)
+        _ = await store.insertOrUpdate(msg)
+
+        await store.updateStatus(id: msg.id, status: .sent)
+
+        let listed = await store.list(groupID: msg.groupID)
+        XCTAssertEqual(listed[0].status, .sent)
+        XCTAssertEqual(listed[0].body, "in flight",
+                       "body must survive a status-only update")
+    }
+
+    func test_updateStatus_unknownID_isNoOp() async {
+        await store.updateStatus(id: UUID(), status: .sent)
+        // No throw, no row, no surprise.
+        let listed = await store.list(groupID: "aa".repeated(32))
+        XCTAssertTrue(listed.isEmpty)
+    }
+
+    // MARK: - delete
+
+    func test_delete_removesRow() async {
+        let msg = makeMessage()
+        _ = await store.insertOrUpdate(msg)
+        await store.delete(id: msg.id)
+        let listed = await store.list(groupID: msg.groupID)
+        XCTAssertTrue(listed.isEmpty)
+    }
+
+    func test_deleteGroup_removesAllMessagesForGroup() async {
+        let groupA = "aa".repeated(32)
+        let groupB = "bb".repeated(32)
+        _ = await store.insertOrUpdate(makeMessage(groupID: groupA, body: "a1"))
+        _ = await store.insertOrUpdate(makeMessage(groupID: groupA, body: "a2"))
+        _ = await store.insertOrUpdate(makeMessage(groupID: groupB, body: "b1"))
+
+        await store.deleteGroup(groupID: groupA)
+        let remainingA = await store.list(groupID: groupA)
+        let remainingB = await store.list(groupID: groupB)
+        XCTAssertTrue(remainingA.isEmpty)
+        XCTAssertEqual(remainingB.count, 1)
+    }
+
+    func test_deleteOwner_removesAllMessagesForIdentity() async {
+        let aliceID = IdentityID()
+        let bobID = IdentityID()
+        let groupA = "aa".repeated(32)
+        _ = await store.insertOrUpdate(
+            makeMessage(groupID: groupA, ownerIdentityID: aliceID, body: "alice")
+        )
+        _ = await store.insertOrUpdate(
+            makeMessage(groupID: groupA, ownerIdentityID: bobID, body: "bob")
+        )
+
+        await store.deleteOwner(aliceID.rawValue.uuidString)
+
+        let remaining = await store.list(groupID: groupA)
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining[0].body, "bob")
+    }
+
+    // MARK: - Helpers
+
+    private func makeMessage(
+        id: UUID = UUID(),
+        groupID: String = "aa".repeated(32),
+        ownerIdentityID: IdentityID = IdentityID(),
+        senderHex: String = "11".repeated(48),
+        body: String = "hi",
+        sentAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        direction: MessageDirection = .outgoing,
+        status: MessageStatus = .sent
+    ) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            groupID: groupID,
+            ownerIdentityID: ownerIdentityID,
+            senderBlsPubkeyHex: senderHex,
+            body: body,
+            sentAt: sentAt,
+            direction: direction,
+            status: status,
+            groupType: .tyranny
+        )
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}


### PR DESCRIPTION
Second PR in the chat stack. Adds on-disk persistence + a reactive snapshots stream for chat messages. **Mirrors `GroupStore` / `GroupRepository` exactly** so the chat thread UI (later PRs) can subscribe to one group's messages the same way `ChatsView` subscribes to the group list.

## What's in here

| File | Role |
|---|---|
| `ChatMessage` | Domain type (id, groupID, owner, sender BLS hex, body, sentAt, direction, status, groupType) |
| `MessageDirection` / `MessageStatus` | enums: `.incoming` / `.outgoing` ; `.pending` / `.sent` / `.failed` / `.received` |
| `PersistedMessage` | `@Model`. Plain columns (id / groupID / sentAt / direction / status / groupType) for querying + sort; sender BLS hex and body encrypted via `StorageEncryption` |
| `MessageStore` | Async protocol seam |
| `SwiftDataMessageStore` | Actor impl. **Separate `Messages.store` file** next to `Groups.store` so a schema bump in either domain doesn't force a wipe of the other |
| `MessageRepository` | Actor with per-group `snapshots(groupID:)` streams. **Lazy per-group cache** — chat thread reads one group at a time, so loading the whole messages table at launch would be wasted I/O |

## Design notes
- Encryption split matches `PersistedGroup`: queryable / sort columns stay plain, content is encrypted.
- `MessageRepository.removeForOwner` refreshes each cached group from the store rather than wiping in-memory — other-identity rows in the same group must survive (tested in `test_removeForOwner_emptiesAllCachedGroups`).
- `updateStatus` is a hot-path API for the outgoing pipeline (pending → sent/failed) so we don't round-trip the whole row through the encryption boundary.

## Out of scope (deferred)
- No wiring to `IncomingMessageDispatcher` or any send path — that lands in PR 4.
- No app-shell wiring (the production `init()` initializer exists but isn't called anywhere yet).

## Test plan
- [x] `SwiftDataMessageStoreTests` — 10 tests (roundtrip, in-place update, sort, filter, updateStatus, cascade deletes)
- [x] `MessageRepositoryTests` — 10 tests (initial snapshot, broadcast on mutate, per-group isolation, cascade behavior)
- [x] Full `OnymIOSTests` suite — 538 / 538 pass (3 pre-existing skips, 0 regressions)

## Plan context
PR 2 of 11. **PR 1** (#147) added the wire-format payload. **PR 3 next** extends `MemberProfile` with `sendingPubkey` so PR 4 can do Ed25519 envelope-signature verification on incoming chat messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)