### PR TITLE
feat(groups): broadcast avatar changes via a dedicated message [3/3]

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1125,6 +1125,22 @@
         }
       }
     },
+    "Couldn’t verify — the admin is offline. The group stays hidden until it can be verified on chain." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn’t verify — the admin is offline. The group stays hidden until it can be verified on chain."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось проверить — администратор не в сети. Группа останется скрытой, пока её не удастся проверить в сети."
+          }
+        }
+      }
+    },
     "Create an end-to-end encrypted group anchored on Stellar." : {
       "localizations" : {
         "en" : {
@@ -1286,6 +1302,22 @@
         }
       }
     },
+    "Dismiss" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть"
+          }
+        }
+      }
+    },
     "Don’t have their key? " : {
       "localizations" : {
         "en" : {
@@ -1399,6 +1431,23 @@
         }
       }
     },
+    "Founder" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Founder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Основатель"
+          }
+        }
+      }
+    },
     "Generating proof and updating the on-chain commitment. This usually takes a few seconds." : {
       "localizations" : {
         "en" : {
@@ -1411,6 +1460,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Генерируется доказательство и обновляется обязательство в блокчейне. Обычно занимает несколько секунд."
+          }
+        }
+      }
+    },
+    "Group invites you receive show up here for you to accept." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Group invites you receive show up here for you to accept."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приглашения в группы, которые вы получаете, появляются здесь для принятия."
           }
         }
       }
@@ -1527,6 +1592,22 @@
         }
       }
     },
+    "Invitations" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invitations"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приглашения"
+          }
+        }
+      }
+    },
     "Invite" : {
       "localizations" : {
         "en" : {
@@ -1587,6 +1668,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пригласите людей в чат — они появятся здесь."
+          }
+        }
+      }
+    },
+    "invited you to “%@”" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "invited you to “%@”"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "пригласил вас в «%@»"
           }
         }
       }
@@ -1784,6 +1881,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Контрактов пока нет"
+          }
+        }
+      }
+    },
+    "No invitations" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No invitations"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет приглашений"
           }
         }
       }
@@ -2441,6 +2554,22 @@
         }
       }
     },
+    "Retry" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторить"
+          }
+        }
+      }
+    },
     "Run a relayer for yourself, your team, or your org. End-to-end encryption stays intact — Onym never sees your messages." : {
       "localizations" : {
         "en" : {
@@ -2928,22 +3057,6 @@
         }
       }
     },
-    "Founder" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Founder"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Основатель"
-          }
-        }
-      }
-    },
     "Up to date" : {
       "localizations" : {
         "en" : {
@@ -2990,6 +3103,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Проверка"
+          }
+        }
+      }
+    },
+    "Verifying group state…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifying group state…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка состояния группы…"
           }
         }
       }
@@ -3268,6 +3397,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваш релеер — ваши правила"
+          }
+        }
+      }
+    },
+    "Group photo" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Group photo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фото группы"
+          }
+        }
+      }
+    },
+    "Choose Photo" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Photo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать фото"
+          }
+        }
+      }
+    },
+    "Generate with AI" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate with AI"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать с помощью ИИ"
+          }
+        }
+      }
+    },
+    "Remove Photo" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Photo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить фото"
           }
         }
       }

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -39,4 +39,8 @@ struct AppDependencies {
     /// (it's an actor); each chat-thread view captures it and
     /// dispatches `send(groupID:body:)` on the send-button tap.
     let sendMessageInteractor: SendMessageInteractor
+    /// Admin sets/clears a group photo: applies it locally and fans a
+    /// `GroupAvatarPayload` out to members. Backs the admin-only picker
+    /// in `ChatMembersView`; `nil` JPEG clears the photo.
+    let setGroupAvatar: @MainActor (_ groupIDHex: String, _ jpeg: Data?) async -> Void
 }

