### PR TITLE
feat(groups): invite-offer handshake for create-time members

### DIFF
--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -24,6 +24,11 @@ struct AppDependencies {
     /// and the underlying collector should run for the app's
     /// lifetime regardless of which surface is mounted.
     let approveRequestsFlow: ApproveRequestsFlow
+    /// Single shared instance — the invitee-side push-invitation
+    /// surface. Backs the Chats toolbar "Invitations" badge + modal,
+    /// and its store watcher runs for the app's lifetime like
+    /// `approveRequestsFlow`.
+    let pendingInvitesFlow: PendingInvitesFlow
     /// Single shared instance — the chat-thread screen subscribes to
     /// per-group message snapshots, and the receive-side dispatcher
     /// writes into the same actor. Constructed once in

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -9,6 +9,7 @@ struct ChatsView: View {
     let flow: ChatsFlow
     let identitiesFlow: IdentitiesFlow
     let approveRequestsFlow: ApproveRequestsFlow
+    let pendingInvitesFlow: PendingInvitesFlow
     let messageRepository: MessageRepository
     let sendMessageInteractor: SendMessageInteractor
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
@@ -37,6 +38,11 @@ struct ChatsView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 ApproveRequestsToolbarButton(flow: approveRequestsFlow)
             }
+            // Invitations received by this identity (push offers). Same
+            // always-rendered + badge-on-nonempty treatment.
+            ToolbarItem(placement: .topBarTrailing) {
+                PendingInvitesToolbarButton(flow: pendingInvitesFlow)
+            }
             // Plus button mirrors iOS Mail / Messages — useful once
             // the user already has at least one chat. Hidden in the
             // empty state because the central CTA already covers it.
@@ -54,6 +60,7 @@ struct ChatsView: View {
         .task { flow.start() }
         .task { await identitiesFlow.start() }
         .task { await approveRequestsFlow.start() }
+        .task { await pendingInvitesFlow.start() }
         .fullScreenCover(isPresented: $showCreateGroup) {
             CreateGroupViewHost(
                 makeFlow: makeCreateGroupFlow,

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -38,6 +38,11 @@ struct CreateGroupInteractor: Sendable {
     let networkPreference: any NetworkPreferenceProviding
     let proofGenerator: any GroupProofGenerator
     let inboxTransport: any InboxTransport
+    /// Mints a per-invitee intro key for each create-time invite offer
+    /// (Tyranny). That intro key is the reply channel the invitee seals
+    /// their `JoinRequestPayload` to when they accept — the same
+    /// machinery the deeplink share-invite flow uses, just pushed.
+    let introducer: InviteIntroducer
     /// Builds a `SEPContractTransport` from the relayer URL chosen
     /// per-call. Injected so tests can swap in a fake without
     /// touching `URLSession`.
@@ -51,6 +56,7 @@ struct CreateGroupInteractor: Sendable {
         networkPreference: any NetworkPreferenceProviding = UserDefaultsNetworkPreference(),
         proofGenerator: any GroupProofGenerator = OnymGroupProofGenerator(),
         inboxTransport: any InboxTransport,
+        introducer: InviteIntroducer,
         makeContractTransport: @escaping @Sendable (URL) -> any SEPContractTransport = { url in
             URLSessionSEPContractTransport(
                 endpoint: url,
@@ -65,6 +71,7 @@ struct CreateGroupInteractor: Sendable {
         self.networkPreference = networkPreference
         self.proofGenerator = proofGenerator
         self.inboxTransport = inboxTransport
+        self.introducer = introducer
         self.makeContractTransport = makeContractTransport
     }
 
@@ -249,24 +256,25 @@ struct CreateGroupInteractor: Sendable {
         _ = await groups.insert(group)
         await groups.markPublished(id: group.id, commitment: proof.commitment)
 
-        // 8. Send invitations
+        // 8. Send durable invite offers. Each invitee gets a freshly-
+        // minted per-invite intro key (the reply channel) wrapped in a
+        // `GroupInviteOfferPayload`. The offer carries no epoch /
+        // commitment / roster — it grants nothing and never expires.
+        // The invitee explicitly accepts (ships a `JoinRequestPayload`
+        // to that intro key) and the admin explicitly approves
+        // (`update_commitment`) before anyone is added to the on-chain
+        // roster. The creator stays the only on-chain member until
+        // then — exactly what the chats list shows.
         if !invitees.isEmpty {
             onProgress(.sendingInvitations(total: invitees.count))
-            let invitePayload = GroupInvitationPayload(
-                version: 1,
+            let inviterAlias = await identity.currentIdentityName() ?? ""
+            try await sendOffers(
+                to: invitees,
+                ownerIdentityID: ownerID,
                 groupID: groupID,
-                groupSecret: groupSecret,
-                name: trimmedName,
-                members: members,
-                epoch: 0,
-                salt: salt,
-                commitment: proof.commitment,
-                tierRaw: tier.rawValue,
-                groupTypeRaw: SEPGroupType.tyranny.rawValue,
-                adminPubkeyHex: adminPubkeyHex,
-                memberProfiles: creatorProfiles
+                groupName: trimmedName,
+                inviterAlias: inviterAlias
             )
-            try await sendInvitations(invitePayload, to: invitees)
         }
 
         return await reloadGroup(group)
@@ -684,6 +692,92 @@ struct CreateGroupInteractor: Sendable {
                 throw CreateGroupError.invitationSendFailed(
                     index: index,
                     reason: "no relay accepted the invitation"
+                )
+            }
+        }
+    }
+
+    // MARK: - Invite-offer send loop (Tyranny)
+
+    /// Mint a per-invitee intro key and ship a durable
+    /// `GroupInviteOfferPayload` to each invitee's inbox. Reuses the
+    /// inbox seal+send path, but the payload grants nothing: it carries
+    /// only the reply channel + display context, so it never expires
+    /// and never anchors anyone. The invitee turns it into a join
+    /// request on accept; the admin anchors only on explicit approve.
+    private func sendOffers(
+        to invitees: [Data],
+        ownerIdentityID: IdentityID,
+        groupID: Data,
+        groupName: String,
+        inviterAlias: String
+    ) async throws {
+        for (index, inboxKey) in invitees.enumerated() {
+            // One fresh intro key per invitee → granular revoke and a
+            // clean 1:1 mapping from an inbound join request back to
+            // the person the admin meant to invite.
+            let capability: IntroCapability
+            do {
+                capability = try await introducer.mint(
+                    ownerIdentityID: ownerIdentityID,
+                    groupId: groupID,
+                    groupName: groupName
+                )
+            } catch {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: "mint intro key: \(error)"
+                )
+            }
+            let offer: GroupInviteOfferPayload
+            do {
+                offer = try GroupInviteOfferPayload(
+                    introPublicKey: capability.introPublicKey,
+                    groupID: groupID,
+                    groupName: groupName,
+                    inviterAlias: inviterAlias
+                )
+            } catch {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: "build offer: \(error)"
+                )
+            }
+            let payloadBytes: Data
+            do {
+                payloadBytes = try JSONEncoder().encode(offer)
+            } catch {
+                throw CreateGroupError.invitationEncodingFailed
+            }
+            let sealed: Data
+            do {
+                sealed = try await identity.sealInvitation(
+                    payload: payloadBytes,
+                    to: inboxKey
+                )
+            } catch {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: String(describing: error)
+                )
+            }
+            let inboxTag = Self.inboxTag(from: inboxKey)
+            let receipt: PublishReceipt
+            do {
+                receipt = try await inboxTransport.send(
+                    sealed,
+                    to: TransportInboxID(rawValue: inboxTag)
+                )
+            } catch {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: String(describing: error)
+                )
+            }
+            guard receipt.acceptedBy >= 1 else {
+                throw CreateGroupError.invitationSendFailed(
+                    index: index,
+                    reason: "no relay accepted the invite offer"
                 )
             }
         }

--- a/Sources/OnymIOS/Group/GroupInviteOfferPayload.swift
+++ b/Sources/OnymIOS/Group/GroupInviteOfferPayload.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Admin → invitee "you've been invited" offer, sealed to the
+/// invitee's X25519 inbox key and delivered over the normal inbox
+/// transport (NOT an intro tag — the invitee doesn't have one yet).
+///
+/// ## Why this is not a `GroupInvitationPayload`
+///
+/// A `GroupInvitationPayload` is a *membership grant*: it pins
+/// `(members, epoch, commitment, salt)` for one on-chain epoch, and
+/// the receiver auto-materializes a group from it. Shipping that at
+/// create time is wrong on two counts:
+///   1. The invitee isn't on chain yet — they have no BLS leaf in the
+///      committed roster, so the snapshot is a lie.
+///   2. It's epoch-pinned, so the moment any *other* invitee is
+///      anchored the snapshot goes stale and the receiver drops it.
+///
+/// The offer instead carries only what the invitee needs to *ask* to
+/// join: a fresh per-invite intro public key (the reply channel the
+/// admin minted via `InviteIntroducer`) plus enough context to render
+/// "Alice invited you to Maple Garden". It contains **no** epoch,
+/// commitment, members, or group secret — so it never expires and
+/// grants nothing. Membership only happens later, when the invitee
+/// explicitly accepts (ships a `JoinRequestPayload` to `introPublicKey`)
+/// and the admin explicitly approves (anchors via `update_commitment`).
+///
+/// ## Wire disambiguation
+///
+/// The receive-side dispatcher trial-decodes inbound plaintext against
+/// several payload types. `offer_version` + `inviter_alias` +
+/// `intro_pub` are required and unique to this type, so a successful
+/// decode is unambiguous — no other inbox payload carries
+/// `inviter_alias`.
+struct GroupInviteOfferPayload: Codable, Equatable, Sendable {
+    let version: Int
+    /// 32-byte X25519 public key of the admin's freshly-minted intro
+    /// key for this invite. The invitee seals their `JoinRequestPayload`
+    /// to this and the admin's `IntroInboxPump` picks it up.
+    let introPublicKey: Data
+    /// 32-byte on-chain `group_id` the invite is for. Lets the invitee
+    /// verify the group exists on chain before responding.
+    let groupID: Data
+    /// Optional plaintext group name for the invitee's preview. Mirrors
+    /// `IntroCapability.groupName` — public, transits cleartext-ish
+    /// channels (it's sealed here, but treat as low-sensitivity).
+    let groupName: String?
+    /// Admin's self-asserted display name, surfaced in the invitee's
+    /// "X invited you" prompt. Untrusted text — render, don't trust.
+    let inviterAlias: String
+
+    enum CodingKeys: String, CodingKey {
+        case version = "offer_version"
+        case introPublicKey = "intro_pub"
+        case groupID = "group_id"
+        case groupName = "group_name"
+        case inviterAlias = "inviter_alias"
+    }
+
+    init(
+        version: Int = 1,
+        introPublicKey: Data,
+        groupID: Data,
+        groupName: String?,
+        inviterAlias: String
+    ) throws {
+        guard introPublicKey.count == 32 else {
+            throw GroupInviteOfferPayloadError.shape(
+                "introPublicKey: expected 32 bytes, got \(introPublicKey.count)"
+            )
+        }
+        guard groupID.count == 32 else {
+            throw GroupInviteOfferPayloadError.shape(
+                "groupID: expected 32 bytes, got \(groupID.count)"
+            )
+        }
+        self.version = version
+        self.introPublicKey = introPublicKey
+        self.groupID = groupID
+        self.groupName = groupName
+        self.inviterAlias = inviterAlias
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            version: c.decode(Int.self, forKey: .version),
+            introPublicKey: c.decode(Data.self, forKey: .introPublicKey),
+            groupID: c.decode(Data.self, forKey: .groupID),
+            groupName: c.decodeIfPresent(String.self, forKey: .groupName),
+            inviterAlias: c.decode(String.self, forKey: .inviterAlias)
+        )
+    }
+
+    /// Rebuild the `IntroCapability` the invitee feeds to
+    /// `JoinRequestSender.send` on accept. Throws if the offer's bytes
+    /// don't satisfy `IntroCapability`'s shape invariants (can't happen
+    /// for an offer that decoded successfully, but `IntroCapability`'s
+    /// init is the single source of truth for the sizes).
+    func introCapability() throws -> IntroCapability {
+        try IntroCapability(
+            introPublicKey: introPublicKey,
+            groupId: groupID,
+            groupName: groupName
+        )
+    }
+}
+
+enum GroupInviteOfferPayloadError: Error, Equatable {
+    case shape(String)
+}

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -118,6 +118,16 @@ actor JoinRequestApprover: JoinRequestApproving {
     private var pendingContinuations: [UUID: AsyncStream<[PendingRequest]>.Continuation] = [:]
     private var decryptFailures: Int = 0
     private var collectorTask: Task<Void, Never>?
+    /// Serializes `approve` calls. Each approval reads `group.epoch`,
+    /// proves an `update_commitment` from it, submits, then persists
+    /// `epoch + 1`. The actor re-enters at the multi-second prove /
+    /// submit awaits, so two overlapping approvals would both read the
+    /// same stale epoch — the chain accepts the first and rejects the
+    /// second as a stale-epoch replay (the loser's join silently
+    /// fails). Chaining each approval onto the previous one's
+    /// completion guarantees the read-prove-submit-persist critical
+    /// section runs to completion before the next begins.
+    private var approvalChain: Task<ApproveOutcome, Never>?
 
     init(
         identity: IdentityRepository,
@@ -192,6 +202,22 @@ actor JoinRequestApprover: JoinRequestApproving {
         await refresh(from: raw)
     }
 
+    /// Public entry point. Serializes onto any in-flight approval via
+    /// `approvalChain` so each on-chain `update_commitment` reads the
+    /// epoch the previous approval persisted, then defers to
+    /// `performApprove` for the actual anchor flow. The read-and-assign
+    /// of `approvalChain` is synchronous (no `await` between), so
+    /// overlapping callers chain deterministically.
+    func approve(requestId: String) async -> ApproveOutcome {
+        let previous = approvalChain
+        let task = Task { () -> ApproveOutcome in
+            _ = await previous?.value
+            return await self.performApprove(requestId: requestId)
+        }
+        approvalChain = task
+        return await task.value
+    }
+
     /// Approve a pending request. Tyranny-only on-chain anchor flow:
     ///
     ///   1. Verify joiner shipped both `bls_pub` + `leaf_hash`.
@@ -217,7 +243,7 @@ actor JoinRequestApprover: JoinRequestApproving {
     /// in `OneOnOne` / `Anarchy`. PR-13b's receiver verification
     /// gates announcements to Tyranny groups specifically; other
     /// types stay best-effort.
-    func approve(requestId: String) async -> ApproveOutcome {
+    private func performApprove(requestId: String) async -> ApproveOutcome {
         guard let req = pendingValue.first(where: { $0.id == requestId }) else {
             return .unknownRequest
         }

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -50,6 +50,20 @@ struct IncomingMessageDispatcher: Sendable {
     /// the envelope's Ed25519 signer matches, and writes the message
     /// here for the chat screen to render.
     let messageRepository: MessageRepository
+    /// Receive-side sink for decoded `GroupInviteOfferPayload`s — the
+    /// push counterpart to the deeplink join flow. An offer lands here
+    /// as a `PendingInvite` awaiting the user's explicit Accept (which
+    /// ships a `JoinRequestPayload`) or dismiss. It grants nothing and
+    /// never materializes a group: membership only follows the
+    /// invitee's accept + the admin's explicit on-chain approve.
+    ///
+    /// Defaulted to a fresh store so the many existing test
+    /// constructions don't have to thread a spy they don't exercise;
+    /// production (`OnymIOSApp`) passes the shared store explicitly.
+    /// `var` (not `let`) so the synthesized memberwise initializer
+    /// keeps it as a defaulted parameter — a `let` with a default is
+    /// omitted from the memberwise init entirely.
+    var pendingInvites: any PendingInvitesRecording = PendingInvitesStore()
 
     func dispatch(
         messageID: String,
@@ -70,6 +84,25 @@ struct IncomingMessageDispatcher: Sendable {
                 messageID: messageID,
                 ownerIdentityID: ownerIdentityID,
                 payload: payload,
+                receivedAt: receivedAt
+            )
+            return
+        }
+
+        // Fast path 0: GroupInviteOfferPayload — a push invitation.
+        // Decoded + queued for the user's explicit Accept; it carries
+        // no epoch / commitment / roster, so it never materializes a
+        // group or touches the on-chain commitment. Tried first
+        // because its required `inviter_alias` + `intro_pub` keys are
+        // unique to this type — no other inbox payload decodes as one.
+        if let offer = try? JSONDecoder().decode(
+            GroupInviteOfferPayload.self,
+            from: envelope.plaintext
+        ) {
+            await recordOffer(
+                offer,
+                messageID: messageID,
+                ownerIdentityID: ownerIdentityID,
                 receivedAt: receivedAt
             )
             return
@@ -126,6 +159,27 @@ struct IncomingMessageDispatcher: Sendable {
             payload: payload,
             receivedAt: receivedAt
         )
+    }
+
+    /// Queue a decoded push offer for the user's explicit Accept.
+    /// Keyed by the inbound Nostr event id so a re-delivered offer
+    /// (replaceable events are re-fetched on every relaunch) is
+    /// idempotent in the store.
+    private func recordOffer(
+        _ offer: GroupInviteOfferPayload,
+        messageID: String,
+        ownerIdentityID: IdentityID,
+        receivedAt: Date
+    ) async {
+        await pendingInvites.record(PendingInvite(
+            id: messageID,
+            ownerIdentityID: ownerIdentityID,
+            introPublicKey: offer.introPublicKey,
+            groupID: offer.groupID,
+            groupName: offer.groupName,
+            inviterAlias: offer.inviterAlias,
+            receivedAt: receivedAt
+        ))
     }
 
     private func fallThrough(
@@ -298,8 +352,23 @@ struct IncomingMessageDispatcher: Sendable {
         } catch {
             return false
         }
-        guard onchain.commitment == claimedCommitment else { return false }
-        guard onchain.epoch == invitation.epoch else { return false }
+        // Converge-forward gate. The chain only stores the *latest*
+        // commitment+epoch, so a snapshot can't be byte-verified once
+        // the chain has moved past its epoch (e.g. another invitee was
+        // anchored between this invite being sealed and it landing).
+        //   - chain behind the snapshot  → impossible for a real
+        //     anchored snapshot; reject.
+        //   - chain exactly at the snapshot's epoch → byte-verify the
+        //     committed roster (the strong anti-forgery anchor for a
+        //     first-contact invite).
+        //   - chain ahead → the group provably exists on chain and the
+        //     snapshot is internally consistent; accept and let
+        //     subsequent `MemberAnnouncementPayload`s carry the roster
+        //     forward rather than dropping the invite outright.
+        guard onchain.epoch >= invitation.epoch else { return false }
+        if onchain.epoch == invitation.epoch {
+            guard onchain.commitment == claimedCommitment else { return false }
+        }
         return true
     }
 
@@ -334,8 +403,16 @@ struct IncomingMessageDispatcher: Sendable {
         } catch {
             return false
         }
-        guard onchain.commitment == claimedCommitment else { return false }
-        guard onchain.epoch == claimedEpoch else { return false }
+        // Same converge-forward gate as the invitation verifier. The
+        // announcement is already admin-Ed25519-signed (checked by the
+        // caller), so a stale-but-signed roster delta is a legitimate
+        // update we may have missed — accept when the chain is at or
+        // ahead of the claimed epoch, byte-verifying only on an exact
+        // epoch match.
+        guard onchain.epoch >= claimedEpoch else { return false }
+        if onchain.epoch == claimedEpoch {
+            guard onchain.commitment == claimedCommitment else { return false }
+        }
         return true
     }
 

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -352,25 +352,47 @@ struct IncomingMessageDispatcher: Sendable {
         } catch {
             return false
         }
-        // Converge-forward gate. The chain only stores the *latest*
-        // commitment+epoch, so a snapshot can't be byte-verified once
-        // the chain has moved past its epoch (e.g. another invitee was
-        // anchored between this invite being sealed and it landing).
-        //   - chain behind the snapshot  → impossible for a real
-        //     anchored snapshot; reject.
-        //   - chain exactly at the snapshot's epoch → byte-verify the
-        //     committed roster (the strong anti-forgery anchor for a
-        //     first-contact invite).
-        //   - chain ahead → the group provably exists on chain and the
-        //     snapshot is internally consistent; accept and let
-        //     subsequent `MemberAnnouncementPayload`s carry the roster
-        //     forward rather than dropping the invite outright.
+        // Bounded converge-forward gate. The chain stores only the
+        // LATEST (commitment, epoch), so a snapshot can't be byte-checked
+        // once the chain moves past its epoch.
+        //   - chain behind the snapshot → impossible for a real anchored
+        //     snapshot; reject.
+        //   - chain EXACTLY at the snapshot's epoch → byte-verify the
+        //     committed roster. This is the strong anti-forgery anchor: a
+        //     forger would have to reproduce `Poseidon(Poseidon(root,
+        //     epoch), salt)`, but `salt` is random and never on chain —
+        //     only a legitimate invitation carries it.
+        //   - chain AHEAD → we can't reproduce the byte-check, so accept
+        //     only within a small staleness window. This covers a burst
+        //     of concurrent approvals advancing the epoch between an
+        //     invite being sealed and it landing, while bounding the
+        //     forgery surface (a dropped salt-check would otherwise let
+        //     anyone who knows the recipient's inbox key + a real groupID
+        //     materialize an arbitrary fake group).
+        //
+        // SECURITY: even within the window a self-consistent fake snapshot
+        // for a *young* group is accepted. Fully closing this needs the
+        // chain read to expose `admin_pubkey_commitment` so the snapshot's
+        // adminPubkeyHex can be bound to chain independent of epoch —
+        // tracked as a follow-up (relayer + SDK support required).
         guard onchain.epoch >= invitation.epoch else { return false }
         if onchain.epoch == invitation.epoch {
             guard onchain.commitment == claimedCommitment else { return false }
+        } else {
+            guard onchain.epoch - invitation.epoch <= Self.maxInvitationStaleEpochs
+            else { return false }
         }
         return true
     }
+
+    /// Upper bound on how far the chain may have advanced past an
+    /// inbound invitation's epoch and still materialize. Sized to absorb
+    /// a realistic burst of serialized approvals during delivery latency
+    /// while keeping the salt-free forgery surface (chain-ahead branch of
+    /// `verifyTyrannyInvitation`) confined to young groups. A
+    /// longer-offline invitee on a fast-growing group beyond this falls
+    /// back to a re-invite rather than trusting an unverifiable snapshot.
+    static let maxInvitationStaleEpochs: UInt64 = 16
 
     /// PR 13b: validate a Tyranny `MemberAnnouncementPayload`'s
     /// claimed commitment + epoch against the on-chain state. Same

--- a/Sources/OnymIOS/Inbox/PendingInvitesFlow.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesFlow.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Observation
+
+/// `@Observable @MainActor` driver for the invitee-side "you've been
+/// invited" surface — the push counterpart to `JoinFlow` (which handles
+/// deeplink joins). Mirrors `ApproveRequestsFlow`'s shape: a shared
+/// instance whose `pending` list backs both the Chats toolbar badge and
+/// the modal list.
+///
+/// Accept is the *explicit* step the design requires: it turns a
+/// `PendingInvite` (an offer) into a `JoinRequestPayload` shipped to the
+/// admin's intro key. Nothing here anchors the roster — the admin still
+/// has to explicitly approve the resulting request. The group appears
+/// on accept only after that approval lands and materializes it, at
+/// which point `start()`'s group watcher consumes the spent invite.
+@MainActor
+@Observable
+final class PendingInvitesFlow {
+    /// Pending invites for the current identity, newest first.
+    var pending: [PendingInvite] = []
+    /// IDs whose accept call is in flight (drives the per-row spinner).
+    var inFlightIDs: Set<String> = []
+    /// IDs whose join request has been sent and is awaiting the admin's
+    /// approval. Relabels the row and disables Accept so the user
+    /// doesn't double-request.
+    var requestedIDs: Set<String> = []
+    var lastError: String?
+
+    private let store: PendingInvitesStore
+    private let groupRepository: GroupRepository
+    /// Mirrors `JoinFlow`'s injected `submitRequest` — seals + sends a
+    /// `JoinRequestPayload` for the given capability. Returns the
+    /// sender outcome so the flow can surface errors.
+    private let submitJoin: @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome
+    /// Resolves the joiner's display label at accept time (the active
+    /// identity's alias). Read lazily so an identity rename is picked
+    /// up without re-wiring.
+    private let displayLabel: @MainActor () -> String
+
+    private var streamingTask: Task<Void, Never>?
+    private var groupWatchTask: Task<Void, Never>?
+
+    init(
+        store: PendingInvitesStore,
+        groupRepository: GroupRepository,
+        submitJoin: @escaping @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome,
+        displayLabel: @escaping @MainActor () -> String
+    ) {
+        self.store = store
+        self.groupRepository = groupRepository
+        self.submitJoin = submitJoin
+        self.displayLabel = displayLabel
+    }
+
+    func isInFlight(_ id: String) -> Bool { inFlightIDs.contains(id) }
+    func isRequested(_ id: String) -> Bool { requestedIDs.contains(id) }
+
+    /// Mirror the store's snapshot into `pending` and watch groups so a
+    /// spent invite is dropped once its group materializes. Idempotent.
+    func start() async {
+        guard streamingTask == nil else { return }
+        let stream = store.snapshots
+        streamingTask = Task { @MainActor [weak self] in
+            for await snapshot in stream {
+                guard let self else { break }
+                self.pending = snapshot
+                // Forget request/in-flight bookkeeping for invites that
+                // are no longer present (consumed / identity switch).
+                let live = Set(snapshot.map(\.id))
+                self.requestedIDs.formIntersection(live)
+                self.inFlightIDs.formIntersection(live)
+            }
+        }
+        let groups = groupRepository.snapshots
+        let store = self.store
+        groupWatchTask = Task {
+            for await groups in groups {
+                await store.consumeForMaterializedGroups(
+                    Set(groups.map(\.groupIDData))
+                )
+            }
+        }
+    }
+
+    func stop() {
+        streamingTask?.cancel()
+        streamingTask = nil
+        groupWatchTask?.cancel()
+        groupWatchTask = nil
+    }
+
+    /// Explicit Accept: ship a join request to the offer's intro key.
+    /// No-op while already in flight or already requested.
+    func accept(_ id: String) {
+        guard !inFlightIDs.contains(id), !requestedIDs.contains(id) else { return }
+        guard let invite = pending.first(where: { $0.id == id }) else { return }
+        let capability: IntroCapability
+        do {
+            capability = try IntroCapability(
+                introPublicKey: invite.introPublicKey,
+                groupId: invite.groupID,
+                groupName: invite.groupName
+            )
+        } catch {
+            lastError = "This invite is malformed and can't be accepted."
+            return
+        }
+        inFlightIDs.insert(id)
+        lastError = nil
+        let label = displayLabel()
+        let submitJoin = self.submitJoin
+        Task { @MainActor [weak self] in
+            let outcome = await submitJoin(capability, label)
+            guard let self else { return }
+            self.inFlightIDs.remove(id)
+            switch outcome {
+            case .sent:
+                self.requestedIDs.insert(id)
+            case .noIdentityLoaded:
+                self.lastError = "Sign in first."
+            case .transportFailed(let reason):
+                self.lastError = "Couldn't send request: \(reason)"
+            }
+        }
+    }
+
+    /// Drop an invite the user doesn't want. Local-only — no NACK to
+    /// the admin (their outstanding intro key just goes unused).
+    func dismiss(_ id: String) {
+        let store = self.store
+        Task { await store.consume(id: id) }
+    }
+
+    func dismissError() { lastError = nil }
+}

--- a/Sources/OnymIOS/Inbox/PendingInvitesStore.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesStore.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// One decoded `GroupInviteOfferPayload` awaiting the user's explicit
+/// Accept / Dismiss. Unlike `IncomingInvitation` (opaque ciphertext),
+/// the offer is decrypted + decoded at receive time by
+/// `IncomingMessageDispatcher`, so this record carries the structured
+/// fields the UI needs to render "X invited you to Y" and the intro
+/// public key the Accept action replies to.
+struct PendingInvite: Identifiable, Equatable, Sendable {
+    /// Nostr event id of the inbound offer — the dedupe + consume key.
+    let id: String
+    /// Identity the offer was delivered to (the inbox tag it arrived
+    /// on). The Accept action replies *as* this identity.
+    let ownerIdentityID: IdentityID
+    /// Admin's per-invite intro pubkey — the reply channel the join
+    /// request is sealed to.
+    let introPublicKey: Data
+    let groupID: Data
+    let groupName: String?
+    let inviterAlias: String
+    let receivedAt: Date
+}
+
+/// Receive-side seam the dispatcher writes decoded offers into. Kept
+/// minimal (one method) so the dispatcher depends on a narrow protocol
+/// rather than the concrete store.
+protocol PendingInvitesRecording: Sendable {
+    /// Idempotent on `PendingInvite.id`. Re-delivery of the same offer
+    /// (replaceable Nostr event re-fetched on relaunch) is a no-op.
+    func record(_ invite: PendingInvite) async
+}
+
+/// Process-lifetime store of pending invites, filtered by the
+/// currently-selected identity. In-memory by design: the offer itself
+/// is a retained Nostr event, so the inbox fan-out re-delivers it on
+/// every launch — exactly like `InMemoryIntroRequestStore` for join
+/// requests. Snapshots mirror `IncomingInvitationsRepository`'s
+/// per-identity filtering so the list flips when the user switches
+/// identity.
+actor PendingInvitesStore: PendingInvitesRecording {
+    private var all: [PendingInvite] = []
+    private var currentIdentity: IdentityID?
+    private var continuations: [UUID: AsyncStream<[PendingInvite]>.Continuation] = [:]
+
+    init() {}
+
+    func record(_ invite: PendingInvite) async {
+        guard !all.contains(where: { $0.id == invite.id }) else { return }
+        all.append(invite)
+        publish()
+    }
+
+    /// Drop an invite after the user accepted or dismissed it.
+    func consume(id: String) {
+        let before = all.count
+        all.removeAll { $0.id == id }
+        if all.count != before { publish() }
+    }
+
+    /// Cascade for the identity-removal flow.
+    func removeForOwner(_ id: IdentityID) {
+        let before = all.count
+        all.removeAll { $0.ownerIdentityID == id }
+        if all.count != before { publish() }
+    }
+
+    /// Drop every pending invite whose group now exists locally — the
+    /// admin approved + the `GroupInvitationPayload` materialized the
+    /// group, so the offer has served its purpose. Called by the flow
+    /// when `GroupRepository` emits.
+    func consumeForMaterializedGroups(_ groupIDs: Set<Data>) {
+        guard !groupIDs.isEmpty else { return }
+        let before = all.count
+        all.removeAll { groupIDs.contains($0.groupID) }
+        if all.count != before { publish() }
+    }
+
+    func setCurrentIdentity(_ id: IdentityID?) {
+        currentIdentity = id
+        publish()
+    }
+
+    /// Hot stream of pending invites for the current identity, newest
+    /// first. New subscribers get the current snapshot immediately.
+    nonisolated var snapshots: AsyncStream<[PendingInvite]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<[PendingInvite]>.Continuation
+    ) {
+        continuations[id] = continuation
+        continuation.yield(filtered())
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func filtered() -> [PendingInvite] {
+        guard let currentIdentity else { return [] }
+        return all
+            .filter { $0.ownerIdentityID == currentIdentity }
+            .sorted { $0.receivedAt > $1.receivedAt }
+    }
+
+    private func publish() {
+        let snapshot = filtered()
+        for cont in continuations.values { cont.yield(snapshot) }
+    }
+}

--- a/Sources/OnymIOS/Inbox/PendingInvitesView.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesView.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+
+/// Invitee-side "you've been invited" list — the push counterpart to
+/// the deeplink `JoinView`. Mirrors `ApproveRequestsView`: a modal of
+/// cards, each offering Accept (ship a join request) or Dismiss. Accept
+/// is the explicit step; the group only appears once the admin approves
+/// the resulting request on chain.
+struct PendingInvitesView: View {
+    @Bindable var flow: PendingInvitesFlow
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            topBar
+            if let error = flow.lastError {
+                errorBanner(error)
+            }
+            if flow.pending.isEmpty {
+                emptyState
+            } else {
+                inviteList
+            }
+        }
+        .background(OnymTokens.bg)
+    }
+
+    private var topBar: some View {
+        HStack {
+            Text("Invitations")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Spacer()
+            Button("Done", action: onClose)
+                .font(.system(size: 16))
+                .foregroundStyle(OnymAccent.blue.color)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(OnymTokens.red)
+            Text(message)
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.text)
+            Spacer()
+            Button {
+                flow.dismissError()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+        }
+        .padding(12)
+        .background(OnymTokens.red.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Spacer()
+            Image(systemName: "envelope.open")
+                .font(.system(size: 34))
+                .foregroundStyle(OnymTokens.text2)
+            Text("No invitations")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(OnymTokens.text)
+            Text("Group invites you receive show up here for you to accept.")
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var inviteList: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                Spacer().frame(height: 8)
+                ForEach(flow.pending) { invite in
+                    inviteCard(invite)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+        }
+    }
+
+    private func inviteCard(_ invite: PendingInvite) -> some View {
+        let inFlight = flow.isInFlight(invite.id)
+        let requested = flow.isRequested(invite.id)
+        return VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(displayAlias(invite.inviterAlias))
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("invited you to \u{201C}\(invite.groupName ?? "a group")\u{201D}")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            HStack(spacing: 8) {
+                Button {
+                    flow.dismiss(invite.id)
+                } label: {
+                    Text("Dismiss")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 11)
+                        .background(OnymTokens.surface3)
+                        .foregroundStyle(OnymTokens.text)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .disabled(inFlight)
+                Button {
+                    flow.accept(invite.id)
+                } label: {
+                    HStack(spacing: 6) {
+                        if inFlight {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .tint(OnymTokens.onAccent)
+                                .scaleEffect(0.8)
+                        }
+                        Text(acceptLabel(inFlight: inFlight, requested: requested))
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 11)
+                    .background(OnymAccent.blue.color.opacity(inFlight || requested ? 0.7 : 1.0))
+                    .foregroundStyle(OnymTokens.onAccent)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .disabled(inFlight || requested)
+            }
+        }
+        .padding(14)
+        .background(OnymTokens.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .accessibilityIdentifier("pending_invites.card.\(invite.id)")
+    }
+
+    private func acceptLabel(inFlight: Bool, requested: Bool) -> String {
+        if requested { return "Requested \u{2014} awaiting approval" }
+        if inFlight { return "Sending\u{2026}" }
+        return "Accept"
+    }
+
+    private func displayAlias(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Someone" : trimmed
+    }
+}
+
+/// Chats-toolbar entry point: an envelope with a count badge, opening
+/// the invitations sheet. Always rendered (like the join-requests
+/// button) so the surface is discoverable; the badge only shows when
+/// there's at least one pending invite.
+struct PendingInvitesToolbarButton: View {
+    @Bindable var flow: PendingInvitesFlow
+    @State private var showSheet = false
+
+    var body: some View {
+        Button {
+            showSheet = true
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: "envelope")
+                    .font(.system(size: 17))
+                if !flow.pending.isEmpty {
+                    Text("\(flow.pending.count)")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Capsule().fill(OnymTokens.red))
+                        .offset(x: 8, y: -6)
+                        .accessibilityIdentifier("pending_invites.toolbar_badge")
+                }
+            }
+        }
+        .accessibilityLabel("Invitations")
+        .accessibilityIdentifier("pending_invites.toolbar_button")
+        .sheet(isPresented: $showSheet) {
+            PendingInvitesView(flow: flow, onClose: { showSheet = false })
+        }
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -11,6 +11,7 @@ struct OnymIOSApp: App {
     private let inboxTransport: any InboxTransport
     private let nostrRelaysRepository: NostrRelaysRepository
     private let incomingInvitations: IncomingInvitationsRepository
+    private let pendingInvitesStore: PendingInvitesStore
     private let introKeyStore: any IntroKeyStore
     private let introRequestStore: any IntroRequestStore
 
@@ -157,6 +158,33 @@ struct OnymIOSApp: App {
         )
         let approveRequestsFlow = ApproveRequestsFlow(approver: joinRequestApprover)
 
+        // Invitee-side push invitations. The dispatcher records decoded
+        // `GroupInviteOfferPayload`s here; the flow drives the Chats
+        // "Invitations" surface and, on explicit Accept, ships a
+        // `JoinRequestPayload` to the offer's intro key via a sender
+        // identical to the deeplink join path.
+        let pendingInvitesStore = PendingInvitesStore()
+        self.pendingInvitesStore = pendingInvitesStore
+        let pendingInvitesSender = JoinRequestSender(
+            identity: repository,
+            inboxTransport: inboxTransport
+        )
+        let pendingInvitesFlow = PendingInvitesFlow(
+            store: pendingInvitesStore,
+            groupRepository: groupRepository,
+            submitJoin: { cap, label in
+                await pendingInvitesSender.send(
+                    capability: cap,
+                    joinerDisplayLabel: label
+                )
+            },
+            displayLabel: { @MainActor [identitiesFlow] in
+                identitiesFlow.identities
+                    .first { $0.id == identitiesFlow.currentID }?
+                    .name ?? ""
+            }
+        )
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -179,7 +207,8 @@ struct OnymIOSApp: App {
                     relayers: relayerRepository,
                     contracts: contractsRepository,
                     groups: groupRepository,
-                    inboxTransport: inboxTransport
+                    inboxTransport: inboxTransport,
+                    introducer: inviteIntroducer
                 ))
             },
             makeShareInviteFlow: { @MainActor in
@@ -220,6 +249,7 @@ struct OnymIOSApp: App {
             },
             identitiesFlow: identitiesFlow,
             approveRequestsFlow: approveRequestsFlow,
+            pendingInvitesFlow: pendingInvitesFlow,
             messageRepository: messageRepository,
             sendMessageInteractor: SendMessageInteractor(
                 identity: repository,
@@ -254,6 +284,10 @@ struct OnymIOSApp: App {
                     // before the user opens the modal request list.
                     // Idempotent — `ChatsView.task` calls it too.
                     await dependencies.approveRequestsFlow.start()
+                    // Start the invitee-side invitations flow eagerly so
+                    // the Chats toolbar badge reflects offers from the
+                    // moment the app is on screen. Idempotent.
+                    await dependencies.pendingInvitesFlow.start()
                     // Kick off both GitHub Releases fetches as soon as the
                     // app is on screen. Failures are silent; the user can
                     // still enter a custom relayer URL / pick an older
@@ -268,6 +302,7 @@ struct OnymIOSApp: App {
                     if let initialID = await identityRepository.currentSelectedID() {
                         await groupRepository.setCurrentIdentity(initialID)
                         await incomingInvitations.setCurrentIdentity(initialID)
+                        await pendingInvitesStore.setCurrentIdentity(initialID)
                     }
                 }
                 .task {
@@ -276,6 +311,7 @@ struct OnymIOSApp: App {
                     for await id in identityRepository.currentIdentityID {
                         await groupRepository.setCurrentIdentity(id)
                         await incomingInvitations.setCurrentIdentity(id)
+                        await pendingInvitesStore.setCurrentIdentity(id)
                     }
                 }
                 .task {
@@ -287,6 +323,7 @@ struct OnymIOSApp: App {
                     for await removed in identityRepository.identityRemoved {
                         await groupRepository.removeForOwner(removed)
                         await incomingInvitations.removeForOwner(removed)
+                        await pendingInvitesStore.removeForOwner(removed)
                         // Cascade-wipe the removed identity's intro
                         // privkeys so an attacker who restores a
                         // backup post-removal can't decrypt
@@ -325,7 +362,8 @@ struct OnymIOSApp: App {
                         groupRepository: groupRepository,
                         invitationsRepository: incomingInvitations,
                         chainState: chainStateReader,
-                        messageRepository: messageRepository
+                        messageRepository: messageRepository,
+                        pendingInvites: pendingInvitesStore
                     )
                     let fanout = InboxFanoutInteractor(
                         inboxTransport: inboxTransport,

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -30,6 +30,7 @@ struct RootView: View {
                         flow: dependencies.makeChatsFlow(),
                         identitiesFlow: dependencies.identitiesFlow,
                         approveRequestsFlow: dependencies.approveRequestsFlow,
+                        pendingInvitesFlow: dependencies.pendingInvitesFlow,
                         messageRepository: dependencies.messageRepository,
                         sendMessageInteractor: dependencies.sendMessageInteractor,
                         makeCreateGroupFlow: dependencies.makeCreateGroupFlow,

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -418,6 +418,7 @@ private final class CreateGroupFlowTestEnv {
             contracts: contracts,
             groups: GroupRepository(store: SwiftDataGroupStore.inMemory()),
             inboxTransport: FlowTestInboxTransport(),
+            introducer: InviteIntroducer(store: InMemoryIntroKeyStore()),
             makeContractTransport: { _ in FlowTestContractTransport() }
         )
         return CreateGroupFlowTestEnv(interactor: interactor, keychain: keychain)

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -507,6 +507,7 @@ private final class CreateGroupTestEnv {
             networkPreference: networkPreference,
             proofGenerator: proofGenerator,
             inboxTransport: inboxTransport,
+            introducer: InviteIntroducer(store: InMemoryIntroKeyStore()),
             makeContractTransport: { [contractTransport] _ in contractTransport }
         )
     }

--- a/Tests/OnymIOSTests/GroupInviteOfferPayloadTests.swift
+++ b/Tests/OnymIOSTests/GroupInviteOfferPayloadTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import XCTest
+@testable import OnymIOS
+
+final class GroupInviteOfferPayloadTests: XCTestCase {
+
+    private func makeValid() throws -> GroupInviteOfferPayload {
+        try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x11, count: 32),
+            groupID: Data(repeating: 0x22, count: 32),
+            groupName: "Maple Garden",
+            inviterAlias: "Alice"
+        )
+    }
+
+    func test_roundTrip_preservesAllFields() throws {
+        let offer = try makeValid()
+        let encoded = try JSONEncoder().encode(offer)
+        let decoded = try JSONDecoder().decode(GroupInviteOfferPayload.self, from: encoded)
+        XCTAssertEqual(decoded, offer)
+        XCTAssertEqual(decoded.version, 1)
+        XCTAssertEqual(decoded.introPublicKey, Data(repeating: 0x11, count: 32))
+        XCTAssertEqual(decoded.groupID, Data(repeating: 0x22, count: 32))
+        XCTAssertEqual(decoded.groupName, "Maple Garden")
+        XCTAssertEqual(decoded.inviterAlias, "Alice")
+    }
+
+    func test_nilGroupName_roundTrips() throws {
+        let offer = try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x01, count: 32),
+            groupID: Data(repeating: 0x02, count: 32),
+            groupName: nil,
+            inviterAlias: ""
+        )
+        let decoded = try JSONDecoder().decode(
+            GroupInviteOfferPayload.self,
+            from: JSONEncoder().encode(offer)
+        )
+        XCTAssertNil(decoded.groupName)
+        XCTAssertEqual(decoded, offer)
+    }
+
+    func test_wrongIntroKeyLength_throws() {
+        XCTAssertThrowsError(try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x11, count: 31),
+            groupID: Data(repeating: 0x22, count: 32),
+            groupName: nil,
+            inviterAlias: "A"
+        ))
+    }
+
+    func test_wrongGroupIDLength_throws() {
+        XCTAssertThrowsError(try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x11, count: 32),
+            groupID: Data(repeating: 0x22, count: 16),
+            groupName: nil,
+            inviterAlias: "A"
+        ))
+    }
+
+    /// The dispatcher relies on `inviter_alias` + `intro_pub` being
+    /// unique to this type. A `JoinRequestPayload` (the other
+    /// intro-keyed payload) must NOT decode as an offer.
+    func test_joinRequestPayload_doesNotDecodeAsOffer() throws {
+        let join = try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0x01, count: 32),
+            joinerBlsPublicKey: Data(repeating: 0x02, count: 48),
+            joinerLeafHash: Data(repeating: 0x03, count: 32),
+            joinerSendingPublicKey: Data(repeating: 0x04, count: 32),
+            joinerDisplayLabel: "Bob",
+            groupId: Data(repeating: 0x05, count: 32)
+        )
+        let bytes = try JSONEncoder().encode(join)
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(GroupInviteOfferPayload.self, from: bytes),
+            "JoinRequestPayload must not be mistaken for an offer"
+        )
+    }
+
+    func test_introCapability_rebuildsFromOffer() throws {
+        let offer = try makeValid()
+        let cap = try offer.introCapability()
+        XCTAssertEqual(cap.introPublicKey, offer.introPublicKey)
+        XCTAssertEqual(cap.groupId, offer.groupID)
+        XCTAssertEqual(cap.groupName, offer.groupName)
+    }
+}

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -938,6 +938,51 @@ final class IncomingMessageDispatcherTests: XCTestCase {
                        "stale-but-valid Tyranny invite should still materialize when the chain is ahead")
         XCTAssertEqual(after.first?.groupIDData, groupID)
     }
+
+    func test_invitation_tyranny_rejectsWhenChainEpochTooFarAhead() async throws {
+        // Beyond the bounded staleness window the snapshot can't be
+        // byte-verified (the salt-gated commitment check only works at an
+        // exact epoch), so it could be a salt-free forgery — drop it
+        // rather than materialize a fake group.
+        let groupID = Data(repeating: 0x42, count: 32)
+        let salt = Data(repeating: 0x66, count: 32)
+        let realCommitment = try Self.makeRealTyrannyCommitment(
+            members: [], epoch: 0, salt: salt, tier: .small
+        )
+        let farAhead = IncomingMessageDispatcher.maxInvitationStaleEpochs + 1
+        chainState.setNext(commitment: Data(repeating: 0x99, count: 32), epoch: farAhead)
+        let payload = makeInvitationPayload(
+            groupID: groupID,
+            name: "Family",
+            memberProfiles: nil,
+            groupType: .tyranny,
+            commitment: realCommitment
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: Data(repeating: 0xED, count: 32)
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-too-stale",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        XCTAssertTrue(after.isEmpty,
+                      "invitation more than maxInvitationStaleEpochs behind chain must be rejected")
+    }
 }
 
 // MARK: - Stub identity provider

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -846,6 +846,98 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             memberProfiles: memberProfiles
         )
     }
