### PR TITLE
feat(inbox): dispatch lanes — invitation backlog can't starve live chat (reconnect PR-5)

### DIFF
--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -78,6 +78,13 @@ struct IncomingMessageDispatcher: Sendable {
     /// raises a message to `.read` when this device also sends read
     /// receipts. Defaulted to `true` (the shipping default).
     var readReceiptsEnabled: @Sendable () -> Bool = { true }
+    /// The slow lane: FIFO, serial, non-blocking-to-enqueue. Every
+    /// invitation / group-state payload runs here so a backlog of
+    /// chain-verifying handlers can never starve live chat (F6). One
+    /// lane per dispatcher instance; the struct's copies share it
+    /// (actor reference), preserving FIFO across the app's single
+    /// dispatcher.
+    var slowLane = SerialDispatchLane()
 
     func dispatch(
         messageID: String,
@@ -94,111 +101,132 @@ struct IncomingMessageDispatcher: Sendable {
             envelopeBytes: payload,
             asIdentity: ownerIdentityID
         ) else {
-            await fallThrough(
-                messageID: messageID,
-                ownerIdentityID: ownerIdentityID,
-                payload: payload,
-                receivedAt: receivedAt
-            )
+            // Undecryptable ciphertext lands in the opaque invitations
+            // queue — invitation domain, so it rides the slow lane.
+            await slowLane.enqueue { [self] in
+                await fallThrough(
+                    messageID: messageID,
+                    ownerIdentityID: ownerIdentityID,
+                    payload: payload,
+                    receivedAt: receivedAt
+                )
+            }
             return
         }
 
-        // Fast path 0: GroupInviteOfferPayload — a push invitation.
-        // Decoded + queued for the user's explicit Accept; it carries
-        // no epoch / commitment / roster, so it never materializes a
-        // group or touches the on-chain commitment. Tried first
-        // because its required `inviter_alias` + `intro_pub` keys are
-        // unique to this type — no other inbox payload decodes as one.
+        // ── Lane routing ────────────────────────────────────────────
+        // Chat messages + receipts are handled INLINE (fast lane): pure
+        // local work, milliseconds. Everything invitation / group-state
+        // shaped goes through `slowLane` (FIFO, serial): those handlers
+        // may hit the relayer for a chain read, and processing them
+        // inline meant a backlog of replayed invitations stalled live
+        // chat for minutes (F6). The fan-out's serial loop returns
+        // immediately for slow payloads; relative order WITHIN the slow
+        // family is preserved by the lane's FIFO guarantee.
+
+        // Slow: GroupInviteOfferPayload — a push invitation. Decoded +
+        // queued for the user's explicit Accept; carries no epoch /
+        // commitment / roster, so it never materializes a group. Tried
+        // first because its required `inviter_alias` + `intro_pub` keys
+        // are unique to this type.
         if let offer = try? JSONDecoder().decode(
             GroupInviteOfferPayload.self,
             from: envelope.plaintext
         ) {
-            await recordOffer(
-                offer,
-                messageID: messageID,
-                ownerIdentityID: ownerIdentityID,
-                receivedAt: receivedAt
-            )
+            await slowLane.enqueue { [self] in
+                await recordOffer(
+                    offer,
+                    messageID: messageID,
+                    ownerIdentityID: ownerIdentityID,
+                    receivedAt: receivedAt
+                )
+            }
             return
         }
 
-        // Fast path 0.5: GroupStateRefreshRequest — a member asking the
-        // admin for the current group state (Option 2 verify-at-current).
+        // Slow: GroupStateRefreshRequest — a member asking the admin for
+        // the current group state (Option 2 verify-at-current).
         // Admin-side; delegated to the verifier, which gates on the
         // requester being a current member before disclosing the salt.
         if let refresh = try? JSONDecoder().decode(
             GroupStateRefreshRequest.self,
             from: envelope.plaintext
         ) {
-            await groupStateRefresher.handleRefreshRequest(
-                refresh,
-                ownerIdentityID: ownerIdentityID,
-                requesterEd25519: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await groupStateRefresher.handleRefreshRequest(
+                    refresh,
+                    ownerIdentityID: ownerIdentityID,
+                    requesterEd25519: senderKey
+                )
+            }
             return
         }
 
-        // Fast path 1: MemberAnnouncementPayload — incremental roster
-        // delta for an existing local group.
+        // Slow: MemberAnnouncementPayload — incremental roster delta for
+        // an existing local group (may verify against the chain).
         if let announcement = try? JSONDecoder().decode(
             MemberAnnouncementPayload.self,
             from: envelope.plaintext
         ) {
-            await applyAnnouncement(
-                announcement,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await applyAnnouncement(
+                    announcement,
+                    senderEd25519PublicKey: senderKey
+                )
+            }
             return
         }
 
-        // Fast path 1.5: GroupAvatarPayload — admin updated the group
-        // photo. Group-state delta like the announcement above; its
-        // unique `avatar_*` keys keep it from decoding as a chat
-        // message (which shares version / group_id / sender).
+        // Slow: GroupAvatarPayload — admin updated the group photo.
+        // Group-state delta; its unique `avatar_*` keys keep it from
+        // decoding as a chat message. Local-only work, but it rides the
+        // slow lane so group-state mutations stay mutually ordered.
         if let avatarMsg = try? JSONDecoder().decode(
             GroupAvatarPayload.self,
             from: envelope.plaintext
         ) {
-            await applyAvatar(
-                avatarMsg,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await applyAvatar(avatarMsg, senderEd25519PublicKey: senderKey)
+            }
             return
         }
 
-        // Fast path 1.6: GroupNamePayload — admin renamed the group.
-        // Group-state delta like the avatar above; its unique `name_*`
-        // keys keep it from decoding as any other payload.
+        // Slow: GroupNamePayload — admin renamed the group. Same
+        // ordering rationale as the avatar above.
         if let nameMsg = try? JSONDecoder().decode(
             GroupNamePayload.self,
             from: envelope.plaintext
         ) {
-            await applyName(
-                nameMsg,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await applyName(nameMsg, senderEd25519PublicKey: senderKey)
+            }
             return
         }
 
-        // Fast path 2: GroupInvitationPayload — materialize a local
-        // group under `ownerIdentityID`. Skips the invitations queue
-        // because the group is now visible in the chat list.
+        // Slow: GroupInvitationPayload — materialize a local group under
+        // `ownerIdentityID` (chain-verifies the snapshot commitment).
         if let invitation = try? JSONDecoder().decode(
             GroupInvitationPayload.self,
             from: envelope.plaintext
         ) {
-            await materializeGroup(
-                invitation,
-                ownerIdentityID: ownerIdentityID,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await materializeGroup(
+                    invitation,
+                    ownerIdentityID: ownerIdentityID,
+                    senderEd25519PublicKey: senderKey
+                )
+            }
             return
         }
 
-        // Fast path: chat receipt — a peer acking one of OUR messages
-        // as delivered / read. Wire-shape-disjoint from every other
-        // payload (unique `kind` + `message_ids` keys), so this `try?`
-        // decode can't steal a different payload.
+        // Fast: chat receipt — a peer acking one of OUR messages as
+        // delivered / read. Wire-shape-disjoint from every other payload
+        // (unique `kind` + `message_ids` keys). Pure local status flip.
         if let receipt = try? JSONDecoder().decode(
             ChatReceiptPayload.self,
             from: envelope.plaintext
@@ -207,10 +235,11 @@ struct IncomingMessageDispatcher: Sendable {
             return
         }
 
-        // Fast path 3: ChatMessagePayload — body of the chat thread.
-        // Verifies the envelope's Ed25519 signer matches the claimed
-        // sender's `MemberProfile.sendingPubkey` (insider-spoof
-        // defense, PR 3), then persists via `messageRepository`.
+        // Fast: ChatMessagePayload — body of the chat thread. Verifies
+        // the envelope's Ed25519 signer matches the claimed sender's
+        // `MemberProfile.sendingPubkey` (insider-spoof defense), then
+        // persists via `messageRepository`. Never waits behind the slow
+        // lane — this is the latency-critical path.
         if let chatMessage = try? JSONDecoder().decode(
             ChatMessagePayload.self,
             from: envelope.plaintext
@@ -223,13 +252,22 @@ struct IncomingMessageDispatcher: Sendable {
             return
         }
 
-        // Plaintext didn't match any known payload — fall through.
-        await fallThrough(
-            messageID: messageID,
-            ownerIdentityID: ownerIdentityID,
-            payload: payload,
-            receivedAt: receivedAt
-        )
+        // Plaintext didn't match any known payload — fall through to the
+        // opaque invitations queue (invitation domain → slow lane).
+        await slowLane.enqueue { [self] in
+            await fallThrough(
+                messageID: messageID,
+                ownerIdentityID: ownerIdentityID,
+                payload: payload,
+                receivedAt: receivedAt
+            )
+        }
+    }
+
+    /// Test seam: wait for every slow-lane job enqueued so far (plus any
+    /// they chain, e.g. the chat retry) to finish.
+    func drainSlowLane() async {
+        await slowLane.drain()
     }
 
     /// Queue a decoded push offer for the user's explicit Accept.
@@ -736,7 +774,8 @@ struct IncomingMessageDispatcher: Sendable {
     private func persistChatMessage(
         _ payload: ChatMessagePayload,
         ownerIdentityID: IdentityID,
-        senderEd25519PublicKey: Data?
+        senderEd25519PublicKey: Data?,
+        allowRetry: Bool = true
     ) async {
         // Envelope must have been signed — anonymous chat messages
         // are not part of the v1 trust model.
@@ -751,6 +790,23 @@ struct IncomingMessageDispatcher: Sendable {
         guard let group = groups.first(where: {
             $0.id == groupIDHex && $0.ownerIdentityID == ownerIdentityID
         }) else {
+            // The group may be *about to* exist: with the lane split, a
+            // chat message can race ahead of the invitation that
+            // materializes its group (the invitation rides the slow
+            // lane). Retry once BEHIND the slow lane's current queue —
+            // if a materializing invitation is in flight, the retry runs
+            // after it and the message lands; otherwise it's a genuine
+            // stale delivery and the retry drops it like before.
+            if allowRetry {
+                await slowLane.enqueue { [self] in
+                    await persistChatMessage(
+                        payload,
+                        ownerIdentityID: ownerIdentityID,
+                        senderEd25519PublicKey: senderEd25519PublicKey,
+                        allowRetry: false
+                    )
+                }
+            }
             return
         }
 

--- a/Sources/OnymIOS/Inbox/SerialDispatchLane.swift
+++ b/Sources/OnymIOS/Inbox/SerialDispatchLane.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// FIFO serial execution lane: jobs run strictly in enqueue order, one
+/// at a time, without blocking the enqueuer. Implemented as a chain of
+/// Tasks — each new job awaits the previous tail before running.
+///
+/// This is the dispatcher's *slow lane*: invitation / group-state
+/// payloads (which may hit the relayer for a chain read) are enqueued
+/// here so a backlog of them can never starve live chat delivery — the
+/// fan-out's `for await → dispatch` loop returns immediately for slow
+/// payloads instead of stalling behind a network round-trip per event
+/// (design doc F6: an invitation-spammed device queued live messages
+/// behind minutes of chain reads).
+actor SerialDispatchLane {
+    private var tail: Task<Void, Never>?
+    private var enqueuedCount = 0
+
+    /// Append a job. Returns immediately; the job runs after every job
+    /// enqueued before it has finished.
+    func enqueue(_ job: @escaping @Sendable () async -> Void) {
+        enqueuedCount += 1
+        let previous = tail
+        tail = Task {
+            await previous?.value
+            await job()
+        }
+    }
+
+    /// Suspend until everything enqueued so far — including jobs that
+    /// running jobs enqueue (e.g. the chat group-not-found retry) — has
+    /// finished. Test seam; production code never needs a barrier.
+    func drain() async {
+        while true {
+            let snapshot = enqueuedCount
+            guard let current = tail else { return }
+            await current.value
+            if enqueuedCount == snapshot { return }
+        }
+    }
+}

--- a/Tests/OnymIOSTests/DispatchLanesTests.swift
+++ b/Tests/OnymIOSTests/DispatchLanesTests.swift
@@ -1,0 +1,300 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-5 of the reconnect design: invitation / group-state payloads ride
+/// a serial slow lane so a backlog of chain-verifying handlers can never
+/// starve live chat (F6). Chat messages and receipts stay inline.
+final class DispatchLanesTests: XCTestCase {
+    private let owner = IdentityID()
+
+    // MARK: - SerialDispatchLane
+
+    func test_lane_runsJobsInFIFOOrder() async {
+        let lane = SerialDispatchLane()
+        let box = OrderBox()
+        for i in 0..<20 {
+            await lane.enqueue { await box.append(i) }
+        }
+        await lane.drain()
+        let order = await box.all()
+        XCTAssertEqual(order, Array(0..<20), "slow-lane jobs must run strictly FIFO")
+    }
+
+    func test_lane_enqueueDoesNotBlockOnRunningJob() async {
+        let lane = SerialDispatchLane()
+        let gate = Gate()
+        await lane.enqueue { await gate.wait() }  // job that blocks until opened
+
+        // Enqueueing behind a blocked job must return immediately.
+        let start = Date()
+        await lane.enqueue {}
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.5,
+                          "enqueue must never wait for running jobs")
+        await gate.open()
+        await lane.drain()
+    }
+
+    func test_lane_drainWaitsForChainedJobs() async {
+        let lane = SerialDispatchLane()
+        let box = OrderBox()
+        await lane.enqueue {
+            await box.append(1)
+            // A running job enqueues a successor (the chat retry shape).
+            await lane.enqueue { await box.append(2) }
+        }
+        await lane.drain()
+        let order = await box.all()
+        XCTAssertEqual(order, [1, 2], "drain must also cover jobs enqueued by running jobs")
+    }
+
+    // MARK: - Starvation: slow payloads must not delay chat
+
+    func test_chatMessage_isNotStarvedBySlowGroupStateWork() async throws {
+        // A refresh request whose handler stalls (models a slow chain
+        // read) is dispatched first; the chat message dispatched right
+        // after must land in the repository without waiting for it.
+        let group = TestGroupFactory.group(owner: owner)
+        let groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        _ = await groups.insert(group.chatGroup)
+        let messages = MessageRepository(store: SwiftDataMessageStore.inMemory())
+
+        let refresh = TestGroupFactory.refreshRequest(group: group)
+        let chat = TestGroupFactory.chatMessagePayload(group: group, body: "live message")
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .scripted([
+                Data("refresh-envelope".utf8): try JSONEncoder().encode(refresh),
+                Data("chat-envelope".utf8): try JSONEncoder().encode(chat),
+            ]),
+            senderEd25519PublicKey: group.senderEd25519
+        )
+        let stalledRefresher = StallingRefresher(stallSeconds: 2)
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentitiesForLanes(),
+            groupRepository: groups,
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: ThrowingChainStateForLanes(),
+            messageRepository: messages,
+            groupStateRefresher: stalledRefresher
+        )
+
+        // Slow payload first — it occupies the slow lane for ~2s.
+        await dispatcher.dispatch(
+            messageID: "m-refresh", ownerIdentityID: owner,
+            payload: Data("refresh-envelope".utf8), receivedAt: Date()
+        )
+        // Chat message next — must not wait behind it.
+        let start = Date()
+        await dispatcher.dispatch(
+            messageID: "m-chat", ownerIdentityID: owner,
+            payload: Data("chat-envelope".utf8), receivedAt: Date()
+        )
+        let dispatchLatency = Date().timeIntervalSince(start)
+
+        let persisted = await messages.currentMessages(
+            groupID: group.chatGroup.id, owner: owner
+        )
+        XCTAssertEqual(persisted.map(\.body), ["live message"],
+                       "the chat message must be persisted immediately")
+        XCTAssertLessThan(dispatchLatency, 1.0,
+                          "chat dispatch must not stall behind slow group-state work")
+        await dispatcher.drainSlowLane()
+    }
+
+    // MARK: - Group-not-found retry through the slow lane
+
+    func test_chatArrivingBeforeGroupMaterializes_isRetriedAfterSlowLane() async throws {
+        // The lane-split race: a chat message reaches the fast lane while
+        // the work that materializes its group is still queued in the
+        // slow lane. The retry must run AFTER that work and persist.
+        let group = TestGroupFactory.group(owner: owner)
+        let groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        let messages = MessageRepository(store: SwiftDataMessageStore.inMemory())
+
+        let refresh = TestGroupFactory.refreshRequest(group: group)
+        let chat = TestGroupFactory.chatMessagePayload(group: group, body: "raced ahead")
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .scripted([
+                Data("materialize-envelope".utf8): try JSONEncoder().encode(refresh),
+                Data("chat-envelope".utf8): try JSONEncoder().encode(chat),
+            ]),
+            senderEd25519PublicKey: group.senderEd25519
+        )
+        // A "refresher" that materializes the group when it runs —
+        // standing in for the invitation handler occupying the slow lane.
+        let materializer = MaterializingRefresher(groups: groups, group: group.chatGroup)
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentitiesForLanes(),
+            groupRepository: groups,
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: ThrowingChainStateForLanes(),
+            messageRepository: messages,
+            groupStateRefresher: materializer
+        )
+
+        // Slow lane: the group-materializing work.
+        await dispatcher.dispatch(
+            messageID: "m-mat", ownerIdentityID: owner,
+            payload: Data("materialize-envelope".utf8), receivedAt: Date()
+        )
+        // Fast lane: the chat message — group doesn't exist yet.
+        await dispatcher.dispatch(
+            messageID: "m-chat", ownerIdentityID: owner,
+            payload: Data("chat-envelope".utf8), receivedAt: Date()
+        )
+        await dispatcher.drainSlowLane()
+
+        let persisted = await messages.currentMessages(
+            groupID: group.chatGroup.id, owner: owner
+        )
+        XCTAssertEqual(persisted.map(\.body), ["raced ahead"],
+                       "the retry must land once the slow lane materializes the group")
+    }
+
+    func test_chatForGenuinelyUnknownGroup_isDroppedAfterOneRetry() async throws {
+        let group = TestGroupFactory.group(owner: owner)
+        let messages = MessageRepository(store: SwiftDataMessageStore.inMemory())
+        let chat = TestGroupFactory.chatMessagePayload(group: group, body: "stale")
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(try JSONEncoder().encode(chat)),
+                senderEd25519PublicKey: group.senderEd25519
+            ),
+            identities: StubIdentitiesForLanes(),
+            groupRepository: GroupRepository(store: SwiftDataGroupStore.inMemory()),
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: ThrowingChainStateForLanes(),
+            messageRepository: messages
+        )
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m1", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let persisted = await messages.currentMessages(
+            groupID: group.chatGroup.id, owner: owner
+        )
+        XCTAssertTrue(persisted.isEmpty, "no group after the retry ⇒ drop, no infinite loop")
+    }
+}
+
+// MARK: - Test doubles
+
+/// Shared factory for a group + a matching signed chat payload, so the
+/// insider-spoof guards pass.
+private enum TestGroupFactory {
+    struct Made {
+        let chatGroup: ChatGroup
+        let senderBlsHex: String
+        let senderEd25519: Data
+    }
+
+    static func group(owner: IdentityID) -> Made {
+        let senderBlsHex = String(repeating: "11", count: 48)
+        let senderEd25519 = Data(repeating: 0xED, count: 32)
+        let groupID = Data(repeating: 0x42, count: 32)
+        let group = ChatGroup(
+            id: groupID.map { String(format: "%02x", $0) }.joined(),
+            ownerIdentityID: owner,
+            name: "Lane Group",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [],
+            memberProfiles: [
+                senderBlsHex: MemberProfile(
+                    alias: "Alice",
+                    inboxPublicKey: Data(repeating: 0x10, count: 32),
+                    sendingPubkey: senderEd25519
+                )
+            ],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: true
+        )
+        return Made(chatGroup: group, senderBlsHex: senderBlsHex, senderEd25519: senderEd25519)
+    }
+
+    static func chatMessagePayload(group: Made, body: String) -> ChatMessagePayload {
+        ChatMessagePayload(
+            version: 1,
+            messageID: UUID(),
+            groupID: group.chatGroup.groupIDData,
+            senderBlsPubkeyHex: group.senderBlsHex,
+            sentAtMillis: 1_700_000_000_000,
+            replyToMessageID: nil,
+            variant: .tyranny(body: body)
+        )
+    }
+
+    static func refreshRequest(group: Made) -> GroupStateRefreshRequest {
+        try! GroupStateRefreshRequest(
+            groupID: group.chatGroup.groupIDData,
+            requesterInboxPublicKey: Data(repeating: 0x21, count: 32),
+            requesterBlsPublicKey: Data(repeating: 0x31, count: 48)
+        )
+    }
+}
+
+private struct StubIdentitiesForLanes: IdentitiesProviding {
+    func currentIdentities() async -> [IdentitySummary] { [] }
+}
+
+private struct ThrowingChainStateForLanes: ChainStateReading {
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        throw URLError(.unsupportedURL)
+    }
+}
+
+/// Refresher that stalls — models a slow chain read occupying the lane.
+private struct StallingRefresher: GroupStateRefreshing {
+    let stallSeconds: Double
+    func deferVerification(invitation: GroupInvitationPayload, ownerIdentityID: IdentityID) async {}
+    func handleRefreshRequest(
+        _ request: GroupStateRefreshRequest,
+        ownerIdentityID: IdentityID,
+        requesterEd25519: Data?
+    ) async {
+        try? await Task.sleep(for: .seconds(stallSeconds))
+    }
+}
+
+/// Refresher that materializes a group when it runs — stands in for the
+/// invitation handler in the slow lane.
+private struct MaterializingRefresher: GroupStateRefreshing {
+    let groups: GroupRepository
+    let group: ChatGroup
+    func deferVerification(invitation: GroupInvitationPayload, ownerIdentityID: IdentityID) async {}
+    func handleRefreshRequest(
+        _ request: GroupStateRefreshRequest,
+        ownerIdentityID: IdentityID,
+        requesterEd25519: Data?
+    ) async {
+        _ = await groups.insert(group)
+    }
+}
+
+private actor OrderBox {
+    private var values: [Int] = []
+    func append(_ value: Int) { values.append(value) }
+    func all() -> [Int] { values }
+}
+
+private actor Gate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+    func open() {
+        isOpen = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+}

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -78,7 +78,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -103,7 +103,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-reply",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -128,7 +128,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -151,7 +151,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -173,7 +173,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: Data(repeating: 0xBB, count: 32)  // not Alice
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -195,7 +195,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: nil
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -219,7 +219,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: otherIdentity,
             payload: Data("envelope".utf8),
