### PR TITLE
feat(chats): message list rendering (PR 6/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -24,4 +24,9 @@ struct AppDependencies {
     /// and the underlying collector should run for the app's
     /// lifetime regardless of which surface is mounted.
     let approveRequestsFlow: ApproveRequestsFlow
+    /// Single shared instance — the chat-thread screen subscribes to
+    /// per-group message snapshots, and the receive-side dispatcher
+    /// writes into the same actor. Constructed once in
+    /// `OnymIOSApp.init` and threaded down.
+    let messageRepository: MessageRepository
 }

--- a/Sources/OnymIOS/Chats/ChatBubbleCell.swift
+++ b/Sources/OnymIOS/Chats/ChatBubbleCell.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import UIKit
+
+/// One message bubble row. Two visual styles toggled by
+/// `ChatMessage.direction`:
+///
+///   - `.outgoing` — accent-filled bubble pinned to the trailing edge.
+///   - `.incoming` — surface-tinted bubble pinned to the leading edge.
+///
+/// Layout is a single `UILabel` inside a `UIView` bubble container.
+/// The bubble's leading/trailing edge is swapped via two stored
+/// constraints; the `lessThanOrEqualTo` width cap keeps long
+/// messages from filling the full row.
+///
+/// PR 6 scope: no avatars, no timestamps, no status glyphs, no
+/// emoji rendering. Status indicator lands in PR 8.
+final class ChatBubbleCell: UITableViewCell {
+    static let reuseID = "ChatBubbleCell"
+
+    /// Max bubble width as a fraction of the cell's content width.
+    /// Matches the usual messenger convention — long messages wrap
+    /// but never reach the opposite edge.
+    private let maxWidthFraction: CGFloat = 0.75
+
+    private let bubble = UIView()
+    private let bodyLabel = UILabel()
+
+    // Direction-dependent constraints — only one of these pair is
+    // active at a time.
+    private var leadingAlignConstraint: NSLayoutConstraint!
+    private var trailingAlignConstraint: NSLayoutConstraint!
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = .clear
+        selectionStyle = .none
+        contentView.backgroundColor = UIColor(OnymTokens.bg)
+        buildBubble()
+        layoutBubble()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+
+    /// Swap colors + alignment for the message's direction. Caller
+    /// (the diffable data source's cell provider) invokes this on
+    /// every dequeue.
+    func configure(message: ChatMessage) {
+        bodyLabel.text = message.body
+        switch message.direction {
+        case .outgoing:
+            bubble.backgroundColor = UIColor(OnymAccent.blue.color)
+            bodyLabel.textColor = UIColor(OnymTokens.onAccent)
+            leadingAlignConstraint.isActive = false
+            trailingAlignConstraint.isActive = true
+        case .incoming:
+            bubble.backgroundColor = UIColor(OnymTokens.surface2)
+            bodyLabel.textColor = UIColor(OnymTokens.text)
+            trailingAlignConstraint.isActive = false
+            leadingAlignConstraint.isActive = true
+        }
+    }
+
+    private func buildBubble() {
+        bubble.translatesAutoresizingMaskIntoConstraints = false
+        bubble.layer.cornerRadius = 14
+        bubble.layer.cornerCurve = .continuous
+        contentView.addSubview(bubble)
+
+        bodyLabel.translatesAutoresizingMaskIntoConstraints = false
+        bodyLabel.numberOfLines = 0
+        bodyLabel.font = .systemFont(ofSize: 15)
+        bubble.addSubview(bodyLabel)
+    }
+
+    private func layoutBubble() {
+        // Outer margins from the cell edges. The 56pt opposite-edge
+        // inset is what gives the "addressed to the other side"
+        // visual — a bubble pinned trailing still leaves room on
+        // the left.
+        let edgeInset: CGFloat = 12
+        let opposite: CGFloat = 56
+
+        leadingAlignConstraint = bubble.leadingAnchor.constraint(
+            equalTo: contentView.leadingAnchor, constant: edgeInset
+        )
+        trailingAlignConstraint = bubble.trailingAnchor.constraint(
+            equalTo: contentView.trailingAnchor, constant: -edgeInset
+        )
+
+        let widthCap = bubble.widthAnchor.constraint(
+            lessThanOrEqualTo: contentView.widthAnchor,
+            multiplier: maxWidthFraction
+        )
+
+        NSLayoutConstraint.activate([
+            // Vertical padding between rows.
+            bubble.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
+            bubble.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4),
+
+            // Always keep a gap on the opposite side from the active
+            // alignment constraint so the bubble doesn't collide with
+            // the opposite edge.
+            bubble.leadingAnchor.constraint(
+                greaterThanOrEqualTo: contentView.leadingAnchor, constant: opposite
+            ),
+            bubble.trailingAnchor.constraint(
+                lessThanOrEqualTo: contentView.trailingAnchor, constant: -opposite
+            ),
+            widthCap,
+
+            // Body label fills the bubble with padding.
+            bodyLabel.leadingAnchor.constraint(equalTo: bubble.leadingAnchor, constant: 12),
+            bodyLabel.trailingAnchor.constraint(equalTo: bubble.trailingAnchor, constant: -12),
+            bodyLabel.topAnchor.constraint(equalTo: bubble.topAnchor, constant: 8),
+            bodyLabel.bottomAnchor.constraint(equalTo: bubble.bottomAnchor, constant: -8),
+        ])
+
+        // Default to leading (incoming). `configure(message:)` flips
+        // before the cell is shown — but the default keeps the cell
+        // layout-valid even if a configurer skips us.
+        leadingAlignConstraint.isActive = true
+    }
+}

