### PR TITLE
feat(chat): background-arrived messages are user-visible — deferred scroll + new-messages pill

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -34,6 +34,59 @@
         }
       }
     },
+    "%lld new messages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld new message"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld new messages"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld новое сообщение"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld новых сообщения"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld новых сообщений"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld новых сообщений"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "—": {
       "localizations": {
         "en": {

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -61,6 +61,31 @@ final class ChatThreadViewController: UIViewController {
     var onRemovePendingMedia: ((UUID) -> Void)?
 
     private let tableView = UITableView()
+    /// Floating "N new messages" affordance, shown above the input panel
+    /// when incoming messages land while the user is scrolled up in
+    /// history — auto-scrolling would yank them away from what they're
+    /// reading, but the arrival must still be user-visible. Tapping
+    /// scrolls to the bottom; reaching the bottom by hand clears it too.
+    private let newMessagesPill = UIButton(type: .system)
+    /// Incoming messages that arrived while the user was away from the
+    /// bottom — the pill's count. Reset whenever the bottom is reached.
+    private var unseenIncomingCount = 0
+    /// Deferred auto-scroll: set when a fresh message wants the scroll
+    /// pulled to the bottom but the view can't scroll reliably right now
+    /// (app backgrounded / mid-foreground-transition / view not in a
+    /// window — exactly where the reconnect backfill lands). Flushed on
+    /// `viewDidAppear` and `didBecomeActiveNotification`, so a message
+    /// received while backgrounded is on screen the moment the user is.
+    private(set) var pendingScrollToBottom = false
+    /// Whether a scroll performed right now will actually stick. UIKit
+    /// quietly drops scroll-to-row work applied while the app isn't
+    /// active or the view isn't in a window. Injectable so tests can
+    /// drive the deferred path without a real app lifecycle.
+    lazy var canScrollNow: () -> Bool = { [weak self] in
+        guard let self, let view = self.viewIfLoaded else { return false }
+        return view.window != nil
+            && UIApplication.shared.applicationState == .active
+    }
     /// The group's invitation message, surfaced in the empty state.
     private var invitationMessage: String?
     /// Rich empty state (invitation + members + privacy points), hosted
@@ -118,7 +143,18 @@ final class ChatThreadViewController: UIViewController {
         buildTableView()
         buildInputPanel()
         layout()
+        buildNewMessagesPill()
         configureDataSource()
+
+        // A backfilled message can land while the app is backgrounded or
+        // mid-foreground-transition, where a scroll won't stick — flush
+        // the deferred scroll the moment the app is actually active.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
 
         // The input panel rides the keyboard up via the
         // `keyboardLayoutGuide` constraint, which shrinks the message
@@ -148,6 +184,21 @@ final class ChatThreadViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         installFullWidthPopGesture()
+        flushPendingScrollToBottom()
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        flushPendingScrollToBottom()
+    }
+
+    /// Perform a deferred scroll-to-bottom (see `pendingScrollToBottom`).
+    /// Non-animated: the user is just arriving; the latest message should
+    /// simply already be there, like it is after a relaunch.
+    private func flushPendingScrollToBottom() {
+        guard pendingScrollToBottom else { return }
+        pendingScrollToBottom = false
+        tableView.layoutIfNeeded()
+        scrollToBottom(animated: false)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -249,6 +300,12 @@ final class ChatThreadViewController: UIViewController {
             guard let prior = messagesByID[msg.id], prior != msg else { return nil }
             return msg.id
         }
+        // Incoming rows this update introduces (computed against the
+        // *previous* messagesByID) — drives the "N new messages" pill
+        // when the user is scrolled up and auto-scroll would be rude.
+        let newIncomingCount = sorted.count(where: { msg in
+            msg.direction == .incoming && messagesByID[msg.id] == nil
+        })
         messagesByID = Dictionary(uniqueKeysWithValues: sorted.map { ($0.id, $0) })
         orderedMessages = sorted
         rebuildSenderDisplays()
@@ -277,8 +334,26 @@ final class ChatThreadViewController: UIViewController {
                 self.jumpToBottomForColdOpen()
                 self.hasAppliedFirstSnapshot = true
             } else if wasNearBottom && sorted.count > previousCount {
-                self.scrollToBottom(animated: true)
+                if self.canScrollNow() {
+                    self.scrollToBottom(animated: true)
+                } else {
+                    // Backgrounded / mid-foreground-transition / not in a
+                    // window: a scroll now would be silently dropped and
+                    // the fresh message would sit below the fold —
+                    // delivered but invisible. Defer; `viewDidAppear` /
+                    // `didBecomeActive` flushes it.
+                    self.pendingScrollToBottom = true
+                }
             }
+        }
+
+        // The user is scrolled up in history and new incoming messages
+        // just landed: don't yank the scroll — surface the arrival with
+        // the pill instead. (Own outgoing sends keep today's behavior:
+        // no pill, no scroll unless near bottom.)
+        if !isFirstApply, !wasNearBottom, newIncomingCount > 0 {
+            unseenIncomingCount += newIncomingCount
+            showNewMessagesPill(count: unseenIncomingCount)
         }
     }
 
@@ -483,12 +558,66 @@ final class ChatThreadViewController: UIViewController {
         tableView.scrollToRow(at: lastIndex, at: .bottom, animated: animated)
     }
 
+    // MARK: - New-messages pill
+
+    private func buildNewMessagesPill() {
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = UIColor(OnymTokens.surface3)
+        config.baseForegroundColor = UIColor(OnymTokens.text)
+        config.cornerStyle = .capsule
+        config.image = UIImage(systemName: "chevron.down")
+        config.preferredSymbolConfigurationForImage =
+            UIImage.SymbolConfiguration(pointSize: 11, weight: .semibold)
+        config.imagePadding = 6
+        config.contentInsets = NSDirectionalEdgeInsets(
+            top: 8, leading: 14, bottom: 8, trailing: 14
+        )
+        newMessagesPill.configuration = config
+        newMessagesPill.layer.shadowColor = UIColor.black.cgColor
+        newMessagesPill.layer.shadowOpacity = 0.18
+        newMessagesPill.layer.shadowRadius = 10
+        newMessagesPill.layer.shadowOffset = CGSize(width: 0, height: 4)
+        newMessagesPill.accessibilityIdentifier = "chat.newMessagesPill"
+        newMessagesPill.isHidden = true
+        newMessagesPill.addTarget(self, action: #selector(newMessagesPillTapped), for: .touchUpInside)
+
+        newMessagesPill.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(newMessagesPill)
+        NSLayoutConstraint.activate([
+            newMessagesPill.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            newMessagesPill.bottomAnchor.constraint(equalTo: inputPanel.topAnchor, constant: -12),
+        ])
+    }
+
+    private func showNewMessagesPill(count: Int) {
+        var config = newMessagesPill.configuration
+        config?.title = String(localized: "\(count) new messages")
+        newMessagesPill.configuration = config
+        newMessagesPill.isHidden = false
+    }
+
+    /// Hide the pill and forget the unseen count — the user has reached
+    /// (or jumped to) the bottom, so everything is seen.
+    private func clearNewMessagesPill() {
+        unseenIncomingCount = 0
+        newMessagesPill.isHidden = true
+    }
+
+    @objc private func newMessagesPillTapped() {
+        clearNewMessagesPill()
+        tableView.layoutIfNeeded()
+        scrollToBottom(animated: true)
+    }
+
     // MARK: - Table view (message list)
 
     private func buildTableView() {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.backgroundColor = UIColor(OnymTokens.bg)
         tableView.separatorStyle = .none
+        // Scroll tracking for the new-messages pill: reaching the bottom
+        // (by hand or via the pill) clears the unseen count.
+        tableView.delegate = self
         // Hidden until the cold open is positioned at the bottom, so the
         // user never sees the initial top→bottom scroll. Revealed by
         // `jumpToBottomForColdOpen` once the latest message is in place.
@@ -730,6 +859,17 @@ final class ChatThreadViewController: UIViewController {
         handleSend(body)
     }
     #endif
+}
+
+extension ChatThreadViewController: UITableViewDelegate {
+    /// Clears the new-messages pill once the user reaches the bottom —
+    /// whether by scrolling there themselves, tapping the pill, or an
+    /// auto-scroll pulling them down. Cheap: bails immediately while the
+    /// pill is hidden.
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard !newMessagesPill.isHidden else { return }
+        if isNearBottom { clearNewMessagesPill() }
+    }
 }
 
 extension ChatThreadViewController: UIGestureRecognizerDelegate {

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -437,6 +437,138 @@ final class ChatThreadViewControllerTests: XCTestCase {
         RunLoop.current.run(until: Date(timeIntervalSinceNow: seconds))
     }
 
+    // MARK: - New-message awareness (pill + deferred scroll)
+
+    /// Mount a controller with a long thread, cold-opened at the bottom,
+    /// then scrolled up to the top — the "user is reading history" state
+    /// the pill exists for.
+    private func scrolledUpController(messageCount: Int = 40) -> (ChatThreadViewController, UITableView, [ChatMessage]) {
+        let vc = mountedController()
+        let msgs = (0..<messageCount).map {
+            incoming(sender: "aa".repeated(48), body: "message \($0)", at: TimeInterval($0))
+        }
+        vc.update(messages: msgs)
+        let table = layoutTable(in: vc)
+        pumpMainRunLoop()  // cold open completes; hasAppliedFirstSnapshot set
+        table.contentOffset = .zero
+        table.layoutIfNeeded()
+        XCTAssertFalse(vc.isNearBottom, "precondition: the user is scrolled up")
+        return (vc, table, msgs)
+    }
+
+    private func newMessagesPill(in vc: UIViewController) -> UIButton? {
+        find(in: vc.view) { $0.accessibilityIdentifier == "chat.newMessagesPill" } as? UIButton
+    }
+
+    func test_newMessagesPill_hiddenInitially() {
+        let vc = mountedController()
+        vc.update(messages: [makeMessage(body: "hi", direction: .incoming)])
+        _ = layoutTable(in: vc)
+        pumpMainRunLoop()
+        XCTAssertTrue(newMessagesPill(in: vc)?.isHidden ?? false)
+    }
+
+    func test_incomingWhileScrolledUp_showsPillWithCount() {
+        let (vc, _, msgs) = scrolledUpController()
+        vc.update(messages: msgs + [
+            incoming(sender: "bb".repeated(48), body: "new 1", at: 100),
+            incoming(sender: "bb".repeated(48), body: "new 2", at: 101),
+        ])
+        pumpMainRunLoop()
+        let pill = newMessagesPill(in: vc)
+        XCTAssertEqual(pill?.isHidden, false,
+                       "incoming messages while scrolled up must surface the pill")
+        XCTAssertTrue(pill?.configuration?.title?.contains("2") ?? false,
+                      "the pill must carry the unseen count")
+        XCTAssertFalse(vc.isNearBottom,
+                       "the scroll position must NOT be yanked while reading history")
+    }
+
+    func test_pillCount_accumulatesAcrossUpdates() {
+        let (vc, _, msgs) = scrolledUpController()
+        let first = msgs + [incoming(sender: "bb".repeated(48), body: "new 1", at: 100)]
+        vc.update(messages: first)
+        pumpMainRunLoop(0.05)
+        vc.update(messages: first + [incoming(sender: "bb".repeated(48), body: "new 2", at: 101)])
+        pumpMainRunLoop(0.05)
+        XCTAssertTrue(newMessagesPill(in: vc)?.configuration?.title?.contains("2") ?? false,
+                      "unseen count must accumulate until the bottom is reached")
+    }
+
+    func test_reachingBottom_clearsPill() {
+        let (vc, table, msgs) = scrolledUpController()
+        vc.update(messages: msgs + [incoming(sender: "bb".repeated(48), body: "new", at: 100)])
+        pumpMainRunLoop(0.05)
+        XCTAssertEqual(newMessagesPill(in: vc)?.isHidden, false)
+
+        vc.scrollToBottom(animated: false)
+        table.layoutIfNeeded()
+        vc.scrollViewDidScroll(table)
+        XCTAssertEqual(newMessagesPill(in: vc)?.isHidden, true,
+                       "reaching the bottom must clear the pill")
+    }
+
+    func test_pillTap_scrollsToBottomAndHides() {
+        let (vc, table, msgs) = scrolledUpController()
+        vc.update(messages: msgs + [incoming(sender: "bb".repeated(48), body: "new", at: 100)])
+        pumpMainRunLoop(0.05)
+        let pill = newMessagesPill(in: vc)!
+        XCTAssertFalse(pill.isHidden)
+
+        pill.sendActions(for: .touchUpInside)
+        // The tap scrolls animated from ~40 rows up — give the scroll
+        // animation time to settle before asserting the landing spot.
+        pumpMainRunLoop(0.6)
+        table.layoutIfNeeded()
+        XCTAssertTrue(pill.isHidden)
+        XCTAssertTrue(vc.isNearBottom, "tapping the pill must land on the latest message")
+    }
+
+    func test_incomingNearBottom_autoScrolls_noPill() {
+        let vc = mountedController()
+        let msgs = (0..<40).map {
+            incoming(sender: "aa".repeated(48), body: "message \($0)", at: TimeInterval($0))
+        }
+        vc.update(messages: msgs)
+        _ = layoutTable(in: vc)
+        pumpMainRunLoop()  // cold open → at bottom
+
+        vc.update(messages: msgs + [incoming(sender: "bb".repeated(48), body: "new", at: 100)])
+        pumpMainRunLoop()
+        XCTAssertTrue(newMessagesPill(in: vc)?.isHidden ?? false,
+                      "near-bottom arrivals auto-scroll; the pill must not appear")
+        XCTAssertTrue(vc.isNearBottom, "the fresh message must be pulled into view")
+    }
+
+    /// The reported field bug: a message lands while the app can't
+    /// scroll (backgrounded / mid-foreground-transition). The scroll must
+    /// be deferred — and flushed the moment the app becomes active, so
+    /// the message is on screen when the user is.
+    func test_arrivalWhileNotScrollable_deferredAndFlushedOnBecomeActive() {
+        let vc = mountedController()
+        let msgs = (0..<40).map {
+            incoming(sender: "aa".repeated(48), body: "message \($0)", at: TimeInterval($0))
+        }
+        vc.update(messages: msgs)
+        let table = layoutTable(in: vc)
+        pumpMainRunLoop()  // cold open → at bottom
+        XCTAssertTrue(vc.isNearBottom)
+
+        vc.canScrollNow = { false }  // "backgrounded"
+        vc.update(messages: msgs + [incoming(sender: "bb".repeated(48), body: "bg message", at: 100)])
+        pumpMainRunLoop()
+        XCTAssertTrue(vc.pendingScrollToBottom,
+                      "an arrival that can't scroll now must arm the deferred scroll")
+
+        vc.canScrollNow = { true }  // "foregrounded"
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        pumpMainRunLoop()
+        table.layoutIfNeeded()
+        XCTAssertFalse(vc.pendingScrollToBottom, "didBecomeActive must flush the deferred scroll")
+        XCTAssertTrue(vc.isNearBottom,
+                      "the message received while away must be on screen after foregrounding")
+    }
+
     // MARK: - Sender differentiation (run grouping + name headers)
 
     func test_runGrouping_headerOnlyAtStartOfSameSenderRun() {


### PR DESCRIPTION
Stacked on #194 (reconnect PR-2). Fixes the last mile of the reconnect work: a message backfilled on foreground was **delivered but invisible** — the auto-scroll ran while the app wasn't active yet, UIKit silently dropped it, and the fresh message sat below the fold.

## Changes (`ChatThreadViewController`)

**1. Deferred auto-scroll (the reported bug).**
When new rows want the bottom but a scroll can't stick right now (backgrounded / mid-foreground-transition / view not in a window — exactly where reconnect backfill lands), the controller arms `pendingScrollToBottom` and flushes it on `viewDidAppear` + `didBecomeActiveNotification`. Result: the message received while away is on screen the moment the user is — same as after a relaunch, without the relaunch. `canScrollNow` is an injectable seam so tests drive the lifecycle without a real app transition.

**2. New-messages pill (awareness without rudeness).**
When incoming messages land while the user is scrolled up reading history, auto-scrolling would yank them away — instead a floating **"N new messages"** capsule appears above the composer:
- tap → scrolls to the latest and clears
- manually reaching the bottom clears it too
- count accumulates across updates until seen
- localized (en/ru with proper plural variations), `accessibilityIdentifier: chat.newMessagesPill`, built from `OnymTokens`

Own outgoing sends keep today's behavior (no pill; scroll only when near bottom).

## Tests (7 new; full suite 871 green)

- pill hidden initially; appears with count while scrolled up **and does not yank the scroll position**
- count accumulates across updates; clears on reaching bottom; tap lands at latest and hides
- near-bottom arrivals auto-scroll with no pill
- **the field repro**: arrival while unscrollable arms the deferred scroll; `didBecomeActive` flushes it onto screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)