### PR TITLE
feat(groups): invite by QR — show from Group Settings, scan to join

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -896,6 +896,23 @@
         }
       }
     },
+    "Choose Photo" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Photo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать фото"
+          }
+        }
+      }
+    },
     "Choose the contract version used to anchor on-chain group state. Selection per (network, governance type) pins to new chats; existing chats keep the contract they were created with." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1448,6 +1465,23 @@
         }
       }
     },
+    "Generate with AI" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate with AI"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать с помощью ИИ"
+          }
+        }
+      }
+    },
     "Generating proof and updating the on-chain commitment. This usually takes a few seconds." : {
       "localizations" : {
         "en" : {
@@ -1496,6 +1530,23 @@
         }
       }
     },
+    "Group photo" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Group photo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фото группы"
+          }
+        }
+      }
+    },
     "Have someone scan this code with Onym to open a private chat with %@." : {
       "localizations" : {
         "en" : {
@@ -1511,6 +1562,9 @@
           }
         }
       }
+    },
+    "Have them scan this with their camera to join." : {
+
     },
     "i" : {
       "localizations" : {
@@ -2489,6 +2543,23 @@
         }
       }
     },
+    "Remove Photo" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Photo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить фото"
+          }
+        }
+      }
+    },
     "Removing **%@** wipes its on-device secrets and every chat created under it. This cannot be undone — the recovery phrase is the only way back in." : {
       "localizations" : {
         "en" : {
@@ -2976,6 +3047,9 @@
         }
       }
     },
+    "That QR code isn't an Onym group invite. Ask the host to show the invite QR from the group's member list." : {
+
+    },
     "The phrase is generated on-device and never sent off the device." : {
       "localizations" : {
         "en" : {
@@ -3397,70 +3471,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваш релеер — ваши правила"
-          }
-        }
-      }
-    },
-    "Group photo" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Group photo"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Фото группы"
-          }
-        }
-      }
-    },
-    "Choose Photo" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose Photo"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбрать фото"
-          }
-        }
-      }
-    },
-    "Generate with AI" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generate with AI"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать с помощью ИИ"
-          }
-        }
-      }
-    },
-    "Remove Photo" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove Photo"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить фото"
           }
         }
       }

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -14,9 +14,19 @@ struct ChatsView: View {
     let sendMessageInteractor: SendMessageInteractor
     let makeCreateGroupFlow: @MainActor () -> CreateGroupFlow
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
+    let makeJoinFlow: @MainActor (IntroCapability) -> JoinFlow
     let setGroupAvatar: @MainActor (String, Data?) async -> Void
 
     @State private var showCreateGroup = false
+    @State private var showScanner = false
+    // Stashed across the scanner's dismissal — presenting the join
+    // sheet while the full-screen scanner is still tearing down races
+    // SwiftUI's presentation machinery, so we hand off in the cover's
+    // `onDismiss` instead. Exactly one is non-nil at a time.
+    @State private var scannedCapability: IntroCapability?
+    @State private var scannedInvalid = false
+    @State private var scanRejected = false
+    @State private var joinCapability: IntroCapability?
 
     var body: some View {
         Group {
@@ -44,6 +54,19 @@ struct ChatsView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 PendingInvitesToolbarButton(flow: pendingInvitesFlow)
             }
+            // Scan-to-join — the joiner-side counterpart to the host's
+            // invite QR (shown from Group Settings). Always available so
+            // a brand-new user can scan their way into a first group
+            // without a chat of their own yet.
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showScanner = true
+                } label: {
+                    Image(systemName: "qrcode.viewfinder")
+                }
+                .accessibilityLabel("Scan invite QR")
+                .accessibilityIdentifier("chats.scan_join_toolbar")
+            }
             // Plus button mirrors iOS Mail / Messages — useful once
             // the user already has at least one chat. Hidden in the
             // empty state because the central CTA already covers it.
@@ -68,6 +91,45 @@ struct ChatsView: View {
                 makeShareInviteFlow: makeShareInviteFlow,
                 onClose: { showCreateGroup = false }
             )
+        }
+        .fullScreenCover(isPresented: $showScanner, onDismiss: handleScannerDismiss) {
+            QRCodeScannerView(
+                onScanned: { raw in
+                    // Same allowlist + decode the deeplink path uses, so
+                    // a scanned link and a tapped link reach JoinView
+                    // identically. A non-invite QR yields nil → reject.
+                    if let cap = DeeplinkCapture.introCapability(fromString: raw) {
+                        scannedCapability = cap
+                    } else {
+                        scannedInvalid = true
+                    }
+                    showScanner = false
+                },
+                onCancel: { showScanner = false }
+            )
+        }
+        .sheet(item: $joinCapability) { cap in
+            JoinView(
+                flow: makeJoinFlow(cap),
+                onClose: { joinCapability = nil }
+            )
+        }
+        .alert("Not an Onym invite", isPresented: $scanRejected) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("That QR code isn't an Onym group invite. Ask the host to show the invite QR from the group's member list.")
+        }
+    }
+
+    /// Hands off the scan result once the full-screen scanner has fully
+    /// dismissed — see the `joinCapability`/`scannedCapability` note above.
+    private func handleScannerDismiss() {
+        if let cap = scannedCapability {
+            scannedCapability = nil
+            joinCapability = cap
+        } else if scannedInvalid {
+            scannedInvalid = false
+            scanRejected = true
         }
     }
 
