### PR TITLE
fix(l10n): translate QR-invite strings to satisfy the catalog test

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1564,7 +1564,68 @@
       }
     },
     "Have them scan this with their camera to join." : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Have them scan this with their camera to join."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Попросите отсканировать этот код камерой, чтобы присоединиться."
+          }
+        }
+      }
+    },
+    "Not an Onym invite" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not an Onym invite"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это не приглашение Onym"
+          }
+        }
+      }
+    },
+    "Scan a QR to join" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan a QR to join"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканируйте QR, чтобы присоединиться"
+          }
+        }
+      }
+    },
+    "Scan invite QR" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan invite QR"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканировать QR приглашения"
+          }
+        }
+      }
     },
     "i" : {
       "localizations" : {
@@ -3048,7 +3109,20 @@
       }
     },
     "That QR code isn't an Onym group invite. Ask the host to show the invite QR from the group's member list." : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That QR code isn't an Onym group invite. Ask the host to show the invite QR from the group's member list."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это не QR-код приглашения в группу Onym. Попросите администратора показать QR-код приглашения из списка участников группы."
+          }
+        }
+      }
     },
     "The phrase is generated on-device and never sent off the device." : {
       "localizations" : {


### PR DESCRIPTION
## Why

`main` is red on `LocalizationCatalogTests.test_localizable_xcstrings_everyKey_hasEnAndRu` (e.g. [this run](https://github.com/onymchat/onym-ios/actions/runs/26341553006/job/77544386469)). The QR-invite PRs (#168/#169) left two catalog keys with **no `en`/`ru` localizations** (`[en=false ru=false]`):

- `Have them scan this with their camera to join.`
- `That QR code isn't an Onym group invite. Ask the host to show the invite QR from the group's member list.`

## What

- Populate `en` + `ru` for both flagged keys.
- Add the three QR strings that weren't in the catalog at all yet — `Not an Onym invite`, `Scan a QR to join`, `Scan invite QR`. The test only checks keys already present, so these weren't failing it *yet*, but they'd render in English for `ru` users and would re-break CI the moment they got extracted. Adding them now closes both gaps.

## Verification

`xcodebuild test … -only-testing:OnymIOSTests/LocalizationCatalogTests` → **passed** (`test_localizable_xcstrings_everyKey_hasEnAndRu` green). JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)