### PR TITLE
fix(security): recovery-phrase biometric gate fails closed in release

### DIFF
--- a/Sources/OnymIOS/Recovery/BiometricAuthenticator.swift
+++ b/Sources/OnymIOS/Recovery/BiometricAuthenticator.swift
@@ -7,20 +7,62 @@ import LocalAuthentication
 protocol BiometricAuthenticator: Sendable {
     /// Prompts the user. Returns on success; throws on cancel / failure.
     /// On devices/simulators where `canEvaluatePolicy` is false (no enrolled
-    /// biometric and no passcode), the call returns successfully without
-    /// prompting — matches the reference impl's "fail open in dev" behaviour.
+    /// biometric and no passcode), behaviour depends on the build: DEBUG
+    /// returns successfully ("fail open") so dev/simulator flows work, while
+    /// Release throws ("fail closed") so the recovery phrase is never revealed
+    /// without authentication.
     func authenticate(reason: String) async throws
 }
 
+/// Raised by `LAContextAuthenticator` when the device cannot evaluate the
+/// auth policy (no passcode / no enrolled biometric) and the build is
+/// configured to fail closed. The message never reveals the phrase.
+enum BiometricAuthError: LocalizedError {
+    case deviceSecurityUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .deviceSecurityUnavailable:
+            return String(localized: "Set a device passcode to view your recovery phrase.")
+        }
+    }
+}
+
 struct LAContextAuthenticator: BiometricAuthenticator {
+    /// Whether an unevaluable auth policy fails CLOSED (throws) or OPEN
+    /// (returns). Defaults to the compile-time posture: Release fails closed
+    /// so production never bypasses auth; DEBUG fails open so a fresh
+    /// simulator dev flow still works. Injectable so both branches stay
+    /// unit-testable under the DEBUG test build.
+    #if DEBUG
+    static let failClosedByDefault = false
+    #else
+    static let failClosedByDefault = true
+    #endif
+
+    let failClosed: Bool
+    private let canEvaluate: @Sendable (LAContext) -> Bool
+
+    init(
+        failClosed: Bool = LAContextAuthenticator.failClosedByDefault,
+        canEvaluate: @escaping @Sendable (LAContext) -> Bool = { context in
+            var error: NSError?
+            return context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
+        }
+    ) {
+        self.failClosed = failClosed
+        self.canEvaluate = canEvaluate
+    }
+
     func authenticate(reason: String) async throws {
         let context = LAContext()
-        var error: NSError?
-        guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) else {
-            // No biometric / no passcode set up — proceed so the dev flow
-            // still works on a fresh simulator. Production devices in this
-            // state are extremely rare and the user has explicitly opted
-            // out of device security.
+        guard canEvaluate(context) else {
+            // No biometric / no passcode set up. Fail CLOSED in Release so the
+            // phrase is never revealed without authentication; fail OPEN in
+            // DEBUG so the dev flow still works on a fresh simulator.
+            if failClosed {
+                throw BiometricAuthError.deviceSecurityUnavailable
+            }
             return
         }
         try await context.evaluatePolicyAsync(

--- a/Tests/OnymIOSTests/RecoveryPhraseBackupFlowTests.swift
+++ b/Tests/OnymIOSTests/RecoveryPhraseBackupFlowTests.swift
@@ -103,6 +103,90 @@ final class RecoveryPhraseBackupFlowTests: XCTestCase {
         XCTAssertEqual(flow.step, .intro)
     }
 
+    // MARK: - Biometric fail-closed (recovery-phrase gate)
+
+    // Drives the *real* `LAContextAuthenticator` decision (not a fake) with
+    // `canEvaluate` forced false to simulate a device with no passcode /
+    // biometric enrolled. `failClosed: true` is the Release posture.
+    func test_unevaluablePolicy_failClosed_blocksReveal() async {
+        let authenticator = LAContextAuthenticator(
+            failClosed: true,
+            canEvaluate: { _ in false }
+        )
+        let gatedFlow = RecoveryPhraseBackupFlow(
+            repository: repository,
+            authenticator: authenticator,
+            pasteboard: pasteboard
+        )
+        defer { gatedFlow.stop() }
+
+        await gatedFlow.authenticate()
+
+        guard case let .authFailed(reason) = gatedFlow.step else {
+            return XCTFail("expected .authFailed, got \(gatedFlow.step)")
+        }
+        XCTAssertEqual(reason, "Set a device passcode to view your recovery phrase.")
+        if case .reveal = gatedFlow.step {
+            XCTFail("reveal must be blocked when the policy is unevaluable and failClosed")
+        }
+    }
+
+    // DEBUG posture: the same unevaluable policy fails OPEN so the dev flow
+    // proceeds to the reveal step.
+    func test_unevaluablePolicy_failOpen_reachesReveal() async {
+        let authenticator = LAContextAuthenticator(
+            failClosed: false,
+            canEvaluate: { _ in false }
+        )
+        let openFlow = RecoveryPhraseBackupFlow(
+            repository: repository,
+            authenticator: authenticator,
+            pasteboard: pasteboard
+        )
+        defer { openFlow.stop() }
+        openFlow.start()
+        await waitForReady(openFlow)
+
+        await openFlow.authenticate()
+
+        guard case .reveal = openFlow.step else {
+            return XCTFail("fail-open should reach .reveal, got \(openFlow.step)")
+        }
+    }
+
+    // Direct unit tests of the authenticator's decision, independent of the flow.
+    func test_laContextAuthenticator_failClosed_throwsOnUnevaluablePolicy() async {
+        let auth = LAContextAuthenticator(failClosed: true, canEvaluate: { _ in false })
+        do {
+            try await auth.authenticate(reason: "x")
+            XCTFail("expected a throw when failClosed and policy is unevaluable")
+        } catch {
+            XCTAssertEqual(
+                (error as? LocalizedError)?.errorDescription,
+                "Set a device passcode to view your recovery phrase."
+            )
+        }
+    }
+
+    func test_laContextAuthenticator_failOpen_returnsOnUnevaluablePolicy() async throws {
+        let auth = LAContextAuthenticator(failClosed: false, canEvaluate: { _ in false })
+        try await auth.authenticate(reason: "x")  // must not throw
+    }
+
+    func test_laContextAuthenticator_defaultPosture_matchesBuildConfiguration() {
+        #if DEBUG
+        XCTAssertFalse(
+            LAContextAuthenticator.failClosedByDefault,
+            "DEBUG builds fail open so simulator/dev flows work"
+        )
+        #else
+        XCTAssertTrue(
+            LAContextAuthenticator.failClosedByDefault,
+            "Release builds must fail closed"
+        )
+        #endif
+    }
+
     // MARK: - Reveal
 
     func test_tappedReveal_flipsRevealedTrue() async {
@@ -217,11 +301,12 @@ final class RecoveryPhraseBackupFlowTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func waitForReady() async {
+    private func waitForReady(_ target: RecoveryPhraseBackupFlow? = nil) async {
         // setUp triggers `flow.start()` which kicks off bootstrap + snapshot
         // drain. Spin briefly for the first snapshot to land.
+        let target = target ?? flow!
         for _ in 0..<50 {
-            if flow.isReady { return }
+            if target.isReady { return }
             try? await Task.sleep(for: .milliseconds(10))
         }
         XCTFail("flow.isReady never flipped true within 500ms")


### PR DESCRIPTION
## Summary

The recovery-phrase biometric gate failed **open** in Release. In `LAContextAuthenticator.authenticate(reason:)`, when `LAContext.canEvaluatePolicy(.deviceOwnerAuthentication)` was false (no passcode / no enrolled biometric), the method simply `return`ed — treated as success — with no prompt. Since this shipped in Release, a device with no device security would reveal the recovery phrase with no authentication at all.

### Fix
- Fail-open is now **DEBUG-only**. In Release, an unevaluable policy fails **closed**: `LAContextAuthenticator` throws `BiometricAuthError.deviceSecurityUnavailable` ("Set a device passcode to view your recovery phrase."). The message never reveals the phrase.
- DEBUG keeps the fail-open `return` so simulator/dev flows still work on a fresh simulator without a passcode.
- The posture is a compile-time default (`failClosedByDefault`: `false` in DEBUG, `true` in Release) but injectable via a `failClosed` flag so both branches are unit-testable under the DEBUG test build. The `canEvaluate` check is likewise injectable for deterministic testing.
- The throw propagates into `RecoveryPhraseBackupFlow.authenticate()`, which routes it to `.authFailed` — the flow never reaches `.reveal` on this path.
- `AlwaysAcceptAuthenticator` was already correctly gated behind `#if DEBUG` and is left untouched.

## Testing

`xcodebuild test -scheme OnymIOS -only-testing:OnymIOSTests/RecoveryPhraseBackupFlowTests` on the iPhone 17 simulator (derived data `/tmp/onym-ddp-bio`): **18 tests, 0 failures**.

New tests:
- `test_unevaluablePolicy_failClosed_blocksReveal` — real `LAContextAuthenticator` with policy forced unevaluable + `failClosed: true` drives the flow to `.authFailed` (not `.reveal`) with the passcode message.
- `test_unevaluablePolicy_failOpen_reachesReveal` — same but `failClosed: false` reaches `.reveal` (DEBUG posture).
- `test_laContextAuthenticator_failClosed_throwsOnUnevaluablePolicy` / `..._failOpen_returnsOnUnevaluablePolicy` — direct unit tests of both branches.
- `test_laContextAuthenticator_defaultPosture_matchesBuildConfiguration` — asserts the compile-time default matches the build config.

All pre-existing tests remain green.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)