### PR TITLE
feat(identity): plumb Ed25519 sender pubkey through member profiles (PR 3/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -720,7 +720,8 @@ struct CreateGroupInteractor: Sendable {
         return [
             creatorBlsHex: MemberProfile(
                 alias: alias,
-                inboxPublicKey: identitySnapshot.inboxPublicKey
+                inboxPublicKey: identitySnapshot.inboxPublicKey,
+                sendingPubkey: identitySnapshot.stellarPublicKey
             )
         ]
     }

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -52,6 +52,13 @@ actor JoinRequestApprover: JoinRequestApproving {
         /// requests can't be approved on-chain and surface as
         /// `.outdatedJoinerClient`.
         let joinerLeafHash: Data?
+        /// 32-byte Ed25519 raw pubkey — joiner's
+        /// `Identity.stellarPublicKey`. Plumbed through to the
+        /// joiner's `MemberProfile` and the fan-out
+        /// `MemberAnnouncementPayload` so existing members can
+        /// verify the joiner's chat-message envelope signatures
+        /// (PR 4). Optional for back-compat with pre-PR-3 joiners.
+        let joinerSendingPublicKey: Data?
         let joinerDisplayLabel: String
         let groupId: Data
         /// Looked up from the local `GroupRepository`. nil if the
@@ -297,12 +304,14 @@ actor JoinRequestApprover: JoinRequestApproving {
                 in: anchored,
                 blsPub: blsPub,
                 inboxPub: req.joinerInboxPublicKey,
+                sendingPub: req.joinerSendingPublicKey,
                 alias: req.joinerDisplayLabel
             )
             await broadcastJoin(
                 in: anchored,
                 joinerBlsPub: blsPub,
                 joinerInboxPub: req.joinerInboxPublicKey,
+                joinerSendingPub: req.joinerSendingPublicKey,
                 joinerAlias: req.joinerDisplayLabel
             )
         }
@@ -473,13 +482,15 @@ actor JoinRequestApprover: JoinRequestApproving {
         in group: ChatGroup,
         blsPub: Data,
         inboxPub: Data,
+        sendingPub: Data?,
         alias: String
     ) async {
         let key = blsPub.map { String(format: "%02x", $0) }.joined()
         var updated = group
         updated.memberProfiles[key] = MemberProfile(
             alias: alias,
-            inboxPublicKey: inboxPub
+            inboxPublicKey: inboxPub,
+            sendingPubkey: sendingPub
         )
         await groupRepository.insert(updated)
     }
@@ -500,6 +511,7 @@ actor JoinRequestApprover: JoinRequestApproving {
         in group: ChatGroup,
         joinerBlsPub: Data,
         joinerInboxPub: Data,
+        joinerSendingPub: Data?,
         joinerAlias: String
     ) async {
         let adminAlias = await identity.currentIdentityName() ?? ""
@@ -508,7 +520,8 @@ actor JoinRequestApprover: JoinRequestApproving {
             announced = try MemberAnnouncementPayload.AnnouncedMember(
                 blsPub: joinerBlsPub,
                 inboxPub: joinerInboxPub,
-                alias: joinerAlias
+                alias: joinerAlias,
+                sendingPub: joinerSendingPub
             )
         } catch {
             // Wrong-sized BLS pubkey shouldn't happen — we already
@@ -651,6 +664,7 @@ actor JoinRequestApprover: JoinRequestApproving {
             joinerInboxPublicKey: payload.joinerInboxPublicKey,
             joinerBlsPublicKey: payload.joinerBlsPublicKey,
             joinerLeafHash: payload.joinerLeafHash,
+            joinerSendingPublicKey: payload.joinerSendingPublicKey,
             joinerDisplayLabel: payload.joinerDisplayLabel,
             groupId: payload.groupId,
             groupName: groupName

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -57,8 +57,8 @@ actor JoinRequestApprover: JoinRequestApproving {
         /// joiner's `MemberProfile` and the fan-out
         /// `MemberAnnouncementPayload` so existing members can
         /// verify the joiner's chat-message envelope signatures
-        /// (PR 4). Optional for back-compat with pre-PR-3 joiners.
-        let joinerSendingPublicKey: Data?
+        /// (PR 4).
+        let joinerSendingPublicKey: Data
         let joinerDisplayLabel: String
         let groupId: Data
         /// Looked up from the local `GroupRepository`. nil if the
@@ -482,7 +482,7 @@ actor JoinRequestApprover: JoinRequestApproving {
         in group: ChatGroup,
         blsPub: Data,
         inboxPub: Data,
-        sendingPub: Data?,
+        sendingPub: Data,
         alias: String
     ) async {
         let key = blsPub.map { String(format: "%02x", $0) }.joined()
@@ -511,7 +511,7 @@ actor JoinRequestApprover: JoinRequestApproving {
         in group: ChatGroup,
         joinerBlsPub: Data,
         joinerInboxPub: Data,
-        joinerSendingPub: Data?,
+        joinerSendingPub: Data,
         joinerAlias: String
     ) async {
         let adminAlias = await identity.currentIdentityName() ?? ""

--- a/Sources/OnymIOS/Group/JoinRequestPayload.swift
+++ b/Sources/OnymIOS/Group/JoinRequestPayload.swift
@@ -54,11 +54,8 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
     /// request and ships it back to existing members via
     /// `MemberAnnouncementPayload.AnnouncedMember.sendingPub` so they
     /// can verify the joiner's future chat-message envelope
-    /// signatures (PR 4). Optional for back-compat with pre-PR-3
-    /// joiner builds; admins running PR-3+ store `nil` and the
-    /// dispatcher falls back to BLS-claim trust until the joiner
-    /// updates.
-    let joinerSendingPublicKey: Data?
+    /// signatures (PR 4).
+    let joinerSendingPublicKey: Data
     let joinerDisplayLabel: String
     let groupId: Data
 
@@ -75,7 +72,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         joinerInboxPublicKey: Data,
         joinerBlsPublicKey: Data?,
         joinerLeafHash: Data?,
-        joinerSendingPublicKey: Data? = nil,
+        joinerSendingPublicKey: Data,
         joinerDisplayLabel: String,
         groupId: Data
     ) throws {
@@ -94,9 +91,9 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
                 "joinerLeafHash: expected 32 bytes, got \(leaf.count)"
             )
         }
-        if let send = joinerSendingPublicKey, send.count != 32 {
+        guard joinerSendingPublicKey.count == 32 else {
             throw JoinRequestPayloadError.shape(
-                "joinerSendingPublicKey: expected 32 bytes, got \(send.count)"
+                "joinerSendingPublicKey: expected 32 bytes, got \(joinerSendingPublicKey.count)"
             )
         }
         guard groupId.count == 32 else {
@@ -117,7 +114,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         let pub = try c.decode(Data.self, forKey: .joinerInboxPublicKey)
         let bls = try c.decodeIfPresent(Data.self, forKey: .joinerBlsPublicKey)
         let leaf = try c.decodeIfPresent(Data.self, forKey: .joinerLeafHash)
-        let sending = try c.decodeIfPresent(Data.self, forKey: .joinerSendingPublicKey)
+        let sending = try c.decode(Data.self, forKey: .joinerSendingPublicKey)
         let label = try c.decode(String.self, forKey: .joinerDisplayLabel)
         let gid = try c.decode(Data.self, forKey: .groupId)
         guard pub.count == 32 else {
@@ -135,9 +132,9 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
                 "joinerLeafHash: expected 32 bytes, got \(leafBytes.count)"
             )
         }
-        if let sendBytes = sending, sendBytes.count != 32 {
+        guard sending.count == 32 else {
             throw JoinRequestPayloadError.shape(
-                "joinerSendingPublicKey: expected 32 bytes, got \(sendBytes.count)"
+                "joinerSendingPublicKey: expected 32 bytes, got \(sending.count)"
             )
         }
         guard gid.count == 32 else {

--- a/Sources/OnymIOS/Group/JoinRequestPayload.swift
+++ b/Sources/OnymIOS/Group/JoinRequestPayload.swift
@@ -49,6 +49,16 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
     /// because the on-chain `update_commitment` proof can't be
     /// generated without it.
     let joinerLeafHash: Data?
+    /// 32-byte Ed25519 raw public key — joiner's
+    /// `Identity.stellarPublicKey`. The admin reads this off the
+    /// request and ships it back to existing members via
+    /// `MemberAnnouncementPayload.AnnouncedMember.sendingPub` so they
+    /// can verify the joiner's future chat-message envelope
+    /// signatures (PR 4). Optional for back-compat with pre-PR-3
+    /// joiner builds; admins running PR-3+ store `nil` and the
+    /// dispatcher falls back to BLS-claim trust until the joiner
+    /// updates.
+    let joinerSendingPublicKey: Data?
     let joinerDisplayLabel: String
     let groupId: Data
 
@@ -56,6 +66,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         case joinerInboxPublicKey = "joiner_inbox_pub"
         case joinerBlsPublicKey = "joiner_bls_pub"
         case joinerLeafHash = "joiner_leaf_hash"
+        case joinerSendingPublicKey = "joiner_sending_pub"
         case joinerDisplayLabel = "joiner_display_label"
         case groupId = "group_id"
     }
@@ -64,6 +75,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         joinerInboxPublicKey: Data,
         joinerBlsPublicKey: Data?,
         joinerLeafHash: Data?,
+        joinerSendingPublicKey: Data? = nil,
         joinerDisplayLabel: String,
         groupId: Data
     ) throws {
@@ -82,6 +94,11 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
                 "joinerLeafHash: expected 32 bytes, got \(leaf.count)"
             )
         }
+        if let send = joinerSendingPublicKey, send.count != 32 {
+            throw JoinRequestPayloadError.shape(
+                "joinerSendingPublicKey: expected 32 bytes, got \(send.count)"
+            )
+        }
         guard groupId.count == 32 else {
             throw JoinRequestPayloadError.shape(
                 "groupId: expected 32 bytes, got \(groupId.count)"
@@ -90,6 +107,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         self.joinerInboxPublicKey = joinerInboxPublicKey
         self.joinerBlsPublicKey = joinerBlsPublicKey
         self.joinerLeafHash = joinerLeafHash
+        self.joinerSendingPublicKey = joinerSendingPublicKey
         self.joinerDisplayLabel = joinerDisplayLabel
         self.groupId = groupId
     }
@@ -99,6 +117,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         let pub = try c.decode(Data.self, forKey: .joinerInboxPublicKey)
         let bls = try c.decodeIfPresent(Data.self, forKey: .joinerBlsPublicKey)
         let leaf = try c.decodeIfPresent(Data.self, forKey: .joinerLeafHash)
+        let sending = try c.decodeIfPresent(Data.self, forKey: .joinerSendingPublicKey)
         let label = try c.decode(String.self, forKey: .joinerDisplayLabel)
         let gid = try c.decode(Data.self, forKey: .groupId)
         guard pub.count == 32 else {
@@ -116,6 +135,11 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
                 "joinerLeafHash: expected 32 bytes, got \(leafBytes.count)"
             )
         }
+        if let sendBytes = sending, sendBytes.count != 32 {
+            throw JoinRequestPayloadError.shape(
+                "joinerSendingPublicKey: expected 32 bytes, got \(sendBytes.count)"
+            )
+        }
         guard gid.count == 32 else {
             throw JoinRequestPayloadError.shape(
                 "groupId: expected 32 bytes, got \(gid.count)"
@@ -124,6 +148,7 @@ struct JoinRequestPayload: Codable, Equatable, Sendable {
         self.joinerInboxPublicKey = pub
         self.joinerBlsPublicKey = bls
         self.joinerLeafHash = leaf
+        self.joinerSendingPublicKey = sending
         self.joinerDisplayLabel = label
         self.groupId = gid
     }

--- a/Sources/OnymIOS/Group/JoinRequestSender.swift
+++ b/Sources/OnymIOS/Group/JoinRequestSender.swift
@@ -64,6 +64,7 @@ actor JoinRequestSender {
                 joinerInboxPublicKey: active.inboxPublicKey,
                 joinerBlsPublicKey: active.blsPublicKey,
                 joinerLeafHash: leafHash,
+                joinerSendingPublicKey: active.stellarPublicKey,
                 joinerDisplayLabel: joinerDisplayLabel,
                 groupId: capability.groupId
             )

--- a/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
+++ b/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
@@ -91,18 +91,33 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
         let inboxPub: Data
         /// Self-asserted display alias.
         let alias: String
+        /// 32-byte Ed25519 raw public key — the joiner's
+        /// `Identity.stellarPublicKey`. PR 4's chat dispatcher
+        /// verifies incoming chat-message envelope signatures
+        /// against this so an insider can't forge another member's
+        /// `senderBlsPubkeyHex` claim. Optional for back-compat with
+        /// pre-PR-3 announcers; receivers fall back to "trust the
+        /// BLS claim" when missing.
+        let sendingPub: Data?
 
         enum CodingKeys: String, CodingKey {
             case blsPub = "bls_pub"
             case inboxPub = "inbox_pub"
             case alias
+            case sendingPub = "sending_pub"
         }
 
-        init(blsPub: Data, inboxPub: Data, alias: String) throws {
-            try Self.validate(blsPub: blsPub, inboxPub: inboxPub)
+        init(
+            blsPub: Data,
+            inboxPub: Data,
+            alias: String,
+            sendingPub: Data? = nil
+        ) throws {
+            try Self.validate(blsPub: blsPub, inboxPub: inboxPub, sendingPub: sendingPub)
             self.blsPub = blsPub
             self.inboxPub = inboxPub
             self.alias = alias
+            self.sendingPub = sendingPub
         }
 
         init(from decoder: Decoder) throws {
@@ -110,13 +125,19 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
             let bls = try c.decode(Data.self, forKey: .blsPub)
             let inbox = try c.decode(Data.self, forKey: .inboxPub)
             let alias = try c.decode(String.self, forKey: .alias)
-            try Self.validate(blsPub: bls, inboxPub: inbox)
+            let sending = try c.decodeIfPresent(Data.self, forKey: .sendingPub)
+            try Self.validate(blsPub: bls, inboxPub: inbox, sendingPub: sending)
             self.blsPub = bls
             self.inboxPub = inbox
             self.alias = alias
+            self.sendingPub = sending
         }
 
-        private static func validate(blsPub: Data, inboxPub: Data) throws {
+        private static func validate(
+            blsPub: Data,
+            inboxPub: Data,
+            sendingPub: Data?
+        ) throws {
             guard blsPub.count == 48 else {
                 throw MemberAnnouncementPayloadError.shape(
                     "blsPub: expected 48 bytes, got \(blsPub.count)"
@@ -125,6 +146,11 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
             guard inboxPub.count == 32 else {
                 throw MemberAnnouncementPayloadError.shape(
                     "inboxPub: expected 32 bytes, got \(inboxPub.count)"
+                )
+            }
+            if let s = sendingPub, s.count != 32 {
+                throw MemberAnnouncementPayloadError.shape(
+                    "sendingPub: expected 32 bytes, got \(s.count)"
                 )
             }
         }

--- a/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
+++ b/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
@@ -95,10 +95,8 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
         /// `Identity.stellarPublicKey`. PR 4's chat dispatcher
         /// verifies incoming chat-message envelope signatures
         /// against this so an insider can't forge another member's
-        /// `senderBlsPubkeyHex` claim. Optional for back-compat with
-        /// pre-PR-3 announcers; receivers fall back to "trust the
-        /// BLS claim" when missing.
-        let sendingPub: Data?
+        /// `senderBlsPubkeyHex` claim.
+        let sendingPub: Data
 
         enum CodingKeys: String, CodingKey {
             case blsPub = "bls_pub"
@@ -111,7 +109,7 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
             blsPub: Data,
             inboxPub: Data,
             alias: String,
-            sendingPub: Data? = nil
+            sendingPub: Data
         ) throws {
             try Self.validate(blsPub: blsPub, inboxPub: inboxPub, sendingPub: sendingPub)
             self.blsPub = blsPub
@@ -125,7 +123,7 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
             let bls = try c.decode(Data.self, forKey: .blsPub)
             let inbox = try c.decode(Data.self, forKey: .inboxPub)
             let alias = try c.decode(String.self, forKey: .alias)
-            let sending = try c.decodeIfPresent(Data.self, forKey: .sendingPub)
+            let sending = try c.decode(Data.self, forKey: .sendingPub)
             try Self.validate(blsPub: bls, inboxPub: inbox, sendingPub: sending)
             self.blsPub = bls
             self.inboxPub = inbox
@@ -136,7 +134,7 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
         private static func validate(
             blsPub: Data,
             inboxPub: Data,
-            sendingPub: Data?
+            sendingPub: Data
         ) throws {
             guard blsPub.count == 48 else {
                 throw MemberAnnouncementPayloadError.shape(
@@ -148,9 +146,9 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
                     "inboxPub: expected 32 bytes, got \(inboxPub.count)"
                 )
             }
-            if let s = sendingPub, s.count != 32 {
+            guard sendingPub.count == 32 else {
                 throw MemberAnnouncementPayloadError.shape(
-                    "sendingPub: expected 32 bytes, got \(s.count)"
+                    "sendingPub: expected 32 bytes, got \(sendingPub.count)"
                 )
             }
         }

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -24,9 +24,32 @@ import Foundation
 struct MemberProfile: Codable, Equatable, Hashable, Sendable {
     let alias: String
     let inboxPublicKey: Data
+    /// 32-byte Ed25519 raw public key (`Identity.stellarPublicKey`).
+    /// Same key that signs every `SealedEnvelope` — the chat dispatcher
+    /// (PR 4) verifies an incoming chat message's envelope signature
+    /// against this so an insider can't forge another member's
+    /// `senderBlsPubkeyHex` claim.
+    ///
+    /// Optional for back-compat: rows / wire shapes that predate this
+    /// field land with `nil`. The dispatcher treats a missing
+    /// `sendingPubkey` as "trust the BLS claim, no signature check"
+    /// for one migration window so old members aren't locked out of
+    /// their own groups.
+    let sendingPubkey: Data?
 
     enum CodingKeys: String, CodingKey {
         case alias
         case inboxPublicKey = "inbox_public_key"
+        case sendingPubkey = "sending_pubkey"
+    }
+
+    init(
+        alias: String,
+        inboxPublicKey: Data,
+        sendingPubkey: Data? = nil
+    ) {
+        self.alias = alias
+        self.inboxPublicKey = inboxPublicKey
+        self.sendingPubkey = sendingPubkey
     }
 }

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -29,27 +29,11 @@ struct MemberProfile: Codable, Equatable, Hashable, Sendable {
     /// (PR 4) verifies an incoming chat message's envelope signature
     /// against this so an insider can't forge another member's
     /// `senderBlsPubkeyHex` claim.
-    ///
-    /// Optional for back-compat: rows / wire shapes that predate this
-    /// field land with `nil`. The dispatcher treats a missing
-    /// `sendingPubkey` as "trust the BLS claim, no signature check"
-    /// for one migration window so old members aren't locked out of
-    /// their own groups.
-    let sendingPubkey: Data?
+    let sendingPubkey: Data
 
     enum CodingKeys: String, CodingKey {
         case alias
         case inboxPublicKey = "inbox_public_key"
         case sendingPubkey = "sending_pubkey"
-    }
-
-    init(
-        alias: String,
-        inboxPublicKey: Data,
-        sendingPubkey: Data? = nil
-    ) {
-        self.alias = alias
-        self.inboxPublicKey = inboxPublicKey
-        self.sendingPubkey = sendingPubkey
     }
 }

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -36,4 +36,40 @@ struct MemberProfile: Codable, Equatable, Hashable, Sendable {
         case inboxPublicKey = "inbox_public_key"
         case sendingPubkey = "sending_pubkey"
     }
+
+    init(alias: String, inboxPublicKey: Data, sendingPubkey: Data) {
+        self.alias = alias
+        self.inboxPublicKey = inboxPublicKey
+        self.sendingPubkey = sendingPubkey
+    }
+
+    /// The wire-side decode boundary. `MemberProfile` ships inside
+    /// `GroupInvitationPayload.memberProfiles` and
+    /// `MemberAnnouncementPayload` (via the dispatcher's profile
+    /// merge), so a wrong-sized key on the wire becomes a bogus
+    /// verification key for PR 4. Validate at decode — same pattern
+    /// as `MemberAnnouncementPayload.AnnouncedMember`.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let alias = try c.decode(String.self, forKey: .alias)
+        let inbox = try c.decode(Data.self, forKey: .inboxPublicKey)
+        let sending = try c.decode(Data.self, forKey: .sendingPubkey)
+        guard inbox.count == 32 else {
+            throw MemberProfileError.shape(
+                "inboxPublicKey: expected 32 bytes, got \(inbox.count)"
+            )
+        }
+        guard sending.count == 32 else {
+            throw MemberProfileError.shape(
+                "sendingPubkey: expected 32 bytes, got \(sending.count)"
+            )
+        }
+        self.alias = alias
+        self.inboxPublicKey = inbox
+        self.sendingPubkey = sending
+    }
+}
+
+enum MemberProfileError: Error, Equatable {
+    case shape(String)
 }

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -555,7 +555,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
             id: id,
             name: names[id] ?? Self.fallbackName(forNewSlot: 1),
             blsPublicKey: identity.blsPublicKey,
-            inboxPublicKey: identity.inboxPublicKey
+            inboxPublicKey: identity.inboxPublicKey,
+            sendingPublicKey: identity.stellarPublicKey
         )
     }
 

--- a/Sources/OnymIOS/Identity/IdentitySummary.swift
+++ b/Sources/OnymIOS/Identity/IdentitySummary.swift
@@ -18,4 +18,10 @@ struct IdentitySummary: Hashable, Sendable {
     /// need; also feeds the inbox-tag derivation that PR-4's transport
     /// fan-out subscribes against.
     let inboxPublicKey: Data
+    /// 32-byte Ed25519 raw public key (`Identity.stellarPublicKey`).
+    /// Same key that signs every `SealedEnvelope`. Carried on the
+    /// summary so the chat dispatcher can populate the receiver's own
+    /// `MemberProfile.sendingPubkey` without crossing into the
+    /// repository's secret-material path.
+    let sendingPublicKey: Data
 }

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -333,7 +333,8 @@ struct IncomingMessageDispatcher: Sendable {
             .map { String(format: "%02x", $0) }.joined()
         let profile = MemberProfile(
             alias: me.name,
-            inboxPublicKey: me.inboxPublicKey
+            inboxPublicKey: me.inboxPublicKey,
+            sendingPubkey: me.sendingPublicKey
         )
         return (key, profile)
     }
@@ -391,7 +392,8 @@ struct IncomingMessageDispatcher: Sendable {
         var updated = group
         updated.memberProfiles[key] = MemberProfile(
             alias: payload.newMember.alias,
-            inboxPublicKey: payload.newMember.inboxPub
+            inboxPublicKey: payload.newMember.inboxPub,
+            sendingPubkey: payload.newMember.sendingPub
         )
         await groupRepository.insert(updated)
     }

--- a/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
+++ b/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
@@ -198,6 +198,7 @@ final class ApproveRequestsFlowTests: XCTestCase {
             joinerInboxPublicKey: Data(repeating: 0xAA, count: 32),
             joinerBlsPublicKey: Data(repeating: 0xCC, count: 48),
             joinerLeafHash: Data(repeating: 0xDD, count: 32),
+            joinerSendingPublicKey: nil,
             joinerDisplayLabel: alias,
             groupId: Data(repeating: 0xBB, count: 32),
             groupName: "Family"

--- a/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
+++ b/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
@@ -198,7 +198,7 @@ final class ApproveRequestsFlowTests: XCTestCase {
             joinerInboxPublicKey: Data(repeating: 0xAA, count: 32),
             joinerBlsPublicKey: Data(repeating: 0xCC, count: 48),
             joinerLeafHash: Data(repeating: 0xDD, count: 32),
-            joinerSendingPublicKey: nil,
+            joinerSendingPublicKey: Data(repeating: 0xEE, count: 32),
             joinerDisplayLabel: alias,
             groupId: Data(repeating: 0xBB, count: 32),
             groupName: "Family"

--- a/Tests/OnymIOSTests/GroupInvitationPayloadTests.swift
+++ b/Tests/OnymIOSTests/GroupInvitationPayloadTests.swift
@@ -15,7 +15,8 @@ final class GroupInvitationPayloadTests: XCTestCase {
         let profiles: [String: MemberProfile] = [
             aliceHex: MemberProfile(
                 alias: "Alice",
-                inboxPublicKey: Data(repeating: 0xAA, count: 32)
+                inboxPublicKey: Data(repeating: 0xAA, count: 32),
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
             )
         ]
         let original = makePayload(memberProfiles: profiles)
@@ -58,7 +59,8 @@ final class GroupInvitationPayloadTests: XCTestCase {
         let payload = makePayload(memberProfiles: [
             "ab".repeated(48): MemberProfile(
                 alias: "x",
-                inboxPublicKey: Data(repeating: 0, count: 32)
+                inboxPublicKey: Data(repeating: 0, count: 32),
+                sendingPubkey: Data(repeating: 0, count: 32)
             )
         ])
         let encoded = try JSONEncoder().encode(payload)

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -39,7 +39,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let groupID = Data(repeating: 0xAB, count: 32)
         let creator = MemberProfile(
             alias: "Alice",
-            inboxPublicKey: Data(repeating: 0x10, count: 32)
+            inboxPublicKey: Data(repeating: 0x10, count: 32),
+            sendingPubkey: Data(repeating: 0xEE, count: 32)
         )
         let creatorBlsHex = "aa".repeated(48)
         await seedGroup(
@@ -117,7 +118,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let bobBlsHex = "bb".repeated(48)
         let bob = MemberProfile(
             alias: "Bob (original)",
-            inboxPublicKey: Data(repeating: 0x33, count: 32)
+            inboxPublicKey: Data(repeating: 0x33, count: 32),
+            sendingPubkey: Data(repeating: 0xEE, count: 32)
         )
         await seedGroup(
             groupID: groupID,
@@ -501,7 +503,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let member = try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0xBB, count: 48),
             inboxPub: Data(repeating: 0x33, count: 32),
-            alias: "Bob"
+            alias: "Bob",
+            sendingPub: Data(repeating: 0xEE, count: 32)
         )
         let payload = try MemberAnnouncementPayload(
             version: 1,
@@ -543,7 +546,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let creatorBlsHex = "11".repeated(48)
         let creatorProfile = MemberProfile(
             alias: "Alice",
-            inboxPublicKey: Data(repeating: 0xAA, count: 32)
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: Data(repeating: 0xEE, count: 32)
         )
         let payload = makeInvitationPayload(
             groupID: Data(repeating: 0x42, count: 32),
@@ -643,7 +647,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             name: "Race",
             memberProfiles: [creatorBlsHex: MemberProfile(
                 alias: "Alice",
-                inboxPublicKey: Data(repeating: 0x44, count: 32)
+                inboxPublicKey: Data(repeating: 0x44, count: 32),
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
             )]
         )
         let plaintext = try JSONEncoder().encode(payload)
@@ -765,7 +770,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         let member = try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: blsPub,
             inboxPub: Data(repeating: joinerInboxByte, count: 32),
-            alias: joinerAlias
+            alias: joinerAlias,
+            sendingPub: Data(repeating: 0xEE, count: 32)
         )
         return try MemberAnnouncementPayload(
             version: 1,

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -560,7 +560,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             id: owner,
             name: "Bob",
             blsPublicKey: Data(repeating: 0x22, count: 48),
-            inboxPublicKey: Data(repeating: 0xBB, count: 32)
+            inboxPublicKey: Data(repeating: 0xBB, count: 32),
+            sendingPublicKey: Data(repeating: 0xCC, count: 32)
         )
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
@@ -607,7 +608,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             id: owner,
             name: "Carol",
             blsPublicKey: Data(repeating: 0x33, count: 48),
-            inboxPublicKey: Data(repeating: 0xCC, count: 32)
+            inboxPublicKey: Data(repeating: 0xCC, count: 32),
+            sendingPublicKey: Data(repeating: 0xDD, count: 32)
         )
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -179,8 +179,8 @@ final class JoinRequestApproverTests: XCTestCase {
         let peerOneInbox = Data(repeating: 0x77, count: 32)
         let peerTwoInbox = Data(repeating: 0x88, count: 32)
         let extraProfiles: [String: MemberProfile] = [
-            "77".repeated(48): MemberProfile(alias: "PeerOne", inboxPublicKey: peerOneInbox),
-            "88".repeated(48): MemberProfile(alias: "PeerTwo", inboxPublicKey: peerTwoInbox),
+            "77".repeated(48): MemberProfile(alias: "PeerOne", inboxPublicKey: peerOneInbox, sendingPubkey: Data(repeating: 0xE1, count: 32)),
+            "88".repeated(48): MemberProfile(alias: "PeerTwo", inboxPublicKey: peerTwoInbox, sendingPubkey: Data(repeating: 0xE2, count: 32)),
         ]
         let env = try await seedEnvironment(extraMemberProfiles: extraProfiles)
         await env.approver.pumpOnce()
@@ -361,6 +361,7 @@ final class JoinRequestApproverTests: XCTestCase {
             joinerInboxPublicKey: joinerInboxPub,
             joinerBlsPublicKey: joinerBlsPub,
             joinerLeafHash: omitJoinerLeafHash ? nil : joinerLeafHash,
+            joinerSendingPublicKey: Data(repeating: 0xEE, count: 32),
             joinerDisplayLabel: joinerAlias,
             groupId: groupID
         )
@@ -387,7 +388,8 @@ final class JoinRequestApproverTests: XCTestCase {
             var profiles = extraMemberProfiles
             profiles[adminBlsHex] = MemberProfile(
                 alias: "Admin",
-                inboxPublicKey: active.inboxPublicKey
+                inboxPublicKey: active.inboxPublicKey,
+                sendingPubkey: active.stellarPublicKey
             )
             // Admin must be in the cryptographic roster for the
             // anchor path to find adminIndexOld. Real groups land

--- a/Tests/OnymIOSTests/JoinRequestPayloadTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestPayloadTests.swift
@@ -13,12 +13,59 @@ final class JoinRequestPayloadTests: XCTestCase {
             joinerInboxPublicKey: Data(repeating: 0xAA, count: 32),
             joinerBlsPublicKey: Data(repeating: 0xBB, count: 48),
             joinerLeafHash: Data(repeating: 0xCC, count: 32),
+            joinerSendingPublicKey: Data(repeating: 0xEE, count: 32),
             joinerDisplayLabel: "Bob",
             groupId: Data(repeating: 0x42, count: 32)
         )
         let encoded = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(JoinRequestPayload.self, from: encoded)
         XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.joinerSendingPublicKey, Data(repeating: 0xEE, count: 32))
+    }
+
+    func test_wire_carries_joiner_sending_pub() throws {
+        let payload = try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0, count: 32),
+            joinerBlsPublicKey: Data(repeating: 0, count: 48),
+            joinerLeafHash: Data(repeating: 0, count: 32),
+            joinerSendingPublicKey: Data(repeating: 0xEE, count: 32),
+            joinerDisplayLabel: "x",
+            groupId: Data(repeating: 0, count: 32)
+        )
+        let encoded = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNotNil(obj?["joiner_sending_pub"],
+                        "PR 3 wire key must match Android parity")
+    }
+
+    func test_decoder_acceptsLegacyPayloadWithoutSendingPub() throws {
+        // Pre-PR-3 joiners ship requests without joiner_sending_pub.
+        // The wire format must round-trip those into a payload with
+        // `joinerSendingPublicKey == nil` so the approver still ships
+        // the invitation back; PR 4's dispatcher falls back to the
+        // BLS-claim-only trust path for that member's messages.
+        let inbox = Data(repeating: 0, count: 32).base64EncodedString()
+        let gid = Data(repeating: 0, count: 32).base64EncodedString()
+        let bls = Data(repeating: 0, count: 48).base64EncodedString()
+        let legacy = #"""
+        {"joiner_inbox_pub":"\#(inbox)","joiner_bls_pub":"\#(bls)","joiner_display_label":"Bob","group_id":"\#(gid)"}
+        """#
+        let bytes = legacy.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(JoinRequestPayload.self, from: bytes)
+        XCTAssertNil(decoded.joinerSendingPublicKey)
+    }
+
+    func test_constructor_rejectsWrongSizedSendingPubkey() {
+        XCTAssertThrowsError(try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0, count: 32),
+            joinerBlsPublicKey: nil,
+            joinerLeafHash: nil,
+            joinerSendingPublicKey: Data(repeating: 0, count: 31),
+            joinerDisplayLabel: "x",
+            groupId: Data(repeating: 0, count: 32)
+        )) { error in
+            XCTAssertTrue(error is JoinRequestPayloadError)
+        }
     }
 
     func test_snake_case_keys_match_android_parity() throws {

--- a/Tests/OnymIOSTests/JoinRequestPayloadTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestPayloadTests.swift
@@ -38,21 +38,18 @@ final class JoinRequestPayloadTests: XCTestCase {
                         "PR 3 wire key must match Android parity")
     }
 
-    func test_decoder_acceptsLegacyPayloadWithoutSendingPub() throws {
-        // Pre-PR-3 joiners ship requests without joiner_sending_pub.
-        // The wire format must round-trip those into a payload with
-        // `joinerSendingPublicKey == nil` so the approver still ships
-        // the invitation back; PR 4's dispatcher falls back to the
-        // BLS-claim-only trust path for that member's messages.
+    func test_decoder_rejectsRequestWithoutSendingPub() throws {
+        // `joiner_sending_pub` is required — receivers must reject
+        // any request that omits it. (No real users on the join
+        // path yet, so we ship without a migration window.)
         let inbox = Data(repeating: 0, count: 32).base64EncodedString()
         let gid = Data(repeating: 0, count: 32).base64EncodedString()
         let bls = Data(repeating: 0, count: 48).base64EncodedString()
-        let legacy = #"""
+        let json = #"""
         {"joiner_inbox_pub":"\#(inbox)","joiner_bls_pub":"\#(bls)","joiner_display_label":"Bob","group_id":"\#(gid)"}
         """#
-        let bytes = legacy.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(JoinRequestPayload.self, from: bytes)
-        XCTAssertNil(decoded.joinerSendingPublicKey)
+        let bytes = json.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(JoinRequestPayload.self, from: bytes))
     }
 
     func test_constructor_rejectsWrongSizedSendingPubkey() {
@@ -76,6 +73,7 @@ final class JoinRequestPayloadTests: XCTestCase {
             joinerInboxPublicKey: Data(repeating: 0, count: 32),
             joinerBlsPublicKey: Data(repeating: 0, count: 48),
             joinerLeafHash: Data(repeating: 0, count: 32),
+            joinerSendingPublicKey: Data(repeating: 0, count: 32),
             joinerDisplayLabel: "Bob",
             groupId: Data(repeating: 0, count: 32)
         )
@@ -93,6 +91,7 @@ final class JoinRequestPayloadTests: XCTestCase {
             joinerInboxPublicKey: Data(repeating: 0, count: 31),
             joinerBlsPublicKey: nil,
             joinerLeafHash: nil,
+            joinerSendingPublicKey: Data(repeating: 0, count: 32),
             joinerDisplayLabel: "x",
             groupId: Data(repeating: 0, count: 32)
         )) { error in
@@ -102,6 +101,7 @@ final class JoinRequestPayloadTests: XCTestCase {
             joinerInboxPublicKey: Data(repeating: 0, count: 32),
             joinerBlsPublicKey: nil,
             joinerLeafHash: nil,
+            joinerSendingPublicKey: Data(repeating: 0, count: 32),
             joinerDisplayLabel: "x",
             groupId: Data(repeating: 0, count: 33)
         )) { error in
@@ -111,6 +111,7 @@ final class JoinRequestPayloadTests: XCTestCase {
             joinerInboxPublicKey: Data(repeating: 0, count: 32),
             joinerBlsPublicKey: Data(repeating: 0, count: 47),
             joinerLeafHash: nil,
+            joinerSendingPublicKey: Data(repeating: 0, count: 32),
             joinerDisplayLabel: "x",
             groupId: Data(repeating: 0, count: 32)
         )) { error in
@@ -121,6 +122,7 @@ final class JoinRequestPayloadTests: XCTestCase {
             joinerInboxPublicKey: Data(repeating: 0, count: 32),
             joinerBlsPublicKey: Data(repeating: 0, count: 48),
             joinerLeafHash: Data(repeating: 0, count: 31),
+            joinerSendingPublicKey: Data(repeating: 0, count: 32),
             joinerDisplayLabel: "x",
             groupId: Data(repeating: 0, count: 32)
         )) { error in
@@ -130,7 +132,7 @@ final class JoinRequestPayloadTests: XCTestCase {
 
     func test_decoder_rejectsWrongSizedKeys() {
         let payloadJSON = #"""
-        {"joiner_inbox_pub":"AAA=","joiner_display_label":"Bob","group_id":"AAA="}
+        {"joiner_inbox_pub":"AAA=","joiner_sending_pub":"AAA=","joiner_display_label":"Bob","group_id":"AAA="}
         """#
         let bytes = payloadJSON.data(using: .utf8)!
         XCTAssertThrowsError(try JSONDecoder().decode(JoinRequestPayload.self, from: bytes)) { error in
@@ -138,18 +140,18 @@ final class JoinRequestPayloadTests: XCTestCase {
         }
     }
 
-    func test_decoder_acceptsLegacyPayloadWithoutBlsPub() throws {
-        // Older onym-android / pre-PR-4 builds ship requests without
-        // joiner_bls_pub. The wire format must round-trip those into
-        // a payload with `joinerBlsPublicKey == nil` so the approver
-        // can still ship the invitation back; only the local roster
-        // update is skipped.
+    func test_decoder_acceptsPayloadWithoutBlsPub() throws {
+        // `joiner_bls_pub` stays optional — a request without it
+        // round-trips into `joinerBlsPublicKey == nil` so the
+        // approver can still ship the invitation back (only the
+        // local roster update is skipped).
         let inbox = Data(repeating: 0, count: 32).base64EncodedString()
         let gid = Data(repeating: 0, count: 32).base64EncodedString()
-        let legacy = #"""
-        {"joiner_inbox_pub":"\#(inbox)","joiner_display_label":"Bob","group_id":"\#(gid)"}
+        let sending = Data(repeating: 0, count: 32).base64EncodedString()
+        let json = #"""
+        {"joiner_inbox_pub":"\#(inbox)","joiner_sending_pub":"\#(sending)","joiner_display_label":"Bob","group_id":"\#(gid)"}
         """#
-        let bytes = legacy.data(using: .utf8)!
+        let bytes = json.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(JoinRequestPayload.self, from: bytes)
         XCTAssertNil(decoded.joinerBlsPublicKey)
         XCTAssertEqual(decoded.joinerDisplayLabel, "Bob")

--- a/Tests/OnymIOSTests/MemberAnnouncementPayloadTests.swift
+++ b/Tests/OnymIOSTests/MemberAnnouncementPayloadTests.swift
@@ -14,7 +14,8 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
         let member = try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0x11, count: 48),
             inboxPub: Data(repeating: 0x33, count: 32),
-            alias: "Bob"
+            alias: "Bob",
+            sendingPub: Data(repeating: 0xEE, count: 32)
         )
         let original = try MemberAnnouncementPayload(
             version: 1,
@@ -28,6 +29,55 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
             from: encoded
         )
         XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.newMember.sendingPub, Data(repeating: 0xEE, count: 32))
+    }
+
+    func test_wire_carries_sending_pub() throws {
+        let member = try MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: Data(repeating: 0, count: 48),
+            inboxPub: Data(repeating: 0, count: 32),
+            alias: "Bob",
+            sendingPub: Data(repeating: 0xEE, count: 32)
+        )
+        let payload = try MemberAnnouncementPayload(
+            version: 1,
+            groupId: Data(repeating: 0, count: 32),
+            newMember: member,
+            adminAlias: "Alice"
+        )
+        let encoded = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let memberObj = obj?["new_member"] as? [String: Any]
+        XCTAssertNotNil(memberObj?["sending_pub"],
+                        "PR 3 wire key must match Android parity")
+    }
+
+    func test_decoder_acceptsLegacyAnnouncementWithoutSendingPub() throws {
+        // Pre-PR-3 announcers shipped without `sending_pub`.
+        // Receivers must round-trip those into an announcement with
+        // `sendingPub == nil` so the local roster updates still
+        // succeed; PR 4's dispatcher will then fall back to trusting
+        // the BLS claim alone for that member's messages.
+        let bls = Data(repeating: 0, count: 48).base64EncodedString()
+        let inbox = Data(repeating: 0, count: 32).base64EncodedString()
+        let gid = Data(repeating: 0, count: 32).base64EncodedString()
+        let legacy = #"""
+        {"version":1,"group_id":"\#(gid)","admin_alias":"Alice","new_member":{"bls_pub":"\#(bls)","inbox_pub":"\#(inbox)","alias":"Bob"}}
+        """#
+        let bytes = legacy.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(MemberAnnouncementPayload.self, from: bytes)
+        XCTAssertNil(decoded.newMember.sendingPub)
+    }
+
+    func test_constructor_rejectsWrongSizedSendingPub() {
+        XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
+            blsPub: Data(repeating: 0, count: 48),
+            inboxPub: Data(repeating: 0, count: 32),
+            alias: "x",
+            sendingPub: Data(repeating: 0, count: 31)
+        )) { error in
+            XCTAssertTrue(error is MemberAnnouncementPayloadError)
+        }
     }
 
     // MARK: - Wire shape

--- a/Tests/OnymIOSTests/MemberAnnouncementPayloadTests.swift
+++ b/Tests/OnymIOSTests/MemberAnnouncementPayloadTests.swift
@@ -52,23 +52,6 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
                         "PR 3 wire key must match Android parity")
     }
 
-    func test_decoder_acceptsLegacyAnnouncementWithoutSendingPub() throws {
-        // Pre-PR-3 announcers shipped without `sending_pub`.
-        // Receivers must round-trip those into an announcement with
-        // `sendingPub == nil` so the local roster updates still
-        // succeed; PR 4's dispatcher will then fall back to trusting
-        // the BLS claim alone for that member's messages.
-        let bls = Data(repeating: 0, count: 48).base64EncodedString()
-        let inbox = Data(repeating: 0, count: 32).base64EncodedString()
-        let gid = Data(repeating: 0, count: 32).base64EncodedString()
-        let legacy = #"""
-        {"version":1,"group_id":"\#(gid)","admin_alias":"Alice","new_member":{"bls_pub":"\#(bls)","inbox_pub":"\#(inbox)","alias":"Bob"}}
-        """#
-        let bytes = legacy.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(MemberAnnouncementPayload.self, from: bytes)
-        XCTAssertNil(decoded.newMember.sendingPub)
-    }
-
     func test_constructor_rejectsWrongSizedSendingPub() {
         XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 48),
@@ -86,7 +69,8 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
         let member = try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 48),
             inboxPub: Data(repeating: 0, count: 32),
-            alias: "Bob"
+            alias: "Bob",
+            sendingPub: Data(repeating: 0, count: 32)
         )
         let payload = try MemberAnnouncementPayload(
             version: 1,
@@ -116,7 +100,8 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
         let member = try! MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 48),
             inboxPub: Data(repeating: 0, count: 32),
-            alias: "x"
+            alias: "x",
+            sendingPub: Data(repeating: 0, count: 32)
         )
         XCTAssertThrowsError(try MemberAnnouncementPayload(
             version: 1,
@@ -132,7 +117,8 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
         XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 47),
             inboxPub: Data(repeating: 0, count: 32),
-            alias: "x"
+            alias: "x",
+            sendingPub: Data(repeating: 0, count: 32)
         )) { error in
             XCTAssertTrue(error is MemberAnnouncementPayloadError)
         }
@@ -142,7 +128,8 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
         XCTAssertThrowsError(try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: Data(repeating: 0, count: 48),
             inboxPub: Data(repeating: 0, count: 31),
-            alias: "x"
+            alias: "x",
+            sendingPub: Data(repeating: 0, count: 32)
         )) { error in
             XCTAssertTrue(error is MemberAnnouncementPayloadError)
         }
@@ -164,7 +151,7 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
 
     func test_decoder_rejectsWrongSizedBlsPub() {
         let bad = #"""
-        {"version":1,"group_id":"\#(base64Zeros(32))","new_member":{"bls_pub":"AAA=","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
+        {"version":1,"group_id":"\#(base64Zeros(32))","new_member":{"bls_pub":"AAA=","inbox_pub":"\#(base64Zeros(32))","alias":"x","sending_pub":"\#(base64Zeros(32))"},"admin_alias":"y"}
         """#
         let bytes = bad.data(using: .utf8)!
         XCTAssertThrowsError(
@@ -178,7 +165,7 @@ final class MemberAnnouncementPayloadTests: XCTestCase {
         // V2 receivers may add `leaf_hash`; V1 receivers MUST decode
         // payloads carrying it, ignoring the unknown field.
         let v2Shape = #"""
-        {"version":2,"group_id":"\#(base64Zeros(32))","new_member":{"bls_pub":"\#(base64Zeros(48))","leaf_hash":"\#(base64Zeros(32))","inbox_pub":"\#(base64Zeros(32))","alias":"x"},"admin_alias":"y"}
+        {"version":2,"group_id":"\#(base64Zeros(32))","new_member":{"bls_pub":"\#(base64Zeros(48))","leaf_hash":"\#(base64Zeros(32))","inbox_pub":"\#(base64Zeros(32))","alias":"x","sending_pub":"\#(base64Zeros(32))"},"admin_alias":"y"}
         """#
         let bytes = v2Shape.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(

--- a/Tests/OnymIOSTests/MemberProfileTests.swift
+++ b/Tests/OnymIOSTests/MemberProfileTests.swift
@@ -8,7 +8,7 @@ import XCTest
 /// and persistence at once.
 final class MemberProfileTests: XCTestCase {
 
-    func test_roundtrip_withSendingPubkey_preservesAllFields() throws {
+    func test_roundtrip_preservesAllFields() throws {
         let original = MemberProfile(
             alias: "Bob",
             inboxPublicKey: Data(repeating: 0xAA, count: 32),
@@ -20,18 +20,7 @@ final class MemberProfileTests: XCTestCase {
         XCTAssertEqual(decoded.sendingPubkey, Data(repeating: 0xEE, count: 32))
     }
 
-    func test_roundtrip_withoutSendingPubkey_decodesAsNil() throws {
-        let original = MemberProfile(
-            alias: "Bob",
-            inboxPublicKey: Data(repeating: 0xAA, count: 32)
-        )
-        let encoded = try JSONEncoder().encode(original)
-        let decoded = try JSONDecoder().decode(MemberProfile.self, from: encoded)
-        XCTAssertNil(decoded.sendingPubkey)
-        XCTAssertEqual(decoded, original)
-    }
-
-    func test_wireFormat_snakeCaseKey() throws {
+    func test_wireFormat_snakeCaseKeys() throws {
         let payload = MemberProfile(
             alias: "x",
             inboxPublicKey: Data(repeating: 0, count: 32),
@@ -40,24 +29,8 @@ final class MemberProfileTests: XCTestCase {
         let encoded = try JSONEncoder().encode(payload)
         let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         XCTAssertNotNil(obj?["sending_pubkey"],
-                        "PR 3 wire key must match Android parity")
+                        "wire key must match Android parity")
         XCTAssertNotNil(obj?["inbox_public_key"])
         XCTAssertNotNil(obj?["alias"])
-    }
-
-    func test_decoder_acceptsLegacyProfileWithoutSendingPubkey() throws {
-        // Pre-PR-3 senders (and any member who joined before PR 3
-        // shipped) won't carry `sending_pubkey`. Receivers must
-        // decode those into a profile with `sendingPubkey == nil` so
-        // the group still materializes; PR 4's dispatcher then falls
-        // back to BLS-claim trust for that member.
-        let inbox = Data(repeating: 0, count: 32).base64EncodedString()
-        let legacy = #"""
-        {"alias":"Bob","inbox_public_key":"\#(inbox)"}
-        """#
-        let bytes = legacy.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(MemberProfile.self, from: bytes)
-        XCTAssertNil(decoded.sendingPubkey)
-        XCTAssertEqual(decoded.alias, "Bob")
     }
 }

--- a/Tests/OnymIOSTests/MemberProfileTests.swift
+++ b/Tests/OnymIOSTests/MemberProfileTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import OnymIOS
+
+/// Wire-format pin for `MemberProfile`. The struct rides inside two
+/// other payloads (`GroupInvitationPayload.memberProfiles` and as a
+/// stored value in `ChatGroup.memberProfiles`), so the shape needs
+/// independent coverage — a regression here breaks both transport
+/// and persistence at once.
+final class MemberProfileTests: XCTestCase {
+
+    func test_roundtrip_withSendingPubkey_preservesAllFields() throws {
+        let original = MemberProfile(
+            alias: "Bob",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: Data(repeating: 0xEE, count: 32)
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MemberProfile.self, from: encoded)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.sendingPubkey, Data(repeating: 0xEE, count: 32))
+    }
+
+    func test_roundtrip_withoutSendingPubkey_decodesAsNil() throws {
+        let original = MemberProfile(
+            alias: "Bob",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32)
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MemberProfile.self, from: encoded)
+        XCTAssertNil(decoded.sendingPubkey)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_wireFormat_snakeCaseKey() throws {
+        let payload = MemberProfile(
+            alias: "x",
+            inboxPublicKey: Data(repeating: 0, count: 32),
+            sendingPubkey: Data(repeating: 0, count: 32)
+        )
+        let encoded = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNotNil(obj?["sending_pubkey"],
+                        "PR 3 wire key must match Android parity")
+        XCTAssertNotNil(obj?["inbox_public_key"])
+        XCTAssertNotNil(obj?["alias"])
+    }
+
+    func test_decoder_acceptsLegacyProfileWithoutSendingPubkey() throws {
+        // Pre-PR-3 senders (and any member who joined before PR 3
+        // shipped) won't carry `sending_pubkey`. Receivers must
+        // decode those into a profile with `sendingPubkey == nil` so
+        // the group still materializes; PR 4's dispatcher then falls
+        // back to BLS-claim trust for that member.
+        let inbox = Data(repeating: 0, count: 32).base64EncodedString()
+        let legacy = #"""
+        {"alias":"Bob","inbox_public_key":"\#(inbox)"}
+        """#
+        let bytes = legacy.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(MemberProfile.self, from: bytes)
+        XCTAssertNil(decoded.sendingPubkey)
+        XCTAssertEqual(decoded.alias, "Bob")
+    }
+}

--- a/Tests/OnymIOSTests/MemberProfileTests.swift
+++ b/Tests/OnymIOSTests/MemberProfileTests.swift
@@ -33,4 +33,43 @@ final class MemberProfileTests: XCTestCase {
         XCTAssertNotNil(obj?["inbox_public_key"])
         XCTAssertNotNil(obj?["alias"])
     }
+
+    // MARK: - Decode validation
+
+    func test_decoder_rejectsWrongSizedSendingPubkey() throws {
+        // A wrong-sized key on the wire would become a bogus
+        // verification key for PR 4. Reject at decode.
+        let inbox = Data(repeating: 0, count: 32).base64EncodedString()
+        let badSending = Data(repeating: 0, count: 31).base64EncodedString()
+        let json = #"""
+        {"alias":"x","inbox_public_key":"\#(inbox)","sending_pubkey":"\#(badSending)"}
+        """#
+        let bytes = json.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(MemberProfile.self, from: bytes)) { error in
+            XCTAssertTrue(error is MemberProfileError)
+        }
+    }
+
+    func test_decoder_rejectsWrongSizedInboxPublicKey() throws {
+        let badInbox = Data(repeating: 0, count: 31).base64EncodedString()
+        let sending = Data(repeating: 0, count: 32).base64EncodedString()
+        let json = #"""
+        {"alias":"x","inbox_public_key":"\#(badInbox)","sending_pubkey":"\#(sending)"}
+        """#
+        let bytes = json.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(MemberProfile.self, from: bytes)) { error in
+            XCTAssertTrue(error is MemberProfileError)
+        }
+    }
+
+    func test_decoder_rejectsMissingSendingPubkey() throws {
+        // Hard cutover — no `nil` migration window. Wire shapes
+        // without `sending_pubkey` must fail loudly.
+        let inbox = Data(repeating: 0, count: 32).base64EncodedString()
+        let json = #"""
+        {"alias":"x","inbox_public_key":"\#(inbox)"}
+        """#
+        let bytes = json.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(MemberProfile.self, from: bytes))
+    }
 }

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -59,11 +59,13 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         let profiles: [String: MemberProfile] = [
             aliceHex: MemberProfile(
                 alias: "alice",
-                inboxPublicKey: Data(repeating: 0xAA, count: 32)
+                inboxPublicKey: Data(repeating: 0xAA, count: 32),
+                sendingPubkey: Data(repeating: 0xE1, count: 32)
             ),
             bobHex: MemberProfile(
                 alias: "bob",
-                inboxPublicKey: Data(repeating: 0xBB, count: 32)
+                inboxPublicKey: Data(repeating: 0xBB, count: 32),
+                sendingPubkey: Data(repeating: 0xE2, count: 32)
             ),
         ]
         let group = makeGroup(


### PR DESCRIPTION
**Insider-spoofing fix.** Plumbs the per-member Ed25519 sending pubkey (== `Identity.stellarPublicKey`, the key that already signs every `SealedEnvelope`) end-to-end through the join + invite flows. **Sets up PR 4's chat dispatcher to verify a chat message's envelope signature against the claimed BLS sender.** Without this, a group member could forge another member's `senderBlsPubkeyHex` claim — the BLS pubkey alone is a claim, not a proof.

## Wire compatibility — hard cutover, no migration window

Pre-release, no installed base of join requests or member announcements. All three new fields are **required** on the wire and at construction; receivers throw at decode if missing or wrong-sized.

| Type | New field | Wire key |
|---|---|---|
| `MemberProfile` | `sendingPubkey: Data` | `sending_pubkey` |
| `MemberAnnouncementPayload.AnnouncedMember` | `sendingPub: Data` | `sending_pub` |
| `JoinRequestPayload` | `joinerSendingPublicKey: Data` | `joiner_sending_pub` |
| `IdentitySummary` | `sendingPublicKey: Data` (internal projection only) | n/a |

All three wire-shipped types validate `count == 32` at decode (`MemberProfile.init(from:)`, `AnnouncedMember.init(from:)`, `JoinRequestPayload.init(from:)`). Wrong-sized or missing values throw a `*Error.shape(...)`. No `nil` fallback in PR 4's dispatcher — wire shapes that decode produce a real 32-byte verification key by construction.

## Population sites
- **`JoinRequestSender`** — joiner ships their own Ed25519 pubkey to the admin.
- **`JoinRequestApprover`** — admin reads from request, stores on local roster (`recordJoiner`), broadcasts via the fan-out announcement (`broadcastJoin`).
- **`IncomingMessageDispatcher`** — joiner reads from incoming `MemberAnnouncementPayload` + the inviting `GroupInvitationPayload.memberProfiles`. Self-profile populated via `IdentitySummary.sendingPublicKey`.
- **`CreateGroupInteractor`** — creator stamps their own Ed25519 pubkey into their own profile so it rides on the `GroupInvitationPayload` to every joiner.
- **`JoinRequestApprover.PendingRequest`** — new field carries it through approval UI plumbing.

## Out of scope
Verification logic — that lands in PR 4 along with the chat dispatcher branch.

## Test plan
- [x] `MemberProfileTests` (new) — 5 tests: roundtrip, snake_case wire pin, wrong-sized `sending_pubkey` rejected, wrong-sized `inbox_public_key` rejected, missing `sending_pubkey` rejected.
- [x] `MemberAnnouncementPayloadTests` +2 — `sending_pub` wire pin, wrong-sized rejection. The existing back-compat decode tests were updated to ship `sending_pub` since it's now required.
- [x] `JoinRequestPayloadTests` +3 — `joiner_sending_pub` wire pin, wrong-sized rejection, and the **renamed** `test_decoder_acceptsLegacyPayloadWithoutBlsPub` → `test_decoder_acceptsPayloadWithoutBlsPub` (still verifies `joiner_bls_pub` stays optional — that field is unrelated to this PR's cutover).
- [x] Constructor-adapter updates in `ApproveRequestsFlowTests`, `IncomingMessageDispatcherTests`, `SwiftDataGroupStoreTests`, `JoinRequestApproverTests`, `GroupInvitationPayloadTests` — all passing real 32-byte values.
- [x] Full `OnymIOSTests` suite — 528 / 528 pass (3 pre-existing skips, 0 regressions).

## Commits
1. Initial plumbing (with optional fallback).
2. `fixup: drop optionality on new sendingPubkey fields` — non-optional cutover, dropped the legacy-shape back-compat tests.
3. `fix(MemberProfile): validate field lengths at decode boundary` — addresses review point about `MemberProfile` using synthesized `Codable` and skipping length validation.

## Plan context
PR 3 of 11. **PR 1** (#147) added the wire-format payload. **PR 2** (#148) added persistence. **PR 4 next**: dispatcher branch + `SendMessageInteractor` + envelope-signature verification against this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)