### PR TITLE
feat(chats): message status indicator + retry on failed (PR 9/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatBubbleCell.swift
+++ b/Sources/OnymIOS/Chats/ChatBubbleCell.swift
@@ -7,13 +7,12 @@ import UIKit
 ///   - `.outgoing` — accent-filled bubble pinned to the trailing edge.
 ///   - `.incoming` — surface-tinted bubble pinned to the leading edge.
 ///
-/// Layout is a single `UILabel` inside a `UIView` bubble container.
-/// The bubble's leading/trailing edge is swapped via two stored
-/// constraints; the `lessThanOrEqualTo` width cap keeps long
-/// messages from filling the full row.
-///
-/// PR 6 scope: no avatars, no timestamps, no status glyphs, no
-/// emoji rendering. Status indicator lands in PR 8.
+/// Status indicator (PR 9): outgoing rows show a tiny glyph below
+/// the bubble's trailing edge that reflects `ChatMessage.status`
+/// (clock / check / red bang). Incoming rows hide the indicator —
+/// the message arriving is the proof. Tapping a `.failed` bubble
+/// invokes `onRetryRequested`, which the controller wires to
+/// `SendMessageInteractor.retry`.
 final class ChatBubbleCell: UITableViewCell {
     static let reuseID = "ChatBubbleCell"
 
@@ -24,16 +23,32 @@ final class ChatBubbleCell: UITableViewCell {
 
     private let bubble = UIView()
     private let bodyLabel = UILabel()
+    private let statusImageView = UIImageView()
+
+    /// Set by the diffable data source's cell provider on every
+    /// dequeue. Fires when the user taps a `.failed` bubble —
+    /// `configure(message:onRetry:)` only installs the tap target
+    /// when the message is retry-eligible, so other states never
+    /// fire this.
+    private var onRetryRequested: (() -> Void)?
+    private var retryTapRecognizer: UITapGestureRecognizer?
 
     // Direction-dependent constraints — only one pair is active at a
     // time. Each pair contains the alignment pin (`==` to the pinned
     // edge) and the opposite-edge breathing-room gap on the *other*
     // side. Pairing this way prevents the obvious-but-wrong layout:
     // pinning `leading == +12` while also asserting `leading >= +56`
-    // (the original PR 6 shape) breaks every cell with a constraint
-    // log.
+    // breaks every cell with a constraint log.
     private var outgoingConstraints: [NSLayoutConstraint] = []
     private var incomingConstraints: [NSLayoutConstraint] = []
+
+    // Direction-dependent "where does the cell's bottom come from"
+    // constraint. For incoming, the bubble's bottom is the cell's
+    // bottom (status indicator hidden, no extra height). For
+    // outgoing, the status indicator's bottom drives the cell so
+    // the indicator has room below the bubble.
+    private var bubbleBottomConstraint: NSLayoutConstraint!
+    private var statusBottomConstraint: NSLayoutConstraint!
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -41,6 +56,7 @@ final class ChatBubbleCell: UITableViewCell {
         selectionStyle = .none
         contentView.backgroundColor = UIColor(OnymTokens.bg)
         buildBubble()
+        buildStatusIndicator()
         layoutBubble()
     }
 
@@ -49,10 +65,11 @@ final class ChatBubbleCell: UITableViewCell {
         fatalError("init(coder:) not implemented")
     }
 
-    /// Swap colors + alignment for the message's direction. Caller
-    /// (the diffable data source's cell provider) invokes this on
-    /// every dequeue.
-    func configure(message: ChatMessage) {
+    /// Swap colors + alignment + status indicator for the message.
+    /// Caller (the diffable data source's cell provider) invokes
+    /// this on every dequeue *and* every reconfigure — status flips
+    /// on the same UUID land here too.
+    func configure(message: ChatMessage, onRetry: (() -> Void)? = nil) {
         bodyLabel.text = message.body
         switch message.direction {
         case .outgoing:
@@ -60,13 +77,73 @@ final class ChatBubbleCell: UITableViewCell {
             bodyLabel.textColor = UIColor(OnymTokens.onAccent)
             NSLayoutConstraint.deactivate(incomingConstraints)
             NSLayoutConstraint.activate(outgoingConstraints)
+            bubbleBottomConstraint.isActive = false
+            statusBottomConstraint.isActive = true
+            applyStatus(message.status)
         case .incoming:
             bubble.backgroundColor = UIColor(OnymTokens.surface2)
             bodyLabel.textColor = UIColor(OnymTokens.text)
             NSLayoutConstraint.deactivate(outgoingConstraints)
             NSLayoutConstraint.activate(incomingConstraints)
+            statusBottomConstraint.isActive = false
+            bubbleBottomConstraint.isActive = true
+            statusImageView.isHidden = true
+        }
+
+        // Retry tap is only installed when the message is failed
+        // *and* the host provided a retry callback. Cell reuse:
+        // first remove any prior recognizer so a previously-failed
+        // bubble doesn't keep its tap target after status flips.
+        if let existing = retryTapRecognizer {
+            bubble.removeGestureRecognizer(existing)
+            retryTapRecognizer = nil
+        }
+        onRetryRequested = nil
+        if message.status == .failed, message.direction == .outgoing, let onRetry {
+            onRetryRequested = onRetry
+            let tap = UITapGestureRecognizer(target: self, action: #selector(tappedBubble))
+            bubble.addGestureRecognizer(tap)
+            retryTapRecognizer = tap
         }
     }
+
+    private func applyStatus(_ status: MessageStatus) {
+        statusImageView.isHidden = false
+        switch status {
+        case .pending:
+            statusImageView.image = UIImage(systemName: "clock")
+            statusImageView.tintColor = UIColor(OnymTokens.text3)
+            statusImageView.accessibilityLabel = "Sending"
+        case .sent:
+            statusImageView.image = UIImage(systemName: "checkmark")
+            statusImageView.tintColor = UIColor(OnymTokens.text3)
+            statusImageView.accessibilityLabel = "Sent"
+        case .failed:
+            statusImageView.image = UIImage(systemName: "exclamationmark.circle.fill")
+            statusImageView.tintColor = UIColor(OnymTokens.red)
+            statusImageView.accessibilityLabel = "Failed — tap to retry"
+        case .received:
+            // Outgoing rows never carry .received; hide as a
+            // defensive default if a bad row somehow lands here.
+            statusImageView.isHidden = true
+        }
+    }
+
+    @objc private func tappedBubble() {
+        onRetryRequested?()
+    }
+
+    /// Test seam — fires the same handler the bubble's
+    /// `UITapGestureRecognizer` would on a real touch. Without
+    /// this, tests would need runtime-private hooks to synthesize
+    /// the tap; this single internal method keeps the rest of
+    /// the cell API private. Marked `internal` so `@testable import`
+    /// can reach it.
+    #if DEBUG
+    func simulateBubbleTapForTest() {
+        tappedBubble()
+    }
+    #endif
 
     private func buildBubble() {
         bubble.translatesAutoresizingMaskIntoConstraints = false
@@ -76,28 +153,36 @@ final class ChatBubbleCell: UITableViewCell {
 
         bodyLabel.translatesAutoresizingMaskIntoConstraints = false
         bodyLabel.numberOfLines = 0
-        // Dynamic Type — the chat body should scale with the user's
-        // preferred text size. Full a11y polish pass happens later
-        // (PR 9+), but using `preferredFont(forTextStyle:)` here
-        // costs nothing now and avoids a fixed-size regression.
         bodyLabel.font = .preferredFont(forTextStyle: .body)
         bodyLabel.adjustsFontForContentSizeCategory = true
         bubble.addSubview(bodyLabel)
     }
 
+    private func buildStatusIndicator() {
+        statusImageView.translatesAutoresizingMaskIntoConstraints = false
+        statusImageView.contentMode = .scaleAspectFit
+        statusImageView.preferredSymbolConfiguration = UIImage.SymbolConfiguration(
+            pointSize: 11,
+            weight: .semibold
+        )
+        statusImageView.isHidden = true
+        statusImageView.accessibilityIdentifier = "chat.bubble.status"
+        contentView.addSubview(statusImageView)
+    }
+
     private func layoutBubble() {
         let edgeInset: CGFloat = 12
-        // Opposite-edge gap: the side the bubble does NOT pin to
-        // still leaves this much breathing room from the cell edge.
-        // Gives the "addressed to one side" visual without the
-        // bubble ever filling the row, even for super-short content
-        // that the width cap doesn't bind on.
         let oppositeGap: CGFloat = 56
 
-        // Always-active constraints (don't depend on direction).
+        bubbleBottomConstraint = bubble.bottomAnchor.constraint(
+            equalTo: contentView.bottomAnchor, constant: -4
+        )
+        statusBottomConstraint = contentView.bottomAnchor.constraint(
+            equalTo: statusImageView.bottomAnchor, constant: 4
+        )
+
         NSLayoutConstraint.activate([
             bubble.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
-            bubble.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4),
             bubble.widthAnchor.constraint(
                 lessThanOrEqualTo: contentView.widthAnchor,
                 multiplier: maxWidthFraction
@@ -106,6 +191,16 @@ final class ChatBubbleCell: UITableViewCell {
             bodyLabel.trailingAnchor.constraint(equalTo: bubble.trailingAnchor, constant: -12),
             bodyLabel.topAnchor.constraint(equalTo: bubble.topAnchor, constant: 8),
             bodyLabel.bottomAnchor.constraint(equalTo: bubble.bottomAnchor, constant: -8),
+
+            // Status indicator sits in the gap below the bubble,
+            // trailing-aligned. Always positioned relative to the
+            // bubble; only the cell-bottom anchor differs between
+            // directions (see `bubbleBottomConstraint` vs
+            // `statusBottomConstraint`).
+            statusImageView.topAnchor.constraint(equalTo: bubble.bottomAnchor, constant: 2),
+            statusImageView.trailingAnchor.constraint(equalTo: bubble.trailingAnchor),
+            statusImageView.widthAnchor.constraint(equalToConstant: 14),
+            statusImageView.heightAnchor.constraint(equalToConstant: 14),
         ])
 
         // Outgoing pair — trailing-pinned, leading has the
@@ -132,5 +227,6 @@ final class ChatBubbleCell: UITableViewCell {
         // overrides before the cell is shown, but the default keeps
         // the cell layout-valid even if a configurer skips us.
         NSLayoutConstraint.activate(incomingConstraints)
+        bubbleBottomConstraint.isActive = true
     }
 }

--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -53,6 +53,19 @@ struct ChatThreadView: View {
                 Task {
                     try? await interactor.send(groupID: groupID, body: body)
                 }
+            },
+            onRetryRequested: { messageID in
+                // PR 9: retry a failed outgoing message. Same
+                // fire-and-forget shape as the send path — the
+                // interactor flips status to .pending before the
+                // network work begins (so the glyph swaps to the
+                // in-flight clock immediately), runs the fan-out,
+                // then flips to .sent / .failed on completion.
+                let interactor = sendMessageInteractor
+                let groupID = groupID
+                Task {
+                    await interactor.retry(groupID: groupID, messageID: messageID)
+                }
             }
         )
         .toolbar(.hidden, for: .navigationBar)
@@ -85,12 +98,14 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let onBack: () -> Void
     let onShowMembers: () -> Void
     let onSendTapped: (String) -> Void
+    let onRetryRequested: (UUID) -> Void
 
     func makeUIViewController(context: Context) -> ChatThreadViewController {
         let vc = ChatThreadViewController()
         vc.onBack = onBack
         vc.onShowMembers = onShowMembers
         vc.onSendTapped = onSendTapped
+        vc.onRetryRequested = onRetryRequested
         vc.loadViewIfNeeded()
         vc.update(groupName: groupName)
         vc.update(messages: messages)
@@ -100,11 +115,12 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     func updateUIViewController(_ vc: ChatThreadViewController, context: Context) {
         // Closures are refreshed every render — SwiftUI captures the
         // *current* `dismiss` + `showMembers` setters + send-tap
-        // dispatcher, so the version the controller invokes always
-        // reflects the live binding.
+        // dispatcher + retry dispatcher, so the version the
+        // controller invokes always reflects the live binding.
         vc.onBack = onBack
         vc.onShowMembers = onShowMembers
         vc.onSendTapped = onSendTapped
+        vc.onRetryRequested = onRetryRequested
         vc.update(groupName: groupName)
         vc.update(messages: messages)
     }

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -37,6 +37,14 @@ final class ChatThreadViewController: UIViewController {
     /// input panel.
     var onSendTapped: ((String) -> Void)?
 
+    /// Invoked when the user taps a `.failed` outgoing bubble.
+    /// The SwiftUI wrapper points this at
+    /// `SendMessageInteractor.retry(groupID:messageID:)` — same
+    /// fire-and-forget contract as `onSendTapped`. Only `.failed`
+    /// rows have the tap target installed by `ChatBubbleCell`, so
+    /// this never fires for other statuses.
+    var onRetryRequested: ((UUID) -> Void)?
+
     private let titleLabel = UILabel()
     private let backButton = UIButton(type: .system)
     private let infoButton = UIButton(type: .system)
@@ -99,21 +107,31 @@ final class ChatThreadViewController: UIViewController {
     /// but a future caller / test stub might violate that without
     /// the sort here protecting the table's row order.
     ///
-    /// PR 8 note: `messagesByID` is updated on every call, but the
-    /// diffable identity is just `UUID` — when a status flip lands
-    /// (pending → sent), visible cells won't reconfigure. PR 8 should
-    /// switch to `snapshot.reconfigureItems(changedIDs)` or include
-    /// status in the diff identity.
+    /// Status flips on the same UUID land via
+    /// `snapshot.reconfigureItems(changedIDs)` — the row stays at
+    /// the same index but the cell provider re-runs against the
+    /// updated `messagesByID` entry, so a `.pending` → `.sent`
+    /// transition swaps the glyph without animating the bubble.
     func update(messages: [ChatMessage]) {
         let isFirstApply = !hasAppliedFirstSnapshot
         let wasNearBottom = isNearBottom
 
         let sorted = messages.sorted { $0.sentAt < $1.sentAt }
+        // Detect status/body changes on already-known rows so
+        // `reconfigureItems` can repaint their cells without
+        // deleting + reinserting (which would animate the bubble).
+        let changedIDs: [UUID] = sorted.compactMap { msg in
+            guard let prior = messagesByID[msg.id], prior != msg else { return nil }
+            return msg.id
+        }
         messagesByID = Dictionary(uniqueKeysWithValues: sorted.map { ($0.id, $0) })
 
         var snapshot = NSDiffableDataSourceSnapshot<Section, UUID>()
         snapshot.appendSections([.main])
         snapshot.appendItems(sorted.map(\.id))
+        if !changedIDs.isEmpty {
+            snapshot.reconfigureItems(changedIDs)
+        }
         // First apply is non-animated to avoid an initial-load
         // "fly-in" of every existing message.
         dataSource.apply(snapshot, animatingDifferences: !isFirstApply) { [weak self] in
@@ -226,7 +244,12 @@ final class ChatThreadViewController: UIViewController {
             )
             if let bubble = cell as? ChatBubbleCell,
                let message = self?.messagesByID[id] {
-                bubble.configure(message: message)
+                let retryHandler: (() -> Void)? = {
+                    guard message.direction == .outgoing,
+                          message.status == .failed else { return nil }
+                    return { [weak self] in self?.onRetryRequested?(id) }
+                }()
+                bubble.configure(message: message, onRetry: retryHandler)
             }
             return cell
         }

--- a/Sources/OnymIOS/Chats/SendMessageInteractor.swift
+++ b/Sources/OnymIOS/Chats/SendMessageInteractor.swift
@@ -117,28 +117,114 @@ actor SendMessageInteractor {
             .filter { $0.key != myBlsHex }
             .map { $0.value.inboxPublicKey }
 
+        let finalStatus = await fanOut(
+            payload: payload,
+            recipients: recipients
+        )
+        await messageRepository.updateStatus(
+            id: messageID,
+            status: finalStatus,
+            groupID: groupID
+        )
+
+        return ChatMessage(
+            id: pending.id,
+            groupID: pending.groupID,
+            ownerIdentityID: pending.ownerIdentityID,
+            senderBlsPubkeyHex: pending.senderBlsPubkeyHex,
+            body: pending.body,
+            sentAt: pending.sentAt,
+            direction: pending.direction,
+            status: finalStatus,
+            groupType: pending.groupType
+        )
+    }
+
+    /// Retry a previously-failed outgoing message. Looks up the row
+    /// by `messageID`, flips status back to `.pending` so the UI
+    /// shows the in-flight glyph, then re-runs the fan-out using the
+    /// original payload fields (same UUID + body + sentAt) so
+    /// receivers can dedup against any earlier delivery. Status is
+    /// flipped to `.sent` / `.failed` on completion.
+    ///
+    /// No-op (silent) when:
+    ///   - The message isn't in the local repository for that group.
+    ///   - The row isn't `.outgoing` with `.failed` status. Retrying
+    ///     an already-pending or already-sent message would
+    ///     double-deliver; retrying an incoming message makes no
+    ///     sense.
+    ///   - The group isn't on this device, no identity is loaded,
+    ///     or the message's group type isn't supported by v1 chat.
+    func retry(groupID: String, messageID: UUID) async {
+        let messages = await messageRepository.currentMessages(groupID: groupID)
+        guard let message = messages.first(where: { $0.id == messageID }),
+              message.direction == .outgoing,
+              message.status == .failed
+        else { return }
+
+        guard await identity.currentIdentity() != nil else { return }
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }) else { return }
+
+        let myBlsHex = message.senderBlsPubkeyHex
+        guard group.memberProfiles[myBlsHex] != nil else { return }
+
+        let variant: ChatMessageVariant
+        switch group.groupType {
+        case .tyranny:
+            variant = .tyranny(body: message.body)
+        case .oneOnOne, .anarchy, .democracy, .oligarchy:
+            return
+        }
+
+        // Flip the row to `.pending` first so the UI's status
+        // glyph swaps from the red-bang to the in-flight clock
+        // before the network work starts. Receivers dedup against
+        // any prior delivery via the same `messageID`.
+        await messageRepository.updateStatus(
+            id: messageID,
+            status: .pending,
+            groupID: groupID
+        )
+
+        let payload = ChatMessagePayload(
+            version: 1,
+            messageID: messageID,
+            groupID: group.groupIDData,
+            senderBlsPubkeyHex: myBlsHex,
+            sentAtMillis: Int64(message.sentAt.timeIntervalSince1970 * 1000),
+            variant: variant
+        )
+
+        let recipients = group.memberProfiles
+            .filter { $0.key != myBlsHex }
+            .map { $0.value.inboxPublicKey }
+
+        let finalStatus = await fanOut(payload: payload, recipients: recipients)
+        await messageRepository.updateStatus(
+            id: messageID,
+            status: finalStatus,
+            groupID: groupID
+        )
+    }
+
+    /// Encode the payload, seal one envelope per recipient, ship
+    /// each, return `.sent` if any relay accepted (or the recipient
+    /// list was empty), `.failed` if every send threw or every
+    /// relay rejected. Shared between `send` and `retry` since the
+    /// per-recipient fan-out shape is identical.
+    private func fanOut(
+        payload: ChatMessagePayload,
+        recipients: [Data]
+    ) async -> MessageStatus {
         let payloadBytes: Data
         do {
             payloadBytes = try JSONEncoder().encode(payload)
         } catch {
-            // Encoding failure is a programmer error (Data field
-            // can't fail at JSON encode); mark failed and surface.
-            await messageRepository.updateStatus(
-                id: messageID,
-                status: .failed,
-                groupID: groupID
-            )
-            return ChatMessage(
-                id: pending.id,
-                groupID: pending.groupID,
-                ownerIdentityID: pending.ownerIdentityID,
-                senderBlsPubkeyHex: pending.senderBlsPubkeyHex,
-                body: pending.body,
-                sentAt: pending.sentAt,
-                direction: pending.direction,
-                status: .failed,
-                groupType: pending.groupType
-            )
+            // JSONEncoder on a static-typed Codable value can't
+            // realistically fail; surface as a transport failure
+            // so the caller marks the row `.failed`.
+            return .failed
         }
 
         var successCount = 0
@@ -162,25 +248,7 @@ actor SendMessageInteractor {
         // Empty roster (only the sender is a member) is fine — the
         // message is local-only. Anything with recipients must reach
         // at least one to count as sent.
-        let finalStatus: MessageStatus =
-            recipients.isEmpty || successCount > 0 ? .sent : .failed
-        await messageRepository.updateStatus(
-            id: messageID,
-            status: finalStatus,
-            groupID: groupID
-        )
-
-        return ChatMessage(
-            id: pending.id,
-            groupID: pending.groupID,
-            ownerIdentityID: pending.ownerIdentityID,
-            senderBlsPubkeyHex: pending.senderBlsPubkeyHex,
-            body: pending.body,
-            sentAt: pending.sentAt,
-            direction: pending.direction,
-            status: finalStatus,
-            groupType: pending.groupType
-        )
+        return recipients.isEmpty || successCount > 0 ? .sent : .failed
     }
 
     /// Same derivation as `IdentityRepository.inboxTag(from:)` —

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -45,6 +45,125 @@ final class ChatBubbleCellTests: XCTestCase {
         XCTAssertEqual(label?.text, "hello, world")
     }
 
+    // MARK: - Status indicator (PR 9)
+
+    func test_outgoingPending_showsClockIcon() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .outgoing, status: .pending))
+        let icon = statusIcon(in: cell)
+        XCTAssertFalse(icon.isHidden)
+        // SF Symbols comparison via `accessibilityLabel` since the
+        // UIImage isn't easily equatable across symbol-config
+        // variations.
+        XCTAssertEqual(icon.accessibilityLabel, "Sending")
+    }
+
+    func test_outgoingSent_showsCheckIcon() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .outgoing, status: .sent))
+        let icon = statusIcon(in: cell)
+        XCTAssertFalse(icon.isHidden)
+        XCTAssertEqual(icon.accessibilityLabel, "Sent")
+    }
+
+    func test_outgoingFailed_showsExclamationInRed() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .outgoing, status: .failed))
+        let icon = statusIcon(in: cell)
+        XCTAssertFalse(icon.isHidden)
+        XCTAssertEqual(icon.accessibilityLabel, "Failed — tap to retry")
+    }
+
+    func test_incoming_hidesStatusIndicator() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .incoming, status: .received))
+        XCTAssertTrue(statusIcon(in: cell).isHidden,
+                      "incoming rows must hide the status indicator")
+    }
+
+    func test_reconfigure_flipsStatusIcon() {
+        // Cell reuse path: a row that was .pending must update to
+        // .sent when its message is reconfigured against an updated
+        // ChatMessage. Without this, the diffable data source's
+        // `reconfigureItems` path would update messagesByID but the
+        // glyph would stay stale.
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        let id = UUID()
+        cell.configure(message: makeMessage(id: id, direction: .outgoing, status: .pending))
+        XCTAssertEqual(statusIcon(in: cell).accessibilityLabel, "Sending")
+
+        cell.configure(message: makeMessage(id: id, direction: .outgoing, status: .sent))
+        XCTAssertEqual(statusIcon(in: cell).accessibilityLabel, "Sent")
+    }
+
+    // MARK: - Retry tap
+
+    func test_failed_tapInvokesRetryClosure() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        var retryCount = 0
+        cell.configure(
+            message: makeMessage(direction: .outgoing, status: .failed),
+            onRetry: { retryCount += 1 }
+        )
+        cell.simulateBubbleTapForTest()
+        XCTAssertEqual(retryCount, 1)
+    }
+
+    func test_nonFailed_tapIsNoOp() {
+        // Sent / pending / received bubbles must not fire the
+        // retry closure. `configure(message:onRetry:)` only stores
+        // the closure when status == .failed && direction ==
+        // .outgoing, so a tap on a non-failed bubble reads `nil`
+        // and does nothing.
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        var retryCount = 0
+        cell.configure(
+            message: makeMessage(direction: .outgoing, status: .sent),
+            onRetry: { retryCount += 1 }
+        )
+        cell.simulateBubbleTapForTest()
+        XCTAssertEqual(retryCount, 0,
+                       "non-failed bubbles must not fire the retry closure")
+    }
+
+    func test_reconfigureFromFailedToSent_dropsRetry() {
+        // Cell reuse: a failed bubble that flips to sent must
+        // forget its retry closure, so a stray tap on the
+        // now-sent bubble doesn't re-fire it.
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        var retryCount = 0
+        let id = UUID()
+        cell.configure(
+            message: makeMessage(id: id, direction: .outgoing, status: .failed),
+            onRetry: { retryCount += 1 }
+        )
+        cell.configure(
+            message: makeMessage(id: id, direction: .outgoing, status: .sent),
+            onRetry: { retryCount += 1 }
+        )
+        cell.simulateBubbleTapForTest()
+        XCTAssertEqual(retryCount, 0,
+                       "reconfigured-to-sent bubble must drop its retry closure")
+    }
+
+    // MARK: - Helpers
+
+    private func statusIcon(in cell: ChatBubbleCell) -> UIImageView {
+        guard let icon = find(in: cell.contentView, identifier: "chat.bubble.status")
+                as? UIImageView else {
+            fatalError("status icon not found")
+        }
+        return icon
+    }
+
+    private func find(in view: UIView, identifier: String) -> UIView? {
+        if view.accessibilityIdentifier == identifier { return view }
+        for sub in view.subviews {
+            if let found = find(in: sub, identifier: identifier) { return found }
+        }
+        return nil
+    }
+
     func test_layoutResolves_withoutConstraintConflicts() {
         // Guards the bug the PR-6 review caught: pairing the
         // opposite-edge `>=`/`<=` gap with the *same-direction*
@@ -128,18 +247,20 @@ final class ChatBubbleCellTests: XCTestCase {
     }
 
     private func makeMessage(
+        id: UUID = UUID(),
         direction: MessageDirection,
-        body: String = "hi"
+        body: String = "hi",
+        status: MessageStatus? = nil
     ) -> ChatMessage {
         ChatMessage(
-            id: UUID(),
+            id: id,
             groupID: "aa".repeated(32),
             ownerIdentityID: IdentityID(),
             senderBlsPubkeyHex: "11".repeated(48),
             body: body,
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
             direction: direction,
-            status: direction == .incoming ? .received : .sent,
+            status: status ?? (direction == .incoming ? .received : .sent),
             groupType: .tyranny
         )
     }

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -206,6 +206,107 @@ final class ChatThreadViewControllerTests: XCTestCase {
         return b
     }
 
+    // MARK: - Retry wiring (PR 9)
+
+    func test_failedBubble_tap_invokesOnRetryRequested() {
+        // Window-hosted to give the table real frames so the
+        // failed cell actually mounts.
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 800))
+        let vc = ChatThreadViewController()
+        window.rootViewController = vc
+        window.isHidden = false
+
+        let failed = makeMessage(body: "uh oh", direction: .outgoing)
+        let failedRow = ChatMessage(
+            id: failed.id,
+            groupID: failed.groupID,
+            ownerIdentityID: failed.ownerIdentityID,
+            senderBlsPubkeyHex: failed.senderBlsPubkeyHex,
+            body: failed.body,
+            sentAt: failed.sentAt,
+            direction: failed.direction,
+            status: .failed,
+            groupType: failed.groupType
+        )
+
+        var retriedIDs: [UUID] = []
+        vc.onRetryRequested = { retriedIDs.append($0) }
+        vc.update(messages: [failedRow])
+        vc.view.layoutIfNeeded()
+        let table = tableView(in: vc)!
+        table.layoutIfNeeded()
+
+        guard let cell = table.cellForRow(at: IndexPath(row: 0, section: 0))
+                as? ChatBubbleCell else {
+            return XCTFail("failed bubble cell not mounted")
+        }
+        cell.simulateBubbleTapForTest()
+        XCTAssertEqual(retriedIDs, [failedRow.id],
+                       "tapping a failed bubble must fire onRetryRequested with the message id")
+    }
+
+    // MARK: - Diffable reconfigure (PR 9)
+
+    func test_statusFlip_reconfiguresVisibleCell() {
+        // The diffable identity is just `UUID`, so a status flip
+        // (same id, different content) must use `reconfigureItems`
+        // to re-run the cell provider. Without that, the bubble's
+        // status glyph would stay stale until cell reuse.
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 800))
+        let vc = ChatThreadViewController()
+        window.rootViewController = vc
+        window.isHidden = false
+
+        let id = UUID()
+        let pending = ChatMessage(
+            id: id,
+            groupID: "aa".repeated(32),
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: "11".repeated(48),
+            body: "hi",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            direction: .outgoing,
+            status: .pending,
+            groupType: .tyranny
+        )
+        vc.update(messages: [pending])
+        vc.view.layoutIfNeeded()
+        let table = tableView(in: vc)!
+        table.layoutIfNeeded()
+
+        guard let cell = table.cellForRow(at: IndexPath(row: 0, section: 0))
+                as? ChatBubbleCell else {
+            return XCTFail("pending bubble cell not mounted")
+        }
+        let pendingIcon = find(in: cell.contentView) {
+            $0.accessibilityIdentifier == "chat.bubble.status"
+        } as? UIImageView
+        XCTAssertEqual(pendingIcon?.accessibilityLabel, "Sending")
+
+        // Flip to .sent — same id, different status.
+        let sentRow = ChatMessage(
+            id: id,
+            groupID: pending.groupID,
+            ownerIdentityID: pending.ownerIdentityID,
+            senderBlsPubkeyHex: pending.senderBlsPubkeyHex,
+            body: pending.body,
+            sentAt: pending.sentAt,
+            direction: .outgoing,
+            status: .sent,
+            groupType: .tyranny
+        )
+        vc.update(messages: [sentRow])
+        table.layoutIfNeeded()
+
+        // Same cell instance (reconfigured, not reloaded). The
+        // status glyph swapped.
+        let sentIcon = find(in: cell.contentView) {
+            $0.accessibilityIdentifier == "chat.bubble.status"
+        } as? UIImageView
+        XCTAssertEqual(sentIcon?.accessibilityLabel, "Sent",
+                       "reconfigureItems must re-run the cell provider so the glyph updates")
+    }
+
     // MARK: - Auto-scroll heuristic
 
     func test_isNearBottom_emptyContent_isTrue() {

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -198,6 +198,63 @@ final class SendMessageInteractorTests: XCTestCase {
         }
     }
 
