### PR TITLE
feat(inbox): verify-at-current group state (Option 2) — replaces staleness window

### DIFF
--- a/Sources/OnymIOS/Group/GroupStateRefreshRequest.swift
+++ b/Sources/OnymIOS/Group/GroupStateRefreshRequest.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Member → admin "send me the current group state" request, sealed to
+/// the admin's inbox and signed by the requester's Ed25519.
+///
+/// ## Why this exists
+///
+/// A Tyranny invitation is a snapshot pinned to one epoch. The receiver
+/// verifies it by recomputing `Poseidon(Poseidon(merkleRoot(members),
+/// epoch), salt)` and matching the on-chain commitment — but the chain
+/// only stores the *latest* `(commitment, epoch)`. If another invitee
+/// was anchored between the snapshot being sealed and it landing, the
+/// snapshot is from a past epoch the chain no longer holds, so it can't
+/// be verified (and we refuse to materialize an unverifiable group —
+/// see `GroupStateVerifier`).
+///
+/// To recover, the receiver asks the admin for the *current* state. The
+/// admin replies with a fresh `GroupInvitationPayload` at the current
+/// `(epoch, salt, members, commitment)`, which the receiver verifies at
+/// an exact epoch match. This is the "verify at current state" leg of
+/// the converge-forward design.
+///
+/// ## Privacy
+///
+/// The reply carries `salt` (the on-chain roster-privacy blinding
+/// factor), so the admin MUST only answer requesters that are in the
+/// *current* roster — `GroupStateVerifier.handleRefreshRequest` gates on
+/// membership + an Ed25519-signer check before replying. The request
+/// itself reveals only that the requester wants to resync a group it was
+/// invited to.
+///
+/// ## Wire disambiguation
+///
+/// `refresh_group_id` + `requester_inbox_pub` are required and unique to
+/// this type; no other inbox payload decodes as one.
+struct GroupStateRefreshRequest: Codable, Equatable, Sendable {
+    let version: Int
+    /// 32-byte on-chain `group_id` the requester wants the current
+    /// state for.
+    let groupID: Data
+    /// Requester's 32-byte X25519 inbox key — where the admin seals the
+    /// fresh snapshot reply.
+    let requesterInboxPublicKey: Data
+    /// Requester's 48-byte compressed BLS pubkey — used by the admin to
+    /// confirm the requester is in the current roster before disclosing
+    /// the salt.
+    let requesterBlsPublicKey: Data
+
+    enum CodingKeys: String, CodingKey {
+        case version = "refresh_version"
+        case groupID = "refresh_group_id"
+        case requesterInboxPublicKey = "requester_inbox_pub"
+        case requesterBlsPublicKey = "requester_bls_pub"
+    }
+
+    init(
+        version: Int = 1,
+        groupID: Data,
+        requesterInboxPublicKey: Data,
+        requesterBlsPublicKey: Data
+    ) throws {
+        guard groupID.count == 32 else {
+            throw GroupStateRefreshRequestError.shape(
+                "groupID: expected 32 bytes, got \(groupID.count)"
+            )
+        }
+        guard requesterInboxPublicKey.count == 32 else {
+            throw GroupStateRefreshRequestError.shape(
+                "requesterInboxPublicKey: expected 32 bytes, got \(requesterInboxPublicKey.count)"
+            )
+        }
+        guard requesterBlsPublicKey.count == 48 else {
+            throw GroupStateRefreshRequestError.shape(
+                "requesterBlsPublicKey: expected 48 bytes, got \(requesterBlsPublicKey.count)"
+            )
+        }
+        self.version = version
+        self.groupID = groupID
+        self.requesterInboxPublicKey = requesterInboxPublicKey
+        self.requesterBlsPublicKey = requesterBlsPublicKey
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            version: c.decode(Int.self, forKey: .version),
+            groupID: c.decode(Data.self, forKey: .groupID),
+            requesterInboxPublicKey: c.decode(Data.self, forKey: .requesterInboxPublicKey),
+            requesterBlsPublicKey: c.decode(Data.self, forKey: .requesterBlsPublicKey)
+        )
+    }
+}
+
+enum GroupStateRefreshRequestError: Error, Equatable {
+    case shape(String)
+}