--- a/Sources/OnymIOS/Chats/ChatBubbleCell.swift
+++ b/Sources/OnymIOS/Chats/ChatBubbleCell.swift
@@ -25,10 +25,15 @@ final class ChatBubbleCell: UITableViewCell {
     private let bubble = UIView()
     private let bodyLabel = UILabel()
 
-    // Direction-dependent constraints — only one of these pair is
-    // active at a time.
-    private var leadingAlignConstraint: NSLayoutConstraint!
-    private var trailingAlignConstraint: NSLayoutConstraint!
+    // Direction-dependent constraints — only one pair is active at a
+    // time. Each pair contains the alignment pin (`==` to the pinned
+    // edge) and the opposite-edge breathing-room gap on the *other*
+    // side. Pairing this way prevents the obvious-but-wrong layout:
+    // pinning `leading == +12` while also asserting `leading >= +56`
+    // (the original PR 6 shape) breaks every cell with a constraint
+    // log.
+    private var outgoingConstraints: [NSLayoutConstraint] = []
+    private var incomingConstraints: [NSLayoutConstraint] = []
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -53,13 +58,13 @@ final class ChatBubbleCell: UITableViewCell {
         case .outgoing:
             bubble.backgroundColor = UIColor(OnymAccent.blue.color)
             bodyLabel.textColor = UIColor(OnymTokens.onAccent)
-            leadingAlignConstraint.isActive = false
-            trailingAlignConstraint.isActive = true
+            NSLayoutConstraint.deactivate(incomingConstraints)
+            NSLayoutConstraint.activate(outgoingConstraints)
         case .incoming:
             bubble.backgroundColor = UIColor(OnymTokens.surface2)
             bodyLabel.textColor = UIColor(OnymTokens.text)
-            trailingAlignConstraint.isActive = false
-            leadingAlignConstraint.isActive = true
+            NSLayoutConstraint.deactivate(outgoingConstraints)
+            NSLayoutConstraint.activate(incomingConstraints)
         }
     }
 
@@ -71,56 +76,61 @@ final class ChatBubbleCell: UITableViewCell {
 
         bodyLabel.translatesAutoresizingMaskIntoConstraints = false
         bodyLabel.numberOfLines = 0
-        bodyLabel.font = .systemFont(ofSize: 15)
+        // Dynamic Type — the chat body should scale with the user's
+        // preferred text size. Full a11y polish pass happens later
+        // (PR 9+), but using `preferredFont(forTextStyle:)` here
+        // costs nothing now and avoids a fixed-size regression.
+        bodyLabel.font = .preferredFont(forTextStyle: .body)
+        bodyLabel.adjustsFontForContentSizeCategory = true
         bubble.addSubview(bodyLabel)
     }
 
     private func layoutBubble() {
-        // Outer margins from the cell edges. The 56pt opposite-edge
-        // inset is what gives the "addressed to the other side"
-        // visual — a bubble pinned trailing still leaves room on
-        // the left.
         let edgeInset: CGFloat = 12
-        let opposite: CGFloat = 56
+        // Opposite-edge gap: the side the bubble does NOT pin to
+        // still leaves this much breathing room from the cell edge.
+        // Gives the "addressed to one side" visual without the
+        // bubble ever filling the row, even for super-short content
+        // that the width cap doesn't bind on.
+        let oppositeGap: CGFloat = 56
 
-        leadingAlignConstraint = bubble.leadingAnchor.constraint(
-            equalTo: contentView.leadingAnchor, constant: edgeInset
-        )
-        trailingAlignConstraint = bubble.trailingAnchor.constraint(
-            equalTo: contentView.trailingAnchor, constant: -edgeInset
-        )
-
-        let widthCap = bubble.widthAnchor.constraint(
-            lessThanOrEqualTo: contentView.widthAnchor,
-            multiplier: maxWidthFraction
-        )
-
+        // Always-active constraints (don't depend on direction).
         NSLayoutConstraint.activate([
-            // Vertical padding between rows.
             bubble.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
             bubble.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4),
-
-            // Always keep a gap on the opposite side from the active
-            // alignment constraint so the bubble doesn't collide with
-            // the opposite edge.
-            bubble.leadingAnchor.constraint(
-                greaterThanOrEqualTo: contentView.leadingAnchor, constant: opposite
+            bubble.widthAnchor.constraint(
+                lessThanOrEqualTo: contentView.widthAnchor,
+                multiplier: maxWidthFraction
             ),
-            bubble.trailingAnchor.constraint(
-                lessThanOrEqualTo: contentView.trailingAnchor, constant: -opposite
-            ),
-            widthCap,
-
-            // Body label fills the bubble with padding.
             bodyLabel.leadingAnchor.constraint(equalTo: bubble.leadingAnchor, constant: 12),
             bodyLabel.trailingAnchor.constraint(equalTo: bubble.trailingAnchor, constant: -12),
             bodyLabel.topAnchor.constraint(equalTo: bubble.topAnchor, constant: 8),
             bodyLabel.bottomAnchor.constraint(equalTo: bubble.bottomAnchor, constant: -8),
         ])
 
-        // Default to leading (incoming). `configure(message:)` flips
-        // before the cell is shown — but the default keeps the cell
-        // layout-valid even if a configurer skips us.
-        leadingAlignConstraint.isActive = true
+        // Outgoing pair — trailing-pinned, leading has the
+        // opposite-edge gap. Activating the leading-`==` from the
+        // other pair simultaneously would conflict with this gap;
+        // `configure(message:)` toggles the pairs together.
+        outgoingConstraints = [
+            bubble.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor, constant: -edgeInset
+            ),
+            bubble.leadingAnchor.constraint(
+                greaterThanOrEqualTo: contentView.leadingAnchor, constant: oppositeGap
+            ),
+        ]
+        incomingConstraints = [
+            bubble.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor, constant: edgeInset
+            ),
+            bubble.trailingAnchor.constraint(
+                lessThanOrEqualTo: contentView.trailingAnchor, constant: -oppositeGap
+            ),
+        ]
+        // Default to leading (incoming) — `configure(message:)`
+        // overrides before the cell is shown, but the default keeps
+        // the cell layout-valid even if a configurer skips us.
+        NSLayoutConstraint.activate(incomingConstraints)
     }
 }

