### PR TITLE
refactor(transport): lifecycle owned by repository layer; view observes one flag (reconnect PR-8)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -121,6 +121,40 @@
         }
       }
     },
+    "Not connected to a relay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not connected to a relay"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет соединения с релеем"
+          }
+        }
+      }
+    },
+    "Offline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offline"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не в сети"
+          }
+        }
+      }
+    },
     "Request sent — awaiting approval": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -20,6 +20,9 @@ struct AppDependencies {
     /// Settings → Identities screen observe the same state, so a
     /// factory closure here would split them.
     let identitiesFlow: IdentitiesFlow
+    /// Presentation mirror of the transport connection state — the view
+    /// layer's ONLY contact with the transport (offline indicator).
+    let connectionStatusFlow: ConnectionStatusFlow
     /// Single shared instance — the toolbar badge on Chats and the
     /// modal `ApproveRequestsView` observe the same `pending` list,
     /// and the underlying collector should run for the app's

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -8,6 +8,10 @@ import SwiftUI
 struct ChatsView: View {
     let flow: ChatsFlow
     let identitiesFlow: IdentitiesFlow
+    /// The presentation layer's entire view of the transport: a single
+    /// connected/disconnected flag. Reconnecting is the repository
+    /// layer's job; this view only renders the offline indicator.
+    let connectionStatusFlow: ConnectionStatusFlow
     let approveRequestsFlow: ApproveRequestsFlow
     let pendingInvitesFlow: PendingInvitesFlow
     let messageRepository: MessageRepository
@@ -50,6 +54,24 @@ struct ChatsView: View {
             ToolbarItem(placement: .topBarLeading) {
                 IdentityPickerMenu(flow: identitiesFlow)
             }
+            // Relay connection indicator — rendered ONLY while no relay
+            // is confirmed live. Purely observational: the repository
+            // layer keeps reconnecting on its own; this just tells the
+            // user why nothing new is arriving right now.
+            if !connectionStatusFlow.isConnected {
+                ToolbarItem(placement: .topBarLeading) {
+                    HStack(spacing: 5) {
+                        Circle()
+                            .fill(OnymTokens.red)
+                            .frame(width: 7, height: 7)
+                        Text("Offline")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(OnymTokens.text2)
+                    }
+                    .accessibilityIdentifier("chats.connection_offline")
+                    .accessibilityLabel(Text("Not connected to a relay"))
+                }
+            }
             // Pending join requests — always rendered so the surface
             // is discoverable even before the first request lands;
             // the badge only appears when `pending.count > 0`.
@@ -90,6 +112,7 @@ struct ChatsView: View {
         }
         .task { flow.start() }
         .task { await identitiesFlow.start() }
+        .task { connectionStatusFlow.start() }
         .task { await approveRequestsFlow.start() }
         .task { await pendingInvitesFlow.start() }
         .fullScreenCover(isPresented: $showCreateGroup) {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -13,6 +13,7 @@ struct OnymIOSApp: App {
     private let videoLoader: ChatVideoLoader
     private let voiceLoader: ChatVoiceLoader
     private let inboxTransport: any InboxTransport
+    private let transportLifecycle: TransportLifecycleRepository
     private let nostrRelaysRepository: NostrRelaysRepository
     private let blossomServersRepository: BlossomServersRepository
     private let incomingInvitations: IncomingInvitationsRepository
@@ -148,6 +149,21 @@ struct OnymIOSApp: App {
         #endif
         self.inboxTransport = inboxTransport
         self.contractTransportFactory = contractTransportFactory
+
+        // Transport lifecycle lives in the repository layer, not the
+        // view tree: it owns connect + every reconnect trigger, and the
+        // presentation layer's ONLY contact with the transport is the
+        // connection-state flow below. The trigger streams (UIKit
+        // foreground notification, NWPathMonitor) are built here at the
+        // shell and injected, keeping the repository itself UIKit-free
+        // and unit-testable with hand-driven streams.
+        let transportLifecycle = TransportLifecycleRepository(
+            transport: inboxTransport,
+            foregroundSignals: Self.foregroundSignalStream(),
+            connectivitySignals: NetworkPathMonitor.connectivityRegainedStream()
+        )
+        self.transportLifecycle = transportLifecycle
+        let connectionStatusFlow = ConnectionStatusFlow(repository: transportLifecycle)
 
         // DEBUG deeplink injection for UI tests (see `initialDeeplinkURL`).
         #if DEBUG
@@ -429,6 +445,7 @@ struct OnymIOSApp: App {
                 ChatsFlow(repository: groupRepository, messages: messageRepository)
             },
             identitiesFlow: identitiesFlow,
+            connectionStatusFlow: connectionStatusFlow,
             approveRequestsFlow: approveRequestsFlow,
             pendingInvitesFlow: pendingInvitesFlow,
             messageRepository: messageRepository,
@@ -492,6 +509,25 @@ struct OnymIOSApp: App {
         )
     }
     #endif
+
+    /// UIKit foreground notification adapted to a plain `AsyncStream<Void>`
+    /// so the transport-lifecycle repository stays UIKit-free. Fires only
+    /// on a real background→foreground transition. (Deliberately NOT
+    /// `scenePhase` on the App — that re-evaluates the entire view tree
+    /// per phase change.)
+    private static func foregroundSignalStream() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            let task = Task {
+                let notifications = NotificationCenter.default.notifications(
+                    named: UIApplication.willEnterForegroundNotification
+                )
+                for await _ in notifications {
+                    continuation.yield(())
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -580,16 +616,16 @@ struct OnymIOSApp: App {
                     }
                 }
                 .task {
-                    // Connect the Nostr inbox transport to every
-                    // configured relay BEFORE the fanout interactor
-                    // attempts to subscribe. Without this, both legs
-                    // of the inbox are silently dead: subscribe()
-                    // no-ops on an empty connections dict and send()
-                    // throws TransportError.notConnected.
+                    // Start the transport-lifecycle repository BEFORE the
+                    // fanout interactor subscribes. The repository owns
+                    // the initial connect AND every reconnect trigger
+                    // (foreground / connectivity) — no view code drives
+                    // the transport; the presentation layer only observes
+                    // `ConnectionStatusFlow`.
                     let endpoints = await nostrRelaysRepository
                         .currentEndpoints()
                         .map { TransportEndpoint(url: $0.url) }
-                    await inboxTransport.connect(to: endpoints)
+                    await transportLifecycle.start(endpoints: endpoints)
 
                     // PR-4: subscribe to every identity's inbox
                     // concurrently. Without this, messages addressed
@@ -668,36 +704,6 @@ struct OnymIOSApp: App {
                         currentTask = Task { await pump.run(entries: entries) }
                     }
                     currentTask?.cancel()
-                }
-                .task {
-                    // Refresh relay sockets when connectivity is regained.
-                    // NetworkPathMonitor is edge-triggered (only a genuine
-                    // unsatisfied→satisfied transition) and debounced, so
-                    // interface churn can't storm reconnects; the rebuild
-                    // itself is cheap (since-bounded replay + dedup).
-                    for await _ in NetworkPathMonitor.connectivityRegainedStream() {
-                        await inboxTransport.reconnect()
-                    }
-                }
-                .task {
-                    // A backgrounded app has its relay WebSocket torn down
-                    // (or half-opened) by the OS; nothing in URLSession
-                    // re-establishes it on resume, and only a fresh REQ
-                    // backfills what was missed while suspended. Rebuild
-                    // unconditionally on return to foreground.
-                    //
-                    // `willEnterForeground` (not `scenePhase` on the App):
-                    // observing scenePhase re-evaluates the entire view
-                    // tree on every phase change; the notification fires
-                    // only on a real background→foreground transition and
-                    // drives the side effect without touching the render
-                    // path.
-                    let foregrounded = NotificationCenter.default.notifications(
-                        named: UIApplication.willEnterForegroundNotification
-                    )
-                    for await _ in foregrounded {
-                        await inboxTransport.reconnect()
-                    }
                 }
                 .onOpenURL { url in
                     // Custom URL scheme (`onym://join?c=…`) and

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -46,6 +46,7 @@ struct RootView: View {
                     ChatsView(
                         flow: chatsFlow,
                         identitiesFlow: dependencies.identitiesFlow,
+                        connectionStatusFlow: dependencies.connectionStatusFlow,
                         approveRequestsFlow: dependencies.approveRequestsFlow,
                         pendingInvitesFlow: dependencies.pendingInvitesFlow,
                         messageRepository: dependencies.messageRepository,

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -41,6 +41,18 @@ final class NostrInboxTransport: InboxTransport {
         await state.reconnect()
     }
 
+    nonisolated func connectionStateStream() -> AsyncStream<Bool> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { [state] in
+                await state.subscribeConnectionState(id: id, continuation: continuation)
+            }
+            continuation.onTermination = { @Sendable [state] _ in
+                Task { await state.unsubscribeConnectionState(id: id) }
+            }
+        }
+    }
+
     @discardableResult
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         let signer = try signerProvider.makeEphemeralSigner()
@@ -129,6 +141,11 @@ final class NostrInboxTransport: InboxTransport {
         /// Per-inbox high-water marks (persisted). Read at every REQ send
         /// via the connection's `sinceProvider`, raised as events arrive.
         private let highWaterMarks: any InboxHighWaterMarkStoring
+        /// Per-relay confirmed-live flags + the aggregate's subscribers.
+        /// Aggregate rule: connected iff ANY relay is confirmed live —
+        /// one reachable relay delivers messages.
+        private var liveByRelay: [URL: Bool] = [:]
+        private var stateContinuations: [UUID: AsyncStream<Bool>.Continuation] = [:]
 
         init(highWaterMarks: any InboxHighWaterMarkStoring) {
             self.highWaterMarks = highWaterMarks
@@ -139,9 +156,38 @@ final class NostrInboxTransport: InboxTransport {
                 if connections[endpoint.url] == nil {
                     let conn = NostrRelayConnection(url: endpoint.url)
                     connections[endpoint.url] = conn
+                    let url = endpoint.url
+                    await conn.setOnLiveStateChange { [weak self] live in
+                        Task { await self?.relayLiveStateChanged(url: url, live: live) }
+                    }
                     await conn.connect()
                 }
             }
+        }
+
+        // MARK: - Connection state (presentation-facing signal)
+
+        private var aggregateConnected: Bool {
+            liveByRelay.values.contains(true)
+        }
+
+        private func relayLiveStateChanged(url: URL, live: Bool) {
+            let before = aggregateConnected
+            liveByRelay[url] = live
+            let after = aggregateConnected
+            guard before != after else { return }
+            for continuation in stateContinuations.values {
+                continuation.yield(after)
+            }
+        }
+
+        func subscribeConnectionState(id: UUID, continuation: AsyncStream<Bool>.Continuation) {
+            stateContinuations[id] = continuation
+            continuation.yield(aggregateConnected)
+        }
+
+        func unsubscribeConnectionState(id: UUID) {
+            stateContinuations.removeValue(forKey: id)
         }
 
         func disconnect() async {
@@ -153,6 +199,13 @@ final class NostrInboxTransport: InboxTransport {
                 await conn.disconnect()
             }
             connections.removeAll()
+            let wasConnected = aggregateConnected
+            liveByRelay.removeAll()
+            if wasConnected {
+                for continuation in stateContinuations.values {
+                    continuation.yield(false)
+                }
+            }
         }
 
         /// Rebuild every connection in place. The per-connection

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -85,6 +85,26 @@ actor NostrRelayConnection {
         onOKCallback = callback
     }
 
+    /// Confirmed-live state, with transitions surfaced to the owner.
+    /// `true` only when a frame has actually arrived on the current
+    /// socket (the same "confirmed live" semantics the backoff uses);
+    /// `false` from every teardown path (failure funnel, disconnect,
+    /// forced rebuild). The transport aggregates these across relays
+    /// into the connection state the app's repository layer publishes.
+    private var confirmedLive = false
+    private var onLiveStateChange: ((Bool) -> Void)?
+
+    func setOnLiveStateChange(_ callback: @escaping (Bool) -> Void) {
+        onLiveStateChange = callback
+        callback(confirmedLive)
+    }
+
+    private func setConfirmedLive(_ live: Bool) {
+        guard live != confirmedLive else { return }
+        confirmedLive = live
+        onLiveStateChange?(live)
+    }
+
     // Timings — injectable so the (otherwise minute-scale) liveness and
     // backoff paths are exercisable in tests. Defaults are production
     // values.
@@ -175,6 +195,7 @@ actor NostrRelayConnection {
         webSocketTask = nil
         isConnected = false
         reconnectAttempts = 0
+        setConfirmedLive(false)
     }
 
     /// Tear down the current socket and rebuild it immediately,
@@ -191,6 +212,7 @@ actor NostrRelayConnection {
         webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
         webSocketTask = nil
         isConnected = false
+        setConfirmedLive(false)
         connect()
     }
 
@@ -355,6 +377,7 @@ actor NostrRelayConnection {
                 // (CLOSEDs), and treating those as health is what made
                 // the CLOSED path hot-loop.
                 reconnectAttempts = 0
+                setConfirmedLive(true)
                 let text: String
                 switch message {
                 case .string(let s): text = s
@@ -386,6 +409,7 @@ actor NostrRelayConnection {
         livenessTask?.cancel()
         livenessTask = nil
         isConnected = false
+        setConfirmedLive(false)
         webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
         webSocketTask = nil
         reconnectAttempts += 1

--- a/Sources/OnymIOS/Transport/Transport.swift
+++ b/Sources/OnymIOS/Transport/Transport.swift
@@ -121,4 +121,22 @@ protocol InboxTransport: Sendable {
     func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox>
 
     func unsubscribe(inbox: TransportInboxID) async
+
+    /// Hot stream of the transport's connection state: `true` while at
+    /// least one endpoint is *confirmed live* (a frame has actually
+    /// arrived on its current socket), `false` otherwise. Emits the
+    /// current value on subscribe, then transitions. This is the ONLY
+    /// signal the presentation layer consumes from the transport — the
+    /// repository layer owns reconnecting; views only render the state.
+    nonisolated func connectionStateStream() -> AsyncStream<Bool>
+}
+
+extension InboxTransport {
+    /// Default for transports without a meaningful connection lifecycle
+    /// (in-process loopback, test fakes): permanently connected.
+    nonisolated func connectionStateStream() -> AsyncStream<Bool> {
+        AsyncStream { continuation in
+            continuation.yield(true)
+        }
+    }
 }

--- a/Sources/OnymIOS/Transport/TransportLifecycleRepository.swift
+++ b/Sources/OnymIOS/Transport/TransportLifecycleRepository.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Observation
+
+/// Owns the inbox transport's lifecycle end to end: the initial connect,
+/// the unconditional rebuild on app-lifecycle triggers (return to
+/// foreground, regained connectivity), and the connection-state signal.
+///
+/// Layering contract: this repository is the ONLY component that drives
+/// the transport, and `connectionSnapshots` is the ONLY thing the
+/// presentation layer consumes from it. No view code observes lifecycle
+/// notifications or calls `reconnect()` — the trigger streams are
+/// injected (the app shell passes `UIApplication`-notification and
+/// `NWPathMonitor` streams; tests pass hand-driven ones), so the
+/// repository itself is UIKit-free and the transport's lifetime is
+/// independent of any view's.
+///
+/// Note there is no "reconnect failed" event by design: the transport
+/// retries internally with escalating backoff and never gives up, so the
+/// honest presentation signal is the continuous connected/disconnected
+/// state — a failure shows as `false` persisting, and recovery flips it
+/// back without any extra machinery.
+actor TransportLifecycleRepository {
+    private let transport: any InboxTransport
+    private let foregroundSignals: AsyncStream<Void>
+    private let connectivitySignals: AsyncStream<Void>
+    private var triggerTasks: [Task<Void, Never>] = []
+    private var mirrorTask: Task<Void, Never>?
+    private var started = false
+
+    /// Latest known state, replayed to new subscribers. Optimistic
+    /// `true` before the first transport report so the UI doesn't flash
+    /// an offline indicator during a normal launch.
+    private var isConnected = true
+    private var continuations: [UUID: AsyncStream<Bool>.Continuation] = [:]
+
+    init(
+        transport: any InboxTransport,
+        foregroundSignals: AsyncStream<Void>,
+        connectivitySignals: AsyncStream<Void>
+    ) {
+        self.transport = transport
+        self.foregroundSignals = foregroundSignals
+        self.connectivitySignals = connectivitySignals
+    }
+
+    /// Connect to `endpoints` and begin owning the lifecycle. Returns
+    /// once the initial connect has been issued (callers that must
+    /// subscribe only after connect — the fan-out — can await this).
+    /// Idempotent.
+    func start(endpoints: [TransportEndpoint]) async {
+        guard !started else { return }
+        started = true
+
+        await transport.connect(to: endpoints)
+
+        // Mirror the transport's confirmed-live aggregate into the
+        // presentation-facing snapshots.
+        let stateStream = transport.connectionStateStream()
+        mirrorTask = Task { [weak self] in
+            for await connected in stateStream {
+                await self?.updateConnected(connected)
+            }
+        }
+
+        // Both triggers rebuild unconditionally: a fresh REQ is the only
+        // mechanism that backfills events missed while suspended, and
+        // the rebuild is cheap (since-bounded replay + pre-decrypt
+        // dedup). The streams are already edge-triggered/debounced at
+        // their sources.
+        let transport = self.transport
+        triggerTasks.append(Task { [foregroundSignals] in
+            for await _ in foregroundSignals {
+                // A yield buffered before stop()'s cancel can still
+                // resume the loop — never forward it.
+                guard !Task.isCancelled else { break }
+                await transport.reconnect()
+            }
+        })
+        triggerTasks.append(Task { [connectivitySignals] in
+            for await _ in connectivitySignals {
+                guard !Task.isCancelled else { break }
+                await transport.reconnect()
+            }
+        })
+    }
+
+    func stop() async {
+        for task in triggerTasks { task.cancel() }
+        triggerTasks.removeAll()
+        mirrorTask?.cancel()
+        mirrorTask = nil
+        started = false
+    }
+
+    /// Hot stream of the connection state for the presentation layer.
+    /// Replays the current value on subscribe.
+    nonisolated var connectionSnapshots: AsyncStream<Bool> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func updateConnected(_ connected: Bool) {
+        guard connected != isConnected else { return }
+        isConnected = connected
+        for continuation in continuations.values {
+            continuation.yield(connected)
+        }
+    }
+
+    private func subscribe(id: UUID, continuation: AsyncStream<Bool>.Continuation) {
+        continuations[id] = continuation
+        continuation.yield(isConnected)
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+}
+
+/// `@Observable` mirror of the repository's connection state for SwiftUI
+/// — the presentation layer's entire view of the transport. Mirrors the
+/// flow shape used across the app (`PendingInvitesFlow` etc.).
+@MainActor
+@Observable
+final class ConnectionStatusFlow {
+    /// `false` while no relay is confirmed live — drives the offline
+    /// indicator on the chats screen.
+    private(set) var isConnected = true
+
+    private let repository: TransportLifecycleRepository
+    private var streamTask: Task<Void, Never>?
+
+    init(repository: TransportLifecycleRepository) {
+        self.repository = repository
+    }
+
+    /// Idempotent.
+    func start() {
+        guard streamTask == nil else { return }
+        let snapshots = repository.connectionSnapshots
+        streamTask = Task { @MainActor [weak self] in
+            for await connected in snapshots {
+                self?.isConnected = connected
+            }
+        }
+    }
+
+    func stop() {
+        streamTask?.cancel()
+        streamTask = nil
+    }
+}

--- a/Tests/OnymIOSTests/Support/FakeInboxTransport.swift
+++ b/Tests/OnymIOSTests/Support/FakeInboxTransport.swift
@@ -42,9 +42,13 @@ actor FakeInboxTransport: InboxTransport {
         continuations.removeAll()
     }
 
+    private(set) var reconnectCallCount = 0
+
     func reconnect() async {
-        // No-op: the fake drives live subscriptions directly via `emit`,
-        // so there is nothing to rebuild.
+        // Nothing to rebuild (live subscriptions are driven via `emit`);
+        // counted so the lifecycle-repository tests can assert the
+        // trigger streams actually forward.
+        reconnectCallCount += 1
     }
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {

--- a/Tests/OnymIOSTests/TransportLifecycleRepositoryTests.swift
+++ b/Tests/OnymIOSTests/TransportLifecycleRepositoryTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-8 of the reconnect design: the transport's lifecycle belongs to
+/// the repository layer, not the view tree. The repository owns connect
+/// + every reconnect trigger (injected streams — no UIKit here), and the
+/// presentation layer's ONLY contact with the transport is the
+/// connection-state snapshot stream.
+final class TransportLifecycleRepositoryTests: XCTestCase {
+    private func makeSignals() -> (stream: AsyncStream<Void>, fire: () -> Void, finish: () -> Void) {
+        var continuation: AsyncStream<Void>.Continuation!
+        let stream = AsyncStream<Void> { continuation = $0 }
+        let cont = continuation!
+        return (stream, { cont.yield(()) }, { cont.finish() })
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 3,
+        _ condition: () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTFail("condition not met within \(timeout)s")
+    }
+
+    func test_start_connectsToEndpoints() async throws {
+        let transport = FakeInboxTransport()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: makeSignals().stream,
+            connectivitySignals: makeSignals().stream
+        )
+        let endpoint = TransportEndpoint(url: URL(string: "wss://relay.example")!)
+        await repo.start(endpoints: [endpoint])
+
+        let connected = await transport.connectedEndpoints
+        XCTAssertEqual(connected, [endpoint], "start() must issue the initial connect")
+        await repo.stop()
+    }
+
+    func test_foregroundSignal_triggersReconnect() async throws {
+        let transport = FakeInboxTransport()
+        let foreground = makeSignals()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: foreground.stream,
+            connectivitySignals: makeSignals().stream
+        )
+        await repo.start(endpoints: [])
+
+        foreground.fire()
+        try await waitUntil { await transport.reconnectCallCount >= 1 }
+
+        foreground.fire()
+        try await waitUntil { await transport.reconnectCallCount >= 2 }
+        await repo.stop()
+    }
+
+    func test_connectivitySignal_triggersReconnect() async throws {
+        let transport = FakeInboxTransport()
+        let connectivity = makeSignals()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: makeSignals().stream,
+            connectivitySignals: connectivity.stream
+        )
+        await repo.start(endpoints: [])
+
+        connectivity.fire()
+        try await waitUntil { await transport.reconnectCallCount >= 1 }
+        await repo.stop()
+    }
+
+    func test_connectionSnapshots_replayCurrentAndMirrorTransport() async throws {
+        // FakeInboxTransport uses the protocol's default state stream
+        // (permanently connected) — the repository must replay `true`
+        // on subscribe.
+        let transport = FakeInboxTransport()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: makeSignals().stream,
+            connectivitySignals: makeSignals().stream
+        )
+        await repo.start(endpoints: [])
+
+        var iterator = repo.connectionSnapshots.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first, true)
+        await repo.stop()
+    }
+
+    func test_stop_endsTriggerForwarding() async throws {
+        let transport = FakeInboxTransport()
+        let foreground = makeSignals()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: foreground.stream,
+            connectivitySignals: makeSignals().stream
+        )
+        await repo.start(endpoints: [])
+        await repo.stop()
+
+        foreground.fire()
+        try await Task.sleep(for: .milliseconds(300))
+        let count = await transport.reconnectCallCount
+        XCTAssertEqual(count, 0, "a stopped repository must not forward triggers")
+    }
+
+    /// End-to-end state signal against the loopback relay: connected
+    /// flips true when a frame confirms the socket live, and false when
+    /// the relay dies while backoff retries run.
+    func test_connectionState_reflectsRelayLiveness() async throws {
+        let relay = try LocalWebSocketRelay()
+        let transport = NostrInboxTransport(
+            signerProvider: OnymNostrSignerProvider(),
+            highWaterMarks: UserDefaultsInboxTransportTestStore()
+        )
+        let url = URL(string: "ws://127.0.0.1:\(try await relay.port())")!
+
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: makeSignals().stream,
+            connectivitySignals: makeSignals().stream
+        )
+        await repo.start(endpoints: [TransportEndpoint(url: url)])
+
+        let states = StateBox()
+        let snapshots = repo.connectionSnapshots
+        let pump = Task { for await state in snapshots { await states.append(state) } }
+        defer { pump.cancel() }
+
+        // A subscription draws an EOSE — the confirming frame.
+        let stream = transport.subscribe(inbox: TransportInboxID(rawValue: "feed0001"))
+        let subPump = Task { for await _ in stream {} }
+        defer { subPump.cancel() }
+
+        try await waitUntil { await states.all().contains(true) }
+
+        // Kill the relay entirely: the receive error tears the socket
+        // down and reconnect attempts fail — state must flip false.
+        relay.stop()
+        try await waitUntil { await states.all().last == false }
+        await repo.stop()
+        await transport.disconnect()
+    }
+}
+
+private actor StateBox {
+    private var values: [Bool] = []
+    func append(_ value: Bool) { values.append(value) }
+    func all() -> [Bool] { values }
+}
+
+/// Isolated HWM store so the state test never touches shared defaults.
+private final class UserDefaultsInboxTransportTestStore: InboxHighWaterMarkStoring, @unchecked Sendable {
+    private let inner = UserDefaultsInboxHighWaterMarkStore(
+        defaults: UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+    )
+    func highWaterMark(inbox: String) -> Int64? { inner.highWaterMark(inbox: inbox) }
+    func raise(inbox: String, to createdAt: Int64) { inner.raise(inbox: inbox, to: createdAt) }
+}


### PR DESCRIPTION
Stacked on #200. Addresses a layering flaw in PR-4 (#197): the reconnect trigger loops lived in `.task` modifiers on the App's view body — presentation-layer code orchestrating transport concerns.

## Architecture after this PR

```
UIApplication.willEnterForeground ─┐            (adapted to plain AsyncStream<Void>
NWPathMonitor (edge+debounced) ────┤             at the app shell; repository is UIKit-free)
                                   ▼
                     TransportLifecycleRepository (actor)
                       • owns connect(endpoints:) + every reconnect
                       • mirrors transport connection state
                                   │  connectionSnapshots: AsyncStream<Bool>
                                   ▼
                        ConnectionStatusFlow (@Observable)
                                   │  isConnected — THE seam
                                   ▼
                     ChatsView: red "Offline" toolbar indicator
```

- **The view layer's only contact with the transport is one observable flag.** No view code observes lifecycle notifications or calls `reconnect()`; the transport's lifetime is independent of any view by construction.
- **Connection state end to end**: `NostrRelayConnection` reports confirmed-live transitions (true only when a frame actually arrives; false from every teardown) → transport aggregates across relays (connected iff any live) → protocol `connectionStateStream()` with an "always connected" default so loopback/fakes are untouched.
- **Offline indicator**: red dot + "Offline" in the Chats toolbar whenever no relay is confirmed live (en/ru, `chats.connection_offline`). One deliberate design note: there is **no "reconnect failed" one-shot event** — the transport retries with escalating backoff forever, so the honest signal is continuous state: failure shows as `false` persisting, recovery flips it back with no extra machinery.

## Tests (6 new; full suite green)

Repository: `start()` connects; foreground and connectivity signals each forward to `reconnect()`; snapshots replay current state on subscribe; `stop()` ends forwarding (race-safe against buffered yields). End-to-end vs the loopback relay: state flips **true** on the confirming frame and **false** when the relay dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)