### PR TITLE
fix(transport): connection state machine, CLOSED handling, single-REQ subscriptions (reconnect PR-2)

### DIFF
--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -58,12 +58,19 @@ final class NostrInboxTransport: InboxTransport {
     }
 
     func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
-        AsyncStream<InboundInbox> { continuation in
+        // Per-stream token: this stream's termination may fire *after* a
+        // newer subscription for the same inbox has been installed
+        // (re-subscribe on identity rebalance / pump restart). Cleanup
+        // is token-guarded so the stale termination can't tear down the
+        // fresh subscription — the same race the per-generation subIDs
+        // close at the relay-connection level.
+        let token = UUID()
+        return AsyncStream<InboundInbox> { continuation in
             Task { [state] in
-                await state.subscribe(inbox: inbox, continuation: continuation)
+                await state.subscribe(inbox: inbox, token: token, continuation: continuation)
             }
             continuation.onTermination = { @Sendable [state] _ in
-                Task { await state.unsubscribe(inbox: inbox) }
+                Task { await state.unsubscribe(inbox: inbox, ifToken: token) }
             }
         }
     }
@@ -97,7 +104,15 @@ final class NostrInboxTransport: InboxTransport {
 
     fileprivate actor State {
         private var connections: [URL: NostrRelayConnection] = [:]
-        private var activeSubscriptions: [TransportInboxID: Task<Void, Never>] = [:]
+        /// Live per-inbox subscription: the pump task plus the stream
+        /// token that owns it (see `subscribe`'s token guard).
+        private var activeSubscriptions: [TransportInboxID: (token: UUID, task: Task<Void, Never>)] = [:]
+        /// Monotonic counter for relay subscription IDs. Each subscribe
+        /// gets a unique id so an old stream's asynchronous
+        /// `onTermination` CLOSE can't tear down a freshly opened REQ
+        /// for the same inbox — the exact race `NostrMessageTransport`
+        /// already guards against with its own generation counter.
+        private var subscriptionGeneration: UInt64 = 0
 
         func connect(to endpoints: [TransportEndpoint]) async {
             for endpoint in endpoints {
@@ -110,8 +125,8 @@ final class NostrInboxTransport: InboxTransport {
         }
 
         func disconnect() async {
-            for task in activeSubscriptions.values {
-                task.cancel()
+            for entry in activeSubscriptions.values {
+                entry.task.cancel()
             }
             activeSubscriptions.removeAll()
             for conn in connections.values {
@@ -171,10 +186,12 @@ final class NostrInboxTransport: InboxTransport {
 
         func subscribe(
             inbox: TransportInboxID,
+            token: UUID,
             continuation: AsyncStream<InboundInbox>.Continuation
         ) {
-            activeSubscriptions[inbox]?.cancel()
-            let subID = "inbox-\(inbox.rawValue)"
+            activeSubscriptions[inbox]?.task.cancel()
+            subscriptionGeneration += 1
+            let subID = "inbox-\(inbox.rawValue)-\(subscriptionGeneration)"
             let filters = NostrInboxTransport.subscriptionFilters(inbox: inbox.rawValue)
             let conns = Array(connections.values)
 
@@ -207,12 +224,24 @@ final class NostrInboxTransport: InboxTransport {
                     }
                 }
             }
-            activeSubscriptions[inbox] = task
+            activeSubscriptions[inbox] = (token: token, task: task)
         }
 
+        /// Deliberate unsubscribe (protocol surface): unconditional.
         func unsubscribe(inbox: TransportInboxID) {
-            activeSubscriptions[inbox]?.cancel()
+            activeSubscriptions[inbox]?.task.cancel()
             activeSubscriptions.removeValue(forKey: inbox)
+        }
+
+        /// Stream-termination cleanup: only tears down the subscription
+        /// the terminating stream actually owns. A stale termination
+        /// (its inbox was re-subscribed and a newer stream installed)
+        /// is a no-op — without this guard the old stream's async
+        /// cleanup cancelled the fresh subscription and the inbox went
+        /// silently deaf.
+        func unsubscribe(inbox: TransportInboxID, ifToken token: UUID) {
+            guard activeSubscriptions[inbox]?.token == token else { return }
+            unsubscribe(inbox: inbox)
         }
     }
 }

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -174,28 +174,34 @@ final class NostrInboxTransport: InboxTransport {
             continuation: AsyncStream<InboundInbox>.Continuation
         ) {
             activeSubscriptions[inbox]?.cancel()
-            let subIDBase = "inbox-\(inbox.rawValue)"
+            let subID = "inbox-\(inbox.rawValue)"
             let filters = NostrInboxTransport.subscriptionFilters(inbox: inbox.rawValue)
             let conns = Array(connections.values)
 
             let task = Task {
                 await withTaskGroup(of: Void.self) { group in
                     for conn in conns {
-                        for (index, filter) in filters.enumerated() {
-                            group.addTask {
-                                let filterSubID = "\(subIDBase)-\(index)"
-                                let stream = await conn.subscribe(subscriptionID: filterSubID, filter: filter)
-                                for await event in stream {
-                                    guard !Task.isCancelled else { break }
-                                    guard let payload = Data(base64Encoded: event.content) else { continue }
-                                    let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
-                                    continuation.yield(InboundInbox(
-                                        inbox: inbox,
-                                        payload: payload,
-                                        receivedAt: received,
-                                        messageID: event.id
-                                    ))
-                                }
+                        // One REQ carrying all three filter shapes — NOT
+                        // one REQ per filter. The relay dedups events
+                        // across a subscription's filters (NIP-01), and a
+                        // single subscription per inbox keeps the
+                        // connection well under relay
+                        // `maxSubsPerConnection` caps (strfry default 20;
+                        // 3 REQs per inbox tripped it on
+                        // subscription-heavy devices and the overflow was
+                        // silently CLOSED).
+                        group.addTask {
+                            let stream = await conn.subscribe(subscriptionID: subID, filters: filters)
+                            for await event in stream {
+                                guard !Task.isCancelled else { break }
+                                guard let payload = Data(base64Encoded: event.content) else { continue }
+                                let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
+                                continuation.yield(InboundInbox(
+                                    inbox: inbox,
+                                    payload: payload,
+                                    receivedAt: received,
+                                    messageID: event.id
+                                ))
                             }
                         }
                     }

--- a/Sources/OnymIOS/Transport/Nostr/NostrMessageTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrMessageTransport.swift
@@ -160,7 +160,7 @@ final class NostrMessageTransport: MessageTransport {
                                 "#t": [topic.rawValue],
                                 "since": sinceUnix,
                             ]
-                            let stream = await conn.subscribe(subscriptionID: subID, filter: filter)
+                            let stream = await conn.subscribe(subscriptionID: subID, filters: [filter])
                             for await event in stream {
                                 guard !Task.isCancelled else { break }
                                 guard let payload = Data(base64Encoded: event.content) else { continue }

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -29,7 +29,10 @@ import os.log
 ///  - A subscription is one `REQ` carrying *all* of its filters (NIP-01
 ///    dedups within a subscription) — never one REQ per filter, which
 ///    multiplied subscription count 3× and tripped relay
-///    `maxSubsPerConnection` caps.
+///    `maxSubsPerConnection` caps. The connection's relay-side budget is
+///    `subscriptions.count + 1`: the liveness probe holds one extra sub
+///    slot for the connection's lifetime (it is never CLOSEd — its
+///    periodic re-REQ replaces itself in place).
 ///  - `CLOSED` is handled, not ignored: first CLOSED for a live
 ///    subscription re-REQs it once; a repeat within the same connection
 ///    generation treats the connection as unhealthy and rebuilds. A
@@ -58,7 +61,18 @@ actor NostrRelayConnection {
     private var lastActivityAt = Date()
     /// Subscription ids already re-REQ'd after a CLOSED in the current
     /// generation. A second CLOSED for the same id escalates to a rebuild.
+    /// An id is removed again when its subscription is confirmed accepted
+    /// (EOSE/EVENT lands for it), so benign CLOSEDs hours apart on a
+    /// long-lived socket don't accumulate into a spurious rebuild.
     private var closedRetriedSubIDs: Set<String> = []
+    /// Consecutive rebuilds caused by repeated CLOSED. Deliberately NOT
+    /// reset by frame arrival (a CLOSED-spewing relay still sends
+    /// frames — that's what made the naive backoff hot-loop at ~1 Hz);
+    /// reset only when a subscription is confirmed accepted (EOSE/EVENT
+    /// for a live subID). Feeds the failure funnel's backoff so a
+    /// persistently rejected subscription escalates to `maxReconnectDelay`
+    /// instead of hammering the relay.
+    private var closedRebuilds = 0
 
     func setOnOK(_ callback: @escaping (String, Bool) -> Void) {
         onOKCallback = callback
@@ -269,7 +283,18 @@ actor NostrRelayConnection {
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
               let string = String(data: data, encoding: .utf8)
         else { return }
-        Task { try? await webSocketTask?.send(.string(string)) }
+        // A REQ lost on a wounded socket is a deaf subscription for up
+        // to `livenessTimeout` — route the send failure into the failure
+        // funnel instead of waiting for the staleness check to notice.
+        let generation = connectionGeneration
+        Task { [weak self, webSocketTask] in
+            do {
+                guard let task = webSocketTask else { return }
+                try await task.send(.string(string))
+            } catch {
+                await self?.handleConnectionFailure(generation: generation)
+            }
+        }
     }
 
     private func replaySubscriptions(generation: UInt64) {
@@ -284,9 +309,18 @@ actor NostrRelayConnection {
             guard let task = webSocketTask else { return }
             do {
                 let message = try await task.receive()
+                // The generation may have advanced while `receive()` was
+                // suspended (a forced reconnect raced an in-flight
+                // frame). A stale frame must not refresh the NEW
+                // generation's liveness clock or backoff state.
+                guard generation == connectionGeneration else { return }
                 lastActivityAt = Date()
                 // A frame arrived — the connection is confirmed live.
-                // This (and only this) resets the backoff counter.
+                // This (and only this) resets the error backoff. NB it
+                // deliberately does NOT reset `closedRebuilds`: a relay
+                // that keeps rejecting our REQs still sends frames
+                // (CLOSEDs), and treating those as health is what made
+                // the CLOSED path hot-loop.
                 reconnectAttempts = 0
                 let text: String
                 switch message {
@@ -304,23 +338,31 @@ actor NostrRelayConnection {
 
     /// Single funnel for "this socket is dead, rebuild it". Guarded by
     /// the connection generation so a stale receive loop or liveness
-    /// monitor firing after a newer connect() is a no-op. Sleeps out the
-    /// backoff (escalating only while no frame has confirmed the
-    /// connection live) before reconnecting.
+    /// monitor firing after a newer connect() is a no-op; the generation
+    /// is bumped on entry so two failure paths for the same generation
+    /// (liveness + receive-loop catch, interleaved across the backoff
+    /// sleep) can't both run — the second is guarded out. Backoff uses
+    /// the max of the error counter and the CLOSED-rebuild counter, so
+    /// a persistently rejected subscription escalates to
+    /// `maxReconnectDelay` even though its socket "successfully"
+    /// receives CLOSED frames.
     private func handleConnectionFailure(generation: UInt64) async {
         guard generation == connectionGeneration else { return }
+        connectionGeneration &+= 1
+        let rebuildGeneration = connectionGeneration
         livenessTask?.cancel()
         livenessTask = nil
         isConnected = false
         webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
         webSocketTask = nil
         reconnectAttempts += 1
+        let effectiveAttempts = max(reconnectAttempts, closedRebuilds)
         let delay = min(
             maxReconnectDelay,
-            baseReconnectDelay * pow(2.0, Double(min(reconnectAttempts - 1, 6)))
+            baseReconnectDelay * pow(2.0, Double(min(effectiveAttempts - 1, 6)))
         )
         try? await Task.sleep(for: .seconds(delay))
-        guard generation == connectionGeneration else { return }
+        guard rebuildGeneration == connectionGeneration else { return }
         connect()
     }
 
@@ -403,10 +445,24 @@ actor NostrRelayConnection {
             if let event = parseEvent(eventObj),
                let entry = subscriptions[subID]
             {
+                // Same acceptance proof as EOSE: events flowing for a
+                // subscription mean its REQ stuck.
+                closedRebuilds = 0
+                closedRetriedSubIDs.remove(subID)
                 entry.callback(event)
             }
         case "EOSE":
-            break
+            // EOSE for one of OUR subscriptions proves the relay accepted
+            // its REQ: the CLOSED bookkeeping resets. `closedRebuilds`
+            // stops escalating (the condition cleared), and the sub's
+            // retried flag decays so a benign CLOSED hours from now gets
+            // a fresh retry instead of an immediate rebuild.
+            if array.count >= 2,
+               let subID = array[1] as? String,
+               subscriptions[subID] != nil {
+                closedRebuilds = 0
+                closedRetriedSubIDs.remove(subID)
+            }
         case "OK":
             if array.count >= 3,
                let eventID = array[1] as? String,
@@ -430,6 +486,13 @@ actor NostrRelayConnection {
             guard let entry = subscriptions[subID] else { return }
             if closedRetriedSubIDs.contains(subID) {
                 Self.securityLogger.warning("Relay repeatedly closed a subscription; rebuilding connection: \(self.url.absoluteString, privacy: .public)")
+                // Escalating counter that SURVIVES the rebuild and is
+                // immune to frame arrival (see `closedRebuilds`) — a
+                // persistently rejected subscription backs off to
+                // `maxReconnectDelay` instead of hot-looping at
+                // `baseReconnectDelay` (the relay's own CLOSED frames
+                // would otherwise keep resetting the error backoff).
+                closedRebuilds += 1
                 Task { await handleConnectionFailure(generation: generation) }
             } else {
                 closedRetriedSubIDs.insert(subID)

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -2,73 +2,173 @@ import Foundation
 import os.log
 
 /// Persistent WebSocket connection to a single Nostr relay. Owns the
-/// REQ/EVENT/EOSE/OK/CLOSE framing and is the only place in the
-/// transport layer that touches `URLSessionWebSocketTask`. Reconnect with
-/// exponential backoff, heartbeat ping, and a per-publish OK await are
-/// all internal — the surface for callers is `connect`, `disconnect`,
-/// `publish`, `publishAndAwaitOK`, `subscribe`, `unsubscribe`.
+/// REQ/EVENT/EOSE/OK/CLOSED framing and is the only place in the
+/// transport layer that touches `URLSessionWebSocketTask`.
+///
+/// Lifecycle is a small state machine (see `docs`/reconnect design):
+///
+/// ```
+///             connect()                first frame received
+/// Disconnected ────────► Connecting ─────────────────────► Live
+///      ▲                     │ receive() throws /             │
+///      │                     │ repeated CLOSED /              │ staleness /
+///      │    backoff sleep    ▼ probe failure                  │ receive() throws /
+///      └────────────────── Backoff ◄───────────────────────────┘ forceReconnect()
+///          (attempts++; reset only on entering Live)
+/// ```
+///
+/// Key invariants:
+///  - Every (re)connect bumps `connectionGeneration`; the receive loop,
+///    liveness monitor, and failure funnel all no-op when superseded, so
+///    overlapping reconnects can never leave two loops fighting over the
+///    same socket.
+///  - The connection is *confirmed live* only when a frame actually
+///    arrives — `reconnectAttempts` resets there, never in `connect()`,
+///    so backoff escalates across genuinely failing attempts (capped at
+///    `maxReconnectDelay`, default 30 s).
+///  - A subscription is one `REQ` carrying *all* of its filters (NIP-01
+///    dedups within a subscription) — never one REQ per filter, which
+///    multiplied subscription count 3× and tripped relay
+///    `maxSubsPerConnection` caps.
+///  - `CLOSED` is handled, not ignored: first CLOSED for a live
+///    subscription re-REQs it once; a repeat within the same connection
+///    generation treats the connection as unhealthy and rebuilds. A
+///    relay-side subscription rejection is therefore visible and
+///    recoverable instead of silent deafness.
+///  - Prolonged silence is death: the liveness monitor probes with a
+///    match-nothing REQ (the relay's immediate EOSE is a pong stand-in;
+///    verified against nostr.onym.app) and rebuilds when no frame lands
+///    within `livenessTimeout`. A half-open socket — where `receive()`
+///    hangs forever and never throws — cannot stay deaf.
 actor NostrRelayConnection {
     let url: URL
     private var webSocketTask: URLSessionWebSocketTask?
     private let session: URLSession
-    private var subscriptions: [String: ([String: Any], (NostrEvent) -> Void)] = [:]
+    /// Live subscriptions: subID → (filters, per-event callback). All of
+    /// a subscription's filters ship in one REQ frame.
+    private var subscriptions: [String: (filters: [[String: Any]], callback: (NostrEvent) -> Void)] = [:]
     private(set) var isConnected = false
     private var reconnectAttempts = 0
     private var pendingOKContinuations: [String: CheckedContinuation<Bool, any Error>] = [:]
-    private var pingTask: Task<Void, Never>?
+    private var livenessTask: Task<Void, Never>?
     private var onOKCallback: ((String, Bool) -> Void)?
+    /// Bumped on every `connect()`/`disconnect()`/`forceReconnect()`.
+    private var connectionGeneration: UInt64 = 0
+    /// Wall-clock time of the last frame received on the current socket.
+    private var lastActivityAt = Date()
+    /// Subscription ids already re-REQ'd after a CLOSED in the current
+    /// generation. A second CLOSED for the same id escalates to a rebuild.
+    private var closedRetriedSubIDs: Set<String> = []
 
     func setOnOK(_ callback: @escaping (String, Bool) -> Void) {
         onOKCallback = callback
     }
 
-    private static let maxReconnectDelay: TimeInterval = 120
-    private static let baseReconnectDelay: TimeInterval = 1
-    private static let pingInterval: TimeInterval = 30
+    // Timings — injectable so the (otherwise minute-scale) liveness and
+    // backoff paths are exercisable in tests. Defaults are production
+    // values.
+    /// How often the liveness monitor probes the relay and checks for
+    /// staleness.
+    private let pingInterval: TimeInterval
+    /// No frame within this window ⇒ the socket is treated as dead and
+    /// rebuilt. Must comfortably exceed `pingInterval` so a healthy
+    /// relay's probe reply (EOSE) keeps the connection alive.
+    private let livenessTimeout: TimeInterval
+    private let baseReconnectDelay: TimeInterval
+    /// Backoff cap. Deliberately modest: minute-scale retry gaps read as
+    /// "the app is dead" to a user mid-conversation.
+    private let maxReconnectDelay: TimeInterval
     private static let connectionTimeout: TimeInterval = 15
     private static let publishTimeout: TimeInterval = 5
+    /// Subscription id for the liveness probe. A REQ under this id with a
+    /// filter matching nothing draws an immediate EOSE from a conformant
+    /// relay — our stand-in for a WebSocket pong (sendPing is avoided:
+    /// CFNetwork's pong handler has a known crash where it fires on an
+    /// internal queue after the task is cancelled and dereferences a
+    /// freed nw_connection).
+    private static let livenessSubID = "__onym_hb"
 
-    init(url: URL) {
+    init(
+        url: URL,
+        pingInterval: TimeInterval = 20,
+        livenessTimeout: TimeInterval = 55,
+        baseReconnectDelay: TimeInterval = 1,
+        maxReconnectDelay: TimeInterval = 30
+    ) {
         self.url = url
+        self.pingInterval = pingInterval
+        self.livenessTimeout = livenessTimeout
+        self.baseReconnectDelay = baseReconnectDelay
+        self.maxReconnectDelay = maxReconnectDelay
         let config = URLSessionConfiguration.default
         config.waitsForConnectivity = true
         config.timeoutIntervalForRequest = Self.connectionTimeout
-        // WebSocket connections are long-lived — never let the system kill them
+        // Long-lived WebSocket: no wall-clock resource bound. Death is
+        // detected by the liveness monitor, not the URL loader. (A finite
+        // bound would force periodic full-history replays until the
+        // since-bounded replay of the next PR lands; revisit there.)
         config.timeoutIntervalForResource = 0
         self.session = URLSession(configuration: config)
     }
 
     func connect() {
         guard webSocketTask == nil else { return }
+        connectionGeneration &+= 1
+        let generation = connectionGeneration
+        closedRetriedSubIDs.removeAll()
         let task = session.webSocketTask(with: url)
         self.webSocketTask = task
         task.resume()
         isConnected = true
-        reconnectAttempts = 0
-        Task { await receiveLoop() }
-        startHeartbeat()
+        // NB: `reconnectAttempts` is NOT reset here — connecting is an
+        // attempt, not a confirmed-live connection. It resets on the
+        // first frame received (see `receiveLoop`), so backoff escalates
+        // across a run of failed attempts against a dead relay.
+        lastActivityAt = Date()
+        Task { await receiveLoop(generation: generation) }
+        startLivenessMonitor(generation: generation)
 
-        for (subID, (filter, _)) in subscriptions {
-            sendREQ(subscriptionID: subID, filter: filter)
+        for (subID, entry) in subscriptions {
+            sendREQ(subscriptionID: subID, filters: entry.filters)
         }
 
-        // URLSessionWebSocketTask exposes no reliable onOpen callback. Replay
-        // subscriptions shortly after connect so filters added during the
-        // handshake window are not lost if the initial send happens too early.
+        // URLSessionWebSocketTask exposes no reliable onOpen callback.
+        // Replay subscriptions shortly after connect so filters added
+        // during the handshake window are not lost if the initial send
+        // happened too early.
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(1))
             guard let self else { return }
-            await self.replaySubscriptions()
+            await self.replaySubscriptions(generation: generation)
         }
     }
 
     func disconnect() {
-        pingTask?.cancel()
-        pingTask = nil
+        // Supersede any in-flight receive loop / liveness monitor.
+        connectionGeneration &+= 1
+        livenessTask?.cancel()
+        livenessTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
         isConnected = false
         reconnectAttempts = 0
+    }
+
+    /// Tear down the current socket and rebuild it immediately,
+    /// re-issuing every live subscription's REQ. Unconditional by design:
+    /// this is the app-driven refresh (foreground, regained
+    /// connectivity), and a fresh REQ is the only mechanism that
+    /// backfills events missed while the socket was dead or suspended —
+    /// probing first and skipping the rebuild on a healthy-*looking*
+    /// socket provably loses messages (design doc F3).
+    func forceReconnect() {
+        connectionGeneration &+= 1
+        livenessTask?.cancel()
+        livenessTask = nil
+        webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
+        webSocketTask = nil
+        isConnected = false
+        connect()
     }
 
     func publish(event: NostrEvent) async throws {
@@ -130,12 +230,15 @@ actor NostrRelayConnection {
         }
     }
 
+    /// Open one relay subscription carrying every filter in `filters`
+    /// (single REQ frame — the relay dedups events across the filters
+    /// within one subscription, NIP-01).
     func subscribe(
         subscriptionID: String,
-        filter: [String: Any]
+        filters: [[String: Any]]
     ) -> AsyncStream<NostrEvent> {
         let stream = AsyncStream<NostrEvent> { continuation in
-            subscriptions[subscriptionID] = (filter, { event in
+            subscriptions[subscriptionID] = (filters, { event in
                 continuation.yield(event)
             })
             continuation.onTermination = { @Sendable _ in
@@ -144,7 +247,7 @@ actor NostrRelayConnection {
                 }
             }
         }
-        sendREQ(subscriptionID: subscriptionID, filter: filter)
+        sendREQ(subscriptionID: subscriptionID, filters: filters)
         return stream
     }
 
@@ -160,66 +263,119 @@ actor NostrRelayConnection {
 
     // MARK: - Private
 
-    private func sendREQ(subscriptionID: String, filter: [String: Any]) {
-        let frame: [Any] = ["REQ", subscriptionID, filter]
+    private func sendREQ(subscriptionID: String, filters: [[String: Any]]) {
+        var frame: [Any] = ["REQ", subscriptionID]
+        frame.append(contentsOf: filters)
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
               let string = String(data: data, encoding: .utf8)
         else { return }
         Task { try? await webSocketTask?.send(.string(string)) }
     }
 
-    private func replaySubscriptions() {
-        for (subID, (filter, _)) in subscriptions {
-            sendREQ(subscriptionID: subID, filter: filter)
+    private func replaySubscriptions(generation: UInt64) {
+        guard generation == connectionGeneration else { return }
+        for (subID, entry) in subscriptions {
+            sendREQ(subscriptionID: subID, filters: entry.filters)
         }
     }
 
-    private func receiveLoop() async {
-        while isConnected {
-            guard let task = webSocketTask else { break }
+    private func receiveLoop(generation: UInt64) async {
+        while generation == connectionGeneration {
+            guard let task = webSocketTask else { return }
             do {
                 let message = try await task.receive()
+                lastActivityAt = Date()
+                // A frame arrived — the connection is confirmed live.
+                // This (and only this) resets the backoff counter.
+                reconnectAttempts = 0
                 let text: String
                 switch message {
                 case .string(let s): text = s
                 case .data(let d): text = String(data: d, encoding: .utf8) ?? ""
                 @unknown default: continue
                 }
-                handleMessage(text)
+                handleMessage(text, generation: generation)
             } catch {
-                pingTask?.cancel()
-                pingTask = nil
-                isConnected = false
-                webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
-                webSocketTask = nil
-                reconnectAttempts += 1
-                let delay = min(
-                    Self.maxReconnectDelay,
-                    Self.baseReconnectDelay * pow(2.0, Double(min(reconnectAttempts - 1, 6)))
-                )
-                try? await Task.sleep(for: .seconds(delay))
-                connect()
+                await handleConnectionFailure(generation: generation)
                 return
             }
         }
     }
 
-    /// Heartbeat sends a no-op `["CLOSE","__hb"]` instead of using
-    /// `URLSessionWebSocketTask.sendPing`. The CFNetwork ping handler has
-    /// a known crash where the pong fires on an internal queue after the
-    /// task is cancelled and dereferences a freed `nw_connection`. A
-    /// plain `.send()` doesn't have that path — if the connection is
-    /// dead, the send throws and the receive loop reconnects.
-    private func startHeartbeat() {
-        pingTask?.cancel()
-        pingTask = Task { [weak self] in
+    /// Single funnel for "this socket is dead, rebuild it". Guarded by
+    /// the connection generation so a stale receive loop or liveness
+    /// monitor firing after a newer connect() is a no-op. Sleeps out the
+    /// backoff (escalating only while no frame has confirmed the
+    /// connection live) before reconnecting.
+    private func handleConnectionFailure(generation: UInt64) async {
+        guard generation == connectionGeneration else { return }
+        livenessTask?.cancel()
+        livenessTask = nil
+        isConnected = false
+        webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
+        webSocketTask = nil
+        reconnectAttempts += 1
+        let delay = min(
+            maxReconnectDelay,
+            baseReconnectDelay * pow(2.0, Double(min(reconnectAttempts - 1, 6)))
+        )
+        try? await Task.sleep(for: .seconds(delay))
+        guard generation == connectionGeneration else { return }
+        connect()
+    }
+
+    /// Active liveness monitor. Once per `pingInterval`:
+    ///
+    ///  1. **Detect a half-open socket.** If no frame has arrived within
+    ///     `livenessTimeout` the connection is silently dead — the OS
+    ///     still thinks it's open, `receive()` never throws, and the
+    ///     error-path reconnect never fires. Rebuild.
+    ///  2. **Keep the socket provably alive.** Send the match-nothing
+    ///     probe REQ; a conformant relay's immediate EOSE lands in the
+    ///     receive loop and refreshes `lastActivityAt`. If the send
+    ///     itself throws, the socket is dead now — rebuild.
+    ///
+    /// Fail-closed: a nil or non-running task also routes to the failure
+    /// funnel — this is the one component whose job is to catch what the
+    /// error path missed, so it never silently stops.
+    private func startLivenessMonitor(generation: UInt64) {
+        livenessTask?.cancel()
+        livenessTask = Task { [weak self, pingInterval] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(Self.pingInterval))
-                guard !Task.isCancelled else { break }
-                guard let task = await self?.webSocketTask,
-                      task.state == .running else { break }
-                try? await task.send(.string("[\"CLOSE\",\"__hb\"]"))
+                try? await Task.sleep(for: .seconds(pingInterval))
+                guard !Task.isCancelled, let self else { break }
+                let alive = await self.livenessTick(generation: generation)
+                if !alive { break }
             }
+        }
+    }
+
+    /// One liveness cycle. Returns `false` when this monitor should stop:
+    /// superseded by a newer generation (no-op), or it routed a dead
+    /// socket into the failure funnel (which spawns a fresh monitor).
+    private func livenessTick(generation: UInt64) async -> Bool {
+        guard generation == connectionGeneration else { return false }
+
+        guard let task = webSocketTask, task.state == .running else {
+            await handleConnectionFailure(generation: generation)
+            return false
+        }
+
+        if Date().timeIntervalSince(lastActivityAt) > livenessTimeout {
+            await handleConnectionFailure(generation: generation)
+            return false
+        }
+
+        // A single-id filter for a valid but nonexistent (all-zero) event
+        // id matches nothing: immediate EOSE, no live events. Kept plain
+        // (no `limit`, no exotic keys) so strict relays accept it.
+        let probe = "[\"REQ\",\"\(Self.livenessSubID)\",{\"ids\":[\"\(String(repeating: "0", count: 64))\"]}]"
+        do {
+            try await task.send(.string(probe))
+            return true
+        } catch {
+            await handleConnectionFailure(generation: generation)
+            return false
         }
     }
 
@@ -228,7 +384,7 @@ actor NostrRelayConnection {
     private static let maxMessageSize = 1_048_576
     private static let securityLogger = Logger(subsystem: "app.onym.ios", category: "Transport")
 
-    private func handleMessage(_ text: String) {
+    private func handleMessage(_ text: String, generation: UInt64) {
         guard text.utf8.count <= Self.maxMessageSize else {
             Self.securityLogger.warning("Relay oversized message rejected (\(text.utf8.count) bytes): \(self.url.absoluteString, privacy: .public)")
             return
@@ -245,9 +401,9 @@ actor NostrRelayConnection {
                   let eventObj = array[2] as? [String: Any]
             else { return }
             if let event = parseEvent(eventObj),
-               let (_, callback) = subscriptions[subID]
+               let entry = subscriptions[subID]
             {
-                callback(event)
+                entry.callback(event)
             }
         case "EOSE":
             break
@@ -259,6 +415,25 @@ actor NostrRelayConnection {
                     continuation.resume(returning: accepted)
                 }
                 onOKCallback?(eventID, accepted)
+            }
+        case "CLOSED":
+            // The relay rejected or terminated one of our subscriptions
+            // (e.g. a `maxSubsPerConnection` cap). Ignoring this frame is
+            // silent permanent deafness on that inbox — the failure mode
+            // behind "messages stop arriving until relaunch" on
+            // subscription-heavy devices. Retry the REQ once; a repeat
+            // for the same sub in this generation means the condition is
+            // persistent, so rebuild the connection and let the normal
+            // failure/backoff path own it.
+            guard array.count >= 2, let subID = array[1] as? String else { return }
+            guard subID != Self.livenessSubID else { return }
+            guard let entry = subscriptions[subID] else { return }
+            if closedRetriedSubIDs.contains(subID) {
+                Self.securityLogger.warning("Relay repeatedly closed a subscription; rebuilding connection: \(self.url.absoluteString, privacy: .public)")
+                Task { await handleConnectionFailure(generation: generation) }
+            } else {
+                closedRetriedSubIDs.insert(subID)
+                sendREQ(subscriptionID: subID, filters: entry.filters)
             }
         case "NOTICE":
             break

--- a/Tests/OnymIOSTests/NostrRelayConnectionTests.swift
+++ b/Tests/OnymIOSTests/NostrRelayConnectionTests.swift
@@ -179,13 +179,15 @@ final class NostrRelayConnectionTests: XCTestCase {
         await conn.disconnect()
     }
 
-    /// A second `CLOSED` for the same subscription in the same connection
-    /// generation means the rejection is persistent — escalate to a full
-    /// rebuild (visible recovery) instead of retrying forever or going
-    /// silently deaf.
+    /// A second `CLOSED` for the same subscription — with no intervening
+    /// EOSE/EVENT proving the retry stuck — means the rejection is
+    /// persistent: escalate to a full rebuild (visible recovery) instead
+    /// of retrying forever or going silently deaf. The relay is silent
+    /// (no EOSE) so the retry's acceptance-decay doesn't clear the flag.
     func testRepeatedCLOSEDRebuildsConnection() async throws {
         let relay = try LocalWebSocketRelay()
         defer { relay.stop() }
+        relay.autoRespondEOSE = false
         let conn = NostrRelayConnection(
             url: try await relay.wsURL(),
             baseReconnectDelay: 0.05,
@@ -209,6 +211,62 @@ final class NostrRelayConnectionTests: XCTestCase {
         await conn.disconnect()
     }
 
+    /// A relay that persistently rejects the subscription (every REQ →
+    /// CLOSED) must back off, not hot-loop: the relay's own CLOSED
+    /// frames must not count as "confirmed live" and reset the backoff.
+    /// With base 0.05 s / cap 0.4 s over a 1.5 s window, escalating
+    /// backoff yields a handful of rebuilds; the naive reset-on-frame
+    /// behavior yields 15+ at a steady ~20 Hz-equivalent.
+    func testPersistentlyRejectedSubscription_backsOffInsteadOfHotLooping() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        relay.autoCLOSESubscriptions = true
+
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            baseReconnectDelay: 0.05,
+            maxReconnectDelay: 0.4
+        )
+        await conn.connect()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await Task.sleep(for: .seconds(1.5))
+        let rebuilds = relay.connectionCount()
+        XCTAssertGreaterThanOrEqual(rebuilds, 2, "rebuild attempts must continue")
+        XCTAssertLessThanOrEqual(rebuilds, 8,
+                                 "persistent CLOSED must escalate backoff, not hot-loop (~1 Hz+)")
+        await conn.disconnect()
+    }
+
+    /// Benign, isolated CLOSEDs must not accumulate into a rebuild: an
+    /// EOSE for the re-issued REQ proves it stuck and decays the sub's
+    /// retried flag, so a second CLOSED much later gets a fresh retry.
+    func testIsolatedCLOSEDs_decayAfterAcceptedREQ_noRebuild() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        relay.sendCLOSED(subID: "sub1")
+        try await relay.waitForREQs(2)  // retry — auto-answered with EOSE
+        try await Task.sleep(for: .milliseconds(200))  // EOSE decays the flag
+
+        relay.sendCLOSED(subID: "sub1")
+        try await relay.waitForREQs(3)  // a fresh retry, NOT a rebuild
+
+        XCTAssertEqual(relay.connectionCount(), 1,
+                       "isolated CLOSEDs with accepted retries in between must never rebuild")
+        await conn.disconnect()
+    }
+
     /// `CLOSED` for an unknown subscription (e.g. one we already
     /// unsubscribed) is ignored — no retry, no rebuild.
     func testCLOSEDForUnknownSubIsIgnored() async throws {
@@ -228,6 +286,67 @@ final class NostrRelayConnectionTests: XCTestCase {
         XCTAssertEqual(relay.connectionCount(), 1)
         await conn.disconnect()
     }
+}
+
+/// Transport-level: re-subscribing an inbox must not let the OLD
+/// stream's asynchronous `onTermination` CLOSE tear down the NEW
+/// subscription (the generation-token pattern `NostrMessageTransport`
+/// pioneered, now applied to the inbox transport).
+final class NostrInboxTransportResubscribeTests: XCTestCase {
+    func test_resubscribeSameInbox_usesFreshSubID_andStaysLive() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let transport = NostrInboxTransport(signerProvider: OnymNostrSignerProvider())
+        let url = URL(string: "ws://127.0.0.1:\(try await relay.port())")!
+        await transport.connect(to: [TransportEndpoint(url: url)])
+
+        let inbox = TransportInboxID(rawValue: "beef0001")
+        let first = transport.subscribe(inbox: inbox)
+        let firstPump = Task { for await _ in first {} }
+        try await relay.waitForREQs(1)
+
+        // Re-subscribe (identity rebalance / pump restart shape). The
+        // old stream terminates asynchronously and sends CLOSE for ITS
+        // subID — which must not be the new one's.
+        let second = transport.subscribe(inbox: inbox)
+        let received = ResubscribeBox()
+        let secondPump = Task { for await msg in second { await received.append(msg.messageID) } }
+        defer { secondPump.cancel() }
+        firstPump.cancel()
+        try await relay.waitForREQs(2)
+        // Give the old stream's onTermination CLOSE time to land (the
+        // bug window this test exists for).
+        try await Task.sleep(for: .milliseconds(300))
+
+        // The two REQs must carry DISTINCT subIDs — that's the whole fix.
+        let subIDs = relay.recordedSubIDs()
+        XCTAssertEqual(subIDs.count, 2)
+        XCTAssertEqual(Set(subIDs).count, 2, "re-subscribe must mint a fresh subID")
+
+        // The new subscription must still be live: push an event to the
+        // SECOND recorded subID and assert delivery.
+        relay.push(LocalWebSocketRelay.eventFrame(
+            subID: relay.lastRecordedSubID()!,
+            kind: 34113,
+            content: Data("still alive".utf8).base64EncodedString(),
+            tag: ("d", "sep-inbox:beef0001")
+        ))
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            if await received.count() >= 1 { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let count = await received.count()
+        XCTAssertEqual(count, 1,
+                       "the re-subscribed inbox must survive the old stream's CLOSE")
+        await transport.disconnect()
+    }
+}
+
+private actor ResubscribeBox {
+    private var ids: [String] = []
+    func append(_ id: String) { ids.append(id) }
+    func count() -> Int { ids.count }
 }
 
 // MARK: - Helpers

--- a/Tests/OnymIOSTests/NostrRelayConnectionTests.swift
+++ b/Tests/OnymIOSTests/NostrRelayConnectionTests.swift
@@ -1,0 +1,260 @@
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for `NostrRelayConnection`'s lifecycle state machine,
+/// driven against a loopback WebSocket relay (`LocalWebSocketRelay`).
+/// Regression coverage for the field failure modes in the reconnect
+/// design doc: dead-until-relaunch (F1), missed-backfill-on-foreground
+/// (F3), silently-CLOSED subscriptions (F8), and half-open sockets the
+/// error path can't see.
+final class NostrRelayConnectionTests: XCTestCase {
+    /// One subscription = one REQ frame carrying all of its filters —
+    /// never one REQ per filter (relay `maxSubsPerConnection` caps).
+    func testSubscribeSendsSingleREQWithAllFilters() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+
+        let filters: [[String: Any]] = [
+            ["kinds": [34113], "#d": ["sep-inbox:abc"]],
+            ["kinds": [34113], "#t": ["abc"]],
+            ["kinds": [24113], "#t": ["abc"]],
+        ]
+        _ = await conn.subscribe(subscriptionID: "inbox-abc", filters: filters)
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+        // Give a straggler REQ a beat to show up if the code regressed
+        // to one-REQ-per-filter.
+        try await Task.sleep(for: .milliseconds(150))
+
+        let recorded = relay.reqs(subID: "inbox-abc")
+        XCTAssertEqual(recorded.count, 1, "exactly one REQ for the subscription")
+        XCTAssertEqual(recorded[0].count, 3, "the single REQ carries all three filters")
+        await conn.disconnect()
+    }
+
+    /// A subscription established before a server-side drop must resume
+    /// delivering after the passive error-path reconnect — no external
+    /// trigger.
+    func testSubscriptionResumesAfterServerDrop() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            baseReconnectDelay: 0.1,
+            maxReconnectDelay: 0.5
+        )
+        await conn.connect()
+
+        let collector = EventCollector()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await event in stream { await collector.append(event) } }
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        relay.push(LocalWebSocketRelay.eventFrame(
+            subID: "sub1", kind: 34113, content: "first", tag: ("t", "x")
+        ))
+        try await collector.waitForCount(1)
+
+        relay.dropCurrentConnection()
+        try await relay.waitForConnections(2, timeout: 6)
+
+        relay.push(LocalWebSocketRelay.eventFrame(
+            subID: "sub1", kind: 34113, content: "second", tag: ("t", "x")
+        ))
+        try await collector.waitForCount(2, timeout: 6)
+
+        let contents = await collector.contents()
+        XCTAssertEqual(contents, ["first", "second"])
+        await conn.disconnect()
+    }
+
+    /// The canonical background→foreground bug (design doc F3): a message
+    /// stored on the relay while the client was away arrives only via the
+    /// fresh REQ's backfill. `forceReconnect()` must rebuild AND re-REQ —
+    /// no live push happens in this test at all.
+    func testForceReconnectBackfillsEventStoredWhileAway() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+
+        let collector = EventCollector()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await event in stream { await collector.append(event) } }
+        defer { pump.cancel() }
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        // Arrives at the relay while the client is "suspended": stored,
+        // never pushed live to this socket.
+        relay.store(subID: "sub1", eventJSON: LocalWebSocketRelay.eventObjectJSON(
+            kind: 34113, content: "missed-while-bg", tag: ("d", "sep-inbox:abc")
+        ))
+
+        let reqsBefore = relay.reqCount()
+        await conn.forceReconnect()
+        try await relay.waitForConnections(2)
+        try await relay.waitForREQs(reqsBefore + 1)
+        try await collector.waitForCount(1)
+
+        let contents = await collector.contents()
+        XCTAssertEqual(contents, ["missed-while-bg"],
+                       "the rebuilt connection's REQ must backfill the missed event")
+        await conn.disconnect()
+    }
+
+    /// Half-open socket (design doc F1): the peer goes silent without
+    /// closing, `receive()` never throws, so only the liveness monitor
+    /// can notice. With test-scale timings it must rebuild on its own.
+    func testLivenessMonitorHealsSilentSocket() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        relay.autoRespondEOSE = false  // silent peer: no EOSE, no replies
+
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            pingInterval: 0.1,
+            livenessTimeout: 0.3,
+            baseReconnectDelay: 0.05,
+            maxReconnectDelay: 0.2
+        )
+        await conn.connect()
+        _ = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+
+        try await relay.waitForConnections(1)
+        // No traffic at all — staleness must fire and rebuild.
+        let reconnected = try await relay.waitForConnections(2, timeout: 3)
+        XCTAssertGreaterThanOrEqual(reconnected, 2)
+        await conn.disconnect()
+    }
+
+    /// A healthy relay that answers the liveness probe (EOSE) keeps the
+    /// connection alive — no spurious rebuilds from the staleness check.
+    func testProbeAnsweredKeepsConnectionAlive() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            pingInterval: 0.1,
+            livenessTimeout: 0.3,
+            baseReconnectDelay: 0.05,
+            maxReconnectDelay: 0.2
+        )
+        await conn.connect()
+        _ = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+
+        try await relay.waitForConnections(1)
+        // Several liveness windows pass; probe EOSEs keep it alive.
+        try await Task.sleep(for: .seconds(1))
+        XCTAssertEqual(relay.connectionCount(), 1,
+                       "a probe-answering relay must not trigger rebuilds")
+        await conn.disconnect()
+    }
+
+    /// First `CLOSED` for a subscription re-issues its REQ once (design
+    /// doc F8: a silently rejected subscription must be retried, not
+    /// ignored).
+    func testCLOSEDTriggersOneResubscribe() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await _ in stream {} }  // hold the subscription live
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        relay.sendCLOSED(subID: "sub1")
+        try await relay.waitForREQs(2)
+
+        XCTAssertEqual(relay.reqs(subID: "sub1").count, 2, "CLOSED must re-REQ the subscription")
+        XCTAssertEqual(relay.connectionCount(), 1, "a single CLOSED must not rebuild the connection")
+        await conn.disconnect()
+    }
+
+    /// A second `CLOSED` for the same subscription in the same connection
+    /// generation means the rejection is persistent — escalate to a full
+    /// rebuild (visible recovery) instead of retrying forever or going
+    /// silently deaf.
+    func testRepeatedCLOSEDRebuildsConnection() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            baseReconnectDelay: 0.05,
+            maxReconnectDelay: 0.2
+        )
+        await conn.connect()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await _ in stream {} }  // hold the subscription live
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        relay.sendCLOSED(subID: "sub1")
+        try await relay.waitForREQs(2)
+        relay.sendCLOSED(subID: "sub1")
+
+        try await relay.waitForConnections(2, timeout: 4)
+        // The rebuilt connection replays the subscription.
+        try await relay.waitForREQs(3, timeout: 4)
+        await conn.disconnect()
+    }
+
+    /// `CLOSED` for an unknown subscription (e.g. one we already
+    /// unsubscribed) is ignored — no retry, no rebuild.
+    func testCLOSEDForUnknownSubIsIgnored() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+        _ = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        relay.sendCLOSED(subID: "no-such-sub")
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(relay.reqCount(), 1)
+        XCTAssertEqual(relay.connectionCount(), 1)
+        await conn.disconnect()
+    }
+}
+
+// MARK: - Helpers
+
+private extension LocalWebSocketRelay {
+    func wsURL() async throws -> URL {
+        URL(string: "ws://127.0.0.1:\(try await port())")!
+    }
+}
+
+/// Actor sink for events pumped off a subscription stream, with a poll
+/// helper so tests can await a target count without racing the stream.
+private actor EventCollector {
+    private var events: [NostrEvent] = []
+
+    func append(_ event: NostrEvent) { events.append(event) }
+    func contents() -> [String] { events.map(\.content) }
+    private func count() -> Int { events.count }
+
+    func waitForCount(_ target: Int, timeout: TimeInterval = 3) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if count() >= target { return }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        throw CollectorError.timeout
+    }
+
+    enum CollectorError: Error { case timeout }
+}

--- a/Tests/OnymIOSTests/Support/LocalWebSocketRelay.swift
+++ b/Tests/OnymIOSTests/Support/LocalWebSocketRelay.swift
@@ -1,0 +1,215 @@
+import CryptoKit
+import Foundation
+import Network
+
+/// Minimal in-process WebSocket server for transport tests. Not a real
+/// Nostr relay — just enough NIP-01 to drive `NostrRelayConnection`:
+///
+///  - accepts connections (keeps the most recent one), counts them
+///  - records every `["REQ", subID, filter...]` (excluding the client's
+///    internal liveness probe) so tests can assert REQ replay and filter
+///    shape
+///  - "stores" events per subID and replays them (+ EOSE) on each REQ,
+///    like a real relay's backfill-on-subscribe
+///  - auto-answers every REQ (including the liveness probe) with EOSE —
+///    disable via `autoRespondEOSE = false` to model a silent/half-open
+///    peer for liveness tests
+///  - can inject `["CLOSED", subID, reason]` and hard-drop the socket
+final class LocalWebSocketRelay: @unchecked Sendable {
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "test.ws.relay")
+    private let lock = NSLock()
+    private var current: NWConnection?
+    private var acceptedCount = 0
+    /// Recorded REQs in arrival order: (subID, filters). Probe excluded.
+    private var recordedREQs: [(subID: String, filters: [[String: Any]])] = []
+    /// Events "stored" on the relay, keyed by the subID they replay under.
+    private var storedBySubID: [String: [String]] = [:]
+    /// When false, the relay answers nothing at all (no EOSE, no stored
+    /// replay) — a healthy-looking but silent peer.
+    var autoRespondEOSE = true
+
+    init() throws {
+        let params = NWParameters.tcp
+        let ws = NWProtocolWebSocket.Options()
+        ws.autoReplyPing = true
+        params.defaultProtocolStack.applicationProtocols.insert(ws, at: 0)
+        listener = try NWListener(using: params, on: .any)
+
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else { return }
+            self.lock.lock()
+            self.acceptedCount += 1
+            self.current = connection
+            self.lock.unlock()
+            connection.start(queue: self.queue)
+            self.receive(on: connection)
+        }
+        listener.start(queue: queue)
+    }
+
+    // MARK: - Observation
+
+    /// The OS-assigned loopback port (listener start is asynchronous).
+    func port() async throws -> UInt16 {
+        try await poll(timeout: 2) {
+            guard let p = listener.port?.rawValue, p != 0 else { return nil }
+            return p
+        }
+    }
+
+    /// Connections accepted so far. A reconnect shows up as an increment.
+    func connectionCount() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return acceptedCount
+    }
+
+    /// Non-probe REQs seen so far.
+    func reqCount() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return recordedREQs.count
+    }
+
+    /// Non-probe REQs recorded for one subscription id, in order.
+    func reqs(subID: String) -> [[[String: Any]]] {
+        lock.lock(); defer { lock.unlock() }
+        return recordedREQs.filter { $0.subID == subID }.map(\.filters)
+    }
+
+    @discardableResult
+    func waitForConnections(_ count: Int, timeout: TimeInterval = 3) async throws -> Int {
+        try await poll(timeout: timeout) { connectionCount() >= count ? connectionCount() : nil }
+    }
+
+    @discardableResult
+    func waitForREQs(_ count: Int, timeout: TimeInterval = 3) async throws -> Int {
+        try await poll(timeout: timeout) { reqCount() >= count ? reqCount() : nil }
+    }
+
+    // MARK: - Driving
+
+    /// Send a raw text frame to the current connection.
+    func push(_ text: String) {
+        lock.lock(); let conn = current; lock.unlock()
+        guard let conn else { return }
+        let meta = NWProtocolWebSocket.Metadata(opcode: .text)
+        let context = NWConnection.ContentContext(identifier: "send", metadata: [meta])
+        conn.send(
+            content: Data(text.utf8),
+            contentContext: context,
+            isComplete: true,
+            completion: .contentProcessed { _ in }
+        )
+    }
+
+    /// "Store" an event on the relay: replayed (before EOSE) on every
+    /// subsequent REQ for `subID` — models a message that arrived while
+    /// the client was away and must be backfilled on re-subscribe.
+    func store(subID: String, eventJSON: String) {
+        lock.lock(); storedBySubID[subID, default: []].append(eventJSON); lock.unlock()
+    }
+
+    /// Inject a relay-side subscription termination.
+    func sendCLOSED(subID: String, reason: String = "error: too many concurrent REQs") {
+        push("[\"CLOSED\",\"\(subID)\",\"\(reason)\"]")
+    }
+
+    /// Hard-drop the current connection — the client's `receive()` errors
+    /// and its reconnect path must rebuild.
+    func dropCurrentConnection() {
+        lock.lock(); let conn = current; current = nil; lock.unlock()
+        conn?.forceCancel()
+    }
+
+    func stop() {
+        listener.cancel()
+        lock.lock(); let conn = current; current = nil; lock.unlock()
+        conn?.forceCancel()
+    }
+
+    // MARK: - Private
+
+    private func receive(on connection: NWConnection) {
+        connection.receiveMessage { [weak self] data, _, isComplete, error in
+            guard let self, error == nil, isComplete else { return }
+            if let data { self.handleFrame(data, on: connection) }
+            self.receive(on: connection)
+        }
+    }
+
+    /// Record + answer a client `REQ`; drain everything else.
+    private func handleFrame(_ data: Data, on connection: NWConnection) {
+        guard
+            let array = try? JSONSerialization.jsonObject(with: data) as? [Any],
+            array.count >= 2,
+            (array[0] as? String) == "REQ",
+            let subID = array[1] as? String
+        else { return }
+        let filters = array.dropFirst(2).compactMap { $0 as? [String: Any] }
+
+        lock.lock()
+        if subID != "__onym_hb" {
+            recordedREQs.append((subID: subID, filters: filters))
+        }
+        let stored = storedBySubID[subID] ?? []
+        let respond = autoRespondEOSE
+        lock.unlock()
+
+        guard respond else { return }
+        for eventJSON in stored {
+            push("[\"EVENT\",\"\(subID)\",\(eventJSON)]")
+        }
+        push("[\"EOSE\",\"\(subID)\"]")
+    }
+
+    /// Async poll that yields between checks (never blocks a cooperative
+    /// pool thread the way `Thread.sleep` would).
+    private func poll<T>(timeout: TimeInterval, _ probe: () -> T?) async throws -> T {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let value = probe() { return value }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        throw RelayError.timeout
+    }
+
+    enum RelayError: Error { case timeout }
+
+    // MARK: - Event construction
+
+    /// A full `["EVENT", subID, {...}]` frame whose event id is a valid
+    /// NIP-01 hash of its fields (so `parseEvent`'s `verifyEventID()`
+    /// accepts it). The signature is throwaway — the client verifies the
+    /// id, not the signature, at this layer.
+    static func eventFrame(subID: String, kind: Int, content: String, tag: (String, String)) -> String {
+        let event = eventObjectJSON(kind: kind, content: content, tag: tag)
+        return "[\"EVENT\",\"\(subID)\",\(event)]"
+    }
+
+    /// The bare event object (no frame wrapper) for `store(subID:eventJSON:)`.
+    /// The pubkey is derived from `content`, so distinct contents make
+    /// distinct events with distinct ids — mirroring the app's
+    /// ephemeral-pubkey-per-send design.
+    static func eventObjectJSON(kind: Int, content: String, tag: (String, String)) -> String {
+        let pubkey = String(
+            SHA256.hash(data: Data(content.utf8))
+                .map { String(format: "%02x", $0) }.joined().prefix(64)
+        )
+        let createdAt = 1_700_000_000
+        let tags = [[tag.0, tag.1]]
+        let canonical: [Any] = [0, pubkey, createdAt, kind, tags, content]
+        let serialized = try! JSONSerialization.data(withJSONObject: canonical, options: [])
+        let id = Data(SHA256.hash(data: serialized)).map { String(format: "%02x", $0) }.joined()
+        let event: [String: Any] = [
+            "id": id,
+            "pubkey": pubkey,
+            "created_at": createdAt,
+            "kind": kind,
+            "tags": tags,
+            "content": content,
+            "sig": String(repeating: "0", count: 128),
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: event, options: [])
+        return String(data: data, encoding: .utf8)!
+    }
+}

--- a/Tests/OnymIOSTests/Support/LocalWebSocketRelay.swift
+++ b/Tests/OnymIOSTests/Support/LocalWebSocketRelay.swift
@@ -25,9 +25,25 @@ final class LocalWebSocketRelay: @unchecked Sendable {
     private var recordedREQs: [(subID: String, filters: [[String: Any]])] = []
     /// Events "stored" on the relay, keyed by the subID they replay under.
     private var storedBySubID: [String: [String]] = [:]
+    /// Backing storage for the response-mode flags; written by test
+    /// threads, read on the listener queue — lock-guarded.
+    private var _autoRespondEOSE = true
+    private var _autoCLOSESubscriptions = false
+
     /// When false, the relay answers nothing at all (no EOSE, no stored
     /// replay) — a healthy-looking but silent peer.
-    var autoRespondEOSE = true
+    var autoRespondEOSE: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _autoRespondEOSE }
+        set { lock.lock(); defer { lock.unlock() }; _autoRespondEOSE = newValue }
+    }
+
+    /// When true, every non-probe REQ is answered with
+    /// `["CLOSED", subID, …]` — a relay that persistently rejects the
+    /// subscription (e.g. a maxSubsPerConnection cap).
+    var autoCLOSESubscriptions: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _autoCLOSESubscriptions }
+        set { lock.lock(); defer { lock.unlock() }; _autoCLOSESubscriptions = newValue }
+    }
 
     init() throws {
         let params = NWParameters.tcp
@@ -74,6 +90,18 @@ final class LocalWebSocketRelay: @unchecked Sendable {
     func reqs(subID: String) -> [[[String: Any]]] {
         lock.lock(); defer { lock.unlock() }
         return recordedREQs.filter { $0.subID == subID }.map(\.filters)
+    }
+
+    /// All recorded (non-probe) subscription ids, in arrival order.
+    func recordedSubIDs() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return recordedREQs.map(\.subID)
+    }
+
+    /// The most recently REQ'd (non-probe) subscription id.
+    func lastRecordedSubID() -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return recordedREQs.last?.subID
     }
 
     @discardableResult
@@ -131,9 +159,12 @@ final class LocalWebSocketRelay: @unchecked Sendable {
 
     private func receive(on connection: NWConnection) {
         connection.receiveMessage { [weak self] data, _, isComplete, error in
-            guard let self, error == nil, isComplete else { return }
-            if let data { self.handleFrame(data, on: connection) }
+            guard let self, error == nil else { return }
+            // Re-arm FIRST: a non-final or unparseable frame must not
+            // silently kill the read loop mid-test.
             self.receive(on: connection)
+            guard isComplete, let data else { return }
+            self.handleFrame(data, on: connection)
         }
     }
 
@@ -152,9 +183,14 @@ final class LocalWebSocketRelay: @unchecked Sendable {
             recordedREQs.append((subID: subID, filters: filters))
         }
         let stored = storedBySubID[subID] ?? []
-        let respond = autoRespondEOSE
+        let respond = _autoRespondEOSE
+        let reject = _autoCLOSESubscriptions && subID != "__onym_hb"
         lock.unlock()
 
+        if reject {
+            push("[\"CLOSED\",\"\(subID)\",\"error: too many concurrent REQs\"]")
+            return
+        }
         guard respond else { return }
         for eventJSON in stored {
             push("[\"EVENT\",\"\(subID)\",\(eventJSON)]")


### PR DESCRIPTION
PR-2 of the reconnection design (`~/Desktop/reconnect.md`, §5.1–5.2, §9). Transport core only — app-lifecycle triggers land in PR-4, `since`-bounded replay + dedup in PR-3. Supersedes the corresponding parts of closed #193, with the gaps that sank it closed by design.

## Root cause this fixes (F8, confirmed in PR-1)

Stock strfry ships `maxSubsPerConnection = 20` (`onym-infra/strfry/strfry.conf`). The client opened **3 REQs per logical subscription** (three filter shapes) × (identities + outstanding invite links) — ≥7 logical subs blows the cap. strfry rejects the overflow with `["CLOSED", subID, …]`, which the client **silently ignored**: a random inbox (dictionary order) went permanently deaf per launch/reconnect. The relay is stock and stays unmodified — this is a client-side adaptation.

## Changes

**`NostrRelayConnection` → explicit lifecycle state machine** (Disconnected → Connecting → Live → Backoff):
- **Generation token** on every (re)connect — receive loop / liveness monitor / failure funnel no-op when superseded; overlapping reconnects can't race
- **Confirmed-live backoff** — `reconnectAttempts` resets on the first received frame, never in `connect()`; escalates across genuinely failing attempts, capped at 30 s
- **Liveness monitor** (replaces the send-only heartbeat): match-nothing REQ probe, relay's immediate EOSE is the pong (verified live against `nostr.onym.app`); no frame within 55 s ⇒ rebuild. Half-open sockets (where `receive()` hangs forever) can no longer stay deaf. Fail-closed on nil/non-running tasks.
- **`CLOSED` handled, not ignored**: first CLOSED for a live sub → re-REQ once; repeat in the same generation → rebuild via the failure funnel. Relay-side rejection is now visible and recoverable.
- **Injectable timings** for test-scale liveness/backoff.

**Single REQ per subscription** carrying all its filters (NIP-01 dedups within a sub): `NostrInboxTransport`'s 3 filter shapes ship in one REQ — 3× fewer relay subscriptions *and* 3× less duplicate decrypt/dispatch work.

**New `LocalWebSocketRelay` harness** (NWListener loopback): REQ recording w/ filter shapes, store-and-replay-on-REQ, EOSE auto-reply (disableable → silent half-open peer), CLOSED injection, hard-drop.

## Tests (8 new; full suite 864 green)

- one REQ carries all 3 filters (regression: one-REQ-per-filter)
- delivery resumes after server drop (passive error path)
- `forceReconnect()` backfills an event stored while away — **the canonical bg→fg missed-message repro**
- liveness monitor heals a silent (half-open) socket; answered probes cause no spurious rebuilds
- CLOSED → exactly one re-REQ, no rebuild; repeated CLOSED → rebuild + REQ replay; unknown-sub CLOSED ignored

## Privacy note

No activity logging. One new log line: a relay-health warning on repeated CLOSED (relay URL only, no sub id / no user data), matching the pre-existing `securityLogger` pattern (oversized frame / invalid event id). Flagging explicitly — happy to drop it if even that is out of policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)