--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -19,14 +19,20 @@ struct ChatThreadView: View {
     let groupID: String
     @Bindable var chatsFlow: ChatsFlow
     @Bindable var identitiesFlow: IdentitiesFlow
+    let messageRepository: MessageRepository
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
     @Environment(\.dismiss) private var dismiss
     @State private var showMembers: Bool = false
+    /// Live snapshot of the group's messages, sorted ascending by
+    /// `sentAt`. SwiftUI re-renders on every push so the bridge
+    /// hands the controller fresh data via `updateUIViewController`.
+    @State private var messages: [ChatMessage] = []
 
     var body: some View {
         ChatThreadControllerBridge(
             groupName: currentGroupName,
+            messages: messages,
             onBack: { dismiss() },
             onShowMembers: { showMembers = true }
         )
@@ -39,6 +45,14 @@ struct ChatThreadView: View {
                 makeShareInviteFlow: makeShareInviteFlow
             )
         }
+        // Per-group subscription. `task(id:)` cancels + restarts when
+        // groupID changes, so navigating into a different chat
+        // doesn't leak the previous group's stream.
+        .task(id: groupID) {
+            for await snapshot in messageRepository.snapshots(groupID: groupID) {
+                messages = snapshot
+            }
+        }
     }
 
     private var currentGroupName: String {
@@ -48,6 +62,7 @@ struct ChatThreadView: View {
 
 private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let groupName: String
+    let messages: [ChatMessage]
     let onBack: () -> Void
     let onShowMembers: () -> Void
 
@@ -57,6 +72,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         vc.onShowMembers = onShowMembers
         vc.loadViewIfNeeded()
         vc.update(groupName: groupName)
+        vc.update(messages: messages)
         return vc
     }
 
@@ -67,5 +83,6 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         vc.onBack = onBack
         vc.onShowMembers = onShowMembers
         vc.update(groupName: groupName)
+        vc.update(messages: messages)
     }
 }

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -86,18 +86,27 @@ final class ChatThreadViewController: UIViewController {
     ///     the user was already near it (otherwise we'd hijack
     ///     mid-scroll reading of older messages).
     ///
-    /// Caller is expected to pass `messages` sorted ascending by
-    /// `sentAt` — the table's first row is the oldest message,
-    /// last row is the newest.
+    /// Defensively sorts by `sentAt` ascending. The repository's
+    /// contract is already to return sorted snapshots
+    /// (`SwiftDataMessageStoreTests.test_list_sortsBySentAtAscending`),
+    /// but a future caller / test stub might violate that without
+    /// the sort here protecting the table's row order.
+    ///
+    /// PR 8 note: `messagesByID` is updated on every call, but the
+    /// diffable identity is just `UUID` — when a status flip lands
+    /// (pending → sent), visible cells won't reconfigure. PR 8 should
+    /// switch to `snapshot.reconfigureItems(changedIDs)` or include
+    /// status in the diff identity.
     func update(messages: [ChatMessage]) {
         let isFirstApply = !hasAppliedFirstSnapshot
         let wasNearBottom = isNearBottom
 
-        messagesByID = Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
+        let sorted = messages.sorted { $0.sentAt < $1.sentAt }
+        messagesByID = Dictionary(uniqueKeysWithValues: sorted.map { ($0.id, $0) })
 
         var snapshot = NSDiffableDataSourceSnapshot<Section, UUID>()
         snapshot.appendSections([.main])
-        snapshot.appendItems(messages.map(\.id))
+        snapshot.appendItems(sorted.map(\.id))
         // First apply is non-animated to avoid an initial-load
         // "fly-in" of every existing message.
         dataSource.apply(snapshot, animatingDifferences: !isFirstApply) { [weak self] in

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -38,6 +38,24 @@ final class ChatThreadViewController: UIViewController {
     private let inputPanelSeparator = UIView()
     private let inputPlaceholderLabel = UILabel()
 
+    // Diffable data source state. Keyed by message UUID — stable
+    // identity across re-renders, no array-index churn.
+    private enum Section: Hashable { case main }
+    private var dataSource: UITableViewDiffableDataSource<Section, UUID>!
+    /// Lookup table the cell-provider reads from. Keys mirror the
+    /// diffable snapshot's items so a dequeue can always resolve.
+    private var messagesByID: [UUID: ChatMessage] = [:]
+    /// Set after the first `update(messages:)` so the initial load
+    /// applies non-animated + always scrolls to the bottom, while
+    /// subsequent updates animate and only auto-scroll when the
+    /// user is already near the bottom.
+    private var hasAppliedFirstSnapshot = false
+
+    /// "Within this many points of the content bottom" counts as
+    /// "near bottom" for the auto-scroll heuristic. Exposed for
+    /// tests; production-only callers should treat as a constant.
+    static let nearBottomThreshold: CGFloat = 100
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(OnymTokens.bg)
@@ -45,6 +63,7 @@ final class ChatThreadViewController: UIViewController {
         buildTableView()
         buildInputPanel()
         layout()
+        configureDataSource()
     }
 
     /// Push a new group-name into the title. Called by the SwiftUI
@@ -52,6 +71,71 @@ final class ChatThreadViewController: UIViewController {
     /// renames (PR 9 polish) without re-creating the controller.
     func update(groupName: String) {
         titleLabel.text = groupName.isEmpty ? "Chat" : groupName
+    }
+
+    /// Push a new message list into the table. Called by the SwiftUI
+    /// wrapper on every render with the latest snapshot from
+    /// `MessageRepository.snapshots(groupID:)`. The diffable data
+    /// source figures out the inserts/deletes/moves; rows that
+    /// didn't change don't re-layout.
+    ///
+    /// Behavior:
+    ///   - First apply (cold open): non-animated, always scroll to
+    ///     the bottom so the user lands on the latest message.
+    ///   - Subsequent applies: animated; only scroll to bottom if
+    ///     the user was already near it (otherwise we'd hijack
+    ///     mid-scroll reading of older messages).
+    ///
+    /// Caller is expected to pass `messages` sorted ascending by
+    /// `sentAt` — the table's first row is the oldest message,
+    /// last row is the newest.
+    func update(messages: [ChatMessage]) {
+        let isFirstApply = !hasAppliedFirstSnapshot
+        let wasNearBottom = isNearBottom
+
+        messagesByID = Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
+
+        var snapshot = NSDiffableDataSourceSnapshot<Section, UUID>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(messages.map(\.id))
+        // First apply is non-animated to avoid an initial-load
+        // "fly-in" of every existing message.
+        dataSource.apply(snapshot, animatingDifferences: !isFirstApply) { [weak self] in
+            guard let self else { return }
+            if isFirstApply {
+                self.scrollToBottom(animated: false)
+                self.hasAppliedFirstSnapshot = true
+            } else if wasNearBottom {
+                self.scrollToBottom(animated: true)
+            }
+        }
+    }
+
+    /// True when the user is within `nearBottomThreshold` points of
+    /// the content bottom. Used to decide whether a fresh message
+    /// should pull the scroll along or leave the user where they
+    /// are. Exposed for tests; production-only callers should treat
+    /// as private.
+    var isNearBottom: Bool {
+        let contentHeight = tableView.contentSize.height
+        let visibleHeight = tableView.bounds.height
+        let offsetY = tableView.contentOffset.y
+        // When the content is shorter than the viewport (empty / few
+        // messages), we're always "at the bottom" — auto-scroll has
+        // nothing to do.
+        guard contentHeight > visibleHeight else { return true }
+        let maxOffset = contentHeight - visibleHeight
+        return maxOffset - offsetY < Self.nearBottomThreshold
+    }
+
+    /// Scroll the table so the last row is visible.
+    func scrollToBottom(animated: Bool) {
+        let snapshot = dataSource.snapshot()
+        guard let lastSection = snapshot.sectionIdentifiers.last else { return }
+        let itemCount = snapshot.numberOfItems(inSection: lastSection)
+        guard itemCount > 0 else { return }
+        let lastIndex = IndexPath(row: itemCount - 1, section: 0)
+        tableView.scrollToRow(at: lastIndex, at: .bottom, animated: animated)
     }
 
     // MARK: - Top bar
@@ -100,16 +184,41 @@ final class ChatThreadViewController: UIViewController {
         view.addSubview(topBarSeparator)
     }
 
-    // MARK: - Table view (messages placeholder)
+    // MARK: - Table view (message list)
 
     private func buildTableView() {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.backgroundColor = UIColor(OnymTokens.bg)
         tableView.separatorStyle = .none
-        // No data source yet — PR 6 attaches a diffable data source
-        // and a custom bubble cell. Empty table renders as a blank
-        // background, which is the desired PR-5 visual.
+        // Self-sizing rows — bubble height grows with body text.
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 44
+        tableView.register(ChatBubbleCell.self, forCellReuseIdentifier: ChatBubbleCell.reuseID)
+        // Tap to dismiss the keyboard once PR 7 wires the input
+        // panel. No-op pre-PR-7 because nothing is first-responder.
+        tableView.keyboardDismissMode = .interactive
         view.addSubview(tableView)
+    }
+
+    private func configureDataSource() {
+        dataSource = UITableViewDiffableDataSource<Section, UUID>(
+            tableView: tableView
+        ) { [weak self] tableView, indexPath, id in
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: ChatBubbleCell.reuseID,
+                for: indexPath
+            )
+            if let bubble = cell as? ChatBubbleCell,
+               let message = self?.messagesByID[id] {
+                bubble.configure(message: message)
+            }
+            return cell
+        }
+        // No animations on the initial empty section commit; only
+        // mutations after `update(messages:)` need animation.
+        var initial = NSDiffableDataSourceSnapshot<Section, UUID>()
+        initial.appendSections([.main])
+        dataSource.apply(initial, animatingDifferences: false)
     }
 
     // MARK: - Input panel placeholder

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -9,6 +9,7 @@ struct ChatsView: View {
     let flow: ChatsFlow
     let identitiesFlow: IdentitiesFlow
     let approveRequestsFlow: ApproveRequestsFlow
+    let messageRepository: MessageRepository
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
@@ -130,6 +131,7 @@ struct ChatsView: View {
                 groupID: groupID,
                 chatsFlow: flow,
                 identitiesFlow: identitiesFlow,
+                messageRepository: messageRepository,
                 makeShareInviteFlow: makeShareInviteFlow
             )
         }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -219,7 +219,8 @@ struct OnymIOSApp: App {
                 ChatsFlow(repository: groupRepository)
             },
             identitiesFlow: identitiesFlow,
-            approveRequestsFlow: approveRequestsFlow
+            approveRequestsFlow: approveRequestsFlow,
+            messageRepository: messageRepository
         )
     }
 

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -30,6 +30,7 @@ struct RootView: View {
                         flow: dependencies.makeChatsFlow(),
                         identitiesFlow: dependencies.identitiesFlow,
                         approveRequestsFlow: dependencies.approveRequestsFlow,
+                        messageRepository: dependencies.messageRepository,
                         makeCreateGroupFlow: dependencies.makeCreateGroupFlow,
                         makeShareInviteFlow: dependencies.makeShareInviteFlow
                     )

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import OnymIOS
+
+/// Cell-style switch tests for `ChatBubbleCell`. The direction
+/// determines which alignment constraint is active and which color
+/// the bubble + body use — both visible through the cell's
+/// `contentView` subtree without needing the layout engine to
+/// resolve.
+@MainActor
+final class ChatBubbleCellTests: XCTestCase {
+
+    func test_outgoing_pinsToTrailingAndUsesAccentFill() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .outgoing))
+        XCTAssertFalse(activeLeadingAlignment(in: cell),
+                       "outgoing must release the leading-align constraint")
+        XCTAssertTrue(activeTrailingAlignment(in: cell),
+                      "outgoing must pin to the trailing edge")
+    }
+
+    func test_incoming_pinsToLeadingAndUsesSurfaceFill() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .incoming))
+        XCTAssertTrue(activeLeadingAlignment(in: cell))
+        XCTAssertFalse(activeTrailingAlignment(in: cell))
+    }
+
+    func test_reconfigure_flipsAlignment() {
+        // Cell reuse path: a row that was outgoing is now rendering
+        // an incoming message. The alignment must swap; otherwise
+        // we'd see "own" bubbles on the wrong side.
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .outgoing))
+        XCTAssertTrue(activeTrailingAlignment(in: cell))
+
+        cell.configure(message: makeMessage(direction: .incoming))
+        XCTAssertTrue(activeLeadingAlignment(in: cell))
+        XCTAssertFalse(activeTrailingAlignment(in: cell))
+    }
+
+    func test_body_writesThroughToLabel() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .incoming, body: "hello, world"))
+        let label = findLabel(in: cell.contentView)
+        XCTAssertEqual(label?.text, "hello, world")
+    }
+
+    // MARK: - Constraint introspection
+    //
+    // The leading/trailing alignment constraints are private to the
+    // cell. We can still detect which is active by reading the live
+    // constraints attached to the cell's content view + bubble —
+    // there are two `equal`-relation constraints on the bubble's
+    // leading/trailing anchors, one of them inactive at any given
+    // time.
+
+    private func activeLeadingAlignment(in cell: ChatBubbleCell) -> Bool {
+        guard let bubble = cell.contentView.subviews.first else { return false }
+        return cell.contentView.constraints.contains {
+            $0.isActive &&
+            $0.firstItem === bubble &&
+            $0.firstAttribute == .leading &&
+            $0.secondItem === cell.contentView &&
+            $0.secondAttribute == .leading &&
+            $0.relation == .equal
+        }
+    }
+
+    private func activeTrailingAlignment(in cell: ChatBubbleCell) -> Bool {
+        guard let bubble = cell.contentView.subviews.first else { return false }
+        return cell.contentView.constraints.contains {
+            $0.isActive &&
+            $0.firstItem === bubble &&
+            $0.firstAttribute == .trailing &&
+            $0.secondItem === cell.contentView &&
+            $0.secondAttribute == .trailing &&
+            $0.relation == .equal
+        }
+    }
+
+    private func findLabel(in view: UIView) -> UILabel? {
+        if let label = view as? UILabel { return label }
+        for sub in view.subviews {
+            if let found = findLabel(in: sub) { return found }
+        }
+        return nil
+    }
+
+    private func makeMessage(
+        direction: MessageDirection,
+        body: String = "hi"
+    ) -> ChatMessage {
+        ChatMessage(
+            id: UUID(),
+            groupID: "aa".repeated(32),
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: "11".repeated(48),
+            body: body,
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            direction: direction,
+            status: direction == .incoming ? .received : .sent,
+            groupType: .tyranny
+        )
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -45,14 +45,35 @@ final class ChatBubbleCellTests: XCTestCase {
         XCTAssertEqual(label?.text, "hello, world")
     }
 
+    func test_layoutResolves_withoutConstraintConflicts() {
+        // Guards the bug the PR-6 review caught: pairing the
+        // opposite-edge `>=`/`<=` gap with the *same-direction*
+        // alignment pin would conflict (e.g. leading == +12 AND
+        // leading >= +56). UIKit logs and silently disables one,
+        // which the original constraint-isActive tests didn't
+        // notice. Forcing a layout pass and asserting all
+        // constraints are still active is the cheapest way to
+        // catch a regression here.
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.contentView.frame = CGRect(x: 0, y: 0, width: 320, height: 80)
+
+        cell.configure(message: makeMessage(direction: .incoming, body: "hi"))
+        cell.contentView.layoutIfNeeded()
+        XCTAssertTrue(allConstraintsStillActive(cell),
+                      "incoming layout must not auto-deactivate any constraint")
+
+        cell.configure(message: makeMessage(direction: .outgoing, body: "hi"))
+        cell.contentView.layoutIfNeeded()
+        XCTAssertTrue(allConstraintsStillActive(cell),
+                      "outgoing layout must not auto-deactivate any constraint")
+    }
+
     // MARK: - Constraint introspection
     //
-    // The leading/trailing alignment constraints are private to the
-    // cell. We can still detect which is active by reading the live
-    // constraints attached to the cell's content view + bubble —
-    // there are two `equal`-relation constraints on the bubble's
-    // leading/trailing anchors, one of them inactive at any given
-    // time.
+    // The alignment constraint pairs are private to the cell. We
+    // detect which side is pinned by looking for an `equal`-relation
+    // constraint between the bubble's anchor and the corresponding
+    // content-view anchor — that's the alignment pin (one per pair).
 
     private func activeLeadingAlignment(in cell: ChatBubbleCell) -> Bool {
         guard let bubble = cell.contentView.subviews.first else { return false }
@@ -76,6 +97,26 @@ final class ChatBubbleCellTests: XCTestCase {
             $0.secondAttribute == .trailing &&
             $0.relation == .equal
         }
+    }
+
+    /// `true` iff every required constraint on the cell remains
+    /// active after a layout pass. UIKit auto-deactivates the lower-
+    /// priority constraint when a `required` conflict resolves — so
+    /// a count-stable layout proves no conflict happened.
+    private func allConstraintsStillActive(_ cell: ChatBubbleCell) -> Bool {
+        // The cell builds eight always-on constraints + two from the
+        // direction pair == 10 active total. Anything less means
+        // UIKit disabled one to resolve a conflict.
+        let active = collectActiveConstraints(in: cell.contentView)
+        return active.count >= 10
+    }
+
+    private func collectActiveConstraints(in view: UIView) -> [NSLayoutConstraint] {
+        var found: [NSLayoutConstraint] = view.constraints.filter { $0.isActive }
+        for sub in view.subviews {
+            found.append(contentsOf: collectActiveConstraints(in: sub))
+        }
+        return found
     }
 
     private func findLabel(in view: UIView) -> UILabel? {

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -88,6 +88,34 @@ final class ChatThreadViewControllerTests: XCTestCase {
         XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 2)
     }
 
+    func test_updateMessages_unsortedInput_isSortedAscending() {
+        // Defensive: the repository's contract is to emit ascending
+        // snapshots, but a future caller / test stub might violate
+        // it. The controller sorts before applying so row order is
+        // always chronological.
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        let oldest = makeMessage(body: "1", direction: .incoming,
+                                 sentAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let middle = makeMessage(body: "2", direction: .outgoing,
+                                 sentAt: Date(timeIntervalSince1970: 1_700_000_100))
+        let newest = makeMessage(body: "3", direction: .incoming,
+                                 sentAt: Date(timeIntervalSince1970: 1_700_000_200))
+        // Out-of-order input.
+        vc.update(messages: [newest, oldest, middle])
+
+        let table = tableView(in: vc)!
+        table.frame = CGRect(x: 0, y: 0, width: 320, height: 640)
+        table.layoutIfNeeded()
+
+        // Row 0 = oldest (top), row 2 = newest (bottom). Reads via
+        // the cell text.
+        XCTAssertEqual(table.numberOfRows(inSection: 0), 3)
+        XCTAssertEqual(cellBodyText(in: table, row: 0), "1")
+        XCTAssertEqual(cellBodyText(in: table, row: 1), "2")
+        XCTAssertEqual(cellBodyText(in: table, row: 2), "3")
+    }
+
     func test_updateMessages_removeOne_shrinksTable() {
         let vc = ChatThreadViewController()
         vc.loadViewIfNeeded()
@@ -148,18 +176,36 @@ final class ChatThreadViewControllerTests: XCTestCase {
         return nil
     }
 
-    private func makeMessage(body: String, direction: MessageDirection) -> ChatMessage {
+    private func makeMessage(
+        body: String,
+        direction: MessageDirection,
+        sentAt: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    ) -> ChatMessage {
         ChatMessage(
             id: UUID(),
             groupID: "aa".repeated(32),
             ownerIdentityID: IdentityID(),
             senderBlsPubkeyHex: "11".repeated(48),
             body: body,
-            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            sentAt: sentAt,
             direction: direction,
             status: direction == .incoming ? .received : .sent,
             groupType: .tyranny
         )
+    }
+
+    private func cellBodyText(in table: UITableView, row: Int) -> String? {
+        let cell = table.cellForRow(at: IndexPath(row: row, section: 0))
+        guard let cv = cell?.contentView else { return nil }
+        return findLabelText(in: cv)
+    }
+
+    private func findLabelText(in view: UIView) -> String? {
+        if let label = view as? UILabel { return label.text }
+        for sub in view.subviews {
+            if let text = findLabelText(in: sub) { return text }
+        }
+        return nil
     }
 
     // MARK: - Subview lookup

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -55,6 +55,113 @@ final class ChatThreadViewControllerTests: XCTestCase {
         XCTAssertEqual(showCount, 1)
     }
 
+    // MARK: - Message list rendering (PR 6)
+
+    func test_updateMessages_empty_rendersZeroRows() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.update(messages: [])
+        XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 0)
+    }
+
+    func test_updateMessages_appendsRowsForEach() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        let msgs = [
+            makeMessage(body: "one", direction: .incoming),
+            makeMessage(body: "two", direction: .outgoing),
+            makeMessage(body: "three", direction: .incoming),
+        ]
+        vc.update(messages: msgs)
+        XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 3)
+    }
+
+    func test_updateMessages_subsequentAdd_reflectsDiff() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        let m1 = makeMessage(body: "first", direction: .incoming)
+        vc.update(messages: [m1])
+        XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 1)
+
+        let m2 = makeMessage(body: "second", direction: .outgoing)
+        vc.update(messages: [m1, m2])
+        XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 2)
+    }
+
+    func test_updateMessages_removeOne_shrinksTable() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        let m1 = makeMessage(body: "stays", direction: .incoming)
+        let m2 = makeMessage(body: "drops", direction: .outgoing)
+        vc.update(messages: [m1, m2])
+        XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 2)
+
+        vc.update(messages: [m1])
+        XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 1)
+    }
+
+    // MARK: - Auto-scroll heuristic
+
+    func test_isNearBottom_emptyContent_isTrue() {
+        // No messages → content shorter than viewport → trivially
+        // "at the bottom"; auto-scroll has nothing to do.
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        XCTAssertTrue(vc.isNearBottom)
+    }
+
+    func test_isNearBottom_atContentEnd_isTrue() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        let table = tableView(in: vc)!
+        table.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
+        // Simulate scrolled-to-end content. The threshold is 100pt;
+        // setting offsetY to exactly maxOffset means we're 0pt from
+        // the bottom, well within range.
+        table.contentSize = CGSize(width: 320, height: 2000)
+        table.contentOffset = CGPoint(x: 0, y: 1520)  // 2000 - 480 = 1520
+        XCTAssertTrue(vc.isNearBottom)
+    }
+
+    func test_isNearBottom_scrolledUp_isFalse() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        let table = tableView(in: vc)!
+        table.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
+        table.contentSize = CGSize(width: 320, height: 2000)
+        // 500pt away from the bottom — way past the 100pt threshold.
+        table.contentOffset = CGPoint(x: 0, y: 1020)
+        XCTAssertFalse(vc.isNearBottom)
+    }
+
+    // MARK: - Helpers
+
+    private func tableView(in vc: UIViewController) -> UITableView? {
+        find(in: vc.view) { $0 is UITableView } as? UITableView
+    }
+
+    private func find(in view: UIView, where predicate: (UIView) -> Bool) -> UIView? {
+        if predicate(view) { return view }
+        for sub in view.subviews {
+            if let found = find(in: sub, where: predicate) { return found }
+        }
+        return nil
+    }
+
+    private func makeMessage(body: String, direction: MessageDirection) -> ChatMessage {
+        ChatMessage(
+            id: UUID(),
+            groupID: "aa".repeated(32),
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: "11".repeated(48),
+            body: body,
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            direction: direction,
+            status: direction == .incoming ? .received : .sent,
+            groupType: .tyranny
+        )
+    }
+
     // MARK: - Subview lookup
     //
     // The controller's subviews are private; tests reach them via