+
+    // MARK: - Invite offers + converge-forward (handshake)
+
+    func test_offer_isQueuedForAcceptAndDoesNotMaterializeGroup() async throws {
+        // A push offer must NOT materialize a group or land in the
+        // opaque invitations queue — it's queued as a structured
+        // PendingInvite for the user's explicit Accept. Membership only
+        // follows accept + the admin's explicit approve.
+        let offer = try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x44, count: 32),
+            groupID: Data(repeating: 0x42, count: 32),
+            groupName: "Maple Garden",
+            inviterAlias: "Alice"
+        )
+        let plaintext = try JSONEncoder().encode(offer)
+        let decrypter = FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext))
+        let spy = SpyPendingInvites()
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            pendingInvites: spy
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-offer",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        XCTAssertTrue(after.isEmpty, "an offer must NOT materialize a group")
+        let storedCount = await invitationsStore.count
+        XCTAssertEqual(storedCount, 0, "an offer is not an opaque invitation")
+        let recorded = await spy.all()
+        XCTAssertEqual(recorded.count, 1)
+        XCTAssertEqual(recorded.first?.id, "msg-offer")
+        XCTAssertEqual(recorded.first?.introPublicKey, Data(repeating: 0x44, count: 32))
+        XCTAssertEqual(recorded.first?.inviterAlias, "Alice")
+        XCTAssertEqual(recorded.first?.groupName, "Maple Garden")
+    }
+
+    func test_invitation_tyranny_acceptedWhenChainEpochAheadOfSnapshot() async throws {
+        // Converge-forward: a snapshot at epoch 0 must still materialize
+        // when the chain has moved past it (another invitee anchored
+        // first). The internal Poseidon recompute still gates forgery;
+        // the exact-commitment byte-check only applies at an equal
+        // epoch. Pre-relaxation `== epoch` would have dropped this.
+        let groupID = Data(repeating: 0x42, count: 32)
+        let salt = Data(repeating: 0x66, count: 32)  // matches makeInvitationPayload
+        let realCommitment = try Self.makeRealTyrannyCommitment(
+            members: [], epoch: 0, salt: salt, tier: .small
+        )
+        // Chain ahead (epoch 5) with a *different* commitment.
+        chainState.setNext(commitment: Data(repeating: 0x99, count: 32), epoch: 5)
+        let payload = makeInvitationPayload(
+            groupID: groupID,
+            name: "Family",
+            memberProfiles: nil,
+            groupType: .tyranny,
+            commitment: realCommitment
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: Data(repeating: 0xED, count: 32)
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-stale-ok",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        XCTAssertEqual(after.count, 1,
+                       "stale-but-valid Tyranny invite should still materialize when the chain is ahead")
+        XCTAssertEqual(after.first?.groupIDData, groupID)
+    }
 }
 
 // MARK: - Stub identity provider
