### PR TITLE
fix(chat): keep the latest message pinned to the input area as the keyboard moves

### DIFF
--- a/Sources/OnymIOS/Chats/ChatBubbleCell.swift
+++ b/Sources/OnymIOS/Chats/ChatBubbleCell.swift
@@ -119,6 +119,23 @@ final class ChatBubbleCell: UITableViewCell {
     private var onQuoteTapped: (() -> Void)?
     private var quoteTapRecognizer: UITapGestureRecognizer?
 
+    /// Fired when the user drags the bubble far enough left to arm a
+    /// reply (Telegram-style). Available on every message regardless of
+    /// direction or status. Set on each `configure`; reset transform on
+    /// reuse so a recycled mid-drag cell starts clean.
+    var onSwipeToReply: (() -> Void)?
+    private var swipePan: UIPanGestureRecognizer!
+    private let replyHint = UIImageView()
+    /// Drag distance (points) past which releasing arms a reply.
+    private let swipeReplyThreshold: CGFloat = 56
+    /// How far the bubble can travel — past the threshold it resists so
+    /// the gesture has a clear "armed" ceiling.
+    private let swipeMaxTravel: CGFloat = 72
+    /// True once the current drag crossed the threshold — drives the
+    /// one-shot haptic and the release decision.
+    private var swipeArmed = false
+    private let swipeHaptic = UIImpactFeedbackGenerator(style: .medium)
+
     // Direction-dependent constraints — only one pair is active at a
     // time. Each pair contains the alignment pin (`==` to the pinned
     // edge) and the opposite-edge breathing-room gap on the *other*
@@ -160,6 +177,7 @@ final class ChatBubbleCell: UITableViewCell {
         buildStatusIndicator()
         buildNameLabel()
         layoutBubble()
+        installSwipeToReply()
     }
 
     @available(*, unavailable)
@@ -176,8 +194,12 @@ final class ChatBubbleCell: UITableViewCell {
         sender: ChatSenderDisplay = .unknown,
         reply: ChatReplyQuote? = nil,
         onRetry: (() -> Void)? = nil,
-        onQuoteTapped: (() -> Void)? = nil
+        onQuoteTapped: (() -> Void)? = nil,
+        onSwipeToReply: (() -> Void)? = nil
     ) {
+        // Reuse safety: a cell recycled mid-drag must start at rest.
+        resetSwipeState()
+        self.onSwipeToReply = onSwipeToReply
         bodyLabel.text = message.body
         switch message.direction {
         case .outgoing:
@@ -314,6 +336,85 @@ final class ChatBubbleCell: UITableViewCell {
         onQuoteTapped?()
     }
 
+    // MARK: - Swipe to reply
+
+    private func installSwipeToReply() {
+        replyHint.translatesAutoresizingMaskIntoConstraints = false
+        replyHint.image = UIImage(systemName: "arrowshape.turn.up.left.fill")
+        replyHint.tintColor = UIColor(OnymTokens.text3)
+        replyHint.contentMode = .scaleAspectFit
+        replyHint.alpha = 0
+        replyHint.accessibilityIdentifier = "chat.bubble.reply_hint"
+        contentView.addSubview(replyHint)
+        NSLayoutConstraint.activate([
+            replyHint.centerYAnchor.constraint(equalTo: bubble.centerYAnchor),
+            replyHint.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -14),
+            replyHint.widthAnchor.constraint(equalToConstant: 22),
+            replyHint.heightAnchor.constraint(equalToConstant: 22),
+        ])
+
+        let pan = UIPanGestureRecognizer(target: self, action: #selector(handleSwipePan(_:)))
+        pan.delegate = self
+        contentView.addGestureRecognizer(pan)
+        swipePan = pan
+    }
+
+    @objc private func handleSwipePan(_ pan: UIPanGestureRecognizer) {
+        let tx = pan.translation(in: contentView).x
+        switch pan.state {
+        case .began:
+            swipeArmed = false
+            swipeHaptic.prepare()
+        case .changed:
+            // Leftward drag only; clamp travel so the bubble can't be
+            // dragged off-screen and the "armed" point reads as a wall.
+            let drag = min(swipeMaxTravel, max(0, -tx))
+            applySwipeTranslation(drag)
+            let progress = min(1, drag / swipeReplyThreshold)
+            replyHint.alpha = progress
+            let scale = 0.6 + 0.4 * progress
+            replyHint.transform = CGAffineTransform(scaleX: scale, y: scale)
+            if drag >= swipeReplyThreshold, !swipeArmed {
+                swipeArmed = true
+                swipeHaptic.impactOccurred()   // one-shot "armed" tick
+            } else if drag < swipeReplyThreshold {
+                swipeArmed = false
+            }
+        case .ended, .cancelled, .failed:
+            let fire = swipeArmed && pan.state == .ended
+            swipeArmed = false
+            UIView.animate(
+                withDuration: 0.25, delay: 0,
+                usingSpringWithDamping: 0.7, initialSpringVelocity: 0.5,
+                options: [.allowUserInteraction]
+            ) {
+                self.applySwipeTranslation(0)
+                self.replyHint.alpha = 0
+                self.replyHint.transform = .identity
+            }
+            if fire { onSwipeToReply?() }
+        default:
+            break
+        }
+    }
+
+    /// Translate the moving parts of the row by `dx` points to the
+    /// left. The reply hint stays put at the trailing edge and is
+    /// revealed by the gap the bubble opens up.
+    private func applySwipeTranslation(_ dx: CGFloat) {
+        let t = CGAffineTransform(translationX: -dx, y: 0)
+        bubble.transform = t
+        statusImageView.transform = t
+        nameLabel.transform = t
+    }
+
+    private func resetSwipeState() {
+        swipeArmed = false
+        applySwipeTranslation(0)
+        replyHint.alpha = 0
+        replyHint.transform = .identity
+    }
+
     /// Brief background pulse on the bubble — used by the host to draw
     /// the eye to a message after scrolling to it from a tapped quote.
     func flashHighlight() {
@@ -373,6 +474,12 @@ final class ChatBubbleCell: UITableViewCell {
         let installed = quoteTapRecognizer != nil
         tappedQuote()
         return installed
+    }
+
+    /// Test seam for the swipe-to-reply gesture — fires the armed-reply
+    /// callback the same way a past-threshold drag-release would.
+    func simulateSwipeToReplyForTest() {
+        onSwipeToReply?()
     }
     #endif
 
@@ -557,5 +664,29 @@ final class ChatBubbleCell: UITableViewCell {
         bubbleBottomConstraint.isActive = true
         bubbleTopToContentConstraint.isActive = true
         bodyTopToBubbleConstraint.isActive = true
+    }
+}
+
+// UIView already conforms to `UIGestureRecognizerDelegate` and ships
+// these as overridable methods, so we extend (not re-conform) and mark
+// both `override`. The cell is the swipe pan's own delegate.
+extension ChatBubbleCell {
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === swipePan else { return true }
+        // Claim only a clearly leftward, mostly-horizontal drag so the
+        // table's vertical scroll keeps working and the controller's
+        // rightward full-width back-pan is unaffected.
+        let velocity = swipePan.velocity(in: contentView)
+        return velocity.x < 0 && abs(velocity.x) > abs(velocity.y)
+    }
+
+    override func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+    ) -> Bool {
+        // Coexist with the scroll view's pan — `shouldBegin` already
+        // restricts us to horizontal drags, so the two don't fight in
+        // practice.
+        true
     }
 }

--- a/Sources/OnymIOS/Chats/ChatBubbleCell.swift
+++ b/Sources/OnymIOS/Chats/ChatBubbleCell.swift
@@ -28,6 +28,34 @@ struct ChatSenderDisplay {
     static let unknown = ChatSenderDisplay(name: "", accent: .blue, showNameHeader: false)
 }
 
+/// Resolved quote shown at the top of a bubble that replies to an
+/// earlier message — the Telegram-style inset preview. Built by
+/// `ChatThreadViewController` by looking the reply target up in the
+/// local message list; the cell just renders it.
+///
+/// The target is resolved *live* (not snapshotted into the payload),
+/// so when it isn't on this device the controller hands over
+/// `unavailable` and the cell renders a muted placeholder instead of
+/// a real sender + snippet.
+struct ChatReplyQuote {
+    /// Quoted sender's display name (alias or BLS fingerprint).
+    let name: String
+    /// Quoted message body, rendered on a single truncated line.
+    let snippet: String
+    /// Quoted sender's accent — colors the leading bar and the name,
+    /// so the quote reads as "from that person" at a glance.
+    let accent: OnymAccent
+    /// The reply target isn't in the local store (never delivered, or
+    /// deleted). Renders a muted "message unavailable" placeholder and
+    /// the quote isn't tappable.
+    let isUnavailable: Bool
+
+    /// Placeholder for a reply whose target this device doesn't have.
+    static let unavailable = ChatReplyQuote(
+        name: "", snippet: "", accent: .blue, isUnavailable: true
+    )
+}
+
 /// One message bubble row. Two visual styles toggled by
 /// `ChatMessage.direction`:
 ///
@@ -62,6 +90,15 @@ final class ChatBubbleCell: UITableViewCell {
     private let statusImageView = UIImageView()
     private let nameLabel = UILabel()
 
+    // Reply quote (Telegram-style inset preview at the top of the
+    // bubble). `quoteContainer` holds the accent bar + the two labels;
+    // it's hidden unless the message replies to another. Tapping it
+    // fires `onQuoteTapped` so the host can jump to the original.
+    private let quoteContainer = UIView()
+    private let quoteBar = UIView()
+    private let quoteNameLabel = UILabel()
+    private let quoteSnippetLabel = UILabel()
+
     /// Incoming bubble tint opacity over the background. Low enough that
     /// `OnymTokens.text` stays readable on top, high enough that the
     /// sender's accent reads at a glance.
@@ -74,6 +111,13 @@ final class ChatBubbleCell: UITableViewCell {
     /// fire this.
     private var onRetryRequested: (() -> Void)?
     private var retryTapRecognizer: UITapGestureRecognizer?
+
+    /// Set by the cell provider when the message replies to another
+    /// and the target is available. Fires when the user taps the
+    /// quote — the host scrolls to + flashes the original. Cleared on
+    /// every reuse so a recycled cell doesn't keep a stale target.
+    private var onQuoteTapped: (() -> Void)?
+    private var quoteTapRecognizer: UITapGestureRecognizer?
 
     // Direction-dependent constraints — only one pair is active at a
     // time. Each pair contains the alignment pin (`==` to the pinned
@@ -100,12 +144,19 @@ final class ChatBubbleCell: UITableViewCell {
     private var bubbleTopToNameConstraint: NSLayoutConstraint!
     private var nameTopConstraint: NSLayoutConstraint!
 
+    // Body-top toggle for the reply quote. Without a quote the body
+    // pins to the bubble's top inset (the common case); with one it
+    // hangs off the quote container's bottom. Exactly one is active.
+    private var bodyTopToBubbleConstraint: NSLayoutConstraint!
+    private var bodyTopToQuoteConstraint: NSLayoutConstraint!
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         backgroundColor = .clear
         selectionStyle = .none
         contentView.backgroundColor = UIColor(OnymTokens.bg)
         buildBubble()
+        buildQuote()
         buildStatusIndicator()
         buildNameLabel()
         layoutBubble()
@@ -123,7 +174,9 @@ final class ChatBubbleCell: UITableViewCell {
     func configure(
         message: ChatMessage,
         sender: ChatSenderDisplay = .unknown,
-        onRetry: (() -> Void)? = nil
+        reply: ChatReplyQuote? = nil,
+        onRetry: (() -> Void)? = nil,
+        onQuoteTapped: (() -> Void)? = nil
     ) {
         bodyLabel.text = message.body
         switch message.direction {
@@ -151,6 +204,7 @@ final class ChatBubbleCell: UITableViewCell {
             statusImageView.isHidden = true
         }
         applyNameHeader(sender)
+        applyReplyQuote(reply, direction: message.direction, onTap: onQuoteTapped)
 
         // Retry tap is only installed when the message is failed
         // *and* the host provided a retry callback. Cell reuse:
@@ -190,6 +244,90 @@ final class ChatBubbleCell: UITableViewCell {
         }
     }
 
+    /// Show or hide the reply quote, re-pinning the body's top to the
+    /// quote (when shown) or the bubble (when not). Colors track the
+    /// bubble direction: an outgoing bubble is a solid accent fill, so
+    /// the quote reads in the on-accent color; an incoming bubble is a
+    /// light tint, so the quote uses the quoted sender's accent. An
+    /// unavailable target gets a muted, untappable placeholder.
+    ///
+    /// Called on every `configure` (including reuse), so a recycled
+    /// cell that previously showed a quote drops it — and its tap
+    /// target — cleanly.
+    private func applyReplyQuote(
+        _ reply: ChatReplyQuote?,
+        direction: MessageDirection,
+        onTap: (() -> Void)?
+    ) {
+        // Always tear down any prior tap target first (reuse safety).
+        if let existing = quoteTapRecognizer {
+            quoteContainer.removeGestureRecognizer(existing)
+            quoteTapRecognizer = nil
+        }
+        onQuoteTapped = nil
+
+        guard let reply else {
+            quoteContainer.isHidden = true
+            quoteNameLabel.text = nil
+            quoteSnippetLabel.text = nil
+            bodyTopToQuoteConstraint.isActive = false
+            bodyTopToBubbleConstraint.isActive = true
+            return
+        }
+
+        quoteContainer.isHidden = false
+        bodyTopToBubbleConstraint.isActive = false
+        bodyTopToQuoteConstraint.isActive = true
+
+        let onAccent = UIColor(OnymTokens.onAccent)
+        if reply.isUnavailable {
+            // Muted placeholder — no real sender to attribute.
+            let muted = direction == .outgoing
+                ? onAccent.withAlphaComponent(0.7)
+                : UIColor(OnymTokens.text3)
+            quoteBar.backgroundColor = muted
+            quoteNameLabel.text = "Message"
+            quoteNameLabel.textColor = muted
+            quoteSnippetLabel.text = "Message unavailable"
+            quoteSnippetLabel.textColor = muted
+        } else {
+            let accent = UIColor(reply.accent.color)
+            quoteBar.backgroundColor = direction == .outgoing ? onAccent : accent
+            quoteNameLabel.text = reply.name
+            quoteNameLabel.textColor = direction == .outgoing ? onAccent : accent
+            quoteSnippetLabel.text = reply.snippet
+            quoteSnippetLabel.textColor = direction == .outgoing
+                ? onAccent.withAlphaComponent(0.85)
+                : UIColor(OnymTokens.text2)
+
+            // Only an available target is tappable.
+            if let onTap {
+                onQuoteTapped = onTap
+                let tap = UITapGestureRecognizer(target: self, action: #selector(tappedQuote))
+                quoteContainer.addGestureRecognizer(tap)
+                quoteTapRecognizer = tap
+            }
+        }
+    }
+
+    @objc private func tappedQuote() {
+        onQuoteTapped?()
+    }
+
+    /// Brief background pulse on the bubble — used by the host to draw
+    /// the eye to a message after scrolling to it from a tapped quote.
+    func flashHighlight() {
+        let original = bubble.backgroundColor
+        let highlight = UIColor(OnymTokens.text3).withAlphaComponent(0.5)
+        UIView.animate(withDuration: 0.18, animations: {
+            self.bubble.backgroundColor = highlight
+        }, completion: { _ in
+            UIView.animate(withDuration: 0.45) {
+                self.bubble.backgroundColor = original
+            }
+        })
+    }
+
     private func applyStatus(_ status: MessageStatus) {
         statusImageView.isHidden = false
         switch status {
@@ -226,6 +364,16 @@ final class ChatBubbleCell: UITableViewCell {
     func simulateBubbleTapForTest() {
         tappedBubble()
     }
+
+    /// Test seam for the quote tap — fires the same handler the quote's
+    /// recognizer would, and returns whether a tap target was actually
+    /// installed (so tests can assert an unavailable quote is inert).
+    @discardableResult
+    func simulateQuoteTapForTest() -> Bool {
+        let installed = quoteTapRecognizer != nil
+        tappedQuote()
+        return installed
+    }
     #endif
 
     private func buildBubble() {
@@ -239,6 +387,36 @@ final class ChatBubbleCell: UITableViewCell {
         bodyLabel.font = .preferredFont(forTextStyle: .body)
         bodyLabel.adjustsFontForContentSizeCategory = true
         bubble.addSubview(bodyLabel)
+    }
+
+    private func buildQuote() {
+        quoteContainer.translatesAutoresizingMaskIntoConstraints = false
+        quoteContainer.isHidden = true
+        quoteContainer.accessibilityIdentifier = "chat.bubble.quote"
+        bubble.addSubview(quoteContainer)
+
+        quoteBar.translatesAutoresizingMaskIntoConstraints = false
+        quoteBar.layer.cornerRadius = 1.5
+        quoteBar.layer.cornerCurve = .continuous
+        quoteContainer.addSubview(quoteBar)
+
+        let nameBase = UIFont.systemFont(ofSize: 12, weight: .semibold)
+        quoteNameLabel.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: nameBase)
+        quoteNameLabel.adjustsFontForContentSizeCategory = true
+        quoteNameLabel.numberOfLines = 1
+        quoteNameLabel.lineBreakMode = .byTruncatingTail
+        quoteNameLabel.translatesAutoresizingMaskIntoConstraints = false
+        quoteNameLabel.accessibilityIdentifier = "chat.bubble.quote.name"
+        quoteContainer.addSubview(quoteNameLabel)
+
+        let snippetBase = UIFont.systemFont(ofSize: 13, weight: .regular)
+        quoteSnippetLabel.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: snippetBase)
+        quoteSnippetLabel.adjustsFontForContentSizeCategory = true
+        quoteSnippetLabel.numberOfLines = 1
+        quoteSnippetLabel.lineBreakMode = .byTruncatingTail
+        quoteSnippetLabel.translatesAutoresizingMaskIntoConstraints = false
+        quoteSnippetLabel.accessibilityIdentifier = "chat.bubble.quote.snippet"
+        quoteContainer.addSubview(quoteSnippetLabel)
     }
 
     private func buildStatusIndicator() {
@@ -293,6 +471,15 @@ final class ChatBubbleCell: UITableViewCell {
             equalTo: nameLabel.bottomAnchor, constant: 3
         )
 
+        // Body-top toggle — `configure` activates exactly one depending
+        // on whether a reply quote is shown.
+        bodyTopToBubbleConstraint = bodyLabel.topAnchor.constraint(
+            equalTo: bubble.topAnchor, constant: 8
+        )
+        bodyTopToQuoteConstraint = bodyLabel.topAnchor.constraint(
+            equalTo: quoteContainer.bottomAnchor, constant: 6
+        )
+
         NSLayoutConstraint.activate([
             bubble.widthAnchor.constraint(
                 lessThanOrEqualTo: contentView.widthAnchor,
@@ -300,8 +487,29 @@ final class ChatBubbleCell: UITableViewCell {
             ),
             bodyLabel.leadingAnchor.constraint(equalTo: bubble.leadingAnchor, constant: 12),
             bodyLabel.trailingAnchor.constraint(equalTo: bubble.trailingAnchor, constant: -12),
-            bodyLabel.topAnchor.constraint(equalTo: bubble.topAnchor, constant: 8),
             bodyLabel.bottomAnchor.constraint(equalTo: bubble.bottomAnchor, constant: -8),
+
+            // Reply quote — pinned across the top of the bubble. Only
+            // drives the body's top when `bodyTopToQuoteConstraint` is
+            // active (i.e. a quote is shown); otherwise it's hidden and
+            // its labels are cleared so it adds no height.
+            quoteContainer.topAnchor.constraint(equalTo: bubble.topAnchor, constant: 8),
+            quoteContainer.leadingAnchor.constraint(equalTo: bubble.leadingAnchor, constant: 12),
+            quoteContainer.trailingAnchor.constraint(equalTo: bubble.trailingAnchor, constant: -12),
+
+            quoteBar.leadingAnchor.constraint(equalTo: quoteContainer.leadingAnchor),
+            quoteBar.topAnchor.constraint(equalTo: quoteContainer.topAnchor),
+            quoteBar.bottomAnchor.constraint(equalTo: quoteContainer.bottomAnchor),
+            quoteBar.widthAnchor.constraint(equalToConstant: 3),
+
+            quoteNameLabel.leadingAnchor.constraint(equalTo: quoteBar.trailingAnchor, constant: 6),
+            quoteNameLabel.trailingAnchor.constraint(equalTo: quoteContainer.trailingAnchor),
+            quoteNameLabel.topAnchor.constraint(equalTo: quoteContainer.topAnchor),
+
+            quoteSnippetLabel.leadingAnchor.constraint(equalTo: quoteBar.trailingAnchor, constant: 6),
+            quoteSnippetLabel.trailingAnchor.constraint(equalTo: quoteContainer.trailingAnchor),
+            quoteSnippetLabel.topAnchor.constraint(equalTo: quoteNameLabel.bottomAnchor, constant: 1),
+            quoteSnippetLabel.bottomAnchor.constraint(equalTo: quoteContainer.bottomAnchor),
 
             // Name header aligns to the (incoming) bubble's leading edge
             // with a small indent, and never runs into the trailing gap.
@@ -348,5 +556,6 @@ final class ChatBubbleCell: UITableViewCell {
         NSLayoutConstraint.activate(incomingConstraints)
         bubbleBottomConstraint.isActive = true
         bubbleTopToContentConstraint.isActive = true
+        bodyTopToBubbleConstraint.isActive = true
     }
 }

--- a/Sources/OnymIOS/Chats/ChatInputPanelView.swift
+++ b/Sources/OnymIOS/Chats/ChatInputPanelView.swift
@@ -20,6 +20,11 @@ final class ChatInputPanelView: UIView {
     /// to `SendMessageInteractor.send`.
     var onSendTapped: ((String) -> Void)?
 
+    /// Invoked when the user taps the reply banner's cancel button.
+    /// The host clears its armed reply target and calls
+    /// `clearReplyBanner()`.
+    var onCancelReply: (() -> Void)?
+
     var text: String {
         // `UITextView.text` is bridged as `String!`, but Swift
         // still requires unwrap for chained access on the
@@ -45,6 +50,18 @@ final class ChatInputPanelView: UIView {
     private let sendButton = UIButton(type: .system)
     private var textViewHeightConstraint: NSLayoutConstraint!
 
+    // Reply banner — shown above the composer while a reply is armed.
+    // Accent bar + "Replying to {name}" + a one-line snippet + a
+    // cancel button. Hidden by default; `showReplyBanner` reveals it
+    // and re-pins the text view's top below it.
+    private let replyBanner = UIView()
+    private let replyBannerBar = UIView()
+    private let replyBannerTitle = UILabel()
+    private let replyBannerSnippet = UILabel()
+    private let replyCancelButton = UIButton(type: .system)
+    private var textViewTopToPanelConstraint: NSLayoutConstraint!
+    private var textViewTopToBannerConstraint: NSLayoutConstraint!
+
     /// Height for exactly `lines` worth of text plus the text
     /// view's vertical insets. Drives both the natural empty-state
     /// floor (`lines = 1`) and the auto-grow cap
@@ -61,6 +78,7 @@ final class ChatInputPanelView: UIView {
         super.init(frame: frame)
         backgroundColor = UIColor(OnymTokens.surface2)
         buildSubviews()
+        buildReplyBanner()
         layoutSubviewsLocal()
         refreshAfterTextChange()
     }
@@ -116,10 +134,64 @@ final class ChatInputPanelView: UIView {
         addSubview(sendButton)
     }
 
+    private func buildReplyBanner() {
+        replyBanner.translatesAutoresizingMaskIntoConstraints = false
+        replyBanner.isHidden = true
+        replyBanner.accessibilityIdentifier = "chat.input.reply_banner"
+        addSubview(replyBanner)
+
+        replyBannerBar.translatesAutoresizingMaskIntoConstraints = false
+        replyBannerBar.layer.cornerRadius = 1.5
+        replyBannerBar.layer.cornerCurve = .continuous
+        replyBanner.addSubview(replyBannerBar)
+
+        let titleBase = UIFont.systemFont(ofSize: 12, weight: .semibold)
+        replyBannerTitle.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: titleBase)
+        replyBannerTitle.adjustsFontForContentSizeCategory = true
+        replyBannerTitle.numberOfLines = 1
+        replyBannerTitle.lineBreakMode = .byTruncatingTail
+        replyBannerTitle.translatesAutoresizingMaskIntoConstraints = false
+        replyBannerTitle.accessibilityIdentifier = "chat.input.reply_banner.title"
+        replyBanner.addSubview(replyBannerTitle)
+
+        let snippetBase = UIFont.systemFont(ofSize: 13, weight: .regular)
+        replyBannerSnippet.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: snippetBase)
+        replyBannerSnippet.adjustsFontForContentSizeCategory = true
+        replyBannerSnippet.numberOfLines = 1
+        replyBannerSnippet.lineBreakMode = .byTruncatingTail
+        replyBannerSnippet.textColor = UIColor(OnymTokens.text2)
+        replyBannerSnippet.translatesAutoresizingMaskIntoConstraints = false
+        replyBannerSnippet.accessibilityIdentifier = "chat.input.reply_banner.snippet"
+        replyBanner.addSubview(replyBannerSnippet)
+
+        var cancelConfig = UIButton.Configuration.plain()
+        cancelConfig.image = UIImage(
+            systemName: "xmark.circle.fill",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 20, weight: .regular)
+        )
+        cancelConfig.contentInsets = .zero
+        replyCancelButton.configuration = cancelConfig
+        replyCancelButton.tintColor = UIColor(OnymTokens.text3)
+        replyCancelButton.addTarget(self, action: #selector(tappedCancelReply), for: .touchUpInside)
+        replyCancelButton.translatesAutoresizingMaskIntoConstraints = false
+        replyCancelButton.accessibilityIdentifier = "chat.input.reply_banner.cancel"
+        replyCancelButton.accessibilityLabel = "Cancel reply"
+        replyBanner.addSubview(replyCancelButton)
+    }
+
     private func layoutSubviewsLocal() {
         // Initial constant is replaced on the first
         // `refreshAfterTextChange` once the font / insets resolve.
         textViewHeightConstraint = textView.heightAnchor.constraint(equalToConstant: 36)
+
+        // Text-view top toggle. Default: pinned below the panel's top
+        // inset. With a reply banner shown, pinned below the banner.
+        textViewTopToPanelConstraint = textView.topAnchor.constraint(
+            equalTo: topAnchor, constant: 8
+        )
+        textViewTopToBannerConstraint = textView.topAnchor.constraint(
+            equalTo: replyBanner.bottomAnchor, constant: 8
+        )
 
         NSLayoutConstraint.activate([
             topDivider.topAnchor.constraint(equalTo: topAnchor),
@@ -127,8 +199,32 @@ final class ChatInputPanelView: UIView {
             topDivider.trailingAnchor.constraint(equalTo: trailingAnchor),
             topDivider.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
 
+            // Reply banner — spans the width just under the panel top.
+            // Only drives the text view's top when shown (toggle below).
+            replyBanner.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            replyBanner.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            replyBanner.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+
+            replyBannerBar.leadingAnchor.constraint(equalTo: replyBanner.leadingAnchor),
+            replyBannerBar.topAnchor.constraint(equalTo: replyBanner.topAnchor),
+            replyBannerBar.bottomAnchor.constraint(equalTo: replyBanner.bottomAnchor),
+            replyBannerBar.widthAnchor.constraint(equalToConstant: 3),
+
+            replyCancelButton.trailingAnchor.constraint(equalTo: replyBanner.trailingAnchor),
+            replyCancelButton.centerYAnchor.constraint(equalTo: replyBanner.centerYAnchor),
+            replyCancelButton.widthAnchor.constraint(equalToConstant: 28),
+            replyCancelButton.heightAnchor.constraint(equalToConstant: 28),
+
+            replyBannerTitle.leadingAnchor.constraint(equalTo: replyBannerBar.trailingAnchor, constant: 8),
+            replyBannerTitle.trailingAnchor.constraint(lessThanOrEqualTo: replyCancelButton.leadingAnchor, constant: -8),
+            replyBannerTitle.topAnchor.constraint(equalTo: replyBanner.topAnchor),
+
+            replyBannerSnippet.leadingAnchor.constraint(equalTo: replyBannerBar.trailingAnchor, constant: 8),
+            replyBannerSnippet.trailingAnchor.constraint(lessThanOrEqualTo: replyCancelButton.leadingAnchor, constant: -8),
+            replyBannerSnippet.topAnchor.constraint(equalTo: replyBannerTitle.bottomAnchor, constant: 1),
+            replyBannerSnippet.bottomAnchor.constraint(equalTo: replyBanner.bottomAnchor),
+
             textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            textView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
             textViewHeightConstraint,
 
@@ -155,6 +251,43 @@ final class ChatInputPanelView: UIView {
                 constant: textView.textContainerInset.top
             ),
         ])
+
+        // No banner by default — text view hangs off the panel top.
+        textViewTopToPanelConstraint.isActive = true
+    }
+
+    // MARK: - Reply banner
+
+    /// Show the "replying to" banner with the quoted sender + snippet,
+    /// and re-pin the text view below it. Accent colors the bar + the
+    /// title so the banner matches the bubble's quote.
+    func showReplyBanner(name: String, snippet: String, accent: OnymAccent) {
+        replyBannerTitle.text = "Replying to \(name)"
+        replyBannerTitle.textColor = UIColor(accent.color)
+        replyBannerBar.backgroundColor = UIColor(accent.color)
+        replyBannerSnippet.text = snippet
+        replyBanner.isHidden = false
+        textViewTopToPanelConstraint.isActive = false
+        textViewTopToBannerConstraint.isActive = true
+    }
+
+    /// Hide the reply banner and re-pin the text view to the panel top.
+    func clearReplyBanner() {
+        replyBanner.isHidden = true
+        replyBannerTitle.text = nil
+        replyBannerSnippet.text = nil
+        textViewTopToBannerConstraint.isActive = false
+        textViewTopToPanelConstraint.isActive = true
+    }
+
+    @objc private func tappedCancelReply() {
+        onCancelReply?()
+    }
+
+    /// Raise the keyboard by focusing the composer — used by the host
+    /// after arming a reply so the user can type immediately.
+    func focusComposer() {
+        textView.becomeFirstResponder()
     }
 
     // MARK: - Update

--- a/Sources/OnymIOS/Chats/ChatMessage.swift
+++ b/Sources/OnymIOS/Chats/ChatMessage.swift
@@ -44,6 +44,14 @@ struct ChatMessage: Equatable, Sendable, Identifiable {
     /// always `.received` at insert and never changes.
     let status: MessageStatus
 
+    /// The message this one replies to, if any. Mirrors
+    /// `ChatMessagePayload.replyToMessageID`. Only the target ID is
+    /// stored — the UI resolves the quoted sender + body by looking
+    /// this up among the group's other messages at render time, so a
+    /// target that isn't on this device renders as "message
+    /// unavailable" instead of carrying a stale copy of its text.
+    let replyToMessageID: UUID?
+
     /// Mirrors `ChatMessageVariant.kind`. Stored alongside the body so
     /// migrating to multi-variant rendering later doesn't need to
     /// re-fetch the group to learn the flavour.

--- a/Sources/OnymIOS/Chats/ChatMessagePayload.swift
+++ b/Sources/OnymIOS/Chats/ChatMessagePayload.swift
@@ -45,6 +45,16 @@ struct ChatMessagePayload: Codable, Equatable, Sendable {
     /// `Date`) so the wire format is unambiguous and cross-platform.
     let sentAtMillis: Int64
 
+    /// The message this one replies to, if any. Optional + additive,
+    /// so it ships under `version = 1`: a sender that omits it decodes
+    /// to `nil` on any receiver, and an old receiver decoding a payload
+    /// that carries it just ignores the unknown key. Only the target's
+    /// ID travels — the receiver resolves the quoted sender + body from
+    /// its own local store at render time, so a dangling ref (target
+    /// never delivered) degrades to "message unavailable" rather than
+    /// carrying stale text.
+    let replyToMessageID: UUID?
+
     /// Governance-keyed payload body. See `ChatMessageVariant`.
     let variant: ChatMessageVariant
 
@@ -54,6 +64,7 @@ struct ChatMessagePayload: Codable, Equatable, Sendable {
         case groupID = "group_id"
         case senderBlsPubkeyHex = "sender_bls_pubkey_hex"
         case sentAtMillis = "sent_at_millis"
+        case replyToMessageID = "reply_to_message_id"
         case variant
     }
 }

--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -39,7 +39,7 @@ struct ChatThreadView: View {
             messages: messages,
             onBack: { dismiss() },
             onShowMembers: { showMembers = true },
-            onSendTapped: { body in
+            onSendTapped: { body, replyToMessageID in
                 // Fire-and-forget. `SendMessageInteractor` does the
                 // optimistic insert as `.pending` synchronously
                 // before the await, so the new row appears in the
@@ -50,11 +50,15 @@ struct ChatThreadView: View {
                 // a thrown error here would only indicate a
                 // precondition violation (no identity, unknown
                 // group). Those shouldn't happen mid-chat-screen;
-                // swallow with `try?` for PR 8.
+                // swallow with `try?`.
                 let interactor = sendMessageInteractor
                 let groupID = groupID
                 Task {
-                    try? await interactor.send(groupID: groupID, body: body)
+                    try? await interactor.send(
+                        groupID: groupID,
+                        body: body,
+                        replyToMessageID: replyToMessageID
+                    )
                 }
             },
             onRetryRequested: { messageID in
@@ -119,7 +123,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let messages: [ChatMessage]
     let onBack: () -> Void
     let onShowMembers: () -> Void
-    let onSendTapped: (String) -> Void
+    let onSendTapped: (String, UUID?) -> Void
     let onRetryRequested: (UUID) -> Void
 
     func makeUIViewController(context: Context) -> ChatThreadViewController {

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -281,6 +281,39 @@ final class ChatThreadViewController: UIViewController {
         senderDisplays = displays
     }
 
+    /// Resolve the reply quote for a message, if it replies to another.
+    /// The target is looked up *live* in the current message list:
+    ///   - found → quote carries the target's sender name + accent +
+    ///     a one-line body snippet;
+    ///   - not on this device (never delivered / deleted) →
+    ///     `.unavailable` placeholder.
+    /// Returns nil for a non-reply message.
+    private func replyQuote(for message: ChatMessage) -> ChatReplyQuote? {
+        guard let targetID = message.replyToMessageID else { return nil }
+        guard let target = messagesByID[targetID] else { return .unavailable }
+        return ChatReplyQuote(
+            name: senderName(for: target.senderBlsPubkeyHex),
+            snippet: target.body,
+            accent: OnymAccent.forSender(blsPubkeyHex: target.senderBlsPubkeyHex),
+            isUnavailable: false
+        )
+    }
+
+    /// Scroll the replied-to message into view and flash it — the
+    /// payoff for tapping a quote. No-op if the target isn't in the
+    /// current snapshot (it was pruned, or never arrived).
+    func scrollAndHighlight(messageID: UUID) {
+        guard let indexPath = dataSource.indexPath(for: messageID) else { return }
+        tableView.scrollToRow(at: indexPath, at: .middle, animated: true)
+        // Flash after the scroll settles so the target cell is mounted
+        // and the pulse is visible rather than scrolled past.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let cell = self?.tableView.cellForRow(at: indexPath) as? ChatBubbleCell
+            else { return }
+            cell.flashHighlight()
+        }
+    }
+
     /// The sender's display name: their self-asserted alias when set,
     /// else a short BLS-pubkey fingerprint. Mirrors `ChatMembersView`'s
     /// fallback so an unnamed member reads consistently in both places.
@@ -420,7 +453,20 @@ final class ChatThreadViewController: UIViewController {
                     return { [weak self] in self?.onRetryRequested?(id) }
                 }()
                 let sender = self?.senderDisplays[id] ?? .unknown
-                bubble.configure(message: message, sender: sender, onRetry: retryHandler)
+                let reply = self?.replyQuote(for: message)
+                let quoteTap: (() -> Void)? = {
+                    // Only an available target is worth jumping to.
+                    guard let targetID = message.replyToMessageID,
+                          reply?.isUnavailable == false else { return nil }
+                    return { [weak self] in self?.scrollAndHighlight(messageID: targetID) }
+                }()
+                bubble.configure(
+                    message: message,
+                    sender: sender,
+                    reply: reply,
+                    onRetry: retryHandler,
+                    onQuoteTapped: quoteTap
+                )
             }
             return cell
         }

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -30,12 +30,12 @@ final class ChatThreadViewController: UIViewController {
 
     /// Invoked when the user taps the input panel's Send button
     /// with non-whitespace content. The SwiftUI wrapper points
-    /// this at `SendMessageInteractor.send(groupID:body:)` —
-    /// fire-and-forget; the interactor handles optimistic insert,
+    /// this at `SendMessageInteractor.send(groupID:body:replyToMessageID:)`
+    /// — fire-and-forget; the interactor handles optimistic insert,
     /// fan-out, and status flip on its own. Receives the body
-    /// already trimmed of leading/trailing whitespace by the
-    /// input panel.
-    var onSendTapped: ((String) -> Void)?
+    /// already trimmed of leading/trailing whitespace by the input
+    /// panel, plus the armed reply target (nil for a normal message).
+    var onSendTapped: ((String, UUID?) -> Void)?
 
     /// Invoked when the user taps a `.failed` outgoing bubble.
     /// The SwiftUI wrapper points this at
@@ -87,6 +87,12 @@ final class ChatThreadViewController: UIViewController {
     /// subsequent updates animate and only auto-scroll when the
     /// user is already near the bottom.
     private var hasAppliedFirstSnapshot = false
+
+    /// The message the composer is currently replying to, if any. Set
+    /// by a swipe-to-reply on a bubble, cleared on cancel or after a
+    /// send. Threaded into `onSendTapped` so the sent message carries
+    /// the reply reference.
+    private var replyingTo: UUID?
 
     /// "Within this many points of the content bottom" counts as
     /// "near bottom" for the auto-scroll heuristic. Exposed for
@@ -465,7 +471,8 @@ final class ChatThreadViewController: UIViewController {
                     sender: sender,
                     reply: reply,
                     onRetry: retryHandler,
-                    onQuoteTapped: quoteTap
+                    onQuoteTapped: quoteTap,
+                    onSwipeToReply: { [weak self] in self?.armReply(for: id) }
                 )
             }
             return cell
@@ -491,9 +498,42 @@ final class ChatThreadViewController: UIViewController {
         // clearing the field straight after the tap keeps the
         // composer feeling responsive.
         inputPanel.onSendTapped = { [weak self] body in
-            self?.onSendTapped?(body)
-            self?.inputPanel.text = ""
+            self?.handleSend(body)
         }
+        // Tapping the banner's cancel button disarms the reply.
+        inputPanel.onCancelReply = { [weak self] in
+            self?.clearReply()
+        }
+    }
+
+    /// Dispatch a send with the currently-armed reply target (if any),
+    /// then clear the composer + the reply banner. Routed through here
+    /// so the send tap and the test seam share one path.
+    private func handleSend(_ body: String) {
+        onSendTapped?(body, replyingTo)
+        inputPanel.text = ""
+        clearReply()
+    }
+
+    /// Arm a reply to `messageID`: remember the target, show the
+    /// composer banner with the quoted sender + snippet, and raise the
+    /// keyboard so the user can type straight away. No-op if the target
+    /// isn't in the current list.
+    private func armReply(for messageID: UUID) {
+        guard let target = messagesByID[messageID] else { return }
+        replyingTo = messageID
+        inputPanel.showReplyBanner(
+            name: senderName(for: target.senderBlsPubkeyHex),
+            snippet: target.body,
+            accent: OnymAccent.forSender(blsPubkeyHex: target.senderBlsPubkeyHex)
+        )
+        inputPanel.focusComposer()
+    }
+
+    /// Disarm the reply and hide the banner.
+    private func clearReply() {
+        replyingTo = nil
+        inputPanel.clearReplyBanner()
     }
 
     // MARK: - Layout
@@ -567,6 +607,15 @@ final class ChatThreadViewController: UIViewController {
 
     @objc private func tappedBack() { onBack?() }
     @objc private func tappedInfo() { onShowMembers?() }
+
+    #if DEBUG
+    /// Test seam — drives the same send path the input panel's Send
+    /// button would, so tests can assert the armed reply target is
+    /// forwarded and then cleared.
+    func simulateSendForTest(body: String) {
+        handleSend(body)
+    }
+    #endif
 }
 
 extension ChatThreadViewController: UIGestureRecognizerDelegate {

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -107,6 +107,21 @@ final class ChatThreadViewController: UIViewController {
         buildInputPanel()
         layout()
         configureDataSource()
+
+        // The input panel rides the keyboard up via the
+        // `keyboardLayoutGuide` constraint, which shrinks the message
+        // list from the bottom — leaving the latest messages under the
+        // keyboard. Rather than scroll *after* the keyboard settles
+        // (which reads as a late jump), shift the content up by the same
+        // amount the keyboard moves, animated on the keyboard's own
+        // duration + curve, so the bottom message stays glued to the
+        // input area throughout the transition.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillChangeFrame(_:)),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
     }
 
     // The SwiftUI wrapper hides the nav bar (the controller paints its
@@ -344,6 +359,77 @@ final class ChatThreadViewController: UIViewController {
         guard contentHeight > visibleHeight else { return true }
         let maxOffset = contentHeight - visibleHeight
         return maxOffset - offsetY < Self.nearBottomThreshold
+    }
+
+    /// The keyboard is changing frame: shift the message list's content
+    /// up (or down) by the same distance the keyboard's top edge moves,
+    /// animated on the keyboard's own duration + curve. Because the
+    /// input panel is glued to the keyboard top and the table's bottom
+    /// to the input panel, the table shrinks/grows by exactly that
+    /// distance — so translating the content by it keeps every visible
+    /// message, the latest included, pinned in place relative to the
+    /// input area while the keyboard slides.
+    ///
+    /// This works regardless of whether the `keyboardLayoutGuide`-driven
+    /// table resize has been applied yet: the shift is `contentOffset +
+    /// delta`, and `contentOffset` is unchanged by a bounds resize, so
+    /// the target is correct either way. (Scrolling after the fact, in
+    /// `keyboardDidShow`, read as a late jump — this rides the same
+    /// animation as the keyboard.)
+    @objc private func keyboardWillChangeFrame(_ notification: Notification) {
+        guard
+            let info = notification.userInfo,
+            let endFrame = (info[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
+            let beginFrame = (info[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue,
+            let duration = info[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+            let curveRaw = info[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int
+        else { return }
+
+        // How far the keyboard's top edge travels in our coordinates —
+        // positive when rising. The table's bottom moves the same amount.
+        let endTop = view.convert(endFrame, from: view.window).minY
+        let beginTop = view.convert(beginFrame, from: view.window).minY
+        let delta = beginTop - endTop
+        guard abs(delta) > 0.5 else { return }
+
+        // Final visible table height once the keyboard settles, derived
+        // from the keyboard's end frame (not the current bounds, which
+        // may or may not have resized yet) so the clamp is correct
+        // regardless of layout ordering.
+        let panelBottom = min(endTop, view.bounds.maxY - view.safeAreaInsets.bottom)
+        let finalViewportHeight = max(0, panelBottom - tableView.frame.minY - inputPanel.bounds.height)
+
+        let target = Self.keyboardAdjustedOffsetY(
+            currentOffsetY: tableView.contentOffset.y,
+            delta: delta,
+            contentHeight: tableView.contentSize.height,
+            finalViewportHeight: finalViewportHeight,
+            topInset: tableView.adjustedContentInset.top,
+            bottomInset: tableView.adjustedContentInset.bottom
+        )
+        guard abs(target - tableView.contentOffset.y) > 0.5 else { return }
+
+        let options = UIView.AnimationOptions(rawValue: UInt(curveRaw) << 16)
+            .union(.beginFromCurrentState)
+        UIView.animate(withDuration: duration, delay: 0, options: options) {
+            self.tableView.contentOffset.y = target
+        }
+    }
+
+    /// Translate the content offset by `delta` and clamp it to the
+    /// table's scrollable range for the post-keyboard viewport. Pure +
+    /// static so the clamp logic is unit-tested without a live keyboard.
+    static func keyboardAdjustedOffsetY(
+        currentOffsetY: CGFloat,
+        delta: CGFloat,
+        contentHeight: CGFloat,
+        finalViewportHeight: CGFloat,
+        topInset: CGFloat,
+        bottomInset: CGFloat
+    ) -> CGFloat {
+        let minY = -topInset
+        let maxY = max(minY, contentHeight + bottomInset - finalViewportHeight)
+        return min(max(currentOffsetY + delta, minY), maxY)
     }
 
     /// Scroll the table so the last row is visible.

--- a/Sources/OnymIOS/Chats/PersistedMessage.swift
+++ b/Sources/OnymIOS/Chats/PersistedMessage.swift
@@ -12,6 +12,11 @@ import SwiftData
 ///   delete on identity removal needs a predicate over this.
 /// - `sentAt` — sort column for the chat scroll order.
 /// - `directionRaw`, `statusRaw`, `groupTypeRaw` — small enums.
+/// - `replyToMessageIDString` — optional UUID of the replied-to
+///   message. Plain (not sensitive — it's just a pointer to another
+///   row in this same table) and left queryable for a future
+///   "replies to X" lookup. Optional, so adding it is a SwiftData
+///   lightweight migration over the existing store.
 ///
 /// Encrypted (`StorageEncryption.encrypt`):
 /// - `senderBlsPubkeyHex` — group-membership identifier; consistent
@@ -30,6 +35,7 @@ final class PersistedMessage {
     var directionRaw: String
     var statusRaw: String
     var groupTypeRaw: String
+    var replyToMessageIDString: String?
 
     var encryptedSenderBlsPubkeyHex: Data
     var encryptedBody: Data
@@ -42,6 +48,7 @@ final class PersistedMessage {
         directionRaw: String,
         statusRaw: String,
         groupTypeRaw: String,
+        replyToMessageIDString: String?,
         encryptedSenderBlsPubkeyHex: Data,
         encryptedBody: Data
     ) {
@@ -52,6 +59,7 @@ final class PersistedMessage {
         self.directionRaw = directionRaw
         self.statusRaw = statusRaw
         self.groupTypeRaw = groupTypeRaw
+        self.replyToMessageIDString = replyToMessageIDString
         self.encryptedSenderBlsPubkeyHex = encryptedSenderBlsPubkeyHex
         self.encryptedBody = encryptedBody
     }

--- a/Sources/OnymIOS/Chats/SendMessageInteractor.swift
+++ b/Sources/OnymIOS/Chats/SendMessageInteractor.swift
@@ -52,6 +52,7 @@ actor SendMessageInteractor {
     func send(
         groupID: String,
         body: String,
+        replyToMessageID: UUID? = nil,
         now: Date = Date()
     ) async throws -> ChatMessage {
         guard !body.isEmpty else { throw SendError.emptyBody }
@@ -90,6 +91,7 @@ actor SendMessageInteractor {
             groupID: group.groupIDData,
             senderBlsPubkeyHex: myBlsHex,
             sentAtMillis: sentAtMillis,
+            replyToMessageID: replyToMessageID,
             variant: variant
         )
 
@@ -106,6 +108,7 @@ actor SendMessageInteractor {
             sentAt: now,
             direction: .outgoing,
             status: .pending,
+            replyToMessageID: replyToMessageID,
             groupType: group.groupType
         )
         await messageRepository.insert(pending)
@@ -136,6 +139,7 @@ actor SendMessageInteractor {
             sentAt: pending.sentAt,
             direction: pending.direction,
             status: finalStatus,
+            replyToMessageID: pending.replyToMessageID,
             groupType: pending.groupType
         )
     }
@@ -193,6 +197,7 @@ actor SendMessageInteractor {
             groupID: group.groupIDData,
             senderBlsPubkeyHex: myBlsHex,
             sentAtMillis: Int64(message.sentAt.timeIntervalSince1970 * 1000),
+            replyToMessageID: message.replyToMessageID,
             variant: variant
         )
 

--- a/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
+++ b/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
@@ -91,6 +91,7 @@ actor SwiftDataMessageStore: MessageStore {
             existing.directionRaw = encoded.directionRaw
             existing.statusRaw = encoded.statusRaw
             existing.groupTypeRaw = encoded.groupTypeRaw
+            existing.replyToMessageIDString = encoded.replyToMessageIDString
             existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
             existing.encryptedBody = encoded.encryptedBody
             try? context.save()
@@ -154,6 +155,7 @@ actor SwiftDataMessageStore: MessageStore {
             directionRaw: message.direction.rawValue,
             statusRaw: message.status.rawValue,
             groupTypeRaw: message.groupType.rawValue,
+            replyToMessageIDString: message.replyToMessageID?.uuidString,
             encryptedSenderBlsPubkeyHex: try StorageEncryption.encrypt(message.senderBlsPubkeyHex),
             encryptedBody: try StorageEncryption.encrypt(message.body)
         )
@@ -180,6 +182,7 @@ actor SwiftDataMessageStore: MessageStore {
             sentAt: row.sentAt,
             direction: direction,
             status: status,
+            replyToMessageID: row.replyToMessageIDString.flatMap(UUID.init(uuidString:)),
             groupType: groupType
         )
     }

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -698,6 +698,13 @@ struct IncomingMessageDispatcher: Sendable {
             sentAt: sentAt,
             direction: .incoming,
             status: .received,
+            // Pointer to the quoted message, resolved against the
+            // local store at render time. No trust gate needed: a ref
+            // to a message we never received (or a forged one) just
+            // renders as "message unavailable" — it can't pull in
+            // content from outside this group because rendering only
+            // looks up local rows.
+            replyToMessageID: payload.replyToMessageID,
             groupType: group.groupType
         )
         await messageRepository.insert(message)

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -319,6 +319,7 @@ final class ChatBubbleCellTests: XCTestCase {
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
             direction: direction,
             status: status ?? (direction == .incoming ? .received : .sent),
+            replyToMessageID: nil,
             groupType: .tyranny
         )
     }

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -284,6 +284,48 @@ final class ChatBubbleCellTests: XCTestCase {
         find(in: cell.contentView, identifier: "chat.bubble.quote.snippet") as? UILabel
     }
 
+    // MARK: - Swipe to reply (PR 3)
+
+    func test_swipeToReply_firesCallback() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        var swipes = 0
+        cell.configure(
+            message: makeMessage(direction: .incoming),
+            onSwipeToReply: { swipes += 1 }
+        )
+        cell.simulateSwipeToReplyForTest()
+        XCTAssertEqual(swipes, 1)
+    }
+
+    func test_swipeToReply_availableForOutgoingAndAnyStatus() {
+        // Unlike retry, swipe-to-reply works on every bubble — own or
+        // others', sent / pending / failed alike.
+        for status in [MessageStatus.sent, .pending, .failed] {
+            let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+            var swipes = 0
+            cell.configure(
+                message: makeMessage(direction: .outgoing, status: status),
+                onSwipeToReply: { swipes += 1 }
+            )
+            cell.simulateSwipeToReplyForTest()
+            XCTAssertEqual(swipes, 1, "swipe-to-reply must be available for status \(status)")
+        }
+    }
+
+    func test_swipeToReply_droppedOnReuse() {
+        // A cell reused for a message whose host wires no swipe handler
+        // must not keep the prior one.
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        var swipes = 0
+        cell.configure(
+            message: makeMessage(direction: .incoming),
+            onSwipeToReply: { swipes += 1 }
+        )
+        cell.configure(message: makeMessage(direction: .incoming))
+        cell.simulateSwipeToReplyForTest()
+        XCTAssertEqual(swipes, 0, "reused cell must drop the previous swipe handler")
+    }
+
     // MARK: - Helpers
 
     private func statusIcon(in cell: ChatBubbleCell) -> UIImageView {

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -204,6 +204,86 @@ final class ChatBubbleCellTests: XCTestCase {
                        "reconfigured-to-sent bubble must drop its retry closure")
     }
 
+    // MARK: - Reply quote (PR 2)
+
+    func test_reply_showsQuoteWithSenderAndSnippet() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(
+            message: makeMessage(direction: .incoming),
+            reply: ChatReplyQuote(
+                name: "Alice", snippet: "the original", accent: .purple, isUnavailable: false
+            )
+        )
+        let container = find(in: cell.contentView, identifier: "chat.bubble.quote")
+        XCTAssertNotNil(container)
+        XCTAssertFalse(container!.isHidden, "quote must be visible for a reply")
+        XCTAssertEqual(quoteName(in: cell)?.text, "Alice")
+        XCTAssertEqual(quoteSnippet(in: cell)?.text, "the original")
+    }
+
+    func test_noReply_hidesQuote() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .incoming))
+        let container = find(in: cell.contentView, identifier: "chat.bubble.quote")
+        XCTAssertTrue(container?.isHidden ?? false,
+                      "a non-reply message must not show the quote")
+    }
+
+    func test_reply_tapInvokesQuoteClosure() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        var taps = 0
+        cell.configure(
+            message: makeMessage(direction: .incoming),
+            reply: ChatReplyQuote(
+                name: "Alice", snippet: "x", accent: .purple, isUnavailable: false
+            ),
+            onQuoteTapped: { taps += 1 }
+        )
+        let installed = cell.simulateQuoteTapForTest()
+        XCTAssertTrue(installed, "an available quote must install a tap target")
+        XCTAssertEqual(taps, 1)
+    }
+
+    func test_reply_unavailable_showsPlaceholderAndIsInert() {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        var taps = 0
+        cell.configure(
+            message: makeMessage(direction: .incoming),
+            reply: .unavailable,
+            onQuoteTapped: { taps += 1 }
+        )
+        XCTAssertEqual(quoteSnippet(in: cell)?.text, "Message unavailable")
+        let installed = cell.simulateQuoteTapForTest()
+        XCTAssertFalse(installed,
+                       "an unavailable quote must not be tappable")
+        XCTAssertEqual(taps, 0)
+    }
+
+    func test_reply_droppedOnReuse() {
+        // Cell reuse: a bubble that showed a quote is reused for a
+        // non-reply message. The quote must hide, or it'd carry a
+        // stale original.
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(
+            message: makeMessage(direction: .incoming),
+            reply: ChatReplyQuote(
+                name: "Alice", snippet: "x", accent: .purple, isUnavailable: false
+            )
+        )
+        cell.configure(message: makeMessage(direction: .incoming))
+        let container = find(in: cell.contentView, identifier: "chat.bubble.quote")
+        XCTAssertTrue(container?.isHidden ?? false,
+                      "reused cell must drop the previously-shown quote")
+    }
+
+    private func quoteName(in cell: ChatBubbleCell) -> UILabel? {
+        find(in: cell.contentView, identifier: "chat.bubble.quote.name") as? UILabel
+    }
+
+    private func quoteSnippet(in cell: ChatBubbleCell) -> UILabel? {
+        find(in: cell.contentView, identifier: "chat.bubble.quote.snippet") as? UILabel
+    }
+
     // MARK: - Helpers
 
     private func statusIcon(in cell: ChatBubbleCell) -> UIImageView {

--- a/Tests/OnymIOSTests/ChatInputPanelViewTests.swift
+++ b/Tests/OnymIOSTests/ChatInputPanelViewTests.swift
@@ -70,6 +70,61 @@ final class ChatInputPanelViewTests: XCTestCase {
         XCTAssertFalse(fired)
     }
 
+    // MARK: - Reply banner (PR 3)
+
+    func test_replyBanner_shown_writesTitleAndSnippet() {
+        let panel = ChatInputPanelView()
+        panel.showReplyBanner(name: "Alice", snippet: "the original", accent: .purple)
+        XCTAssertFalse(replyBanner(in: panel).isHidden, "banner must be visible once armed")
+        XCTAssertEqual(replyBannerTitle(in: panel)?.text, "Replying to Alice")
+        XCTAssertEqual(replyBannerSnippet(in: panel)?.text, "the original")
+    }
+
+    func test_replyBanner_initiallyHidden() {
+        let panel = ChatInputPanelView()
+        XCTAssertTrue(replyBanner(in: panel).isHidden,
+                      "no reply armed → banner hidden")
+    }
+
+    func test_replyBanner_cleared_hides() {
+        let panel = ChatInputPanelView()
+        panel.showReplyBanner(name: "Alice", snippet: "x", accent: .purple)
+        panel.clearReplyBanner()
+        XCTAssertTrue(replyBanner(in: panel).isHidden,
+                      "clearReplyBanner must hide the banner")
+    }
+
+    func test_replyBanner_cancelButton_invokesOnCancelReply() {
+        let panel = ChatInputPanelView()
+        var cancels = 0
+        panel.onCancelReply = { cancels += 1 }
+        panel.showReplyBanner(name: "Alice", snippet: "x", accent: .purple)
+        cancelButton(in: panel).sendActions(for: .touchUpInside)
+        XCTAssertEqual(cancels, 1)
+    }
+
+    private func replyBanner(in panel: ChatInputPanelView) -> UIView {
+        guard let v = find(in: panel, identifier: "chat.input.reply_banner") else {
+            fatalError("reply banner not found")
+        }
+        return v
+    }
+
+    private func replyBannerTitle(in panel: ChatInputPanelView) -> UILabel? {
+        find(in: panel, identifier: "chat.input.reply_banner.title") as? UILabel
+    }
+
+    private func replyBannerSnippet(in panel: ChatInputPanelView) -> UILabel? {
+        find(in: panel, identifier: "chat.input.reply_banner.snippet") as? UILabel
+    }
+
+    private func cancelButton(in panel: ChatInputPanelView) -> UIButton {
+        guard let b = find(in: panel, identifier: "chat.input.reply_banner.cancel") as? UIButton else {
+            fatalError("cancel button not found")
+        }
+        return b
+    }
+
     // MARK: - Auto-height
     //
     // Asserting absolute pixel values is brittle — UITextView's

--- a/Tests/OnymIOSTests/ChatMessagePayloadTests.swift
+++ b/Tests/OnymIOSTests/ChatMessagePayloadTests.swift
@@ -37,6 +37,50 @@ final class ChatMessagePayloadTests: XCTestCase {
         XCTAssertEqual(decoded.variant.body, "héllo 🌍 こんにちは")
     }
 
+    // MARK: - Reply reference
+
+    func test_roundtrip_replyRef_preservesTargetID() throws {
+        let target = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let original = makePayload(body: "agreed", replyToMessageID: target)
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: encoded)
+        XCTAssertEqual(decoded.replyToMessageID, target)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_wireFormat_replyKeyIsSnakeCase() throws {
+        let target = UUID()
+        let encoded = try JSONEncoder().encode(makePayload(body: "hi", replyToMessageID: target))
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertEqual(obj?["reply_to_message_id"] as? String, target.uuidString)
+    }
+
+    func test_wireFormat_noReply_omitsKey() throws {
+        // A non-reply message should encode `null` (or omit) — never a
+        // bogus UUID. `JSONEncoder` writes `null` for a nil Optional.
+        let encoded = try JSONEncoder().encode(makePayload(body: "hi"))
+        let obj = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertNil(obj?["reply_to_message_id"] as? String,
+                     "a non-reply message must not carry a reply target")
+    }
+
+    func test_decode_missingReplyKey_isNil() throws {
+        // Backward compat: a payload from an older sender (pre-replies)
+        // has no `reply_to_message_id` — it must decode to nil, not throw.
+        let json = #"""
+        {
+          "version": 1,
+          "message_id": "11111111-1111-1111-1111-111111111111",
+          "group_id": "QkJC",
+          "sender_bls_pubkey_hex": "ab",
+          "sent_at_millis": 0,
+          "variant": { "kind": "tyranny", "body": "hi" }
+        }
+        """#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: json)
+        XCTAssertNil(decoded.replyToMessageID)
+    }
+
     // MARK: - Wire format
 
     func test_wireFormat_snakeCaseKeys() throws {
@@ -129,13 +173,17 @@ final class ChatMessagePayloadTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makePayload(body: String) -> ChatMessagePayload {
+    private func makePayload(
+        body: String,
+        replyToMessageID: UUID? = nil
+    ) -> ChatMessagePayload {
         ChatMessagePayload(
             version: 1,
             messageID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
             groupID: Data(repeating: 0x42, count: 32),
             senderBlsPubkeyHex: String(repeating: "ab", count: 48),
             sentAtMillis: 1_700_000_000_000,
+            replyToMessageID: replyToMessageID,
             variant: .tyranny(body: body)
         )
     }

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -221,7 +221,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             return XCTFail("input panel not found in controller hierarchy")
         }
         var receivedBodies: [String] = []
-        vc.onSendTapped = { receivedBodies.append($0) }
+        vc.onSendTapped = { body, _ in receivedBodies.append(body) }
 
         panel.text = "   hello   "
         sendButton(in: panel).sendActions(for: .touchUpInside)
@@ -241,7 +241,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             return XCTFail("input panel not found")
         }
         var fired = false
-        vc.onSendTapped = { _ in fired = true }
+        vc.onSendTapped = { _, _ in fired = true }
 
         panel.text = "   "
         sendButton(in: panel).sendActions(for: .touchUpInside)
@@ -513,6 +513,74 @@ final class ChatThreadViewControllerTests: XCTestCase {
         _ = layoutTable(in: vc)
         // Must not crash / trap when the target isn't in the snapshot.
         vc.scrollAndHighlight(messageID: UUID())
+    }
+
+    // MARK: - Swipe to reply (PR 3)
+
+    func test_swipeToReply_armsBanner_withTargetSender() {
+        let vc = mountedController()
+        let alice = "aa".repeated(48)
+        vc.update(memberProfiles: [alice: profile(alias: "Alice")])
+        vc.update(messages: [incoming(sender: alice, body: "the original", at: 1)])
+        let table = layoutTable(in: vc)
+        guard let cell = table.cellForRow(at: IndexPath(row: 0, section: 0)) as? ChatBubbleCell
+        else { return XCTFail("bubble cell not mounted") }
+
+        cell.simulateSwipeToReplyForTest()
+
+        XCTAssertEqual(replyBanner(in: vc)?.isHidden, false,
+                       "a swipe-to-reply must reveal the composer banner")
+        XCTAssertEqual(replyBannerTitle(in: vc), "Replying to Alice")
+    }
+
+    func test_send_afterArming_forwardsReplyTarget_andClearsBanner() {
+        let vc = mountedController()
+        let original = incoming(sender: "aa".repeated(48), body: "orig", at: 1)
+        vc.update(messages: [original])
+        let table = layoutTable(in: vc)
+        guard let cell = table.cellForRow(at: IndexPath(row: 0, section: 0)) as? ChatBubbleCell
+        else { return XCTFail("bubble cell not mounted") }
+
+        var captured: (body: String, target: UUID?)?
+        vc.onSendTapped = { captured = ($0, $1) }
+        cell.simulateSwipeToReplyForTest()
+        vc.simulateSendForTest(body: "agreed")
+
+        XCTAssertEqual(captured?.body, "agreed")
+        XCTAssertEqual(captured?.target, original.id,
+                       "a send after arming must carry the reply target")
+        XCTAssertEqual(replyBanner(in: vc)?.isHidden, true,
+                       "the banner must clear once the reply is sent")
+    }
+
+    func test_cancelReply_thenSend_carriesNoTarget() {
+        let vc = mountedController()
+        vc.update(messages: [incoming(sender: "aa".repeated(48), body: "orig", at: 1)])
+        let table = layoutTable(in: vc)
+        guard let cell = table.cellForRow(at: IndexPath(row: 0, section: 0)) as? ChatBubbleCell
+        else { return XCTFail("bubble cell not mounted") }
+
+        var captured: (body: String, target: UUID?)?
+        vc.onSendTapped = { captured = ($0, $1) }
+        cell.simulateSwipeToReplyForTest()
+        let cancel = find(in: vc.view) {
+            $0.accessibilityIdentifier == "chat.input.reply_banner.cancel"
+        } as? UIButton
+        cancel?.sendActions(for: .touchUpInside)
+        vc.simulateSendForTest(body: "plain")
+
+        XCTAssertNil(captured?.target,
+                     "after cancelling, a send must carry no reply target")
+    }
+
+    private func replyBanner(in vc: ChatThreadViewController) -> UIView? {
+        find(in: vc.view) { $0.accessibilityIdentifier == "chat.input.reply_banner" }
+    }
+
+    private func replyBannerTitle(in vc: ChatThreadViewController) -> String? {
+        (find(in: vc.view) {
+            $0.accessibilityIdentifier == "chat.input.reply_banner.title"
+        } as? UILabel)?.text
     }
 
     // MARK: - Sender-test helpers

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -282,6 +282,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             sentAt: failed.sentAt,
             direction: failed.direction,
             status: .failed,
+            replyToMessageID: nil,
             groupType: failed.groupType
         )
 
@@ -323,6 +324,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
             direction: .outgoing,
             status: .pending,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
         vc.update(messages: [pending])
@@ -349,6 +351,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             sentAt: pending.sentAt,
             direction: .outgoing,
             status: .sent,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
         vc.update(messages: [sentRow])
@@ -516,7 +519,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             id: UUID(), groupID: "aa".repeated(32), ownerIdentityID: IdentityID(),
             senderBlsPubkeyHex: sender, body: body,
             sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
-            direction: .incoming, status: .received, groupType: groupType
+            direction: .incoming, status: .received, replyToMessageID: nil, groupType: groupType
         )
     }
 
@@ -527,7 +530,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             id: UUID(), groupID: "aa".repeated(32), ownerIdentityID: IdentityID(),
             senderBlsPubkeyHex: sender, body: body,
             sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
-            direction: .outgoing, status: .sent, groupType: .tyranny
+            direction: .outgoing, status: .sent, replyToMessageID: nil, groupType: .tyranny
         )
     }
 
@@ -559,6 +562,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             sentAt: sentAt,
             direction: direction,
             status: direction == .incoming ? .received : .sent,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
     }

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -475,7 +475,83 @@ final class ChatThreadViewControllerTests: XCTestCase {
                        "a later profile update must refresh the on-screen header")
     }
 
+    // MARK: - Reply quote (PR 2)
+
+    func test_reply_rendersQuoteResolvedFromTargetSender() {
+        let vc = mountedController()
+        let alice = "aa".repeated(48)
+        vc.update(memberProfiles: [alice: profile(alias: "Alice")])
+        let original = incoming(sender: alice, body: "the original", at: 1)
+        let reply = replyMessage(
+            sender: "cc".repeated(48), body: "agreed", to: original.id, at: 2
+        )
+        vc.update(messages: [original, reply])
+        let table = layoutTable(in: vc)
+
+        // Row 1 is the reply; its quote must name the target's sender
+        // and preview the target's body.
+        XCTAssertEqual(quoteName(in: table, row: 1), "Alice")
+        XCTAssertEqual(quoteSnippet(in: table, row: 1), "the original")
+        // Row 0 (the original, a non-reply) shows no quote.
+        XCTAssertTrue(quoteHidden(in: table, row: 0))
+    }
+
+    func test_reply_unknownTarget_showsUnavailablePlaceholder() {
+        let vc = mountedController()
+        let reply = replyMessage(
+            sender: "cc".repeated(48), body: "agreed", to: UUID(), at: 1
+        )
+        vc.update(messages: [reply])
+        let table = layoutTable(in: vc)
+        XCTAssertEqual(quoteSnippet(in: table, row: 0), "Message unavailable",
+                       "a reply to a message we don't have renders the placeholder")
+    }
+
+    func test_scrollAndHighlight_unknownID_isNoOp() {
+        let vc = mountedController()
+        vc.update(messages: [incoming(sender: "aa".repeated(48), body: "hi", at: 1)])
+        _ = layoutTable(in: vc)
+        // Must not crash / trap when the target isn't in the snapshot.
+        vc.scrollAndHighlight(messageID: UUID())
+    }
+
     // MARK: - Sender-test helpers
+
+    private func replyMessage(
+        sender: String, body: String, to target: UUID, at seconds: TimeInterval
+    ) -> ChatMessage {
+        ChatMessage(
+            id: UUID(), groupID: "aa".repeated(32), ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: sender, body: body,
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
+            direction: .outgoing, status: .sent,
+            replyToMessageID: target, groupType: .tyranny
+        )
+    }
+
+    private func quoteLabel(
+        in table: UITableView, row: Int, identifier: String
+    ) -> UILabel? {
+        let cell = table.cellForRow(at: IndexPath(row: row, section: 0))
+        guard let cv = cell?.contentView else { return nil }
+        return find(in: cv) { $0.accessibilityIdentifier == identifier } as? UILabel
+    }
+
+    private func quoteName(in table: UITableView, row: Int) -> String? {
+        quoteLabel(in: table, row: row, identifier: "chat.bubble.quote.name")?.text
+    }
+
+    private func quoteSnippet(in table: UITableView, row: Int) -> String? {
+        quoteLabel(in: table, row: row, identifier: "chat.bubble.quote.snippet")?.text
+    }
+
+    private func quoteHidden(in table: UITableView, row: Int) -> Bool {
+        let cell = table.cellForRow(at: IndexPath(row: row, section: 0))
+        guard let cv = cell?.contentView,
+              let container = find(in: cv, where: { $0.accessibilityIdentifier == "chat.bubble.quote" })
+        else { return true }
+        return container.isHidden
+    }
 
     private func mountedController() -> ChatThreadViewController {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 800))

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -400,6 +400,65 @@ final class ChatThreadViewControllerTests: XCTestCase {
         XCTAssertFalse(vc.isNearBottom)
     }
 
+    // MARK: - Keyboard keeps latest visible
+
+    // The content is shifted by the keyboard's frame delta so the bottom
+    // message stays glued to the input area while the keyboard slides.
+    // `keyboardAdjustedOffsetY` is the pure clamp at the heart of it.
+
+    func test_keyboardOffset_parkedAtBottom_risesToNewBottom() {
+        // At the bottom (offset 1520 in a 480pt viewport over 2000pt of
+        // content); keyboard rises 300pt → viewport becomes 180. The
+        // content must end exactly at the new bottom (2000 - 180 = 1820).
+        let y = ChatThreadViewController.keyboardAdjustedOffsetY(
+            currentOffsetY: 1520, delta: 300, contentHeight: 2000,
+            finalViewportHeight: 180, topInset: 0, bottomInset: 0
+        )
+        XCTAssertEqual(y, 1820, accuracy: 0.5,
+                       "a message at the bottom must stay pinned to the input area")
+    }
+
+    func test_keyboardOffset_scrolledUp_translatesByDelta_noYank() {
+        // Reading history (offset 1000); a 300pt rise shifts the content
+        // up by 300 so what was visible stays visible — not yanked to
+        // the bottom.
+        let y = ChatThreadViewController.keyboardAdjustedOffsetY(
+            currentOffsetY: 1000, delta: 300, contentHeight: 2000,
+            finalViewportHeight: 180, topInset: 0, bottomInset: 0
+        )
+        XCTAssertEqual(y, 1300, accuracy: 0.5)
+    }
+
+    func test_keyboardOffset_shortContent_doesNotScroll() {
+        // Content shorter than even the shrunken viewport → nothing to
+        // scroll; clamp pins to the top (0).
+        let y = ChatThreadViewController.keyboardAdjustedOffsetY(
+            currentOffsetY: 0, delta: 300, contentHeight: 150,
+            finalViewportHeight: 180, topInset: 0, bottomInset: 0
+        )
+        XCTAssertEqual(y, 0, accuracy: 0.5)
+    }
+
+    func test_keyboardOffset_dismiss_returnsToBottom() {
+        // Keyboard retracts 300pt (delta negative): viewport grows back
+        // to 480, content settles to the resting bottom (2000 - 480).
+        let y = ChatThreadViewController.keyboardAdjustedOffsetY(
+            currentOffsetY: 1820, delta: -300, contentHeight: 2000,
+            finalViewportHeight: 480, topInset: 0, bottomInset: 0
+        )
+        XCTAssertEqual(y, 1520, accuracy: 0.5)
+    }
+
+    func test_keyboardOffset_respectsTopInset() {
+        // Can't scroll above the top inset, even if the delta would.
+        let y = ChatThreadViewController.keyboardAdjustedOffsetY(
+            currentOffsetY: -40, delta: -50, contentHeight: 100,
+            finalViewportHeight: 400, topInset: 40, bottomInset: 0
+        )
+        XCTAssertEqual(y, -40, accuracy: 0.5,
+                       "must not scroll above the top content inset")
+    }
+
     // MARK: - Sender differentiation (run grouping + name headers)
 
     func test_runGrouping_headerOnlyAtStartOfSameSenderRun() {

--- a/Tests/OnymIOSTests/GroupAvatarPayloadTests.swift
+++ b/Tests/OnymIOSTests/GroupAvatarPayloadTests.swift
@@ -44,6 +44,7 @@ final class GroupAvatarPayloadTests: XCTestCase {
             groupID: Data(repeating: 0x42, count: 32),
             senderBlsPubkeyHex: "aa".repeated(48),
             sentAtMillis: 1_700_000_000_000,
+            replyToMessageID: nil,
             variant: .tyranny(body: "hello")
         )
         let bytes = try JSONEncoder().encode(chat)

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -92,6 +92,27 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         XCTAssertEqual(stored[0].status, .received)
         XCTAssertEqual(stored[0].senderBlsPubkeyHex, senderBlsHex)
         XCTAssertEqual(stored[0].groupType, .tyranny)
+        XCTAssertNil(stored[0].replyToMessageID)
+    }
+
+    func test_chatMessage_withReplyRef_persistsTargetID() async throws {
+        let target = UUID()
+        let payload = makePayload(body: "agreed", replyToMessageID: target)
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-reply",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex)
+        XCTAssertEqual(stored.first?.replyToMessageID, target,
+                       "an inbound reply must carry its target id onto the persisted message")
     }
 
     // MARK: - Drop paths
@@ -257,6 +278,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             groupID: secondGroupBytes,
             senderBlsPubkeyHex: secondSenderBlsHex,
             sentAtMillis: 1_700_000_500_000,
+            replyToMessageID: nil,
             variant: .tyranny(body: "for the second identity")
         )
         let dispatcher = makeDispatcher(
@@ -315,7 +337,8 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         body: String,
         groupIDBytes: Data? = nil,
         senderBlsHex: String? = nil,
-        messageID: UUID = UUID()
+        messageID: UUID = UUID(),
+        replyToMessageID: UUID? = nil
     ) -> ChatMessagePayload {
         ChatMessagePayload(
             version: 1,
@@ -323,6 +346,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             groupID: groupIDBytes ?? self.groupIDBytes,
             senderBlsPubkeyHex: senderBlsHex ?? self.senderBlsHex,
             sentAtMillis: 1_700_000_000_000,
+            replyToMessageID: replyToMessageID,
             variant: .tyranny(body: body)
         )
     }

--- a/Tests/OnymIOSTests/MessageRepositoryTests.swift
+++ b/Tests/OnymIOSTests/MessageRepositoryTests.swift
@@ -196,6 +196,7 @@ final class MessageRepositoryTests: XCTestCase {
             sentAt: sentAt,
             direction: .outgoing,
             status: status,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
     }
@@ -235,6 +236,7 @@ private actor InMemoryMessageStore: MessageStore {
             sentAt: existing.sentAt,
             direction: existing.direction,
             status: status,
+            replyToMessageID: existing.replyToMessageID,
             groupType: existing.groupType
         )
     }

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -135,6 +135,29 @@ final class SendMessageInteractorTests: XCTestCase {
         XCTAssertEqual(stored.count, 1)
     }
 
+    func test_send_withReplyRef_carriesTargetOntoMessage() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        let target = UUID()
+
+        let result = try await interactor.send(
+            groupID: groupID,
+            body: "agreed",
+            replyToMessageID: target
+        )
+        XCTAssertEqual(result.replyToMessageID, target,
+                       "the returned message must carry the reply target")
+
+        let stored = await messages.currentMessages(groupID: groupID)
+        XCTAssertEqual(stored.first?.replyToMessageID, target,
+                       "the optimistically-inserted row must carry the reply target")
+    }
+
+    func test_send_noReplyRef_isNil() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        let result = try await interactor.send(groupID: groupID, body: "plain")
+        XCTAssertNil(result.replyToMessageID)
+    }
+
     // MARK: - Status transitions
 
     func test_send_allRelaysReject_marksFailed() async throws {

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -50,6 +50,20 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         XCTAssertEqual(first.direction, .outgoing)
         XCTAssertEqual(first.status, .pending)
         XCTAssertEqual(first.groupType, .tyranny)
+        XCTAssertNil(first.replyToMessageID,
+                     "a non-reply message round-trips with no reply target")
+    }
+
+    func test_insertOrUpdate_replyRef_roundtrips() async {
+        let groupID = "aa".repeated(32)
+        let target = UUID()
+        let reply = makeMessage(groupID: groupID, body: "agreed", replyToMessageID: target)
+
+        _ = await store.insertOrUpdate(reply)
+
+        let listed = await store.list(groupID: groupID)
+        XCTAssertEqual(listed.first?.replyToMessageID, target,
+                       "the reply target id must survive the encrypted-store round-trip")
     }
 
     func test_insertOrUpdate_sameID_updatesInPlace() async {
@@ -66,6 +80,7 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             sentAt: msg.sentAt,
             direction: .outgoing,
             status: .sent,
+            replyToMessageID: nil,
             groupType: .tyranny
         )
         let inserted = await store.insertOrUpdate(updated)
@@ -190,7 +205,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         body: String = "hi",
         sentAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
         direction: MessageDirection = .outgoing,
-        status: MessageStatus = .sent
+        status: MessageStatus = .sent,
+        replyToMessageID: UUID? = nil
     ) -> ChatMessage {
         ChatMessage(
             id: id,
@@ -201,6 +217,7 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             sentAt: sentAt,
             direction: direction,
             status: status,
+            replyToMessageID: replyToMessageID,
             groupType: .tyranny
         )
     }


### PR DESCRIPTION
Small chat UX fix. **Stacked on #175 (the replies stack) — merge that first.**

## Problem
When the keyboard opens, the input panel rides up with it (via `keyboardLayoutGuide`), shrinking the message list from the bottom — so with a long thread the newest messages end up under the keyboard.

## Approach
Earlier iterations scrolled to the bottom *after* the keyboard settled (`keyboardDidShow`). That landed in the right place but read as a **late jump**. 

Now the content is **shifted in lock-step with the keyboard**: on `keyboardWillChangeFrame`, translate the table's content offset by the same distance the keyboard's top edge travels, animated on the keyboard's own duration + curve. The input panel is glued to the keyboard top and the table's bottom to the input panel, so the table shrinks/grows by exactly that delta — translating the content by it keeps every visible message (the latest included) **pinned to the input area** while the keyboard slides.

Key robustness point: the target is `contentOffset + delta`, and `contentOffset` is unchanged by a bounds resize — so it's correct whether or not the guide-driven shrink has applied yet. That's the layout-ordering trap that broke the `isNearBottom`-at-keyboard-time attempts.

## Behavior
- At the bottom → stays pinned to the input area (no jump).
- Scrolled up reading history → content translates with the keyboard, nothing you were reading gets covered, no yank to the bottom.
- Dismissal → reverses smoothly back to the resting bottom.
- Short threads → no spurious scroll.

The clamp to the post-keyboard scrollable range is factored into the pure, static `keyboardAdjustedOffsetY`.

## Tests
5 cases on `keyboardAdjustedOffsetY` (parked-at-bottom, scrolled-up translate, short content, dismissal, top-inset). Full unit target: 711 tests, 0 failures.

## Manual check
Open a long thread, tap the composer — the latest message should ride up *with* the keyboard and sit just above the input area, no late jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)