### PR TITLE
feat(chat): plumb reply-to message reference end-to-end [1/3]

### DIFF
--- a/Sources/OnymIOS/Chats/ChatMessage.swift
+++ b/Sources/OnymIOS/Chats/ChatMessage.swift
@@ -44,6 +44,14 @@ struct ChatMessage: Equatable, Sendable, Identifiable {
     /// always `.received` at insert and never changes.
     let status: MessageStatus
 
+    /// The message this one replies to, if any. Mirrors
+    /// `ChatMessagePayload.replyToMessageID`. Only the target ID is
+    /// stored — the UI resolves the quoted sender + body by looking
+    /// this up among the group's other messages at render time, so a
+    /// target that isn't on this device renders as "message
+    /// unavailable" instead of carrying a stale copy of its text.
+    let replyToMessageID: UUID?
+
     /// Mirrors `ChatMessageVariant.kind`. Stored alongside the body so
     /// migrating to multi-variant rendering later doesn't need to
     /// re-fetch the group to learn the flavour.

--- a/Sources/OnymIOS/Chats/ChatMessagePayload.swift
+++ b/Sources/OnymIOS/Chats/ChatMessagePayload.swift
@@ -45,6 +45,16 @@ struct ChatMessagePayload: Codable, Equatable, Sendable {
     /// `Date`) so the wire format is unambiguous and cross-platform.
     let sentAtMillis: Int64
 
+    /// The message this one replies to, if any. Optional + additive,
+    /// so it ships under `version = 1`: a sender that omits it decodes
+    /// to `nil` on any receiver, and an old receiver decoding a payload
+    /// that carries it just ignores the unknown key. Only the target's
+    /// ID travels — the receiver resolves the quoted sender + body from
+    /// its own local store at render time, so a dangling ref (target
+    /// never delivered) degrades to "message unavailable" rather than
+    /// carrying stale text.
+    let replyToMessageID: UUID?
+
     /// Governance-keyed payload body. See `ChatMessageVariant`.
     let variant: ChatMessageVariant
 
@@ -54,6 +64,7 @@ struct ChatMessagePayload: Codable, Equatable, Sendable {
         case groupID = "group_id"
         case senderBlsPubkeyHex = "sender_bls_pubkey_hex"
         case sentAtMillis = "sent_at_millis"
+        case replyToMessageID = "reply_to_message_id"
         case variant
     }
 }

--- a/Sources/OnymIOS/Chats/PersistedMessage.swift
+++ b/Sources/OnymIOS/Chats/PersistedMessage.swift
@@ -12,6 +12,11 @@ import SwiftData
 ///   delete on identity removal needs a predicate over this.
 /// - `sentAt` — sort column for the chat scroll order.
 /// - `directionRaw`, `statusRaw`, `groupTypeRaw` — small enums.
+/// - `replyToMessageIDString` — optional UUID of the replied-to
+///   message. Plain (not sensitive — it's just a pointer to another
+///   row in this same table) and left queryable for a future
+///   "replies to X" lookup. Optional, so adding it is a SwiftData
+///   lightweight migration over the existing store.
 ///
 /// Encrypted (`StorageEncryption.encrypt`):
 /// - `senderBlsPubkeyHex` — group-membership identifier; consistent
@@ -30,6 +35,7 @@ final class PersistedMessage {
     var directionRaw: String
     var statusRaw: String
     var groupTypeRaw: String
+    var replyToMessageIDString: String?
 
     var encryptedSenderBlsPubkeyHex: Data
     var encryptedBody: Data
@@ -42,6 +48,7 @@ final class PersistedMessage {
         directionRaw: String,
         statusRaw: String,
         groupTypeRaw: String,
+        replyToMessageIDString: String?,
         encryptedSenderBlsPubkeyHex: Data,
         encryptedBody: Data
     ) {
@@ -52,6 +59,7 @@ final class PersistedMessage {
         self.directionRaw = directionRaw
         self.statusRaw = statusRaw
         self.groupTypeRaw = groupTypeRaw
+        self.replyToMessageIDString = replyToMessageIDString
         self.encryptedSenderBlsPubkeyHex = encryptedSenderBlsPubkeyHex
         self.encryptedBody = encryptedBody
     }

--- a/Sources/OnymIOS/Chats/SendMessageInteractor.swift
+++ b/Sources/OnymIOS/Chats/SendMessageInteractor.swift
@@ -52,6 +52,7 @@ actor SendMessageInteractor {
     func send(
         groupID: String,
         body: String,
+        replyToMessageID: UUID? = nil,
         now: Date = Date()
     ) async throws -> ChatMessage {
         guard !body.isEmpty else { throw SendError.emptyBody }
@@ -90,6 +91,7 @@ actor SendMessageInteractor {
             groupID: group.groupIDData,
             senderBlsPubkeyHex: myBlsHex,
             sentAtMillis: sentAtMillis,
+            replyToMessageID: replyToMessageID,
             variant: variant
         )
 
@@ -106,6 +108,7 @@ actor SendMessageInteractor {
             sentAt: now,
             direction: .outgoing,
             status: .pending,
+            replyToMessageID: replyToMessageID,
             groupType: group.groupType
         )
         await messageRepository.insert(pending)
@@ -136,6 +139,7 @@ actor SendMessageInteractor {
             sentAt: pending.sentAt,
             direction: pending.direction,
             status: finalStatus,
+            replyToMessageID: pending.replyToMessageID,
             groupType: pending.groupType
         )
     }
@@ -193,6 +197,7 @@ actor SendMessageInteractor {
             groupID: group.groupIDData,
             senderBlsPubkeyHex: myBlsHex,
             sentAtMillis: Int64(message.sentAt.timeIntervalSince1970 * 1000),
+            replyToMessageID: message.replyToMessageID,
             variant: variant
         )
 

--- a/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
+++ b/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
@@ -91,6 +91,7 @@ actor SwiftDataMessageStore: MessageStore {
             existing.directionRaw = encoded.directionRaw
             existing.statusRaw = encoded.statusRaw
             existing.groupTypeRaw = encoded.groupTypeRaw
+            existing.replyToMessageIDString = encoded.replyToMessageIDString
             existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
             existing.encryptedBody = encoded.encryptedBody
             try? context.save()
@@ -154,6 +155,7 @@ actor SwiftDataMessageStore: MessageStore {
             directionRaw: message.direction.rawValue,
             statusRaw: message.status.rawValue,
             groupTypeRaw: message.groupType.rawValue,
+            replyToMessageIDString: message.replyToMessageID?.uuidString,
             encryptedSenderBlsPubkeyHex: try StorageEncryption.encrypt(message.senderBlsPubkeyHex),
             encryptedBody: try StorageEncryption.encrypt(message.body)
         )
@@ -180,6 +182,7 @@ actor SwiftDataMessageStore: MessageStore {
             sentAt: row.sentAt,
             direction: direction,
             status: status,
+            replyToMessageID: row.replyToMessageIDString.flatMap(UUID.init(uuidString:)),
             groupType: groupType
         )
     }

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -698,6 +698,13 @@ struct IncomingMessageDispatcher: Sendable {
             sentAt: sentAt,
             direction: .incoming,
             status: .received,
+            // Pointer to the quoted message, resolved against the
+            // local store at render time. No trust gate needed: a ref
+            // to a message we never received (or a forged one) just
+            // renders as "message unavailable" — it can't pull in
+            // content from outside this group because rendering only
+            // looks up local rows.
+            replyToMessageID: payload.replyToMessageID,
             groupType: group.groupType
         )
         await messageRepository.insert(message)

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -319,6 +319,7 @@ final class ChatBubbleCellTests: XCTestCase {
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
             direction: direction,
             status: status ?? (direction == .incoming ? .received : .sent),
+            replyToMessageID: nil,
             groupType: .tyranny
         )
     }

--- a/Tests/OnymIOSTests/ChatMessagePayloadTests.swift
+++ b/Tests/OnymIOSTests/ChatMessagePayloadTests.swift
@@ -37,6 +37,50 @@ final class ChatMessagePayloadTests: XCTestCase {
         XCTAssertEqual(decoded.variant.body, "héllo 🌍 こんにちは")
     }
 
+    // MARK: - Reply reference
+
+    func test_roundtrip_replyRef_preservesTargetID() throws {
+        let target = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let original = makePayload(body: "agreed", replyToMessageID: target)
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: encoded)
+        XCTAssertEqual(decoded.replyToMessageID, target)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_wireFormat_replyKeyIsSnakeCase() throws {
+        let target = UUID()
+        let encoded = try JSONEncoder().encode(makePayload(body: "hi", replyToMessageID: target))
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertEqual(obj?["reply_to_message_id"] as? String, target.uuidString)
+    }
+
+    func test_wireFormat_noReply_omitsKey() throws {
+        // A non-reply message should encode `null` (or omit) — never a
+        // bogus UUID. `JSONEncoder` writes `null` for a nil Optional.
+        let encoded = try JSONEncoder().encode(makePayload(body: "hi"))
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNil(obj?["reply_to_message_id"] as? String,
+                     "a non-reply message must not carry a reply target")
+    }
+
+    func test_decode_missingReplyKey_isNil() throws {
+        // Backward compat: a payload from an older sender (pre-replies)
+        // has no `reply_to_message_id` — it must decode to nil, not throw.
+        let json = #"""
+        {
+          "version": 1,
+          "message_id": "11111111-1111-1111-1111-111111111111",
+          "group_id": "QkJC",
+          "sender_bls_pubkey_hex": "ab",
+          "sent_at_millis": 0,
+          "variant": { "kind": "tyranny", "body": "hi" }
+        }
+        """#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: json)
+        XCTAssertNil(decoded.replyToMessageID)
+    }
+
     // MARK: - Wire format
 
     func test_wireFormat_snakeCaseKeys() throws {
@@ -129,13 +173,17 @@ final class ChatMessagePayloadTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makePayload(body: String) -> ChatMessagePayload {
+    private func makePayload(
+        body: String,
+        replyToMessageID: UUID? = nil
+    ) -> ChatMessagePayload {
         ChatMessagePayload(
             version: 1,
             messageID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
             groupID: Data(repeating: 0x42, count: 32),
             senderBlsPubkeyHex: String(repeating: "ab", count: 48),
             sentAtMillis: 1_700_000_000_000,
+            replyToMessageID: replyToMessageID,
             variant: .tyranny(body: body)
         )
     }

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -282,6 +282,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             sentAt: failed.sentAt,
             direction: failed.direction,
             status: .failed,
+            replyToMessageID: nil,
             groupType: failed.groupType
         )
 
@@ -323,6 +324,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
             direction: .outgoing,
             status: .pending,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
         vc.update(messages: [pending])
@@ -349,6 +351,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             sentAt: pending.sentAt,
             direction: .outgoing,
             status: .sent,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
         vc.update(messages: [sentRow])
@@ -516,7 +519,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             id: UUID(), groupID: "aa".repeated(32), ownerIdentityID: IdentityID(),
             senderBlsPubkeyHex: sender, body: body,
             sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
-            direction: .incoming, status: .received, groupType: groupType
+            direction: .incoming, status: .received, replyToMessageID: nil, groupType: groupType
         )
     }
 
@@ -527,7 +530,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             id: UUID(), groupID: "aa".repeated(32), ownerIdentityID: IdentityID(),
             senderBlsPubkeyHex: sender, body: body,
             sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
-            direction: .outgoing, status: .sent, groupType: .tyranny
+            direction: .outgoing, status: .sent, replyToMessageID: nil, groupType: .tyranny
         )
     }
 
@@ -559,6 +562,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             sentAt: sentAt,
             direction: direction,
             status: direction == .incoming ? .received : .sent,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
     }

--- a/Tests/OnymIOSTests/GroupAvatarPayloadTests.swift
+++ b/Tests/OnymIOSTests/GroupAvatarPayloadTests.swift
@@ -44,6 +44,7 @@ final class GroupAvatarPayloadTests: XCTestCase {
             groupID: Data(repeating: 0x42, count: 32),
             senderBlsPubkeyHex: "aa".repeated(48),
             sentAtMillis: 1_700_000_000_000,
+            replyToMessageID: nil,
             variant: .tyranny(body: "hello")
         )
         let bytes = try JSONEncoder().encode(chat)

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -92,6 +92,27 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         XCTAssertEqual(stored[0].status, .received)
         XCTAssertEqual(stored[0].senderBlsPubkeyHex, senderBlsHex)
         XCTAssertEqual(stored[0].groupType, .tyranny)
+        XCTAssertNil(stored[0].replyToMessageID)
+    }
+
+    func test_chatMessage_withReplyRef_persistsTargetID() async throws {
+        let target = UUID()
+        let payload = makePayload(body: "agreed", replyToMessageID: target)
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-reply",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertEqual(stored.first?.replyToMessageID, target,
+                       "an inbound reply must carry its target id onto the persisted message")
     }
 
     // MARK: - Drop paths
@@ -257,6 +278,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             groupID: secondGroupBytes,
             senderBlsPubkeyHex: secondSenderBlsHex,
             sentAtMillis: 1_700_000_500_000,
+            replyToMessageID: nil,
             variant: .tyranny(body: "for the second identity")
         )
         let dispatcher = makeDispatcher(
@@ -315,7 +337,8 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         body: String,
         groupIDBytes: Data? = nil,
         senderBlsHex: String? = nil,
-        messageID: UUID = UUID()
+        messageID: UUID = UUID(),
+        replyToMessageID: UUID? = nil
     ) -> ChatMessagePayload {
         ChatMessagePayload(
             version: 1,
@@ -323,6 +346,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             groupID: groupIDBytes ?? self.groupIDBytes,
             senderBlsPubkeyHex: senderBlsHex ?? self.senderBlsHex,
             sentAtMillis: 1_700_000_000_000,
+            replyToMessageID: replyToMessageID,
             variant: .tyranny(body: body)
         )
     }

--- a/Tests/OnymIOSTests/MessageRepositoryTests.swift
+++ b/Tests/OnymIOSTests/MessageRepositoryTests.swift
@@ -196,6 +196,7 @@ final class MessageRepositoryTests: XCTestCase {
             sentAt: sentAt,
             direction: .outgoing,
             status: status,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
     }
@@ -235,6 +236,7 @@ private actor InMemoryMessageStore: MessageStore {
             sentAt: existing.sentAt,
             direction: existing.direction,
             status: status,
+            replyToMessageID: existing.replyToMessageID,
             groupType: existing.groupType
         )
     }

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -135,6 +135,29 @@ final class SendMessageInteractorTests: XCTestCase {
         XCTAssertEqual(stored.count, 1)
     }
 
+    func test_send_withReplyRef_carriesTargetOntoMessage() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        let target = UUID()
+
+        let result = try await interactor.send(
+            groupID: groupID,
+            body: "agreed",
+            replyToMessageID: target
+        )
+        XCTAssertEqual(result.replyToMessageID, target,
+                       "the returned message must carry the reply target")
+
+        let stored = await messages.currentMessages(groupID: groupID)
+        XCTAssertEqual(stored.first?.replyToMessageID, target,
+                       "the optimistically-inserted row must carry the reply target")
+    }
+
+    func test_send_noReplyRef_isNil() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        let result = try await interactor.send(groupID: groupID, body: "plain")
+        XCTAssertNil(result.replyToMessageID)
+    }
+
     // MARK: - Status transitions
 
     func test_send_allRelaysReject_marksFailed() async throws {

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -50,6 +50,20 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         XCTAssertEqual(first.direction, .outgoing)
         XCTAssertEqual(first.status, .pending)
         XCTAssertEqual(first.groupType, .tyranny)
+        XCTAssertNil(first.replyToMessageID,
+                     "a non-reply message round-trips with no reply target")
+    }
+
+    func test_insertOrUpdate_replyRef_roundtrips() async {
+        let groupID = "aa".repeated(32)
+        let target = UUID()
+        let reply = makeMessage(groupID: groupID, body: "agreed", replyToMessageID: target)
+
+        _ = await store.insertOrUpdate(reply)
+
+        let listed = await store.list(groupID: groupID)
+        XCTAssertEqual(listed.first?.replyToMessageID, target,
+                       "the reply target id must survive the encrypted-store round-trip")
     }
 
     func test_insertOrUpdate_sameID_updatesInPlace() async {
@@ -66,6 +80,7 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             sentAt: msg.sentAt,
             direction: .outgoing,
             status: .sent,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
         let inserted = await store.insertOrUpdate(updated)
@@ -190,7 +205,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         body: String = "hi",
         sentAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
         direction: MessageDirection = .outgoing,
-        status: MessageStatus = .sent
+        status: MessageStatus = .sent,
+        replyToMessageID: UUID? = nil
     ) -> ChatMessage {
         ChatMessage(
             id: id,
@@ -201,6 +217,7 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             sentAt: sentAt,
             direction: direction,
             status: status,
+            replyToMessageID: replyToMessageID,
             groupType: .tyranny
         )
     }


### PR DESCRIPTION
First of three stacked PRs adding Telegram-style replies to chat. **Data layer only — no UI yet.**

## What
Carry an optional `replyToMessageID` through the full chat round-trip so a message can point at an earlier one in the same group. Only the target id travels on the wire and to disk; the quoted sender + body are resolved live from the local store at render time (PR 2).

## Changes
- **`ChatMessagePayload`** — add optional `reply_to_message_id`. Additive + optional, so it ships under `version = 1`: older senders omit it (decodes to nil), older receivers ignore it.
- **`ChatMessage` / `PersistedMessage`** — add `replyToMessageID`. Plain (unencrypted) column — it's a pointer to another row in the same table, left queryable for a future "replies to X" lookup. Adding an optional property is a SwiftData lightweight migration.
- **`SendMessageInteractor`** — `send(...)` takes the ref (default nil) → payload + optimistic row + return value; `retry(...)` reconstructs it from the stored row so retries don't drop it.
- **`IncomingMessageDispatcher`** — map the ref onto the inbound message. No new trust gate: a dangling/forged ref just renders "unavailable" since rendering only resolves local rows.

## Tests
6 new (payload round-trip + back-compat decode of a pre-replies payload, store round-trip, inbound mapping, send carrying the ref) plus every existing `ChatMessage`/`ChatMessagePayload` constructor updated. Full affected suite: **108 tests, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)