### PR TITLE
feat(inbox): durable invite disposition ledger + awaiting-approval UI (reconnect PR-6)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -87,6 +87,57 @@
         }
       }
     },
+    "Group": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Группа"
+          }
+        }
+      }
+    },
+    "Invited by %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invited by %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пригласил(а) %@"
+          }
+        }
+      }
+    },
+    "Request sent — awaiting approval": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request sent — awaiting approval"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запрос отправлен — ожидает одобрения"
+          }
+        }
+      }
+    },
     "—": {
       "localizations": {
         "en": {

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -85,6 +85,14 @@ struct IncomingMessageDispatcher: Sendable {
     /// (actor reference), preserving FIFO across the app's single
     /// dispatcher.
     var slowLane = SerialDispatchLane()
+    /// Durable per-(owner, group) invite dispositions. Consulted before
+    /// queueing a `GroupInviteOfferPayload`: a relay retains the offer
+    /// and re-serves it on every re-subscribe, so once the user has
+    /// requested / declined / joined, re-deliveries must be dropped at
+    /// the door — otherwise the offer "blinks" back into the inbox
+    /// forever. Defaulted to a no-op for the same reason as
+    /// `pendingInvites`.
+    var inviteDispositions: any InviteDispositionStoring = NoopInviteDispositionStore()
 
     func dispatch(
         messageID: String,
@@ -280,6 +288,39 @@ struct IncomingMessageDispatcher: Sendable {
         ownerIdentityID: IdentityID,
         receivedAt: Date
     ) async {
+        // Disposition gate: once this (owner, group) invite has been
+        // requested / declined / joined, a re-delivered offer (the relay
+        // re-serves retained events on every re-subscribe, possibly
+        // under a fresh event id) is dropped at the door. Without this
+        // the offer re-enters the pending list and the materialized-
+        // group consumer removes it again — the "blinking invite" loop.
+        switch await inviteDispositions.disposition(
+            owner: ownerIdentityID, groupID: offer.groupID
+        ) {
+        case .requested, .declined, .joined:
+            return
+        case .offered, nil:
+            break
+        }
+
+        // Belt for the joined case the ledger may not have seen (e.g. a
+        // group materialized before this ledger existed): a local group
+        // for this (owner, group) means the invite is spent.
+        let alreadyJoined = await groupRepository.currentGroups().contains {
+            $0.groupIDData == offer.groupID && $0.ownerIdentityID == ownerIdentityID
+        }
+        if alreadyJoined {
+            await inviteDispositions.record(
+                .joined, owner: ownerIdentityID, groupID: offer.groupID,
+                groupName: offer.groupName, inviterAlias: offer.inviterAlias
+            )
+            return
+        }
+
+        await inviteDispositions.record(
+            .offered, owner: ownerIdentityID, groupID: offer.groupID,
+            groupName: offer.groupName, inviterAlias: offer.inviterAlias
+        )
         await pendingInvites.record(PendingInvite(
             id: messageID,
             ownerIdentityID: ownerIdentityID,

--- a/Sources/OnymIOS/Inbox/InviteDispositionLedger.swift
+++ b/Sources/OnymIOS/Inbox/InviteDispositionLedger.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+/// What this device has already decided about a group invite, keyed by
+/// the *logical* invite `(owner identity, group id)` — deliberately not
+/// the Nostr event id, so a re-broadcast offer under a fresh event id
+/// for a group the user already acted on is still recognized.
+enum InviteDisposition: String, Codable, Sendable {
+    /// Offer surfaced, awaiting the user's Accept / Dismiss.
+    case offered
+    /// User accepted: a join request was sent, awaiting the admin's
+    /// approval. Survives relaunch — the UI shows an honest
+    /// "request sent, awaiting approval" row instead of re-offering.
+    case requested
+    /// User dismissed the offer. Sticky: re-delivered offers stay dropped.
+    case declined
+    /// The group materialized locally — the invite is spent.
+    case joined
+
+    /// Monotonic rank: a disposition only ever moves forward, so a
+    /// re-delivered stale offer can never resurrect a handled invite.
+    /// `requested` and `declined` share a rank (mutually exclusive user
+    /// choices); `joined` is terminal.
+    var rank: Int {
+        switch self {
+        case .offered: return 0
+        case .requested, .declined: return 1
+        case .joined: return 2
+        }
+    }
+}
+
+/// One ledger row, carrying enough display metadata to render the
+/// "awaiting approval" surface without the original offer event.
+struct InviteDispositionEntry: Codable, Equatable, Sendable, Identifiable {
+    let ownerIdentityID: String
+    let groupIDHex: String
+    var state: InviteDisposition
+    var groupName: String?
+    var inviterAlias: String?
+    var updatedAt: Date
+
+    var id: String { "\(ownerIdentityID)|\(groupIDHex)" }
+}
+
+/// Narrow write/read seam the dispatcher depends on (mirrors
+/// `PendingInvitesRecording`).
+protocol InviteDispositionStoring: Sendable {
+    func disposition(owner: IdentityID, groupID: Data) async -> InviteDisposition?
+    func record(
+        _ state: InviteDisposition,
+        owner: IdentityID,
+        groupID: Data,
+        groupName: String?,
+        inviterAlias: String?
+    ) async
+}
+
+/// Persisted, per-identity-filtered ledger of invite dispositions.
+/// The durable "I already handled this" record the relay can't provide:
+/// a Nostr relay is a store, not a queue — it may re-serve an invite
+/// offer forever, so the client must own the disposition state. Mirrors
+/// the snapshot/filter shape of `PendingInvitesStore`.
+actor InviteDispositionLedger: InviteDispositionStoring {
+    private let defaults: UserDefaults
+    private var entries: [String: InviteDispositionEntry]
+    private var currentIdentity: IdentityID?
+    private var continuations: [UUID: AsyncStream<[InviteDispositionEntry]>.Continuation] = [:]
+    private static let key = "app.onym.ios.inbox.inviteDispositions"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.key),
+           let decoded = try? JSONDecoder().decode([InviteDispositionEntry].self, from: data) {
+            self.entries = Dictionary(uniqueKeysWithValues: decoded.map { ($0.id, $0) })
+        } else {
+            self.entries = [:]
+        }
+    }
+
+    // MARK: - InviteDispositionStoring
+
+    func disposition(owner: IdentityID, groupID: Data) -> InviteDisposition? {
+        entries[Self.entryID(owner: owner, groupID: groupID)]?.state
+    }
+
+    /// Record a disposition. Monotonic: writes that don't advance the
+    /// rank are ignored (a re-delivered offer can't downgrade
+    /// `requested` back to `offered`). Metadata is refreshed when
+    /// provided so later states keep the best-known display strings.
+    func record(
+        _ state: InviteDisposition,
+        owner: IdentityID,
+        groupID: Data,
+        groupName: String?,
+        inviterAlias: String?
+    ) {
+        let id = Self.entryID(owner: owner, groupID: groupID)
+        if var existing = entries[id] {
+            guard state.rank > existing.state.rank else {
+                // Same-or-lower rank: keep the state, still absorb
+                // fresher metadata (e.g. a renamed group on a re-offer).
+                var changed = false
+                if let groupName, existing.groupName != groupName {
+                    existing.groupName = groupName; changed = true
+                }
+                if let inviterAlias, existing.inviterAlias != inviterAlias {
+                    existing.inviterAlias = inviterAlias; changed = true
+                }
+                if changed { entries[id] = existing; persistAndPublish() }
+                return
+            }
+            existing.state = state
+            existing.updatedAt = Date()
+            if let groupName { existing.groupName = groupName }
+            if let inviterAlias { existing.inviterAlias = inviterAlias }
+            entries[id] = existing
+        } else {
+            entries[id] = InviteDispositionEntry(
+                ownerIdentityID: owner.rawValue.uuidString,
+                groupIDHex: Self.hex(groupID),
+                state: state,
+                groupName: groupName,
+                inviterAlias: inviterAlias,
+                updatedAt: Date()
+            )
+        }
+        persistAndPublish()
+    }
+
+    // MARK: - Identity scoping (mirrors PendingInvitesStore)
+
+    func setCurrentIdentity(_ id: IdentityID?) {
+        currentIdentity = id
+        publish()
+    }
+
+    /// Cascade for the identity-removal flow.
+    func removeForOwner(_ id: IdentityID) {
+        let owner = id.rawValue.uuidString
+        let before = entries.count
+        entries = entries.filter { $0.value.ownerIdentityID != owner }
+        if entries.count != before { persistAndPublish() }
+    }
+
+    /// Hot stream of the current identity's entries, newest first.
+    nonisolated var snapshots: AsyncStream<[InviteDispositionEntry]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    static func entryID(owner: IdentityID, groupID: Data) -> String {
+        "\(owner.rawValue.uuidString)|\(hex(groupID))"
+    }
+
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<[InviteDispositionEntry]>.Continuation
+    ) {
+        continuations[id] = continuation
+        continuation.yield(filtered())
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func filtered() -> [InviteDispositionEntry] {
+        guard let currentIdentity else { return [] }
+        let owner = currentIdentity.rawValue.uuidString
+        return entries.values
+            .filter { $0.ownerIdentityID == owner }
+            .sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    private func persistAndPublish() {
+        if let data = try? JSONEncoder().encode(Array(entries.values)) {
+            defaults.set(data, forKey: Self.key)
+        }
+        publish()
+    }
+
+    private func publish() {
+        let snapshot = filtered()
+        for continuation in continuations.values { continuation.yield(snapshot) }
+    }
+}
+
+/// Default for the dispatcher's seam: records nothing, reports nothing —
+/// existing tests construct dispatchers without threading a ledger.
+struct NoopInviteDispositionStore: InviteDispositionStoring {
+    func disposition(owner: IdentityID, groupID: Data) async -> InviteDisposition? { nil }
+    func record(
+        _ state: InviteDisposition,
+        owner: IdentityID,
+        groupID: Data,
+        groupName: String?,
+        inviterAlias: String?
+    ) async {}
+}

--- a/Sources/OnymIOS/Inbox/PendingInvitesFlow.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesFlow.swift
@@ -18,6 +18,12 @@ import Observation
 final class PendingInvitesFlow {
     /// Pending invites for the current identity, newest first.
     var pending: [PendingInvite] = []
+    /// Accepted-but-unapproved invites for the current identity — the
+    /// durable "Request sent · awaiting approval" rows. Sourced from the
+    /// disposition ledger, so they survive relaunch instead of vanishing
+    /// (and can't be accepted twice); each clears when its group
+    /// materializes (→ `.joined`).
+    var awaitingApproval: [InviteDispositionEntry] = []
     /// Groups that were accepted but couldn't be verified at an exact
     /// epoch yet — awaiting (or unable to get) the current state from
     /// the admin. Surfaced so the user knows a join is in flight or
@@ -38,6 +44,11 @@ final class PendingInvitesFlow {
     private let store: PendingInvitesStore
     private let verificationStore: PendingVerificationStore
     private let groupRepository: GroupRepository
+    /// Durable (owner, group) dispositions — written on accept / dismiss
+    /// / group-materialize; read by the dispatcher to drop re-delivered
+    /// offers and by this flow for the awaiting-approval rows. nil keeps
+    /// the pre-ledger behavior (existing tests).
+    private let dispositions: InviteDispositionLedger?
     /// Mirrors `JoinFlow`'s injected `submitRequest` — seals + sends a
     /// `JoinRequestPayload` for the given capability. Returns the
     /// sender outcome so the flow can surface errors.
@@ -52,6 +63,7 @@ final class PendingInvitesFlow {
     private var streamingTask: Task<Void, Never>?
     private var verifyingTask: Task<Void, Never>?
     private var groupWatchTask: Task<Void, Never>?
+    private var ledgerTask: Task<Void, Never>?
 
     init(
         store: PendingInvitesStore,
@@ -59,7 +71,8 @@ final class PendingInvitesFlow {
         groupRepository: GroupRepository,
         submitJoin: @escaping @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome,
         displayLabel: @escaping @MainActor () -> String,
-        retryVerification: @escaping @Sendable (String) async -> Void
+        retryVerification: @escaping @Sendable (String) async -> Void,
+        dispositions: InviteDispositionLedger? = nil
     ) {
         self.store = store
         self.verificationStore = verificationStore
@@ -67,6 +80,7 @@ final class PendingInvitesFlow {
         self.submitJoin = submitJoin
         self.displayLabel = displayLabel
         self.retryVerification = retryVerification
+        self.dispositions = dispositions
     }
 
     func isInFlight(_ id: String) -> Bool { inFlightIDs.contains(id) }
@@ -95,13 +109,38 @@ final class PendingInvitesFlow {
                 self.verifying = snapshot
             }
         }
+        // Awaiting-approval rows: mirror the ledger's requested entries.
+        if let dispositions {
+            let dstream = dispositions.snapshots
+            ledgerTask = Task { @MainActor [weak self] in
+                for await entries in dstream {
+                    guard let self else { break }
+                    self.awaitingApproval = entries.filter { $0.state == .requested }
+                }
+            }
+        }
         let groups = groupRepository.snapshots
         let store = self.store
+        let dispositions = self.dispositions
         groupWatchTask = Task {
             for await groups in groups {
                 await store.consumeForMaterializedGroups(
                     Set(groups.map(\.groupIDData))
                 )
+                // A materialized group spends its invite: record .joined
+                // so re-delivered offers stay dropped and the awaiting-
+                // approval row clears.
+                if let dispositions {
+                    for group in groups {
+                        await dispositions.record(
+                            .joined,
+                            owner: group.ownerIdentityID,
+                            groupID: group.groupIDData,
+                            groupName: group.name,
+                            inviterAlias: nil
+                        )
+                    }
+                }
             }
         }
     }
@@ -113,6 +152,8 @@ final class PendingInvitesFlow {
         verifyingTask = nil
         groupWatchTask?.cancel()
         groupWatchTask = nil
+        ledgerTask?.cancel()
+        ledgerTask = nil
     }
 
     /// Retry a verification that got stuck because the admin was
@@ -142,6 +183,7 @@ final class PendingInvitesFlow {
         lastError = nil
         let label = displayLabel()
         let submitJoin = self.submitJoin
+        let dispositions = self.dispositions
         Task { @MainActor [weak self] in
             let outcome = await submitJoin(capability, label)
             guard let self else { return }
@@ -149,6 +191,23 @@ final class PendingInvitesFlow {
             switch outcome {
             case .sent:
                 self.requestedIDs.insert(id)
+                // Durable: the accept survives relaunch as an
+                // "awaiting approval" row, and the dispatcher drops
+                // re-delivered offers for this (owner, group) from now
+                // on — the invite can never blink back or be accepted
+                // twice.
+                if let dispositions {
+                    await dispositions.record(
+                        .requested,
+                        owner: invite.ownerIdentityID,
+                        groupID: invite.groupID,
+                        groupName: invite.groupName,
+                        inviterAlias: invite.inviterAlias
+                    )
+                    // The offer card is superseded by the durable
+                    // awaiting-approval row.
+                    await self.store.consume(id: id)
+                }
             case .noIdentityLoaded:
                 self.lastError = "Sign in first."
             case .transportFailed(let reason):
@@ -158,10 +217,25 @@ final class PendingInvitesFlow {
     }
 
     /// Drop an invite the user doesn't want. Local-only — no NACK to
-    /// the admin (their outstanding intro key just goes unused).
+    /// the admin (their outstanding intro key just goes unused). The
+    /// declined disposition is durable, so the relay re-serving the
+    /// offer can't resurrect it.
     func dismiss(_ id: String) {
         let store = self.store
-        Task { await store.consume(id: id) }
+        let dispositions = self.dispositions
+        let invite = pending.first(where: { $0.id == id })
+        Task {
+            if let dispositions, let invite {
+                await dispositions.record(
+                    .declined,
+                    owner: invite.ownerIdentityID,
+                    groupID: invite.groupID,
+                    groupName: invite.groupName,
+                    inviterAlias: invite.inviterAlias
+                )
+            }
+            await store.consume(id: id)
+        }
     }
 
     func dismissError() { lastError = nil }

--- a/Sources/OnymIOS/Inbox/PendingInvitesView.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesView.swift
@@ -15,7 +15,8 @@ struct PendingInvitesView: View {
                 if let error = flow.lastError {
                     errorBanner(error)
                 }
-                if flow.pending.isEmpty && flow.verifying.isEmpty {
+                if flow.pending.isEmpty && flow.verifying.isEmpty
+                    && flow.awaitingApproval.isEmpty {
                     emptyState
                 } else {
                     inviteList
@@ -86,6 +87,9 @@ struct PendingInvitesView: View {
                 ForEach(flow.verifying) { entry in
                     verifyingCard(entry)
                 }
+                ForEach(flow.awaitingApproval) { entry in
+                    awaitingApprovalCard(entry)
+                }
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
@@ -130,6 +134,36 @@ struct PendingInvitesView: View {
         .background(OnymTokens.surface)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .accessibilityIdentifier("pending_invites.verifying.\(entry.groupIDHex)")
+    }
+
+    /// An accepted invite whose join request is with the admin. Durable
+    /// (ledger-backed): survives relaunch, can't be re-accepted, clears
+    /// on its own the moment the admin approves and the group
+    /// materializes.
+    private func awaitingApprovalCard(_ entry: InviteDispositionEntry) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(entry.groupName?.isEmpty == false ? entry.groupName! : String(localized: "Group"))
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            HStack(spacing: 8) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text3)
+                Text("Request sent \u{2014} awaiting approval")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            if let inviter = entry.inviterAlias, !inviter.isEmpty {
+                Text("Invited by \(inviter)")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text3)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(OnymTokens.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .accessibilityIdentifier("pending_invites.awaiting.\(entry.groupIDHex)")
     }
 
     private func inviteCard(_ invite: PendingInvite) -> some View {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -18,6 +18,7 @@ struct OnymIOSApp: App {
     private let incomingInvitations: IncomingInvitationsRepository
     private let pendingInvitesStore: PendingInvitesStore
     private let pendingVerificationStore: PendingVerificationStore
+    private let inviteDispositionLedger: InviteDispositionLedger
     private let groupStateVerifier: GroupStateVerifier
     private let introKeyStore: any IntroKeyStore
     private let introRequestStore: any IntroRequestStore
@@ -309,6 +310,13 @@ struct OnymIOSApp: App {
         // identical to the deeplink join path.
         let pendingInvitesStore = PendingInvitesStore()
         self.pendingInvitesStore = pendingInvitesStore
+        // Durable (owner, group) invite dispositions — the "I already
+        // handled this" record a relay can't provide (it re-serves
+        // retained offers on every re-subscribe). Written by the invites
+        // flow (accept/dismiss/joined), read by the dispatcher to drop
+        // re-delivered offers at the door.
+        let inviteDispositionLedger = InviteDispositionLedger()
+        self.inviteDispositionLedger = inviteDispositionLedger
         // Verify-at-current (Option 2): stale snapshots defer here; the
         // verifier asks the admin for current state and surfaces a
         // "couldn't verify" state if the admin is offline.
@@ -350,7 +358,8 @@ struct OnymIOSApp: App {
             },
             retryVerification: { [groupStateVerifier] groupIDHex in
                 await groupStateVerifier.retry(groupIDHex: groupIDHex)
-            }
+            },
+            dispositions: inviteDispositionLedger
         )
 
         self.dependencies = AppDependencies(
@@ -537,6 +546,7 @@ struct OnymIOSApp: App {
                         await incomingInvitations.setCurrentIdentity(initialID)
                         await pendingInvitesStore.setCurrentIdentity(initialID)
                         await pendingVerificationStore.setCurrentIdentity(initialID)
+                        await inviteDispositionLedger.setCurrentIdentity(initialID)
                     }
                 }
                 .task {
@@ -547,6 +557,7 @@ struct OnymIOSApp: App {
                         await incomingInvitations.setCurrentIdentity(id)
                         await pendingInvitesStore.setCurrentIdentity(id)
                         await pendingVerificationStore.setCurrentIdentity(id)
+                        await inviteDispositionLedger.setCurrentIdentity(id)
                     }
                 }
                 .task {
@@ -560,6 +571,7 @@ struct OnymIOSApp: App {
                         await incomingInvitations.removeForOwner(removed)
                         await pendingInvitesStore.removeForOwner(removed)
                         await pendingVerificationStore.removeForOwner(removed)
+                        await inviteDispositionLedger.removeForOwner(removed)
                         // Cascade-wipe the removed identity's intro
                         // privkeys so an attacker who restores a
                         // backup post-removal can't decrypt
@@ -613,7 +625,8 @@ struct OnymIOSApp: App {
                             identity: identityRepository,
                             inboxTransport: inboxTransport
                         ),
-                        readReceiptsEnabled: { ReadReceiptsPreference.isEnabled }
+                        readReceiptsEnabled: { ReadReceiptsPreference.isEnabled },
+                        inviteDispositions: inviteDispositionLedger
                     )
                     let fanout = InboxFanoutInteractor(
                         inboxTransport: inboxTransport,

--- a/Tests/OnymIOSTests/InviteDispositionLedgerTests.swift
+++ b/Tests/OnymIOSTests/InviteDispositionLedgerTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-6 of the reconnect design: a Nostr relay may re-serve an invite
+/// offer forever, so the client owns a durable record of what the user
+/// already decided. Covers the ledger's monotonic state machine +
+/// persistence, and the dispatcher's drop-at-the-door enforcement.
+final class InviteDispositionLedgerTests: XCTestCase {
+    private let owner = IdentityID()
+    private let groupID = Data(repeating: 0x42, count: 32)
+
+    private func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+    }
+
+    // MARK: - Ledger semantics
+
+    func test_record_isMonotonic_reofferCannotDowngradeRequested() async {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: "G", inviterAlias: "A")
+        await ledger.record(.offered, owner: owner, groupID: groupID, groupName: "G", inviterAlias: "A")
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .requested, "a re-delivered offer must not downgrade requested")
+    }
+
+    func test_joined_isTerminal() async {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.joined, owner: owner, groupID: groupID, groupName: "G", inviterAlias: nil)
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: "G", inviterAlias: nil)
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .joined)
+    }
+
+    func test_declinedThenJoined_upgrades() async {
+        // The admin's approval can land after a local dismiss — joined
+        // always wins.
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.declined, owner: owner, groupID: groupID, groupName: "G", inviterAlias: nil)
+        await ledger.record(.joined, owner: owner, groupID: groupID, groupName: "G", inviterAlias: nil)
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .joined)
+    }
+
+    func test_persistsAcrossInstances() async {
+        let defaults = isolatedDefaults()
+        let ledger = InviteDispositionLedger(defaults: defaults)
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: "Maple", inviterAlias: "Alice")
+
+        let reloaded = InviteDispositionLedger(defaults: defaults)
+        let state = await reloaded.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .requested, "an accepted invite must survive relaunch")
+    }
+
+    func test_removeForOwner_cascades() async {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        let otherOwner = IdentityID()
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: nil, inviterAlias: nil)
+        await ledger.record(.requested, owner: otherOwner, groupID: groupID, groupName: nil, inviterAlias: nil)
+
+        await ledger.removeForOwner(owner)
+        let removed = await ledger.disposition(owner: owner, groupID: groupID)
+        let kept = await ledger.disposition(owner: otherOwner, groupID: groupID)
+        XCTAssertNil(removed)
+        XCTAssertEqual(kept, .requested, "other identities' rows must be untouched")
+    }
+
+    func test_snapshots_filterByCurrentIdentity() async throws {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        let otherOwner = IdentityID()
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: "Mine", inviterAlias: nil)
+        await ledger.record(.requested, owner: otherOwner, groupID: groupID, groupName: "Theirs", inviterAlias: nil)
+        await ledger.setCurrentIdentity(owner)
+
+        var iterator = ledger.snapshots.makeAsyncIterator()
+        let snapshot = await iterator.next()
+        XCTAssertEqual(snapshot?.map(\.groupName), ["Mine"])
+    }
+
+    // MARK: - Dispatcher enforcement
+
+    private func makeDispatcher(
+        ledger: InviteDispositionLedger,
+        spy: LedgerSpyPendingInvites,
+        groups: GroupRepository = GroupRepository(store: SwiftDataGroupStore.inMemory()),
+        offer: GroupInviteOfferPayload
+    ) throws -> IncomingMessageDispatcher {
+        IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(try JSONEncoder().encode(offer))
+            ),
+            identities: LedgerStubIdentities(),
+            groupRepository: groups,
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: LedgerThrowingChainState(),
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            pendingInvites: spy,
+            inviteDispositions: ledger
+        )
+    }
+
+    private func makeOffer() throws -> GroupInviteOfferPayload {
+        try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x44, count: 32),
+            groupID: groupID,
+            groupName: "Maple Garden",
+            inviterAlias: "Alice"
+        )
+    }
+
+    func test_freshOffer_isQueuedAndRecordedOffered() async throws {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        let spy = LedgerSpyPendingInvites()
+        let dispatcher = try makeDispatcher(ledger: ledger, spy: spy, offer: makeOffer())
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m1", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let recorded = await spy.all()
+        XCTAssertEqual(recorded.count, 1)
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .offered)
+    }
+
+    func test_redeliveredOffer_afterRequested_isDropped() async throws {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: nil, inviterAlias: nil)
+        let spy = LedgerSpyPendingInvites()
+        let dispatcher = try makeDispatcher(ledger: ledger, spy: spy, offer: makeOffer())
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m-redelivered", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let recorded = await spy.all()
+        XCTAssertTrue(recorded.isEmpty,
+                      "an offer for an already-requested invite must be dropped at the door")
+    }
+
+    func test_redeliveredOffer_afterDeclined_isDropped() async throws {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.declined, owner: owner, groupID: groupID, groupName: nil, inviterAlias: nil)
+        let spy = LedgerSpyPendingInvites()
+        let dispatcher = try makeDispatcher(ledger: ledger, spy: spy, offer: makeOffer())
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m-redelivered", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let recorded = await spy.all()
+        XCTAssertTrue(recorded.isEmpty, "declined is sticky across re-deliveries")
+    }
+
+    func test_offerForLocallyExistingGroup_isDroppedAndMarkedJoined() async throws {
+        // The blink loop's root case: the group already materialized;
+        // the re-served offer must be dropped and the ledger updated so
+        // even the group's later deletion can't resurrect the offer.
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        let groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        _ = await groups.insert(ChatGroup(
+            id: groupID.map { String(format: "%02x", $0) }.joined(),
+            ownerIdentityID: owner,
+            name: "Maple Garden",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [], memberProfiles: [:],
+            epoch: 0, salt: Data(repeating: 0x66, count: 32),
+            commitment: nil, tier: .small, groupType: .tyranny,
+            adminPubkeyHex: nil, adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: true
+        ))
+        let spy = LedgerSpyPendingInvites()
+        let dispatcher = try makeDispatcher(ledger: ledger, spy: spy, groups: groups, offer: makeOffer())
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m1", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let recorded = await spy.all()
+        XCTAssertTrue(recorded.isEmpty, "an offer for a joined group must never re-enter the inbox")
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .joined)
+    }
+}
+
+// MARK: - Test doubles
+
+private actor LedgerSpyPendingInvites: PendingInvitesRecording {
+    private var recorded: [PendingInvite] = []
+    func record(_ invite: PendingInvite) async { recorded.append(invite) }
+    func all() -> [PendingInvite] { recorded }
+}
+
+private struct LedgerStubIdentities: IdentitiesProviding {
+    func currentIdentities() async -> [IdentitySummary] { [] }
+}
+
+private struct LedgerThrowingChainState: ChainStateReading {
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        throw URLError(.unsupportedURL)
+    }
+}


