### PR TITLE
feat(chats): wire chat-message transport directions (PR 4/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/Chats/SendMessageInteractor.swift
+++ b/Sources/OnymIOS/Chats/SendMessageInteractor.swift
@@ -1,0 +1,197 @@
+import Foundation
+import CryptoKit
+
+/// Outgoing-message pipeline: persist a `.pending` row locally,
+/// seal + ship one envelope per other group member, then flip the
+/// status to `.sent` (at least one relay accepted) or `.failed`
+/// (every send threw or no relay accepted).
+///
+/// Mirrors `CreateGroupInteractor.sendInvitations` shape — same
+/// `sealInvitation` + `InboxTransport.send` per recipient, same
+/// inbox-tag derivation. The local insert happens *before* the fan-
+/// out so the chat thread sees the bubble immediately; the status
+/// flip is the UI's signal that the network is done.
+actor SendMessageInteractor {
+    private let identity: IdentityRepository
+    private let inboxTransport: any InboxTransport
+    private let messageRepository: MessageRepository
+    private let groupRepository: GroupRepository
+
+    enum SendError: Error, Equatable {
+        case noIdentityLoaded
+        case unknownGroup
+        /// Current identity isn't in the group's `memberProfiles`. The
+        /// roster lookup is by BLS pubkey hex, so this fires when the
+        /// creator's own profile was never recorded (shouldn't happen
+        /// post-PR-3) or when the active identity switched mid-flight.
+        case senderNotAMember
+        /// Caller-side guard. Empty bodies are technically valid on
+        /// the wire (the payload encodes them) but the interactor
+        /// refuses to ship them — a no-op send would burn a relay
+        /// publish for nothing.
+        case emptyBody
+    }
+
+    init(
+        identity: IdentityRepository,
+        inboxTransport: any InboxTransport,
+        messageRepository: MessageRepository,
+        groupRepository: GroupRepository
+    ) {
+        self.identity = identity
+        self.inboxTransport = inboxTransport
+        self.messageRepository = messageRepository
+        self.groupRepository = groupRepository
+    }
+
+    /// Returns the locally-persisted `ChatMessage` after the fan-out
+    /// completes. The returned row always reflects the final status
+    /// (`.sent` or `.failed`) — callers that want the optimistic
+    /// `.pending` view subscribe to `MessageRepository.snapshots`.
+    @discardableResult
+    func send(
+        groupID: String,
+        body: String,
+        now: Date = Date()
+    ) async throws -> ChatMessage {
+        guard !body.isEmpty else { throw SendError.emptyBody }
+
+        guard let active = await identity.currentIdentity() else {
+            throw SendError.noIdentityLoaded
+        }
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }) else {
+            throw SendError.unknownGroup
+        }
+
+        let myBlsHex = active.blsPublicKey
+            .map { String(format: "%02x", $0) }.joined()
+        guard group.memberProfiles[myBlsHex] != nil else {
+            throw SendError.senderNotAMember
+        }
+
+        // Variant is governance-keyed; today only Tyranny ships.
+        // Other group types throw at the payload layer because their
+        // variants aren't implemented yet — PR 4 only supports the
+        // tyranny case end-to-end.
+        let variant: ChatMessageVariant
+        switch group.groupType {
+        case .tyranny:
+            variant = .tyranny(body: body)
+        case .oneOnOne, .anarchy, .democracy, .oligarchy:
+            throw SendError.unknownGroup  // surfaces as "not supported"
+        }
+
+        let messageID = UUID()
+        let sentAtMillis = Int64(now.timeIntervalSince1970 * 1000)
+        let payload = ChatMessagePayload(
+            version: 1,
+            messageID: messageID,
+            groupID: group.groupIDData,
+            senderBlsPubkeyHex: myBlsHex,
+            sentAtMillis: sentAtMillis,
+            variant: variant
+        )
+
+        // Optimistic insert — chat UI sees the bubble immediately.
+        // Status flips later after the fan-out completes; the bubble
+        // never disappears (re-tries flip pending → sent again, not
+        // back to a different id).
+        let pending = ChatMessage(
+            id: messageID,
+            groupID: groupID,
+            ownerIdentityID: group.ownerIdentityID,
+            senderBlsPubkeyHex: myBlsHex,
+            body: body,
+            sentAt: now,
+            direction: .outgoing,
+            status: .pending,
+            groupType: group.groupType
+        )
+        await messageRepository.insert(pending)
+
+        // Fan out to every member except self. Best-effort per
+        // recipient — one failed send doesn't doom the whole message;
+        // we mark `.sent` if at least one relay accepted any envelope.
+        let recipients = group.memberProfiles
+            .filter { $0.key != myBlsHex }
+            .map { $0.value.inboxPublicKey }
+
+        let payloadBytes: Data
+        do {
+            payloadBytes = try JSONEncoder().encode(payload)
+        } catch {
+            // Encoding failure is a programmer error (Data field
+            // can't fail at JSON encode); mark failed and surface.
+            await messageRepository.updateStatus(
+                id: messageID,
+                status: .failed,
+                groupID: groupID
+            )
+            return ChatMessage(
+                id: pending.id,
+                groupID: pending.groupID,
+                ownerIdentityID: pending.ownerIdentityID,
+                senderBlsPubkeyHex: pending.senderBlsPubkeyHex,
+                body: pending.body,
+                sentAt: pending.sentAt,
+                direction: pending.direction,
+                status: .failed,
+                groupType: pending.groupType
+            )
+        }
+
+        var successCount = 0
+        for inboxKey in recipients {
+            do {
+                let sealed = try await identity.sealInvitation(
+                    payload: payloadBytes,
+                    to: inboxKey
+                )
+                let receipt = try await inboxTransport.send(
+                    sealed,
+                    to: TransportInboxID(rawValue: Self.inboxTag(from: inboxKey))
+                )
+                if receipt.acceptedBy >= 1 { successCount += 1 }
+            } catch {
+                // Swallow — best-effort per recipient.
+                continue
+            }
+        }
+
+        // Empty roster (only the sender is a member) is fine — the
+        // message is local-only. Anything with recipients must reach
+        // at least one to count as sent.
+        let finalStatus: MessageStatus =
+            recipients.isEmpty || successCount > 0 ? .sent : .failed
+        await messageRepository.updateStatus(
+            id: messageID,
+            status: finalStatus,
+            groupID: groupID
+        )
+
+        return ChatMessage(
+            id: pending.id,
+            groupID: pending.groupID,
+            ownerIdentityID: pending.ownerIdentityID,
+            senderBlsPubkeyHex: pending.senderBlsPubkeyHex,
+            body: pending.body,
+            sentAt: pending.sentAt,
+            direction: pending.direction,
+            status: finalStatus,
+            groupType: pending.groupType
+        )
+    }
+
+    /// Same derivation as `IdentityRepository.inboxTag(from:)` —
+    /// duplicated here because the repo's helper is private and we
+    /// only need the formula, not the keychain lookup. Matches
+    /// `CreateGroupInteractor.inboxTag(from:)`.
+    private static func inboxTag(from inboxPublicKey: Data) -> String {
+        var hasher = SHA256()
+        hasher.update(data: Data("sep-inbox-v1".utf8))
+        hasher.update(data: inboxPublicKey)
+        let hash = hasher.finalize()
+        return hash.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -45,6 +45,11 @@ struct IncomingMessageDispatcher: Sendable {
     /// `commitment` field fetch the live state via this seam and
     /// reject on mismatch.
     let chainState: any ChainStateReading
+    /// Persistence target for incoming chat messages. The dispatcher
+    /// looks up the sender's `MemberProfile.sendingPubkey`, verifies
+    /// the envelope's Ed25519 signer matches, and writes the message
+    /// here for the chat screen to render.
+    let messageRepository: MessageRepository
 
     func dispatch(
         messageID: String,
@@ -92,6 +97,22 @@ struct IncomingMessageDispatcher: Sendable {
         ) {
             await materializeGroup(
                 invitation,
+                ownerIdentityID: ownerIdentityID,
+                senderEd25519PublicKey: envelope.senderEd25519PublicKey
+            )
+            return
+        }
+
+        // Fast path 3: ChatMessagePayload — body of the chat thread.
+        // Verifies the envelope's Ed25519 signer matches the claimed
+        // sender's `MemberProfile.sendingPubkey` (insider-spoof
+        // defense, PR 3), then persists via `messageRepository`.
+        if let chatMessage = try? JSONDecoder().decode(
+            ChatMessagePayload.self,
+            from: envelope.plaintext
+        ) {
+            await persistChatMessage(
+                chatMessage,
                 ownerIdentityID: ownerIdentityID,
                 senderEd25519PublicKey: envelope.senderEd25519PublicKey
             )
@@ -396,5 +417,84 @@ struct IncomingMessageDispatcher: Sendable {
             sendingPubkey: payload.newMember.sendingPub
         )
         await groupRepository.insert(updated)
+    }
+
+    /// Persist an incoming chat message after authenticating the
+    /// sender. The trust chain:
+    ///
+    ///   1. The envelope was decrypted to us, so the sender knew our
+    ///      inbox pubkey (a group-membership-gated secret).
+    ///   2. The envelope's Ed25519 signer was verified by
+    ///      `decryptInvitationWithSender` — `senderEd25519PublicKey`
+    ///      is *who* signed, not just *what was claimed*.
+    ///   3. The payload's `senderBlsPubkeyHex` claim is cross-checked
+    ///      against `memberProfiles[claim].sendingPubkey`: if the
+    ///      envelope's signer matches the stored Ed25519 for the
+    ///      claimed BLS member, the claim is authentic.
+    ///
+    /// Receive-side dedup happens in `MessageRepository.insert`
+    /// (idempotent on `message.id`).
+    private func persistChatMessage(
+        _ payload: ChatMessagePayload,
+        ownerIdentityID: IdentityID,
+        senderEd25519PublicKey: Data?
+    ) async {
+        // Envelope must have been signed — anonymous chat messages
+        // are not part of the v1 trust model.
+        guard let senderEd25519PublicKey else { return }
+
+        // Look up the local group. Drop if we don't know it (stale
+        // delivery for a group we left, or routing mistake) or if it
+        // belongs to a different identity than the receiving inbox.
+        let groupIDHex = payload.groupID
+            .map { String(format: "%02x", $0) }.joined()
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: {
+            $0.id == groupIDHex && $0.ownerIdentityID == ownerIdentityID
+        }) else {
+            return
+        }
+
+        // Sender must be a known member. `memberProfiles` is keyed by
+        // lowercase BLS pubkey hex; normalize the payload's claim
+        // before lookup.
+        let senderKey = payload.senderBlsPubkeyHex.lowercased()
+        guard let senderProfile = group.memberProfiles[senderKey] else {
+            return
+        }
+
+        // Insider-spoof check: the verified envelope signer must match
+        // the stored Ed25519 for the claimed BLS member. Without this,
+        // Bob (a member) could write Alice's BLS hex into the payload
+        // and the receiver would attribute it wrong.
+        guard senderEd25519PublicKey == senderProfile.sendingPubkey else {
+            return
+        }
+
+        // Variant must match the group's governance type — Tyranny
+        // payloads belong in Tyranny groups, etc. Today only Tyranny
+        // chat ships; the variant kind doubles as a forward-compat
+        // gate for when other group types come online.
+        let variantKind: SEPGroupType = {
+            switch payload.variant {
+            case .tyranny: return .tyranny
+            }
+        }()
+        guard variantKind == group.groupType else { return }
+
+        let sentAt = Date(timeIntervalSince1970:
+            TimeInterval(payload.sentAtMillis) / 1000.0)
+        let message = ChatMessage(
+            id: payload.messageID,
+            groupID: groupIDHex,
+            ownerIdentityID: ownerIdentityID,
+            senderBlsPubkeyHex: senderKey,
+            body: payload.variant.body,
+            sentAt: sentAt,
+            direction: .incoming,
+            status: .received,
+            groupType: group.groupType
+        )
+        await messageRepository.insert(message)
     }
 }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -7,6 +7,7 @@ struct OnymIOSApp: App {
     private let relayerRepository: RelayerRepository
     private let contractsRepository: ContractsRepository
     private let groupRepository: GroupRepository
+    private let messageRepository: MessageRepository
     private let inboxTransport: any InboxTransport
     private let nostrRelaysRepository: NostrRelaysRepository
     private let incomingInvitations: IncomingInvitationsRepository
@@ -85,6 +86,18 @@ struct OnymIOSApp: App {
             groupRepository = GroupRepository(store: SwiftDataGroupStore.inMemory())
         }
         self.groupRepository = groupRepository
+
+        // Chat messages — same fall-back policy as `groupRepository`
+        // (on-disk store with in-memory fallback if FileProtection /
+        // sandbox blocks the file). Separate `Messages.store` keeps
+        // schema migrations from cross-domain wipes.
+        let messageRepository: MessageRepository
+        if let store = try? SwiftDataMessageStore() {
+            messageRepository = MessageRepository(store: store)
+        } else {
+            messageRepository = MessageRepository(store: SwiftDataMessageStore.inMemory())
+        }
+        self.messageRepository = messageRepository
 
         // Inbox transport for invitation send. The endpoint list comes
         // from `NostrRelaysRepository` — read at app boot in the
@@ -304,7 +317,8 @@ struct OnymIOSApp: App {
                         identities: identityRepository,
                         groupRepository: groupRepository,
                         invitationsRepository: incomingInvitations,
-                        chainState: chainStateReader
+                        chainState: chainStateReader,
+                        messageRepository: messageRepository
                     )
                     let fanout = InboxFanoutInteractor(
                         inboxTransport: inboxTransport,

--- a/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
+++ b/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
@@ -42,7 +42,8 @@ final class InboxFanoutInteractorTests: XCTestCase {
             identities: identity,
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: FanoutNoChainState()
+            chainState: FanoutNoChainState(),
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
     }
 

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -1,0 +1,368 @@
+import XCTest
+@testable import OnymIOS
+
+/// Tests for the chat-message branch of `IncomingMessageDispatcher`.
+/// Kept separate from the announcement / invitation paths so the
+/// trust-check surface is easy to scan: every test seeds a group +
+/// member roster, then asserts whether a chat message envelope
+/// lands in `MessageRepository` or gets dropped.
+@MainActor
+final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
+
+    private var groups: GroupRepository!
+    private var invitations: IncomingInvitationsRepository!
+    private var messages: MessageRepository!
+    private var chainState: DispatcherStubChainState!
+    private var owner: IdentityID!
+
+    // Sender identity. BLS pubkey is the roster key; Ed25519 is the
+    // envelope's verified signer.
+    private let senderBlsHex = "11".repeated(48)
+    private let senderEd25519 = Data(repeating: 0xE1, count: 32)
+    private let senderInbox = Data(repeating: 0x11, count: 32)
+
+    private let groupIDBytes = Data(repeating: 0x42, count: 32)
+    private var groupIDHex: String { groupIDBytes.map { String(format: "%02x", $0) }.joined() }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        invitations = IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory())
+        messages = MessageRepository(store: SwiftDataMessageStore.inMemory())
+        chainState = DispatcherStubChainState()
+        owner = IdentityID()
+        await groups.setCurrentIdentity(owner)
+
+        // Seed a Tyranny group with the sender as a member.
+        let group = ChatGroup(
+            id: groupIDHex,
+            ownerIdentityID: owner,
+            name: "Family",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [],
+            memberProfiles: [
+                senderBlsHex: MemberProfile(
+                    alias: "Alice",
+                    inboxPublicKey: senderInbox,
+                    sendingPubkey: senderEd25519
+                )
+            ],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: true
+        )
+        _ = await groups.insert(group)
+    }
+
+    override func tearDown() async throws {
+        groups = nil
+        invitations = nil
+        messages = nil
+        chainState = nil
+        owner = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Happy path
+
+    func test_chatMessage_validSignature_persistsAsIncoming() async throws {
+        let payload = makePayload(body: "hello, group")
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored[0].body, "hello, group")
+        XCTAssertEqual(stored[0].direction, .incoming)
+        XCTAssertEqual(stored[0].status, .received)
+        XCTAssertEqual(stored[0].senderBlsPubkeyHex, senderBlsHex)
+        XCTAssertEqual(stored[0].groupType, .tyranny)
+    }
+
+    // MARK: - Drop paths
+
+    func test_chatMessage_unknownGroup_drops() async throws {
+        // Payload claims a group we don't have locally.
+        let payload = makePayload(
+            body: "hi",
+            groupIDBytes: Data(repeating: 0xFF, count: 32)
+        )
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertTrue(stored.isEmpty,
+                      "message for unknown group must not be persisted")
+    }
+
+    func test_chatMessage_senderNotInRoster_drops() async throws {
+        // Sender BLS hex doesn't appear in the group's memberProfiles.
+        let payload = makePayload(
+            body: "hi",
+            senderBlsHex: "ff".repeated(48)
+        )
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertTrue(stored.isEmpty,
+                      "message from non-member must not be persisted")
+    }
+
+    func test_chatMessage_signatureMismatch_drops() async throws {
+        // Payload claims to be from Alice (in the roster) but the
+        // envelope is signed by a different Ed25519 — i.e. Bob is
+        // trying to forge Alice's identity.
+        let payload = makePayload(body: "i am alice (lying)")
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: Data(repeating: 0xBB, count: 32)  // not Alice
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertTrue(stored.isEmpty,
+                      "envelope signed by wrong Ed25519 must be dropped (insider-spoof defense)")
+    }
+
+    func test_chatMessage_missingEnvelopeSignature_drops() async throws {
+        // Envelope decrypter returns the plaintext but no
+        // senderEd25519PublicKey — anonymous chat messages are not
+        // part of the v1 trust model.
+        let payload = makePayload(body: "hi")
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: nil
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertTrue(stored.isEmpty,
+                      "envelope without a signature must be dropped")
+    }
+
+    func test_chatMessage_wrongOwnerIdentity_drops() async throws {
+        // Group is owned by `self.owner` but the dispatch call uses a
+        // different identity. This shouldn't happen in production
+        // (inbox routing is per-identity) but guards against a
+        // delivery mistake.
+        let otherIdentity = IdentityID()
+        let payload = makePayload(body: "hi")
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: otherIdentity,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertTrue(stored.isEmpty)
+    }
+
+    func test_chatMessage_persistsForNonActiveIdentity() async throws {
+        // Multi-identity correctness: each identity has its own inbox
+        // subscription via `InboxFanoutInteractor`, and the dispatcher
+        // takes `ownerIdentityID` as a parameter (per inbox), not from
+        // an "active identity" global. Messages addressed to a
+        // non-active identity must still persist so they're visible
+        // when the user switches identities.
+        let secondIdentity = IdentityID()
+        await groups.setCurrentIdentity(owner)  // first identity stays "active"
+
+        // Seed a separate Tyranny group owned by the second identity.
+        let secondGroupBytes = Data(repeating: 0x99, count: 32)
+        let secondGroupHex = secondGroupBytes
+            .map { String(format: "%02x", $0) }.joined()
+        let secondSenderBlsHex = "22".repeated(48)
+        let secondSenderEd25519 = Data(repeating: 0xE2, count: 32)
+        let secondGroup = ChatGroup(
+            id: secondGroupHex,
+            ownerIdentityID: secondIdentity,
+            name: "Work",
+            groupSecret: Data(repeating: 0x77, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_001),
+            members: [],
+            memberProfiles: [
+                secondSenderBlsHex: MemberProfile(
+                    alias: "Eve",
+                    inboxPublicKey: Data(repeating: 0x22, count: 32),
+                    sendingPubkey: secondSenderEd25519
+                )
+            ],
+            epoch: 0,
+            salt: Data(repeating: 0x88, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: true
+        )
+        _ = await groups.insert(secondGroup)
+
+        // Dispatch a message addressed to the non-active identity.
+        let payload = ChatMessagePayload(
+            version: 1,
+            messageID: UUID(),
+            groupID: secondGroupBytes,
+            senderBlsPubkeyHex: secondSenderBlsHex,
+            sentAtMillis: 1_700_000_500_000,
+            variant: .tyranny(body: "for the second identity")
+        )
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: secondSenderEd25519
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-multi",
+            ownerIdentityID: secondIdentity,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        // First identity's group sees nothing.
+        let firstStored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertTrue(firstStored.isEmpty)
+
+        // Second identity's group has the message even though it
+        // wasn't the active identity at delivery time.
+        let secondStored = await messages.currentMessages(groupID: secondGroupHex)
+        XCTAssertEqual(secondStored.count, 1)
+        XCTAssertEqual(secondStored[0].body, "for the second identity")
+        XCTAssertEqual(secondStored[0].ownerIdentityID, secondIdentity)
+    }
+
+    func test_chatMessage_duplicateMessageID_idempotent() async throws {
+        let payload = makePayload(body: "hi", messageID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!)
+        let envelopeBytes = Data("envelope".utf8)
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519
+        )
+
+        // Same message delivered twice (Nostr re-delivery, etc.).
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: envelopeBytes,
+            receivedAt: Date()
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-1-retry",
+            ownerIdentityID: owner,
+            payload: envelopeBytes,
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertEqual(stored.count, 1,
+                       "second delivery of the same message id must be a no-op")
+    }
+
+    // MARK: - Helpers
+
+    private func makePayload(
+        body: String,
+        groupIDBytes: Data? = nil,
+        senderBlsHex: String? = nil,
+        messageID: UUID = UUID()
+    ) -> ChatMessagePayload {
+        ChatMessagePayload(
+            version: 1,
+            messageID: messageID,
+            groupID: groupIDBytes ?? self.groupIDBytes,
+            senderBlsPubkeyHex: senderBlsHex ?? self.senderBlsHex,
+            sentAtMillis: 1_700_000_000_000,
+            variant: .tyranny(body: body)
+        )
+    }
+
+    private func makeDispatcher(
+        plaintext: Data,
+        envelopeSigner: Data?
+    ) -> IncomingMessageDispatcher {
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: envelopeSigner
+        )
+        return IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: messages
+        )
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}
+
+/// Stub `IdentitiesProviding` for the chat-message dispatcher tests.
+/// The chat branch doesn't read identities (sender attribution comes
+/// from the payload, verified against `memberProfiles`), so this can
+/// always return empty. Duplicated from the announcement-test file's
+/// private stub because Swift `private` is file-scoped.
+private actor StubIdentities: IdentitiesProviding {
+    private let summaries: [IdentitySummary]
+
+    init(summaries: [IdentitySummary]) {
+        self.summaries = summaries
+    }
+
+    func currentIdentities() -> [IdentitySummary] { summaries }
+}

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -61,7 +61,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
         await dispatcher.dispatch(
@@ -96,7 +97,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
         await dispatcher.dispatch(
@@ -141,7 +143,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
         await dispatcher.dispatch(
@@ -185,7 +188,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-trust-ok",
@@ -226,7 +230,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-trust-bad",
@@ -269,7 +274,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-unsigned",
@@ -305,7 +311,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-legacy-fallback",
@@ -356,7 +363,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-cap",
@@ -390,7 +398,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-no-commitment",
@@ -434,7 +443,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-onchain-mismatch",
@@ -470,7 +480,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-internal-mismatch",
@@ -524,7 +535,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
         await dispatcher.dispatch(
             messageID: "msg-announce-mismatch",
@@ -572,7 +584,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: [selfSummary]),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
         await dispatcher.dispatch(
@@ -620,7 +633,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: [selfSummary]),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
         await dispatcher.dispatch(
@@ -658,7 +672,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
         await dispatcher.dispatch(
@@ -684,7 +699,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
         await dispatcher.dispatch(
@@ -712,7 +728,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
-            chainState: chainState
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
         await dispatcher.dispatch(

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -1,0 +1,329 @@
+import CryptoKit
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for `SendMessageInteractor`. Uses a real
+/// `IdentityRepository` (test-namespaced keychain, in-memory
+/// selection) so the `sealInvitation` path is exercised end-to-end;
+/// the transport is a `RecordingInboxTransport` that lets each test
+/// control whether sends "succeed" (acceptedBy >= 1) or "fail"
+/// (acceptedBy == 0).
+@MainActor
+final class SendMessageInteractorTests: XCTestCase {
+
+    private var identity: IdentityRepository!
+    private var transport: RecordingInboxTransport!
+    private var groups: GroupRepository!
+    private var messages: MessageRepository!
+    private var interactor: SendMessageInteractor!
+
+    // Set after `bootstrap()`. The active identity's BLS hex —
+    // matches the `senderBlsPubkeyHex` the interactor will mint.
+    private var myBlsHex: String!
+    private var myInbox: Data!
+    private var mySendingPubkey: Data!
+    private var currentIdentityID: IdentityID!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        let keychain = IdentityKeychainStore(
+            testNamespace: "send-message-\(UUID().uuidString)"
+        )
+        identity = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory()
+        )
+        // Real BIP39 vector so we get real BLS + Ed25519 keys.
+        _ = try await identity.restore(
+            mnemonic: "legal winner thank year wave sausage worth useful legal winner thank yellow"
+        )
+        let active = await identity.currentIdentity()!
+        myBlsHex = active.blsPublicKey.map { String(format: "%02x", $0) }.joined()
+        myInbox = active.inboxPublicKey
+        mySendingPubkey = active.stellarPublicKey
+        currentIdentityID = await identity.currentSelectedID()!
+
+        transport = RecordingInboxTransport()
+        groups = GroupRepository(
+            store: SwiftDataGroupStore.inMemory(),
+            currentIdentityID: currentIdentityID
+        )
+        messages = MessageRepository(store: SwiftDataMessageStore.inMemory())
+
+        interactor = SendMessageInteractor(
+            identity: identity,
+            inboxTransport: transport,
+            messageRepository: messages,
+            groupRepository: groups
+        )
+    }
+
+    override func tearDown() async throws {
+        identity = nil
+        transport = nil
+        groups = nil
+        messages = nil
+        interactor = nil
+        myBlsHex = nil
+        myInbox = nil
+        mySendingPubkey = nil
+        currentIdentityID = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Happy path
+
+    func test_send_persistsAsSent_andFansOutToOtherMembers() async throws {
+        // Group has me + two peers.
+        let groupID = await seedGroupWithTwoPeers()
+
+        let result = try await interactor.send(groupID: groupID, body: "hello")
+        XCTAssertEqual(result.status, .sent)
+        XCTAssertEqual(result.direction, .outgoing)
+        XCTAssertEqual(result.body, "hello")
+        XCTAssertEqual(result.senderBlsPubkeyHex, myBlsHex)
+
+        let sends = await transport.recordedSends
+        XCTAssertEqual(sends.count, 2,
+                       "must fan out to N-1 members (skipping self)")
+
+        let stored = await messages.currentMessages(groupID: groupID)
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored[0].status, .sent)
+    }
+
+    func test_send_skipsSelfRecipient() async throws {
+        // Even though our profile is in memberProfiles, we must not
+        // send a copy to our own inbox.
+        let groupID = await seedGroupWithTwoPeers()
+
+        _ = try await interactor.send(groupID: groupID, body: "hi")
+
+        let sentInboxes = await transport.recordedSends.map(\.inbox)
+        // Inbox tag derives from the recipient's inboxPublicKey.
+        // Self's tag must not appear.
+        let myTag = Self.inboxTag(from: myInbox)
+        XCTAssertFalse(
+            sentInboxes.contains(TransportInboxID(rawValue: myTag)),
+            "must not send to self's inbox"
+        )
+    }
+
+    func test_send_zeroOtherMembers_persistsAsSentWithNoFanout() async throws {
+        // Group has only me — no one to send to.
+        let groupID = "11".repeated(32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [
+                myBlsHex: MemberProfile(
+                    alias: "Me",
+                    inboxPublicKey: myInbox,
+                    sendingPubkey: mySendingPubkey
+                )
+            ]
+        )
+
+        let result = try await interactor.send(groupID: groupID, body: "lonely")
+        XCTAssertEqual(result.status, .sent)
+
+        let sends = await transport.recordedSends
+        XCTAssertTrue(sends.isEmpty,
+                      "no recipients → no transport sends")
+
+        let stored = await messages.currentMessages(groupID: groupID)
+        XCTAssertEqual(stored.count, 1)
+    }
+
+    // MARK: - Status transitions
+
+    func test_send_allRelaysReject_marksFailed() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        await transport.setAcceptedBy(0)
+
+        let result = try await interactor.send(groupID: groupID, body: "hi")
+        XCTAssertEqual(result.status, .failed)
+
+        let stored = await messages.currentMessages(groupID: groupID)
+        XCTAssertEqual(stored[0].status, .failed)
+    }
+
+    func test_send_oneRelayAccepts_marksSent_bestEffort() async throws {
+        // First send succeeds, second throws. With best-effort
+        // semantics, status is `.sent` because at least one envelope
+        // landed.
+        let groupID = await seedGroupWithTwoPeers()
+        await transport.setBehavior(.firstSucceedsThenThrows)
+
+        let result = try await interactor.send(groupID: groupID, body: "hi")
+        XCTAssertEqual(result.status, .sent,
+                       "best-effort: any successful relay marks the message sent")
+    }
+
+    // MARK: - Error paths
+
+    func test_send_unknownGroup_throws() async throws {
+        await assertThrows(SendMessageInteractor.SendError.unknownGroup) {
+            try await self.interactor.send(
+                groupID: "ff".repeated(32),
+                body: "hi"
+            )
+        }
+    }
+
+    func test_send_notAMember_throws() async throws {
+        // Seed a group where the current identity is NOT in
+        // memberProfiles.
+        let groupID = "22".repeated(32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [
+                "ab".repeated(48): MemberProfile(
+                    alias: "Other",
+                    inboxPublicKey: Data(repeating: 0xAB, count: 32),
+                    sendingPubkey: Data(repeating: 0xCD, count: 32)
+                )
+            ]
+        )
+
+        await assertThrows(SendMessageInteractor.SendError.senderNotAMember) {
+            try await self.interactor.send(groupID: groupID, body: "hi")
+        }
+    }
+
+    func test_send_emptyBody_throws() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        await assertThrows(SendMessageInteractor.SendError.emptyBody) {
+            try await self.interactor.send(groupID: groupID, body: "")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func seedGroupWithTwoPeers() async -> String {
+        let groupID = "44".repeated(32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [
+                myBlsHex: MemberProfile(
+                    alias: "Me",
+                    inboxPublicKey: myInbox,
+                    sendingPubkey: mySendingPubkey
+                ),
+                "aa".repeated(48): MemberProfile(
+                    alias: "Alice",
+                    inboxPublicKey: Data(repeating: 0xA1, count: 32),
+                    sendingPubkey: Data(repeating: 0xE1, count: 32)
+                ),
+                "bb".repeated(48): MemberProfile(
+                    alias: "Bob",
+                    inboxPublicKey: Data(repeating: 0xB1, count: 32),
+                    sendingPubkey: Data(repeating: 0xE2, count: 32)
+                ),
+            ]
+        )
+        return groupID
+    }
+
+    private func seedGroup(
+        groupID: String,
+        memberProfiles: [String: MemberProfile]
+    ) async {
+        let group = ChatGroup(
+            id: groupID,
+            ownerIdentityID: currentIdentityID,
+            name: "Group",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [],
+            memberProfiles: memberProfiles,
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: myBlsHex,
+            adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: true
+        )
+        _ = await groups.insert(group)
+    }
+
+    private func assertThrows<E: Error & Equatable>(
+        _ expected: E,
+        _ block: @escaping () async throws -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            try await block()
+            XCTFail("expected throw of \(expected)", file: file, line: line)
+        } catch let error as E {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("expected \(expected), got \(error)", file: file, line: line)
+        }
+    }
+
+    private static func inboxTag(from inboxPublicKey: Data) -> String {
+        // Same derivation as `SendMessageInteractor.inboxTag(from:)`.
+        let prefix = Data("sep-inbox-v1".utf8) + inboxPublicKey
+        let digest = SHA256.hash(data: prefix)
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}
+
+/// Recording transport with a configurable success behavior. Each
+/// test calls `setAcceptedBy` or `setBehavior` before driving the
+/// interactor; the recorded sends are available via `recordedSends`.
+private actor RecordingInboxTransport: InboxTransport {
+    struct Record: Sendable {
+        let payload: Data
+        let inbox: TransportInboxID
+    }
+
+    enum Behavior: Sendable {
+        case constantAcceptedBy(Int)
+        case firstSucceedsThenThrows
+    }
+
+    private(set) var recordedSends: [Record] = []
+    private var behavior: Behavior = .constantAcceptedBy(1)
+    private var sendCount = 0
+
+    func setAcceptedBy(_ count: Int) {
+        behavior = .constantAcceptedBy(count)
+    }
+
+    func setBehavior(_ b: Behavior) {
+        behavior = b
+    }
+
+    func connect(to endpoints: [TransportEndpoint]) async {}
+    func disconnect() async {}
+
+    func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
+        recordedSends.append(Record(payload: payload, inbox: inbox))
+        sendCount += 1
+        switch behavior {
+        case .constantAcceptedBy(let n):
+            return PublishReceipt(messageID: "fake-\(UUID().uuidString)", acceptedBy: n)
+        case .firstSucceedsThenThrows:
+            if sendCount == 1 {
+                return PublishReceipt(messageID: "fake-\(UUID().uuidString)", acceptedBy: 1)
+            }
+            throw NSError(domain: "test", code: 1)
+        }
+    }
+
+    nonisolated func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
+        AsyncStream { _ in }
+    }
+    func unsubscribe(inbox: TransportInboxID) async {}
+}


### PR DESCRIPTION
**Both directions wired in one PR — symmetric, paired because they share `ChatMessagePayload`.** With PRs 1-3 underneath, two users in a Tyranny group can now exchange encrypted text end-to-end at the data + transport layer. No UI yet.

## Stacked on
This PR's branch is stacked on PRs #147, #148, #149 (chat-stack PRs 1, 2, 3). Once those merge to main, rebase this onto main and the predecessor commits drop out.

## Receive — `IncomingMessageDispatcher` chat-message branch

New third fast path on `dispatch()`: try-decode plaintext as a `ChatMessagePayload`. On match, run the trust chain:

1. **Envelope must have been signed** — guard `senderEd25519PublicKey` is non-nil. Anonymous chat messages aren't part of the v1 trust model.
2. **Group lookup** — payload's `group_id` must match a local `ChatGroup` owned by the receiving identity. Multi-identity correct: `groupRepository.currentGroups()` returns all cached groups across identities; the filter uses the `ownerIdentityID` parameter passed to `dispatch` (each identity's `InboxFanoutInteractor` subscription supplies the right value).
3. **Sender lookup** — payload's `sender_bls_pubkey_hex` must be in the group's `memberProfiles`.
4. **Insider-spoof check** — envelope's verified Ed25519 signer must equal that member's stored `MemberProfile.sendingPubkey`. Closes the gap PR 3 (#149) set up; without this, any group member could write another's BLS hex into the payload and the receiver would mis-attribute.
5. **Variant gate** — variant must match the group's governance type.
6. **Persist** via `messageRepository.insert` (idempotent on `messageID` so Nostr re-delivery is a no-op).

Dispatcher gains a `messageRepository: MessageRepository` field; production wiring in `OnymIOSApp` instantiates one alongside `GroupRepository` with the same on-disk-or-in-memory fallback.

## Send — `SendMessageInteractor`

Optimistic-insert pipeline mirroring `CreateGroupInteractor.sendInvitations`:

1. Validate (identity loaded, group exists, current identity is in roster, body non-empty, variant matches governance).
2. Mint `messageID` + payload, persist locally as `.pending` so the chat thread shows the bubble immediately.
3. Fan out one sealed envelope per **other** member's inbox key — best-effort, swallow per-recipient failures.
4. Flip status: `.sent` if any relay accepted (or no recipients), `.failed` if all sends rejected.

Today only the `.tyranny` variant ships; other group types throw `unknownGroup` until their variants come online.

## Tests
- **`IncomingMessageDispatcherChatMessageTests`** (8): happy path, unknown group / sender / signature mismatch / missing signature / wrong owner identity / **non-active identity (proves multi-identity)** / duplicate messageID idempotency.
- **`SendMessageInteractorTests`** (8): persist + fan out, skip self recipient, zero peers, all-fail / partial-fail status, error paths (unknown group, not a member, empty body).
- Existing dispatcher tests adapted to pass a `MessageRepository`.
- Full suite: **573 / 573**, 0 regressions.

## Multi-identity correctness (called out)
A specific test (`test_chatMessage_persistsForNonActiveIdentity`) seeds two identities, leaves identity A active, and dispatches a message addressed to identity B's inbox. Asserts the message lands in identity B's group regardless. The dispatcher reads `groups.currentGroups()` (unfiltered) and routes by the `ownerIdentityID` parameter, so inbox fan-out per identity does the right thing.

## Out of scope
UI — that's PR 5+ (`ChatThreadViewController`, UIKit shell, input panel, etc).

## Plan context
PR 4 of 11. **PR 1** (#147) — payload type. **PR 2** (#148) — persistence. **PR 3** (#149) — Ed25519 sender pubkey plumbing. **PR 5 next**: UIKit `ChatThreadViewController` skeleton + SwiftUI bridge + replace `ChatMembersView` entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)