### PR TITLE
feat(chats): UIKit chat-thread shell + SwiftUI bridge (PR 5/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// SwiftUI host for `ChatThreadViewController`. The chat screen is
+/// UIKit (per the design call on #150) but the surrounding app is
+/// SwiftUI, so this wrapper:
+///
+/// 1. Embeds the controller via `UIViewControllerRepresentable`.
+/// 2. Hides the SwiftUI nav bar — the controller paints its own.
+/// 3. Pipes the controller's back tap through `Environment(\.dismiss)`
+///    so the surrounding `NavigationStack` pops cleanly.
+/// 4. Pushes `ChatMembersView` when the controller fires its
+///    "info tapped" closure, via `navigationDestination(isPresented:)`.
+///
+/// The group name is computed reactively from `chatsFlow` and pushed
+/// into the controller on every render — `updateUIViewController`
+/// keeps the title in sync as the group renames without re-creating
+/// the controller.
+struct ChatThreadView: View {
+    let groupID: String
+    @Bindable var chatsFlow: ChatsFlow
+    @Bindable var identitiesFlow: IdentitiesFlow
+    let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showMembers: Bool = false
+
+    var body: some View {
+        ChatThreadControllerBridge(
+            groupName: currentGroupName,
+            onBack: { dismiss() },
+            onShowMembers: { showMembers = true }
+        )
+        .toolbar(.hidden, for: .navigationBar)
+        .navigationDestination(isPresented: $showMembers) {
+            ChatMembersView(
+                groupID: groupID,
+                chatsFlow: chatsFlow,
+                identitiesFlow: identitiesFlow,
+                makeShareInviteFlow: makeShareInviteFlow
+            )
+        }
+    }
+
+    private var currentGroupName: String {
+        chatsFlow.groups.first { $0.id == groupID }?.name ?? "Chat"
+    }
+}
+
+private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
+    let groupName: String
+    let onBack: () -> Void
+    let onShowMembers: () -> Void
+
+    func makeUIViewController(context: Context) -> ChatThreadViewController {
+        let vc = ChatThreadViewController()
+        vc.onBack = onBack
+        vc.onShowMembers = onShowMembers
+        vc.loadViewIfNeeded()
+        vc.update(groupName: groupName)
+        return vc
+    }
+
+    func updateUIViewController(_ vc: ChatThreadViewController, context: Context) {
+        // Closures are refreshed every render — SwiftUI captures the
+        // *current* `dismiss` + `showMembers` setters, so the version
+        // the controller invokes always reflects the live binding.
+        vc.onBack = onBack
+        vc.onShowMembers = onShowMembers
+        vc.update(groupName: groupName)
+    }
+}

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+import UIKit
+
+/// Top-level chat-screen controller. UIKit-first per the design call
+/// (#150 plan): nav bar, message list, and input panel are all
+/// UIKit. SwiftUI hosts this controller via `ChatThreadView`.
+///
+/// PR 5 scope — skeleton only:
+/// - Custom title bar at the top (back chevron, group name, info
+///   button). SwiftUI's nav bar is hidden by the wrapper.
+/// - Empty `UITableView` placeholder where messages will render in
+///   PR 6.
+/// - Empty `UIView` placeholder where the input panel + send button
+///   will land in PR 6 / PR 7.
+///
+/// No keyboard handling, no message rendering, no send — those
+/// arrive in later PRs. Tapping the info button forwards to the
+/// SwiftUI parent, which pushes `ChatMembersView` via
+/// `navigationDestination(isPresented:)`.
+final class ChatThreadViewController: UIViewController {
+    /// Invoked when the user taps the back chevron. The SwiftUI
+    /// wrapper points this at `Environment(\.dismiss)` so the
+    /// existing `NavigationStack` pops correctly.
+    var onBack: (() -> Void)?
+
+    /// Invoked when the user taps the info button. The SwiftUI
+    /// wrapper toggles a `@State` flag that triggers the members-
+    /// view push.
+    var onShowMembers: (() -> Void)?
+
+    private let titleLabel = UILabel()
+    private let backButton = UIButton(type: .system)
+    private let infoButton = UIButton(type: .system)
+    private let topBar = UIView()
+    private let topBarSeparator = UIView()
+    private let tableView = UITableView()
+    private let inputPanel = UIView()
+    private let inputPanelSeparator = UIView()
+    private let inputPlaceholderLabel = UILabel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor(OnymTokens.bg)
+        buildTopBar()
+        buildTableView()
+        buildInputPanel()
+        layout()
+    }
+
+    /// Push a new group-name into the title. Called by the SwiftUI
+    /// wrapper on every render — keeps the bar in sync as the group
+    /// renames (PR 9 polish) without re-creating the controller.
+    func update(groupName: String) {
+        titleLabel.text = groupName.isEmpty ? "Chat" : groupName
+    }
+
+    // MARK: - Top bar
+
+    private func buildTopBar() {
+        topBar.backgroundColor = UIColor(OnymTokens.bg)
+        topBar.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(topBar)
+
+        // Back chevron. SF Symbol chevron.left at semantic accent so
+        // it reads as a tap target in both light and dark.
+        var backConfig = UIButton.Configuration.plain()
+        backConfig.image = UIImage(systemName: "chevron.left",
+                                   withConfiguration: UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold))
+        backConfig.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+        backButton.configuration = backConfig
+        backButton.tintColor = UIColor(OnymTokens.text2)
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        backButton.addTarget(self, action: #selector(tappedBack), for: .touchUpInside)
+        backButton.accessibilityLabel = "Back"
+        backButton.accessibilityIdentifier = "chat.back"
+        topBar.addSubview(backButton)
+
+        titleLabel.font = .systemFont(ofSize: 16, weight: .semibold)
+        titleLabel.textColor = UIColor(OnymTokens.text)
+        titleLabel.textAlignment = .center
+        titleLabel.text = "Chat"
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.accessibilityIdentifier = "chat.title"
+        topBar.addSubview(titleLabel)
+
+        var infoConfig = UIButton.Configuration.plain()
+        infoConfig.image = UIImage(systemName: "info.circle",
+                                   withConfiguration: UIImage.SymbolConfiguration(pointSize: 17, weight: .regular))
+        infoConfig.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+        infoButton.configuration = infoConfig
+        infoButton.tintColor = UIColor(OnymTokens.text2)
+        infoButton.translatesAutoresizingMaskIntoConstraints = false
+        infoButton.addTarget(self, action: #selector(tappedInfo), for: .touchUpInside)
+        infoButton.accessibilityLabel = "Group info"
+        infoButton.accessibilityIdentifier = "chat.info"
+        topBar.addSubview(infoButton)
+
+        topBarSeparator.backgroundColor = UIColor(OnymTokens.hairline)
+        topBarSeparator.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(topBarSeparator)
+    }
+
+    // MARK: - Table view (messages placeholder)
+
+    private func buildTableView() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = UIColor(OnymTokens.bg)
+        tableView.separatorStyle = .none
+        // No data source yet — PR 6 attaches a diffable data source
+        // and a custom bubble cell. Empty table renders as a blank
+        // background, which is the desired PR-5 visual.
+        view.addSubview(tableView)
+    }
+
+    // MARK: - Input panel placeholder
+
+    private func buildInputPanel() {
+        inputPanel.backgroundColor = UIColor(OnymTokens.surface2)
+        inputPanel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(inputPanel)
+
+        inputPanelSeparator.backgroundColor = UIColor(OnymTokens.hairline)
+        inputPanelSeparator.translatesAutoresizingMaskIntoConstraints = false
+        inputPanel.addSubview(inputPanelSeparator)
+
+        // Placeholder copy so the panel is visible during PR 5
+        // without doing anything yet. PR 6 replaces the label with
+        // a real UITextView + send button.
+        inputPlaceholderLabel.text = "Message input lands in PR 6"
+        inputPlaceholderLabel.font = .systemFont(ofSize: 14)
+        inputPlaceholderLabel.textColor = UIColor(OnymTokens.text3)
+        inputPlaceholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        inputPanel.addSubview(inputPlaceholderLabel)
+    }
+
+    // MARK: - Layout
+
+    private func layout() {
+        let safeArea = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+            // Top bar — pinned to the safe area, fixed 44pt height
+            // (matches iOS nav bar default).
+            topBar.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            topBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topBar.heightAnchor.constraint(equalToConstant: 44),
+
+            backButton.leadingAnchor.constraint(equalTo: topBar.leadingAnchor, constant: 8),
+            backButton.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            backButton.widthAnchor.constraint(equalToConstant: 36),
+            backButton.heightAnchor.constraint(equalToConstant: 36),
+
+            infoButton.trailingAnchor.constraint(equalTo: topBar.trailingAnchor, constant: -8),
+            infoButton.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            infoButton.widthAnchor.constraint(equalToConstant: 36),
+            infoButton.heightAnchor.constraint(equalToConstant: 36),
+
+            titleLabel.centerXAnchor.constraint(equalTo: topBar.centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor, constant: 8),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: infoButton.leadingAnchor, constant: -8),
+
+            topBarSeparator.topAnchor.constraint(equalTo: topBar.bottomAnchor),
+            topBarSeparator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topBarSeparator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topBarSeparator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+
+            // Table view — fills the space between the top bar and
+            // the input panel.
+            tableView.topAnchor.constraint(equalTo: topBarSeparator.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: inputPanel.topAnchor),
+
+            // Input panel — pinned to the safe-area bottom, fixed
+            // 56pt height for PR 5. PR 6 swaps this for a layout
+            // that grows with the text view (up to a 3-line cap).
+            inputPanel.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            inputPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            inputPanel.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            inputPanel.heightAnchor.constraint(equalToConstant: 56),
+
+            inputPanelSeparator.topAnchor.constraint(equalTo: inputPanel.topAnchor),
+            inputPanelSeparator.leadingAnchor.constraint(equalTo: inputPanel.leadingAnchor),
+            inputPanelSeparator.trailingAnchor.constraint(equalTo: inputPanel.trailingAnchor),
+            inputPanelSeparator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+
+            inputPlaceholderLabel.leadingAnchor.constraint(equalTo: inputPanel.leadingAnchor, constant: 16),
+            inputPlaceholderLabel.centerYAnchor.constraint(equalTo: inputPanel.centerYAnchor),
+        ])
+    }
+
+    // MARK: - Actions
+
+    @objc private func tappedBack() { onBack?() }
+    @objc private func tappedInfo() { onShowMembers?() }
+}

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -121,7 +121,12 @@ struct ChatsView: View {
         }
         .listStyle(.plain)
         .navigationDestination(for: String.self) { groupID in
-            ChatMembersView(
+            // PR 5 of the chat stack: tapping a group opens the
+            // UIKit chat thread instead of the members roster. The
+            // thread's info button pushes `ChatMembersView` from
+            // there, so the existing surface is still reachable —
+            // just one tap deeper.
+            ChatThreadView(
                 groupID: groupID,
                 chatsFlow: flow,
                 identitiesFlow: identitiesFlow,

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import OnymIOS
+
+/// Smoke tests for `ChatThreadViewController`. PR 5 ships an empty
+/// shell — these tests pin the wiring contract the SwiftUI bridge
+/// depends on:
+///
+///   - `viewDidLoad` doesn't crash.
+///   - `update(groupName:)` writes through to a label the bridge
+///     calls every render.
+///   - The back / info buttons invoke their closures when tapped.
+///
+/// Message rendering, input, keyboard behavior arrive in later PRs;
+/// the assertions here are intentionally narrow so they don't
+/// constrain the layout work yet to come.
+@MainActor
+final class ChatThreadViewControllerTests: XCTestCase {
+
+    func test_loadView_doesNotCrash() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        XCTAssertNotNil(vc.view)
+    }
+
+    func test_updateGroupName_writesThroughToTitleLabel() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.update(groupName: "Family")
+        XCTAssertEqual(titleLabel(in: vc)?.text, "Family")
+    }
+
+    func test_updateGroupName_emptyFallsBackToChat() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.update(groupName: "")
+        XCTAssertEqual(titleLabel(in: vc)?.text, "Chat",
+                       "empty group names fall back to the generic title so the bar isn't blank")
+    }
+
+    func test_backButtonTap_invokesOnBackClosure() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        var backCount = 0
+        vc.onBack = { backCount += 1 }
+        backButton(in: vc)?.sendActions(for: .touchUpInside)
+        XCTAssertEqual(backCount, 1)
+    }
+
+    func test_infoButtonTap_invokesOnShowMembersClosure() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        var showCount = 0
+        vc.onShowMembers = { showCount += 1 }
+        infoButton(in: vc)?.sendActions(for: .touchUpInside)
+        XCTAssertEqual(showCount, 1)
+    }
+
+    // MARK: - Subview lookup
+    //
+    // The controller's subviews are private; tests reach them via
+    // accessibility identifiers — same approach the create-group
+    // UI tests use. Keeps the production code free of test seams.
+
+    private func titleLabel(in vc: UIViewController) -> UILabel? {
+        find(in: vc.view, identifier: "chat.title") as? UILabel
+    }
+
+    private func backButton(in vc: UIViewController) -> UIButton? {
+        find(in: vc.view, identifier: "chat.back") as? UIButton
+    }
+
+    private func infoButton(in vc: UIViewController) -> UIButton? {
+        find(in: vc.view, identifier: "chat.info") as? UIButton
+    }
+
+    private func find(in view: UIView, identifier: String) -> UIView? {
+        if view.accessibilityIdentifier == identifier { return view }
+        for sub in view.subviews {
+            if let found = find(in: sub, identifier: identifier) { return found }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
**First user-visible PR of the chat stack.** Tapping a group in the Chats tab now opens a UIKit `ChatThreadViewController` instead of the members roster. The members list moves one tap deeper, behind the thread's info button.

## Stacked on
This PR's branch is stacked on #150 (PR 4). Base is `pr-chat-4-dispatcher-and-send`.

## What's in here

**`ChatThreadViewController` (UIKit)** — `Sources/OnymIOS/Chats/ChatThreadViewController.swift`
- Custom top bar: back chevron (left) + centered group name + info button (right).
- Empty `UITableView` placeholder. PR 6 attaches a diffable data source + custom bubble cell.
- Empty `UIView` input-panel placeholder. PR 6/7 build the UITextView + send button + keyboard handling.
- Fired-via-closure: `onBack` and `onShowMembers`. No internal navigation — the SwiftUI wrapper handles all routing.

**`ChatThreadView` (SwiftUI bridge)** — `Sources/OnymIOS/Chats/ChatThreadView.swift`
- `UIViewControllerRepresentable` wrapping the controller.
- `.toolbar(.hidden, for: .navigationBar)` so SwiftUI's nav bar disappears — the controller's custom top bar is the only one drawn.
- `Environment(\.dismiss)` wired to the back chevron.
- `navigationDestination(isPresented:)` pushes `ChatMembersView` when info is tapped.
- Group name is computed from `chatsFlow.groups.first { $0.id == groupID }?.name` and passed in every render — `updateUIViewController` keeps the title in sync as the group renames (PR 9 polish) without recreating the controller.

**`ChatsView` rewire** — `Sources/OnymIOS/Chats/ChatsView.swift`
- `.navigationDestination(for: String.self)` body switched from `ChatMembersView` to `ChatThreadView`.
- One-line change. Members surface is still reachable from the thread's info button.

## What's NOT in here
- No message rendering (PR 6).
- No input UI or send wiring (PR 6 / PR 7).
- No keyboard avoidance (PR 6).
- No styling polish (PR 9).
- The input panel shows placeholder text "Message input lands in PR 6" so the UI region is visible during this slice.

## Tests
- `ChatThreadViewControllerTests` (5 new): viewDidLoad doesn't crash, `update(groupName:)` writes through, empty name falls back to "Chat", back/info button taps invoke their closures.
- Full `OnymIOSTests` suite: **578 / 578**, 0 regressions.

## Visual correctness — NOT covered by tests
Tests verify the bridge contract, not the layout. Launch the simulator, tap a group, verify: top bar shows the group name, back chevron pops, info button pushes the members screen, table view fills the body, input placeholder sits at the bottom safe area.

## Plan context
PR 5 of 11. **PR 1** (#147) payload • **PR 2** (#148) persistence • **PR 3** (#149) Ed25519 sender pubkey • **PR 4** (#150) dispatcher + send interactor. **PR 6 next**: message-list rendering — custom bubble cell, diffable data source, subscribe to `MessageRepository.snapshots(groupID:)`, auto-scroll to bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)