### PR TITLE
fix(security): check CSPRNG status via shared SecureRandom helper (H-1)

### DIFF
--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -1,6 +1,5 @@
 import CryptoKit
 import Foundation
-import Security
 
 /// Stateless orchestration for the create-group flow. Holds dependencies
 /// only — every call to `create` is independent. The view-model
@@ -147,8 +146,8 @@ struct CreateGroupInteractor: Sendable {
         // exists to close a same-`group_id_fr` collision via
         // `group_id + p (mod 2^256)` — see the contract comment at
         // sep-tyranny/src/lib.rs:290–298.
-        let groupID = Self.randomCanonicalFr()
-        let groupSecret = Self.randomBytes(32)
+        let groupID = try Self.randomCanonicalFr()
+        let groupSecret = try Self.randomBytes(32)
         let salt = GroupCommitmentBuilder.generateSalt()
         let tier: SEPTier = .small
 
@@ -326,8 +325,8 @@ struct CreateGroupInteractor: Sendable {
         // proof binding), but we use the canonical sampler anyway for
         // consistency with Tyranny + to keep all on-chain group IDs
         // valid Fr scalars in case a future contract rev adds the check.
-        let groupID = Self.randomCanonicalFr()
-        let groupSecret = Self.randomBytes(32)
+        let groupID = try Self.randomCanonicalFr()
+        let groupSecret = try Self.randomBytes(32)
         let salt = GroupCommitmentBuilder.generateSalt()
 
         // 4. Both BLS secrets must be present at create time — the SDK's
@@ -355,12 +354,12 @@ struct CreateGroupInteractor: Sendable {
         // BLS secret keys are canonical Fr by convention. The SDK reduces
         // silently if not, but any future strictness check would silently
         // break us — so generate canonical at the source.
-        var peerBlsSecret = Self.randomCanonicalFr()
+        var peerBlsSecret = try Self.randomCanonicalFr()
         // The OneOnOne SDK rejects equal secrets. Vanishingly unlikely
         // with 256 bits of entropy, but cheap to defend against —
         // resample on the off chance of a collision.
         while peerBlsSecret == creatorBlsSecret {
-            peerBlsSecret = Self.randomCanonicalFr()
+            peerBlsSecret = try Self.randomCanonicalFr()
         }
 
         let creatorMember: GovernanceMember
@@ -525,8 +524,8 @@ struct CreateGroupInteractor: Sendable {
         // 3. Group params. sep-anarchy doesn't gate `group_id`
         // canonicality today (no proof binding), but use the canonical
         // sampler anyway for consistency with Tyranny / OneOnOne.
-        let groupID = Self.randomCanonicalFr()
-        let groupSecret = Self.randomBytes(32)
+        let groupID = try Self.randomCanonicalFr()
+        let groupSecret = try Self.randomBytes(32)
         let salt = GroupCommitmentBuilder.generateSalt()
         let tier: SEPTier = .small
 
@@ -854,10 +853,8 @@ struct CreateGroupInteractor: Sendable {
         return hash.prefix(8).map { String(format: "%02x", $0) }.joined()
     }
 
-    private static func randomBytes(_ count: Int) -> Data {
-        var bytes = [UInt8](repeating: 0, count: count)
-        _ = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
-        return Data(bytes)
+    private static func randomBytes(_ count: Int) throws -> Data {
+        try SecureRandom.data(count)
     }
 
     /// Uniformly-random 32-byte BE value strictly less than the
@@ -871,10 +868,9 @@ struct CreateGroupInteractor: Sendable {
     /// reduction would diverge from the contract's check on ~25% of
     /// inputs. Generating canonically at the source removes the
     /// reduction question entirely.
-    static func randomCanonicalFr() -> Data {
+    static func randomCanonicalFr() throws -> Data {
         while true {
-            var bytes = [UInt8](repeating: 0, count: 32)
-            _ = SecRandomCopyBytes(kSecRandomDefault, 32, &bytes)
+            let bytes = try SecureRandom.bytes(32)
             if isCanonicalFr(bytes) {
                 return Data(bytes)
             }

--- a/Sources/OnymIOS/Identity/Bip39.swift
+++ b/Sources/OnymIOS/Identity/Bip39.swift
@@ -2058,10 +2058,10 @@ enum Bip39 {
     ]
 
     /// Generate a new 12-word BIP39 mnemonic from 128 bits of secure random entropy.
-    static func generateMnemonic() -> String {
-        var entropy = [UInt8](repeating: 0, count: 16) // 128 bits
-        _ = SecRandomCopyBytes(kSecRandomDefault, entropy.count, &entropy)
-        return mnemonicFromEntropy(Data(entropy))
+    /// Throws if the CSPRNG fails rather than emitting an all-zero mnemonic.
+    static func generateMnemonic() throws -> String {
+        let entropy = try SecureRandom.data(16) // 128 bits
+        return mnemonicFromEntropy(entropy)
     }
 
     /// Convert raw entropy bytes to a BIP39 mnemonic string.

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -529,7 +529,7 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
             }
             entropy = parsed
         } else {
-            let fresh = Bip39.generateMnemonic()
+            let fresh = try Bip39.generateMnemonic()
             guard let parsed = Bip39.entropyFromMnemonic(fresh) else {
                 throw IdentityError.invalidMnemonic
             }

--- a/Sources/OnymIOS/Identity/SecureRandom.swift
+++ b/Sources/OnymIOS/Identity/SecureRandom.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Security
+
+/// Centralised CSPRNG access. Every caller that needs security-grade
+/// random bytes routes through here so a `SecRandomCopyBytes` failure
+/// surfaces as a thrown error instead of silently leaving the all-zero
+/// buffer in place and using it as key material.
+///
+/// Mirrors the status-checking pattern already used by
+/// `OnymNostrSigner.ephemeral()`.
+enum SecureRandom {
+    /// Fill and return `count` cryptographically-secure random bytes.
+    /// Throws `SecureRandomError.csprngFailed` when the system CSPRNG
+    /// reports failure, rather than returning the all-zero buffer.
+    static func bytes(_ count: Int) throws -> [UInt8] {
+        var buffer = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &buffer)
+        guard status == errSecSuccess else {
+            throw SecureRandomError.csprngFailed(status: Int(status))
+        }
+        return buffer
+    }
+
+    /// Convenience returning `Data` instead of `[UInt8]`.
+    static func data(_ count: Int) throws -> Data {
+        Data(try bytes(count))
+    }
+}
+
+enum SecureRandomError: LocalizedError {
+    case csprngFailed(status: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case let .csprngFailed(status):
+            return "Secure random generation failed (OSStatus \(status))"
+        }
+    }
+}

--- a/Sources/OnymIOS/Persistence/StorageEncryption.swift
+++ b/Sources/OnymIOS/Persistence/StorageEncryption.swift
@@ -19,18 +19,27 @@ enum StorageEncryption {
     /// Memoised so repeated `encrypt` / `decrypt` calls don't round-trip
     /// to the Keychain. The seed itself never changes for the lifetime
     /// of the install (changing it would orphan every encrypted column).
-    private static let cachedRootSecret: Data = loadOrCreateRootSecret()
+    ///
+    /// Stored as a `Result` so the once-only, thread-safe `static let`
+    /// initialisation is preserved while still letting a CSPRNG or
+    /// Keychain failure propagate to callers instead of yielding a
+    /// silent all-zero root key.
+    private static let cachedRootSecret: Result<Data, Error> = Result {
+        try loadOrCreateRootSecret()
+    }
 
     /// AES-256 key derived from the root secret. HKDF salt + info pin
     /// the derivation to this specific use ("storage at-rest, v1") so a
     /// future second consumer of the same root secret won't collide.
     static var storageKey: SymmetricKey {
-        HKDF<SHA256>.deriveKey(
-            inputKeyMaterial: SymmetricKey(data: cachedRootSecret),
-            salt: Data("app.onym.ios.storage".utf8),
-            info: Data("local-storage-v1".utf8),
-            outputByteCount: 32
-        )
+        get throws {
+            HKDF<SHA256>.deriveKey(
+                inputKeyMaterial: SymmetricKey(data: try cachedRootSecret.get()),
+                salt: Data("app.onym.ios.storage".utf8),
+                info: Data("local-storage-v1".utf8),
+                outputByteCount: 32
+            )
+        }
     }
 
     // MARK: - Encrypt / Decrypt
@@ -39,7 +48,7 @@ enum StorageEncryption {
     /// `nonce (12B) || ciphertext || tag (16B)`. Decryption is the
     /// inverse — `decrypt` accepts that exact byte shape.
     static func encrypt(_ plaintext: Data) throws -> Data {
-        let sealed = try AES.GCM.seal(plaintext, using: storageKey)
+        let sealed = try AES.GCM.seal(plaintext, using: try storageKey)
         guard let combined = sealed.combined else {
             throw StorageEncryptionError.encryptionFailed
         }
@@ -55,7 +64,7 @@ enum StorageEncryption {
     /// truncated input (AES-GCM tag verification fails).
     static func decrypt(_ combined: Data) throws -> Data {
         let box = try AES.GCM.SealedBox(combined: combined)
-        return try AES.GCM.open(box, using: storageKey)
+        return try AES.GCM.open(box, using: try storageKey)
     }
 
     /// Decrypt to a UTF-8 string.
@@ -69,14 +78,12 @@ enum StorageEncryption {
 
     // MARK: - Keychain
 
-    private static func loadOrCreateRootSecret() -> Data {
+    private static func loadOrCreateRootSecret() throws -> Data {
         if let existing = loadFromKeychain() {
             return existing
         }
-        var bytes = [UInt8](repeating: 0, count: 32)
-        _ = SecRandomCopyBytes(kSecRandomDefault, 32, &bytes)
-        let secret = Data(bytes)
-        saveToKeychain(secret)
+        let secret = try SecureRandom.data(32)
+        try saveToKeychain(secret)
         return secret
     }
 
@@ -94,7 +101,7 @@ enum StorageEncryption {
         return nil
     }
 
-    private static func saveToKeychain(_ data: Data) {
+    private static func saveToKeychain(_ data: Data) throws {
         let deleteQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: keychainAccount,
@@ -107,18 +114,24 @@ enum StorageEncryption {
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
-        SecItemAdd(query as CFDictionary, nil)
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw StorageEncryptionError.keychainWriteFailed(status: Int(status))
+        }
     }
 }
 
 enum StorageEncryptionError: LocalizedError {
     case encryptionFailed
     case decodingFailed
+    case keychainWriteFailed(status: Int)
 
     var errorDescription: String? {
         switch self {
         case .encryptionFailed: return "Failed to encrypt data for storage"
         case .decodingFailed: return "Failed to decode decrypted data"
+        case let .keychainWriteFailed(status):
+            return "Failed to persist storage root key to Keychain (OSStatus \(status))"
         }
     }
 }

--- a/Tests/OnymIOSTests/CanonicalFrTests.swift
+++ b/Tests/OnymIOSTests/CanonicalFrTests.swift
@@ -88,12 +88,12 @@ final class CanonicalFrTests: XCTestCase {
 
     // MARK: - randomCanonicalFr sampling
 
-    func test_randomCanonicalFr_alwaysCanonical_over10kSamples() {
+    func test_randomCanonicalFr_alwaysCanonical_over10kSamples() throws {
         // Statistically, the sampler's accept rate is `r / 2^256 ≈ 0.453`.
         // 10k samples give a generous floor on rejected-path coverage
         // (~5.5k rejections), and the assertion is unconditional.
         for _ in 0..<10_000 {
-            let bytes = CreateGroupInteractor.randomCanonicalFr()
+            let bytes = try CreateGroupInteractor.randomCanonicalFr()
             XCTAssertEqual(bytes.count, 32)
             XCTAssertTrue(
                 CreateGroupInteractor.isCanonicalFr(Array(bytes)),
@@ -102,12 +102,12 @@ final class CanonicalFrTests: XCTestCase {
         }
     }
 
-    func test_randomCanonicalFr_isNonZeroAndDistinct() {
+    func test_randomCanonicalFr_isNonZeroAndDistinct() throws {
         // Sanity: the sampler isn't returning a constant. 100 draws
         // should yield 100 distinct values with overwhelming probability.
         var seen = Set<Data>()
         for _ in 0..<100 {
-            seen.insert(CreateGroupInteractor.randomCanonicalFr())
+            seen.insert(try CreateGroupInteractor.randomCanonicalFr())
         }
         XCTAssertEqual(seen.count, 100, "sampler should not collide over 100 draws")
         XCTAssertFalse(seen.contains(Data(repeating: 0, count: 32)),

--- a/Tests/OnymIOSTests/SecureRandomTests.swift
+++ b/Tests/OnymIOSTests/SecureRandomTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import OnymIOS
+
+/// Coverage for the shared CSPRNG helper (`SecureRandom`) introduced to
+/// close H-1 — the family of `_ = SecRandomCopyBytes(...)` call sites
+/// that discarded the `OSStatus` and would have used an all-zero buffer
+/// as key material on CSPRNG failure. These pin the success-path
+/// contract (correct length, non-constant output) and that the four
+/// former call sites still produce valid non-zero material.
+final class SecureRandomTests: XCTestCase {
+
+    // MARK: - Helper
+
+    func test_bytes_returnsRequestedLength() throws {
+        for count in [0, 1, 16, 32, 64, 256] {
+            XCTAssertEqual(try SecureRandom.bytes(count).count, count)
+            XCTAssertEqual(try SecureRandom.data(count).count, count)
+        }
+    }
+
+    func test_bytes_isNotConstant() throws {
+        // 100 draws of 32 bytes should all differ with overwhelming
+        // probability — a broken RNG returning a constant (or all-zero)
+        // would collapse the set.
+        var seen = Set<Data>()
+        for _ in 0..<100 {
+            seen.insert(try SecureRandom.data(32))
+        }
+        XCTAssertEqual(seen.count, 100, "CSPRNG output should not collide over 100 draws")
+        XCTAssertFalse(seen.contains(Data(repeating: 0, count: 32)),
+                       "all-zero output would indicate a broken/ignored CSPRNG")
+    }
+
+    // MARK: - Former H-1 call sites still produce valid non-zero output
+
+    func test_generateMnemonic_producesValidNonZeroEntropy() throws {
+        let mnemonic = try Bip39.generateMnemonic()
+        XCTAssertTrue(Bip39.isValidMnemonic(mnemonic), "generated mnemonic must be valid BIP39")
+        let entropy = try XCTUnwrap(Bip39.entropyFromMnemonic(mnemonic))
+        XCTAssertEqual(entropy.count, 16)
+        XCTAssertNotEqual(entropy, Data(repeating: 0, count: 16),
+                          "all-zero entropy would mean the CSPRNG failure went unchecked")
+    }
+
+    func test_randomCanonicalFr_producesCanonicalNonZeroFr() throws {
+        let fr = try CreateGroupInteractor.randomCanonicalFr()
+        XCTAssertEqual(fr.count, 32)
+        XCTAssertTrue(CreateGroupInteractor.isCanonicalFr(Array(fr)))
+        XCTAssertNotEqual(fr, Data(repeating: 0, count: 32))
+    }
+
+    func test_storageEncryption_roundtripsWithNonZeroKey() throws {
+        // Exercises the root-secret path (formerly an unchecked
+        // SecRandomCopyBytes): a zeroed root key would still roundtrip,
+        // so this is a smoke test that the throwing wiring compiles and
+        // the encrypt/decrypt pair remains intact.
+        let plaintext = Data("h1-secure-random".utf8)
+        let combined = try StorageEncryption.encrypt(plaintext)
+        XCTAssertEqual(try StorageEncryption.decrypt(combined), plaintext)
+    }
+}

--- a/Tests/OnymIOSTests/StorageEncryptionTests.swift
+++ b/Tests/OnymIOSTests/StorageEncryptionTests.swift
@@ -63,12 +63,12 @@ final class StorageEncryptionTests: XCTestCase {
 
     // MARK: - Key stability
 
-    func test_storageKey_isStableAcrossCalls() {
+    func test_storageKey_isStableAcrossCalls() throws {
         // The cached root secret should produce the same derived key
         // every time within a single install — otherwise persisted
         // ciphertext becomes unreadable across method calls.
-        let keyA = StorageEncryption.storageKey
-        let keyB = StorageEncryption.storageKey
+        let keyA = try StorageEncryption.storageKey
+        let keyB = try StorageEncryption.storageKey
         let dataA = keyA.withUnsafeBytes { Data($0) }
         let dataB = keyB.withUnsafeBytes { Data($0) }
         XCTAssertEqual(dataA, dataB)


### PR DESCRIPTION
## Summary

Fixes **H-1 (High)**: four call sites invoked `SecRandomCopyBytes(...)` as `_ = SecRandomCopyBytes(...)`, discarding the `OSStatus`, then used the buffer as security material. On a CSPRNG failure the buffer stays all-zeros — a silent, catastrophic all-zero mnemonic, storage root key, or group salt/scalar. (A zero scalar is a canonical `Fr`, so `randomCanonicalFr()`'s rejection loop would have happily accepted a zero-on-failure result.)

### Fix
- New `Sources/OnymIOS/Identity/SecureRandom.swift`: `SecureRandom.bytes(_:)` / `.data(_:)` call `SecRandomCopyBytes`, check the status, and throw `SecureRandomError.csprngFailed(status:)` on any non-`errSecSuccess`. Mirrors the existing correct pattern in `OnymNostrSigner.ephemeral()`.
- Routed all four sites through it:
  - `Bip39.generateMnemonic()` — now `throws`; its only caller (`IdentityRepository.addLocked`, already `throws`) threads `try`.
  - `StorageEncryption` root secret — `loadOrCreateRootSecret()` / `saveToKeychain()` now `throw`; `storageKey` became a `get throws` property; the memoised `cachedRootSecret` is stored as a `Result` so the thread-safe once-only `static let` init is preserved while errors still propagate. `encrypt`/`decrypt` already `throws`.
  - `CreateGroupInteractor.randomBytes(_:)` and `randomCanonicalFr()` — now `throw`; all call sites are already inside `throws` contexts and thread `try`.
- Also checked the previously-ignored `SecItemAdd` status in `StorageEncryption.saveToKeychain()` — now throws `StorageEncryptionError.keychainWriteFailed(status:)` on failure.
- Removed the now-unused `import Security` from `CreateGroupInteractor`.

## Testing

Ran on iOS Simulator (iPhone 17, iOS 26), Xcode 26, unique derived data path `/tmp/onym-ddp-h1`:

- `xcodebuild build-for-testing` → **TEST BUILD SUCCEEDED**
- `xcodebuild test-without-building` restricted to the affected classes: `SecureRandomTests`, `StorageEncryptionTests`, `CanonicalFrTests`, `CreateGroupInteractorTests`, `IdentityRepositoryTests`, `IdentityRepositoryMultiIdentityTests` → **67 tests, 0 failures**.

New `Tests/OnymIOSTests/SecureRandomTests.swift` covers: helper returns the requested length (incl. 0), output is non-constant / non-zero across 100 draws, and the three former call sites (`generateMnemonic`, `randomCanonicalFr`, storage encrypt/decrypt roundtrip) still produce valid non-zero output. Existing `CanonicalFrTests` / `StorageEncryptionTests` updated to thread `try` through the newly-throwing APIs.

Forcing a real CSPRNG failure isn't feasible in a unit test, so the throw path is verified by compilation/wiring (all callers propagate) plus the success-path length/smoke assertions.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)