### PR TITLE
fix(chat): render-acknowledged read receipts + badge clearing (reconnect PR-7)

### DIFF
--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -126,7 +126,8 @@ struct ChatThreadView: View {
             voiceLoader: voiceLoader,
             pendingMedia: pendingMedia.map { (id: $0.id, thumbnail: $0.thumbnail) },
             onSendMedia: { handleSendPendingMedia() },
-            onRemovePendingMedia: { id in pendingMedia.removeAll { $0.id == id } }
+            onRemovePendingMedia: { id in pendingMedia.removeAll { $0.id == id } },
+            onMessagesSeen: handleMessagesSeen
         )
         // One combined picker for photos + videos. Each pick is classified
         // in `onChange` by its content type.
@@ -255,25 +256,37 @@ struct ChatThreadView: View {
             else { return }
             for await snapshot in messageRepository.snapshots(groupID: groupID, owner: owner) {
                 messages = snapshot
-                // Read receipts: the thread is on-screen (this task is
-                // tied to its lifetime), so any incoming message here is
-                // "read". Gated by the symmetric setting, batched per
-                // sender, and de-duped via `ackedReadIDs`.
-                await sendReadReceipts(for: snapshot)
-                // Clear the chat-list unread badge: mark the group read up
-                // to the newest message the user is now looking at. No-op
-                // in the repo when it isn't newer than the stored marker.
-                if let newest = snapshot.map(\.sentAt).max() {
-                    await chatsFlow.markRead(groupID: groupID, upTo: newest)
-                }
+                // NB: read receipts + unread-badge clearing deliberately
+                // do NOT happen here. A snapshot reaching this task only
+                // proves the data arrived — not that a person saw it
+                // (app may be backgrounded, message below the fold).
+                // Both are driven by `handleMessagesSeen`, fed by the
+                // controller when bubbles are actually rendered on an
+                // active screen.
             }
         }
     }
 