--- a/Sources/OnymIOS/Chats/ChatMembersView.swift
+++ b/Sources/OnymIOS/Chats/ChatMembersView.swift
@@ -22,16 +22,20 @@ struct ChatMembersView: View {
     @Bindable var chatsFlow: ChatsFlow
     @Bindable var identitiesFlow: IdentitiesFlow
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
+    let setGroupAvatar: @MainActor (String, Data?) async -> Void
 
     @State private var shareInviteFlow: ShareInviteFlow?
 
     var body: some View {
         Group {
             if let group = currentGroup {
-                if group.memberProfiles.isEmpty {
-                    emptyState
-                } else {
-                    list(for: group)
+                VStack(spacing: 0) {
+                    header(for: group)
+                    if group.memberProfiles.isEmpty {
+                        emptyState
+                    } else {
+                        list(for: group)
+                    }
                 }
             } else {
                 missingGroupState
@@ -105,6 +109,27 @@ struct ChatMembersView: View {
         return activeHex == storedAdminHex
     }
 
+    /// Whether to show the editable (picker) avatar vs a read-only one.
+    /// Same gate as `canShareInvite`: only the Tyranny admin can change
+    /// the photo, because only their broadcast passes the receiver-side
+    /// admin-signature check. Anarchy / OneOnOne have no admin, so the
+    /// photo stays as set at create time in this pass.
+    private var canChangeAvatar: Bool { canShareInvite }
+
+    /// Bridges the picker to the broadcaster: reads the live group photo,
+    /// and on a pick/clear ships it via `setGroupAvatar` (which applies
+    /// locally + fans out). The local store write flows back through
+    /// `chatsFlow.groups`, so the `get` reflects the change on the next
+    /// render without extra @State.
+    private var avatarBinding: Binding<Data?> {
+        Binding(
+            get: { currentGroup?.avatarJPEG },
+            set: { [groupID, setGroupAvatar] newValue in
+                Task { await setGroupAvatar(groupID, newValue) }
+            }
+        )
+    }
+
     private var activeBlsHex: String? {
         guard
             let id = identitiesFlow.currentID,
@@ -117,6 +142,26 @@ struct ChatMembersView: View {
     }
 
     // MARK: - Subviews
+
+    /// Group-photo hero. Editable picker for the admin; a plain
+    /// photo-or-mark for everyone else.
+    @ViewBuilder
+    private func header(for group: ChatGroup) -> some View {
+        Group {
+            if canChangeAvatar {
+                GroupAvatarPickerButton(
+                    imageData: avatarBinding,
+                    size: 72,
+                    accent: OnymAccent.blue.color,
+                    conceptText: group.name
+                )
+            } else {
+                OnymGroupAvatar(size: 72, imageData: group.avatarJPEG)
+            }
+        }
+        .padding(.top, 16)
+        .padding(.bottom, 4)
+    }
 
     private func list(for group: ChatGroup) -> some View {
         ScrollView {

--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -22,6 +22,7 @@ struct ChatThreadView: View {
     let messageRepository: MessageRepository
     let sendMessageInteractor: SendMessageInteractor
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
+    let setGroupAvatar: @MainActor (String, Data?) async -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var showMembers: Bool = false
@@ -77,7 +78,8 @@ struct ChatThreadView: View {
                 groupID: groupID,
                 chatsFlow: chatsFlow,
                 identitiesFlow: identitiesFlow,
-                makeShareInviteFlow: makeShareInviteFlow
+                makeShareInviteFlow: makeShareInviteFlow,
+                setGroupAvatar: setGroupAvatar
             )
         }
         // Per-group subscription. `task(id:)` cancels + restarts when

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -14,6 +14,7 @@ struct ChatsView: View {
     let sendMessageInteractor: SendMessageInteractor
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
+    let setGroupAvatar: @MainActor (String, Data?) async -> Void
 
     @State private var showCreateGroup = false
 
@@ -141,7 +142,8 @@ struct ChatsView: View {
                 identitiesFlow: identitiesFlow,
                 messageRepository: messageRepository,
                 sendMessageInteractor: sendMessageInteractor,
-                makeShareInviteFlow: makeShareInviteFlow
+                makeShareInviteFlow: makeShareInviteFlow,
+                setGroupAvatar: setGroupAvatar
             )
         }
     }

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -152,16 +152,15 @@ private struct ChatsRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            // Reuse the broken-ring brand mark as the per-chat avatar
-            // — same identity the user saw on the Create Group hero.
-            // Once group avatars / uploads ship this becomes the
-            // image-or-mark fallback.
+            // Group photo when set, else the broken-ring brand mark —
+            // same identity the user saw on the Create Group hero.
             OnymGroupAvatar(
                 size: 44,
                 accent: OnymAccent.blue.color,
                 ringPulse: false,
                 spinning: false,
-                brand: false
+                brand: false,
+                imageData: group.avatarJPEG
             )
 
             VStack(alignment: .leading, spacing: 2) {

--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -67,6 +67,12 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     /// `accepted = true`. Persisted-but-not-anchored groups can be
     /// retried.
     var isPublishedOnChain: Bool
+    /// Square JPEG (256×256, ≤16 KB — see `GroupAvatarImage`) the user
+    /// or admin set as the group photo. `nil` falls back to the Onym
+    /// brand mark in `OnymGroupAvatar`. Travels in the invitation
+    /// snapshot at create time and via `GroupAvatarPayload` afterwards.
+    /// Defaulted so existing construction sites need no change.
+    var avatarJPEG: Data? = nil
 
     /// Group ID as the raw 32-byte payload (parsed back from `id`).
     /// Used directly when building chain payloads + invitations.

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -291,6 +291,7 @@ final class CreateGroupFlow {
                 governanceType: governance.sepGroupType,
                 name: effectiveName,
                 invitees: invitees,
+                avatar: avatarImageData,
                 onProgress: { [weak self] p in
                     Task { @MainActor in self?.progress = p }
                 }

--- a/Sources/OnymIOS/Group/CreateGroupFlow.swift
+++ b/Sources/OnymIOS/Group/CreateGroupFlow.swift
@@ -37,6 +37,11 @@ final class CreateGroupFlow {
     /// Always `.tyranny` in PR-C — the picker disables the others.
     var governance: OnymUIGovernance = .tyranny
     var invitees: [OnymInvitee] = []
+    /// Square JPEG group photo chosen from the gallery or generated
+    /// with Image Playground, already squared/downscaled/budgeted by
+    /// `GroupAvatarImage`. `nil` → the brand mark stands in. Passed to
+    /// the interactor at submit and sealed into the invitation snapshot.
+    var avatarImageData: Data?
 
     /// Friendly placeholder generated on init / reset (e.g. "Maple
     /// Garden"). The TextField pre-fills with this so the user can
@@ -343,6 +348,7 @@ final class CreateGroupFlow {
         accent = .blue
         governance = .tyranny
         invitees = []
+        avatarImageData = nil
         inviteeInput = ""
         inviteeError = nil
         progress = nil

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -93,15 +93,16 @@ struct CreateGroupInteractor: Sendable {
         governanceType: SEPGroupType = .tyranny,
         name: String,
         invitees: [Data],
+        avatar: Data? = nil,
         onProgress: @Sendable (CreateGroupProgress) -> Void = { _ in }
     ) async throws -> ChatGroup {
         switch governanceType {
         case .tyranny:
-            return try await createTyranny(name: name, invitees: invitees, onProgress: onProgress)
+            return try await createTyranny(name: name, invitees: invitees, avatar: avatar, onProgress: onProgress)
         case .oneOnOne:
-            return try await createOneOnOne(name: name, invitees: invitees, onProgress: onProgress)
+            return try await createOneOnOne(name: name, invitees: invitees, avatar: avatar, onProgress: onProgress)
         case .anarchy:
-            return try await createAnarchy(name: name, invitees: invitees, onProgress: onProgress)
+            return try await createAnarchy(name: name, invitees: invitees, avatar: avatar, onProgress: onProgress)
         case .democracy, .oligarchy:
             throw CreateGroupError.unsupportedGovernanceType(governanceType)
         }
@@ -112,6 +113,7 @@ struct CreateGroupInteractor: Sendable {
     private func createTyranny(
         name: String,
         invitees: [Data],
+        avatar: Data?,
         onProgress: @Sendable (CreateGroupProgress) -> Void
     ) async throws -> ChatGroup {
         // 1. Validate
@@ -251,7 +253,8 @@ struct CreateGroupInteractor: Sendable {
             groupType: .tyranny,
             adminPubkeyHex: adminPubkeyHex,
             adminEd25519PubkeyHex: adminEd25519PubkeyHex,
-            isPublishedOnChain: false
+            isPublishedOnChain: false,
+            avatarJPEG: avatar
         )
         _ = await groups.insert(group)
         await groups.markPublished(id: group.id, commitment: proof.commitment)
@@ -285,6 +288,7 @@ struct CreateGroupInteractor: Sendable {
     private func createOneOnOne(
         name: String,
         invitees: [Data],
+        avatar: Data?,
         onProgress: @Sendable (CreateGroupProgress) -> Void
     ) async throws -> ChatGroup {
         // 1. Validate — 1-on-1 is exactly two parties: the creator and
@@ -439,7 +443,8 @@ struct CreateGroupInteractor: Sendable {
             groupType: .oneOnOne,
             adminPubkeyHex: nil,
             adminEd25519PubkeyHex: nil,
-            isPublishedOnChain: false
+            isPublishedOnChain: false,
+            avatarJPEG: avatar
         )
         _ = await groups.insert(group)
         await groups.markPublished(id: group.id, commitment: proof.commitment)
@@ -459,7 +464,8 @@ struct CreateGroupInteractor: Sendable {
             groupTypeRaw: SEPGroupType.oneOnOne.rawValue,
             adminPubkeyHex: nil,
             peerBlsSecret: peerBlsSecret,
-            memberProfiles: creatorProfiles
+            memberProfiles: creatorProfiles,
+            avatar: avatar
         )
         try await sendInvitations(invitePayload, to: [peerInboxKey])
 
@@ -483,6 +489,7 @@ struct CreateGroupInteractor: Sendable {
     private func createAnarchy(
         name: String,
         invitees: [Data],
+        avatar: Data?,
         onProgress: @Sendable (CreateGroupProgress) -> Void
     ) async throws -> ChatGroup {
         // 1. Validate
@@ -619,7 +626,8 @@ struct CreateGroupInteractor: Sendable {
             groupType: .anarchy,
             adminPubkeyHex: nil,
             adminEd25519PubkeyHex: nil,
-            isPublishedOnChain: false
+            isPublishedOnChain: false,
+            avatarJPEG: avatar
         )
         _ = await groups.insert(group)
         await groups.markPublished(id: group.id, commitment: proof.commitment)
@@ -642,7 +650,8 @@ struct CreateGroupInteractor: Sendable {
                 tierRaw: tier.rawValue,
                 groupTypeRaw: SEPGroupType.anarchy.rawValue,
                 adminPubkeyHex: nil,
-                memberProfiles: creatorProfiles
+                memberProfiles: creatorProfiles,
+                avatar: avatar
             )
             try await sendInvitations(invitePayload, to: invitees)
         }

--- a/Sources/OnymIOS/Group/CreateGroupView.swift
+++ b/Sources/OnymIOS/Group/CreateGroupView.swift
@@ -212,21 +212,12 @@ private struct CreateGroupStep1View: View {
     private var accentColor: Color { flow.accent.color }
 
     private var avatar: some View {
-        ZStack(alignment: .bottomTrailing) {
-            OnymGroupAvatar(size: 92, accent: accentColor)
-            ZStack {
-                Circle()
-                    .fill(accentColor)
-                    .frame(width: 28, height: 28)
-                    .overlay(
-                        Circle().stroke(OnymTokens.bg, lineWidth: 2)
-                    )
-                Image(systemName: "camera.fill")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(OnymTokens.onAccent)
-            }
-            .offset(x: 4, y: 4)
-        }
+        GroupAvatarPickerButton(
+            imageData: $flow.avatarImageData,
+            size: 92,
+            accent: accentColor,
+            conceptText: flow.effectiveName
+        )
         .padding(.top, 10)
         .padding(.bottom, 18)
     }
@@ -1126,7 +1117,11 @@ private struct CreateGroupSuccessView: View {
     private var hero: some View {
         VStack(spacing: 0) {
             ZStack(alignment: .bottomTrailing) {
-                OnymGroupAvatar(size: 96, accent: accentColor)
+                OnymGroupAvatar(
+                    size: 96,
+                    accent: accentColor,
+                    imageData: flow.createdGroup?.avatarJPEG ?? flow.avatarImageData
+                )
                 ZStack {
                     Circle().fill(OnymTokens.green)
                         .overlay(Circle().stroke(OnymTokens.bg, lineWidth: 2))

--- a/Sources/OnymIOS/Group/GroupAvatarBroadcaster.swift
+++ b/Sources/OnymIOS/Group/GroupAvatarBroadcaster.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Admin-side counterpart to `GroupAvatarPayload`: applies a new (or
+/// cleared) group photo locally, then fans it out to every member's
+/// inbox, sealed per recipient — the same best-effort broadcast shape
+/// as `JoinRequestApprover`'s member-announcement loop.
+///
+/// The caller is expected to be the group admin (the change-photo UI is
+/// admin-gated); receivers independently verify the envelope's Ed25519
+/// signer against the group's stored admin key and drop anything else,
+/// so a non-admin sender can't move another device's avatar.
+actor GroupAvatarBroadcaster {
+    private let identity: IdentityRepository
+    private let inboxTransport: any InboxTransport
+    private let groupRepository: GroupRepository
+
+    init(
+        identity: IdentityRepository,
+        inboxTransport: any InboxTransport,
+        groupRepository: GroupRepository
+    ) {
+        self.identity = identity
+        self.inboxTransport = inboxTransport
+        self.groupRepository = groupRepository
+    }
+
+    /// Set (or clear, with `jpeg == nil`) the photo for `groupIDHex`.
+    /// Persists the local change first so the UI reflects it even if
+    /// every send fails, then ships one sealed `GroupAvatarPayload` to
+    /// each member inbox except the admin's own.
+    func setAvatar(groupIDHex: String, jpeg: Data?) async {
+        let groups = await groupRepository.currentGroups()
+        guard var group = groups.first(where: { $0.id == groupIDHex }) else { return }
+
+        // Local apply + persist up front — broadcast is best-effort.
+        group.avatarJPEG = jpeg
+        await groupRepository.insert(group)
+
+        let payload = GroupAvatarPayload(
+            version: 1,
+            groupID: group.groupIDData,
+            senderBlsPubkeyHex: group.adminPubkeyHex?.lowercased() ?? "",
+            sentAtMillis: Int64(Date().timeIntervalSince1970 * 1000),
+            avatar: jpeg
+        )
+        guard let payloadBytes = try? JSONEncoder().encode(payload) else { return }
+
+        let adminKey = group.adminPubkeyHex?.lowercased()
+        for (memberKey, profile) in group.memberProfiles {
+            // Skip self — the admin already applied the change locally.
+            if let adminKey, memberKey == adminKey { continue }
+            guard let sealed = try? await identity.sealInvitation(
+                payload: payloadBytes,
+                to: profile.inboxPublicKey
+            ) else { continue }
+            let tag = TransportInboxID(
+                rawValue: IntroInboxPump.inboxTag(from: profile.inboxPublicKey)
+            )
+            // Receipt discarded — a member that misses this update will
+            // catch the photo on the next snapshot / refresh.
+            _ = try? await inboxTransport.send(sealed, to: tag)
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/GroupAvatarImage.swift
+++ b/Sources/OnymIOS/Group/GroupAvatarImage.swift
@@ -1,0 +1,64 @@
+import UIKit
+
+/// Funnels every avatar source — gallery pick, Image Playground
+/// generation, a future paste — through one square-crop / downscale /
+/// JPEG-budget pipeline so the bytes that land on `ChatGroup.avatarJPEG`
+/// (and therefore in a sealed NOSTR envelope) are always small enough
+/// to ship.
+///
+/// The avatar renders at most ~96 pt, so 256×256 px covers @2x/@3x with
+/// headroom while keeping the encode tiny. `maxBytes` is the *raw* JPEG
+/// budget; base64 on the wire adds ~33 %, leaving the sealed payload
+/// comfortably inside relay event-size limits.
+enum GroupAvatarImage {
+    /// Square edge length, in pixels, of the stored/transmitted image.
+    static let dimension: CGFloat = 256
+    /// Hard cap on the encoded JPEG. ~16 KB → ~22 KB base64.
+    static let maxBytes = 16 * 1024
+
+    /// Square-crop (centre), downscale to `dimension`px, then JPEG-encode
+    /// at the highest quality that fits `maxBytes`. Returns `nil` only if
+    /// the image can't be drawn at all. Orientation is normalised by the
+    /// renderer, so EXIF-rotated camera shots come out upright.
+    static func encode(_ image: UIImage) -> Data? {
+        let square = squareScaled(image, to: dimension)
+        // 256² is small; quality 0.8 usually already fits, but step down
+        // for busy photos. The floor (0.2) is a safety net — if even that
+        // overshoots we return it anyway rather than dropping the avatar.
+        var quality: CGFloat = 0.8
+        var encoded = square.jpegData(compressionQuality: quality)
+        while let data = encoded, data.count > maxBytes, quality > 0.2 {
+            quality -= 0.1
+            encoded = square.jpegData(compressionQuality: quality)
+        }
+        return encoded
+    }
+
+    /// Convenience for the gallery path, which hands us raw file `Data`.
+    static func encode(fromImageData data: Data) -> Data? {
+        guard let image = UIImage(data: data) else { return nil }
+        return encode(image)
+    }
+
+    /// Centre-crop to a square, then render at exactly `edge`×`edge` px
+    /// (`scale = 1` so the output is in pixels, not points).
+    private static func squareScaled(_ image: UIImage, to edge: CGFloat) -> UIImage {
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        format.opaque = true
+        let size = CGSize(width: edge, height: edge)
+        return UIGraphicsImageRenderer(size: size, format: format).image { _ in
+            let src = image.size
+            let side = min(src.width, src.height)
+            // aspect-fill: scale so the short side maps to `edge`, then
+            // centre the overflow off-canvas.
+            let scale = edge / side
+            let drawSize = CGSize(width: src.width * scale, height: src.height * scale)
+            let origin = CGPoint(
+                x: (edge - drawSize.width) / 2,
+                y: (edge - drawSize.height) / 2
+            )
+            image.draw(in: CGRect(origin: origin, size: drawSize))
+        }
+    }
+}

--- a/Sources/OnymIOS/Group/GroupAvatarPayload.swift
+++ b/Sources/OnymIOS/Group/GroupAvatarPayload.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Dedicated "avatar" control message: the admin broadcasting the group
+/// photo to every member, out of band from the chat timeline. Sealed
+/// (X25519 + AES-GCM via `IdentityRepository.sealInvitation`) and
+/// shipped on the same per-inbox envelope path as
+/// `MemberAnnouncementPayload` — one envelope per member inbox.
+///
+/// Reaches members who weren't present when the photo was set into the
+/// invitation snapshot (late joiners) and carries every later change.
+///
+/// The `avatar_*` wire keys are deliberately distinct (mirroring
+/// `GroupStateRefreshRequest`'s `refresh_*`) so the dispatcher's
+/// structural JSON decode can't confuse this with a `ChatMessagePayload`
+/// — the two otherwise share `version` / `group_id` / sender / timestamp.
+///
+/// This message always expresses the *current* avatar state, so a `nil`
+/// / absent `avatar` means the photo was removed, not "unspecified".
+struct GroupAvatarPayload: Codable, Equatable, Sendable {
+    /// Wire schema version. `1` is the only shape today.
+    let version: Int
+    /// 32-byte group ID. Receiver looks up the local `ChatGroup` by it
+    /// and drops the message if no such group exists.
+    let groupID: Data
+    /// Lowercase BLS pubkey hex (96 chars) of the admin who set it.
+    /// Informational — receiver authenticates via the envelope's
+    /// Ed25519 signer against the group's stored admin key, not this.
+    let senderBlsPubkeyHex: String
+    /// Milliseconds since Unix epoch at send time. Int64 for an
+    /// unambiguous cross-platform wire format.
+    let sentAtMillis: Int64
+    /// Square JPEG (256×256, ≤16 KB — see `GroupAvatarImage`), base64 on
+    /// the wire via `Data`'s default Codable. `nil` = photo removed.
+    let avatar: Data?
+
+    enum CodingKeys: String, CodingKey {
+        case version = "avatar_version"
+        case groupID = "avatar_group_id"
+        case senderBlsPubkeyHex = "avatar_sender_bls_hex"
+        case sentAtMillis = "avatar_sent_at_millis"
+        case avatar
+    }
+}

--- a/Sources/OnymIOS/Group/GroupAvatarPickerButton.swift
+++ b/Sources/OnymIOS/Group/GroupAvatarPickerButton.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+import PhotosUI
+#if canImport(ImagePlayground)
+import ImagePlayground
+#endif
+
+/// Tappable group-avatar slot: shows the photo-or-mark (`OnymGroupAvatar`)
+/// with a camera badge, and on tap offers a gallery pick or an on-device
+/// Image Playground generation. Both sources funnel through
+/// `GroupAvatarImage` so whatever lands on the bound `imageData` is the
+/// squared, budgeted JPEG we can seal into a NOSTR envelope.
+///
+/// Reused by the create flow and (later) the admin "change photo" entry
+/// point — it owns no group state, just edits a `Data?` binding.
+struct GroupAvatarPickerButton: View {
+    @Binding var imageData: Data?
+    var size: CGFloat = 92
+    var accent: Color = OnymAccent.blue.color
+    /// Seeds Image Playground (e.g. the group name) so the first
+    /// suggestions relate to the group. Empty → no seed concept.
+    var conceptText: String = ""
+
+    @State private var showOptions = false
+    @State private var photosItem: PhotosPickerItem?
+    @State private var showPhotosPicker = false
+    @State private var showAISheet = false
+
+    /// On-device generation is iOS 18.1+ and only on Apple-Intelligence
+    /// capable hardware. Hide the option entirely otherwise — gallery
+    /// still works everywhere.
+    private var aiAvailable: Bool {
+        #if canImport(ImagePlayground)
+        if #available(iOS 18.1, *) {
+            return ImagePlaygroundViewController.isAvailable
+        }
+        #endif
+        return false
+    }
+
+    var body: some View {
+        Button { showOptions = true } label: { avatarVisual }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("group.avatar.edit")
+            .confirmationDialog("Group photo", isPresented: $showOptions, titleVisibility: .visible) {
+                Button("Choose Photo") { showPhotosPicker = true }
+                if aiAvailable {
+                    Button("Generate with AI") { showAISheet = true }
+                }
+                if imageData != nil {
+                    Button("Remove Photo", role: .destructive) { imageData = nil }
+                }
+            }
+            .photosPicker(isPresented: $showPhotosPicker, selection: $photosItem, matching: .images)
+            .onChange(of: photosItem) { _, item in
+                guard let item else { return }
+                Task { await loadFromGallery(item) }
+            }
+            .modifier(
+                ImagePlaygroundPresenter(
+                    isPresented: $showAISheet,
+                    concept: conceptText,
+                    onImage: setFromURL
+                )
+            )
+    }
+
+    private var avatarVisual: some View {
+        ZStack(alignment: .bottomTrailing) {
+            OnymGroupAvatar(size: size, accent: accent, imageData: imageData)
+            ZStack {
+                Circle()
+                    .fill(accent)
+                    .frame(width: 28, height: 28)
+                    .overlay(Circle().stroke(OnymTokens.bg, lineWidth: 2))
+                Image(systemName: "camera.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(OnymTokens.onAccent)
+            }
+            .offset(x: 4, y: 4)
+        }
+    }
+
+    private func loadFromGallery(_ item: PhotosPickerItem) async {
+        guard
+            let data = try? await item.loadTransferable(type: Data.self),
+            let encoded = GroupAvatarImage.encode(fromImageData: data)
+        else { return }
+        await MainActor.run { imageData = encoded }
+    }
+
+    private func setFromURL(_ url: URL) {
+        guard
+            let data = try? Data(contentsOf: url),
+            let encoded = GroupAvatarImage.encode(fromImageData: data)
+        else { return }
+        imageData = encoded
+    }
+}
+
+/// Applies `imagePlaygroundSheet` only where it exists (iOS 18.1+ with
+/// the framework present); a no-op passthrough otherwise. Isolating the
+/// availability fork here keeps `GroupAvatarPickerButton.body` clean.
+private struct ImagePlaygroundPresenter: ViewModifier {
+    @Binding var isPresented: Bool
+    var concept: String
+    var onImage: (URL) -> Void
+
+    func body(content: Content) -> some View {
+        #if canImport(ImagePlayground)
+        if #available(iOS 18.1, *) {
+            content.imagePlaygroundSheet(
+                isPresented: $isPresented,
+                concepts: concept.isEmpty ? [] : [.text(concept)]
+            ) { url in
+                onImage(url)
+            }
+        } else {
+            content
+        }
+        #else
+        content
+        #endif
+    }
+}

--- a/Sources/OnymIOS/Group/GroupInvitationPayload.swift
+++ b/Sources/OnymIOS/Group/GroupInvitationPayload.swift
@@ -57,6 +57,13 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
     /// fingerprint until a future `MemberAnnouncementPayload` fills
     /// in the aliases.
     let memberProfiles: [String: MemberProfile]?
+    /// Square JPEG group photo (≤16 KB — see `GroupAvatarImage`), base64
+    /// on the wire via `Data`'s default Codable. Lets create-time
+    /// members land the photo with the initial snapshot instead of
+    /// waiting for a `GroupAvatarPayload`. Optional + `decodeIfPresent`
+    /// so avatar-less groups and pre-avatar senders round-trip cleanly;
+    /// a later avatar message can still set or replace it.
+    let avatar: Data?
 
     enum CodingKeys: String, CodingKey {
         case version
@@ -72,6 +79,7 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         case adminPubkeyHex = "admin_pubkey_hex"
         case peerBlsSecret = "peer_bls_secret"
         case memberProfiles = "member_profiles"
+        case avatar
     }
 
     init(
@@ -87,7 +95,8 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         groupTypeRaw: String,
         adminPubkeyHex: String?,
         peerBlsSecret: Data? = nil,
-        memberProfiles: [String: MemberProfile]? = nil
+        memberProfiles: [String: MemberProfile]? = nil,
+        avatar: Data? = nil
     ) {
         self.version = version
         self.groupID = groupID
@@ -102,6 +111,7 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
         self.adminPubkeyHex = adminPubkeyHex
         self.peerBlsSecret = peerBlsSecret
         self.memberProfiles = memberProfiles
+        self.avatar = avatar
     }
 
     init(from decoder: Decoder) throws {
@@ -122,5 +132,6 @@ struct GroupInvitationPayload: Codable, Equatable, Sendable {
             [String: MemberProfile].self,
             forKey: .memberProfiles
         )
+        avatar = try c.decodeIfPresent(Data.self, forKey: .avatar)
     }
 }

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -291,7 +291,11 @@ actor JoinRequestApprover: JoinRequestApproving {
             // peers + admin by name from the moment they land. The
             // joiner's own profile gets backfilled by the receiver's
             // materializer from their active identity.
-            memberProfiles: anchored.memberProfiles.isEmpty ? nil : anchored.memberProfiles
+            memberProfiles: anchored.memberProfiles.isEmpty ? nil : anchored.memberProfiles,
+            // Tyranny invitees only get the full snapshot here (the
+            // create-time offer carries nothing), so this is where the
+            // group photo reaches them.
+            avatar: anchored.avatarJPEG
         )
         let payloadBytes: Data
         do {

--- a/Sources/OnymIOS/Group/OnymBrand.swift
+++ b/Sources/OnymIOS/Group/OnymBrand.swift
@@ -350,11 +350,12 @@ struct OnymGovIcon: View {
     }
 }
 
-// MARK: - Group avatar (Onym mark as upload placeholder)
+// MARK: - Group avatar (image-or-mark)
 
-/// Avatar slot. In this prototype the user never uploads an image, so
-/// the slot always shows the brand mark — same behaviour as the
-/// design's `GroupAvatar` after the `forceInitials` refactor.
+/// Avatar slot. Renders the group photo (`imageData`, a square JPEG —
+/// see `GroupAvatarImage`) clipped to a circle when one is set, else
+/// falls back to the Onym brand mark — the same fallback the design's
+/// `GroupAvatar` used before uploads shipped.
 struct OnymGroupAvatar: View {
     var size: CGFloat = 96
     var accent: Color = OnymAccent.blue.color
@@ -363,6 +364,8 @@ struct OnymGroupAvatar: View {
     /// When `true` the mark renders in the accent colour rather than
     /// the neutral text colour — used on the Creating screen.
     var brand: Bool = false
+    /// Square JPEG to show instead of the brand mark. `nil` → mark.
+    var imageData: Data? = nil
 
     var body: some View {
         ZStack {
@@ -372,12 +375,20 @@ struct OnymGroupAvatar: View {
                     .padding(-8)
                     .modifier(PulseModifier())
             }
-            OnymMark(
-                size: size,
-                color: brand ? accent : OnymTokens.text,
-                spinning: spinning,
-                fillOpacity: brand ? 1.0 : 0.92
-            )
+            if let imageData, let uiImage = UIImage(data: imageData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: size, height: size)
+                    .clipShape(Circle())
+            } else {
+                OnymMark(
+                    size: size,
+                    color: brand ? accent : OnymTokens.text,
+                    spinning: spinning,
+                    fillOpacity: brand ? 1.0 : 0.92
+                )
+            }
         }
         .frame(width: size, height: size)
     }

--- a/Sources/OnymIOS/Group/PersistedGroup.swift
+++ b/Sources/OnymIOS/Group/PersistedGroup.swift
@@ -49,6 +49,10 @@ final class PersistedGroup {
     /// migrated from pre-PR-9 schema, or for governance models
     /// without an admin.
     var encryptedAdminEd25519PubkeyHex: Data?
+    /// Optional square JPEG group photo. Optional so SwiftData's
+    /// lightweight migration lands the column on existing rows without a
+    /// wipe; `nil` decodes to "no avatar" (brand-mark fallback).
+    var encryptedAvatar: Data?
 
     init(
         id: String,
@@ -65,7 +69,8 @@ final class PersistedGroup {
         encryptedCommitment: Data?,
         encryptedAdminPubkeyHex: Data?,
         encryptedMemberProfilesJSON: Data?,
-        encryptedAdminEd25519PubkeyHex: Data?
+        encryptedAdminEd25519PubkeyHex: Data?,
+        encryptedAvatar: Data? = nil
     ) {
         self.id = id
         self.ownerIdentityIDString = ownerIdentityIDString
@@ -82,5 +87,6 @@ final class PersistedGroup {
         self.encryptedAdminPubkeyHex = encryptedAdminPubkeyHex
         self.encryptedMemberProfilesJSON = encryptedMemberProfilesJSON
         self.encryptedAdminEd25519PubkeyHex = encryptedAdminEd25519PubkeyHex
+        self.encryptedAvatar = encryptedAvatar
     }
 }

--- a/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
+++ b/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
@@ -93,6 +93,7 @@ actor SwiftDataGroupStore: GroupStore {
             existing.encryptedAdminPubkeyHex = encoded.encryptedAdminPubkeyHex
             existing.encryptedMemberProfilesJSON = encoded.encryptedMemberProfilesJSON
             existing.encryptedAdminEd25519PubkeyHex = encoded.encryptedAdminEd25519PubkeyHex
+            existing.encryptedAvatar = encoded.encryptedAvatar
             try? context.save()
             return false
         }
@@ -166,7 +167,8 @@ actor SwiftDataGroupStore: GroupStore {
             encryptedCommitment: try group.commitment.map(StorageEncryption.encrypt),
             encryptedAdminPubkeyHex: try group.adminPubkeyHex.map(StorageEncryption.encrypt),
             encryptedMemberProfilesJSON: encryptedProfilesJSON,
-            encryptedAdminEd25519PubkeyHex: try group.adminEd25519PubkeyHex.map(StorageEncryption.encrypt)
+            encryptedAdminEd25519PubkeyHex: try group.adminEd25519PubkeyHex.map(StorageEncryption.encrypt),
+            encryptedAvatar: try group.avatarJPEG.map(StorageEncryption.encrypt)
         )
     }
 
@@ -197,6 +199,9 @@ actor SwiftDataGroupStore: GroupStore {
             .flatMap { try? StorageEncryption.decrypt($0) }
             .flatMap { try? JSONDecoder().decode([String: MemberProfile].self, from: $0) }
             ?? [:]
+        // Advisory like the profiles map: a decode miss just costs the
+        // brand-mark fallback until the next avatar message arrives.
+        let avatarJPEG = row.encryptedAvatar.flatMap { try? StorageEncryption.decrypt($0) }
         return ChatGroup(
             id: row.id,
             ownerIdentityID: owner,
@@ -212,7 +217,8 @@ actor SwiftDataGroupStore: GroupStore {
             groupType: groupType,
             adminPubkeyHex: adminPubkeyHex,
             adminEd25519PubkeyHex: adminEd25519PubkeyHex,
-            isPublishedOnChain: row.isPublishedOnChain
+            isPublishedOnChain: row.isPublishedOnChain,
+            avatarJPEG: avatarJPEG
         )
     }
 }

--- a/Sources/OnymIOS/Inbox/GroupStateVerifier.swift
+++ b/Sources/OnymIOS/Inbox/GroupStateVerifier.swift
@@ -252,7 +252,8 @@ actor GroupStateVerifier: GroupStateRefreshing {
             tierRaw: group.tier.rawValue,
             groupTypeRaw: group.groupType.rawValue,
             adminPubkeyHex: group.adminPubkeyHex,
-            memberProfiles: group.memberProfiles.isEmpty ? nil : group.memberProfiles
+            memberProfiles: group.memberProfiles.isEmpty ? nil : group.memberProfiles,
+            avatar: group.avatarJPEG
         )
         guard let bytes = try? JSONEncoder().encode(invite),
               let sealed = try? await identity.sealInvitation(

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -313,7 +313,11 @@ struct IncomingMessageDispatcher: Sendable {
             adminEd25519PubkeyHex: adminEd25519PubkeyHex,
             // Sender already anchored before sending the invite, so
             // by the time it lands the group is on chain.
-            isPublishedOnChain: true
+            isPublishedOnChain: true,
+            // Group photo as the sender knew it. `nil` for avatar-less
+            // groups or pre-avatar senders; a later GroupAvatarPayload
+            // can still fill it in.
+            avatarJPEG: invitation.avatar
         )
         await groupRepository.insert(group)
     }

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -143,6 +143,21 @@ struct IncomingMessageDispatcher: Sendable {
             return
         }
 
+        // Fast path 1.5: GroupAvatarPayload — admin updated the group
+        // photo. Group-state delta like the announcement above; its
+        // unique `avatar_*` keys keep it from decoding as a chat
+        // message (which shares version / group_id / sender).
+        if let avatarMsg = try? JSONDecoder().decode(
+            GroupAvatarPayload.self,
+            from: envelope.plaintext
+        ) {
+            await applyAvatar(
+                avatarMsg,
+                senderEd25519PublicKey: envelope.senderEd25519PublicKey
+            )
+            return
+        }
+
         // Fast path 2: GroupInvitationPayload — materialize a local
         // group under `ownerIdentityID`. Skips the invitations queue
         // because the group is now visible in the chat list.
@@ -542,6 +557,34 @@ struct IncomingMessageDispatcher: Sendable {
             inboxPublicKey: payload.newMember.inboxPub,
             sendingPubkey: payload.newMember.sendingPub
         )
+        await groupRepository.insert(updated)
+    }
+
+    /// Apply an inbound group-photo update to the matching local group.
+    /// Same admin-trust gate as `applyAnnouncement`: the envelope's
+    /// Ed25519 signer must match the group's stored
+    /// `adminEd25519PubkeyHex` (skipped best-effort for admin-less
+    /// governance models / pre-PR-9 rows). No on-chain cross-check —
+    /// the avatar isn't part of the group commitment. No-op when the
+    /// group is unknown or the photo already matches (re-delivery).
+    private func applyAvatar(
+        _ payload: GroupAvatarPayload,
+        senderEd25519PublicKey: Data?
+    ) async {
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.groupIDData == payload.groupID }) else {
+            return
+        }
+        if let storedAdmin = group.adminEd25519PubkeyHex {
+            guard let senderEd25519PublicKey else { return }
+            let senderHex = senderEd25519PublicKey
+                .map { String(format: "%02x", $0) }.joined()
+                .lowercased()
+            guard senderHex == storedAdmin.lowercased() else { return }
+        }
+        guard group.avatarJPEG != payload.avatar else { return }
+        var updated = group
+        updated.avatarJPEG = payload.avatar
         await groupRepository.insert(updated)
     }
 

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -183,6 +183,14 @@ struct OnymIOSApp: App {
             identity: repository,
             inboxTransport: inboxTransport
         )
+        // Admin-side group-photo broadcaster — applies locally + fans a
+        // GroupAvatarPayload to members. Shared actor; the change-photo
+        // UI calls it through `AppDependencies.setGroupAvatar`.
+        let groupAvatarBroadcaster = GroupAvatarBroadcaster(
+            identity: repository,
+            inboxTransport: inboxTransport,
+            groupRepository: groupRepository
+        )
         let pendingInvitesFlow = PendingInvitesFlow(
             store: pendingInvitesStore,
             verificationStore: pendingVerificationStore,
@@ -274,7 +282,10 @@ struct OnymIOSApp: App {
                 inboxTransport: inboxTransport,
                 messageRepository: messageRepository,
                 groupRepository: groupRepository
-            )
+            ),
+            setGroupAvatar: { groupIDHex, jpeg in
+                await groupAvatarBroadcaster.setAvatar(groupIDHex: groupIDHex, jpeg: jpeg)
+            }
         )
     }
 

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -34,7 +34,8 @@ struct RootView: View {
                         messageRepository: dependencies.messageRepository,
                         sendMessageInteractor: dependencies.sendMessageInteractor,
                         makeCreateGroupFlow: dependencies.makeCreateGroupFlow,
-                        makeShareInviteFlow: dependencies.makeShareInviteFlow
+                        makeShareInviteFlow: dependencies.makeShareInviteFlow,
+                        setGroupAvatar: dependencies.setGroupAvatar
                     )
                 }
             }

--- a/Tests/OnymIOSTests/GroupAvatarImageTests.swift
+++ b/Tests/OnymIOSTests/GroupAvatarImageTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import UIKit
+@testable import OnymIOS
+
+/// `GroupAvatarImage` is the single funnel every avatar source passes
+/// through, so these lock the two invariants the wire format depends
+/// on: the output is a 256×256 square, and it never exceeds the byte
+/// budget — even for a high-entropy image that resists JPEG.
+final class GroupAvatarImageTests: XCTestCase {
+
+    func test_encode_producesSquare256pxJPEG() throws {
+        // Deliberately non-square (landscape) so the centre-crop path runs.
+        let source = solidImage(size: CGSize(width: 800, height: 400), color: .systemTeal)
+        let data = try XCTUnwrap(GroupAvatarImage.encode(source))
+
+        let decoded = try XCTUnwrap(UIImage(data: data))
+        XCTAssertEqual(decoded.size.width, GroupAvatarImage.dimension)
+        XCTAssertEqual(decoded.size.height, GroupAvatarImage.dimension)
+        XCTAssertLessThanOrEqual(data.count, GroupAvatarImage.maxBytes)
+    }
+
+    func test_encode_highEntropyImageStaysUnderBudget() throws {
+        // Random per-pixel noise is the worst case for JPEG — if the
+        // quality loop holds the budget here, real photos are safe.
+        let source = noiseImage(edge: 512)
+        let data = try XCTUnwrap(GroupAvatarImage.encode(source))
+        XCTAssertLessThanOrEqual(data.count, GroupAvatarImage.maxBytes)
+    }
+
+    func test_encode_fromImageData_roundtrips() throws {
+        let pngData = try XCTUnwrap(solidImage(size: CGSize(width: 256, height: 256), color: .red).pngData())
+        let encoded = try XCTUnwrap(GroupAvatarImage.encode(fromImageData: pngData))
+        XCTAssertLessThanOrEqual(encoded.count, GroupAvatarImage.maxBytes)
+        XCTAssertNotNil(UIImage(data: encoded))
+    }
+
+    func test_encode_fromGarbageDataReturnsNil() {
+        XCTAssertNil(GroupAvatarImage.encode(fromImageData: Data([0x00, 0x01, 0x02])))
+    }
+
+    // MARK: - Helpers
+
+    private func solidImage(size: CGSize, color: UIColor) -> UIImage {
+        UIGraphicsImageRenderer(size: size).image { ctx in
+            color.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
+    private func noiseImage(edge: CGFloat) -> UIImage {
+        let size = CGSize(width: edge, height: edge)
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: size, format: format).image { ctx in
+            var generator = SystemRandomNumberGenerator()
+            let step = 2
+            for x in stride(from: 0, to: Int(edge), by: step) {
+                for y in stride(from: 0, to: Int(edge), by: step) {
+                    let c = UIColor(
+                        red: CGFloat(UInt8.random(in: 0...255, using: &generator)) / 255,
+                        green: CGFloat(UInt8.random(in: 0...255, using: &generator)) / 255,
+                        blue: CGFloat(UInt8.random(in: 0...255, using: &generator)) / 255,
+                        alpha: 1
+                    )
+                    c.setFill()
+                    ctx.fill(CGRect(x: x, y: y, width: step, height: step))
+                }
+            }
+        }
+    }
+}

--- a/Tests/OnymIOSTests/GroupAvatarPayloadTests.swift
+++ b/Tests/OnymIOSTests/GroupAvatarPayloadTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import OnymIOS
+
+/// Wire-format pin for `GroupAvatarPayload`. The load-bearing property
+/// is that its distinct `avatar_*` keys keep the dispatcher's structural
+/// decode from confusing it with a `ChatMessagePayload` (which shares
+/// version / group_id / sender / timestamp) — so both directions of that
+/// collision are asserted alongside the basic round-trip.
+final class GroupAvatarPayloadTests: XCTestCase {
+
+    func test_roundtrip_withAvatar_preservesBytes() throws {
+        let original = makePayload(avatar: Data(repeating: 0x5A, count: 2048))
+        let decoded = try JSONDecoder().decode(
+            GroupAvatarPayload.self,
+            from: JSONEncoder().encode(original)
+        )
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_roundtrip_nilAvatar_isRemoval() throws {
+        let original = makePayload(avatar: nil)
+        let encoded = try JSONEncoder().encode(original)
+        // nil avatar must not emit the key (encodeIfPresent).
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNil(obj?["avatar"])
+        let decoded = try JSONDecoder().decode(GroupAvatarPayload.self, from: encoded)
+        XCTAssertNil(decoded.avatar)
+    }
+
+    func test_wireKeys_useAvatarPrefix() throws {
+        let encoded = try JSONEncoder().encode(makePayload(avatar: Data([0x01])))
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNotNil(obj?["avatar_version"])
+        XCTAssertNotNil(obj?["avatar_group_id"])
+        XCTAssertNotNil(obj?["avatar_sent_at_millis"])
+    }
+
+    // MARK: - Anti-collision with ChatMessagePayload
+
+    func test_chatMessage_doesNotDecodeAsAvatar() throws {
+        let chat = ChatMessagePayload(
+            version: 1,
+            messageID: UUID(),
+            groupID: Data(repeating: 0x42, count: 32),
+            senderBlsPubkeyHex: "aa".repeated(48),
+            sentAtMillis: 1_700_000_000_000,
+            variant: .tyranny(body: "hello")
+        )
+        let bytes = try JSONEncoder().encode(chat)
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(GroupAvatarPayload.self, from: bytes),
+            "a chat message lacks avatar_* keys and must not decode as an avatar payload"
+        )
+    }
+
+    func test_avatar_doesNotDecodeAsChatMessage() throws {
+        let bytes = try JSONEncoder().encode(makePayload(avatar: Data([0x01, 0x02])))
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(ChatMessagePayload.self, from: bytes),
+            "an avatar payload lacks message_id / variant and must not decode as a chat message"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makePayload(avatar: Data?) -> GroupAvatarPayload {
+        GroupAvatarPayload(
+            version: 1,
+            groupID: Data(repeating: 0x42, count: 32),
+            senderBlsPubkeyHex: "aa".repeated(48),
+            sentAtMillis: 1_700_000_000_000,
+            avatar: avatar
+        )
+    }
+}
+
+private extension String {
+    func repeated(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}

--- a/Tests/OnymIOSTests/GroupInvitationPayloadTests.swift
+++ b/Tests/OnymIOSTests/GroupInvitationPayloadTests.swift
@@ -53,6 +53,49 @@ final class GroupInvitationPayloadTests: XCTestCase {
         XCTAssertEqual(decoded.name, "Family")
     }
 
+    // MARK: - Avatar
+
+    func test_roundtrip_withAvatar_preservesBytes() throws {
+        let avatar = Data(repeating: 0xC3, count: 4096)
+        let original = makePayload(memberProfiles: nil, avatar: avatar)
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GroupInvitationPayload.self, from: encoded)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.avatar, avatar)
+    }
+
+    func test_roundtrip_withoutAvatar_decodesAsNil() throws {
+        let original = makePayload(memberProfiles: nil, avatar: nil)
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GroupInvitationPayload.self, from: encoded)
+        XCTAssertNil(decoded.avatar)
+    }
+
+    func test_decoder_acceptsLegacyPayloadWithoutAvatar() throws {
+        // Pre-avatar senders ship no `avatar` key. Decode must fall back
+        // to `nil` (brand-mark fallback) rather than failing.
+        let gid = Data(repeating: 0, count: 32).base64EncodedString()
+        let secret = Data(repeating: 0, count: 32).base64EncodedString()
+        let salt = Data(repeating: 0, count: 32).base64EncodedString()
+        let legacy = #"""
+        {"version":1,"group_id":"\#(gid)","group_secret":"\#(secret)","name":"Family","members":[],"epoch":0,"salt":"\#(salt)","tier_raw":1,"group_type_raw":"tyranny"}
+        """#
+        let decoded = try JSONDecoder().decode(
+            GroupInvitationPayload.self,
+            from: legacy.data(using: .utf8)!
+        )
+        XCTAssertNil(decoded.avatar)
+    }
+
+    func test_avatar_absentFromWireWhenNil() throws {
+        // Synthesized encoder uses encodeIfPresent for optionals, so a
+        // nil avatar must not emit the key at all (keeps the common,
+        // photo-less invite small).
+        let encoded = try JSONEncoder().encode(makePayload(memberProfiles: nil, avatar: nil))
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNil(obj?["avatar"])
+    }
+
     // MARK: - Wire shape
 
     func test_member_profiles_keySpelling_matches_android_parity() throws {
@@ -72,7 +115,8 @@ final class GroupInvitationPayloadTests: XCTestCase {
     // MARK: - Helpers
 
     private func makePayload(
-        memberProfiles: [String: MemberProfile]?
+        memberProfiles: [String: MemberProfile]?,
+        avatar: Data? = nil
     ) -> GroupInvitationPayload {
         GroupInvitationPayload(
             version: 1,
@@ -87,7 +131,8 @@ final class GroupInvitationPayloadTests: XCTestCase {
             groupTypeRaw: "tyranny",
             adminPubkeyHex: nil,
             peerBlsSecret: nil,
-            memberProfiles: memberProfiles
+            memberProfiles: memberProfiles,
+            avatar: avatar
         )
     }
 }

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -325,6 +325,108 @@ final class IncomingMessageDispatcherTests: XCTestCase {
                        "legacy group accepts announcements (best-effort)")
     }
 
+    // MARK: - Avatar path (GroupAvatarPayload)
+
+    func test_avatar_appliedWhenSenderMatchesStoredAdmin() async throws {
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let adminEd25519 = Data(repeating: 0xED, count: 32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [:],
+            adminEd25519PubkeyHex: "ed".repeated(32)
+        )
+        let jpeg = Data(repeating: 0x7A, count: 800)
+        let plaintext = try Self.encode(avatar: Self.makeAvatar(groupID: groupID, jpeg: jpeg))
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: adminEd25519
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        await dispatcher.dispatch(
+            messageID: "avatar-ok",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let after = await groups.currentGroups()
+        XCTAssertEqual(after.first { $0.groupIDData == groupID }?.avatarJPEG, jpeg,
+                       "admin-signed avatar update is applied")
+    }
+
+    func test_avatar_rejectedWhenSenderDoesNotMatchStoredAdmin() async throws {
+        let groupID = Data(repeating: 0xAB, count: 32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [:],
+            adminEd25519PubkeyHex: "ed".repeated(32)
+        )
+        let plaintext = try Self.encode(avatar: Self.makeAvatar(
+            groupID: groupID,
+            jpeg: Data(repeating: 0x01, count: 64)
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: Data(repeating: 0xBA, count: 32)  // imposter
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        await dispatcher.dispatch(
+            messageID: "avatar-imposter",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let after = await groups.currentGroups()
+        XCTAssertNil(after.first { $0.groupIDData == groupID }?.avatarJPEG,
+                     "imposter avatar update must not mutate the group photo")
+    }
+
+    func test_avatar_nilPayloadClearsExistingPhoto() async throws {
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let adminEd25519 = Data(repeating: 0xED, count: 32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [:],
+            adminEd25519PubkeyHex: "ed".repeated(32),
+            avatarJPEG: Data(repeating: 0x09, count: 128)
+        )
+        let plaintext = try Self.encode(avatar: Self.makeAvatar(groupID: groupID, jpeg: nil))
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: adminEd25519
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        await dispatcher.dispatch(
+            messageID: "avatar-clear",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let after = await groups.currentGroups()
+        XCTAssertNil(after.first { $0.groupIDData == groupID }?.avatarJPEG,
+                     "admin-signed nil avatar clears the photo")
+    }
+
     func test_invitation_capturesSenderEd25519AsAdmin() async throws {
         // PR 9: the materializer stamps the inviting envelope's
         // senderEd25519PublicKey as the group's adminEd25519PubkeyHex
@@ -750,7 +852,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         groupID: Data,
         memberProfiles: [String: MemberProfile],
         adminEd25519PubkeyHex: String? = nil,
-        groupType: SEPGroupType = .anarchy
+        groupType: SEPGroupType = .anarchy,
+        avatarJPEG: Data? = nil
     ) async {
         // Default to .anarchy so the existing dispatcher tests skip
         // PR 13b's Tyranny-only on-chain commitment verification.
@@ -771,7 +874,8 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupType: groupType,
             adminPubkeyHex: nil,
             adminEd25519PubkeyHex: adminEd25519PubkeyHex,
-            isPublishedOnChain: true
+            isPublishedOnChain: true,
+            avatarJPEG: avatarJPEG
         )
         _ = await groups.insert(group)
     }
@@ -800,6 +904,20 @@ final class IncomingMessageDispatcherTests: XCTestCase {
 
     private static func encode(announcement: MemberAnnouncementPayload) throws -> Data {
         try JSONEncoder().encode(announcement)
+    }
+
+    private static func makeAvatar(groupID: Data, jpeg: Data?) -> GroupAvatarPayload {
+        GroupAvatarPayload(
+            version: 1,
+            groupID: groupID,
+            senderBlsPubkeyHex: "aa".repeated(48),
+            sentAtMillis: 1_700_000_000_000,
+            avatar: jpeg
+        )
+    }
+
+    private static func encode(avatar: GroupAvatarPayload) throws -> Data {
+        try JSONEncoder().encode(avatar)
     }
 
     /// Compute the real Tyranny commitment for a given (members,

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -88,6 +88,39 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         XCTAssertEqual(listed[0].memberProfiles, [:])
     }
 
+    // MARK: - Avatar
+
+    func test_insertOrUpdate_persistsAvatar() async {
+        let avatar = Data(repeating: 0xAB, count: 1234)
+        var group = makeGroup(id: "a0".repeated(32), name: "With photo")
+        group.avatarJPEG = avatar
+        _ = await store.insertOrUpdate(group)
+
+        let listed = await store.list()
+        XCTAssertEqual(listed[0].avatarJPEG, avatar)
+    }
+
+    func test_insertOrUpdate_nilAvatarRoundtripsAsNil() async {
+        let group = makeGroup(id: "a1".repeated(32), name: "No photo")
+        _ = await store.insertOrUpdate(group)
+
+        let listed = await store.list()
+        XCTAssertNil(listed[0].avatarJPEG)
+    }
+
+    func test_insertOrUpdate_clearsAvatarOnUpdate() async {
+        var group = makeGroup(id: "a2".repeated(32), name: "G")
+        group.avatarJPEG = Data(repeating: 0x01, count: 64)
+        _ = await store.insertOrUpdate(group)
+
+        var cleared = group
+        cleared.avatarJPEG = nil
+        _ = await store.insertOrUpdate(cleared)
+
+        let listed = await store.list()
+        XCTAssertNil(listed[0].avatarJPEG)
+    }
+
     // MARK: - Idempotence
 
     func test_insertOrUpdate_secondCallUpdatesInPlace() async {


### PR DESCRIPTION
Last of the group-avatar stack. **Base: #165.**

Adds the dedicated "avatar" message so the photo reaches late-joiners and can be changed after creation — the cases the invitation snapshot can't cover.

## What's here
- **`GroupAvatarPayload`** — admin-signed control message carrying the JPEG (or `nil` to clear). Distinct `avatar_*` wire keys so it can't structurally decode as a `ChatMessagePayload` (which shares version/group_id/sender/timestamp).
- **`GroupAvatarBroadcaster`** — applies locally, then seals + fans out one envelope per member inbox, mirroring `JoinRequestApprover`'s member-announcement loop.
- **Dispatcher fast-path** — decodes it, verifies the envelope's Ed25519 signer against the group's stored admin key (same trust gate as member announcements; no on-chain check since the avatar isn't part of the commitment), then applies.
- **Change-photo entry point** — admin-only picker in `ChatMembersView`, wired through `AppDependencies.setGroupAvatar`; non-admins see a read-only hero.
- **i18n** — en/ru for the new picker strings, plus fills the empty catalog keys `LocalizationCatalogTests` was already flagging (unrelated in-progress feature copy that was sitting untranslated in the catalog).

## Tests
`GroupAvatarPayloadTests` (round-trip, nil=removal, anti-collision both directions vs `ChatMessagePayload`); `IncomingMessageDispatcherTests` (apply on admin match, reject on mismatch, clear on nil). Full suite: 672 pass.

## Cross-platform follow-up
Android + relayer need to learn the `avatar` field on `GroupInvitationPayload` (#165) and the `GroupAvatarPayload` kind here to interop. iOS decodes both defensively, so nothing breaks until they catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)