### PR TITLE
sec(H-3): verify detached signatures on fetched trust-critical lists

### DIFF
--- a/Resources/contracts-trust-pubkey.json
+++ b/Resources/contracts-trust-pubkey.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "PLACEHOLDER — DO NOT ship enforcement with this file unchanged. Replace `publicKeyBase64` with the REAL offline release-signing Ed25519 public key (32 raw bytes, base64-encoded) before flipping ContractsTrust.enforceSignatures to true. While `publicKeyBase64` is empty the app runs in H-3 soft mode: signatures are checked and logged but never enforced. See the release-signing pipeline follow-up (issue #183).",
+  "algorithm": "ed25519",
+  "publicKeyBase64": ""
+}

--- a/Sources/OnymIOS/Chain/ContractsManifestFetcher.swift
+++ b/Sources/OnymIOS/Chain/ContractsManifestFetcher.swift
@@ -35,6 +35,16 @@ struct GitHubReleasesContractsManifestFetcher: ContractsManifestFetcher {
         guard (200..<300).contains(statusCode) else {
             throw ContractsManifestFetchError.badStatus(statusCode)
         }
+        // H-3: verify the detached Ed25519 signature at `<url>.sig`
+        // before trusting the manifest (its `id` becomes the Soroban
+        // governance authority). Soft mode by default — see
+        // `ContractsTrust`. Throws only under enforcement.
+        try await SignedAsset.verify(
+            assetData: data,
+            assetURL: url,
+            session: session,
+            label: "contracts-manifest.json"
+        )
         return try Self.decodeFiltering(data)
     }
 