@@ -285,7 +285,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             plaintext: try JSONEncoder().encode(payload),
             envelopeSigner: secondSenderEd25519
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-multi",
             ownerIdentityID: secondIdentity,
             payload: Data("envelope".utf8),
@@ -313,13 +313,13 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         )
 
         // Same message delivered twice (Nostr re-delivery, etc.).
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: envelopeBytes,
             receivedAt: Date()
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1-retry",
             ownerIdentityID: owner,
             payload: envelopeBytes,
@@ -383,7 +383,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519,
             receiptSender: spy
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -408,7 +408,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             plaintext: try JSONEncoder().encode(receipt),
             envelopeSigner: senderEd25519
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "rcpt-1", ownerIdentityID: owner,
             payload: Data("envelope".utf8), receivedAt: Date()
         )
@@ -429,7 +429,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519,
             readReceiptsEnabled: { false }
         )
-        await off.dispatch(messageID: "r", ownerIdentityID: owner,
+        await off.dispatchAndDrain(messageID: "r", ownerIdentityID: owner,
                            payload: Data("e".utf8), receivedAt: Date())
         var stored = await messages.currentMessages(groupID: groupIDHex, owner: owner)
         XCTAssertEqual(stored.first { $0.id == idOff }?.status, .delivered,
@@ -441,7 +441,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519,
             readReceiptsEnabled: { true }
         )
-        await on.dispatch(messageID: "r2", ownerIdentityID: owner,
+        await on.dispatchAndDrain(messageID: "r2", ownerIdentityID: owner,
                           payload: Data("e".utf8), receivedAt: Date())
         stored = await messages.currentMessages(groupID: groupIDHex, owner: owner)
         XCTAssertEqual(stored.first { $0.id == idOff }?.status, .read)

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -70,7 +70,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -106,7 +106,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-2",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -152,7 +152,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-3",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -196,7 +196,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-trust-ok",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -238,7 +238,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-trust-bad",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -282,7 +282,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-unsigned",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -328,7 +328,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-adminless-member",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -372,7 +372,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-adminless-nonmember",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -415,7 +415,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-adminless-unsigned",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -452,7 +452,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "name-adminless-nonmember",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -490,7 +490,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "avatar-adminless-nonmember",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -526,7 +526,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "name-adminless-member",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -561,7 +561,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "avatar-ok",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -595,7 +595,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "name-ok",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -626,7 +626,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "name-imposter",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -660,7 +660,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "avatar-imposter",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -693,7 +693,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "avatar-clear",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -745,7 +745,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-cap",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -780,7 +780,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-no-commitment",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -825,7 +825,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-onchain-mismatch",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -862,7 +862,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-internal-mismatch",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -917,7 +917,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-announce-mismatch",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -967,7 +967,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-mat",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1016,7 +1016,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-legacy",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1055,7 +1055,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-race",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1082,7 +1082,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-4",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1111,7 +1111,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-5",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1280,7 +1280,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             pendingInvites: spy
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-offer",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1333,7 +1333,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupStateRefresher: refresher
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-stale",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1380,9 +1380,9 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(messageID: "mat-1", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "mat-1", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
-        await dispatcher.dispatch(messageID: "mat-1-replay", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "mat-1-replay", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
 
         let after = await groups.currentGroups()
@@ -1426,7 +1426,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupStateRefresher: refresher
         )
 
-        await dispatcher.dispatch(messageID: "mat-throw", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "mat-throw", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
 
         let after = await groups.currentGroups()
@@ -1477,7 +1477,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupStateRefresher: refresher
         )
 
-        await dispatcher.dispatch(messageID: "mat-behind", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "mat-behind", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
 
         let after = await groups.currentGroups()
@@ -1523,7 +1523,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(messageID: "ann-known", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "ann-known", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
 
         XCTAssertEqual(chainState.calls.count, 0,
@@ -1555,7 +1555,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupStateRefresher: refresher
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-refresh",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),

--- a/Tests/OnymIOSTests/Support/DispatcherTestHelpers.swift
+++ b/Tests/OnymIOSTests/Support/DispatcherTestHelpers.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import OnymIOS
+
+extension IncomingMessageDispatcher {
+    /// Dispatch and then wait for the slow lane to finish — restores the
+    /// pre-lane synchronous-effects contract most dispatcher tests were
+    /// written against: after this returns, invitation / group-state
+    /// side effects (and any chained retries) have been applied.
+    func dispatchAndDrain(
+        messageID: String,
+        ownerIdentityID: IdentityID,
+        payload: Data,
+        receivedAt: Date
+    ) async {
+        await dispatch(
+            messageID: messageID,
+            ownerIdentityID: ownerIdentityID,
+            payload: payload,
+            receivedAt: receivedAt
+        )
+        await drainSlowLane()
+    }
+}


### PR DESCRIPTION
Stacked on #197. Design doc §5.4 (F6): the fan-out's strictly serial `for await → dispatch` meant every replayed invitation — each potentially a relayer chain read — stalled live chat delivery behind it. On the invitation-spammed device this read as "messages don't arrive while the app is open."

## Changes

- **Fast lane (inline)**: chat messages + receipts — pure local work, dispatched without ever waiting on network-bound handlers.
- **Slow lane** (`SerialDispatchLane`: FIFO chained-Task actor, non-blocking enqueue): offers, refresh requests, roster announcements, avatar/name updates, group-materializing invitations, undecryptable fall-throughs. Relative order within the group-state family is preserved.
- **Lane-split race handled**: a chat message can now beat the slow-lane work that materializes its group. On group-not-found it retries exactly once, queued *behind* the slow lane's current queue — a materializing invitation in flight completes first and the message lands; a genuinely stale delivery still drops (no retry loops).
- Existing dispatcher tests migrate to `dispatchAndDrain` (dispatch + slow-lane barrier) to keep their synchronous-effects contract explicit.

## Tests (6 new; full suite green)

Lane FIFO; enqueue never blocks on a running job; `drain` covers chained jobs; **chat persists in <1 s while a 2 s group-state job occupies the slow lane** (the starvation repro); chat-before-group lands via the retry; unknown-group chat drops after one retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)