### PR TITLE
fix(security): recovery-phrase clipboard copy local-only + OS expiry (H-4)

### DIFF
--- a/Sources/OnymIOS/Recovery/RecoveryPhraseBackupFlow.swift
+++ b/Sources/OnymIOS/Recovery/RecoveryPhraseBackupFlow.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import UniformTypeIdentifiers
 
 /// Single source of truth for the "Back up keys" flow.
 ///
@@ -116,9 +117,14 @@ final class RecoveryPhraseBackupFlow {
     func tappedCopyPhrase() {
         guard case let .reveal(phrase, true) = step else { return }
         // onym:allow-secret-read: copy is the explicit user intent on the
-        // reveal screen; auto-clears after `clipboardClearDelay` so the
-        // value doesn't sit on the system pasteboard indefinitely.
-        pasteboard.write(phrase)
+        // reveal screen. The write is `localOnly` so the seed never crosses
+        // Universal Clipboard to the user's other Apple devices, and carries
+        // an OS-enforced expiry so the system clears it even if the app is
+        // backgrounded or killed before the in-app timer below fires.
+        let expiresAt = Date().addingTimeInterval(clipboardClearDelay.seconds)
+        pasteboard.write(phrase, localOnly: true, expiresAt: expiresAt)
+        // The in-app timer stays only as UX/messaging (clears sooner while the
+        // app is foregrounded); the OS expiry above is the real guarantee.
         clipboardClearTask?.cancel()
         clipboardClearTask = Task { [pasteboard, clipboardClearDelay] in
             try? await Task.sleep(for: clipboardClearDelay)
@@ -220,17 +226,38 @@ final class RecoveryPhraseBackupFlow {
 /// Minimal seam over `UIPasteboard` so the flow's clipboard side effect can
 /// be observed in tests without writing to the actual system pasteboard.
 protocol PasteboardWriter: Sendable {
-    func write(_ value: String)
+    /// Write `value` to the pasteboard.
+    /// - Parameters:
+    ///   - localOnly: when `true`, the item stays on this device and never
+    ///     syncs via Universal Clipboard to the user's other Apple devices.
+    ///   - expiresAt: instant at which the OS drops the item, even if the
+    ///     app is backgrounded or killed before then.
+    func write(_ value: String, localOnly: Bool, expiresAt: Date)
     func clearIfStill(_ value: String)
 }
 
 struct UIPasteboardWriter: PasteboardWriter {
-    func write(_ value: String) {
-        UIPasteboard.general.string = value
+    func write(_ value: String, localOnly: Bool, expiresAt: Date) {
+        UIPasteboard.general.setItems(
+            [[UTType.utf8PlainText.identifier: value]],
+            options: [
+                .localOnly: localOnly,
+                .expirationDate: expiresAt
+            ]
+        )
     }
     func clearIfStill(_ value: String) {
         if UIPasteboard.general.string == value {
             UIPasteboard.general.string = ""
         }
+    }
+}
+
+private extension Duration {
+    /// Whole + fractional seconds as a `TimeInterval`, for bridging to the
+    /// `Date`-based pasteboard expiry API.
+    var seconds: TimeInterval {
+        let (secs, attos) = components
+        return TimeInterval(secs) + TimeInterval(attos) / 1e18
     }
 }

--- a/Tests/OnymIOSTests/RecoveryPhraseBackupFlowTests.swift
+++ b/Tests/OnymIOSTests/RecoveryPhraseBackupFlowTests.swift
@@ -126,6 +126,43 @@ final class RecoveryPhraseBackupFlowTests: XCTestCase {
         XCTAssertTrue(pasteboard.didClear, "clipboard auto-clear didn't run")
     }
 
+    func test_tappedCopyPhrase_writesLocalOnly_withExpiryMatchingDelay() async throws {
+        // Build a flow with the production 60s clipboard delay (setUp's flow
+        // uses a 50ms delay so the auto-clear test runs fast). The OS-enforced
+        // expiry — not the in-app timer — is the real guarantee that the seed
+        // can't linger on the system pasteboard after a background/kill, so we
+        // assert it lands ~60s out and is marked local-only (no Universal
+        // Clipboard sync to the user's other Apple devices).
+        let flow60 = RecoveryPhraseBackupFlow(
+            repository: repository,
+            authenticator: authenticator,
+            pasteboard: pasteboard,
+            clipboardClearDelay: .seconds(60),
+            verifyAdvanceDelay: .milliseconds(20)
+        )
+        flow60.start()
+        defer { flow60.stop() }
+        for _ in 0..<50 where !flow60.isReady {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertTrue(flow60.isReady, "flow60 never became ready")
+
+        authenticator.outcome = .success
+        await flow60.authenticate()
+        flow60.tappedReveal()
+
+        let before = Date()
+        flow60.tappedCopyPhrase()
+        let after = Date()
+
+        XCTAssertEqual(pasteboard.lastWritten, testMnemonic)
+        XCTAssertEqual(pasteboard.lastLocalOnly, true, "seed must be pinned local-only")
+
+        let expiry = try XCTUnwrap(pasteboard.lastExpiresAt, "expiry must be set")
+        XCTAssertGreaterThanOrEqual(expiry.timeIntervalSince(after), 60 - 2)
+        XCTAssertLessThanOrEqual(expiry.timeIntervalSince(before), 60 + 2)
+    }
+
     func test_tappedCopyPhrase_isNoop_beforeReveal() async throws {
         try await advanceToReveal()
         // Don't tap reveal — phrase still hidden
@@ -274,9 +311,15 @@ private final class FakeAuthenticator: BiometricAuthenticator, @unchecked Sendab
 
 private final class FakePasteboard: PasteboardWriter, @unchecked Sendable {
     var lastWritten: String?
+    var lastLocalOnly: Bool?
+    var lastExpiresAt: Date?
     var didClear: Bool = false
 
-    func write(_ value: String) { lastWritten = value }
+    func write(_ value: String, localOnly: Bool, expiresAt: Date) {
+        lastWritten = value
+        lastLocalOnly = localOnly
+        lastExpiresAt = expiresAt
+    }
     func clearIfStill(_ value: String) {
         if lastWritten == value { didClear = true }
     }


### PR DESCRIPTION
## Summary

Fixes **H-4 (High)** — the recovery-phrase backup flow copied the seed to the pasteboard insecurely.

`RecoveryPhraseBackupFlow.tappedCopyPhrase()` wrote the phrase through `UIPasteboardWriter`, which set `UIPasteboard.general.string = value`. That produces a **non-local, non-expiring** pasteboard item:

- It can sync via **Universal Clipboard** to the user's other Apple devices.
- The only clear was an in-process `Task.sleep(60s)` — which does **not** survive app suspension/kill and is cancelled by `stop()`. If the user backgrounds the app within 60s (e.g. switching to a password manager), the full seed sits on the system pasteboard for any app to read. The phrase reconstructs all keys → total account compromise.

## Fix

Rewrote the pasteboard write inside the `UIPasteboardWriter` abstraction to use OS-enforced protections:

```swift
UIPasteboard.general.setItems(
    [[UTType.utf8PlainText.identifier: value]],
    options: [.localOnly: localOnly, .expirationDate: expiresAt]
)
```

- `.localOnly: true` — the seed never crosses Universal Clipboard.
- `.expirationDate` (`clipboardClearDelay` in the future, default 60s) — the OS drops the item even if the app is suspended or killed.

The injected `PasteboardWriter` seam is preserved (write now takes `localOnly` + `expiresAt`), so tests still mock the clipboard. The in-app 60s timer remains as foreground UX/messaging; the OS expiry is now the real guarantee. Added `import UniformTypeIdentifiers`.

## Testing

Ran `RecoveryPhraseBackupFlowTests` on the iOS 26 simulator (iPhone 17):

```
xcodebuild test -project OnymIOS.xcodeproj -scheme OnymIOS \
  -destination 'platform=iOS Simulator,id=<iPhone 17>' \
  -derivedDataPath /tmp/onym-ddp-h4 \
  -only-testing:OnymIOSTests/RecoveryPhraseBackupFlowTests
```

**Result: TEST SUCCEEDED — 14 tests, 0 failures.**

- The `FakePasteboard` mock now captures `localOnly` and `expiresAt`.
- New test `test_tappedCopyPhrase_writesLocalOnly_withExpiryMatchingDelay` asserts `localOnly == true` and an expiration ~60s out (using a flow built with the production 60s delay).
- All pre-existing tests remain green.

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)