### PR TITLE
fix(inbox): stop the launch-time get_commitment storm that breaks live joins

### DIFF
--- a/Sources/OnymIOS/Chain/CachingChainStateReader.swift
+++ b/Sources/OnymIOS/Chain/CachingChainStateReader.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Wraps a `ChainStateReading` with two defenses against the launch-time
+/// `get_commitment` request storm and the relayer throttling it triggers:
+///
+///  1. **Bounded retry** — a single transient read failure (relayer 429 /
+///     network blip) no longer surfaces as "couldn't verify". We retry a
+///     few times with linear backoff before giving up, so a momentarily
+///     throttled relayer doesn't make a fresh join silently fail.
+///  2. **Short TTL cache** — collapses a burst of reads for the *same*
+///     group (e.g. an invitation plus several member announcements
+///     replayed together on a relay reconnect) into one round-trip.
+///
+/// The TTL is deliberately short: a stale entry can only ever make a
+/// caller see an older `(commitment, epoch)`, which the dispatcher treats
+/// as "chain behind → defer + retry" (never a reject), so staleness
+/// self-heals once the entry expires. It is therefore safe to cache
+/// without risking a false rejection — the worst case is a brief deferral.
+///
+/// `SEPContractChainStateReader` itself stays cache-free (chain state is
+/// the source of truth); this decorator is the single place that trades a
+/// little staleness for far fewer relayer calls. Mirrors the posture
+/// onym-android should adopt around its own commitment reads.
+actor CachingChainStateReader: ChainStateReading {
+    private let inner: any ChainStateReading
+    private let ttl: TimeInterval
+    private let maxAttempts: Int
+    private let baseRetryDelayMillis: UInt64
+    private let now: @Sendable () -> Date
+
+    private var cache: [Data: (entry: SEPCommitmentEntry, at: Date)] = [:]
+
+    init(
+        inner: any ChainStateReading,
+        ttl: TimeInterval = 10,
+        maxAttempts: Int = 3,
+        baseRetryDelayMillis: UInt64 = 300,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.inner = inner
+        self.ttl = ttl
+        self.maxAttempts = max(1, maxAttempts)
+        self.baseRetryDelayMillis = baseRetryDelayMillis
+        self.now = now
+    }
+
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        if let hit = cache[groupID], now().timeIntervalSince(hit.at) < ttl {
+            return hit.entry
+        }
+
+        var lastError: Error?
+        for attempt in 0..<maxAttempts {
+            do {
+                let entry = try await inner.tyrannyCommitment(groupID: groupID)
+                cache[groupID] = (entry, now())
+                return entry
+            } catch {
+                lastError = error
+                // Linear backoff between attempts; no sleep after the last.
+                if attempt < maxAttempts - 1, baseRetryDelayMillis > 0 {
+                    let delay = baseRetryDelayMillis * UInt64(attempt + 1)
+                    try? await Task.sleep(nanoseconds: delay * 1_000_000)
+                }
+            }
+        }
+        throw lastError ?? ChainReadError.noActiveRelayer
+    }
+}

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -407,6 +407,23 @@ struct IncomingMessageDispatcher: Sendable {
             return .reject
         }
         guard recomputed == claimedCommitment else { return .reject }
+
+        // Skip the chain read when we've already verified+materialized
+        // this exact (commitment, epoch). Re-confirming what we confirmed
+        // on a prior pass adds nothing — the recompute above already
+        // rejects a replay that swaps the roster while reusing the
+        // commitment (Poseidon would have to collide). This is the
+        // load-bearing fix for the launch-time `get_commitment` storm:
+        // every relay reconnect replays the full inbox, and without this
+        // each replayed invitation re-hit the relayer, tripping its rate
+        // limit and making fresh joins fail until the burst subsided.
+        if let existing = await groupRepository.currentGroups()
+            .first(where: { $0.groupIDData == invitation.groupID }),
+           existing.commitment == claimedCommitment,
+           existing.epoch == invitation.epoch {
+            return .verified
+        }
+
         // External anchor: matches what's on chain.
         let onchain: SEPCommitmentEntry
         do {
@@ -414,13 +431,24 @@ struct IncomingMessageDispatcher: Sendable {
                 groupID: invitation.groupID
             )
         } catch {
-            return .reject
+            // Couldn't reach / read the relayer (throttled, offline, or
+            // unconfigured). NOT evidence of forgery — never reject. Defer
+            // so the verifier retries via the admin-refresh path and the
+            // group materializes once the read succeeds, instead of being
+            // silently dropped until the next relay replay (a restart).
+            return .staleNeedsRefresh
         }
         // Verify at current chain state (Option 2). The chain stores
         // only the LATEST (commitment, epoch), so a snapshot is only
         // byte-verifiable when the chain is exactly at its epoch.
