### PR TITLE
feat(ui): rename "Tyranny" to "Founder" in user-facing copy

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2928,19 +2928,18 @@
         }
       }
     },
-    "Tyranny" : {
-      "extractionState" : "stale",
+    "Founder" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tyranny"
+            "value" : "Founder"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Тирания"
+            "value" : "Основатель"
           }
         }
       }

--- a/Sources/OnymIOS/Chain/ContractEntry.swift
+++ b/Sources/OnymIOS/Chain/ContractEntry.swift
@@ -36,7 +36,7 @@ enum GovernanceType: String, Codable, CaseIterable, Hashable, Sendable {
         case .democracy: return String(localized: "Democracy")
         case .oligarchy: return String(localized: "Oligarchy")
         case .oneonone: return String(localized: "One-on-one")
-        case .tyranny: return String(localized: "Tyranny")
+        case .tyranny: return String(localized: "Founder")
         }
     }
 }

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -215,7 +215,7 @@ private extension SEPGroupType {
         case .oneOnOne:  "1-on-1"
         case .democracy: "Democracy"
         case .oligarchy: "Oligarchy"
-        case .tyranny:   "Tyranny"
+        case .tyranny:   "Founder"
         }
     }
 }

--- a/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
+++ b/Sources/OnymIOS/Group/ApproveRequestsFlow.swift
@@ -146,7 +146,7 @@ final class ApproveRequestsFlow {
         case .noActiveRelayer:
             return "No chain relayer configured. Set one in Settings \u{2192} Network \u{2192} Relayer."
         case .noContractBinding:
-            return "No Tyranny contract selected for this network. Pick one in Settings \u{2192} Network \u{2192} Anchors."
+            return "No Founder contract selected for this network. Pick one in Settings \u{2192} Network \u{2192} Anchors."
         case .notAdminOfThisGroup:
             return "The active identity isn\u{2019}t this group\u{2019}s admin. Switch to the identity that created the group, then try again."
         case .proofFailed(let reason):

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -942,7 +942,7 @@ extension GroupProofGeneratorError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case let .notYetSupported(type):
-            return "\(type) is not supported yet — only Tyranny ships in this release"
+            return "\(type) is not supported yet — only Founder ships in this release"
         case let .adminIndexOutOfRange(index, count):
             return "Admin index \(index) is out of range for \(count) members"
         case .missingPeerSecret:

--- a/Sources/OnymIOS/Group/OnymBrand.swift
+++ b/Sources/OnymIOS/Group/OnymBrand.swift
@@ -168,7 +168,7 @@ enum OnymUIGovernance: String, CaseIterable, Identifiable, Sendable {
 
     var label: String {
         switch self {
-        case .tyranny: "Tyranny"
+        case .tyranny: "Founder"
         case .oneOnOne: "1\u{2011}on\u{2011}1"  // non-breaking hyphens
         case .anarchy: "Anarchy"
         }

--- a/Sources/OnymIOS/Settings/AnchorsView.swift
+++ b/Sources/OnymIOS/Settings/AnchorsView.swift
@@ -169,7 +169,7 @@ private struct GovernanceTypeTile: View {
         case .democracy: return "DE"
         case .oligarchy: return "OL"
         case .oneonone:  return "1\u{00B7}1"
-        case .tyranny:   return "TY"
+        case .tyranny:   return "FO"
         }
     }
 


### PR DESCRIPTION
## Summary
Renames the single-admin governance type from **Tyranny** to the friendlier **Founder** wherever it's visible to the user. This is purely a display-string change — no code identifiers, payload types, SDK calls, contract-layer names, or comments were touched.

## What changed (all user-visible)
| File | User sees |
|------|-----------|
| `Group/OnymBrand.swift` | Governance card label in Create Group |
| `Chats/ChatsView.swift` | Chat-row subtitle |
| `Chain/ContractEntry.swift` | `displayName` (Settings → Network → Anchors) |
| `Settings/AnchorsView.swift` | Tile mnemonic `TY` → `FO` |
| `Group/CreateGroupInteractor.swift` | "…only Founder ships in this release" error |
| `Group/ApproveRequestsFlow.swift` | "No Founder contract selected…" error |
| `Resources/Localizable.xcstrings` | Key `Tyranny`→`Founder`; en `Founder`, ru `Основатель` |

## Deliberately left unchanged
- Enum cases: `OnymUIGovernance.tyranny`, `SEPGroupType.tyranny`, `GovernanceType.tyranny`
- SDK calls: `Tyranny.proveCreate` / `Tyranny.proveUpdate`
- Payload types: `TyrannyCreateGroupPayload`, `TyrannyUpdateCommitmentPayload`, etc.
- Test file `CreateGroupTyrannyE2ETests.swift` and explanatory comments

## Notes
- Russian translation updated too (`Тирания` → `Основатель`) for cross-locale consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)