### PR TITLE
feat(app): foreground + connectivity reconnect triggers; RootView flow ownership (reconnect PR-4)

### DIFF
--- a/Sources/OnymIOS/Chain/UITestFakes.swift
+++ b/Sources/OnymIOS/Chain/UITestFakes.swift
@@ -130,6 +130,8 @@ final class UITestLoopbackInboxTransport: InboxTransport, @unchecked Sendable {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    // In-process loopback: subscriber continuations survive; nothing to rebuild.
+    func reconnect() async {}
 
     @discardableResult
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 @main
 struct OnymIOSApp: App {
@@ -654,6 +655,36 @@ struct OnymIOSApp: App {
                         currentTask = Task { await pump.run(entries: entries) }
                     }
                     currentTask?.cancel()
+                }
+                .task {
+                    // Refresh relay sockets when connectivity is regained.
+                    // NetworkPathMonitor is edge-triggered (only a genuine
+                    // unsatisfied→satisfied transition) and debounced, so
+                    // interface churn can't storm reconnects; the rebuild
+                    // itself is cheap (since-bounded replay + dedup).
+                    for await _ in NetworkPathMonitor.connectivityRegainedStream() {
+                        await inboxTransport.reconnect()
+                    }
+                }
+                .task {
+                    // A backgrounded app has its relay WebSocket torn down
+                    // (or half-opened) by the OS; nothing in URLSession
+                    // re-establishes it on resume, and only a fresh REQ
+                    // backfills what was missed while suspended. Rebuild
+                    // unconditionally on return to foreground.
+                    //
+                    // `willEnterForeground` (not `scenePhase` on the App):
+                    // observing scenePhase re-evaluates the entire view
+                    // tree on every phase change; the notification fires
+                    // only on a real background→foreground transition and
+                    // drives the side effect without touching the render
+                    // path.
+                    let foregrounded = NotificationCenter.default.notifications(
+                        named: UIApplication.willEnterForegroundNotification
+                    )
+                    for await _ in foregrounded {
+                        await inboxTransport.reconnect()
+                    }
                 }
                 .onOpenURL { url in
                     // Custom URL scheme (`onym://join?c=…`) and

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -21,13 +21,30 @@ struct RootView: View {
     let dependencies: AppDependencies
 
     @State private var selectedTab: RootTab = .chats
+    // Held in @State so they survive RootView body re-evaluations. Built
+    // inline in `body` before, a fresh ChatsFlow was minted on every
+    // re-render; `.task { flow.start() }` keys off the view's identity
+    // and does NOT re-fire for the replacement instance, so an unstarted
+    // (empty) flow backed the chat list until a tab switch forced `.task`
+    // to run again — the "chat list empty until I visit Settings and come
+    // back" bug (design doc F5). A view must tolerate body re-evaluation;
+    // owning the flows here makes their subscriptions durable.
+    @State private var chatsFlow: ChatsFlow
+    @State private var searchChatsFlow: ChatsFlow
+
+    @MainActor
+    init(dependencies: AppDependencies) {
+        self.dependencies = dependencies
+        _chatsFlow = State(initialValue: dependencies.makeChatsFlow())
+        _searchChatsFlow = State(initialValue: dependencies.makeChatsFlow())
+    }
 
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: .chats) {
                 NavigationStack {
                     ChatsView(
-                        flow: dependencies.makeChatsFlow(),
+                        flow: chatsFlow,
                         identitiesFlow: dependencies.identitiesFlow,
                         approveRequestsFlow: dependencies.approveRequestsFlow,
                         pendingInvitesFlow: dependencies.pendingInvitesFlow,
@@ -64,7 +81,7 @@ struct RootView: View {
                 NavigationStack {
                     SearchView(
                         messageRepository: dependencies.messageRepository,
-                        chatsFlow: dependencies.makeChatsFlow(),
+                        chatsFlow: searchChatsFlow,
                         identitiesFlow: dependencies.identitiesFlow,
                         sendMessageInteractor: dependencies.sendMessageInteractor,
                         chatReceiptSender: dependencies.chatReceiptSender,

--- a/Sources/OnymIOS/Transport/NetworkPathMonitor.swift
+++ b/Sources/OnymIOS/Transport/NetworkPathMonitor.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Network
+
+/// Bridges `NWPathMonitor` to an `AsyncStream` of "connectivity was just
+/// regained" signals. Each emission is a cue to refresh long-lived
+/// sockets — the app forwards it to `InboxTransport.reconnect()`.
+///
+/// Emission policy lives in `ConnectivityRegainDetector` (below):
+///
+///  - **Edge-triggered.** `NWPathMonitor` invokes its handler on *any*
+///    path change, including route/interface/proxy churn while the path
+///    stays satisfied (frequent on real devices). Emitting on every
+///    satisfied callback caused a reconnect storm (design doc F2). We
+///    emit only on a genuine unsatisfied→satisfied transition.
+///  - **Baseline suppressed.** The first callback establishes the
+///    starting state and never emits — the launch-time connect already
+///    covers a satisfied start, while an *unsatisfied* start still arms
+///    the detector so the first real regain fires (launch-offline case).
+///  - **Coalesced.** A flapping link emits at most once per cooldown
+///    window, so the transport isn't rebuilt at the flap rate.
+enum NetworkPathMonitor {
+    static func connectivityRegainedStream() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            let monitor = NWPathMonitor()
+            let detector = ConnectivityRegainDetector()
+            monitor.pathUpdateHandler = { path in
+                if detector.shouldEmit(satisfied: path.status == .satisfied) {
+                    continuation.yield(())
+                }
+            }
+            continuation.onTermination = { @Sendable _ in monitor.cancel() }
+            monitor.start(queue: DispatchQueue(label: "app.onym.ios.netpath"))
+        }
+    }
+}
+
+/// Decides when a sequence of `NWPathMonitor` status callbacks should
+/// produce a "connectivity regained" signal. Pure logic with an
+/// injectable clock — no `Network` dependency — so the edge + cooldown
+/// behavior is unit-testable. Callbacks arrive on `NWPathMonitor`'s own
+/// queue, so state is lock-guarded.
+final class ConnectivityRegainDetector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lastSatisfied: Bool?
+    private var lastEmitAt: Date?
+    private let cooldown: TimeInterval
+    private let now: () -> Date
+
+    init(cooldown: TimeInterval = 3, now: @escaping () -> Date = Date.init) {
+        self.cooldown = cooldown
+        self.now = now
+    }
+
+    func shouldEmit(satisfied: Bool) -> Bool {
+        lock.lock()
+        defer { lastSatisfied = satisfied; lock.unlock() }
+        // First callback is the baseline — arm, never emit.
+        guard let previous = lastSatisfied else { return false }
+        // Only the unsatisfied→satisfied edge is a regain.
+        guard satisfied, !previous else { return false }
+        // Debounce a flapping link.
+        let timestamp = now()
+        if let last = lastEmitAt, timestamp.timeIntervalSince(last) < cooldown {
+            return false
+        }
+        lastEmitAt = timestamp
+        return true
+    }
+}

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -37,6 +37,10 @@ final class NostrInboxTransport: InboxTransport {
         await state.disconnect()
     }
 
+    func reconnect() async {
+        await state.reconnect()
+    }
+
     @discardableResult
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         let signer = try signerProvider.makeEphemeralSigner()
@@ -134,6 +138,18 @@ final class NostrInboxTransport: InboxTransport {
                 await conn.disconnect()
             }
             connections.removeAll()
+        }
+
+        /// Rebuild every connection in place. The per-connection
+        /// subscription dicts survive the rebuild and their REQs replay
+        /// (`since`-bounded), so consumers' AsyncStreams never break and
+        /// the relay backfills exactly the gap missed while away.
+        func reconnect() async {
+            await withTaskGroup(of: Void.self) { group in
+                for conn in connections.values {
+                    group.addTask { await conn.forceReconnect() }
+                }
+            }
         }
 
         /// Per-relay publish outcome — split so the thrown error can

--- a/Sources/OnymIOS/Transport/Transport.swift
+++ b/Sources/OnymIOS/Transport/Transport.swift
@@ -104,6 +104,17 @@ protocol InboxTransport: Sendable {
     func connect(to endpoints: [TransportEndpoint]) async
     func disconnect() async
 
+    /// Tear down and rebuild every underlying connection, re-issuing all
+    /// live subscriptions. Unconditional by design: it exists for the
+    /// app-driven refresh triggers (return to foreground, regained
+    /// connectivity), where a fresh REQ is the only mechanism that
+    /// backfills events missed while the socket was dead or suspended —
+    /// probing first and skipping the rebuild on a healthy-*looking*
+    /// socket provably loses messages (design doc F3). Cheap by
+    /// construction: replays are `since`-bounded to the gap. Consumers'
+    /// subscription streams survive the rebuild.
+    func reconnect() async
+
     @discardableResult
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt
 

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -435,6 +435,7 @@ private final class CreateGroupFlowTestEnv {
 private struct FlowTestInboxTransport: InboxTransport {
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         PublishReceipt(messageID: "x", acceptedBy: 1)
     }

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -593,6 +593,7 @@ private actor ConfigurableInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         sends.append(Send(payload: payload, inbox: inbox))

--- a/Tests/OnymIOSTests/GroupStateRefreshTests.swift
+++ b/Tests/OnymIOSTests/GroupStateRefreshTests.swift
@@ -361,6 +361,7 @@ private actor VerifierRecordingInboxTransport: InboxTransport {
     private(set) var sends: Int = 0
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         sends += 1
         return PublishReceipt(messageID: "spy-\(sends)", acceptedBy: 1)

--- a/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
+++ b/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
@@ -216,6 +216,7 @@ private actor RecordingInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         PublishReceipt(messageID: UUID().uuidString, acceptedBy: 1)

--- a/Tests/OnymIOSTests/IntroInboxPumpTests.swift
+++ b/Tests/OnymIOSTests/IntroInboxPumpTests.swift
@@ -172,6 +172,7 @@ private actor PumpRecordingInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         PublishReceipt(messageID: UUID().uuidString, acceptedBy: 1)

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -493,6 +493,7 @@ private actor ApproverRecordingInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         sends.append((payload, inbox))

--- a/Tests/OnymIOSTests/NetworkPathMonitorTests.swift
+++ b/Tests/OnymIOSTests/NetworkPathMonitorTests.swift
@@ -83,8 +83,10 @@ final class NostrInboxTransportReconnectTests: XCTestCase {
         try await relay.waitForREQs(1)
 
         // Arrives while "backgrounded": stored on the relay, never
-        // pushed live to this socket.
-        relay.store(subID: "inbox-cafe0001", eventJSON: LocalWebSocketRelay.eventObjectJSON(
+        // pushed live to this socket. Keyed to the subID the transport
+        // actually REQ'd (generation-suffixed) — a reconnect replays the
+        // same subscription id.
+        relay.store(subID: relay.lastRecordedSubID()!, eventJSON: LocalWebSocketRelay.eventObjectJSON(
             kind: 34113,
             content: Data("missed".utf8).base64EncodedString(),
             tag: ("d", "sep-inbox:cafe0001")

--- a/Tests/OnymIOSTests/NetworkPathMonitorTests.swift
+++ b/Tests/OnymIOSTests/NetworkPathMonitorTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import OnymIOS
+
+/// Unit tests for `ConnectivityRegainDetector` — the emission policy
+/// behind `NetworkPathMonitor`. The two field-proven failure modes it
+/// must prevent: a reconnect storm from satisfied→satisfied path churn
+/// (design doc F2), and a swallowed regain after a launch-offline start.
+final class NetworkPathMonitorTests: XCTestCase {
+    func test_baselineCallbackNeverEmits() {
+        let detector = ConnectivityRegainDetector(cooldown: 0)
+        XCTAssertFalse(detector.shouldEmit(satisfied: true),
+                       "the first (baseline) callback must not emit")
+    }
+
+    func test_offlineLaunchThenRegain_emits() {
+        // Launch offline → connectivity arrives. The one-shot-latch
+        // design swallowed this; the edge detector must fire.
+        let detector = ConnectivityRegainDetector(cooldown: 0)
+        XCTAssertFalse(detector.shouldEmit(satisfied: false))  // baseline, offline
+        XCTAssertTrue(detector.shouldEmit(satisfied: true), "offline→online must emit")
+    }
+
+    func test_satisfiedChurn_doesNotEmit() {
+        let detector = ConnectivityRegainDetector(cooldown: 0)
+        _ = detector.shouldEmit(satisfied: true)  // baseline, online
+        XCTAssertFalse(detector.shouldEmit(satisfied: true),
+                       "interface churn while satisfied must not emit (reconnect storm)")
+        XCTAssertFalse(detector.shouldEmit(satisfied: true))
+    }
+
+    func test_dropAndRegain_emitsOnce() {
+        let detector = ConnectivityRegainDetector(cooldown: 0)
+        _ = detector.shouldEmit(satisfied: true)   // baseline
+        XCTAssertFalse(detector.shouldEmit(satisfied: false))
+        XCTAssertTrue(detector.shouldEmit(satisfied: true))
+        XCTAssertFalse(detector.shouldEmit(satisfied: true), "no re-emit while staying satisfied")
+    }
+
+    func test_flapping_isCoalescedWithinCooldown() {
+        var now = Date(timeIntervalSince1970: 1_000)
+        let detector = ConnectivityRegainDetector(cooldown: 3, now: { now })
+        _ = detector.shouldEmit(satisfied: true)   // baseline online
+
+        now = now.addingTimeInterval(0.1)
+        _ = detector.shouldEmit(satisfied: false)
+        XCTAssertTrue(detector.shouldEmit(satisfied: true), "first regain emits")
+
+        // A rapid flap inside the cooldown is swallowed.
+        now = now.addingTimeInterval(0.5)
+        _ = detector.shouldEmit(satisfied: false)
+        XCTAssertFalse(detector.shouldEmit(satisfied: true),
+                       "a regain within the cooldown must be coalesced")
+
+        // After the cooldown lapses, a regain emits again.
+        now = now.addingTimeInterval(5)
+        _ = detector.shouldEmit(satisfied: false)
+        XCTAssertTrue(detector.shouldEmit(satisfied: true))
+    }
+}
+
+/// Transport-level: `InboxTransport.reconnect()` must rebuild the socket,
+/// replay the REQ, and thereby backfill an event stored while away — the
+/// full foreground-refresh path minus the app trigger.
+final class NostrInboxTransportReconnectTests: XCTestCase {
+    func test_reconnect_rebuildsAndBackfillsStoredEvent() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let transport = NostrInboxTransport(
+            signerProvider: OnymNostrSignerProvider(),
+            highWaterMarks: UserDefaultsInboxHighWaterMarkStore(
+                defaults: UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+            )
+        )
+        let url = URL(string: "ws://127.0.0.1:\(try await relay.port())")!
+        await transport.connect(to: [TransportEndpoint(url: url)])
+
+        let inbox = TransportInboxID(rawValue: "cafe0001")
+        let received = ReceivedMessages()
+        let stream = transport.subscribe(inbox: inbox)
+        let pump = Task { for await msg in stream { await received.append(msg.messageID) } }
+        defer { pump.cancel() }
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        // Arrives while "backgrounded": stored on the relay, never
+        // pushed live to this socket.
+        relay.store(subID: "inbox-cafe0001", eventJSON: LocalWebSocketRelay.eventObjectJSON(
+            kind: 34113,
+            content: Data("missed".utf8).base64EncodedString(),
+            tag: ("d", "sep-inbox:cafe0001")
+        ))
+
+        await transport.reconnect()
+        try await relay.waitForConnections(2)
+        try await relay.waitForREQs(2)
+
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            let count = await received.count()
+            if count >= 1 { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let ids = await received.all()
+        XCTAssertEqual(ids.count, 1,
+                       "reconnect() must re-REQ so the relay backfills the missed event")
+        await transport.disconnect()
+    }
+}
+
+private actor ReceivedMessages {
+    private var ids: [String] = []
+    func append(_ id: String) { ids.append(id) }
+    func all() -> [String] { ids }
+    func count() -> Int { ids.count }
+}

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -826,6 +826,7 @@ private actor RecordingInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         recordedSends.append(Record(payload: payload, inbox: inbox))

--- a/Tests/OnymIOSTests/Support/FakeInboxTransport.swift
+++ b/Tests/OnymIOSTests/Support/FakeInboxTransport.swift
@@ -42,6 +42,11 @@ actor FakeInboxTransport: InboxTransport {
         continuations.removeAll()
     }
 
+    func reconnect() async {
+        // No-op: the fake drives live subscriptions directly via `emit`,
+        // so there is nothing to rebuild.
+    }
+
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         // Not exercised by the pump; tests asserting on send paths use a different fake.
         PublishReceipt(messageID: "fake-\(UUID().uuidString)", acceptedBy: 1)


### PR DESCRIPTION
Stacked on #196. Design doc §5.3 + §5.6: with replays cheap (PR-3), reconnect triggers can be **unconditional** — this is what actually fixes "messages sent while backgrounded appear only after relaunch" end-to-end.

## Changes

- **`InboxTransport.reconnect()`** — tear down + rebuild every connection, re-issuing all subscriptions. Unconditional: a fresh REQ is the only backfill mechanism (probe-first provably lost messages, F3). Cheap by construction (`since`-bounded replay + pre-decrypt dedup); consumer streams survive the rebuild.
- **Foreground trigger**: long-lived `.task` awaiting `willEnterForegroundNotification` → `reconnect()`. Deliberately **not** `scenePhase` on the `App` — that re-evaluates the entire view tree per phase change (the churn that exposed F5).
- **Connectivity trigger**: `NetworkPathMonitor` + `ConnectivityRegainDetector` (pure, clock-injectable): emits only on a genuine unsatisfied→satisfied edge, baseline-suppressed (but a launch-offline start still arms it), 3 s flap coalescing. Satisfied→satisfied interface churn — the F2 reconnect storm — structurally cannot emit.
- **RootView `@State`-owned ChatsFlows** (built once in `@MainActor init`): fixes F5 — flows minted inline in `body` were replaced on every re-render while `.task { flow.start() }` never re-fired, leaving an unstarted empty flow behind the chat list.

## Tests (6 new; full suite green)

Detector: baseline never emits; offline-launch regain emits; satisfied churn never emits; drop→regain emits once; flapping coalesced within cooldown. Transport: `reconnect()` rebuilds, re-REQs, and **backfills an event stored while away** (the canonical bg→fg repro, now at the transport level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)