+    // MARK: - Retry (PR 9)
+
+    func test_retry_failedMessage_flipsToSentOnSuccess() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        // Drive an initial send to .failed by rejecting all relays.
+        await transport.setAcceptedBy(0)
+        let original = try await interactor.send(groupID: groupID, body: "retry me")
+        XCTAssertEqual(original.status, .failed)
+        await transport.clearRecords()
+
+        // Now flip transport back to success and retry.
+        await transport.setAcceptedBy(1)
+        await interactor.retry(groupID: groupID, messageID: original.id)
+
+        let stored = await messages.currentMessages(groupID: groupID)
+        XCTAssertEqual(stored.count, 1, "retry must not duplicate the row")
+        XCTAssertEqual(stored[0].id, original.id, "retry must reuse the same message id")
+        XCTAssertEqual(stored[0].status, .sent)
+
+        let sends = await transport.recordedSends
+        XCTAssertEqual(sends.count, 2, "retry must re-fan out to both peers")
+    }
+
+    func test_retry_failedMessage_staysFailedIfRelaysStillReject() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        await transport.setAcceptedBy(0)
+        let original = try await interactor.send(groupID: groupID, body: "still no luck")
+        XCTAssertEqual(original.status, .failed)
+
+        await interactor.retry(groupID: groupID, messageID: original.id)
+
+        let stored = await messages.currentMessages(groupID: groupID)
+        XCTAssertEqual(stored[0].status, .failed)
+    }
+
+    func test_retry_unknownMessage_isNoOp() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        await interactor.retry(groupID: groupID, messageID: UUID())
+        let sends = await transport.recordedSends
+        XCTAssertTrue(sends.isEmpty,
+                      "retrying an unknown messageID must not perform any sends")
+    }
+
+    func test_retry_nonFailedMessage_isNoOp() async throws {
+        // A .sent message must not re-fan out — that would
+        // double-deliver. Retry is for .failed rows only.
+        let groupID = await seedGroupWithTwoPeers()
+        let sent = try await interactor.send(groupID: groupID, body: "already delivered")
+        XCTAssertEqual(sent.status, .sent)
+        await transport.clearRecords()
+
+        await interactor.retry(groupID: groupID, messageID: sent.id)
+        let sends = await transport.recordedSends
+        XCTAssertTrue(sends.isEmpty,
+                      "retrying a .sent message must not double-deliver")
+    }
+
     // MARK: - Helpers
 
     private func seedGroupWithTwoPeers() async -> String {
@@ -303,6 +360,11 @@ private actor RecordingInboxTransport: InboxTransport {
 
     func setBehavior(_ b: Behavior) {
         behavior = b
+    }
+
+    func clearRecords() {
+        recordedSends.removeAll()
+        sendCount = 0
     }
 
     func connect(to endpoints: [TransportEndpoint]) async {}


### PR DESCRIPTION
**Status glyphs on outgoing bubbles + tap-to-retry on failed.** Tapping a failed bubble retries the send with the original message id so receivers dedup against any prior delivery.

## Stacked on
Base: \`pr-chat-8-wire-send\` (#154).

## `ChatBubbleCell`
- **Status indicator** — `UIImageView` below the bubble's trailing edge (outgoing only). Glyphs:
  | Status | SF Symbol | Color |
  |---|---|---|
  | `.pending` | `clock` | muted (`text3`) |
  | `.sent` | `checkmark` | muted (`text3`) |
  | `.failed` | `exclamationmark.circle.fill` | red |
  Incoming rows hide the indicator (the message arriving is proof of delivery).
- **Conditional cell-bottom anchor** — outgoing pins to the status icon's bottom (extra room for the glyph); incoming pins to the bubble's bottom (no extra height for the hidden indicator).
- **Retry tap** — a `UITapGestureRecognizer` is installed on the bubble **only** when `status == .failed && direction == .outgoing`. Cell reuse forgets the closure on each `configure`, so a bubble that flips out of `.failed` loses its tap target.
- `simulateBubbleTapForTest()` (DEBUG-only) — small internal test seam because `UITapGestureRecognizer` has no clean public "fire" API.

## `ChatThreadViewController`
- **Diffable now reconfigures on content change.** Before this PR, the diff identity was just `UUID`, so a status flip (same id, different content) didn't repaint. Now we detect changed messages (`prior != msg`) and call `snapshot.reconfigureItems(changedIDs)` — the cell stays at the same index, just re-runs the cell provider against the updated `messagesByID`. Closes the PR 6 review TODO.
- `onRetryRequested: ((UUID) -> Void)?` exposed; cell provider passes a per-message retry closure to `ChatBubbleCell` only for failed outgoing rows.

## `ChatThreadView` (SwiftUI bridge)
- Constructs the retry closure as fire-and-forget `Task { await interactor.retry(groupID:messageID:) }` — same shape as the send dispatcher.

## `SendMessageInteractor`
- **Extracted `fanOut(payload:recipients:)`** shared between send + retry. Same encode + per-recipient seal + transport flow.
- **New `retry(groupID:messageID:)`** — no-op (silent) for unknown / non-failed / non-outgoing rows (prevents double-delivery on `.sent` / `.pending`). On a valid retry:
  1. Flips status to `.pending` immediately so the glyph swaps to the in-flight clock before any network work.
  2. Re-fans out using the **original payload fields** (same UUID + body + sentAt) so receivers dedup against any prior delivery.
  3. Flips to `.sent` / `.failed` on completion.

## Tests (14 new, suite 617 / 617)

**`ChatBubbleCellTests`** +6:
- outgoing `.pending` / `.sent` / `.failed` each show the correct glyph
- incoming hides the indicator
- reconfigure flips the glyph (cell reuse)
- failed tap fires the retry closure
- non-failed tap is a no-op
- reconfigure from `.failed` to `.sent` drops the retry closure

**`ChatThreadViewControllerTests`** +2:
- failed-bubble tap invokes `onRetryRequested` with the message id
- status flip on the same UUID reconfigures the visible cell (proves `reconfigureItems` lands)

**`SendMessageInteractorTests`** +4:
- retry on a failed message flips to `.sent` on relay acceptance
- retry stays `.failed` if relays still reject
- retry on an unknown messageID is a no-op
- retry on a `.sent` message is a no-op (prevents double-delivery)

## Plan context
PR 9 of 11. **PR 10 next**: polish — nav title with group avatar + member count, empty-state copy, chats-list last-message preview + timestamp + unread dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)