@@ -79,5 +186,11 @@ final class ChatThreadViewControllerTests: XCTestCase {
             if let found = find(in: sub, identifier: identifier) { return found }
         }
         return nil
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
     }
 }


### PR DESCRIPTION
**Read-only chat scrollback.** Messages from `MessageRepository` flow through SwiftUI into the UIKit controller and render as direction-styled bubbles. No input or send yet — that's PR 7.

## Stacked on
This PR's branch is stacked on #151 (PR 5). Base is \`pr-chat-5-uikit-shell\`.

## What's in here

### `ChatBubbleCell` — `Sources/OnymIOS/Chats/ChatBubbleCell.swift`
Custom `UITableViewCell`. Two visual modes toggled by `ChatMessage.direction`:
- `.outgoing` → accent fill (`OnymAccent.blue`), trailing-aligned, `onAccent` text.
- `.incoming` → `surface2` fill, leading-aligned, text color.

Bubble max width capped at 75% of the cell so long messages don't reach the opposite edge. The two alignment constraints (leading vs trailing) are stored as properties; `configure(message:)` swaps which is active so reused cells flip sides correctly.

### `ChatThreadViewController` gains
- `UITableViewDiffableDataSource<Section, UUID>` keyed by message id — swapping cells across renders doesn't churn rows that didn't actually change.
- `update(messages:)` — called by the SwiftUI bridge on every render. First apply is non-animated and **always scrolls to bottom** (cold open lands on the latest message). Subsequent applies animate and **only auto-scroll when the user was already near the bottom** (reading older messages doesn't get hijacked).
- `isNearBottom` heuristic with a 100pt threshold from the content end. Exposed for tests.

### `ChatThreadView` (SwiftUI bridge)
- New `messageRepository` parameter.
- `task(id: groupID)` subscribes to `messageRepository.snapshots(groupID:)`. Per-group restart on navigation so leaving a chat cancels its stream.
- Snapshot pushed into the controller via `updateUIViewController`.

### `AppDependencies` — adds `messageRepository`
Shared singleton, plumbed through `RootView` → `ChatsView` → `ChatThreadView`.

## What's NOT in here
- Input UI or send wiring (PR 7).
- Keyboard avoidance (PR 7).
- "↓ new messages" pill (deferred to PR 9 polish — for now, messages that arrive while the user is scrolled up simply appear without disrupting their position).
- Avatars, timestamps, status glyphs, emoji rendering (PR 8 + later).

## Tests (11 new, suite 589 / 589)

**`ChatBubbleCellTests`** (4):
- outgoing pins trailing, releases leading.
- incoming pins leading, releases trailing.
- reconfigure flips alignment (cell reuse path).
- body text writes through to the inner label.

**`ChatThreadViewControllerTests`** +7:
- `update(messages:)` renders 0 / N rows.
- subsequent add reflects diff (N → N+1).
- subsequent remove shrinks table.
- `isNearBottom`: empty content → true.
- `isNearBottom`: at content end → true.
- `isNearBottom`: scrolled up → false.

## Visual correctness — NOT covered by tests
Bubble shape, colors, scroll behavior: verify in the simulator. Easiest end-to-end demo: two devices in the same Tyranny group, send a message from one, watch it land on the other. The receive path is already covered by the dispatcher tests in #150.

## Plan context
PR 6 of 11. **PR 7 next**: input panel + send wiring — `UITextView` with auto-height + send button + keyboard handling, hook the Send button to `SendMessageInteractor` (from #150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)