### PR TITLE
fix(transport): bounded reconnect replay (HWM since) + durable event-id dedup (reconnect PR-3)

### DIFF
--- a/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
+++ b/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
@@ -20,17 +20,26 @@ struct InboxFanoutInteractor: Sendable {
     /// Coalescing window — multiple identity changes within this many
     /// milliseconds collapse into one re-subscribe.
     let debounceMilliseconds: UInt64
+    /// Durable dedup by Nostr event id, consulted BEFORE the dispatcher
+    /// decrypts. Re-delivered events (HWM slack overlap, multi-relay,
+    /// reconnect replay) cost a set lookup instead of a decrypt + chain
+    /// read. Marked seen only after a dispatch completes, so a crash
+    /// midway re-delivers rather than loses. nil disables dedup (tests
+    /// that assert re-delivery behavior).
+    let seenEventIDs: SeenEventIDStore?
 
     init(
         inboxTransport: any InboxTransport,
         identityRepository: IdentityRepository,
         dispatcher: IncomingMessageDispatcher,
-        debounceMilliseconds: UInt64 = 250
+        debounceMilliseconds: UInt64 = 250,
+        seenEventIDs: SeenEventIDStore? = nil
     ) {
         self.inboxTransport = inboxTransport
         self.identityRepository = identityRepository
         self.dispatcher = dispatcher
         self.debounceMilliseconds = debounceMilliseconds
+        self.seenEventIDs = seenEventIDs
     }
 
     /// Run until cancelled. Subscribes to every identity's inbox tag
@@ -38,7 +47,8 @@ struct InboxFanoutInteractor: Sendable {
     func run() async {
         let subscriptions = ActiveSubscriptions(
             inboxTransport: inboxTransport,
-            dispatcher: dispatcher
+            dispatcher: dispatcher,
+            seenEventIDs: seenEventIDs
         )
 
         // Apply the current identity set immediately on launch (the
@@ -107,11 +117,17 @@ struct InboxFanoutInteractor: Sendable {
 private actor ActiveSubscriptions {
     private let inboxTransport: any InboxTransport
     private let dispatcher: IncomingMessageDispatcher
+    private let seenEventIDs: SeenEventIDStore?
     private var live: [IdentityID: (tag: TransportInboxID, task: Task<Void, Never>)] = [:]
 
-    init(inboxTransport: any InboxTransport, dispatcher: IncomingMessageDispatcher) {
+    init(
+        inboxTransport: any InboxTransport,
+        dispatcher: IncomingMessageDispatcher,
+        seenEventIDs: SeenEventIDStore?
+    ) {
         self.inboxTransport = inboxTransport
         self.dispatcher = dispatcher
+        self.seenEventIDs = seenEventIDs
     }
 
     func apply(_ wanted: Set<IdentityID>, tagsByID: [IdentityID: TransportInboxID]) async {
@@ -130,15 +146,25 @@ private actor ActiveSubscriptions {
             // `InvitationEnvelopeDecrypting` so cross-identity envelopes
             // decrypt under the right per-identity X25519 key, even if
             // the user has switched to a different identity.
-            let task = Task { [dispatcher, id] in
+            let task = Task { [dispatcher, seenEventIDs, id] in
                 for await message in stream {
                     if Task.isCancelled { break }
+                    // Dedup BEFORE decrypt: a re-delivered event (slack
+                    // overlap, second relay, reconnect replay) is a set
+                    // lookup, not a decrypt + possible chain read.
+                    if let seenEventIDs,
+                       await seenEventIDs.contains(message.messageID) {
+                        continue
+                    }
                     await dispatcher.dispatch(
                         messageID: message.messageID,
                         ownerIdentityID: id,
                         payload: message.payload,
                         receivedAt: message.receivedAt
                     )
+                    // Mark AFTER dispatch: a crash mid-processing means
+                    // re-delivery (idempotent), never loss.
+                    await seenEventIDs?.markSeen(message.messageID)
                 }
             }
             live[id] = (tag, task)

--- a/Sources/OnymIOS/Inbox/SeenEventIDStore.swift
+++ b/Sources/OnymIOS/Inbox/SeenEventIDStore.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Durable, bounded record of Nostr event ids that have already been
+/// fully dispatched. The inbox fan-out consults it *before* decrypting,
+/// so re-delivered events — the HWM slack window, the same event from
+/// multiple relays, a reconnect's replay — cost a set lookup instead of
+/// an X25519/AES-GCM decrypt and a possible chain read.
+///
+/// Ids are marked seen only *after* a dispatch completes: a crash midway
+/// re-delivers (all dispatch paths are idempotent) rather than losing the
+/// event. Eviction is insertion-ordered FIFO with a fixed capacity —
+/// events older than the window are already excluded by the HWM `since`
+/// bound, so the set only needs to cover the recent overlap.
+///
+/// Persistence is debounced (bursty replays write once, not per event);
+/// losing the tail of unsaved marks on a kill is harmless — the events
+/// re-dispatch idempotently next launch.
+actor SeenEventIDStore {
+    private let defaults: UserDefaults
+    private let capacity: Int
+    private var order: [String]
+    private var members: Set<String>
+    private var persistScheduled = false
+    private static let key = "app.onym.ios.inbox.seenEventIDs"
+    private static let persistDebounce: Duration = .seconds(1)
+
+    init(defaults: UserDefaults = .standard, capacity: Int = 4096) {
+        self.defaults = defaults
+        self.capacity = capacity
+        let stored = defaults.stringArray(forKey: Self.key) ?? []
+        self.order = Array(stored.suffix(capacity))
+        self.members = Set(order)
+    }
+
+    func contains(_ id: String) -> Bool {
+        members.contains(id)
+    }
+
+    func markSeen(_ id: String) {
+        guard !members.contains(id) else { return }
+        members.insert(id)
+        order.append(id)
+        if order.count > capacity {
+            let evicted = order.removeFirst()
+            members.remove(evicted)
+        }
+        schedulePersist()
+    }
+
+    private func schedulePersist() {
+        guard !persistScheduled else { return }
+        persistScheduled = true
+        Task {
+            try? await Task.sleep(for: Self.persistDebounce)
+            self.persistNow()
+        }
+    }
+
+    private func persistNow() {
+        persistScheduled = false
+        defaults.set(order, forKey: Self.key)
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -617,7 +617,11 @@ struct OnymIOSApp: App {
                     let fanout = InboxFanoutInteractor(
                         inboxTransport: inboxTransport,
                         identityRepository: identityRepository,
-                        dispatcher: dispatcher
+                        dispatcher: dispatcher,
+                        // Durable event-id dedup: replay overlap and
+                        // multi-relay duplicates are dropped before
+                        // decrypt (marked seen only post-dispatch).
+                        seenEventIDs: SeenEventIDStore()
                     )
                     await fanout.run()
                 }

--- a/Sources/OnymIOS/Transport/InboxHighWaterMarkStore.swift
+++ b/Sources/OnymIOS/Transport/InboxHighWaterMarkStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Persisted per-inbox high-water mark: the highest `created_at` (unix
+/// seconds) seen on each inbox subscription. Every REQ — initial *and*
+/// reconnect replay — is bounded with `since = HWM − slack`, so a
+/// reconnect fetches only the gap since the last event we already have,
+/// never the full retained history. (Unbounded replays through the
+/// serial dispatcher were the flood that starved live chat on
+/// invitation-heavy devices — design doc F2/F6.)
+///
+/// The first-ever run has no mark (nil) ⇒ exactly one unbounded fetch —
+/// a cold start genuinely needs the whole backlog (pending invitations).
+/// Bounded forever after. Slack + downstream dedup absorb relay clock
+/// skew and out-of-order delivery.
+protocol InboxHighWaterMarkStoring: Sendable {
+    func highWaterMark(inbox: String) -> Int64?
+    /// Raise the mark for `inbox` to `createdAt`. Never lowers — a
+    /// replayed old event can't shrink the bound.
+    func raise(inbox: String, to createdAt: Int64)
+}
+
+final class UserDefaultsInboxHighWaterMarkStore: InboxHighWaterMarkStoring, @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let lock = NSLock()
+    private static let key = "app.onym.ios.transport.inboxHighWaterMarks"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func highWaterMark(inbox: String) -> Int64? {
+        lock.lock(); defer { lock.unlock() }
+        let dict = defaults.dictionary(forKey: Self.key) ?? [:]
+        return (dict[inbox] as? NSNumber)?.int64Value
+    }
+
+    func raise(inbox: String, to createdAt: Int64) {
+        lock.lock(); defer { lock.unlock() }
+        var dict = defaults.dictionary(forKey: Self.key) ?? [:]
+        let current = (dict[inbox] as? NSNumber)?.int64Value ?? Int64.min
+        guard createdAt > current else { return }
+        dict[inbox] = NSNumber(value: createdAt)
+        defaults.set(dict, forKey: Self.key)
+    }
+}

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -14,9 +14,18 @@ final class NostrInboxTransport: InboxTransport {
 
     private let state: State
     private let signerProvider: any NostrEphemeralSignerProvider
+    /// Tolerance subtracted from the high-water mark when bounding a
+    /// REQ's `since`, absorbing relay clock skew and out-of-order
+    /// delivery. The small re-fetched overlap is deduped downstream
+    /// (`SeenEventIDStore`); the point is excluding the *ancient*
+    /// backlog, not being exact.
+    static let replaySinceSlack: Int64 = 300
 
-    init(signerProvider: any NostrEphemeralSignerProvider) {
-        self.state = State()
+    init(
+        signerProvider: any NostrEphemeralSignerProvider,
+        highWaterMarks: any InboxHighWaterMarkStoring = UserDefaultsInboxHighWaterMarkStore()
+    ) {
+        self.state = State(highWaterMarks: highWaterMarks)
         self.signerProvider = signerProvider
     }
 
@@ -98,6 +107,13 @@ final class NostrInboxTransport: InboxTransport {
     fileprivate actor State {
         private var connections: [URL: NostrRelayConnection] = [:]
         private var activeSubscriptions: [TransportInboxID: Task<Void, Never>] = [:]
+        /// Per-inbox high-water marks (persisted). Read at every REQ send
+        /// via the connection's `sinceProvider`, raised as events arrive.
+        private let highWaterMarks: any InboxHighWaterMarkStoring
+
+        init(highWaterMarks: any InboxHighWaterMarkStoring) {
+            self.highWaterMarks = highWaterMarks
+        }
 
         func connect(to endpoints: [TransportEndpoint]) async {
             for endpoint in endpoints {
@@ -177,6 +193,18 @@ final class NostrInboxTransport: InboxTransport {
             let subID = "inbox-\(inbox.rawValue)"
             let filters = NostrInboxTransport.subscriptionFilters(inbox: inbox.rawValue)
             let conns = Array(connections.values)
+            // Bound every REQ (initial + reconnect replay) to the gap
+            // since the last event already seen for this inbox. nil on
+            // the first-ever run ⇒ one unbounded cold-start fetch, then
+            // bounded forever. Evaluated at send time, so a reconnect
+            // after hours away fetches hours — not the full history.
+            let inboxTag = inbox.rawValue
+            let hwm = highWaterMarks
+            let sinceProvider: @Sendable () -> Int64? = {
+                hwm.highWaterMark(inbox: inboxTag).map {
+                    max(0, $0 - NostrInboxTransport.replaySinceSlack)
+                }
+            }
 
             let task = Task {
                 await withTaskGroup(of: Void.self) { group in
@@ -191,9 +219,14 @@ final class NostrInboxTransport: InboxTransport {
                         // subscription-heavy devices and the overflow was
                         // silently CLOSED).
                         group.addTask {
-                            let stream = await conn.subscribe(subscriptionID: subID, filters: filters)
+                            let stream = await conn.subscribe(
+                                subscriptionID: subID,
+                                filters: filters,
+                                sinceProvider: sinceProvider
+                            )
                             for await event in stream {
                                 guard !Task.isCancelled else { break }
+                                hwm.raise(inbox: inboxTag, to: event.createdAt)
                                 guard let payload = Data(base64Encoded: event.content) else { continue }
                                 let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
                                 continuation.yield(InboundInbox(

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -44,9 +44,16 @@ actor NostrRelayConnection {
     let url: URL
     private var webSocketTask: URLSessionWebSocketTask?
     private let session: URLSession
-    /// Live subscriptions: subID → (filters, per-event callback). All of
-    /// a subscription's filters ship in one REQ frame.
-    private var subscriptions: [String: (filters: [[String: Any]], callback: (NostrEvent) -> Void)] = [:]
+    /// Live subscriptions: subID → (filters, since-provider, per-event
+    /// callback). All of a subscription's filters ship in one REQ frame.
+    /// `sinceProvider` is consulted at every REQ *send* (initial and
+    /// replay), so the `since` bound reflects the caller's current
+    /// high-water mark rather than a value frozen at subscribe time.
+    private var subscriptions: [String: (
+        filters: [[String: Any]],
+        sinceProvider: (@Sendable () -> Int64?)?,
+        callback: (NostrEvent) -> Void
+    )] = [:]
     private(set) var isConnected = false
     private var reconnectAttempts = 0
     private var pendingOKContinuations: [String: CheckedContinuation<Bool, any Error>] = [:]
@@ -103,11 +110,13 @@ actor NostrRelayConnection {
         let config = URLSessionConfiguration.default
         config.waitsForConnectivity = true
         config.timeoutIntervalForRequest = Self.connectionTimeout
-        // Long-lived WebSocket: no wall-clock resource bound. Death is
-        // detected by the liveness monitor, not the URL loader. (A finite
-        // bound would force periodic full-history replays until the
-        // since-bounded replay of the next PR lands; revisit there.)
-        config.timeoutIntervalForResource = 0
+        // OS-level safety net: after this wall-clock bound the task dies,
+        // `receive()` throws, and the normal failure funnel rebuilds. The
+        // liveness monitor is the real death detector; this only catches
+        // pathological hangs it can't see. Affordable now that reconnect
+        // replays are `since`-bounded (a forced hourly rebuild refetches
+        // the gap, not the full retained history).
+        config.timeoutIntervalForResource = 3600
         self.session = URLSession(configuration: config)
     }
 
@@ -129,7 +138,7 @@ actor NostrRelayConnection {
         startLivenessMonitor(generation: generation)
 
         for (subID, entry) in subscriptions {
-            sendREQ(subscriptionID: subID, filters: entry.filters)
+            sendREQ(subscriptionID: subID, filters: entry.filters, sinceProvider: entry.sinceProvider)
         }
 
         // URLSessionWebSocketTask exposes no reliable onOpen callback.
@@ -233,12 +242,19 @@ actor NostrRelayConnection {
     /// Open one relay subscription carrying every filter in `filters`
     /// (single REQ frame — the relay dedups events across the filters
     /// within one subscription, NIP-01).
+    ///
+    /// `sinceProvider`, when given, bounds every REQ this subscription
+    /// sends — initial and reconnect replay alike — with
+    /// `since = max(filter's own since, provider value)`. Returning nil
+    /// leaves the filters untouched (first-ever run: unbounded cold-start
+    /// fetch).
     func subscribe(
         subscriptionID: String,
-        filters: [[String: Any]]
+        filters: [[String: Any]],
+        sinceProvider: (@Sendable () -> Int64?)? = nil
     ) -> AsyncStream<NostrEvent> {
         let stream = AsyncStream<NostrEvent> { continuation in
-            subscriptions[subscriptionID] = (filters, { event in
+            subscriptions[subscriptionID] = (filters, sinceProvider, { event in
                 continuation.yield(event)
             })
             continuation.onTermination = { @Sendable _ in
@@ -247,7 +263,7 @@ actor NostrRelayConnection {
                 }
             }
         }
-        sendREQ(subscriptionID: subscriptionID, filters: filters)
+        sendREQ(subscriptionID: subscriptionID, filters: filters, sinceProvider: sinceProvider)
         return stream
     }
 
@@ -263,7 +279,24 @@ actor NostrRelayConnection {
 
     // MARK: - Private
 
-    private func sendREQ(subscriptionID: String, filters: [[String: Any]]) {
+    private func sendREQ(
+        subscriptionID: String,
+        filters: [[String: Any]],
+        sinceProvider: (@Sendable () -> Int64?)?
+    ) {
+        var filters = filters
+        // Bound the fetch to the caller's current high-water mark: only
+        // the gap since the last event already seen is replayed, not the
+        // relay's full retained history. Never lowers a since a filter
+        // already carries.
+        if let since = sinceProvider?() {
+            filters = filters.map { filter in
+                var filter = filter
+                let existing = (filter["since"] as? Int64) ?? .min
+                filter["since"] = max(existing, since)
+                return filter
+            }
+        }
         var frame: [Any] = ["REQ", subscriptionID]
         frame.append(contentsOf: filters)
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
@@ -275,7 +308,7 @@ actor NostrRelayConnection {
     private func replaySubscriptions(generation: UInt64) {
         guard generation == connectionGeneration else { return }
         for (subID, entry) in subscriptions {
-            sendREQ(subscriptionID: subID, filters: entry.filters)
+            sendREQ(subscriptionID: subID, filters: entry.filters, sinceProvider: entry.sinceProvider)
         }
     }
 
@@ -433,7 +466,7 @@ actor NostrRelayConnection {
                 Task { await handleConnectionFailure(generation: generation) }
             } else {
                 closedRetriedSubIDs.insert(subID)
-                sendREQ(subscriptionID: subID, filters: entry.filters)
+                sendREQ(subscriptionID: subID, filters: entry.filters, sinceProvider: entry.sinceProvider)
             }
         case "NOTICE":
             break

--- a/Tests/OnymIOSTests/BoundedReplayTests.swift
+++ b/Tests/OnymIOSTests/BoundedReplayTests.swift
@@ -1,0 +1,269 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-3 of the reconnect design: reconnect replays must be cheap so
+/// "always re-REQ" is safe. Covers the persisted high-water-mark store,
+/// the `since` bound applied at REQ-send time (initial + replay), the
+/// transport raising the mark as events arrive, and the durable
+/// seen-event-id dedup in the fan-out.
+final class BoundedReplayTests: XCTestCase {
+    private func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+    }
+
+    // MARK: - InboxHighWaterMarkStore
+
+    func test_hwmStore_unsetReturnsNil_raiseRoundTrips() {
+        let store = UserDefaultsInboxHighWaterMarkStore(defaults: isolatedDefaults())
+        XCTAssertNil(store.highWaterMark(inbox: "abc"))
+        store.raise(inbox: "abc", to: 1_700_000_000)
+        XCTAssertEqual(store.highWaterMark(inbox: "abc"), 1_700_000_000)
+    }
+
+    func test_hwmStore_neverLowers() {
+        let store = UserDefaultsInboxHighWaterMarkStore(defaults: isolatedDefaults())
+        store.raise(inbox: "abc", to: 2_000)
+        store.raise(inbox: "abc", to: 1_000)  // stale replayed event
+        XCTAssertEqual(store.highWaterMark(inbox: "abc"), 2_000)
+    }
+
+    func test_hwmStore_persistsAcrossInstances() {
+        let defaults = isolatedDefaults()
+        UserDefaultsInboxHighWaterMarkStore(defaults: defaults).raise(inbox: "abc", to: 42)
+        let reloaded = UserDefaultsInboxHighWaterMarkStore(defaults: defaults)
+        XCTAssertEqual(reloaded.highWaterMark(inbox: "abc"), 42)
+    }
+
+    func test_hwmStore_isPerInbox() {
+        let store = UserDefaultsInboxHighWaterMarkStore(defaults: isolatedDefaults())
+        store.raise(inbox: "a", to: 10)
+        XCTAssertNil(store.highWaterMark(inbox: "b"))
+    }
+
+    // MARK: - SeenEventIDStore
+
+    func test_seenStore_markAndContains() async {
+        let store = SeenEventIDStore(defaults: isolatedDefaults())
+        let seenBefore = await store.contains("e1")
+        XCTAssertFalse(seenBefore)
+        await store.markSeen("e1")
+        let seenAfter = await store.contains("e1")
+        XCTAssertTrue(seenAfter)
+    }
+
+    func test_seenStore_evictsOldestBeyondCapacity() async {
+        let store = SeenEventIDStore(defaults: isolatedDefaults(), capacity: 3)
+        for id in ["a", "b", "c", "d"] { await store.markSeen(id) }
+        let aSeen = await store.contains("a")
+        let dSeen = await store.contains("d")
+        XCTAssertFalse(aSeen, "oldest id must be evicted at capacity")
+        XCTAssertTrue(dSeen)
+    }
+
+    func test_seenStore_persistsAcrossInstances() async throws {
+        let defaults = isolatedDefaults()
+        let store = SeenEventIDStore(defaults: defaults, capacity: 10)
+        await store.markSeen("e1")
+        // Persistence is debounced ~1s; wait it out.
+        try await Task.sleep(for: .milliseconds(1400))
+        let reloaded = SeenEventIDStore(defaults: defaults, capacity: 10)
+        let seen = await reloaded.contains("e1")
+        XCTAssertTrue(seen, "seen ids must survive a relaunch")
+    }
+
+    // MARK: - Connection applies `since` at REQ-send time
+
+    func test_connection_sinceProvider_boundsInitialREQ() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: URL(string: "ws://127.0.0.1:\(try await relay.port())")!)
+        await conn.connect()
+
+        let stream = await conn.subscribe(
+            subscriptionID: "s1",
+            filters: [["kinds": [34113]], ["kinds": [24113]]],
+            sinceProvider: { 1_000 }
+        )
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await relay.waitForREQs(1)
+        let filters = relay.reqs(subID: "s1")[0]
+        XCTAssertEqual(filters.count, 2)
+        for filter in filters {
+            XCTAssertEqual(filter["since"] as? Int, 1_000, "every filter must carry the since bound")
+        }
+        await conn.disconnect()
+    }
+
+    func test_connection_sinceProvider_neverLowersExplicitSince() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: URL(string: "ws://127.0.0.1:\(try await relay.port())")!)
+        await conn.connect()
+
+        let stream = await conn.subscribe(
+            subscriptionID: "s1",
+            filters: [["kinds": [44114], "since": Int64(5_000)]],
+            sinceProvider: { 1_000 }
+        )
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await relay.waitForREQs(1)
+        let filter = relay.reqs(subID: "s1")[0][0]
+        XCTAssertEqual(filter["since"] as? Int, 5_000,
+                       "a stricter caller-supplied since must win")
+        await conn.disconnect()
+    }
+
+    func test_connection_replayREQ_usesCurrentProviderValue() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: URL(string: "ws://127.0.0.1:\(try await relay.port())")!)
+        await conn.connect()
+
+        // The provider reads mutable state — the replay must see the
+        // *current* value, not one frozen at subscribe time.
+        let hwm = UserDefaultsInboxHighWaterMarkStore(defaults: isolatedDefaults())
+        let stream = await conn.subscribe(
+            subscriptionID: "s1",
+            filters: [["kinds": [34113]]],
+            sinceProvider: { hwm.highWaterMark(inbox: "x") }
+        )
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+        XCTAssertNil(relay.reqs(subID: "s1")[0][0]["since"],
+                     "no mark yet: the cold-start REQ must be unbounded")
+
+        hwm.raise(inbox: "x", to: 9_000)
+        await conn.forceReconnect()
+        try await relay.waitForREQs(2)
+        XCTAssertEqual(relay.reqs(subID: "s1")[1][0]["since"] as? Int, 9_000,
+                       "the reconnect replay must be bounded by the current mark")
+        await conn.disconnect()
+    }
+
+    // MARK: - Transport raises the mark as events arrive
+
+    func test_inboxTransport_raisesHWMOnEvent() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let defaults = isolatedDefaults()
+        let hwm = UserDefaultsInboxHighWaterMarkStore(defaults: defaults)
+        let transport = NostrInboxTransport(
+            signerProvider: OnymNostrSignerProvider(),
+            highWaterMarks: hwm
+        )
+        let url = URL(string: "ws://127.0.0.1:\(try await relay.port())")!
+        await transport.connect(to: [TransportEndpoint(url: url)])
+
+        let inbox = TransportInboxID(rawValue: "abcd1234")
+        let stream = transport.subscribe(inbox: inbox)
+        let received = ReceivedBox()
+        let pump = Task { for await msg in stream { await received.append(msg.messageID) } }
+        defer { pump.cancel() }
+
+        try await relay.waitForREQs(1)
+        // The harness event's created_at is 1_700_000_000; content must
+        // be base64 for the transport to yield it.
+        relay.push(LocalWebSocketRelay.eventFrame(
+            subID: "inbox-abcd1234", kind: 34113,
+            content: Data("hello".utf8).base64EncodedString(),
+            tag: ("d", "sep-inbox:abcd1234")
+        ))
+
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            if hwm.highWaterMark(inbox: "abcd1234") != nil { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(hwm.highWaterMark(inbox: "abcd1234"), 1_700_000_000,
+                       "an arriving event must raise the inbox's high-water mark")
+        await transport.disconnect()
+    }
+
+    // MARK: - Fan-out dedup
+
+    func test_fanout_dropsAlreadySeenEventBeforeDispatch() async throws {
+        // Two deliveries of the same event id (second relay / replay
+        // overlap) must dispatch exactly once.
+        let transport = FakeInboxTransport()
+        let identityRepo = IdentityRepository(
+            keychain: IdentityKeychainStore(testNamespace: "fanout-dedup-\(UUID().uuidString)")
+        )
+        _ = try await identityRepo.bootstrap()
+
+        let offer = try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x44, count: 32),
+            groupID: Data(repeating: 0x42, count: 32),
+            groupName: "G",
+            inviterAlias: "A"
+        )
+        let plaintext = try JSONEncoder().encode(offer)
+        let spy = SpyPendingInvitesForFanout()
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext)),
+            identities: identityRepo,
+            groupRepository: GroupRepository(store: SwiftDataGroupStore.inMemory()),
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: NoopChainStateForFanout(),
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            pendingInvites: spy
+        )
+
+        let fanout = InboxFanoutInteractor(
+            inboxTransport: transport,
+            identityRepository: identityRepo,
+            dispatcher: dispatcher,
+            seenEventIDs: SeenEventIDStore(defaults: isolatedDefaults())
+        )
+        let run = Task { await fanout.run() }
+        defer { run.cancel() }
+
+        // Wait for the fanout's subscription to land, then deliver the
+        // same event id twice.
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            let count = await transport.subscribeCallCount
+            if count >= 1 { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let inbox = await transport.subscribedInboxes.first
+        let message = InboundInbox(
+            inbox: inbox!, payload: Data("envelope".utf8),
+            receivedAt: Date(), messageID: "same-event-id"
+        )
+        await transport.emit(message)
+        try await Task.sleep(for: .milliseconds(300))
+        await transport.emit(message)
+        try await Task.sleep(for: .milliseconds(300))
+
+        let recorded = await spy.all()
+        XCTAssertEqual(recorded.count, 1, "a re-delivered event id must not re-dispatch")
+        await transport.finish()
+    }
+}
+
+// MARK: - Test doubles
+
+private actor ReceivedBox {
+    private var ids: [String] = []
+    func append(_ id: String) { ids.append(id) }
+    func all() -> [String] { ids }
+}
+
+private actor SpyPendingInvitesForFanout: PendingInvitesRecording {
+    private var recorded: [PendingInvite] = []
+    func record(_ invite: PendingInvite) async { recorded.append(invite) }
+    func all() -> [PendingInvite] { recorded }
+}
+
+private struct NoopChainStateForFanout: ChainStateReading {
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        throw URLError(.unsupportedURL)
+    }
+}

--- a/Tests/OnymIOSTests/Support/FakeInboxTransport.swift
+++ b/Tests/OnymIOSTests/Support/FakeInboxTransport.swift
@@ -27,6 +27,7 @@ actor FakeInboxTransport: InboxTransport {
     private(set) var connectedEndpoints: [TransportEndpoint] = []
     private(set) var disconnectCallCount = 0
     private(set) var unsubscribedInboxes: [TransportInboxID] = []
+    private(set) var subscribedInboxes: [TransportInboxID] = []
     private(set) var subscribeCallCount = 0
 
     // MARK: - InboxTransport
@@ -93,6 +94,7 @@ actor FakeInboxTransport: InboxTransport {
         continuation: AsyncStream<InboundInbox>.Continuation
     ) {
         subscribeCallCount += 1
+        subscribedInboxes.append(inbox)
         continuations[inbox] = continuation
     }
 }


### PR DESCRIPTION
Stacked on #195. Design doc §5.2: **replay must be cheap so "always re-REQ" is safe** — this resolves the storm-vs-backfill tension that sank #193 on the invitation-spammed device (F2/F6).

## Changes

- **Persisted per-inbox high-water mark** (`InboxHighWaterMarkStore`, UserDefaults-backed, never lowers). The transport raises it as events arrive and hands the connection a `sinceProvider`, so **every REQ — initial and reconnect replay — carries `since = HWM − 300 s slack`, evaluated at send time** (a reconnect after hours away fetches hours, not the full retained history). First-ever run: no mark ⇒ one unbounded cold-start fetch (the invitation backlog genuinely needed), bounded forever after.
- **Durable seen-event-id dedup** (`SeenEventIDStore`: actor, persisted, FIFO-bounded 4096, debounced writes) consulted in the fan-out **before decrypt** — slack overlap, multi-relay duplicates, and replays cost a set lookup, not an X25519/AES-GCM decrypt + possible chain read. Marked seen only **after** dispatch completes: a crash midway re-delivers (all paths idempotent), never loses.
- `timeoutIntervalForResource` 0 → 3600: the OS safety net is affordable now that a forced rebuild refetches only the gap.

## Tests (12 new; full suite green)

HWM semantics/persistence/per-inbox isolation; seen-store mark/evict/persist-across-instances; `since` applied to all filters of the initial REQ; a stricter caller `since` wins; **replay uses the current provider value** (cold-start unbounded → bounded after first event); transport raises HWM on arrival (loopback relay); fan-out dispatches a re-delivered event id exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)