--- a/Sources/OnymIOS/Inbox/GroupStateVerifier.swift
+++ b/Sources/OnymIOS/Inbox/GroupStateVerifier.swift
@@ -46,6 +46,9 @@ actor GroupStateVerifier: GroupStateRefreshing {
     /// the group materializes.
     private var targets: [String: RefreshTarget] = [:]
     private var timeouts: [String: Task<Void, Never>] = [:]
+    /// Groups with a refresh send currently in flight — guards against
+    /// rapid Retry taps / re-delivery firing duplicate sealed sends.
+    private var inFlight: Set<String> = []
     private var watchTask: Task<Void, Never>?
 
     private struct RefreshTarget {
@@ -59,7 +62,11 @@ actor GroupStateVerifier: GroupStateRefreshing {
         inboxTransport: any InboxTransport,
         groupRepository: GroupRepository,
         store: PendingVerificationStore,
-        refreshTimeoutSeconds: UInt64 = 30
+        // 60s (not 30) to tolerate slow relays / cold inbox
+        // subscriptions before declaring the admin unreachable. Injected
+        // so it can be tuned; a telemetry-driven value is a follow-up
+        // once the app has a metrics seam.
+        refreshTimeoutSeconds: UInt64 = 60
     ) {
         self.identity = identity
         self.inboxTransport = inboxTransport
@@ -89,7 +96,18 @@ actor GroupStateVerifier: GroupStateRefreshing {
         ownerIdentityID: IdentityID
     ) async {
         let groupIDHex = Self.hex(invitation.groupID)
-        guard await !store.contains(groupIDHex: groupIDHex) else { return }
+        // Idempotent per groupID — a forger who knows a recipient inbox
+        // key + a real on-chain groupID can spawn at most ONE pending
+        // card (and one sealed send) per distinct groupID, not an
+        // unbounded stream. Per-peer rate-limiting of deferrals is a
+        // tracked follow-up.
+        if let existing = await store.status(groupIDHex: groupIDHex) {
+            // Re-arm a previously-failed entry on re-delivery of the
+            // retained snapshot — auto-recovery once the admin is back.
+            // A `.verifying` entry already has a request outstanding.
+            if existing == .unreachable { await retry(groupIDHex: groupIDHex) }
+            return
+        }
 
         // We can only ask the admin if the snapshot told us their inbox.
         guard let adminBls = invitation.adminPubkeyHex?.lowercased(),
@@ -124,13 +142,19 @@ actor GroupStateVerifier: GroupStateRefreshing {
     /// auto-retry on foreground). No-op if the group resolved or we have
     /// no target for it.
     func retry(groupIDHex: String) async {
-        guard targets[groupIDHex] != nil else { return }
+        // Need a target, no send already in flight, and a failed entry —
+        // re-sending a `.verifying` one (request still outstanding) would
+        // just burn relay budget.
+        guard targets[groupIDHex] != nil, !inFlight.contains(groupIDHex) else { return }
+        guard await store.status(groupIDHex: groupIDHex) == .unreachable else { return }
         await store.updateStatus(groupIDHex: groupIDHex, status: .verifying)
         await sendRefresh(groupIDHex: groupIDHex)
     }
 
     private func sendRefresh(groupIDHex: String) async {
-        guard let target = targets[groupIDHex] else { return }
+        guard let target = targets[groupIDHex], !inFlight.contains(groupIDHex) else { return }
+        inFlight.insert(groupIDHex)
+        defer { inFlight.remove(groupIDHex) }
         // Build the request from the *current* identity. V1 assumes the
         // owner is the selected identity (matching the single-active
         // assumption elsewhere); if it isn't, the admin's membership
@@ -167,8 +191,10 @@ actor GroupStateVerifier: GroupStateRefreshing {
     }
 
     private func markUnreachableIfStillVerifying(_ groupIDHex: String) async {
-        guard await store.contains(groupIDHex: groupIDHex) else { return }
-        await store.updateStatus(groupIDHex: groupIDHex, status: .unreachable)
+        // Atomic on the store: flips only when still `.verifying`, so a
+        // timer firing after the entry was resolved (or re-armed) can't
+        // clobber it.
+        await store.markUnreachableIfVerifying(groupIDHex: groupIDHex)
     }
 
     private func resolve(_ materializedHexes: Set<String>) async {
@@ -194,6 +220,15 @@ actor GroupStateVerifier: GroupStateRefreshing {
         }) else {
             return
         }
+        // This device must actually BE the group's admin. Requests only
+        // reach admins today (sealed to the snapshot's admin inbox), but
+        // if a member's inbox were ever reused as the admin inbox in some
+        // snapshot, they'd otherwise answer with the salt. Refuse unless
+        // our own BLS is the group's admin pubkey.
+        guard let me = await identity.currentIdentity(),
+              let adminHex = group.adminPubkeyHex,
+              Self.hex(me.blsPublicKey) == adminHex.lowercased()
+        else { return }
         // Membership gate — the reply carries `salt`, so only answer a
         // requester that is a current member, and only after confirming
         // the envelope's signer matches that member's stored Ed25519

--- a/Sources/OnymIOS/Inbox/GroupStateVerifier.swift
+++ b/Sources/OnymIOS/Inbox/GroupStateVerifier.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+/// Seam the dispatcher delegates Tyranny group-state verification to.
+/// Two roles, because any device is both a potential invitee and a
+/// potential admin:
+///   - `deferVerification` (invitee): a snapshot couldn't be verified at
+///     an exact epoch (chain advanced past it) — ask the admin for the
+///     current state instead of materializing an unverifiable group.
+///   - `handleRefreshRequest` (admin): reply to such a request with the
+///     current snapshot, gated on the requester being a current member.
+protocol GroupStateRefreshing: Sendable {
+    func deferVerification(
+        invitation: GroupInvitationPayload,
+        ownerIdentityID: IdentityID
+    ) async
+    func handleRefreshRequest(
+        _ request: GroupStateRefreshRequest,
+        ownerIdentityID: IdentityID,
+        requesterEd25519: Data?
+    ) async
+}
+
+/// No-op conformer — the dispatcher's default so the many existing test
+/// constructions don't have to thread a verifier they don't exercise.
+struct NoopGroupStateRefresher: GroupStateRefreshing {
+    func deferVerification(invitation: GroupInvitationPayload, ownerIdentityID: IdentityID) async {}
+    func handleRefreshRequest(_ request: GroupStateRefreshRequest, ownerIdentityID: IdentityID, requesterEd25519: Data?) async {}
+}
+
+/// Drives the "verify at current state" leg of the converge-forward
+/// design (Option 2). When an invitation snapshot is stale, the invitee
+/// asks the admin for the current `(epoch, salt, members, commitment)`;
+/// the admin replies with a fresh `GroupInvitationPayload` that verifies
+/// at an exact epoch. If the admin can't be reached, the group is left
+/// in a `.unreachable` pending state and surfaced to the user — never
+/// silently materialized or dropped.
+actor GroupStateVerifier: GroupStateRefreshing {
+    private let identity: IdentityRepository
+    private let inboxTransport: any InboxTransport
+    private let groupRepository: GroupRepository
+    private let store: PendingVerificationStore
+    private let refreshTimeoutSeconds: UInt64
+
+    /// Re-send targets, kept so an in-session Retry (and the timeout)
+    /// can act without re-parsing the original snapshot. Cleared when
+    /// the group materializes.
+    private var targets: [String: RefreshTarget] = [:]
+    private var timeouts: [String: Task<Void, Never>] = [:]
+    private var watchTask: Task<Void, Never>?
+
+    private struct RefreshTarget {
+        let groupID: Data
+        let adminInboxKey: Data
+        let ownerIdentityID: IdentityID
+    }
+
+    init(
+        identity: IdentityRepository,
+        inboxTransport: any InboxTransport,
+        groupRepository: GroupRepository,
+        store: PendingVerificationStore,
+        refreshTimeoutSeconds: UInt64 = 30
+    ) {
+        self.identity = identity
+        self.inboxTransport = inboxTransport
+        self.groupRepository = groupRepository
+        self.store = store
+        self.refreshTimeoutSeconds = refreshTimeoutSeconds
+    }
+
+    /// Watch the group repo so a pending verification is resolved (and
+    /// its timeout cancelled) the moment the fresh snapshot materializes
+    /// its group. Idempotent.
+    func start() {
+        watchTask?.cancel()
+        let stream = groupRepository.snapshots
+        watchTask = Task { [weak self] in
+            for await groups in stream {
+                guard let self else { return }
+                await self.resolve(Set(groups.map(\.id)))
+            }
+        }
+    }
+
+    // MARK: - Invitee side
+
+    func deferVerification(
+        invitation: GroupInvitationPayload,
+        ownerIdentityID: IdentityID
+    ) async {
+        let groupIDHex = Self.hex(invitation.groupID)
+        guard await !store.contains(groupIDHex: groupIDHex) else { return }
+
+        // We can only ask the admin if the snapshot told us their inbox.
+        guard let adminBls = invitation.adminPubkeyHex?.lowercased(),
+              let adminInbox = invitation.memberProfiles?[adminBls]?.inboxPublicKey
+        else {
+            await store.record(PendingGroupVerification(
+                groupIDHex: groupIDHex,
+                ownerIdentityID: ownerIdentityID,
+                groupName: invitation.name,
+                status: .unreachable,
+                receivedAt: Date()
+            ))
+            return
+        }
+
+        await store.record(PendingGroupVerification(
+            groupIDHex: groupIDHex,
+            ownerIdentityID: ownerIdentityID,
+            groupName: invitation.name,
+            status: .verifying,
+            receivedAt: Date()
+        ))
+        targets[groupIDHex] = RefreshTarget(
+            groupID: invitation.groupID,
+            adminInboxKey: adminInbox,
+            ownerIdentityID: ownerIdentityID
+        )
+        await sendRefresh(groupIDHex: groupIDHex)
+    }
+
+    /// Re-send a refresh for a still-pending group (manual Retry, or an
+    /// auto-retry on foreground). No-op if the group resolved or we have
+    /// no target for it.
+    func retry(groupIDHex: String) async {
+        guard targets[groupIDHex] != nil else { return }
+        await store.updateStatus(groupIDHex: groupIDHex, status: .verifying)
+        await sendRefresh(groupIDHex: groupIDHex)
+    }
+
+    private func sendRefresh(groupIDHex: String) async {
+        guard let target = targets[groupIDHex] else { return }
+        // Build the request from the *current* identity. V1 assumes the
+        // owner is the selected identity (matching the single-active
+        // assumption elsewhere); if it isn't, the admin's membership
+        // check simply won't match and we fall through to `.unreachable`.
+        guard let me = await identity.currentIdentity(),
+              let request = try? GroupStateRefreshRequest(
+                  groupID: target.groupID,
+                  requesterInboxPublicKey: me.inboxPublicKey,
+                  requesterBlsPublicKey: me.blsPublicKey
+              ),
+              let bytes = try? JSONEncoder().encode(request),
+              let sealed = try? await identity.sealInvitation(payload: bytes, to: target.adminInboxKey)
+        else {
+            await store.updateStatus(groupIDHex: groupIDHex, status: .unreachable)
+            return
+        }
+        let tag = TransportInboxID(rawValue: IntroInboxPump.inboxTag(from: target.adminInboxKey))
+        let receipt = try? await inboxTransport.send(sealed, to: tag)
+        guard let receipt, receipt.acceptedBy >= 1 else {
+            await store.updateStatus(groupIDHex: groupIDHex, status: .unreachable)
+            return
+        }
+        scheduleTimeout(groupIDHex)
+    }
+
+    private func scheduleTimeout(_ groupIDHex: String) {
+        timeouts[groupIDHex]?.cancel()
+        let seconds = refreshTimeoutSeconds
+        timeouts[groupIDHex] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+            guard let self, !Task.isCancelled else { return }
+            await self.markUnreachableIfStillVerifying(groupIDHex)
+        }
+    }
+
+    private func markUnreachableIfStillVerifying(_ groupIDHex: String) async {
+        guard await store.contains(groupIDHex: groupIDHex) else { return }
+        await store.updateStatus(groupIDHex: groupIDHex, status: .unreachable)
+    }
+
+    private func resolve(_ materializedHexes: Set<String>) async {
+        let resolved = targets.keys.filter { materializedHexes.contains($0) }
+        for hex in resolved {
+            timeouts[hex]?.cancel()
+            timeouts[hex] = nil
+            targets[hex] = nil
+        }
+        await store.resolveMaterialized(materializedHexes)
+    }
+
+    // MARK: - Admin side
+
+    func handleRefreshRequest(
+        _ request: GroupStateRefreshRequest,
+        ownerIdentityID: IdentityID,
+        requesterEd25519: Data?
+    ) async {
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: {
+            $0.groupIDData == request.groupID && $0.ownerIdentityID == ownerIdentityID
+        }) else {
+            return
+        }
+        // Membership gate — the reply carries `salt`, so only answer a
+        // requester that is a current member, and only after confirming
+        // the envelope's signer matches that member's stored Ed25519
+        // (insider-spoof defense). Sealing target is pinned to the
+        // member's stored inbox key, not the request's claimed one, so a
+        // forged request can't redirect the salt elsewhere.
+        let key = Self.hex(request.requesterBlsPublicKey)
+        guard let profile = group.memberProfiles[key] else { return }
+        guard let requesterEd25519, requesterEd25519 == profile.sendingPubkey else { return }
+        guard request.requesterInboxPublicKey == profile.inboxPublicKey else { return }
+
+        let invite = GroupInvitationPayload(
+            version: 1,
+            groupID: group.groupIDData,
+            groupSecret: group.groupSecret,
+            name: group.name,
+            members: group.members,
+            epoch: group.epoch,
+            salt: group.salt,
+            commitment: group.commitment,
+            tierRaw: group.tier.rawValue,
+            groupTypeRaw: group.groupType.rawValue,
+            adminPubkeyHex: group.adminPubkeyHex,
+            memberProfiles: group.memberProfiles.isEmpty ? nil : group.memberProfiles
+        )
+        guard let bytes = try? JSONEncoder().encode(invite),
+              let sealed = try? await identity.sealInvitation(
+                  payload: bytes,
+                  to: profile.inboxPublicKey
+              )
+        else { return }
+        let tag = TransportInboxID(rawValue: IntroInboxPump.inboxTag(from: profile.inboxPublicKey))
+        _ = try? await inboxTransport.send(sealed, to: tag)
+    }
+
+    // MARK: - Helpers
+
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -64,6 +64,12 @@ struct IncomingMessageDispatcher: Sendable {
     /// keeps it as a defaulted parameter — a `let` with a default is
     /// omitted from the memberwise init entirely.
     var pendingInvites: any PendingInvitesRecording = PendingInvitesStore()
+    /// Seam for the verify-at-current state machine (Option 2). A stale
+    /// Tyranny snapshot (chain advanced past its epoch) is deferred here
+    /// on the invitee side; inbound `GroupStateRefreshRequest`s are
+    /// answered here on the admin side. Defaulted to a no-op for the
+    /// same reason as `pendingInvites`.
+    var groupStateRefresher: any GroupStateRefreshing = NoopGroupStateRefresher()
 
     func dispatch(
         messageID: String,
@@ -104,6 +110,22 @@ struct IncomingMessageDispatcher: Sendable {
                 messageID: messageID,
                 ownerIdentityID: ownerIdentityID,
                 receivedAt: receivedAt
+            )
+            return
+        }
+
+        // Fast path 0.5: GroupStateRefreshRequest — a member asking the
+        // admin for the current group state (Option 2 verify-at-current).
+        // Admin-side; delegated to the verifier, which gates on the
+        // requester being a current member before disclosing the salt.
+        if let refresh = try? JSONDecoder().decode(
+            GroupStateRefreshRequest.self,
+            from: envelope.plaintext
+        ) {
+            await groupStateRefresher.handleRefreshRequest(
+                refresh,
+                ownerIdentityID: ownerIdentityID,
+                requesterEd25519: envelope.senderEd25519PublicKey
             )
             return
         }
@@ -221,18 +243,28 @@ struct IncomingMessageDispatcher: Sendable {
               let groupType = SEPGroupType(rawValue: invitation.groupTypeRaw)
         else { return }
 
-        // PR 13b: receiver-side commitment verification. For Tyranny
-        // groups, the payload's `commitment` MUST match the on-chain
-        // state and the recomputed Poseidon root over the wire-shipped
-        // members. Either mismatch is treated as a forged invitation —
-        // drop silently. Non-Tyranny groups skip verification (no
-        // admin-anchored update path; trust falls back to the
-        // sender's Ed25519 signature on the envelope).
+        // Receiver-side verification (Option 2). For Tyranny groups the
+        // snapshot's commitment must match the recomputed Poseidon root
+        // AND the on-chain commitment at an exact epoch. Non-Tyranny
+        // groups skip verification (no admin-anchored update path; trust
+        // falls back to the sender's envelope signature).
         if groupType == .tyranny {
-            guard await verifyTyrannyInvitation(
-                invitation,
-                tier: tier
-            ) else {
+            switch await verifyTyrannyInvitation(invitation, tier: tier) {
+            case .verified:
+                break  // materialize below
+            case .reject:
+                return
+            case .staleNeedsRefresh:
+                // The chain has advanced past this snapshot's epoch, so
+                // we can't byte-verify it. Don't materialize an
+                // unverifiable group — hand it to the verifier, which
+                // asks the admin for the current state and surfaces a
+                // "couldn't verify" state to the user if the admin is
+                // unreachable.
+                await groupStateRefresher.deferVerification(
+                    invitation: invitation,
+                    ownerIdentityID: ownerIdentityID
+                )
                 return
             }
         }
@@ -314,12 +346,25 @@ struct IncomingMessageDispatcher: Sendable {
     /// "couldn't verify, reject" — the safe default. Operators
     /// observe these via the `decryptFailures` counter (out of
     /// scope for V1).
+    /// Outcome of receiver-side Tyranny invitation verification.
+    enum TyrannyInvitationVerification: Equatable {
+        /// Internally consistent AND matches the on-chain commitment at
+        /// an exact epoch — safe to materialize.
+        case verified
+        /// Internally consistent and the group exists on chain, but the
+        /// chain has advanced past the snapshot's epoch, so it can't be
+        /// byte-verified. Needs a current-state refresh from the admin.
+        case staleNeedsRefresh
+        /// Forged / unverifiable — drop.
+        case reject
+    }
+
     private func verifyTyrannyInvitation(
         _ invitation: GroupInvitationPayload,
         tier: SEPTier
-    ) async -> Bool {
+    ) async -> TyrannyInvitationVerification {
         guard let claimedCommitment = invitation.commitment else {
-            return false
+            return .reject
         }
         // Internal consistency: recompute the FULL Poseidon
         // commitment from (members, epoch, salt) and compare. The
@@ -340,9 +385,9 @@ struct IncomingMessageDispatcher: Sendable {
                 salt: invitation.salt
             )
         } catch {
-            return false
+            return .reject
         }
-        guard recomputed == claimedCommitment else { return false }
+        guard recomputed == claimedCommitment else { return .reject }
         // External anchor: matches what's on chain.
         let onchain: SEPCommitmentEntry
         do {
@@ -350,49 +395,27 @@ struct IncomingMessageDispatcher: Sendable {
                 groupID: invitation.groupID
             )
         } catch {
-            return false
+            return .reject
         }
-        // Bounded converge-forward gate. The chain stores only the
-        // LATEST (commitment, epoch), so a snapshot can't be byte-checked
-        // once the chain moves past its epoch.
+        // Verify at current chain state (Option 2). The chain stores
+        // only the LATEST (commitment, epoch), so a snapshot is only
+        // byte-verifiable when the chain is exactly at its epoch.
         //   - chain behind the snapshot → impossible for a real anchored
         //     snapshot; reject.
         //   - chain EXACTLY at the snapshot's epoch → byte-verify the
-        //     committed roster. This is the strong anti-forgery anchor: a
-        //     forger would have to reproduce `Poseidon(Poseidon(root,
-        //     epoch), salt)`, but `salt` is random and never on chain —
-        //     only a legitimate invitation carries it.
-        //   - chain AHEAD → we can't reproduce the byte-check, so accept
-        //     only within a small staleness window. This covers a burst
-        //     of concurrent approvals advancing the epoch between an
-        //     invite being sealed and it landing, while bounding the
-        //     forgery surface (a dropped salt-check would otherwise let
-        //     anyone who knows the recipient's inbox key + a real groupID
-        //     materialize an arbitrary fake group).
-        //
-        // SECURITY: even within the window a self-consistent fake snapshot
-        // for a *young* group is accepted. Fully closing this needs the
-        // chain read to expose `admin_pubkey_commitment` so the snapshot's
-        // adminPubkeyHex can be bound to chain independent of epoch —
-        // tracked as a follow-up (relayer + SDK support required).
-        guard onchain.epoch >= invitation.epoch else { return false }
+        //     committed roster. Strong anti-forgery: reproducing
+        //     `Poseidon(Poseidon(root, epoch), salt)` needs the random
+        //     `salt`, which is never on chain — only a legitimate
+        //     invitation carries it.
+        //   - chain AHEAD → can't byte-verify here; defer and ask the
+        //     admin for the current state rather than trusting (and
+        //     thereby letting a self-consistent fake materialize).
+        guard onchain.epoch >= invitation.epoch else { return .reject }
         if onchain.epoch == invitation.epoch {
-            guard onchain.commitment == claimedCommitment else { return false }
-        } else {
-            guard onchain.epoch - invitation.epoch <= Self.maxInvitationStaleEpochs
-            else { return false }
+            return onchain.commitment == claimedCommitment ? .verified : .reject
         }
-        return true
+        return .staleNeedsRefresh
     }
-
-    /// Upper bound on how far the chain may have advanced past an
-    /// inbound invitation's epoch and still materialize. Sized to absorb
-    /// a realistic burst of serialized approvals during delivery latency
-    /// while keeping the salt-free forgery surface (chain-ahead branch of
-    /// `verifyTyrannyInvitation`) confined to young groups. A
-    /// longer-offline invitee on a fast-growing group beyond this falls
-    /// back to a re-invite rather than trusting an unverifiable snapshot.
-    static let maxInvitationStaleEpochs: UInt64 = 16
 
     /// PR 13b: validate a Tyranny `MemberAnnouncementPayload`'s
     /// claimed commitment + epoch against the on-chain state. Same

--- a/Sources/OnymIOS/Inbox/PendingInvitesFlow.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesFlow.swift
@@ -18,6 +18,11 @@ import Observation
 final class PendingInvitesFlow {
     /// Pending invites for the current identity, newest first.
     var pending: [PendingInvite] = []
+    /// Groups that were accepted but couldn't be verified at an exact
+    /// epoch yet — awaiting (or unable to get) the current state from
+    /// the admin. Surfaced so the user knows a join is in flight or
+    /// stuck. Hidden from the chats list until verified.
+    var verifying: [PendingGroupVerification] = []
     /// IDs whose accept call is in flight (drives the per-row spinner).
     var inFlightIDs: Set<String> = []
     /// IDs whose join request has been sent and is awaiting the admin's
@@ -26,7 +31,12 @@ final class PendingInvitesFlow {
     var requestedIDs: Set<String> = []
     var lastError: String?
 
+    /// Total count for the toolbar badge — pending offers plus groups
+    /// still verifying / stuck.
+    var badgeCount: Int { pending.count + verifying.count }
+
     private let store: PendingInvitesStore
+    private let verificationStore: PendingVerificationStore
     private let groupRepository: GroupRepository
     /// Mirrors `JoinFlow`'s injected `submitRequest` — seals + sends a
     /// `JoinRequestPayload` for the given capability. Returns the
@@ -36,20 +46,27 @@ final class PendingInvitesFlow {
     /// identity's alias). Read lazily so an identity rename is picked
     /// up without re-wiring.
     private let displayLabel: @MainActor () -> String
+    /// Re-send a stuck verification's refresh request (Retry button).
+    private let retryVerification: @Sendable (String) async -> Void
 
     private var streamingTask: Task<Void, Never>?
+    private var verifyingTask: Task<Void, Never>?
     private var groupWatchTask: Task<Void, Never>?
 
     init(
         store: PendingInvitesStore,
+        verificationStore: PendingVerificationStore,
         groupRepository: GroupRepository,
         submitJoin: @escaping @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome,
-        displayLabel: @escaping @MainActor () -> String
+        displayLabel: @escaping @MainActor () -> String,
+        retryVerification: @escaping @Sendable (String) async -> Void
     ) {
         self.store = store
+        self.verificationStore = verificationStore
         self.groupRepository = groupRepository
         self.submitJoin = submitJoin
         self.displayLabel = displayLabel
+        self.retryVerification = retryVerification
     }
 
     func isInFlight(_ id: String) -> Bool { inFlightIDs.contains(id) }
@@ -71,6 +88,13 @@ final class PendingInvitesFlow {
                 self.inFlightIDs.formIntersection(live)
             }
         }
+        let vstream = verificationStore.snapshots
+        verifyingTask = Task { @MainActor [weak self] in
+            for await snapshot in vstream {
+                guard let self else { break }
+                self.verifying = snapshot
+            }
+        }
         let groups = groupRepository.snapshots
         let store = self.store
         groupWatchTask = Task {
@@ -85,8 +109,17 @@ final class PendingInvitesFlow {
     func stop() {
         streamingTask?.cancel()
         streamingTask = nil
+        verifyingTask?.cancel()
+        verifyingTask = nil
         groupWatchTask?.cancel()
         groupWatchTask = nil
+    }
+
+    /// Retry a verification that got stuck because the admin was
+    /// unreachable for the current-state refresh.
+    func retry(_ groupIDHex: String) {
+        let retryVerification = self.retryVerification
+        Task { await retryVerification(groupIDHex) }
     }
 
     /// Explicit Accept: ship a join request to the offer's intro key.

--- a/Sources/OnymIOS/Inbox/PendingInvitesView.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesView.swift
@@ -15,7 +15,7 @@ struct PendingInvitesView: View {
             if let error = flow.lastError {
                 errorBanner(error)
             }
-            if flow.pending.isEmpty {
+            if flow.pending.isEmpty && flow.verifying.isEmpty {
                 emptyState
             } else {
                 inviteList
@@ -87,10 +87,53 @@ struct PendingInvitesView: View {
                 ForEach(flow.pending) { invite in
                     inviteCard(invite)
                 }
+                ForEach(flow.verifying) { entry in
+                    verifyingCard(entry)
+                }
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
         }
+    }
+
+    /// A group accepted but not yet verifiable against the current
+    /// on-chain state — kept out of the chats list. Shows progress while
+    /// waiting for the admin's current-state reply, and a Retry when the
+    /// admin couldn't be reached.
+    private func verifyingCard(_ entry: PendingGroupVerification) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(entry.groupName.isEmpty ? "Group" : entry.groupName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            switch entry.status {
+            case .verifying:
+                HStack(spacing: 8) {
+                    ProgressView().scaleEffect(0.8)
+                    Text("Verifying group state\u{2026}")
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.text2)
+                }
+            case .unreachable:
+                Text("Couldn\u{2019}t verify \u{2014} the admin is offline. The group stays hidden until it can be verified on chain.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+                Button {
+                    flow.retry(entry.groupIDHex)
+                } label: {
+                    Text("Retry")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 11)
+                        .background(OnymAccent.blue.color)
+                        .foregroundStyle(OnymTokens.onAccent)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+            }
+        }
+        .padding(14)
+        .background(OnymTokens.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .accessibilityIdentifier("pending_invites.verifying.\(entry.groupIDHex)")
     }
 
     private func inviteCard(_ invite: PendingInvite) -> some View {
@@ -173,8 +216,8 @@ struct PendingInvitesToolbarButton: View {
             ZStack(alignment: .topTrailing) {
                 Image(systemName: "envelope")
                     .font(.system(size: 17))
-                if !flow.pending.isEmpty {
-                    Text("\(flow.pending.count)")
+                if flow.badgeCount > 0 {
+                    Text("\(flow.badgeCount)")
                         .font(.system(size: 10, weight: .bold))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 5)

--- a/Sources/OnymIOS/Inbox/PendingVerificationStore.swift
+++ b/Sources/OnymIOS/Inbox/PendingVerificationStore.swift
@@ -54,6 +54,22 @@ actor PendingVerificationStore {
         all.contains { $0.groupIDHex == groupIDHex }
     }
 
+    func status(groupIDHex: String) -> PendingGroupVerification.Status? {
+        all.first { $0.groupIDHex == groupIDHex }?.status
+    }
+
+    /// Flip `.verifying → .unreachable` only if still verifying. Atomic
+    /// on the store actor, so a stale timeout can't clobber an entry
+    /// that was resolved-then-re-recorded between the timer firing and
+    /// this call.
+    func markUnreachableIfVerifying(groupIDHex: String) {
+        guard let idx = all.firstIndex(where: { $0.groupIDHex == groupIDHex }),
+              all[idx].status == .verifying
+        else { return }
+        all[idx].status = .unreachable
+        publish()
+    }
+
     /// Remove entries whose group now exists locally — the fresh
     /// snapshot verified + materialized, so verification is done.
     func resolveMaterialized(_ groupIDHexes: Set<String>) {

--- a/Sources/OnymIOS/Inbox/PendingVerificationStore.swift
+++ b/Sources/OnymIOS/Inbox/PendingVerificationStore.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// A Tyranny group whose invitation snapshot couldn't be verified at an
+/// exact epoch (the chain had advanced past it), so it's awaiting a
+/// fresh snapshot from the admin before it may materialize. Kept OUT of
+/// the chats list — an unverifiable snapshot must never look like a real
+/// chat — and surfaced in the Invitations UI so the user knows a join is
+/// in flight (or stuck because the admin is offline).
+struct PendingGroupVerification: Identifiable, Equatable, Sendable {
+    enum Status: Sendable, Equatable {
+        /// Refresh request sent; waiting for the admin's reply.
+        case verifying
+        /// No reply within the timeout (or no admin inbox to ask) —
+        /// surfaced to the user with a Retry.
+        case unreachable
+    }
+
+    /// Dedupe key — one pending verification per group.
+    var id: String { groupIDHex }
+    let groupIDHex: String
+    let ownerIdentityID: IdentityID
+    let groupName: String
+    var status: Status
+    let receivedAt: Date
+}
+
+/// In-memory, per-identity-filtered store of groups awaiting
+/// verification. In-memory by design: the stale invitation is a retained
+/// Nostr event re-delivered on every launch, so the verifier re-defers
+/// and re-requests on relaunch — same model as `PendingInvitesStore`.
+actor PendingVerificationStore {
+    private var all: [PendingGroupVerification] = []
+    private var currentIdentity: IdentityID?
+    private var continuations: [UUID: AsyncStream<[PendingGroupVerification]>.Continuation] = [:]
+
+    init() {}
+
+    /// Idempotent on `groupIDHex`. A re-deferred snapshot (re-delivery)
+    /// keeps the existing entry/status rather than resetting it.
+    func record(_ entry: PendingGroupVerification) {
+        guard !all.contains(where: { $0.groupIDHex == entry.groupIDHex }) else { return }
+        all.append(entry)
+        publish()
+    }
+
+    func updateStatus(groupIDHex: String, status: PendingGroupVerification.Status) {
+        guard let idx = all.firstIndex(where: { $0.groupIDHex == groupIDHex }) else { return }
+        guard all[idx].status != status else { return }
+        all[idx].status = status
+        publish()
+    }
+
+    func contains(groupIDHex: String) -> Bool {
+        all.contains { $0.groupIDHex == groupIDHex }
+    }
+
+    /// Remove entries whose group now exists locally — the fresh
+    /// snapshot verified + materialized, so verification is done.
+    func resolveMaterialized(_ groupIDHexes: Set<String>) {
+        guard !groupIDHexes.isEmpty else { return }
+        let before = all.count
+        all.removeAll { groupIDHexes.contains($0.groupIDHex) }
+        if all.count != before { publish() }
+    }
+
+    func removeForOwner(_ id: IdentityID) {
+        let before = all.count
+        all.removeAll { $0.ownerIdentityID == id }
+        if all.count != before { publish() }
+    }
+
+    func setCurrentIdentity(_ id: IdentityID?) {
+        currentIdentity = id
+        publish()
+    }
+
+    /// Snapshot of pending verifications for the current identity,
+    /// newest first.
+    nonisolated var snapshots: AsyncStream<[PendingGroupVerification]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<[PendingGroupVerification]>.Continuation
+    ) {
+        continuations[id] = continuation
+        continuation.yield(filtered())
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func filtered() -> [PendingGroupVerification] {
+        guard let currentIdentity else { return [] }
+        return all
+            .filter { $0.ownerIdentityID == currentIdentity }
+            .sorted { $0.receivedAt > $1.receivedAt }
+    }
+
+    private func publish() {
+        let snapshot = filtered()
+        for cont in continuations.values { cont.yield(snapshot) }
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -12,6 +12,8 @@ struct OnymIOSApp: App {
     private let nostrRelaysRepository: NostrRelaysRepository
     private let incomingInvitations: IncomingInvitationsRepository
     private let pendingInvitesStore: PendingInvitesStore
+    private let pendingVerificationStore: PendingVerificationStore
+    private let groupStateVerifier: GroupStateVerifier
     private let introKeyStore: any IntroKeyStore
     private let introRequestStore: any IntroRequestStore
 
@@ -165,12 +167,25 @@ struct OnymIOSApp: App {
         // identical to the deeplink join path.
         let pendingInvitesStore = PendingInvitesStore()
         self.pendingInvitesStore = pendingInvitesStore
+        // Verify-at-current (Option 2): stale snapshots defer here; the
+        // verifier asks the admin for current state and surfaces a
+        // "couldn't verify" state if the admin is offline.
+        let pendingVerificationStore = PendingVerificationStore()
+        self.pendingVerificationStore = pendingVerificationStore
+        let groupStateVerifier = GroupStateVerifier(
+            identity: repository,
+            inboxTransport: inboxTransport,
+            groupRepository: groupRepository,
+            store: pendingVerificationStore
+        )
+        self.groupStateVerifier = groupStateVerifier
         let pendingInvitesSender = JoinRequestSender(
             identity: repository,
             inboxTransport: inboxTransport
         )
         let pendingInvitesFlow = PendingInvitesFlow(
             store: pendingInvitesStore,
+            verificationStore: pendingVerificationStore,
             groupRepository: groupRepository,
             submitJoin: { cap, label in
                 await pendingInvitesSender.send(
@@ -182,6 +197,9 @@ struct OnymIOSApp: App {
                 identitiesFlow.identities
                     .first { $0.id == identitiesFlow.currentID }?
                     .name ?? ""
+            },
+            retryVerification: { [groupStateVerifier] groupIDHex in
+                await groupStateVerifier.retry(groupIDHex: groupIDHex)
             }
         )
 
@@ -288,6 +306,10 @@ struct OnymIOSApp: App {
                     // the Chats toolbar badge reflects offers from the
                     // moment the app is on screen. Idempotent.
                     await dependencies.pendingInvitesFlow.start()
+                    // Start the verifier's group watcher so a pending
+                    // verification resolves the moment its fresh snapshot
+                    // materializes.
+                    await groupStateVerifier.start()
                     // Kick off both GitHub Releases fetches as soon as the
                     // app is on screen. Failures are silent; the user can
                     // still enter a custom relayer URL / pick an older
@@ -303,6 +325,7 @@ struct OnymIOSApp: App {
                         await groupRepository.setCurrentIdentity(initialID)
                         await incomingInvitations.setCurrentIdentity(initialID)
                         await pendingInvitesStore.setCurrentIdentity(initialID)
+                        await pendingVerificationStore.setCurrentIdentity(initialID)
                     }
                 }
                 .task {
@@ -312,6 +335,7 @@ struct OnymIOSApp: App {
                         await groupRepository.setCurrentIdentity(id)
                         await incomingInvitations.setCurrentIdentity(id)
                         await pendingInvitesStore.setCurrentIdentity(id)
+                        await pendingVerificationStore.setCurrentIdentity(id)
                     }
                 }
                 .task {
@@ -324,6 +348,7 @@ struct OnymIOSApp: App {
                         await groupRepository.removeForOwner(removed)
                         await incomingInvitations.removeForOwner(removed)
                         await pendingInvitesStore.removeForOwner(removed)
+                        await pendingVerificationStore.removeForOwner(removed)
                         // Cascade-wipe the removed identity's intro
                         // privkeys so an attacker who restores a
                         // backup post-removal can't decrypt
@@ -363,7 +388,8 @@ struct OnymIOSApp: App {
                         invitationsRepository: incomingInvitations,
                         chainState: chainStateReader,
                         messageRepository: messageRepository,
-                        pendingInvites: pendingInvitesStore
+                        pendingInvites: pendingInvitesStore,
+                        groupStateRefresher: groupStateVerifier
                     )
                     let fanout = InboxFanoutInteractor(
                         inboxTransport: inboxTransport,

--- a/Tests/OnymIOSTests/GroupStateRefreshTests.swift
+++ b/Tests/OnymIOSTests/GroupStateRefreshTests.swift
@@ -41,6 +41,56 @@ final class GroupStateRefreshRequestCodecTests: XCTestCase {
         let bytes = try JSONEncoder().encode(offer)
         XCTAssertThrowsError(try JSONDecoder().decode(GroupStateRefreshRequest.self, from: bytes))
     }
+
+    /// The dispatcher trial-decodes the offer (fast-path 0) and the
+    /// refresh request (fast-path 0.5) BEFORE the announcement /
+    /// invitation / join-request / chat-message paths. Guard against
+    /// future schema drift: none of those must decode as either control
+    /// payload.
+    func test_otherPayloads_doNotDecodeAsOfferOrRefresh() throws {
+        let announce = try MemberAnnouncementPayload(
+            version: 1,
+            groupId: Data(repeating: 0x42, count: 32),
+            newMember: MemberAnnouncementPayload.AnnouncedMember(
+                blsPub: Data(repeating: 0x01, count: 48),
+                inboxPub: Data(repeating: 0x02, count: 32),
+                alias: "X",
+                sendingPub: Data(repeating: 0x03, count: 32)
+            ),
+            adminAlias: "A"
+        )
+        let invite = GroupInvitationPayload(
+            version: 1,
+            groupID: Data(repeating: 0x42, count: 32),
+            groupSecret: Data(repeating: 0x55, count: 32),
+            name: "G",
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: nil,
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.tyranny.rawValue,
+            adminPubkeyHex: nil,
+            memberProfiles: nil
+        )
+        let join = try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0x01, count: 32),
+            joinerBlsPublicKey: Data(repeating: 0x02, count: 48),
+            joinerLeafHash: Data(repeating: 0x03, count: 32),
+            joinerSendingPublicKey: Data(repeating: 0x04, count: 32),
+            joinerDisplayLabel: "B",
+            groupId: Data(repeating: 0x05, count: 32)
+        )
+        let samples = try [
+            JSONEncoder().encode(announce),
+            JSONEncoder().encode(invite),
+            JSONEncoder().encode(join),
+        ]
+        for bytes in samples {
+            XCTAssertThrowsError(try JSONDecoder().decode(GroupInviteOfferPayload.self, from: bytes))
+            XCTAssertThrowsError(try JSONDecoder().decode(GroupStateRefreshRequest.self, from: bytes))
+        }
+    }
 }
 
 final class GroupStateVerifierTests: XCTestCase {
@@ -55,6 +105,9 @@ final class GroupStateVerifierTests: XCTestCase {
         try await super.setUp()
         keychain = IdentityKeychainStore(testNamespace: "verifier-\(UUID().uuidString)")
         identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        // Bootstrap so `currentIdentity()` is non-nil — the admin-side
+        // "am I the admin?" guard needs a real BLS to compare against.
+        _ = try await identity.bootstrap()
         groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
         transport = VerifierRecordingInboxTransport()
         store = PendingVerificationStore()
@@ -111,54 +164,194 @@ final class GroupStateVerifierTests: XCTestCase {
     }
 
     /// The admin must not answer a refresh request from a non-member —
-    /// the reply carries the salt.
+    /// the reply carries the salt. (We ARE the admin here, so the
+    /// admin-guard passes and the membership gate is what rejects.)
     func test_handleRefreshRequest_nonMember_doesNotReply() async throws {
         let verifier = makeVerifier()
-        let groupID = Data(repeating: 0x42, count: 32)
-        let groupIDHex = String(repeating: "42", count: 32)
-        let memberBlsHex = String(repeating: "bb", count: 48)
-        let group = ChatGroup(
-            id: groupIDHex,
-            ownerIdentityID: owner,
-            name: "Family",
-            groupSecret: Data(repeating: 0x55, count: 32),
-            createdAt: Date(),
-            members: [],
-            memberProfiles: [memberBlsHex: MemberProfile(
-                alias: "Member",
+        let myBlsHex = await myBlsHex()
+        let group = seedTyrannyGroup(
+            adminPubkeyHex: myBlsHex,
+            memberProfiles: [myBlsHex: MemberProfile(
+                alias: "Admin",
                 inboxPublicKey: Data(repeating: 0x10, count: 32),
                 sendingPubkey: Data(repeating: 0xEE, count: 32)
-            )],
-            epoch: 1,
-            salt: Data(repeating: 0x66, count: 32),
-            commitment: Data(repeating: 0x77, count: 32),
-            tier: .small,
-            groupType: .tyranny,
-            adminPubkeyHex: memberBlsHex,
-            adminEd25519PubkeyHex: String(repeating: "ee", count: 32),
-            isPublishedOnChain: true
+            )]
         )
         _ = await groups.insert(group)
 
         // Requester whose BLS isn't in the roster.
         let request = try GroupStateRefreshRequest(
-            groupID: groupID,
+            groupID: Data(repeating: 0x42, count: 32),
             requesterInboxPublicKey: Data(repeating: 0x01, count: 32),
             requesterBlsPublicKey: Data(repeating: 0x02, count: 48)
         )
         await verifier.handleRefreshRequest(
-            request,
-            ownerIdentityID: owner,
-            requesterEd25519: Data(repeating: 0xAB, count: 32)
+            request, ownerIdentityID: owner, requesterEd25519: Data(repeating: 0xAB, count: 32)
         )
 
         let sends = await transport.sendCount()
         XCTAssertEqual(sends, 0, "non-member must not receive the current snapshot (salt)")
     }
 
+    /// If this device isn't the group's admin, refuse even a real member
+    /// — only the admin holds and should disclose the current salt.
+    func test_handleRefreshRequest_notAdmin_doesNotReply() async throws {
+        let verifier = makeVerifier()
+        let requesterBls = Data(repeating: 0x02, count: 48)
+        let requesterBlsHex = requesterBls.map { String(format: "%02x", $0) }.joined()
+        // adminPubkeyHex is some OTHER key — not this device's BLS.
+        let group = seedTyrannyGroup(
+            adminPubkeyHex: String(repeating: "bb", count: 48),
+            memberProfiles: [requesterBlsHex: MemberProfile(
+                alias: "Member",
+                inboxPublicKey: Data(repeating: 0x10, count: 32),
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
+            )]
+        )
+        _ = await groups.insert(group)
+
+        let request = try GroupStateRefreshRequest(
+            groupID: Data(repeating: 0x42, count: 32),
+            requesterInboxPublicKey: Data(repeating: 0x10, count: 32),
+            requesterBlsPublicKey: requesterBls
+        )
+        await verifier.handleRefreshRequest(
+            request, ownerIdentityID: owner, requesterEd25519: Data(repeating: 0xEE, count: 32)
+        )
+
+        let sends = await transport.sendCount()
+        XCTAssertEqual(sends, 0, "a non-admin device must not answer refresh requests")
+    }
+
+    /// Full loop: a pending verification is cleared once the fresh
+    /// snapshot materializes the group.
+    func test_resolve_clearsPendingWhenGroupMaterializes() async throws {
+        let verifier = makeVerifier()
+        await verifier.start()
+        let groupID = Data(repeating: 0x42, count: 32)
+        let groupIDHex = hex(groupID)
+        // No-admin snapshot → recorded as pending (unreachable).
+        await verifier.deferVerification(
+            invitation: tyrannyInvitation(adminPubkeyHex: String(repeating: "aa", count: 48),
+                                          memberProfiles: nil),
+            ownerIdentityID: owner
+        )
+        let present = await store.contains(groupIDHex: groupIDHex)
+        XCTAssertTrue(present)
+
+        // Materialize the group → watcher resolves the pending entry.
+        _ = await groups.insert(seedTyrannyGroup(
+            adminPubkeyHex: String(repeating: "aa", count: 48),
+            memberProfiles: [:]
+        ))
+        try await waitUntil {
+            let stillPending = await self.store.contains(groupIDHex: groupIDHex)
+            return !stillPending
+        }
+    }
+
+    /// The 30/60s timer transitions a sent-but-unanswered request from
+    /// `.verifying` to `.unreachable` (tiny timeout for the test).
+    func test_timeout_transitionsVerifyingToUnreachable() async throws {
+        let verifier = GroupStateVerifier(
+            identity: identity,
+            inboxTransport: transport,
+            groupRepository: groups,
+            store: store,
+            refreshTimeoutSeconds: 0
+        )
+        let adminBlsHex = String(repeating: "aa", count: 48)
+        await verifier.deferVerification(
+            invitation: tyrannyInvitation(
+                adminPubkeyHex: adminBlsHex,
+                memberProfiles: [adminBlsHex: MemberProfile(
+                    alias: "Admin",
+                    inboxPublicKey: Data(repeating: 0x10, count: 32),
+                    sendingPubkey: Data(repeating: 0xEE, count: 32)
+                )]
+            ),
+            ownerIdentityID: owner
+        )
+        // A refresh was actually sent (reachable admin).
+        let sent = await transport.sendCount()
+        XCTAssertGreaterThanOrEqual(sent, 1)
+        // …and the timer flips it to unreachable.
+        let groupIDHex = hex(Data(repeating: 0x42, count: 32))
+        try await waitUntil {
+            let status = await self.store.status(groupIDHex: groupIDHex)
+            return status == .unreachable
+        }
+    }
+
+    // MARK: - Helpers
+
     private func firstSnapshot() async -> [PendingGroupVerification] {
         for await snapshot in store.snapshots { return snapshot }
         return []
+    }
+
+    private func myBlsHex() async -> String {
+        let me = await identity.currentIdentity()
+        return (me?.blsPublicKey ?? Data()).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func tyrannyInvitation(
+        adminPubkeyHex: String?,
+        memberProfiles: [String: MemberProfile]?
+    ) -> GroupInvitationPayload {
+        GroupInvitationPayload(
+            version: 1,
+            groupID: Data(repeating: 0x42, count: 32),
+            groupSecret: Data(repeating: 0x55, count: 32),
+            name: "Family",
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: Data(repeating: 0x77, count: 32),
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.tyranny.rawValue,
+            adminPubkeyHex: adminPubkeyHex,
+            memberProfiles: memberProfiles
+        )
+    }
+
+    private func seedTyrannyGroup(
+        adminPubkeyHex: String,
+        memberProfiles: [String: MemberProfile]
+    ) -> ChatGroup {
+        ChatGroup(
+            id: String(repeating: "42", count: 32),
+            ownerIdentityID: owner,
+            name: "Family",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(),
+            members: [],
+            memberProfiles: memberProfiles,
+            epoch: 1,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: Data(repeating: 0x77, count: 32),
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: adminPubkeyHex,
+            adminEd25519PubkeyHex: String(repeating: "ee", count: 32),
+            isPublishedOnChain: true
+        )
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 3,
+        _ condition: @escaping () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTFail("condition not met within \(timeout)s")
     }
 }
 

--- a/Tests/OnymIOSTests/GroupStateRefreshTests.swift
+++ b/Tests/OnymIOSTests/GroupStateRefreshTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import XCTest
+@testable import OnymIOS
+
+final class GroupStateRefreshRequestCodecTests: XCTestCase {
+    func test_roundTrip() throws {
+        let req = try GroupStateRefreshRequest(
+            groupID: Data(repeating: 0x42, count: 32),
+            requesterInboxPublicKey: Data(repeating: 0x11, count: 32),
+            requesterBlsPublicKey: Data(repeating: 0x22, count: 48)
+        )
+        let decoded = try JSONDecoder().decode(
+            GroupStateRefreshRequest.self,
+            from: JSONEncoder().encode(req)
+        )
+        XCTAssertEqual(decoded, req)
+    }
+
+    func test_wrongSizes_throw() {
+        XCTAssertThrowsError(try GroupStateRefreshRequest(
+            groupID: Data(repeating: 0x42, count: 31),
+            requesterInboxPublicKey: Data(repeating: 0x11, count: 32),
+            requesterBlsPublicKey: Data(repeating: 0x22, count: 48)
+        ))
+        XCTAssertThrowsError(try GroupStateRefreshRequest(
+            groupID: Data(repeating: 0x42, count: 32),
+            requesterInboxPublicKey: Data(repeating: 0x11, count: 32),
+            requesterBlsPublicKey: Data(repeating: 0x22, count: 32)  // BLS must be 48
+        ))
+    }
+
+    /// An invite offer must not decode as a refresh request (disjoint
+    /// required keys keep the dispatcher's trial-decode unambiguous).
+    func test_offer_doesNotDecodeAsRefresh() throws {
+        let offer = try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x11, count: 32),
+            groupID: Data(repeating: 0x42, count: 32),
+            groupName: "G",
+            inviterAlias: "A"
+        )
+        let bytes = try JSONEncoder().encode(offer)
+        XCTAssertThrowsError(try JSONDecoder().decode(GroupStateRefreshRequest.self, from: bytes))
+    }
+}
+
+final class GroupStateVerifierTests: XCTestCase {
+    private var keychain: IdentityKeychainStore!
+    private var identity: IdentityRepository!
+    private var groups: GroupRepository!
+    private var transport: VerifierRecordingInboxTransport!
+    private var store: PendingVerificationStore!
+    private var owner: IdentityID!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        keychain = IdentityKeychainStore(testNamespace: "verifier-\(UUID().uuidString)")
+        identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        transport = VerifierRecordingInboxTransport()
+        store = PendingVerificationStore()
+        owner = IdentityID()
+        await groups.setCurrentIdentity(owner)
+        await store.setCurrentIdentity(owner)
+    }
+
+    override func tearDown() async throws {
+        try? keychain.wipeAll()
+        keychain = nil; identity = nil; groups = nil; transport = nil; store = nil; owner = nil
+        try await super.tearDown()
+    }
+
+    private func makeVerifier() -> GroupStateVerifier {
+        GroupStateVerifier(
+            identity: identity,
+            inboxTransport: transport,
+            groupRepository: groups,
+            store: store
+        )
+    }
+
+    /// A snapshot whose admin we can't reach (no admin entry in the
+    /// shipped roster) is recorded as `.unreachable` and surfaced to the
+    /// user — not silently dropped, never materialized.
+    func test_deferVerification_noAdminInbox_marksUnreachable() async throws {
+        let verifier = makeVerifier()
+        let groupID = Data(repeating: 0x42, count: 32)
+        let invitation = GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),
+            name: "Family",
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: Data(repeating: 0x77, count: 32),
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.tyranny.rawValue,
+            adminPubkeyHex: String(repeating: "aa", count: 48),
+            memberProfiles: nil  // admin not reachable
+        )
+
+        await verifier.deferVerification(invitation: invitation, ownerIdentityID: owner)
+
+        let snapshot = await firstSnapshot()
+        XCTAssertEqual(snapshot.count, 1)
+        XCTAssertEqual(snapshot.first?.status, .unreachable)
+        let groupsAfter = await groups.currentGroups()
+        XCTAssertTrue(groupsAfter.isEmpty, "deferral must not materialize a group")
+        let sends = await transport.sendCount()
+        XCTAssertEqual(sends, 0, "no admin inbox → nothing to send")
+    }
+
+    /// The admin must not answer a refresh request from a non-member —
+    /// the reply carries the salt.
+    func test_handleRefreshRequest_nonMember_doesNotReply() async throws {
+        let verifier = makeVerifier()
+        let groupID = Data(repeating: 0x42, count: 32)
+        let groupIDHex = String(repeating: "42", count: 32)
+        let memberBlsHex = String(repeating: "bb", count: 48)
+        let group = ChatGroup(
+            id: groupIDHex,
+            ownerIdentityID: owner,
+            name: "Family",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(),
+            members: [],
+            memberProfiles: [memberBlsHex: MemberProfile(
+                alias: "Member",
+                inboxPublicKey: Data(repeating: 0x10, count: 32),
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
+            )],
+            epoch: 1,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: Data(repeating: 0x77, count: 32),
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: memberBlsHex,
+            adminEd25519PubkeyHex: String(repeating: "ee", count: 32),
+            isPublishedOnChain: true
+        )
+        _ = await groups.insert(group)
+
+        // Requester whose BLS isn't in the roster.
+        let request = try GroupStateRefreshRequest(
+            groupID: groupID,
+            requesterInboxPublicKey: Data(repeating: 0x01, count: 32),
+            requesterBlsPublicKey: Data(repeating: 0x02, count: 48)
+        )
+        await verifier.handleRefreshRequest(
+            request,
+            ownerIdentityID: owner,
+            requesterEd25519: Data(repeating: 0xAB, count: 32)
+        )
+
+        let sends = await transport.sendCount()
+        XCTAssertEqual(sends, 0, "non-member must not receive the current snapshot (salt)")
+    }
+
+    private func firstSnapshot() async -> [PendingGroupVerification] {
+        for await snapshot in store.snapshots { return snapshot }
+        return []
+    }
+}
+
+// MARK: - Local recording transport
+
+private actor VerifierRecordingInboxTransport: InboxTransport {
+    private(set) var sends: Int = 0
+    func connect(to endpoints: [TransportEndpoint]) async {}
+    func disconnect() async {}
+    func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
+        sends += 1
+        return PublishReceipt(messageID: "spy-\(sends)", acceptedBy: 1)
+    }
+    nonisolated func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
+        AsyncStream { _ in }
+    }
+    func unsubscribe(inbox: TransportInboxID) async {}
+    func sendCount() -> Int { sends }
+}

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -892,18 +892,16 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         XCTAssertEqual(recorded.first?.groupName, "Maple Garden")
     }
 
-    func test_invitation_tyranny_acceptedWhenChainEpochAheadOfSnapshot() async throws {
-        // Converge-forward: a snapshot at epoch 0 must still materialize
-        // when the chain has moved past it (another invitee anchored
-        // first). The internal Poseidon recompute still gates forgery;
-        // the exact-commitment byte-check only applies at an equal
-        // epoch. Pre-relaxation `== epoch` would have dropped this.
+    func test_invitation_tyranny_chainAhead_defersAndDoesNotMaterialize() async throws {
+        // Option 2: a snapshot the chain has advanced past can't be
+        // byte-verified, so it must NOT materialize — it's deferred to
+        // the verifier, which asks the admin for the current state.
         let groupID = Data(repeating: 0x42, count: 32)
         let salt = Data(repeating: 0x66, count: 32)  // matches makeInvitationPayload
         let realCommitment = try Self.makeRealTyrannyCommitment(
             members: [], epoch: 0, salt: salt, tier: .small
         )
-        // Chain ahead (epoch 5) with a *different* commitment.
+        // Chain ahead (epoch 5) — snapshot epoch 0 is stale.
         chainState.setNext(commitment: Data(repeating: 0x99, count: 32), epoch: 5)
         let payload = makeInvitationPayload(
             groupID: groupID,
@@ -917,71 +915,69 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             mode: .fixed(plaintext),
             senderEd25519PublicKey: Data(repeating: 0xED, count: 32)
         )
+        let refresher = SpyGroupStateRefresher()
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
             chainState: chainState,
-            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            groupStateRefresher: refresher
         )
 
         await dispatcher.dispatch(
-            messageID: "msg-stale-ok",
+            messageID: "msg-stale",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
             receivedAt: Date()
         )
 
         let after = await groups.currentGroups()
-        XCTAssertEqual(after.count, 1,
-                       "stale-but-valid Tyranny invite should still materialize when the chain is ahead")
-        XCTAssertEqual(after.first?.groupIDData, groupID)
+        XCTAssertTrue(after.isEmpty, "a stale snapshot must not materialize")
+        let deferred = await refresher.deferredGroupIDs()
+        XCTAssertEqual(deferred, [groupID],
+                       "stale invitation should be deferred to the verifier")
     }
 
-    func test_invitation_tyranny_rejectsWhenChainEpochTooFarAhead() async throws {
-        // Beyond the bounded staleness window the snapshot can't be
-        // byte-verified (the salt-gated commitment check only works at an
-        // exact epoch), so it could be a salt-free forgery — drop it
-        // rather than materialize a fake group.
+    func test_refreshRequest_routedToVerifier() async throws {
+        // An inbound GroupStateRefreshRequest is delegated to the
+        // verifier (admin side) and never materializes / stores anything.
         let groupID = Data(repeating: 0x42, count: 32)
-        let salt = Data(repeating: 0x66, count: 32)
-        let realCommitment = try Self.makeRealTyrannyCommitment(
-            members: [], epoch: 0, salt: salt, tier: .small
-        )
-        let farAhead = IncomingMessageDispatcher.maxInvitationStaleEpochs + 1
-        chainState.setNext(commitment: Data(repeating: 0x99, count: 32), epoch: farAhead)
-        let payload = makeInvitationPayload(
+        let req = try GroupStateRefreshRequest(
             groupID: groupID,
-            name: "Family",
-            memberProfiles: nil,
-            groupType: .tyranny,
-            commitment: realCommitment
+            requesterInboxPublicKey: Data(repeating: 0x01, count: 32),
+            requesterBlsPublicKey: Data(repeating: 0x02, count: 48)
         )
-        let plaintext = try JSONEncoder().encode(payload)
+        let plaintext = try JSONEncoder().encode(req)
         let decrypter = FakeInvitationEnvelopeDecrypter(
             mode: .fixed(plaintext),
-            senderEd25519PublicKey: Data(repeating: 0xED, count: 32)
+            senderEd25519PublicKey: Data(repeating: 0xAB, count: 32)
         )
+        let refresher = SpyGroupStateRefresher()
         let dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
             invitationsRepository: invitations,
             chainState: chainState,
-            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            groupStateRefresher: refresher
         )
 
         await dispatcher.dispatch(
-            messageID: "msg-too-stale",
+            messageID: "msg-refresh",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
             receivedAt: Date()
         )
 
+        let handled = await refresher.handledRefreshGroupIDs()
+        XCTAssertEqual(handled, [groupID])
         let after = await groups.currentGroups()
-        XCTAssertTrue(after.isEmpty,
-                      "invitation more than maxInvitationStaleEpochs behind chain must be rejected")
+        XCTAssertTrue(after.isEmpty)
+        let storedCount = await invitationsStore.count
+        XCTAssertEqual(storedCount, 0)
     }
 }
 
@@ -1003,6 +999,25 @@ private actor SpyPendingInvites: PendingInvitesRecording {
     private(set) var recorded: [PendingInvite] = []
     func record(_ invite: PendingInvite) async { recorded.append(invite) }
     func all() -> [PendingInvite] { recorded }
+}
+
+// MARK: - Group-state refresher spy
+
+private actor SpyGroupStateRefresher: GroupStateRefreshing {
+    private var deferred: [Data] = []
+    private var handled: [Data] = []
+    func deferVerification(invitation: GroupInvitationPayload, ownerIdentityID: IdentityID) async {
+        deferred.append(invitation.groupID)
+    }
+    func handleRefreshRequest(
+        _ request: GroupStateRefreshRequest,
+        ownerIdentityID: IdentityID,
+        requesterEd25519: Data?
+    ) async {
+        handled.append(request.groupID)
+    }
+    func deferredGroupIDs() -> [Data] { deferred }
+    func handledRefreshGroupIDs() -> [Data] { handled }
 }
 
 // MARK: - String / hex helpers (test scope)


### PR DESCRIPTION
Stacked on #158. Replaces the bounded staleness-window stopgap from that PR with the **verify-at-current-state** design (Option 2), which closes the young-group forgery window entirely and adds an explicit admin-offline notification.

## Problem with the window (from #158)
The bounded `maxInvitationStaleEpochs` window still materialized a snapshot the chain had advanced past, trusting only internal-consistency + chain existence. Within the window that let an outsider (who knows a recipient's inbox key + a real groupID) forge a self-consistent fake of a *young* group.

## This PR
A Tyranny snapshot materializes **only** when it byte-verifies against the chain at an **exact epoch** — the salt-gated commitment check that a forger can't reproduce (salt is random and never on chain). When the chain is ahead, the receiver refuses to trust the snapshot and instead **fetches the current state from the admin**.

- **Dispatcher** — `verifyTyrannyInvitation` → `verified | staleNeedsRefresh | reject`. Stale snapshots are deferred to the verifier, not materialized. `maxInvitationStaleEpochs` removed.
- **`GroupStateVerifier` (invitee)** — sends a `GroupStateRefreshRequest` to the admin, marks the group **verifying**, and on timeout / unknown admin inbox marks it **unreachable**. Resolves when the fresh snapshot materializes the group.
- **`GroupStateVerifier` (admin)** — replies with the current `GroupInvitationPayload`, **gated on current membership + Ed25519-signer match**, sealing to the member's *stored* inbox (a forged request can't redirect the salt — the reply carries it).
- **Hidden until verified** — an unverifiable group never enters the chats list; it shows in the Invitations sheet as "Verifying…" or "Couldn't verify — admin offline" with **Retry**.

## Trade-off
Verification now depends on the admin being reachable for the current salt — exactly the liveness the user asked to surface. A long-offline invitee on a fast-growing group falls back to Retry rather than trusting an unverifiable snapshot.

## Tests
Refresh-request codec + wire disambiguation; dispatcher defers stale snapshots and routes refresh requests to the verifier; verifier marks `.unreachable` on unknown admin inbox and refuses a non-member (salt non-disclosure). Full `OnymIOSTests` suite green on iOS Simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)