### PR DESCRIPTION
Stacked on #198. Design doc §5.5: the relay may re-serve an invite offer forever, so the client owns a durable record of the user's decision. Kills the "blinking invite" permanently and gives an accepted-but-unapproved invite an honest, persistent UI state.

## Changes

- **`InviteDispositionLedger`** — persisted, keyed by the *logical* invite `(owner, groupID)` (not event id, so re-broadcasts under fresh ids are still recognized). Monotonic: `offered → requested | declined → joined`; re-deliveries can never downgrade; `joined` terminal; `declined → joined` allowed (admin approval racing a local dismiss). Per-identity snapshots + identity-removal cascade, mirroring the other stores.
- **Dispatcher gate in `recordOffer`**: requested/declined/joined ⇒ dropped at the door; group already materialized locally ⇒ dropped + recorded `joined` (the blink loop's root case); fresh offers recorded `offered`.
- **`PendingInvitesFlow` + `PendingInvitesView`**: Accept (`.sent`) records `requested` — the offer card is replaced by a durable **"Request sent — awaiting approval"** row that survives relaunch and can't be double-accepted; Dismiss records `declined` (sticky); a materializing group records `joined` and the row clears itself. Localized en/ru.
- App wiring: shared ledger, identity switch + removal cascades.

## UX contract after this PR

| user action | re-delivered offer | UI |
|---|---|---|
| none | shown once (deduped) | offer card |
| accepted | dropped | "Request sent — awaiting approval" until the group appears |
| dismissed | dropped forever | nothing |
| joined | dropped forever | the chat itself |

## Tests (10 new; full suite green)

Ledger monotonicity/persistence/cascade/filtering; dispatcher drop-at-door for requested + declined; locally-existing group ⇒ drop + `joined`; fresh offer queued + recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)