### PR TITLE
feat(chats): chat-thread polish — nav subtitle + empty state (PR 10/11 chat stack)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -33,6 +33,7 @@ struct ChatThreadView: View {
     var body: some View {
         ChatThreadControllerBridge(
             groupName: currentGroupName,
+            memberCount: currentMemberCount,
             messages: messages,
             onBack: { dismiss() },
             onShowMembers: { showMembers = true },
@@ -90,10 +91,18 @@ struct ChatThreadView: View {
     private var currentGroupName: String {
         chatsFlow.groups.first { $0.id == groupID }?.name ?? "Chat"
     }
+
+    /// Drives the title subtitle ("N members"). Reads from the same
+    /// `chatsFlow.groups` source as the name so an admin admitting
+    /// a new joiner updates the bar live as the announcement lands.
+    private var currentMemberCount: Int {
+        chatsFlow.groups.first { $0.id == groupID }?.memberProfiles.count ?? 0
+    }
 }
 
 private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let groupName: String
+    let memberCount: Int
     let messages: [ChatMessage]
     let onBack: () -> Void
     let onShowMembers: () -> Void
@@ -107,7 +116,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         vc.onSendTapped = onSendTapped
         vc.onRetryRequested = onRetryRequested
         vc.loadViewIfNeeded()
-        vc.update(groupName: groupName)
+        vc.update(groupName: groupName, memberCount: memberCount)
         vc.update(messages: messages)
         return vc
     }
@@ -121,7 +130,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         vc.onShowMembers = onShowMembers
         vc.onSendTapped = onSendTapped
         vc.onRetryRequested = onRetryRequested
-        vc.update(groupName: groupName)
+        vc.update(groupName: groupName, memberCount: memberCount)
         vc.update(messages: messages)
     }
 }

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -46,11 +46,14 @@ final class ChatThreadViewController: UIViewController {
     var onRetryRequested: ((UUID) -> Void)?
 
     private let titleLabel = UILabel()
+    private let memberCountLabel = UILabel()
+    private let titleStack = UIStackView()
     private let backButton = UIButton(type: .system)
     private let infoButton = UIButton(type: .system)
     private let topBar = UIView()
     private let topBarSeparator = UIView()
     private let tableView = UITableView()
+    private let emptyStateLabel = UILabel()
     private let inputPanel = ChatInputPanelView()
 
     // Diffable data source state. Keyed by message UUID — stable
@@ -81,11 +84,23 @@ final class ChatThreadViewController: UIViewController {
         configureDataSource()
     }
 
-    /// Push a new group-name into the title. Called by the SwiftUI
-    /// wrapper on every render — keeps the bar in sync as the group
-    /// renames (PR 9 polish) without re-creating the controller.
-    func update(groupName: String) {
+    /// Push a new group-name + member-count into the title bar.
+    /// Called by the SwiftUI wrapper on every render — keeps the
+    /// bar in sync as the group renames or new joiners land without
+    /// re-creating the controller.
+    ///
+    /// `memberCount` of zero or one hides the subtitle (singleton
+    /// groups don't need a member count; nothing-known groups
+    /// would just show "0 members" awkwardly).
+    func update(groupName: String, memberCount: Int) {
         titleLabel.text = groupName.isEmpty ? "Chat" : groupName
+        if memberCount > 1 {
+            memberCountLabel.text = "\(memberCount) members"
+            memberCountLabel.isHidden = false
+        } else {
+            memberCountLabel.text = nil
+            memberCountLabel.isHidden = true
+        }
     }
 
     /// Push a new message list into the table. Called by the SwiftUI
@@ -125,6 +140,11 @@ final class ChatThreadViewController: UIViewController {
             return msg.id
         }
         messagesByID = Dictionary(uniqueKeysWithValues: sorted.map { ($0.id, $0) })
+
+        // Empty state: visible iff the message list is empty. Lives
+        // behind the table view (added as a sibling); toggling
+        // `isHidden` is cheap and survives keyboard show/hide.
+        emptyStateLabel.isHidden = !sorted.isEmpty
 
         var snapshot = NSDiffableDataSourceSnapshot<Section, UUID>()
         snapshot.appendSections([.main])
@@ -197,9 +217,21 @@ final class ChatThreadViewController: UIViewController {
         titleLabel.textColor = UIColor(OnymTokens.text)
         titleLabel.textAlignment = .center
         titleLabel.text = "Chat"
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.accessibilityIdentifier = "chat.title"
-        topBar.addSubview(titleLabel)
+
+        memberCountLabel.font = .systemFont(ofSize: 11, weight: .regular)
+        memberCountLabel.textColor = UIColor(OnymTokens.text3)
+        memberCountLabel.textAlignment = .center
+        memberCountLabel.isHidden = true
+        memberCountLabel.accessibilityIdentifier = "chat.title.member_count"
+
+        titleStack.axis = .vertical
+        titleStack.alignment = .center
+        titleStack.spacing = 1
+        titleStack.addArrangedSubview(titleLabel)
+        titleStack.addArrangedSubview(memberCountLabel)
+        titleStack.translatesAutoresizingMaskIntoConstraints = false
+        topBar.addSubview(titleStack)
 
         var infoConfig = UIButton.Configuration.plain()
         infoConfig.image = UIImage(systemName: "info.circle",
@@ -228,10 +260,23 @@ final class ChatThreadViewController: UIViewController {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 44
         tableView.register(ChatBubbleCell.self, forCellReuseIdentifier: ChatBubbleCell.reuseID)
-        // Tap to dismiss the keyboard once PR 7 wires the input
-        // panel. No-op pre-PR-7 because nothing is first-responder.
         tableView.keyboardDismissMode = .interactive
         view.addSubview(tableView)
+
+        // Empty state — shown when the message list is empty, hidden
+        // as soon as the first message arrives. Positioned centered
+        // between the top bar and the input panel so it doesn't get
+        // covered when the keyboard rises.
+        emptyStateLabel.text = "No messages yet. Say hi."
+        emptyStateLabel.textAlignment = .center
+        emptyStateLabel.numberOfLines = 0
+        emptyStateLabel.font = .preferredFont(forTextStyle: .body)
+        emptyStateLabel.adjustsFontForContentSizeCategory = true
+        emptyStateLabel.textColor = UIColor(OnymTokens.text3)
+        emptyStateLabel.translatesAutoresizingMaskIntoConstraints = false
+        emptyStateLabel.isHidden = true
+        emptyStateLabel.accessibilityIdentifier = "chat.empty_state"
+        view.addSubview(emptyStateLabel)
     }
 
     private func configureDataSource() {
@@ -301,10 +346,10 @@ final class ChatThreadViewController: UIViewController {
             infoButton.widthAnchor.constraint(equalToConstant: 36),
             infoButton.heightAnchor.constraint(equalToConstant: 36),
 
-            titleLabel.centerXAnchor.constraint(equalTo: topBar.centerXAnchor),
-            titleLabel.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
-            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor, constant: 8),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: infoButton.leadingAnchor, constant: -8),
+            titleStack.centerXAnchor.constraint(equalTo: topBar.centerXAnchor),
+            titleStack.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            titleStack.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor, constant: 8),
+            titleStack.trailingAnchor.constraint(lessThanOrEqualTo: infoButton.leadingAnchor, constant: -8),
 
             topBarSeparator.topAnchor.constraint(equalTo: topBar.bottomAnchor),
             topBarSeparator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -317,6 +362,18 @@ final class ChatThreadViewController: UIViewController {
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: inputPanel.topAnchor),
+
+            // Empty state — centered in the same region the table
+            // view occupies. Sits behind the table; toggled on
+            // when the message list is empty.
+            emptyStateLabel.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
+            emptyStateLabel.centerYAnchor.constraint(equalTo: tableView.centerYAnchor),
+            emptyStateLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: tableView.leadingAnchor, constant: 32
+            ),
+            emptyStateLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: tableView.trailingAnchor, constant: -32
+            ),
 
             // Input panel — bottom tracks the keyboard. With no
             // keyboard up, `keyboardLayoutGuide.topAnchor` equals

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -25,16 +25,72 @@ final class ChatThreadViewControllerTests: XCTestCase {
     func test_updateGroupName_writesThroughToTitleLabel() {
         let vc = ChatThreadViewController()
         vc.loadViewIfNeeded()
-        vc.update(groupName: "Family")
+        vc.update(groupName: "Family", memberCount: 0)
         XCTAssertEqual(titleLabel(in: vc)?.text, "Family")
     }
 
     func test_updateGroupName_emptyFallsBackToChat() {
         let vc = ChatThreadViewController()
         vc.loadViewIfNeeded()
-        vc.update(groupName: "")
+        vc.update(groupName: "", memberCount: 0)
         XCTAssertEqual(titleLabel(in: vc)?.text, "Chat",
                        "empty group names fall back to the generic title so the bar isn't blank")
+    }
+
+    func test_memberCount_zeroOrOne_hidesSubtitle() {
+        // Singleton groups (just the user) don't need a member
+        // count; nothing-known groups would show "0 members"
+        // awkwardly. Both hide the subtitle.
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+
+        vc.update(groupName: "Group", memberCount: 0)
+        XCTAssertTrue(memberCountLabel(in: vc)?.isHidden ?? false)
+
+        vc.update(groupName: "Group", memberCount: 1)
+        XCTAssertTrue(memberCountLabel(in: vc)?.isHidden ?? false)
+    }
+
+    func test_memberCount_twoOrMore_showsSubtitleWithPluralization() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+
+        vc.update(groupName: "Group", memberCount: 2)
+        XCTAssertFalse(memberCountLabel(in: vc)?.isHidden ?? true)
+        XCTAssertEqual(memberCountLabel(in: vc)?.text, "2 members")
+
+        vc.update(groupName: "Group", memberCount: 5)
+        XCTAssertEqual(memberCountLabel(in: vc)?.text, "5 members")
+    }
+
+    // MARK: - Empty state (PR 10)
+
+    func test_emptyMessageList_showsEmptyStateLabel() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.update(messages: [])
+        XCTAssertFalse(emptyStateLabel(in: vc)?.isHidden ?? true,
+                       "empty state must be visible when there are no messages")
+    }
+
+    func test_nonEmptyMessageList_hidesEmptyState() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.update(messages: [makeMessage(body: "hi", direction: .incoming)])
+        XCTAssertTrue(emptyStateLabel(in: vc)?.isHidden ?? false,
+                      "empty state must disappear once a message lands")
+    }
+
+    func test_messagesClearedAgain_showsEmptyState() {
+        // PR 10 contract: empty state toggle is symmetric — if all
+        // messages get deleted (rare today, possible later), the
+        // empty state should come back without the controller
+        // needing a reset.
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.update(messages: [makeMessage(body: "hi", direction: .incoming)])
+        vc.update(messages: [])
+        XCTAssertFalse(emptyStateLabel(in: vc)?.isHidden ?? true)
     }
 
     func test_backButtonTap_invokesOnBackClosure() {
@@ -395,6 +451,14 @@ final class ChatThreadViewControllerTests: XCTestCase {
 
     private func titleLabel(in vc: UIViewController) -> UILabel? {
         find(in: vc.view, identifier: "chat.title") as? UILabel
+    }
+
+    private func memberCountLabel(in vc: UIViewController) -> UILabel? {
+        find(in: vc.view, identifier: "chat.title.member_count") as? UILabel
+    }
+
+    private func emptyStateLabel(in vc: UIViewController) -> UILabel? {
+        find(in: vc.view, identifier: "chat.empty_state") as? UILabel
     }
 
     private func backButton(in vc: UIViewController) -> UIButton? {


### PR DESCRIPTION
Two view-only improvements that make the chat thread feel complete.

## Stacked on
Base: \`pr-chat-9-status-indicator\` (#155).

## What's in here

**Nav title subtitle.** Replaces the single centered title with a vertical stack: name on top, "N members" below. Hidden when `memberCount <= 1` (singleton groups don't need the count; nothing-known groups would render "0 members" awkwardly).

**Empty state.** Centered "No messages yet. Say hi." label overlaid on the table view. Toggled on when `update(messages:)` lands an empty array and off as soon as the first row arrives. Lives behind the table (added as a sibling) so the keyboard layout guide affects it the same way as the message list.

## Wire-up
- `ChatThreadViewController.update(groupName:memberCount:)` replaces the old single-arg overload.
- The SwiftUI bridge computes `memberCount` from `chatsFlow.groups.first { $0.id == groupID }?.memberProfiles.count` so an admin admitting a new joiner updates the bar live as the announcement lands.
- The `emptyStateLabel` toggle lives inside the existing `update(messages:)` flow — no new hook surface.

## What's NOT in here — deferred to a focused follow-up

The plan's polish bucket also included:
- **Group avatar in the nav.** Would need a UIKit equivalent of `OnymGroupAvatar` or a `UIHostingController` bridge — both heavier than the rest of PR 10.
- **`ChatsView` last-message preview + timestamp + unread dot.** Needs a per-group "last message" query in `MessageRepository` *and* a `PersistedGroup.lastReadMessageID` schema bump. Worth a focused follow-up rather than absorbing here.

PR 10 stays small + view-only so PR 11 (E2E + CI smoke) can ship on the same chain.

## Tests (5 new, suite 622 / 622)

**`ChatThreadViewControllerTests`** +5:
- `memberCount` 0 / 1 → subtitle hidden
- `memberCount >= 2` → subtitle visible, pluralized as "N members"
- empty list → empty state visible
- non-empty list → empty state hidden
- list cleared again → empty state re-appears (symmetric toggle)

Updated two pre-existing tests for the `update(groupName:memberCount:)` signature.

## Plan context
PR 10 of 11. **PR 11 next**: E2E integration test + CI smoke — two-identity round-trip through real `IdentityRepository` + in-memory fake transport, plus a UI smoke that opens a chat and verifies a typed message round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)