@@ -115,6 +177,14 @@ struct ChatsView: View {
             .controlSize(.large)
             .padding(.top, 4)
             .accessibilityIdentifier("chats.create_group_empty_cta")
+            Button {
+                showScanner = true
+            } label: {
+                Label("Scan a QR to join", systemImage: "qrcode.viewfinder")
+                    .font(.subheadline.weight(.medium))
+            }
+            .buttonStyle(.borderless)
+            .accessibilityIdentifier("chats.scan_join_empty_cta")
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/OnymIOS/Group/ShareInviteView.swift
+++ b/Sources/OnymIOS/Group/ShareInviteView.swift
@@ -76,6 +76,20 @@ struct ShareInviteView: View {
                 .accessibilityIdentifier("share_invite.minting")
         case .ready(let link, let groupName):
             VStack(spacing: 12) {
+                SettingsQRCode(value: link, size: 220)
+                    .padding(14)
+                    .background(OnymTokens.surface2,
+                                in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .stroke(OnymTokens.hairline, lineWidth: 1))
+                    .accessibilityIdentifier("share_invite.qr_code")
+
+                Text("Have them scan this with their camera to join.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom, 4)
+
                 ShareLink(
                     item: link,
                     subject: Text(groupName ?? "Onym invite"),

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -35,6 +35,7 @@ struct RootView: View {
                         sendMessageInteractor: dependencies.sendMessageInteractor,
                         makeCreateGroupFlow: dependencies.makeCreateGroupFlow,
                         makeShareInviteFlow: dependencies.makeShareInviteFlow,
+                        makeJoinFlow: dependencies.makeJoinFlow,
                         setGroupAvatar: dependencies.setGroupAvatar
                     )
                 }


### PR DESCRIPTION
## What

Adds a QR-code path to the group-invite flow:

- **Host side** — `ShareInviteView` now renders the minted invite link as a QR code (reusing `SettingsQRCode`, the same renderer the identity `ShareKeyView` uses) above the existing Share / Copy actions. It appears wherever the invite sheet is presented: the post-create flow and **Group Settings** (the admin-only "Share invite" button on the member roster).
- **Joiner side** — `ChatsView` gets a "scan to join" entry point in two places: a toolbar button (`qrcode.viewfinder`, always visible) and a secondary button in the empty state (for a brand-new user joining their first group, who has no chat yet).

## How it routes

The scanned string is parsed through the **same `DeeplinkCapture` allowlist + decoder** that the tapped-universal-link path already uses, so a scanned QR and a tapped link both reach `JoinView` / `JoinFlow` identically — no new join logic. A non-invite QR surfaces a "Not an Onym invite" alert.

The scanner is a `fullScreenCover`; the join sheet / alert are handed off in the cover's `onDismiss` rather than mid-dismissal, because presenting a sheet while the cover is still tearing down races SwiftUI's presentation machinery and silently fails.

`RootView` threads the existing `dependencies.makeJoinFlow` into `ChatsView`. No new files, so no `generate-xcodeproj.sh` run needed.

## Files

- `Sources/OnymIOS/Group/ShareInviteView.swift` — QR in the `.ready` state.
- `Sources/OnymIOS/Chats/ChatsView.swift` — scan entry points + scanner/join/alert presentation.
- `Sources/OnymIOS/RootView.swift` — pass `makeJoinFlow`.
- `Resources/Localizable.xcstrings` — new strings (plus pending avatar strings extracted from the recent group-photo PRs).

## Test plan

- [ ] Group Settings → Share invite shows a scannable QR alongside Share/Copy.
- [ ] Chats toolbar + empty-state "scan" opens the camera; scanning a valid invite QR opens Join.
- [ ] Scanning a non-Onym QR shows the rejection alert.
- [ ] Tapping a universal link still opens Join unchanged.

## ⚠️ Known blocker (separate issue)

While testing this I confirmed a **pre-existing join regression unrelated to this UI**: after the recent *avatar-in-invitation-snapshot* PRs (#164/#165/#166), the sealed invitation now carries a ≤16 KB JPEG. The host's publish treats relay silence as acceptance (`NostrRelayConnection.timeoutPendingOK` returns `true`), so an oversized event that the relay drops looks successful to the host while the joiner receives nothing — joining fails for both scan **and** tapped-link paths. Needs its own fix (e.g. drop the avatar from the snapshot and rely on the dedicated avatar broadcast, or verify/raise the relay size budget). Filing/handling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)