--- a/Sources/OnymIOS/Chain/ContractsTrust.swift
+++ b/Sources/OnymIOS/Chain/ContractsTrust.swift
@@ -1,0 +1,177 @@
+import Foundation
+import CryptoKit
+import os.log
+
+/// Trust configuration for the runtime-fetched, trust-critical JSON
+/// assets — the Soroban `contracts-manifest.json` (whose `id` becomes
+/// the governance authority via `ContractsRepository`) and the curated
+/// relay / server lists that are auto-installed as defaults on a cold
+/// install.
+///
+/// Each of those assets is downloaded over a plain GET (H-3). This type
+/// adds client-side **Ed25519 detached-signature** verification: the
+/// asset is signed offline with a private key that never touches the
+/// app, and the app ships only the matching *public* key. A MITM /
+/// compromised-CDN / trusted-proxy attacker who swaps the JSON can no
+/// longer forge a matching signature.
+///
+/// ## Enforcement is GATED OFF by default
+///
+/// `enforceSignatures` defaults to `false` (soft mode) because **no
+/// signed assets are published yet** — flipping it on before the
+/// release-signing pipeline is live would brick prepopulation on every
+/// install. In soft mode a missing/invalid signature is logged as a
+/// warning and the asset is used anyway (preserving today's behaviour).
+/// In enforce mode an unverified asset is rejected.
+///
+/// Turning enforcement on requires, in order:
+///   1. The offline release-signing pipeline that produces `<asset>.sig`
+///      files and attaches them to each GitHub release (tracked
+///      separately — see PR / issue #183).
+///   2. Replacing the placeholder public key in
+///      `Resources/contracts-trust-pubkey.json` with the real
+///      offline-signing public key.
+///   3. Flipping `enforceSignatures` to `true`.
+enum ContractsTrust {
+    /// MASTER SWITCH. **Leave `false`** until the release-signing
+    /// pipeline is live and real `.sig` assets ship (see the type doc).
+    /// `true` makes the fetchers reject any asset without a valid
+    /// detached signature made by `bundledPublicKey`.
+    static let enforceSignatures = false
+
+    /// The offline-signing public key bundled with the app, or `nil`
+    /// when the placeholder has not yet been replaced (empty
+    /// `publicKeyBase64`). A `nil` key fails **closed**: under
+    /// `enforceSignatures == true` every asset is rejected, so the flag
+    /// can never be flipped on without also shipping a real key.
+    static let bundledPublicKey: Curve25519.Signing.PublicKey? = loadBundledPublicKey()
+
+    private struct PublicKeyDocument: Decodable {
+        let publicKeyBase64: String
+    }
+
+    private static func loadBundledPublicKey() -> Curve25519.Signing.PublicKey? {
+        guard let url = Bundle.main.url(
+            forResource: "contracts-trust-pubkey",
+            withExtension: "json"
+        ) else { return nil }
+        guard
+            let data = try? Data(contentsOf: url),
+            let doc = try? JSONDecoder().decode(PublicKeyDocument.self, from: data),
+            !doc.publicKeyBase64.isEmpty,
+            let raw = Data(base64Encoded: doc.publicKeyBase64),
+            let key = try? Curve25519.Signing.PublicKey(rawRepresentation: raw)
+        else { return nil }
+        return key
+    }
+}
+
+/// Reusable Ed25519 detached-signature verifier. Wraps a single
+/// CryptoKit `Curve25519.Signing.PublicKey`; `isValid` returns `false`
+/// (never throws) for a missing key, a malformed signature, or a genuine
+/// mismatch so callers can apply their own soft/enforce policy.
+struct Ed25519DetachedSignatureVerifier: Sendable {
+    let publicKey: Curve25519.Signing.PublicKey?
+
+    /// The app-wide verifier keyed on the bundled public key.
+    static let bundled = Ed25519DetachedSignatureVerifier(publicKey: ContractsTrust.bundledPublicKey)
+
+    /// Verify a detached `signature` over the exact `data` bytes.
+    /// Returns `false` if no public key is configured.
+    func isValid(signature: Data, for data: Data) -> Bool {
+        guard let publicKey else { return false }
+        return publicKey.isValidSignature(signature, for: data)
+    }
+}
+
+enum SignedAssetVerificationError: Error, Sendable {
+    /// No detached signature could be fetched (network failure / non-2xx
+    /// on the `<asset>.sig` URL). Only thrown under enforcement.
+    case signatureUnavailable
+    /// A signature was fetched but did not verify against the bundled
+    /// public key (tampering, wrong key, or no key configured). Only
+    /// thrown under enforcement.
+    case signatureInvalid
+}
+
+/// Shared verification step wired into every trust-critical fetcher.
+/// Fetches the detached signature that lives alongside the asset at
+/// `<asset-url>.sig`, verifies it against the bundled public key, and
+/// applies the soft/enforce policy from `ContractsTrust`.
+enum SignedAsset {
+    private static let log = Logger(subsystem: "app.onym.ios", category: "ContractsTrust")
+
+    /// - Parameters:
+    ///   - assetData: the exact bytes that were fetched and will be used.
+    ///   - assetURL: the asset's URL; the signature is fetched from
+    ///     `<assetURL>.sig`.
+    ///   - session: the same `URLSession` the asset was fetched with
+    ///     (so tests can stub the `.sig` request too).
+    ///   - label: human-readable asset name for log lines.
+    ///   - verifier: the Ed25519 verifier (defaults to the bundled key).
+    ///   - enforce: policy switch (defaults to `ContractsTrust.enforceSignatures`).
+    /// - Throws: `SignedAssetVerificationError` **only** when `enforce`
+    ///   is `true` and the signature is missing or invalid. In soft mode
+    ///   this never throws — it logs a warning and returns.
+    static func verify(
+        assetData: Data,
+        assetURL: URL,
+        session: URLSession,
+        label: String,
+        verifier: Ed25519DetachedSignatureVerifier = .bundled,
+        enforce: Bool = ContractsTrust.enforceSignatures
+    ) async throws {
+        let signature: Data?
+        do {
+            signature = try await fetchSignature(for: assetURL, session: session)
+        } catch {
+            signature = nil
+        }
+
+        guard let signature else {
+            if enforce {
+                log.error("\(label, privacy: .public): no detached signature available; rejecting (enforcement ON)")
+                throw SignedAssetVerificationError.signatureUnavailable
+            }
+            log.warning("\(label, privacy: .public): no detached signature available; accepting anyway (enforcement OFF, H-3 soft mode)")
+            return
+        }
+
+        if verifier.isValid(signature: signature, for: assetData) {
+            return
+        }
+
+        if enforce {
+            log.error("\(label, privacy: .public): detached signature did NOT verify; rejecting (enforcement ON)")
+            throw SignedAssetVerificationError.signatureInvalid
+        }
+        log.warning("\(label, privacy: .public): detached signature did NOT verify; accepting anyway (enforcement OFF, H-3 soft mode)")
+    }
+
+    /// Fetch and decode the raw signature bytes from `<assetURL>.sig`.
+    /// Accepts either a 64-byte raw Ed25519 signature or its base64
+    /// text encoding. Throws on network failure / non-2xx so the caller
+    /// treats the signature as unavailable.
+    private static func fetchSignature(for assetURL: URL, session: URLSession) async throws -> Data {
+        let sigURL = URL(string: assetURL.absoluteString + ".sig") ?? assetURL.appendingPathExtension("sig")
+        let (data, response) = try await session.data(from: sigURL)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(status) else {
+            throw SignedAssetVerificationError.signatureUnavailable
+        }
+        return decodeSignature(data)
+    }
+
+    /// A raw 64-byte Ed25519 signature is used as-is; otherwise the body
+    /// is treated as base64 (trimmed) and decoded. Falls back to the raw
+    /// bytes so a malformed body simply fails verification rather than
+    /// crashing.
+    static func decodeSignature(_ data: Data) -> Data {
+        if data.count == 64 { return data }
+        if let text = String(data: data, encoding: .utf8),
+           let decoded = Data(base64Encoded: text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            return decoded
+        }
+        return data
+    }
+}

