### PR TITLE
feat(chats): wire Send button to SendMessageInteractor (PR 8/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -29,4 +29,9 @@ struct AppDependencies {
     /// writes into the same actor. Constructed once in
     /// `OnymIOSApp.init` and threaded down.
     let messageRepository: MessageRepository
+    /// Stateless façade over identity + transport + repositories
+    /// for outgoing chat messages. Safe to share across screens
+    /// (it's an actor); each chat-thread view captures it and
+    /// dispatches `send(groupID:body:)` on the send-button tap.
+    let sendMessageInteractor: SendMessageInteractor
 }

--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -20,6 +20,7 @@ struct ChatThreadView: View {
     @Bindable var chatsFlow: ChatsFlow
     @Bindable var identitiesFlow: IdentitiesFlow
     let messageRepository: MessageRepository
+    let sendMessageInteractor: SendMessageInteractor
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
     @Environment(\.dismiss) private var dismiss
@@ -34,7 +35,25 @@ struct ChatThreadView: View {
             groupName: currentGroupName,
             messages: messages,
             onBack: { dismiss() },
-            onShowMembers: { showMembers = true }
+            onShowMembers: { showMembers = true },
+            onSendTapped: { body in
+                // Fire-and-forget. `SendMessageInteractor` does the
+                // optimistic insert as `.pending` synchronously
+                // before the await, so the new row appears in the
+                // `MessageRepository.snapshots` stream we're
+                // subscribing to above — the table updates without
+                // any extra plumbing here. The interactor also
+                // owns the status flip to `.sent` / `.failed`, so
+                // a thrown error here would only indicate a
+                // precondition violation (no identity, unknown
+                // group). Those shouldn't happen mid-chat-screen;
+                // swallow with `try?` for PR 8.
+                let interactor = sendMessageInteractor
+                let groupID = groupID
+                Task {
+                    try? await interactor.send(groupID: groupID, body: body)
+                }
+            }
         )
         .toolbar(.hidden, for: .navigationBar)
         .navigationDestination(isPresented: $showMembers) {
@@ -65,11 +84,13 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let messages: [ChatMessage]
     let onBack: () -> Void
     let onShowMembers: () -> Void
+    let onSendTapped: (String) -> Void
 
     func makeUIViewController(context: Context) -> ChatThreadViewController {
         let vc = ChatThreadViewController()
         vc.onBack = onBack
         vc.onShowMembers = onShowMembers
+        vc.onSendTapped = onSendTapped
         vc.loadViewIfNeeded()
         vc.update(groupName: groupName)
         vc.update(messages: messages)
@@ -78,10 +99,12 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
 
     func updateUIViewController(_ vc: ChatThreadViewController, context: Context) {
         // Closures are refreshed every render — SwiftUI captures the
-        // *current* `dismiss` + `showMembers` setters, so the version
-        // the controller invokes always reflects the live binding.
+        // *current* `dismiss` + `showMembers` setters + send-tap
+        // dispatcher, so the version the controller invokes always
+        // reflects the live binding.
         vc.onBack = onBack
         vc.onShowMembers = onShowMembers
+        vc.onSendTapped = onSendTapped
         vc.update(groupName: groupName)
         vc.update(messages: messages)
     }

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -28,6 +28,15 @@ final class ChatThreadViewController: UIViewController {
     /// view push.
     var onShowMembers: (() -> Void)?
 
+    /// Invoked when the user taps the input panel's Send button
+    /// with non-whitespace content. The SwiftUI wrapper points
+    /// this at `SendMessageInteractor.send(groupID:body:)` —
+    /// fire-and-forget; the interactor handles optimistic insert,
+    /// fan-out, and status flip on its own. Receives the body
+    /// already trimmed of leading/trailing whitespace by the
+    /// input panel.
+    var onSendTapped: ((String) -> Void)?
+
     private let titleLabel = UILabel()
     private let backButton = UIButton(type: .system)
     private let infoButton = UIButton(type: .system)
@@ -233,11 +242,16 @@ final class ChatThreadViewController: UIViewController {
     private func buildInputPanel() {
         inputPanel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(inputPanel)
-        // PR 7 wires the layout + enable-state. PR 8 will replace
-        // this closure with the real `SendMessageInteractor.send`
-        // call; for now we just clear the field so the user sees
-        // the input is responsive.
-        inputPanel.onSendTapped = { [weak self] _ in
+        // Forward to the host-supplied dispatcher first (so the
+        // closure sees the typed body), then clear the field. The
+        // dispatcher is fire-and-forget — `SendMessageInteractor`
+        // does the optimistic insert before the await, so the
+        // user's message appears in the table via the snapshot
+        // stream long before the network round-trip resolves;
+        // clearing the field straight after the tap keeps the
+        // composer feeling responsive.
+        inputPanel.onSendTapped = { [weak self] body in
+            self?.onSendTapped?(body)
             self?.inputPanel.text = ""
         }
     }

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -10,6 +10,7 @@ struct ChatsView: View {
     let identitiesFlow: IdentitiesFlow
     let approveRequestsFlow: ApproveRequestsFlow
     let messageRepository: MessageRepository
+    let sendMessageInteractor: SendMessageInteractor
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
 
@@ -132,6 +133,7 @@ struct ChatsView: View {
                 chatsFlow: flow,
                 identitiesFlow: identitiesFlow,
                 messageRepository: messageRepository,
+                sendMessageInteractor: sendMessageInteractor,
                 makeShareInviteFlow: makeShareInviteFlow
             )
         }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -220,7 +220,13 @@ struct OnymIOSApp: App {
             },
             identitiesFlow: identitiesFlow,
             approveRequestsFlow: approveRequestsFlow,
-            messageRepository: messageRepository
+            messageRepository: messageRepository,
+            sendMessageInteractor: SendMessageInteractor(
+                identity: repository,
+                inboxTransport: inboxTransport,
+                messageRepository: messageRepository,
+                groupRepository: groupRepository
+            )
         )
     }
 

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -31,6 +31,7 @@ struct RootView: View {
                         identitiesFlow: dependencies.identitiesFlow,
                         approveRequestsFlow: dependencies.approveRequestsFlow,
                         messageRepository: dependencies.messageRepository,
+                        sendMessageInteractor: dependencies.sendMessageInteractor,
                         makeCreateGroupFlow: dependencies.makeCreateGroupFlow,
                         makeShareInviteFlow: dependencies.makeShareInviteFlow
                     )

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -136,13 +136,10 @@ final class ChatThreadViewControllerTests: XCTestCase {
         XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 1)
     }
 
-    // MARK: - Input panel wiring (PR 7)
+    // MARK: - Input panel wiring (PR 7 / PR 8)
 
     func test_inputPanel_isHosted_andClearsTextOnSendTap() {
-        // PR 7 only wires the layout + clear-on-tap behavior; PR 8
-        // will swap the closure body for a real send. This test
-        // pins the PR-7 contract: the panel is in the hierarchy
-        // and tapping send clears the field.
+        // Tapping send clears the field — PR 7 contract.
         let vc = ChatThreadViewController()
         vc.loadViewIfNeeded()
         guard let panel = inputPanel(in: vc) else {
@@ -153,9 +150,47 @@ final class ChatThreadViewControllerTests: XCTestCase {
 
         sendButton(in: panel).sendActions(for: .touchUpInside)
         XCTAssertEqual(panel.text, "",
-                       "PR 7 contract: tapping send clears the field")
+                       "tapping send must clear the field")
         XCTAssertFalse(sendButton(in: panel).isEnabled,
                        "after clearing, the send button must disable again")
+    }
+
+    func test_inputPanel_send_invokesOnSendTapped_withTrimmedBody() {
+        // PR 8 contract: the controller forwards the panel's
+        // trimmed body to `onSendTapped` (the SwiftUI bridge
+        // points this at `SendMessageInteractor.send`).
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        guard let panel = inputPanel(in: vc) else {
+            return XCTFail("input panel not found in controller hierarchy")
+        }
+        var receivedBodies: [String] = []
+        vc.onSendTapped = { receivedBodies.append($0) }
+
+        panel.text = "   hello   "
+        sendButton(in: panel).sendActions(for: .touchUpInside)
+        XCTAssertEqual(receivedBodies, ["hello"],
+                       "the controller must forward the trimmed body to the host's send dispatcher")
+    }
+
+    func test_inputPanel_send_doesNotFire_forWhitespaceOnlyBody() {
+        // Belt + braces. The input panel already gates the button
+        // disabled for whitespace-only input, but if anything ever
+        // bypasses that (programmatic tap, accessibility action),
+        // the controller's forwarder must not invoke the
+        // dispatcher with an empty body.
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        guard let panel = inputPanel(in: vc) else {
+            return XCTFail("input panel not found")
+        }
+        var fired = false
+        vc.onSendTapped = { _ in fired = true }
+
+        panel.text = "   "
+        sendButton(in: panel).sendActions(for: .touchUpInside)
+        XCTAssertFalse(fired,
+                       "whitespace-only body must not reach the send dispatcher")
     }
 
     private func inputPanel(in vc: UIViewController) -> ChatInputPanelView? {


### PR DESCRIPTION
**End-to-end.** Type a message, tap Send, see it appear in the thread immediately and propagate to the other group members.

## Stacked on
Base: \`pr-chat-7-input-panel\` (#153).

## What's in here

PR 4 (#150) already built `SendMessageInteractor` with the full optimistic-insert / fan-out / status-flip lifecycle. PR 8 plumbing is thin:

- **`AppDependencies.sendMessageInteractor`** — shared actor, constructed in `OnymIOSApp.init` alongside the existing repositories.
- **`RootView` → `ChatsView` → `ChatThreadView`** thread it through.
- **`ChatThreadView`** constructs the fire-and-forget closure:
  ```swift
  Task { try? await interactor.send(groupID: groupID, body: body) }
  ```
  Errors are swallowed because the `SendError` cases (no identity loaded, unknown group, not a member, empty body) all represent invariants that should hold mid-chat-screen. Network / fan-out failures flip the message status to `.failed` inside the interactor — PR 9 surfaces that visually.
- **`ChatThreadViewController`** exposes `onSendTapped: ((String) -> Void)?`. The input panel forwards its trimmed body to this dispatcher *before* clearing the field, so the host sees the typed content even though the composer empties immediately.

## UX flow
1. User types "hi" → Send button enables (PR 7 trim gate).
2. Tap Send → controller forwards "hi" to the interactor.
3. Interactor inserts a `.pending` row into `MessageRepository` **before** the await.
4. `MessageRepository.snapshots` emits → PR 6 diffable data source reconciles → bubble appears + table auto-scrolls.
5. Input clears immediately (snappier than waiting for the await).
6. Network round-trip resolves → interactor flips status to `.sent` / `.failed`. PR 9 will style the bubble accordingly.

## Tests (2 new, suite 603 / 603)

**`ChatThreadViewControllerTests`** +2:
- `test_inputPanel_send_invokesOnSendTapped_withTrimmedBody` — the controller must forward the trimmed body to the host's dispatcher closure.
- `test_inputPanel_send_doesNotFire_forWhitespaceOnlyBody` — belt-plus-braces; even if a future caller bypasses the input panel's disabled-state gate, the controller forwarder must not invoke the dispatcher with an empty body.

PR 4's `SendMessageInteractorTests` already cover the optimistic-insert / fan-out / status-flip behavior; no new tests needed there.

## Visual / end-to-end correctness — NOT covered by tests
Bubble appearance timing, status flip animation, table auto-scroll on send: **verify in the simulator with two devices in the same Tyranny group** to confirm the full round-trip works.

## Plan context
PR 8 of 11. **PR 9 next**: message status indicator (clock / check / red bang) + retry-on-failed. Needs the PR 6 diffable data source's `reconfigureItems` switch to land too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)