-        //   - chain behind the snapshot → impossible for a real anchored
-        //     snapshot; reject.
+        //   - chain BEHIND the snapshot → our read is lagging the admin's
+        //     just-landed `update_commitment` (indexer/relayer catch-up),
+        //     OR a self-consistent forgery claiming a future epoch. We
+        //     can't tell here, so defer + ask the admin rather than
+        //     reject: deferral never materializes without a later exact-
+        //     epoch match, so a forgery still can't get in, while a real
+        //     lagging read recovers. (Previously a hard reject — the root
+        //     cause of "joiner only sees the chat after a restart".)
         //   - chain EXACTLY at the snapshot's epoch → byte-verify the
         //     committed roster. Strong anti-forgery: reproducing
         //     `Poseidon(Poseidon(root, epoch), salt)` needs the random
@@ -429,7 +457,7 @@ struct IncomingMessageDispatcher: Sendable {
         //   - chain AHEAD → can't byte-verify here; defer and ask the
         //     admin for the current state rather than trusting (and
         //     thereby letting a self-consistent fake materialize).
-        guard onchain.epoch >= invitation.epoch else { return .reject }
+        guard onchain.epoch >= invitation.epoch else { return .staleNeedsRefresh }
         if onchain.epoch == invitation.epoch {
             return onchain.commitment == claimedCommitment ? .verified : .reject
         }
@@ -526,6 +554,17 @@ struct IncomingMessageDispatcher: Sendable {
             return
         }
 
+        // Dedup BEFORE any chain read. The dedup key is BLS pubkey hex,
+        // mirroring the producer-side dictionary key in
+        // `JoinRequestApprover.recordJoiner`. Every relay reconnect
+        // replays the full inbox, so an already-applied announcement is
+        // re-delivered on each launch — bailing here keeps those replays
+        // from each firing a `get_commitment` against the relayer (the
+        // launch-time storm). Cheap, local, and idempotent.
+        let key = payload.newMember.blsPub
+            .map { String(format: "%02x", $0) }.joined()
+        if group.memberProfiles[key] != nil { return }
+
         // PR 9 trust check: announcement must be signed by the
         // group's known admin. Skipped (best-effort) when the group
         // has no stored admin Ed25519 — happens for governance
@@ -548,9 +587,6 @@ struct IncomingMessageDispatcher: Sendable {
             return
         }
 
-        let key = payload.newMember.blsPub
-            .map { String(format: "%02x", $0) }.joined()
-        if group.memberProfiles[key] != nil { return }
         var updated = group
         updated.memberProfiles[key] = MemberProfile(
             alias: payload.newMember.alias,

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -388,9 +388,16 @@ struct OnymIOSApp: App {
                     // announcements apply directly to
                     // `GroupRepository.memberProfiles`, everything
                     // else falls through to the invitations queue.
-                    let chainStateReader = SEPContractChainStateReader(
-                        relayers: relayerRepository,
-                        contracts: contractsRepository
+                    // Cache + retry around the raw relayer reads. Without
+                    // this, every relay reconnect replays the full inbox
+                    // and each replayed group-state message fired its own
+                    // `get_commitment`, storming the relayer into
+                    // throttling fresh joins. See `CachingChainStateReader`.
+                    let chainStateReader = CachingChainStateReader(
+                        inner: SEPContractChainStateReader(
+                            relayers: relayerRepository,
+                            contracts: contractsRepository
+                        )
                     )
                     let dispatcher = IncomingMessageDispatcher(
                         envelopeDecrypter: identityRepository,

--- a/Tests/OnymIOSTests/CachingChainStateReaderTests.swift
+++ b/Tests/OnymIOSTests/CachingChainStateReaderTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import OnymIOS
+
+/// Tests for the cache + retry decorator that tames the launch-time
+/// `get_commitment` storm and survives transient relayer throttling.
+final class CachingChainStateReaderTests: XCTestCase {
+
+    private let groupID = Data(repeating: 0x42, count: 32)
+
+    func test_cacheHit_collapsesRepeatReadsWithinTTL() async throws {
+        let inner = CountingChainState()
+        await inner.setResult(.success(entry(epoch: 3)))
+        let reader = CachingChainStateReader(inner: inner, ttl: 60, baseRetryDelayMillis: 0)
+
+        _ = try await reader.tyrannyCommitment(groupID: groupID)
+        _ = try await reader.tyrannyCommitment(groupID: groupID)
+
+        let calls = await inner.callCount
+        XCTAssertEqual(calls, 1, "second read within TTL is served from cache")
+    }
+
+    func test_cacheExpiry_readsAgainAfterTTL() async throws {
+        let inner = CountingChainState()
+        await inner.setResult(.success(entry(epoch: 3)))
+        // Clock the reader off a controllable now() so we can step past TTL.
+        let clock = MutableClock(start: Date(timeIntervalSince1970: 1_000))
+        let reader = CachingChainStateReader(
+            inner: inner, ttl: 10, baseRetryDelayMillis: 0, now: clock.now
+        )
+
+        _ = try await reader.tyrannyCommitment(groupID: groupID)
+        clock.advance(by: 11)  // past the 10s TTL
+        _ = try await reader.tyrannyCommitment(groupID: groupID)
+
+        let calls = await inner.callCount
+        XCTAssertEqual(calls, 2, "an expired cache entry triggers a fresh read")
+    }
+
+    func test_retry_recoversFromTransientFailure() async throws {
+        let inner = CountingChainState()
+        // Throw twice, then succeed — within the 3-attempt budget.
+        await inner.setSequence([
+            .failure(ChainReadError.noActiveRelayer),
+            .failure(ChainReadError.noActiveRelayer),
+            .success(entry(epoch: 7)),
+        ])
+        let reader = CachingChainStateReader(
+            inner: inner, ttl: 10, maxAttempts: 3, baseRetryDelayMillis: 0
+        )
+
+        let result = try await reader.tyrannyCommitment(groupID: groupID)
+        XCTAssertEqual(result.epoch, 7, "retry rides out two transient failures")
+        let calls = await inner.callCount
+        XCTAssertEqual(calls, 3)
+    }
+
+    func test_retry_exhausted_rethrows() async throws {
+        let inner = CountingChainState()
+        await inner.setResult(.failure(ChainReadError.noContractBinding))
+        let reader = CachingChainStateReader(
+            inner: inner, ttl: 10, maxAttempts: 3, baseRetryDelayMillis: 0
+        )
+
+        do {
+            _ = try await reader.tyrannyCommitment(groupID: groupID)
+            XCTFail("should have thrown after exhausting retries")
+        } catch {
+            XCTAssertEqual(error as? ChainReadError, .noContractBinding)
+        }
+        let calls = await inner.callCount
+        XCTAssertEqual(calls, 3, "all attempts are spent before giving up")
+    }
+
+    // MARK: - Helpers
+
+    private func entry(epoch: UInt64) -> SEPCommitmentEntry {
+        SEPCommitmentEntry(
+            commitment: Data(repeating: 0xCC, count: 32),
+            epoch: epoch,
+            timestamp: 0,
+            tier: 0,
+            active: nil
+        )
+    }
+}
+
+/// Inner reader that counts calls and yields a configurable result (fixed
+/// or a per-call sequence).
+private actor CountingChainState: ChainStateReading {
+    private(set) var callCount = 0
+    private var fixed: Result<SEPCommitmentEntry, Error> = .failure(ChainReadError.noActiveRelayer)
+    private var sequence: [Result<SEPCommitmentEntry, Error>] = []
+
+    func setResult(_ result: Result<SEPCommitmentEntry, Error>) { fixed = result }
+    func setSequence(_ results: [Result<SEPCommitmentEntry, Error>]) { sequence = results }
+
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        callCount += 1
+        if !sequence.isEmpty {
+            return try sequence.removeFirst().get()
+        }
+        return try fixed.get()
+    }
+}
+
+/// Tiny mutable clock so a test can step `now()` past the cache TTL
+/// deterministically (no real sleeping). `@unchecked Sendable` because the
+/// test drives it single-threaded.
+private final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: Date
+
+    init(start: Date) { current = start }
+
+    func advance(by seconds: TimeInterval) {
+        lock.withLock { current.addTimeInterval(seconds) }
+    }
+
+    var now: @Sendable () -> Date {
+        { [self] in lock.withLock { current } }
+    }
+}

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -1058,6 +1058,189 @@ final class IncomingMessageDispatcherTests: XCTestCase {
                        "stale invitation should be deferred to the verifier")
     }
 
+    func test_invitation_tyranny_redelivery_skipsChainReadWhenAlreadyVerified() async throws {
+        // The launch-time storm fix: a re-delivered invitation for an
+        // already-materialized (commitment, epoch) must NOT hit the
+        // relayer again. First delivery verifies (1 chain read) and
+        // materializes; the identical replay short-circuits on the local
+        // match, leaving the chain-read count at 1.
+        let groupID = Data(repeating: 0x42, count: 32)
+        let salt = Data(repeating: 0x66, count: 32)  // matches makeInvitationPayload
+        let realCommitment = try Self.makeRealTyrannyCommitment(
+            members: [], epoch: 0, salt: salt, tier: .small
+        )
+        chainState.setNext(commitment: realCommitment, epoch: 0)
+        let payload = makeInvitationPayload(
+            groupID: groupID,
+            name: "Family",
+            memberProfiles: nil,
+            groupType: .tyranny,
+            commitment: realCommitment
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: Data(repeating: 0xED, count: 32)
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+
+        await dispatcher.dispatch(messageID: "mat-1", ownerIdentityID: owner,
+                                  payload: Data("envelope".utf8), receivedAt: Date())
+        await dispatcher.dispatch(messageID: "mat-1-replay", ownerIdentityID: owner,
+                                  payload: Data("envelope".utf8), receivedAt: Date())
+
+        let after = await groups.currentGroups()
+        XCTAssertEqual(after.filter { $0.groupIDData == groupID }.count, 1,
+                       "idempotent — still exactly one group")
+        XCTAssertEqual(chainState.calls.count, 1,
+                       "replay of an already-verified snapshot must not re-read the chain")
+    }
+
+    func test_invitation_tyranny_chainReadThrows_defersInsteadOfReject() async throws {
+        // A throttled / unreachable relayer is not evidence of forgery.
+        // The invitation must be deferred (retried via the admin-refresh
+        // path), never silently dropped — that drop was the root cause of
+        // "joiner only sees the chat after a restart".
+        let groupID = Data(repeating: 0x42, count: 32)
+        let salt = Data(repeating: 0x66, count: 32)
+        let realCommitment = try Self.makeRealTyrannyCommitment(
+            members: [], epoch: 0, salt: salt, tier: .small
+        )
+        chainState.setNextThrows(ChainReadError.noActiveRelayer)  // simulate throttle/offline
+        let payload = makeInvitationPayload(
+            groupID: groupID,
+            name: "Family",
+            memberProfiles: nil,
+            groupType: .tyranny,
+            commitment: realCommitment
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: Data(repeating: 0xED, count: 32)
+        )
+        let refresher = SpyGroupStateRefresher()
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            groupStateRefresher: refresher
+        )
+
+        await dispatcher.dispatch(messageID: "mat-throw", ownerIdentityID: owner,
+                                  payload: Data("envelope".utf8), receivedAt: Date())
+
+        let after = await groups.currentGroups()
+        XCTAssertTrue(after.isEmpty, "unverifiable-now invitation must not materialize")
+        let deferred = await refresher.deferredGroupIDs()
+        XCTAssertEqual(deferred, [groupID],
+                       "a chain-read failure must defer (retry), not reject+drop")
+    }
+
+    func test_invitation_tyranny_chainBehind_defersInsteadOfReject() async throws {
+        // Admin just anchored epoch 1 and immediately sent the snapshot;
+        // our relayer read still lags at epoch 0. Treat as deferral, not a
+        // hard reject — deferral never materializes without a later exact-
+        // epoch match, so a forgery still can't slip in, while a real
+        // lagging read recovers live instead of only on restart.
+        let groupID = Data(repeating: 0x42, count: 32)
+        let salt = Data(repeating: 0x66, count: 32)
+        let realCommitment = try Self.makeRealTyrannyCommitment(
+            members: [], epoch: 1, salt: salt, tier: .small
+        )
+        chainState.setNext(commitment: Data(repeating: 0x00, count: 32), epoch: 0)  // behind
+        let payload = GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),
+            name: "Family",
+            members: [],
+            epoch: 1,
+            salt: salt,
+            commitment: realCommitment,
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.tyranny.rawValue,
+            adminPubkeyHex: nil
+        )
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: Data(repeating: 0xED, count: 32)
+        )
+        let refresher = SpyGroupStateRefresher()
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            groupStateRefresher: refresher
+        )
+
+        await dispatcher.dispatch(messageID: "mat-behind", ownerIdentityID: owner,
+                                  payload: Data("envelope".utf8), receivedAt: Date())
+
+        let after = await groups.currentGroups()
+        XCTAssertTrue(after.isEmpty, "chain-behind snapshot must not materialize unverified")
+        let deferred = await refresher.deferredGroupIDs()
+        XCTAssertEqual(deferred, [groupID],
+                       "chain-behind must defer (lagging read), not reject+drop")
+    }
+
+    func test_announcement_tyranny_knownMember_skipsChainRead() async throws {
+        // Re-delivered announcement for a member we already have must
+        // dedup BEFORE the chain read, so inbox replays don't storm the
+        // relayer.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let bobBlsHex = "bb".repeated(48)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [bobBlsHex: MemberProfile(
+                alias: "Bob",
+                inboxPublicKey: Data(repeating: 0x33, count: 32),
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
+            )],
+            adminEd25519PubkeyHex: "ed".repeated(32),
+            groupType: .tyranny
+        )
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: bobBlsHex,
+            joinerInboxByte: 0x33,
+            joinerAlias: "Bob",
+            adminAlias: "Alice"
+        ))
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: Data(repeating: 0xED, count: 32)
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+
+        await dispatcher.dispatch(messageID: "ann-known", ownerIdentityID: owner,
+                                  payload: Data("envelope".utf8), receivedAt: Date())
+
+        XCTAssertEqual(chainState.calls.count, 0,
+                       "known-member announcement must dedup before reading the chain")
+    }
+
     func test_refreshRequest_routedToVerifier() async throws {
         // An inbound GroupStateRefreshRequest is delegated to the
         // verifier (admin side) and never materializes / stores anything.


### PR DESCRIPTION
## Symptom

A joiner who scans/taps an invite and is approved often **doesn't see the group live** — it only appears after an app restart.

## Root cause (relayer-side, not transport)

The invitation arrives and persists fine (hence restart shows it). The break is in the receive-side verifier's relayer usage:

- Inbox subscriptions have **no `since` filter**, so every relay (re)connect replays the **entire inbox history**.
- The dispatcher did an **uncached `get_commitment`** per replayed group-state message (`verifyTyrannyInvitation`, `verifyTyrannyAnnouncement`) — and **before any dedup** (`applyAnnouncement`'s member-key check ran *after* the chain read).
- That self-inflicted burst **throttled the relayer**. A throttled/lagging read was then treated as a **hard reject**, silently dropping the very invitation being verified.
- A later replay (after restart, once the burst subsided / chain caught up) succeeded → "works after restart".

The same hard-reject hit a legitimate **chain-behind** read: the admin anchors epoch N then immediately sends the snapshot; the joiner's relayer read still lags at N-1 → `onchain.epoch < snapshot.epoch` → reject + drop.

## Fixes

1. **Skip the chain read when already locally verified.** If a group with the exact `(commitment, epoch)` is already materialized, return `.verified` without a relayer call. The local Poseidon recompute still runs first, so a replay that swaps the roster while reusing the commitment is still rejected. This removes nearly all of the startup reads.
2. **Dedup announcements before the chain read.** Move the BLS-pubkey-hex dedup in `applyAnnouncement` *above* `verifyTyrannyAnnouncement`, so re-delivered known members don't each hit the relayer.
3. **Throttle/lag ⇒ defer, not reject.** A chain-read throw (throttled/offline/unconfigured) and a chain-behind read now return `.staleNeedsRefresh` (defer + admin-refresh retry) instead of `.reject`. **Deferral never materializes without a later exact-epoch chain match**, so forgery protection is unchanged — only the false-drop is fixed.
4. **`CachingChainStateReader`** — bounded retry + short (10s) TTL cache around the raw relayer reads, wired in `OnymIOSApp`. A stale cache entry can only ever cause a brief *deferral* (never a false reject, given #3), so caching is safe here while `SEPContractChainStateReader` stays cache-free.

## Why it's safe (security)

The only `.reject` paths that remain are genuine cryptographic failures: missing commitment, internal recompute mismatch, and commitment mismatch **at an exact epoch**. All "couldn't verify *right now*" cases defer and re-verify, and never materialize a group without an exact-epoch on-chain match. Existing reject-path tests are unchanged and still green.

## Tests

`xcodebuild test … -only-testing:OnymIOSTests/IncomingMessageDispatcherTests -only-testing:OnymIOSTests/CachingChainStateReaderTests` → **31 passed, 0 failures**, including:
- skip-chain-read-on-verified-replay (asserts `calls == 1` across two deliveries)
- announcement dedup-before-read (asserts `calls == 0` for a known member)
- throw → defer, chain-behind → defer
- cache hit / expiry / retry-recovers / retry-exhausted
- all pre-existing reject + materialize tests still pass

## Follow-ups (not in this PR)

- Cap the Nostr replay itself (a `since` / processed-event high-water-mark) to cut inbound bandwidth — this PR cuts the *relayer* RPM, which was the harmful part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)