--- a/Sources/OnymIOS/Chain/KnownRelayersFetcher.swift
+++ b/Sources/OnymIOS/Chain/KnownRelayersFetcher.swift
@@ -42,6 +42,15 @@ struct GitHubReleasesKnownRelayersFetcher: KnownRelayersFetcher {
         guard (200..<300).contains(statusCode) else {
             throw KnownRelayersFetchError.badStatus(statusCode)
         }
+        // H-3: verify the detached Ed25519 signature at `<url>.sig`.
+        // Soft mode by default (see `ContractsTrust`); throws only
+        // under enforcement.
+        try await SignedAsset.verify(
+            assetData: data,
+            assetURL: url,
+            session: session,
+            label: "relayers.json"
+        )
         let document: KnownRelayersDocument
         do {
             document = try decoder.decode(KnownRelayersDocument.self, from: data)

--- a/Sources/OnymIOS/Transport/Blossom/KnownBlossomServersFetcher.swift
+++ b/Sources/OnymIOS/Transport/Blossom/KnownBlossomServersFetcher.swift
@@ -45,6 +45,15 @@ struct GitHubReleasesKnownBlossomServersFetcher: KnownBlossomServersFetcher {
         guard (200..<300).contains(status) else {
             throw KnownBlossomServersFetchError.badStatus(status)
         }
+        // H-3: verify the detached Ed25519 signature at `<url>.sig`.
+        // Soft mode by default (see `ContractsTrust`); throws only
+        // under enforcement.
+        try await SignedAsset.verify(
+            assetData: data,
+            assetURL: url,
+            session: session,
+            label: "blossom-servers.json"
+        )
         do {
             return try decoder.decode(KnownBlossomServersDocument.self, from: data).servers
         } catch {

--- a/Sources/OnymIOS/Transport/Nostr/KnownNostrRelaysFetcher.swift
+++ b/Sources/OnymIOS/Transport/Nostr/KnownNostrRelaysFetcher.swift
@@ -48,6 +48,15 @@ struct GitHubReleasesKnownNostrRelaysFetcher: KnownNostrRelaysFetcher {
         guard (200..<300).contains(status) else {
             throw KnownNostrRelaysFetchError.badStatus(status)
         }
+        // H-3: verify the detached Ed25519 signature at `<url>.sig`.
+        // Soft mode by default (see `ContractsTrust`); throws only
+        // under enforcement.
+        try await SignedAsset.verify(
+            assetData: data,
+            assetURL: url,
+            session: session,
+            label: "nostr-relays.json"
+        )
         do {
             return try decoder.decode(KnownNostrRelaysDocument.self, from: data).relays
         } catch {

--- a/Tests/OnymIOSTests/ContractsManifestFetcherTests.swift
+++ b/Tests/OnymIOSTests/ContractsManifestFetcherTests.swift
@@ -23,6 +23,13 @@ final class ContractsManifestFetcherTests: XCTestCase {
 
     func test_fetchLatest_parsesValidDocument() async throws {
         StubURLProtocol.set { request in
+            // H-3: the fetcher also requests the detached signature at
+            // `<asset>.sig`. Answer that with a 404 so the fetcher runs
+            // in soft mode (no signed assets published yet) and still
+            // returns the decoded manifest.
+            if request.url?.absoluteString.hasSuffix(".sig") == true {
+                return (Data(), HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+            }
             XCTAssertEqual(request.url, self.fixtureURL)
             let body = """
             {

--- a/Tests/OnymIOSTests/ContractsTrustTests.swift
+++ b/Tests/OnymIOSTests/ContractsTrustTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+import CryptoKit
+@testable import OnymIOS
+
+/// H-3 — client-side Ed25519 detached-signature verification for the
+/// trust-critical fetched assets. Covers the pure verifier, the shared
+/// `SignedAsset.verify` policy (soft vs. enforce), and the soft-mode
+/// behaviour through the real manifest fetcher.
+final class ContractsTrustTests: XCTestCase {
+    private var session: URLSession!
+    private let assetURL = URL(string: "https://test.example/contracts-manifest.json")!
+
+    override func setUp() {
+        super.setUp()
+        session = StubURLProtocol.makeSession()
+    }
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        session = nil
+        super.tearDown()
+    }
+
+    // MARK: - Ed25519DetachedSignatureVerifier
+
+    func test_verifier_validSignatureVerifies() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let data = Data("trust-critical payload".utf8)
+        let sig = try key.signature(for: data)
+        let verifier = Ed25519DetachedSignatureVerifier(publicKey: key.publicKey)
+        XCTAssertTrue(verifier.isValid(signature: sig, for: data))
+    }
+
+    func test_verifier_tamperedBytesFail() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let sig = try key.signature(for: Data("original".utf8))
+        let verifier = Ed25519DetachedSignatureVerifier(publicKey: key.publicKey)
+        XCTAssertFalse(verifier.isValid(signature: sig, for: Data("tampered".utf8)))
+    }
+
+    func test_verifier_wrongKeyFails() throws {
+        let signingKey = Curve25519.Signing.PrivateKey()
+        let otherKey = Curve25519.Signing.PrivateKey()
+        let data = Data("payload".utf8)
+        let sig = try signingKey.signature(for: data)
+        let verifier = Ed25519DetachedSignatureVerifier(publicKey: otherKey.publicKey)
+        XCTAssertFalse(verifier.isValid(signature: sig, for: data))
+    }
+
+    func test_verifier_noKeyFailsClosed() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let data = Data("payload".utf8)
+        let sig = try key.signature(for: data)
+        let verifier = Ed25519DetachedSignatureVerifier(publicKey: nil)
+        XCTAssertFalse(verifier.isValid(signature: sig, for: data))
+    }
+
+    // MARK: - SignedAsset.verify — enforce mode
+
+    func test_verify_enforce_validSignaturePasses() async throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let data = Data("asset-bytes".utf8)
+        let sig = try key.signature(for: data)
+        StubURLProtocol.set { request in
+            XCTAssertEqual(request.url?.absoluteString, self.assetURL.absoluteString + ".sig")
+            return (sig, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        try await SignedAsset.verify(
+            assetData: data,
+            assetURL: assetURL,
+            session: session,
+            label: "test",
+            verifier: Ed25519DetachedSignatureVerifier(publicKey: key.publicKey),
+            enforce: true
+        )
+    }
+
+    func test_verify_enforce_invalidSignatureThrows() async throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let data = Data("asset-bytes".utf8)
+        let sig = try key.signature(for: Data("something-else".utf8))
+        StubURLProtocol.set { request in
+            (sig, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        do {
+            try await SignedAsset.verify(
+                assetData: data, assetURL: assetURL, session: session, label: "test",
+                verifier: Ed25519DetachedSignatureVerifier(publicKey: key.publicKey), enforce: true
+            )
+            XCTFail("expected throw")
+        } catch SignedAssetVerificationError.signatureInvalid { /* expected */ }
+        catch { XCTFail("expected signatureInvalid, got \(error)") }
+    }
+
+    func test_verify_enforce_missingSignatureThrows() async {
+        let data = Data("asset-bytes".utf8)
+        StubURLProtocol.set { request in
+            (Data(), HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+        }
+        do {
+            try await SignedAsset.verify(
+                assetData: data, assetURL: assetURL, session: session, label: "test",
+                verifier: Ed25519DetachedSignatureVerifier(publicKey: Curve25519.Signing.PrivateKey().publicKey), enforce: true
+            )
+            XCTFail("expected throw")
+        } catch SignedAssetVerificationError.signatureUnavailable { /* expected */ }
+        catch { XCTFail("expected signatureUnavailable, got \(error)") }
+    }
+
+    // MARK: - SignedAsset.verify — soft mode (default) never throws
+
+    func test_verify_softMode_missingSignatureDoesNotThrow() async throws {
+        let data = Data("asset-bytes".utf8)
+        StubURLProtocol.set { request in
+            (Data(), HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+        }
+        try await SignedAsset.verify(
+            assetData: data, assetURL: assetURL, session: session, label: "test",
+            verifier: .bundled, enforce: false
+        )
+    }
+
+    func test_verify_softMode_invalidSignatureDoesNotThrow() async throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let data = Data("asset-bytes".utf8)
+        let sig = try key.signature(for: Data("something-else".utf8))
+        StubURLProtocol.set { request in
+            (sig, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        try await SignedAsset.verify(
+            assetData: data, assetURL: assetURL, session: session, label: "test",
+            verifier: Ed25519DetachedSignatureVerifier(publicKey: key.publicKey), enforce: false
+        )
+    }
+
+    // MARK: - Soft mode through the real fetcher still yields the manifest
+
+    func test_manifestFetcher_softMode_invalidSignatureStillDecodes() async throws {
+        let manifestBody = """
+        {
+          "version": 1,
+          "releases": [{
+            "release": "v0.0.1",
+            "publishedAt": "2026-05-01T11:43:00Z",
+            "contracts": [{ "network": "testnet", "type": "anarchy", "id": "CID" }]
+          }]
+        }
+        """
+        StubURLProtocol.set { request in
+            if request.url?.absoluteString.hasSuffix(".sig") == true {
+                // A signature is present but does not verify — soft mode
+                // (enforcement OFF) must log and still return the manifest.
+                return (Data("bogus-signature".utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
+            return (Data(manifestBody.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let fetcher = GitHubReleasesContractsManifestFetcher(url: assetURL, session: session)
+        let manifest = try await fetcher.fetchLatest()
+        XCTAssertEqual(manifest.releases.first?.contracts.first?.id, "CID")
+    }
+
+    // MARK: - signature decoding + default policy
+
+    func test_decodeSignature_acceptsRawAndBase64() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let sig = try key.signature(for: Data("x".utf8))
+        XCTAssertEqual(sig.count, 64)
+        XCTAssertEqual(SignedAsset.decodeSignature(sig), sig, "raw 64-byte signature used as-is")
+        let base64Body = Data(sig.base64EncodedString().utf8)
+        XCTAssertEqual(SignedAsset.decodeSignature(base64Body), sig, "base64 text decoded to raw bytes")
+    }
+
+    func test_enforcementDefaultsOff() {
+        XCTAssertFalse(
+            ContractsTrust.enforceSignatures,
+            "H-3: enforcement must stay OFF until the release-signing pipeline ships signed assets and a real public key"
+        )
+    }
+}

--- a/Tests/OnymIOSTests/KnownRelayersFetcherTests.swift
+++ b/Tests/OnymIOSTests/KnownRelayersFetcherTests.swift
@@ -25,6 +25,12 @@ final class KnownRelayersFetcherTests: XCTestCase {
 
     func test_fetchLatest_parsesValidDocument() async throws {
         StubURLProtocol.set { request in
+            // H-3: the fetcher also requests the detached signature at
+            // `<asset>.sig`. Answer that with a 404 so the fetcher runs
+            // in soft mode (no signed assets published yet).
+            if request.url?.absoluteString.hasSuffix(".sig") == true {
+                return (Data(), HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+            }
             XCTAssertEqual(request.url, self.fixtureURL)
             let body = """
             {


### PR DESCRIPTION
## H-3 (High) — fetched trust-critical lists are unverified

The contracts manifest and the relayer / Nostr-relay / Blossom-server lists were fetched over a plain GET and trusted after only a `2xx` + schema check — no detached signature, digest, or pinning. A MITM / compromised-CDN / trusted-proxy attacker could:

- swap `contracts-manifest.json` to an attacker Soroban contract — its `id` becomes the governance authority via `ContractsRepository`; **or**
- swap the relay/server lists to route traffic through attacker infra (auto-installed as defaults on a cold install).

## What this PR does

Adds client-side **Ed25519 detached-signature verification** (CryptoKit `Curve25519.Signing`):

- **`ContractsTrust` + `Ed25519DetachedSignatureVerifier` + `SignedAsset.verify`** (`Sources/OnymIOS/Chain/ContractsTrust.swift`). Each fetcher now additionally fetches the detached signature at `<asset>.sig` and verifies it against a public key bundled in the app.
- **Bundled public-key slot** at `Resources/contracts-trust-pubkey.json`, shipped with a clearly-marked **placeholder** (empty key) and a code comment that it must be replaced with the real offline-signing public key before enforcement is enabled. A `nil`/placeholder key **fails closed** — enforcement can never be turned on without also shipping a real key.
- **Wired into all four fetchers**: `ContractsManifestFetcher` (primary), `KnownRelayersFetcher`, `KnownNostrRelaysFetcher`, `KnownBlossomServersFetcher`. The `.sig` is fetched with the same `URLSession` as the asset.

## Enforcement is GATED OFF (soft mode)

Verification is implemented but **enforcement is disabled by default** behind a single flag: `ContractsTrust.enforceSignatures = false`. **No signed assets are published yet**, so:

- **Soft mode (default):** a missing/invalid signature is logged as a warning (`os.Logger`, category `ContractsTrust`) and the asset is used anyway — today's unsigned assets keep working, no fetching is broken.
- **Enforce mode (`true`):** unverified assets are rejected (`SignedAssetVerificationError`).

**Flipping enforcement on requires, in order (tracked separately — the release-signing pipeline):**
1. The offline release-signing pipeline that produces `<asset>.sig` files and attaches them to each GitHub release.
2. Replacing the placeholder public key in `Resources/contracts-trust-pubkey.json` with the real offline-signing public key.
3. Setting `ContractsTrust.enforceSignatures = true`.

## Testing

Regenerated the project (`./generate-xcodeproj.sh`, new files added) and ran on the iOS 26 `iPhone 17` simulator with `-derivedDataPath /tmp/onym-ddp-h3`:

- `xcodebuild ... build-for-testing` → **TEST BUILD SUCCEEDED**
- `xcodebuild ... test-without-building` for: `ContractsTrustTests`, `ContractsManifestFetcherTests`, `KnownRelayersFetcherTests`, `ContractsManifestDecodingTests`, `ContractsRepositoryTests`, `NostrRelaysRepositoryTests`, `BlossomServersRepositoryTests` → **all passed** (12 new `ContractsTrustTests` + all listed suites green).

New tests (`Tests/OnymIOSTests/ContractsTrustTests.swift`) cover: valid signature verifies; tampered bytes fail; wrong key fails; no key fails closed; enforce-mode passes on valid / throws `signatureInvalid` on tamper / throws `signatureUnavailable` on missing sig; soft-mode never throws on missing/invalid; soft-mode through the real manifest fetcher still yields the decoded manifest (warning path); raw + base64 signature decoding; and that enforcement defaults OFF. Existing network-test handlers were updated to also answer the new `<asset>.sig` request.

## Remaining to enable enforcement

The offline release-signing pipeline (produce + publish `.sig` assets) and the real public key — after which flip `ContractsTrust.enforceSignatures` to `true`.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)