@@ -858,6 +950,14 @@ private actor StubIdentities: IdentitiesProviding {
     }
 
     func currentIdentities() -> [IdentitySummary] { summaries }
+}
+
+// MARK: - Pending-invites spy
+
+private actor SpyPendingInvites: PendingInvitesRecording {
+    private(set) var recorded: [PendingInvite] = []
+    func record(_ invite: PendingInvite) async { recorded.append(invite) }
+    func all() -> [PendingInvite] { recorded }
 }
 
 // MARK: - String / hex helpers (test scope)

--- a/Tests/OnymIOSTests/Integration/CreateGroupOneOnOneE2ETests.swift
+++ b/Tests/OnymIOSTests/Integration/CreateGroupOneOnOneE2ETests.swift
@@ -143,6 +143,7 @@ final class CreateGroupOneOnOneE2ETests: XCTestCase {
                 networkPreference: networkPreference,
                 proofGenerator: proofGenerator,
                 inboxTransport: inboxTransport,
+                introducer: InviteIntroducer(store: InMemoryIntroKeyStore()),
                 makeContractTransport: makeContractTransport
             )
         }

--- a/Tests/OnymIOSTests/Integration/CreateGroupTyrannyE2ETests.swift
+++ b/Tests/OnymIOSTests/Integration/CreateGroupTyrannyE2ETests.swift
@@ -147,6 +147,7 @@ final class CreateGroupTyrannyE2ETests: XCTestCase {
                 networkPreference: networkPreference,
                 proofGenerator: proofGenerator,
                 inboxTransport: inboxTransport,
+                introducer: InviteIntroducer(store: InMemoryIntroKeyStore()),
                 makeContractTransport: makeContractTransport
             )
         }


