### PR TITLE
feat(chats): input panel + keyboard avoidance (PR 7/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatInputPanelView.swift
+++ b/Sources/OnymIOS/Chats/ChatInputPanelView.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+import UIKit
+
+/// Bottom input panel for the chat thread. Hosts the message
+/// composer's `UITextView`, a Send button, and the hairline divider
+/// that separates the panel from the message list.
+///
+/// Height behavior — the text view grows with content up to a
+/// 3-line cap (`maxLineCount`); beyond that it scrolls internally.
+/// Single-line state hugs `minTextViewHeight` so the panel never
+/// shrinks below a thumb-tappable target.
+///
+/// PR 7 scope: layout + keyboard avoidance + enabled-state toggle.
+/// **No real send wiring** — `onSendTapped` clears the text but the
+/// host doesn't do anything else with the body. PR 8 hooks the
+/// closure to `SendMessageInteractor`.
+final class ChatInputPanelView: UIView {
+    /// Invoked when the user taps Send. Receives the current text
+    /// trimmed of leading/trailing whitespace. PR 8 will wire this
+    /// to `SendMessageInteractor.send`.
+    var onSendTapped: ((String) -> Void)?
+
+    var text: String {
+        get { textView.text ?? "" }
+        set {
+            textView.text = newValue
+            // Re-evaluate height + send-button state + placeholder
+            // so external writes look the same as user typing.
+            refreshAfterTextChange()
+        }
+    }
+
+    /// Cap on the auto-grow behavior. Past this many lines the
+    /// text view scrolls internally instead of pushing the
+    /// message list further up.
+    static let maxLineCount = 3
+
+    private let topDivider = UIView()
+    private let textView = UITextView()
+    private let placeholderLabel = UILabel()
+    private let sendButton = UIButton(type: .system)
+    private var textViewHeightConstraint: NSLayoutConstraint!
+
+    /// Height for exactly `lines` worth of text plus the text
+    /// view's vertical insets. Drives both the natural empty-state
+    /// floor (`lines = 1`) and the auto-grow cap
+    /// (`lines = maxLineCount`). Computed dynamically so Dynamic
+    /// Type changes the floor too.
+    func intrinsicHeight(forLines lines: Int) -> CGFloat {
+        let font = textView.font ?? .preferredFont(forTextStyle: .body)
+        let lineHeight = ceil(font.lineHeight)
+        let insets = textView.textContainerInset.top + textView.textContainerInset.bottom
+        return lineHeight * CGFloat(lines) + insets
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = UIColor(OnymTokens.surface2)
+        buildSubviews()
+        layoutSubviewsLocal()
+        refreshAfterTextChange()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+
+    // MARK: - Build
+
+    private func buildSubviews() {
+        topDivider.backgroundColor = UIColor(OnymTokens.hairline)
+        topDivider.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(topDivider)
+
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.textColor = UIColor(OnymTokens.text)
+        textView.backgroundColor = UIColor(OnymTokens.bg)
+        textView.layer.cornerRadius = 18
+        textView.layer.cornerCurve = .continuous
+        textView.textContainerInset = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+        textView.textContainer.lineFragmentPadding = 0
+        textView.delegate = self
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.accessibilityIdentifier = "chat.input.textview"
+        addSubview(textView)
+
+        // UITextView has no native placeholder. Overlay a label
+        // anchored to the same insets the text container uses and
+        // hide it when text is present.
+        placeholderLabel.text = "Message"
+        placeholderLabel.font = textView.font
+        placeholderLabel.adjustsFontForContentSizeCategory = true
+        placeholderLabel.textColor = UIColor(OnymTokens.text3)
+        placeholderLabel.isUserInteractionEnabled = false
+        placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        textView.addSubview(placeholderLabel)
+
+        var sendConfig = UIButton.Configuration.plain()
+        sendConfig.image = UIImage(
+            systemName: "arrow.up.circle.fill",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 28, weight: .regular)
+        )
+        sendConfig.contentInsets = .zero
+        sendButton.configuration = sendConfig
+        sendButton.tintColor = UIColor(OnymAccent.blue.color)
+        sendButton.addTarget(self, action: #selector(tappedSend), for: .touchUpInside)
+        sendButton.translatesAutoresizingMaskIntoConstraints = false
+        sendButton.accessibilityIdentifier = "chat.input.send"
+        sendButton.accessibilityLabel = "Send"
+        addSubview(sendButton)
+    }
+
+    private func layoutSubviewsLocal() {
+        // Initial constant is replaced on the first
+        // `refreshAfterTextChange` once the font / insets resolve.
+        textViewHeightConstraint = textView.heightAnchor.constraint(equalToConstant: 36)
+
+        NSLayoutConstraint.activate([
+            topDivider.topAnchor.constraint(equalTo: topAnchor),
+            topDivider.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topDivider.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topDivider.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+
+            textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            textView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            textViewHeightConstraint,
+
+            sendButton.leadingAnchor.constraint(equalTo: textView.trailingAnchor, constant: 6),
+            sendButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            // Bottom-aligned to the text view's bottom so a growing
+            // text view keeps the send button on the last line.
+            sendButton.bottomAnchor.constraint(equalTo: textView.bottomAnchor),
+            sendButton.widthAnchor.constraint(equalToConstant: 36),
+            sendButton.heightAnchor.constraint(equalToConstant: 36),
+
+            placeholderLabel.leadingAnchor.constraint(
+                equalTo: textView.leadingAnchor,
+                constant: textView.textContainerInset.left
+            ),
+            placeholderLabel.topAnchor.constraint(
+                equalTo: textView.topAnchor,
+                constant: textView.textContainerInset.top
+            ),
+        ])
+    }
+
+    // MARK: - Update
+
+    /// Compute a new text-view height based on the current content,
+    /// clamp to `[minTextViewHeight, maxHeight]`, and update the
+    /// constraint + send button state + placeholder visibility.
+    /// Caller-visible: `textViewDidChange(_:)` and the public
+    /// `text` setter both invoke this.
+    private func refreshAfterTextChange() {
+        let body = textView.text ?? ""
+        // Floor is "exactly one line of body text + insets"; cap is
+        // the same formula at `maxLineCount`. Computed dynamically
+        // so a Dynamic Type size change updates both.
+        let floor = intrinsicHeight(forLines: 1)
+        let cap = intrinsicHeight(forLines: Self.maxLineCount)
+
+        // `sizeThatFits` returns the intrinsic content height for
+        // the text view's current width. Pre-layout (zero width)
+        // it returns garbage; fall back to the natural floor.
+        //
+        // TextKit 2 (iOS 18+ default) sometimes returns the pre-
+        // mutation size when called immediately after a
+        // programmatic `.text = ...` write. Force the text view
+        // to flush its pending layout before measuring so the
+        // value reflects the current body.
+        textView.layoutIfNeeded()
+
+        let measuredHeight: CGFloat = textView.bounds.width > 0
+            ? textView.sizeThatFits(CGSize(
+                width: textView.bounds.width,
+                height: .greatestFiniteMagnitude
+            )).height
+            : floor
+
+        let target = max(floor, min(cap, measuredHeight))
+        if abs(textViewHeightConstraint.constant - target) > 0.5 {
+            textViewHeightConstraint.constant = target
+        }
+        textView.isScrollEnabled = measuredHeight > cap
+        sendButton.isEnabled = !body.isEmpty
+        placeholderLabel.isHidden = !body.isEmpty
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Once a real width is known, re-measure so the height
+        // matches the actual content layout instead of the min-
+        // height fallback used pre-layout.
+        refreshAfterTextChange()
+    }
+
+    @objc private func tappedSend() {
+        let body = (textView.text ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { return }
+        onSendTapped?(body)
+    }
+}
+
+extension ChatInputPanelView: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        refreshAfterTextChange()
+    }
+}

--- a/Sources/OnymIOS/Chats/ChatInputPanelView.swift
+++ b/Sources/OnymIOS/Chats/ChatInputPanelView.swift
@@ -21,6 +21,10 @@ final class ChatInputPanelView: UIView {
     var onSendTapped: ((String) -> Void)?
 
     var text: String {
+        // `UITextView.text` is bridged as `String!`, but Swift
+        // still requires unwrap for chained access on the
+        // surface. Keep the `?? ""` so the compiler is happy and
+        // we don't have a stray force-unwrap site.
         get { textView.text ?? "" }
         set {
             textView.text = newValue
@@ -136,6 +140,12 @@ final class ChatInputPanelView: UIView {
             sendButton.widthAnchor.constraint(equalToConstant: 36),
             sendButton.heightAnchor.constraint(equalToConstant: 36),
 
+            // Placeholder is positioned via static `textContainerInset`
+            // values captured at constraint-creation time. The inset is
+            // a constant today; if it ever becomes Dynamic-Type-driven
+            // (or otherwise mutable), update these constraints' constants
+            // in `refreshAfterTextChange` to keep the placeholder
+            // aligned with the actual text cursor.
             placeholderLabel.leadingAnchor.constraint(
                 equalTo: textView.leadingAnchor,
                 constant: textView.textContainerInset.left
@@ -185,7 +195,16 @@ final class ChatInputPanelView: UIView {
             textViewHeightConstraint.constant = target
         }
         textView.isScrollEnabled = measuredHeight > cap
-        sendButton.isEnabled = !body.isEmpty
+
+        // Send-button enable gate. Matches the trim in `tappedSend`
+        // — whitespace-only input is treated as empty so the
+        // disabled button is the canonical signal that nothing
+        // would be sent. Placeholder visibility uses the raw
+        // emptiness check so typing a space immediately hides the
+        // overlay (the user *is* typing, even if the trimmed
+        // content is still empty).
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        sendButton.isEnabled = !trimmed.isEmpty
         placeholderLabel.isHidden = !body.isEmpty
     }
 

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -34,9 +34,7 @@ final class ChatThreadViewController: UIViewController {
     private let topBar = UIView()
     private let topBarSeparator = UIView()
     private let tableView = UITableView()
-    private let inputPanel = UIView()
-    private let inputPanelSeparator = UIView()
-    private let inputPlaceholderLabel = UILabel()
+    private let inputPanel = ChatInputPanelView()
 
     // Diffable data source state. Keyed by message UUID — stable
     // identity across re-renders, no array-index churn.
@@ -230,25 +228,18 @@ final class ChatThreadViewController: UIViewController {
         dataSource.apply(initial, animatingDifferences: false)
     }
 
-    // MARK: - Input panel placeholder
+    // MARK: - Input panel
 
     private func buildInputPanel() {
-        inputPanel.backgroundColor = UIColor(OnymTokens.surface2)
         inputPanel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(inputPanel)
-
-        inputPanelSeparator.backgroundColor = UIColor(OnymTokens.hairline)
-        inputPanelSeparator.translatesAutoresizingMaskIntoConstraints = false
-        inputPanel.addSubview(inputPanelSeparator)
-
-        // Placeholder copy so the panel is visible during PR 5
-        // without doing anything yet. PR 6 replaces the label with
-        // a real UITextView + send button.
-        inputPlaceholderLabel.text = "Message input lands in PR 6"
-        inputPlaceholderLabel.font = .systemFont(ofSize: 14)
-        inputPlaceholderLabel.textColor = UIColor(OnymTokens.text3)
-        inputPlaceholderLabel.translatesAutoresizingMaskIntoConstraints = false
-        inputPanel.addSubview(inputPlaceholderLabel)
+        // PR 7 wires the layout + enable-state. PR 8 will replace
+        // this closure with the real `SendMessageInteractor.send`
+        // call; for now we just clear the field so the user sees
+        // the input is responsive.
+        inputPanel.onSendTapped = { [weak self] _ in
+            self?.inputPanel.text = ""
+        }
     }
 
     // MARK: - Layout
@@ -290,21 +281,19 @@ final class ChatThreadViewController: UIViewController {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: inputPanel.topAnchor),
 
-            // Input panel — pinned to the safe-area bottom, fixed
-            // 56pt height for PR 5. PR 6 swaps this for a layout
-            // that grows with the text view (up to a 3-line cap).
+            // Input panel — bottom tracks the keyboard. With no
+            // keyboard up, `keyboardLayoutGuide.topAnchor` equals
+            // the safe-area bottom; when the keyboard rises the
+            // guide tracks its top edge and the panel slides
+            // along automatically. No manual frame math or
+            // `keyboardWillShow` notifications required.
+            //
+            // Height is intrinsic — driven by the text view's
+            // height constraint inside the panel — so a multi-
+            // line composition pushes the message list up.
             inputPanel.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             inputPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            inputPanel.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
-            inputPanel.heightAnchor.constraint(equalToConstant: 56),
-
-            inputPanelSeparator.topAnchor.constraint(equalTo: inputPanel.topAnchor),
-            inputPanelSeparator.leadingAnchor.constraint(equalTo: inputPanel.leadingAnchor),
-            inputPanelSeparator.trailingAnchor.constraint(equalTo: inputPanel.trailingAnchor),
-            inputPanelSeparator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
-
-            inputPlaceholderLabel.leadingAnchor.constraint(equalTo: inputPanel.leadingAnchor, constant: 16),
-            inputPlaceholderLabel.centerYAnchor.constraint(equalTo: inputPanel.centerYAnchor),
+            inputPanel.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
         ])
     }
 

--- a/Tests/OnymIOSTests/ChatInputPanelViewTests.swift
+++ b/Tests/OnymIOSTests/ChatInputPanelViewTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for `ChatInputPanelView`. The two contracts
+/// other PRs depend on:
+///
+///   - Send button enabled iff the text view has non-whitespace
+///     content. PR 8's `SendMessageInteractor` wiring will trust
+///     this and skip its own empty-body guard.
+///   - Text view height grows with content, capped at 3 lines.
+///     Beyond the cap the text view scrolls internally instead of
+///     pushing the message list further up.
+@MainActor
+final class ChatInputPanelViewTests: XCTestCase {
+
+    // MARK: - Send-button enable state
+
+    func test_initialState_sendButtonDisabled() {
+        let panel = ChatInputPanelView()
+        XCTAssertFalse(sendButton(in: panel).isEnabled,
+                       "empty composer must not let the send button fire")
+    }
+
+    func test_setText_nonEmpty_enablesSend() {
+        let panel = ChatInputPanelView()
+        panel.text = "hi"
+        XCTAssertTrue(sendButton(in: panel).isEnabled)
+    }
+
+    func test_setText_emptyAgain_disablesSend() {
+        let panel = ChatInputPanelView()
+        panel.text = "hi"
+        XCTAssertTrue(sendButton(in: panel).isEnabled)
+        panel.text = ""
+        XCTAssertFalse(sendButton(in: panel).isEnabled)
+    }
+
+    // MARK: - Send tap
+
+    func test_tappingSend_invokesClosure_withTrimmedText() {
+        let panel = ChatInputPanelView()
+        var received: String?
+        panel.onSendTapped = { received = $0 }
+        panel.text = "   hello   "
+        sendButton(in: panel).sendActions(for: .touchUpInside)
+        XCTAssertEqual(received, "hello",
+                       "send should trim leading/trailing whitespace")
+    }
+
+    func test_tappingSend_emptyText_isNoOp() {
+        // Belt + braces: the button is disabled when empty, but if
+        // a future caller forces a tap programmatically the
+        // closure must still not fire on empty input.
+        let panel = ChatInputPanelView()
+        var fired = false
+        panel.onSendTapped = { _ in fired = true }
+        panel.text = "   "  // whitespace-only also counts as empty
+        sendButton(in: panel).sendActions(for: .touchUpInside)
+        XCTAssertFalse(fired)
+    }
+
+    // MARK: - Auto-height
+    //
+    // Asserting absolute pixel values is brittle — UITextView's
+    // empty-state height doesn't exactly match the obvious
+    // `font.lineHeight + insets` formula (it's typically a point
+    // larger). All height tests below are *relative*: empty,
+    // single-line, multi-line, and capped states compared against
+    // each other rather than against hard-coded numbers.
+
+    func test_singleLineText_doesNotGrowBeyondEmpty() {
+        // Short text fits on one line, so the panel height must
+        // match the empty state's height — auto-grow doesn't kick
+        // in until the second line.
+        let panel = ChatInputPanelView()
+        panel.frame = CGRect(x: 0, y: 0, width: 320, height: 100)
+        panel.layoutIfNeeded()
+        let emptyHeight = textViewHeight(in: panel)
+
+        panel.text = "hi"
+        XCTAssertEqual(textViewHeight(in: panel), emptyHeight, accuracy: 0.5)
+    }
+
+    func test_multiLineText_growsBeyondSingleLine() {
+        let panel = ChatInputPanelView()
+        panel.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
+        panel.layoutIfNeeded()
+        let emptyHeight = textViewHeight(in: panel)
+
+        panel.text = "line 1\nline 2"
+        panel.layoutIfNeeded()
+        XCTAssertGreaterThan(textViewHeight(in: panel), emptyHeight + 1,
+                             "two lines of text must grow the panel")
+    }
+
+    func test_textGrows_capsAtMaxLineCount() {
+        // Three vs ten lines should produce the *same* height —
+        // anything past the cap scrolls internally instead of
+        // pushing the panel taller.
+        let panel = ChatInputPanelView()
+        panel.frame = CGRect(x: 0, y: 0, width: 320, height: 400)
+        panel.layoutIfNeeded()
+
+        panel.text = "1\n2\n3"
+        panel.layoutIfNeeded()
+        let threeLineHeight = textViewHeight(in: panel)
+
+        panel.text = (1...10).map { "line \($0)" }.joined(separator: "\n")
+        panel.layoutIfNeeded()
+        let tenLineHeight = textViewHeight(in: panel)
+
+        XCTAssertEqual(tenLineHeight, threeLineHeight, accuracy: 0.5,
+                       "panel must stop growing past the line cap")
+    }
+
+    // MARK: - Subview lookup
+
+    private func sendButton(in panel: ChatInputPanelView) -> UIButton {
+        guard let b = find(in: panel, identifier: "chat.input.send") as? UIButton else {
+            fatalError("send button not found")
+        }
+        return b
+    }
+
+    private func textView(in panel: ChatInputPanelView) -> UITextView {
+        guard let tv = find(in: panel, identifier: "chat.input.textview") as? UITextView else {
+            fatalError("text view not found")
+        }
+        return tv
+    }
+
+    private func textViewHeight(in panel: ChatInputPanelView) -> CGFloat {
+        // The text view's height is governed by an internal
+        // constraint. Read the resolved height via the constraint
+        // rather than the live frame — the latter can be stale
+        // until the next layout pass.
+        let tv = textView(in: panel)
+        return tv.constraints.first { $0.firstAttribute == .height }?.constant
+            ?? tv.bounds.height
+    }
+
+    private func find(in view: UIView, identifier: String) -> UIView? {
+        if view.accessibilityIdentifier == identifier { return view }
+        for sub in view.subviews {
+            if let found = find(in: sub, identifier: identifier) { return found }
+        }
+        return nil
+    }
+}

--- a/Tests/OnymIOSTests/ChatInputPanelViewTests.swift
+++ b/Tests/OnymIOSTests/ChatInputPanelViewTests.swift
@@ -35,6 +35,17 @@ final class ChatInputPanelViewTests: XCTestCase {
         XCTAssertFalse(sendButton(in: panel).isEnabled)
     }
 
+    func test_setText_whitespaceOnly_disablesSend() {
+        // Whitespace-only input must leave the button disabled —
+        // it's the canonical signal to the user that tapping
+        // wouldn't send anything. (`tappedSend` already no-ops on
+        // whitespace; this asserts the button's enable state
+        // matches that behavior.)
+        let panel = ChatInputPanelView()
+        panel.text = "   \n   "
+        XCTAssertFalse(sendButton(in: panel).isEnabled)
+    }
+
     // MARK: - Send tap
 
     func test_tappingSend_invokesClosure_withTrimmedText() {
@@ -68,23 +79,30 @@ final class ChatInputPanelViewTests: XCTestCase {
     // single-line, multi-line, and capped states compared against
     // each other rather than against hard-coded numbers.
 
+    // Each height test hosts the panel in a real `UIWindow` so
+    // the constraint engine actually drives the height constraint
+    // — without a superview, `layoutIfNeeded()` is a no-op and
+    // the constraint stays at its initial constant, making any
+    // pre/post comparison pass trivially. (PR 7 review point #2.)
+
     func test_singleLineText_doesNotGrowBeyondEmpty() {
         // Short text fits on one line, so the panel height must
         // match the empty state's height — auto-grow doesn't kick
         // in until the second line.
-        let panel = ChatInputPanelView()
-        panel.frame = CGRect(x: 0, y: 0, width: 320, height: 100)
-        panel.layoutIfNeeded()
+        let panel = makePanelInWindow(width: 320)
         let emptyHeight = textViewHeight(in: panel)
+        // Sanity-check: the constraint was actually driven by the
+        // layout pass. A trivial "both reads return 36" failure
+        // mode would slip past the comparison below.
+        XCTAssertGreaterThan(emptyHeight, 0)
 
         panel.text = "hi"
+        panel.layoutIfNeeded()
         XCTAssertEqual(textViewHeight(in: panel), emptyHeight, accuracy: 0.5)
     }
 
     func test_multiLineText_growsBeyondSingleLine() {
-        let panel = ChatInputPanelView()
-        panel.frame = CGRect(x: 0, y: 0, width: 320, height: 200)
-        panel.layoutIfNeeded()
+        let panel = makePanelInWindow(width: 320)
         let emptyHeight = textViewHeight(in: panel)
 
         panel.text = "line 1\nline 2"
@@ -97,9 +115,7 @@ final class ChatInputPanelViewTests: XCTestCase {
         // Three vs ten lines should produce the *same* height —
         // anything past the cap scrolls internally instead of
         // pushing the panel taller.
-        let panel = ChatInputPanelView()
-        panel.frame = CGRect(x: 0, y: 0, width: 320, height: 400)
-        panel.layoutIfNeeded()
+        let panel = makePanelInWindow(width: 400)
 
         panel.text = "1\n2\n3"
         panel.layoutIfNeeded()
@@ -111,6 +127,29 @@ final class ChatInputPanelViewTests: XCTestCase {
 
         XCTAssertEqual(tenLineHeight, threeLineHeight, accuracy: 0.5,
                        "panel must stop growing past the line cap")
+    }
+
+    /// Hosts the panel in a real `UIWindow` of the requested width
+    /// with the panel pinned to leading / trailing / bottom. The
+    /// constraint engine drives the panel's intrinsic height to a
+    /// real value, so subsequent `textViewHeight(in:)` reads
+    /// reflect what production layout would produce.
+    private func makePanelInWindow(width: CGFloat) -> ChatInputPanelView {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: width, height: 600))
+        let host = UIViewController()
+        window.rootViewController = host
+        window.isHidden = false
+
+        let panel = ChatInputPanelView()
+        panel.translatesAutoresizingMaskIntoConstraints = false
+        host.view.addSubview(panel)
+        NSLayoutConstraint.activate([
+            panel.leadingAnchor.constraint(equalTo: host.view.leadingAnchor),
+            panel.trailingAnchor.constraint(equalTo: host.view.trailingAnchor),
+            panel.bottomAnchor.constraint(equalTo: host.view.bottomAnchor),
+        ])
+        host.view.layoutIfNeeded()
+        return panel
     }
 
     // MARK: - Subview lookup

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -93,8 +93,18 @@ final class ChatThreadViewControllerTests: XCTestCase {
         // snapshots, but a future caller / test stub might violate
         // it. The controller sorts before applying so row order is
         // always chronological.
+        //
+        // The assertion reads cell content via `cellForRow(at:)`,
+        // which only returns currently-visible rows. Place the
+        // controller in a real window so Auto Layout (including
+        // the input panel's `keyboardLayoutGuide` constraint)
+        // resolves and the table view ends up tall enough to host
+        // all three rows.
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 800))
         let vc = ChatThreadViewController()
-        vc.loadViewIfNeeded()
+        window.rootViewController = vc
+        window.isHidden = false
+
         let oldest = makeMessage(body: "1", direction: .incoming,
                                  sentAt: Date(timeIntervalSince1970: 1_700_000_000))
         let middle = makeMessage(body: "2", direction: .outgoing,
@@ -103,13 +113,11 @@ final class ChatThreadViewControllerTests: XCTestCase {
                                  sentAt: Date(timeIntervalSince1970: 1_700_000_200))
         // Out-of-order input.
         vc.update(messages: [newest, oldest, middle])
-
+        vc.view.layoutIfNeeded()
         let table = tableView(in: vc)!
-        table.frame = CGRect(x: 0, y: 0, width: 320, height: 640)
         table.layoutIfNeeded()
 
-        // Row 0 = oldest (top), row 2 = newest (bottom). Reads via
-        // the cell text.
+        // Row 0 = oldest (top), row 2 = newest (bottom).
         XCTAssertEqual(table.numberOfRows(inSection: 0), 3)
         XCTAssertEqual(cellBodyText(in: table, row: 0), "1")
         XCTAssertEqual(cellBodyText(in: table, row: 1), "2")
@@ -126,6 +134,41 @@ final class ChatThreadViewControllerTests: XCTestCase {
 
         vc.update(messages: [m1])
         XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 1)
+    }
+
+    // MARK: - Input panel wiring (PR 7)
+
+    func test_inputPanel_isHosted_andClearsTextOnSendTap() {
+        // PR 7 only wires the layout + clear-on-tap behavior; PR 8
+        // will swap the closure body for a real send. This test
+        // pins the PR-7 contract: the panel is in the hierarchy
+        // and tapping send clears the field.
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        guard let panel = inputPanel(in: vc) else {
+            return XCTFail("input panel not found in controller hierarchy")
+        }
+        panel.text = "hello"
+        XCTAssertTrue(sendButton(in: panel).isEnabled)
+
+        sendButton(in: panel).sendActions(for: .touchUpInside)
+        XCTAssertEqual(panel.text, "",
+                       "PR 7 contract: tapping send clears the field")
+        XCTAssertFalse(sendButton(in: panel).isEnabled,
+                       "after clearing, the send button must disable again")
+    }
+
+    private func inputPanel(in vc: UIViewController) -> ChatInputPanelView? {
+        find(in: vc.view) { $0 is ChatInputPanelView } as? ChatInputPanelView
+    }
+
+    private func sendButton(in panel: ChatInputPanelView) -> UIButton {
+        guard let b = find(in: panel, where: {
+            $0.accessibilityIdentifier == "chat.input.send"
+        }) as? UIButton else {
+            fatalError("send button not found")
+        }
+        return b
     }
 
     // MARK: - Auto-scroll heuristic


### PR DESCRIPTION
**Composer is real now.** A `UITextView` that grows to a 3-line cap, a Send button, bottom-anchored to `view.keyboardLayoutGuide.topAnchor` so the panel rides with the keyboard. **No real send wiring yet** — tap is a no-op that clears the field. PR 8 swaps the closure body for `SendMessageInteractor`.

## Stacked on
Base: \`pr-chat-6-message-list\` (#152).

## `ChatInputPanelView`
- `UITextView` with body-font + Dynamic Type, rounded fill, inset 12pt on the leading; Send button on the trailing.
- Placeholder `UILabel` overlay ("Message") that hides on first keystroke.
- **Auto-height**: text view grows up to `intrinsicHeight(forLines: 3)`, then scrolls internally. Below 3 lines it sizes to the actual content, never below the one-line floor. The floor + cap are derived from `font.lineHeight + textContainerInset.top + textContainerInset.bottom` so Dynamic Type re-flows correctly.
- `onSendTapped: (String) -> Void` fires on tap with the body trimmed of leading/trailing whitespace. Whitespace-only input is a no-op (the button's disabled anyway; this is belt-plus-braces).
- `refreshAfterTextChange` calls `textView.layoutIfNeeded()` before measuring — **TextKit 2 (iOS 18+ default) returns stale `sizeThatFits` results immediately after a programmatic `.text = ...` write**. The forced flush makes the height update correctly in both interactive and programmatic paths.

## `ChatThreadViewController` wire-up
- Replaced the PR-5 placeholder UIView with a real `ChatInputPanelView`.
- Bottom anchor switches from `safeArea.bottomAnchor` to `view.keyboardLayoutGuide.topAnchor`. **No manual `keyboardWillShow` notifications or frame math.** With no keyboard up, the guide equals the safe-area bottom; when the keyboard rises, the panel slides automatically.
- Dropped the fixed 56pt height — the panel sizes intrinsically from its text-view height + 16pt vertical padding.
- For PR 7, `onSendTapped` just clears the field. PR 8 will replace this closure body with `SendMessageInteractor.send`.

## Tests (9 new, full suite 600 / 600)

**`ChatInputPanelViewTests`** (8):
- initialState: send disabled
- setText nonEmpty: enables send; emptyAgain: disables
- tap send → closure fires with trimmed body
- tap send on whitespace-only → no-op
- single-line text: same height as empty
- multi-line text: grows beyond single-line height
- text growth caps at `maxLineCount` (3 vs 10 lines = same height)

**`ChatThreadViewControllerTests`** +1:
- inputPanel is hosted; tapping send clears the field (PR-7 closure contract).

One previously-passing controller test (`test_updateMessages_unsortedInput_isSortedAscending`) needed a real `UIWindow` because the PR 7 layout uses `keyboardLayoutGuide`, which only resolves inside a window. Switched that test to host the controller in a window.

## Visual correctness — NOT covered by tests
Bubble layout while typing, keyboard slide animation, Dynamic Type scaling: verify in the simulator. Tap a group, tap the field, type, hit Send → the field should clear and the keyboard stays up.

## Plan context
PR 7 of 11. **PR 8 next**: replace the placeholder `onSendTapped` closure with a real `SendMessageInteractor.send` call — optimistic insert as `.pending`, status flip on completion. Will need to plumb `SendMessageInteractor` through `AppDependencies` → `ChatThreadView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)