-    /// Emit `.read` receipts for incoming messages the user is now
-    /// looking at. No-op when the setting is off. Groups unacked
-    /// incoming IDs by sender and ships one receipt per sender to that
-    /// sender's inbox key (resolved from the group's member profiles).
+    /// Render-acknowledged "seen" handler: the controller reports
+    /// incoming messages whose bubbles were actually painted on an
+    /// active screen. Ship `.read` receipts for them and clear the
+    /// chat-list unread badge up to the newest seen message — both now
+    /// mean what they say.
+    private func handleMessagesSeen(_ seen: [ChatMessage]) {
+        let chatsFlow = chatsFlow
+        let groupID = groupID
+        Task {
+            await sendReadReceipts(for: seen)
+            if let newest = seen.map(\.sentAt).max() {
+                await chatsFlow.markRead(groupID: groupID, upTo: newest)
+            }
+        }
+    }
+
+    /// Emit `.read` receipts for incoming messages the user has now
+    /// seen. No-op when the setting is off. Groups unacked incoming IDs
+    /// by sender and ships one receipt per sender to that sender's
+    /// inbox key (resolved from the group's member profiles).
     private func sendReadReceipts(for snapshot: [ChatMessage]) async {
         guard ReadReceiptsPreference.isEnabled else { return }
         guard let group = chatsFlow.groups.first(where: { $0.id == groupID }) else { return }
@@ -400,6 +413,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let pendingMedia: [(id: UUID, thumbnail: UIImage)]
     let onSendMedia: () -> Void
     let onRemovePendingMedia: (UUID) -> Void
+    let onMessagesSeen: ([ChatMessage]) -> Void
 
     func makeUIViewController(context: Context) -> ChatThreadViewController {
         let vc = ChatThreadViewController()
@@ -447,6 +461,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         vc.voiceLoader = voiceLoader
         vc.onSendMedia = onSendMedia
         vc.onRemovePendingMedia = onRemovePendingMedia
+        vc.onMessagesSeen = onMessagesSeen
         vc.update(memberProfiles: memberProfiles)
         vc.update(invitationMessage: invitationMessage)
         vc.update(messages: messages)

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -59,6 +59,16 @@ final class ChatThreadViewController: UIViewController {
     var onSendMedia: (() -> Void)?
     /// Fired when the ✕ on a staged item is tapped (host drops it).
     var onRemovePendingMedia: ((UUID) -> Void)?
+    /// Fired with incoming messages whose bubbles have actually been
+    /// rendered on screen while the app is active — the host sends
+    /// `.read` receipts and clears the unread badge from here. This is
+    /// deliberately NOT the data stream: receipting from snapshot
+    /// processing marked messages "read" that were never painted (app
+    /// backgrounded, thread below the fold), telling senders a lie.
+    /// Each message is reported at most once per controller lifetime.
+    var onMessagesSeen: (([ChatMessage]) -> Void)?
+    /// Incoming message ids already reported through `onMessagesSeen`.
+    private var reportedSeenIDs: Set<UUID> = []
 
     private let tableView = UITableView()
     /// Floating "N new messages" affordance, shown above the input panel
@@ -185,10 +195,12 @@ final class ChatThreadViewController: UIViewController {
         super.viewDidAppear(animated)
         installFullWidthPopGesture()
         flushPendingScrollToBottom()
+        reportVisibleIncomingMessages()
     }
 
     @objc private func applicationDidBecomeActive() {
         flushPendingScrollToBottom()
+        reportVisibleIncomingMessages()
     }
 
     /// Perform a deferred scroll-to-bottom (see `pendingScrollToBottom`).
@@ -199,6 +211,28 @@ final class ChatThreadViewController: UIViewController {
         pendingScrollToBottom = false
         tableView.layoutIfNeeded()
         scrollToBottom(animated: false)
+    }
+
+    /// Report incoming messages whose cells are on screen right now —
+    /// but only when they're genuinely visible to a person: view in a
+    /// window AND the app active. Called from every point where
+    /// visibility can change (apply completion, scroll, foreground,
+    /// appear); cheap and idempotent, deduped via `reportedSeenIDs`.
+    func reportVisibleIncomingMessages() {
+        guard canScrollNow() else { return }
+        guard let visiblePaths = tableView.indexPathsForVisibleRows,
+              !visiblePaths.isEmpty else { return }
+        var newlySeen: [ChatMessage] = []
+        for path in visiblePaths {
+            guard path.row < orderedMessages.count else { continue }
+            let message = orderedMessages[path.row]
+            guard message.direction == .incoming,
+                  !reportedSeenIDs.contains(message.id) else { continue }
+            reportedSeenIDs.insert(message.id)
+            newlySeen.append(message)
+        }
+        guard !newlySeen.isEmpty else { return }
+        onMessagesSeen?(newlySeen)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -345,6 +379,9 @@ final class ChatThreadViewController: UIViewController {
                     self.pendingScrollToBottom = true
                 }
             }
+            // Whatever the scroll decision, the set of on-screen bubbles
+            // may have changed — report what a person can now see.
+            self.reportVisibleIncomingMessages()
         }
 
         // The user is scrolled up in history and new incoming messages
@@ -862,13 +899,15 @@ final class ChatThreadViewController: UIViewController {
 }
 
 extension ChatThreadViewController: UITableViewDelegate {
-    /// Clears the new-messages pill once the user reaches the bottom —
-    /// whether by scrolling there themselves, tapping the pill, or an
-    /// auto-scroll pulling them down. Cheap: bails immediately while the
-    /// pill is hidden.
+    /// Scrolling changes what's visible: clear the new-messages pill
+    /// once the user reaches the bottom (by hand, pill tap, or
+    /// auto-scroll), and report newly on-screen incoming bubbles for
+    /// read-receipting.
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard !newMessagesPill.isHidden else { return }
-        if isNearBottom { clearNewMessagesPill() }
+        if !newMessagesPill.isHidden, isNearBottom {
+            clearNewMessagesPill()
+        }
+        reportVisibleIncomingMessages()
     }
 }
 

--- a/Tests/OnymIOSTests/RenderAckedSeenTests.swift
+++ b/Tests/OnymIOSTests/RenderAckedSeenTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-7 of the reconnect design (F7): `.read` receipts and unread-badge
+/// clearing must be driven by *actual on-screen rendering*, not by data
+/// processing. `ChatThreadViewController.onMessagesSeen` fires only for
+/// incoming bubbles that are visible while the view is in a window and
+/// the app active — and each message at most once.
+@MainActor
+final class RenderAckedSeenTests: XCTestCase {
+    private func mountedController() -> ChatThreadViewController {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 800))
+        let vc = ChatThreadViewController()
+        window.rootViewController = vc
+        window.isHidden = false
+        return vc
+    }
+
+    private func incoming(_ body: String, at seconds: TimeInterval) -> ChatMessage {
+        ChatMessage(
+            id: UUID(), groupID: String(repeating: "aa", count: 32),
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: String(repeating: "11", count: 48), body: body,
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
+            direction: .incoming, status: .received,
+            replyToMessageID: nil, groupType: .tyranny
+        )
+    }
+
+    private func outgoing(_ body: String, at seconds: TimeInterval) -> ChatMessage {
+        ChatMessage(
+            id: UUID(), groupID: String(repeating: "aa", count: 32),
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: String(repeating: "22", count: 48), body: body,
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
+            direction: .outgoing, status: .sent,
+            replyToMessageID: nil, groupType: .tyranny
+        )
+    }
+
+    private func pump(_ seconds: TimeInterval = 0.3) {
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: seconds))
+    }
+
+    func test_visibleIncomingMessages_areReportedSeen_once() {
+        let vc = mountedController()
+        var seen: [ChatMessage] = []
+        vc.onMessagesSeen = { seen.append(contentsOf: $0) }
+
+        let msgs = [incoming("one", at: 0), incoming("two", at: 1)]
+        vc.update(messages: msgs)
+        vc.view.layoutIfNeeded()
+        pump()
+
+        XCTAssertEqual(Set(seen.map(\.id)), Set(msgs.map(\.id)),
+                       "visible incoming bubbles must be reported seen")
+
+        // Re-report triggers (scroll, appear) must not duplicate.
+        seen.removeAll()
+        vc.reportVisibleIncomingMessages()
+        XCTAssertTrue(seen.isEmpty, "each message is reported at most once")
+    }
+
+    func test_outgoingMessages_areNeverReportedSeen() {
+        let vc = mountedController()
+        var seen: [ChatMessage] = []
+        vc.onMessagesSeen = { seen.append(contentsOf: $0) }
+
+        vc.update(messages: [outgoing("mine", at: 0), incoming("theirs", at: 1)])
+        vc.view.layoutIfNeeded()
+        pump()
+
+        XCTAssertEqual(seen.map(\.body), ["theirs"],
+                       "own outgoing messages are not read-receipt subjects")
+    }
+
+    func test_nothingReported_whileNotVisible_reportedOnBecomeActive() {
+        let vc = mountedController()
+        var seen: [ChatMessage] = []
+        vc.onMessagesSeen = { seen.append(contentsOf: $0) }
+        vc.canScrollNow = { false }  // "backgrounded": not user-visible
+
+        vc.update(messages: [incoming("bg message", at: 0)])
+        vc.view.layoutIfNeeded()
+        pump()
+        XCTAssertTrue(seen.isEmpty,
+                      "a message rendered while backgrounded must NOT be marked read (F7)")
+
+        // Foreground: now a person can actually see it.
+        vc.canScrollNow = { true }
+        NotificationCenter.default.post(
+            name: UIApplication.didBecomeActiveNotification, object: nil
+        )
+        pump()
+        XCTAssertEqual(seen.map(\.body), ["bg message"],
+                       "the message must be reported once the app is active and it's on screen")
+    }
+
+    func test_messageBelowTheFold_reportedOnlyWhenScrolledIntoView() {
+        let vc = mountedController()
+        var seen: [ChatMessage] = []
+        vc.onMessagesSeen = { seen.append(contentsOf: $0) }
+
+        // Long thread: cold open lands at the bottom, so the OLDEST
+        // messages are off screen.
+        let msgs = (0..<60).map { incoming("m\($0)", at: TimeInterval($0)) }
+        vc.update(messages: msgs)
+        vc.view.layoutIfNeeded()
+        pump()
+
+        let table = vc.view.subviews.compactMap { $0 as? UITableView }.first
+            ?? vc.view.subviews.flatMap(\.subviews).compactMap { $0 as? UITableView }.first!
+        XCTAssertFalse(seen.contains { $0.body == "m0" },
+                       "a bubble below/above the fold is not seen")
+        let initiallySeen = Set(seen.map(\.id))
+
+        // Scroll to the top — the oldest bubbles become visible.
+        table.setContentOffset(.zero, animated: false)
+        table.layoutIfNeeded()
+        vc.reportVisibleIncomingMessages()
+        pump(0.1)
+
+        XCTAssertTrue(seen.contains { $0.body == "m0" },
+                      "scrolling a bubble on screen must report it seen")
+        XCTAssertGreaterThan(seen.count, initiallySeen.count)
+    }
+}


### PR DESCRIPTION
Stacked on #199. Design doc §5.6 (F7): `.read` receipts were emitted from the **snapshot stream** — any data reaching the thread's task marked messages read, even with the app backgrounded or the bubble below the fold. Senders were told "read" for messages nobody saw (this false signal also derailed the field diagnosis during the reconnect saga).

## Changes

- **`ChatThreadViewController.onMessagesSeen`** — fires with incoming messages whose bubbles are *actually rendered on an active screen* (view in window + app active, the same gate as the deferred scroll). Hooked at every visibility-changing point: diffable apply completion, scroll, `viewDidAppear`, `didBecomeActive`. Deduped per controller lifetime.
- **`ChatThreadView`** — the snapshot loop now only feeds the table; `.read` receipts (unchanged batching/dedup/setting-gate) and `chatsFlow.markRead` both hang off `onMessagesSeen`.

Semantics now: **"delivered" = persisted; "read" = a person saw the bubble.**

## Tests (4 new; full suite green)

Visible incoming bubbles reported exactly once; outgoing never reported; rendered-while-backgrounded NOT reported until `didBecomeActive` (the F7 repro); below-the-fold bubbles reported only when scrolled into view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)