### PR DESCRIPTION
## Problem

Create-time "add member via QR" shipped a `GroupInvitationPayload` (a *membership grant*) to a non-member's inbox. The invitee was never added to the on-chain roster, never recorded in the inviter's `memberProfiles`, and the epoch-pinned snapshot went stale the moment any other invitee anchored. Observed: **inviter saw 1 member, invitee saw 2, and messages never flowed back.**

## Approach

Replace the broken send with a **push handshake** that funnels into the existing on-chain join machinery (intro keys → `JoinRequestSender` → `IntroInboxPump` → `JoinRequestApprover` → `update_commitment`). Membership stays on-chain (preserving the admin's anonymous-ownership proof), and roster anchoring is gated behind the admin's **explicit Approve** — no auto-anchor, no silent add of an unintended party.

Flow: scan QR → admin sends a durable offer → invitee **explicitly accepts** (ships a join request) → admin **explicitly approves** → `update_commitment` anchors + ships the real invitation.

## Changes

- **`GroupInviteOfferPayload`** — durable, epoch-free offer carrying a freshly-minted per-invitee intro key + display context. Grants nothing, never expires.
- **`CreateGroupInteractor` (Tyranny)** — mint an intro key per invitee and send an offer instead of a snapshot; creator stays the only on-chain member until an approval.
- **`IncomingMessageDispatcher`** — route offers to `PendingInvitesStore`; never materialize a group from an offer.
- **`PendingInvitesStore` / `PendingInvitesFlow` / `PendingInvitesView`** — invitee-side Invitations surface (Chats toolbar) with explicit Accept → ships a `JoinRequestPayload` to the offer's intro key.
- **Bounded converge-forward verification** — the receiver byte-verifies the on-chain commitment at an *exact* epoch match (the strong gate: reproducing it requires the random `salt`, which is never on chain). When the chain is *ahead*, the snapshot can't be byte-verified, so it's accepted only within a small staleness window (`maxInvitationStaleEpochs = 16`) — enough to absorb a burst of serialized approvals during delivery latency, while bounding the salt-free forgery surface to young groups. (Initial revision relaxed this unbounded; see security note below.)
- **Serialize `JoinRequestApprover.approve`** — concurrent approvals no longer both read the same stale epoch (which lost one to a stale-epoch replay).

The existing admin approval UI (`ApproveRequestsView`) is reused unchanged.

## Security note

The chain-ahead branch trades some forgery resistance for late-join delivery: within the window, a party who knows a recipient's inbox key + a real groupID can still materialize a self-consistent fake of a *young* group (the forged envelope's signer becomes the local admin, so the real admin's announcements won't reconcile). The clean fix is to bind the snapshot's `adminPubkeyHex` to the on-chain `admin_pubkey_commitment` regardless of epoch — but `SEPCommitmentEntry` (the `get_commitment` read) doesn't expose it today, so that's a follow-up gated on relayer + SDK support. Announcement verification stays unbounded `>=` because it's already gated by the stored-admin Ed25519 signature check.

## Tests

`GroupInviteOfferPayload` codec + wire-disambiguation; dispatcher offer-route (no materialize, queued for accept); converge-forward materialization when the chain is ahead within the window, and rejection beyond it. Full `OnymIOSTests` suite green on iOS Simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)