### PR TITLE
fix(transport): reconnect — state machine, bounded replay, lifecycle repository (1/4)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -34,6 +34,40 @@
         }
       }
     },
+    "Not connected to a relay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not connected to a relay"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет соединения с релеем"
+          }
+        }
+      }
+    },
+    "Offline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offline"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не в сети"
+          }
+        }
+      }
+    },
     "—": {
       "localizations": {
         "en": {

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -20,6 +20,9 @@ struct AppDependencies {
     /// Settings → Identities screen observe the same state, so a
     /// factory closure here would split them.
     let identitiesFlow: IdentitiesFlow
+    /// Presentation mirror of the transport connection state — the view
+    /// layer's ONLY contact with the transport (offline indicator).
+    let connectionStatusFlow: ConnectionStatusFlow
     /// Single shared instance — the toolbar badge on Chats and the
     /// modal `ApproveRequestsView` observe the same `pending` list,
     /// and the underlying collector should run for the app's

--- a/Sources/OnymIOS/Chain/UITestFakes.swift
+++ b/Sources/OnymIOS/Chain/UITestFakes.swift
@@ -130,6 +130,8 @@ final class UITestLoopbackInboxTransport: InboxTransport, @unchecked Sendable {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    // In-process loopback: subscriber continuations survive; nothing to rebuild.
+    func reconnect() async {}
 
     @discardableResult
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -8,6 +8,10 @@ import SwiftUI
 struct ChatsView: View {
     let flow: ChatsFlow
     let identitiesFlow: IdentitiesFlow
+    /// The presentation layer's entire view of the transport: a single
+    /// connected/disconnected flag. Reconnecting is the repository
+    /// layer's job; this view only renders the offline indicator.
+    let connectionStatusFlow: ConnectionStatusFlow
     let approveRequestsFlow: ApproveRequestsFlow
     let pendingInvitesFlow: PendingInvitesFlow
     let messageRepository: MessageRepository
@@ -50,6 +54,24 @@ struct ChatsView: View {
             ToolbarItem(placement: .topBarLeading) {
                 IdentityPickerMenu(flow: identitiesFlow)
             }
+            // Relay connection indicator — rendered ONLY while no relay
+            // is confirmed live. Purely observational: the repository
+            // layer keeps reconnecting on its own; this just tells the
+            // user why nothing new is arriving right now.
+            if !connectionStatusFlow.isConnected {
+                ToolbarItem(placement: .topBarLeading) {
+                    HStack(spacing: 5) {
+                        Circle()
+                            .fill(OnymTokens.red)
+                            .frame(width: 7, height: 7)
+                        Text("Offline")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(OnymTokens.text2)
+                    }
+                    .accessibilityIdentifier("chats.connection_offline")
+                    .accessibilityLabel(Text("Not connected to a relay"))
+                }
+            }
             // Pending join requests — always rendered so the surface
             // is discoverable even before the first request lands;
             // the badge only appears when `pending.count > 0`.
@@ -90,6 +112,7 @@ struct ChatsView: View {
         }
         .task { flow.start() }
         .task { await identitiesFlow.start() }
+        .task { connectionStatusFlow.start() }
         .task { await approveRequestsFlow.start() }
         .task { await pendingInvitesFlow.start() }
         .fullScreenCover(isPresented: $showCreateGroup) {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 @main
 struct OnymIOSApp: App {
@@ -12,6 +13,7 @@ struct OnymIOSApp: App {
     private let videoLoader: ChatVideoLoader
     private let voiceLoader: ChatVoiceLoader
     private let inboxTransport: any InboxTransport
+    private let transportLifecycle: TransportLifecycleRepository
     private let nostrRelaysRepository: NostrRelaysRepository
     private let blossomServersRepository: BlossomServersRepository
     private let incomingInvitations: IncomingInvitationsRepository
@@ -146,6 +148,21 @@ struct OnymIOSApp: App {
         #endif
         self.inboxTransport = inboxTransport
         self.contractTransportFactory = contractTransportFactory
+
+        // Transport lifecycle lives in the repository layer, not the
+        // view tree: it owns connect + every reconnect trigger, and the
+        // presentation layer's ONLY contact with the transport is the
+        // connection-state flow below. The trigger streams (UIKit
+        // foreground notification, NWPathMonitor) are built here at the
+        // shell and injected, keeping the repository itself UIKit-free
+        // and unit-testable with hand-driven streams.
+        let transportLifecycle = TransportLifecycleRepository(
+            transport: inboxTransport,
+            foregroundSignals: Self.foregroundSignalStream(),
+            connectivitySignals: NetworkPathMonitor.connectivityRegainedStream()
+        )
+        self.transportLifecycle = transportLifecycle
+        let connectionStatusFlow = ConnectionStatusFlow(repository: transportLifecycle)
 
         // DEBUG deeplink injection for UI tests (see `initialDeeplinkURL`).
         #if DEBUG
@@ -419,6 +436,7 @@ struct OnymIOSApp: App {
                 ChatsFlow(repository: groupRepository, messages: messageRepository)
             },
             identitiesFlow: identitiesFlow,
+            connectionStatusFlow: connectionStatusFlow,
             approveRequestsFlow: approveRequestsFlow,
             pendingInvitesFlow: pendingInvitesFlow,
             messageRepository: messageRepository,
@@ -482,6 +500,25 @@ struct OnymIOSApp: App {
         )
     }
     #endif
+
+    /// UIKit foreground notification adapted to a plain `AsyncStream<Void>`
+    /// so the transport-lifecycle repository stays UIKit-free. Fires only
+    /// on a real background→foreground transition. (Deliberately NOT
+    /// `scenePhase` on the App — that re-evaluates the entire view tree
+    /// per phase change.)
+    private static func foregroundSignalStream() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            let task = Task {
+                let notifications = NotificationCenter.default.notifications(
+                    named: UIApplication.willEnterForegroundNotification
+                )
+                for await _ in notifications {
+                    continuation.yield(())
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -567,16 +604,16 @@ struct OnymIOSApp: App {
                     }
                 }
                 .task {
-                    // Connect the Nostr inbox transport to every
-                    // configured relay BEFORE the fanout interactor
-                    // attempts to subscribe. Without this, both legs
-                    // of the inbox are silently dead: subscribe()
-                    // no-ops on an empty connections dict and send()
-                    // throws TransportError.notConnected.
+                    // Start the transport-lifecycle repository BEFORE the
+                    // fanout interactor subscribes. The repository owns
+                    // the initial connect AND every reconnect trigger
+                    // (foreground / connectivity) — no view code drives
+                    // the transport; the presentation layer only observes
+                    // `ConnectionStatusFlow`.
                     let endpoints = await nostrRelaysRepository
                         .currentEndpoints()
                         .map { TransportEndpoint(url: $0.url) }
-                    await inboxTransport.connect(to: endpoints)
+                    await transportLifecycle.start(endpoints: endpoints)
 
                     // PR-4: subscribe to every identity's inbox
                     // concurrently. Without this, messages addressed

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -29,6 +29,7 @@ struct RootView: View {
                     ChatsView(
                         flow: dependencies.makeChatsFlow(),
                         identitiesFlow: dependencies.identitiesFlow,
+                        connectionStatusFlow: dependencies.connectionStatusFlow,
                         approveRequestsFlow: dependencies.approveRequestsFlow,
                         pendingInvitesFlow: dependencies.pendingInvitesFlow,
                         messageRepository: dependencies.messageRepository,

--- a/Sources/OnymIOS/Transport/InboxHighWaterMarkStore.swift
+++ b/Sources/OnymIOS/Transport/InboxHighWaterMarkStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Persisted per-inbox high-water mark: the highest `created_at` (unix
+/// seconds) seen on each inbox subscription. Every REQ — initial *and*
+/// reconnect replay — is bounded with `since = HWM − slack`, so a
+/// reconnect fetches only the gap since the last event we already have,
+/// never the full retained history. (Unbounded replays through the
+/// serial dispatcher were the flood that starved live chat on
+/// invitation-heavy devices — design doc F2/F6.)
+///
+/// The first-ever run has no mark (nil) ⇒ exactly one unbounded fetch —
+/// a cold start genuinely needs the whole backlog (pending invitations).
+/// Bounded forever after. Slack + downstream dedup absorb relay clock
+/// skew and out-of-order delivery.
+protocol InboxHighWaterMarkStoring: Sendable {
+    func highWaterMark(inbox: String) -> Int64?
+    /// Raise the mark for `inbox` to `createdAt`. Never lowers — a
+    /// replayed old event can't shrink the bound.
+    func raise(inbox: String, to createdAt: Int64)
+}
+
+final class UserDefaultsInboxHighWaterMarkStore: InboxHighWaterMarkStoring, @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let lock = NSLock()
+    private static let key = "app.onym.ios.transport.inboxHighWaterMarks"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func highWaterMark(inbox: String) -> Int64? {
+        lock.lock(); defer { lock.unlock() }
+        let dict = defaults.dictionary(forKey: Self.key) ?? [:]
+        return (dict[inbox] as? NSNumber)?.int64Value
+    }
+
+    func raise(inbox: String, to createdAt: Int64) {
+        lock.lock(); defer { lock.unlock() }
+        var dict = defaults.dictionary(forKey: Self.key) ?? [:]
+        let current = (dict[inbox] as? NSNumber)?.int64Value ?? Int64.min
+        guard createdAt > current else { return }
+        dict[inbox] = NSNumber(value: createdAt)
+        defaults.set(dict, forKey: Self.key)
+    }
+}

--- a/Sources/OnymIOS/Transport/NetworkPathMonitor.swift
+++ b/Sources/OnymIOS/Transport/NetworkPathMonitor.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Network
+
+/// Bridges `NWPathMonitor` to an `AsyncStream` of "connectivity was just
+/// regained" signals. Each emission is a cue to refresh long-lived
+/// sockets — the app forwards it to `InboxTransport.reconnect()`.
+///
+/// Emission policy lives in `ConnectivityRegainDetector` (below):
+///
+///  - **Edge-triggered.** `NWPathMonitor` invokes its handler on *any*
+///    path change, including route/interface/proxy churn while the path
+///    stays satisfied (frequent on real devices). Emitting on every
+///    satisfied callback caused a reconnect storm (design doc F2). We
+///    emit only on a genuine unsatisfied→satisfied transition.
+///  - **Baseline suppressed.** The first callback establishes the
+///    starting state and never emits — the launch-time connect already
+///    covers a satisfied start, while an *unsatisfied* start still arms
+///    the detector so the first real regain fires (launch-offline case).
+///  - **Coalesced.** A flapping link emits at most once per cooldown
+///    window, so the transport isn't rebuilt at the flap rate.
+enum NetworkPathMonitor {
+    static func connectivityRegainedStream() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            let monitor = NWPathMonitor()
+            let detector = ConnectivityRegainDetector()
+            monitor.pathUpdateHandler = { path in
+                if detector.shouldEmit(satisfied: path.status == .satisfied) {
+                    continuation.yield(())
+                }
+            }
+            continuation.onTermination = { @Sendable _ in monitor.cancel() }
+            monitor.start(queue: DispatchQueue(label: "app.onym.ios.netpath"))
+        }
+    }
+}
+
+/// Decides when a sequence of `NWPathMonitor` status callbacks should
+/// produce a "connectivity regained" signal. Pure logic with an
+/// injectable clock — no `Network` dependency — so the edge + cooldown
+/// behavior is unit-testable. Callbacks arrive on `NWPathMonitor`'s own
+/// queue, so state is lock-guarded.
+final class ConnectivityRegainDetector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lastSatisfied: Bool?
+    private var lastEmitAt: Date?
+    private let cooldown: TimeInterval
+    private let now: () -> Date
+
+    init(cooldown: TimeInterval = 3, now: @escaping () -> Date = Date.init) {
+        self.cooldown = cooldown
+        self.now = now
+    }
+
+    func shouldEmit(satisfied: Bool) -> Bool {
+        lock.lock()
+        defer { lastSatisfied = satisfied; lock.unlock() }
+        // First callback is the baseline — arm, never emit.
+        guard let previous = lastSatisfied else { return false }
+        // Only the unsatisfied→satisfied edge is a regain.
+        guard satisfied, !previous else { return false }
+        // Debounce a flapping link.
+        let timestamp = now()
+        if let last = lastEmitAt, timestamp.timeIntervalSince(last) < cooldown {
+            return false
+        }
+        lastEmitAt = timestamp
+        return true
+    }
+}

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -14,9 +14,18 @@ final class NostrInboxTransport: InboxTransport {
 
     private let state: State
     private let signerProvider: any NostrEphemeralSignerProvider
+    /// Tolerance subtracted from the high-water mark when bounding a
+    /// REQ's `since`, absorbing relay clock skew and out-of-order
+    /// delivery. The small re-fetched overlap is deduped downstream
+    /// (`SeenEventIDStore`); the point is excluding the *ancient*
+    /// backlog, not being exact.
+    static let replaySinceSlack: Int64 = 300
 
-    init(signerProvider: any NostrEphemeralSignerProvider) {
-        self.state = State()
+    init(
+        signerProvider: any NostrEphemeralSignerProvider,
+        highWaterMarks: any InboxHighWaterMarkStoring = UserDefaultsInboxHighWaterMarkStore()
+    ) {
+        self.state = State(highWaterMarks: highWaterMarks)
         self.signerProvider = signerProvider
     }
 
@@ -26,6 +35,22 @@ final class NostrInboxTransport: InboxTransport {
 
     func disconnect() async {
         await state.disconnect()
+    }
+
+    func reconnect() async {
+        await state.reconnect()
+    }
+
+    nonisolated func connectionStateStream() -> AsyncStream<Bool> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { [state] in
+                await state.subscribeConnectionState(id: id, continuation: continuation)
+            }
+            continuation.onTermination = { @Sendable [state] _ in
+                Task { await state.unsubscribeConnectionState(id: id) }
+            }
+        }
     }
 
     @discardableResult
@@ -58,12 +83,19 @@ final class NostrInboxTransport: InboxTransport {
     }
 
     func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
-        AsyncStream<InboundInbox> { continuation in
+        // Per-stream token: this stream's termination may fire *after* a
+        // newer subscription for the same inbox has been installed
+        // (re-subscribe on identity rebalance / pump restart). Cleanup
+        // is token-guarded so the stale termination can't tear down the
+        // fresh subscription — the same race the per-generation subIDs
+        // close at the relay-connection level.
+        let token = UUID()
+        return AsyncStream<InboundInbox> { continuation in
             Task { [state] in
-                await state.subscribe(inbox: inbox, continuation: continuation)
+                await state.subscribe(inbox: inbox, token: token, continuation: continuation)
             }
             continuation.onTermination = { @Sendable [state] _ in
-                Task { await state.unsubscribe(inbox: inbox) }
+                Task { await state.unsubscribe(inbox: inbox, ifToken: token) }
             }
         }
     }
@@ -97,27 +129,95 @@ final class NostrInboxTransport: InboxTransport {
 
     fileprivate actor State {
         private var connections: [URL: NostrRelayConnection] = [:]
-        private var activeSubscriptions: [TransportInboxID: Task<Void, Never>] = [:]
+        /// Live per-inbox subscription: the pump task plus the stream
+        /// token that owns it (see `subscribe`'s token guard).
+        private var activeSubscriptions: [TransportInboxID: (token: UUID, task: Task<Void, Never>)] = [:]
+        /// Monotonic counter for relay subscription IDs. Each subscribe
+        /// gets a unique id so an old stream's asynchronous
+        /// `onTermination` CLOSE can't tear down a freshly opened REQ
+        /// for the same inbox — the exact race `NostrMessageTransport`
+        /// already guards against with its own generation counter.
+        private var subscriptionGeneration: UInt64 = 0
+        /// Per-inbox high-water marks (persisted). Read at every REQ send
+        /// via the connection's `sinceProvider`, raised as events arrive.
+        private let highWaterMarks: any InboxHighWaterMarkStoring
+        /// Per-relay confirmed-live flags + the aggregate's subscribers.
+        /// Aggregate rule: connected iff ANY relay is confirmed live —
+        /// one reachable relay delivers messages.
+        private var liveByRelay: [URL: Bool] = [:]
+        private var stateContinuations: [UUID: AsyncStream<Bool>.Continuation] = [:]
+
+        init(highWaterMarks: any InboxHighWaterMarkStoring) {
+            self.highWaterMarks = highWaterMarks
+        }
 
         func connect(to endpoints: [TransportEndpoint]) async {
             for endpoint in endpoints {
                 if connections[endpoint.url] == nil {
                     let conn = NostrRelayConnection(url: endpoint.url)
                     connections[endpoint.url] = conn
+                    let url = endpoint.url
+                    await conn.setOnLiveStateChange { [weak self] live in
+                        Task { await self?.relayLiveStateChanged(url: url, live: live) }
+                    }
                     await conn.connect()
                 }
             }
         }
 
+        // MARK: - Connection state (presentation-facing signal)
+
+        private var aggregateConnected: Bool {
+            liveByRelay.values.contains(true)
+        }
+
+        private func relayLiveStateChanged(url: URL, live: Bool) {
+            let before = aggregateConnected
+            liveByRelay[url] = live
+            let after = aggregateConnected
+            guard before != after else { return }
+            for continuation in stateContinuations.values {
+                continuation.yield(after)
+            }
+        }
+
+        func subscribeConnectionState(id: UUID, continuation: AsyncStream<Bool>.Continuation) {
+            stateContinuations[id] = continuation
+            continuation.yield(aggregateConnected)
+        }
+
+        func unsubscribeConnectionState(id: UUID) {
+            stateContinuations.removeValue(forKey: id)
+        }
+
         func disconnect() async {
-            for task in activeSubscriptions.values {
-                task.cancel()
+            for entry in activeSubscriptions.values {
+                entry.task.cancel()
             }
             activeSubscriptions.removeAll()
             for conn in connections.values {
                 await conn.disconnect()
             }
             connections.removeAll()
+            let wasConnected = aggregateConnected
+            liveByRelay.removeAll()
+            if wasConnected {
+                for continuation in stateContinuations.values {
+                    continuation.yield(false)
+                }
+            }
+        }
+
+        /// Rebuild every connection in place. The per-connection
+        /// subscription dicts survive the rebuild and their REQs replay
+        /// (`since`-bounded), so consumers' AsyncStreams never break and
+        /// the relay backfills exactly the gap missed while away.
+        func reconnect() async {
+            await withTaskGroup(of: Void.self) { group in
+                for conn in connections.values {
+                    group.addTask { await conn.forceReconnect() }
+                }
+            }
         }
 
         /// Per-relay publish outcome — split so the thrown error can
@@ -171,42 +271,79 @@ final class NostrInboxTransport: InboxTransport {
 
         func subscribe(
             inbox: TransportInboxID,
+            token: UUID,
             continuation: AsyncStream<InboundInbox>.Continuation
         ) {
-            activeSubscriptions[inbox]?.cancel()
-            let subIDBase = "inbox-\(inbox.rawValue)"
+            activeSubscriptions[inbox]?.task.cancel()
+            subscriptionGeneration += 1
+            let subID = "inbox-\(inbox.rawValue)-\(subscriptionGeneration)"
             let filters = NostrInboxTransport.subscriptionFilters(inbox: inbox.rawValue)
             let conns = Array(connections.values)
+            // Bound every REQ (initial + reconnect replay) to the gap
+            // since the last event already seen for this inbox. nil on
+            // the first-ever run ⇒ one unbounded cold-start fetch, then
+            // bounded forever. Evaluated at send time, so a reconnect
+            // after hours away fetches hours — not the full history.
+            let inboxTag = inbox.rawValue
+            let hwm = highWaterMarks
+            let sinceProvider: @Sendable () -> Int64? = {
+                hwm.highWaterMark(inbox: inboxTag).map {
+                    max(0, $0 - NostrInboxTransport.replaySinceSlack)
+                }
+            }
 
             let task = Task {
                 await withTaskGroup(of: Void.self) { group in
                     for conn in conns {
-                        for (index, filter) in filters.enumerated() {
-                            group.addTask {
-                                let filterSubID = "\(subIDBase)-\(index)"
-                                let stream = await conn.subscribe(subscriptionID: filterSubID, filter: filter)
-                                for await event in stream {
-                                    guard !Task.isCancelled else { break }
-                                    guard let payload = Data(base64Encoded: event.content) else { continue }
-                                    let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
-                                    continuation.yield(InboundInbox(
-                                        inbox: inbox,
-                                        payload: payload,
-                                        receivedAt: received,
-                                        messageID: event.id
-                                    ))
-                                }
+                        // One REQ carrying all three filter shapes — NOT
+                        // one REQ per filter. The relay dedups events
+                        // across a subscription's filters (NIP-01), and a
+                        // single subscription per inbox keeps the
+                        // connection well under relay
+                        // `maxSubsPerConnection` caps (strfry default 20;
+                        // 3 REQs per inbox tripped it on
+                        // subscription-heavy devices and the overflow was
+                        // silently CLOSED).
+                        group.addTask {
+                            let stream = await conn.subscribe(
+                                subscriptionID: subID,
+                                filters: filters,
+                                sinceProvider: sinceProvider
+                            )
+                            for await event in stream {
+                                guard !Task.isCancelled else { break }
+                                hwm.raise(inbox: inboxTag, to: event.createdAt)
+                                guard let payload = Data(base64Encoded: event.content) else { continue }
+                                let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
+                                continuation.yield(InboundInbox(
+                                    inbox: inbox,
+                                    payload: payload,
+                                    receivedAt: received,
+                                    messageID: event.id
+                                ))
                             }
                         }
                     }
                 }
             }
-            activeSubscriptions[inbox] = task
+            activeSubscriptions[inbox] = (token: token, task: task)
         }
 
+        /// Deliberate unsubscribe (protocol surface): unconditional.
         func unsubscribe(inbox: TransportInboxID) {
-            activeSubscriptions[inbox]?.cancel()
+            activeSubscriptions[inbox]?.task.cancel()
             activeSubscriptions.removeValue(forKey: inbox)
+        }
+
+        /// Stream-termination cleanup: only tears down the subscription
+        /// the terminating stream actually owns. A stale termination
+        /// (its inbox was re-subscribed and a newer stream installed)
+        /// is a no-op — without this guard the old stream's async
+        /// cleanup cancelled the fresh subscription and the inbox went
+        /// silently deaf.
+        func unsubscribe(inbox: TransportInboxID, ifToken token: UUID) {
+            guard activeSubscriptions[inbox]?.token == token else { return }
+            unsubscribe(inbox: inbox)
         }
     }
 }

--- a/Sources/OnymIOS/Transport/Nostr/NostrMessageTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrMessageTransport.swift
@@ -160,7 +160,7 @@ final class NostrMessageTransport: MessageTransport {
                                 "#t": [topic.rawValue],
                                 "since": sinceUnix,
                             ]
-                            let stream = await conn.subscribe(subscriptionID: subID, filter: filter)
+                            let stream = await conn.subscribe(subscriptionID: subID, filters: [filter])
                             for await event in stream {
                                 guard !Task.isCancelled else { break }
                                 guard let payload = Data(base64Encoded: event.content) else { continue }

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -2,73 +2,218 @@ import Foundation
 import os.log
 
 /// Persistent WebSocket connection to a single Nostr relay. Owns the
-/// REQ/EVENT/EOSE/OK/CLOSE framing and is the only place in the
-/// transport layer that touches `URLSessionWebSocketTask`. Reconnect with
-/// exponential backoff, heartbeat ping, and a per-publish OK await are
-/// all internal — the surface for callers is `connect`, `disconnect`,
-/// `publish`, `publishAndAwaitOK`, `subscribe`, `unsubscribe`.
+/// REQ/EVENT/EOSE/OK/CLOSED framing and is the only place in the
+/// transport layer that touches `URLSessionWebSocketTask`.
+///
+/// Lifecycle is a small state machine (see `docs`/reconnect design):
+///
+/// ```
+///             connect()                first frame received
+/// Disconnected ────────► Connecting ─────────────────────► Live
+///      ▲                     │ receive() throws /             │
+///      │                     │ repeated CLOSED /              │ staleness /
+///      │    backoff sleep    ▼ probe failure                  │ receive() throws /
+///      └────────────────── Backoff ◄───────────────────────────┘ forceReconnect()
+///          (attempts++; reset only on entering Live)
+/// ```
+///
+/// Key invariants:
+///  - Every (re)connect bumps `connectionGeneration`; the receive loop,
+///    liveness monitor, and failure funnel all no-op when superseded, so
+///    overlapping reconnects can never leave two loops fighting over the
+///    same socket.
+///  - The connection is *confirmed live* only when a frame actually
+///    arrives — `reconnectAttempts` resets there, never in `connect()`,
+///    so backoff escalates across genuinely failing attempts (capped at
+///    `maxReconnectDelay`, default 30 s).
+///  - A subscription is one `REQ` carrying *all* of its filters (NIP-01
+///    dedups within a subscription) — never one REQ per filter, which
+///    multiplied subscription count 3× and tripped relay
+///    `maxSubsPerConnection` caps. The connection's relay-side budget is
+///    `subscriptions.count + 1`: the liveness probe holds one extra sub
+///    slot for the connection's lifetime (it is never CLOSEd — its
+///    periodic re-REQ replaces itself in place).
+///  - `CLOSED` is handled, not ignored: first CLOSED for a live
+///    subscription re-REQs it once; a repeat within the same connection
+///    generation treats the connection as unhealthy and rebuilds. A
+///    relay-side subscription rejection is therefore visible and
+///    recoverable instead of silent deafness.
+///  - Prolonged silence is death: the liveness monitor probes with a
+///    match-nothing REQ (the relay's immediate EOSE is a pong stand-in;
+///    verified against nostr.onym.app) and rebuilds when no frame lands
+///    within `livenessTimeout`. A half-open socket — where `receive()`
+///    hangs forever and never throws — cannot stay deaf.
 actor NostrRelayConnection {
     let url: URL
     private var webSocketTask: URLSessionWebSocketTask?
     private let session: URLSession
-    private var subscriptions: [String: ([String: Any], (NostrEvent) -> Void)] = [:]
+    /// Live subscriptions: subID → (filters, since-provider, per-event
+    /// callback). All of a subscription's filters ship in one REQ frame.
+    /// `sinceProvider` is consulted at every REQ *send* (initial and
+    /// replay), so the `since` bound reflects the caller's current
+    /// high-water mark rather than a value frozen at subscribe time.
+    private var subscriptions: [String: (
+        filters: [[String: Any]],
+        sinceProvider: (@Sendable () -> Int64?)?,
+        callback: (NostrEvent) -> Void
+    )] = [:]
     private(set) var isConnected = false
     private var reconnectAttempts = 0
     private var pendingOKContinuations: [String: CheckedContinuation<Bool, any Error>] = [:]
-    private var pingTask: Task<Void, Never>?
+    private var livenessTask: Task<Void, Never>?
     private var onOKCallback: ((String, Bool) -> Void)?
+    /// Bumped on every `connect()`/`disconnect()`/`forceReconnect()`.
+    private var connectionGeneration: UInt64 = 0
+    /// Wall-clock time of the last frame received on the current socket.
+    private var lastActivityAt = Date()
+    /// Subscription ids already re-REQ'd after a CLOSED in the current
+    /// generation. A second CLOSED for the same id escalates to a rebuild.
+    /// An id is removed again when its subscription is confirmed accepted
+    /// (EOSE/EVENT lands for it), so benign CLOSEDs hours apart on a
+    /// long-lived socket don't accumulate into a spurious rebuild.
+    private var closedRetriedSubIDs: Set<String> = []
+    /// Consecutive rebuilds caused by repeated CLOSED. Deliberately NOT
+    /// reset by frame arrival (a CLOSED-spewing relay still sends
+    /// frames — that's what made the naive backoff hot-loop at ~1 Hz);
+    /// reset only when a subscription is confirmed accepted (EOSE/EVENT
+    /// for a live subID). Feeds the failure funnel's backoff so a
+    /// persistently rejected subscription escalates to `maxReconnectDelay`
+    /// instead of hammering the relay.
+    private var closedRebuilds = 0
 
     func setOnOK(_ callback: @escaping (String, Bool) -> Void) {
         onOKCallback = callback
     }
 
-    private static let maxReconnectDelay: TimeInterval = 120
-    private static let baseReconnectDelay: TimeInterval = 1
-    private static let pingInterval: TimeInterval = 30
+    /// Confirmed-live state, with transitions surfaced to the owner.
+    /// `true` only when a frame has actually arrived on the current
+    /// socket (the same "confirmed live" semantics the backoff uses);
+    /// `false` from every teardown path (failure funnel, disconnect,
+    /// forced rebuild). The transport aggregates these across relays
+    /// into the connection state the app's repository layer publishes.
+    private var confirmedLive = false
+    private var onLiveStateChange: ((Bool) -> Void)?
+
+    func setOnLiveStateChange(_ callback: @escaping (Bool) -> Void) {
+        onLiveStateChange = callback
+        callback(confirmedLive)
+    }
+
+    private func setConfirmedLive(_ live: Bool) {
+        guard live != confirmedLive else { return }
+        confirmedLive = live
+        onLiveStateChange?(live)
+    }
+
+    // Timings — injectable so the (otherwise minute-scale) liveness and
+    // backoff paths are exercisable in tests. Defaults are production
+    // values.
+    /// How often the liveness monitor probes the relay and checks for
+    /// staleness.
+    private let pingInterval: TimeInterval
+    /// No frame within this window ⇒ the socket is treated as dead and
+    /// rebuilt. Must comfortably exceed `pingInterval` so a healthy
+    /// relay's probe reply (EOSE) keeps the connection alive.
+    private let livenessTimeout: TimeInterval
+    private let baseReconnectDelay: TimeInterval
+    /// Backoff cap. Deliberately modest: minute-scale retry gaps read as
+    /// "the app is dead" to a user mid-conversation.
+    private let maxReconnectDelay: TimeInterval
     private static let connectionTimeout: TimeInterval = 15
     private static let publishTimeout: TimeInterval = 5
+    /// Subscription id for the liveness probe. A REQ under this id with a
+    /// filter matching nothing draws an immediate EOSE from a conformant
+    /// relay — our stand-in for a WebSocket pong (sendPing is avoided:
+    /// CFNetwork's pong handler has a known crash where it fires on an
+    /// internal queue after the task is cancelled and dereferences a
+    /// freed nw_connection).
+    private static let livenessSubID = "__onym_hb"
 
-    init(url: URL) {
+    init(
+        url: URL,
+        pingInterval: TimeInterval = 20,
+        livenessTimeout: TimeInterval = 55,
+        baseReconnectDelay: TimeInterval = 1,
+        maxReconnectDelay: TimeInterval = 30
+    ) {
         self.url = url
+        self.pingInterval = pingInterval
+        self.livenessTimeout = livenessTimeout
+        self.baseReconnectDelay = baseReconnectDelay
+        self.maxReconnectDelay = maxReconnectDelay
         let config = URLSessionConfiguration.default
         config.waitsForConnectivity = true
         config.timeoutIntervalForRequest = Self.connectionTimeout
-        // WebSocket connections are long-lived — never let the system kill them
-        config.timeoutIntervalForResource = 0
+        // OS-level safety net: after this wall-clock bound the task dies,
+        // `receive()` throws, and the normal failure funnel rebuilds. The
+        // liveness monitor is the real death detector; this only catches
+        // pathological hangs it can't see. Affordable now that reconnect
+        // replays are `since`-bounded (a forced hourly rebuild refetches
+        // the gap, not the full retained history).
+        config.timeoutIntervalForResource = 3600
         self.session = URLSession(configuration: config)
     }
 
     func connect() {
         guard webSocketTask == nil else { return }
+        connectionGeneration &+= 1
+        let generation = connectionGeneration
+        closedRetriedSubIDs.removeAll()
         let task = session.webSocketTask(with: url)
         self.webSocketTask = task
         task.resume()
         isConnected = true
-        reconnectAttempts = 0
-        Task { await receiveLoop() }
-        startHeartbeat()
+        // NB: `reconnectAttempts` is NOT reset here — connecting is an
+        // attempt, not a confirmed-live connection. It resets on the
+        // first frame received (see `receiveLoop`), so backoff escalates
+        // across a run of failed attempts against a dead relay.
+        lastActivityAt = Date()
+        Task { await receiveLoop(generation: generation) }
+        startLivenessMonitor(generation: generation)
 
-        for (subID, (filter, _)) in subscriptions {
-            sendREQ(subscriptionID: subID, filter: filter)
+        for (subID, entry) in subscriptions {
+            sendREQ(subscriptionID: subID, filters: entry.filters, sinceProvider: entry.sinceProvider)
         }
 
-        // URLSessionWebSocketTask exposes no reliable onOpen callback. Replay
-        // subscriptions shortly after connect so filters added during the
-        // handshake window are not lost if the initial send happens too early.
+        // URLSessionWebSocketTask exposes no reliable onOpen callback.
+        // Replay subscriptions shortly after connect so filters added
+        // during the handshake window are not lost if the initial send
+        // happened too early.
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(1))
             guard let self else { return }
-            await self.replaySubscriptions()
+            await self.replaySubscriptions(generation: generation)
         }
     }
 
     func disconnect() {
-        pingTask?.cancel()
-        pingTask = nil
+        // Supersede any in-flight receive loop / liveness monitor.
+        connectionGeneration &+= 1
+        livenessTask?.cancel()
+        livenessTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
         isConnected = false
         reconnectAttempts = 0
+        setConfirmedLive(false)
+    }
+
+    /// Tear down the current socket and rebuild it immediately,
+    /// re-issuing every live subscription's REQ. Unconditional by design:
+    /// this is the app-driven refresh (foreground, regained
+    /// connectivity), and a fresh REQ is the only mechanism that
+    /// backfills events missed while the socket was dead or suspended —
+    /// probing first and skipping the rebuild on a healthy-*looking*
+    /// socket provably loses messages (design doc F3).
+    func forceReconnect() {
+        connectionGeneration &+= 1
+        livenessTask?.cancel()
+        livenessTask = nil
+        webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
+        webSocketTask = nil
+        isConnected = false
+        setConfirmedLive(false)
+        connect()
     }
 
     func publish(event: NostrEvent) async throws {
@@ -130,12 +275,22 @@ actor NostrRelayConnection {
         }
     }
 
+    /// Open one relay subscription carrying every filter in `filters`
+    /// (single REQ frame — the relay dedups events across the filters
+    /// within one subscription, NIP-01).
+    ///
+    /// `sinceProvider`, when given, bounds every REQ this subscription
+    /// sends — initial and reconnect replay alike — with
+    /// `since = max(filter's own since, provider value)`. Returning nil
+    /// leaves the filters untouched (first-ever run: unbounded cold-start
+    /// fetch).
     func subscribe(
         subscriptionID: String,
-        filter: [String: Any]
+        filters: [[String: Any]],
+        sinceProvider: (@Sendable () -> Int64?)? = nil
     ) -> AsyncStream<NostrEvent> {
         let stream = AsyncStream<NostrEvent> { continuation in
-            subscriptions[subscriptionID] = (filter, { event in
+            subscriptions[subscriptionID] = (filters, sinceProvider, { event in
                 continuation.yield(event)
             })
             continuation.onTermination = { @Sendable _ in
@@ -144,7 +299,7 @@ actor NostrRelayConnection {
                 }
             }
         }
-        sendREQ(subscriptionID: subscriptionID, filter: filter)
+        sendREQ(subscriptionID: subscriptionID, filters: filters, sinceProvider: sinceProvider)
         return stream
     }
 
@@ -160,66 +315,166 @@ actor NostrRelayConnection {
 
     // MARK: - Private
 
-    private func sendREQ(subscriptionID: String, filter: [String: Any]) {
-        let frame: [Any] = ["REQ", subscriptionID, filter]
+    private func sendREQ(
+        subscriptionID: String,
+        filters: [[String: Any]],
+        sinceProvider: (@Sendable () -> Int64?)?
+    ) {
+        var filters = filters
+        // Bound the fetch to the caller's current high-water mark: only
+        // the gap since the last event already seen is replayed, not the
+        // relay's full retained history. Never lowers a since a filter
+        // already carries.
+        if let since = sinceProvider?() {
+            filters = filters.map { filter in
+                var filter = filter
+                let existing = (filter["since"] as? Int64) ?? .min
+                filter["since"] = max(existing, since)
+                return filter
+            }
+        }
+        var frame: [Any] = ["REQ", subscriptionID]
+        frame.append(contentsOf: filters)
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
               let string = String(data: data, encoding: .utf8)
         else { return }
-        Task { try? await webSocketTask?.send(.string(string)) }
-    }
-
-    private func replaySubscriptions() {
-        for (subID, (filter, _)) in subscriptions {
-            sendREQ(subscriptionID: subID, filter: filter)
+        // A REQ lost on a wounded socket is a deaf subscription for up
+        // to `livenessTimeout` — route the send failure into the failure
+        // funnel instead of waiting for the staleness check to notice.
+        let generation = connectionGeneration
+        Task { [weak self, webSocketTask] in
+            do {
+                guard let task = webSocketTask else { return }
+                try await task.send(.string(string))
+            } catch {
+                await self?.handleConnectionFailure(generation: generation)
+            }
         }
     }
 
-    private func receiveLoop() async {
-        while isConnected {
-            guard let task = webSocketTask else { break }
+    private func replaySubscriptions(generation: UInt64) {
+        guard generation == connectionGeneration else { return }
+        for (subID, entry) in subscriptions {
+            sendREQ(subscriptionID: subID, filters: entry.filters, sinceProvider: entry.sinceProvider)
+        }
+    }
+
+    private func receiveLoop(generation: UInt64) async {
+        while generation == connectionGeneration {
+            guard let task = webSocketTask else { return }
             do {
                 let message = try await task.receive()
+                // The generation may have advanced while `receive()` was
+                // suspended (a forced reconnect raced an in-flight
+                // frame). A stale frame must not refresh the NEW
+                // generation's liveness clock or backoff state.
+                guard generation == connectionGeneration else { return }
+                lastActivityAt = Date()
+                // A frame arrived — the connection is confirmed live.
+                // This (and only this) resets the error backoff. NB it
+                // deliberately does NOT reset `closedRebuilds`: a relay
+                // that keeps rejecting our REQs still sends frames
+                // (CLOSEDs), and treating those as health is what made
+                // the CLOSED path hot-loop.
+                reconnectAttempts = 0
+                setConfirmedLive(true)
                 let text: String
                 switch message {
                 case .string(let s): text = s
                 case .data(let d): text = String(data: d, encoding: .utf8) ?? ""
                 @unknown default: continue
                 }
-                handleMessage(text)
+                handleMessage(text, generation: generation)
             } catch {
-                pingTask?.cancel()
-                pingTask = nil
-                isConnected = false
-                webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
-                webSocketTask = nil
-                reconnectAttempts += 1
-                let delay = min(
-                    Self.maxReconnectDelay,
-                    Self.baseReconnectDelay * pow(2.0, Double(min(reconnectAttempts - 1, 6)))
-                )
-                try? await Task.sleep(for: .seconds(delay))
-                connect()
+                await handleConnectionFailure(generation: generation)
                 return
             }
         }
     }
 
-    /// Heartbeat sends a no-op `["CLOSE","__hb"]` instead of using
-    /// `URLSessionWebSocketTask.sendPing`. The CFNetwork ping handler has
-    /// a known crash where the pong fires on an internal queue after the
-    /// task is cancelled and dereferences a freed `nw_connection`. A
-    /// plain `.send()` doesn't have that path — if the connection is
-    /// dead, the send throws and the receive loop reconnects.
-    private func startHeartbeat() {
-        pingTask?.cancel()
-        pingTask = Task { [weak self] in
+    /// Single funnel for "this socket is dead, rebuild it". Guarded by
+    /// the connection generation so a stale receive loop or liveness
+    /// monitor firing after a newer connect() is a no-op; the generation
+    /// is bumped on entry so two failure paths for the same generation
+    /// (liveness + receive-loop catch, interleaved across the backoff
+    /// sleep) can't both run — the second is guarded out. Backoff uses
+    /// the max of the error counter and the CLOSED-rebuild counter, so
+    /// a persistently rejected subscription escalates to
+    /// `maxReconnectDelay` even though its socket "successfully"
+    /// receives CLOSED frames.
+    private func handleConnectionFailure(generation: UInt64) async {
+        guard generation == connectionGeneration else { return }
+        connectionGeneration &+= 1
+        let rebuildGeneration = connectionGeneration
+        livenessTask?.cancel()
+        livenessTask = nil
+        isConnected = false
+        setConfirmedLive(false)
+        webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
+        webSocketTask = nil
+        reconnectAttempts += 1
+        let effectiveAttempts = max(reconnectAttempts, closedRebuilds)
+        let delay = min(
+            maxReconnectDelay,
+            baseReconnectDelay * pow(2.0, Double(min(effectiveAttempts - 1, 6)))
+        )
+        try? await Task.sleep(for: .seconds(delay))
+        guard rebuildGeneration == connectionGeneration else { return }
+        connect()
+    }
+
+    /// Active liveness monitor. Once per `pingInterval`:
+    ///
+    ///  1. **Detect a half-open socket.** If no frame has arrived within
+    ///     `livenessTimeout` the connection is silently dead — the OS
+    ///     still thinks it's open, `receive()` never throws, and the
+    ///     error-path reconnect never fires. Rebuild.
+    ///  2. **Keep the socket provably alive.** Send the match-nothing
+    ///     probe REQ; a conformant relay's immediate EOSE lands in the
+    ///     receive loop and refreshes `lastActivityAt`. If the send
+    ///     itself throws, the socket is dead now — rebuild.
+    ///
+    /// Fail-closed: a nil or non-running task also routes to the failure
+    /// funnel — this is the one component whose job is to catch what the
+    /// error path missed, so it never silently stops.
+    private func startLivenessMonitor(generation: UInt64) {
+        livenessTask?.cancel()
+        livenessTask = Task { [weak self, pingInterval] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(Self.pingInterval))
-                guard !Task.isCancelled else { break }
-                guard let task = await self?.webSocketTask,
-                      task.state == .running else { break }
-                try? await task.send(.string("[\"CLOSE\",\"__hb\"]"))
+                try? await Task.sleep(for: .seconds(pingInterval))
+                guard !Task.isCancelled, let self else { break }
+                let alive = await self.livenessTick(generation: generation)
+                if !alive { break }
             }
+        }
+    }
+
+    /// One liveness cycle. Returns `false` when this monitor should stop:
+    /// superseded by a newer generation (no-op), or it routed a dead
+    /// socket into the failure funnel (which spawns a fresh monitor).
+    private func livenessTick(generation: UInt64) async -> Bool {
+        guard generation == connectionGeneration else { return false }
+
+        guard let task = webSocketTask, task.state == .running else {
+            await handleConnectionFailure(generation: generation)
+            return false
+        }
+
+        if Date().timeIntervalSince(lastActivityAt) > livenessTimeout {
+            await handleConnectionFailure(generation: generation)
+            return false
+        }
+
+        // A single-id filter for a valid but nonexistent (all-zero) event
+        // id matches nothing: immediate EOSE, no live events. Kept plain
+        // (no `limit`, no exotic keys) so strict relays accept it.
+        let probe = "[\"REQ\",\"\(Self.livenessSubID)\",{\"ids\":[\"\(String(repeating: "0", count: 64))\"]}]"
+        do {
+            try await task.send(.string(probe))
+            return true
+        } catch {
+            await handleConnectionFailure(generation: generation)
+            return false
         }
     }
 
@@ -228,7 +483,7 @@ actor NostrRelayConnection {
     private static let maxMessageSize = 1_048_576
     private static let securityLogger = Logger(subsystem: "app.onym.ios", category: "Transport")
 
-    private func handleMessage(_ text: String) {
+    private func handleMessage(_ text: String, generation: UInt64) {
         guard text.utf8.count <= Self.maxMessageSize else {
             Self.securityLogger.warning("Relay oversized message rejected (\(text.utf8.count) bytes): \(self.url.absoluteString, privacy: .public)")
             return
@@ -245,12 +500,26 @@ actor NostrRelayConnection {
                   let eventObj = array[2] as? [String: Any]
             else { return }
             if let event = parseEvent(eventObj),
-               let (_, callback) = subscriptions[subID]
+               let entry = subscriptions[subID]
             {
-                callback(event)
+                // Same acceptance proof as EOSE: events flowing for a
+                // subscription mean its REQ stuck.
+                closedRebuilds = 0
+                closedRetriedSubIDs.remove(subID)
+                entry.callback(event)
             }
         case "EOSE":
-            break
+            // EOSE for one of OUR subscriptions proves the relay accepted
+            // its REQ: the CLOSED bookkeeping resets. `closedRebuilds`
+            // stops escalating (the condition cleared), and the sub's
+            // retried flag decays so a benign CLOSED hours from now gets
+            // a fresh retry instead of an immediate rebuild.
+            if array.count >= 2,
+               let subID = array[1] as? String,
+               subscriptions[subID] != nil {
+                closedRebuilds = 0
+                closedRetriedSubIDs.remove(subID)
+            }
         case "OK":
             if array.count >= 3,
                let eventID = array[1] as? String,
@@ -259,6 +528,32 @@ actor NostrRelayConnection {
                     continuation.resume(returning: accepted)
                 }
                 onOKCallback?(eventID, accepted)
+            }
+        case "CLOSED":
+            // The relay rejected or terminated one of our subscriptions
+            // (e.g. a `maxSubsPerConnection` cap). Ignoring this frame is
+            // silent permanent deafness on that inbox — the failure mode
+            // behind "messages stop arriving until relaunch" on
+            // subscription-heavy devices. Retry the REQ once; a repeat
+            // for the same sub in this generation means the condition is
+            // persistent, so rebuild the connection and let the normal
+            // failure/backoff path own it.
+            guard array.count >= 2, let subID = array[1] as? String else { return }
+            guard subID != Self.livenessSubID else { return }
+            guard let entry = subscriptions[subID] else { return }
+            if closedRetriedSubIDs.contains(subID) {
+                Self.securityLogger.warning("Relay repeatedly closed a subscription; rebuilding connection: \(self.url.absoluteString, privacy: .public)")
+                // Escalating counter that SURVIVES the rebuild and is
+                // immune to frame arrival (see `closedRebuilds`) — a
+                // persistently rejected subscription backs off to
+                // `maxReconnectDelay` instead of hot-looping at
+                // `baseReconnectDelay` (the relay's own CLOSED frames
+                // would otherwise keep resetting the error backoff).
+                closedRebuilds += 1
+                Task { await handleConnectionFailure(generation: generation) }
+            } else {
+                closedRetriedSubIDs.insert(subID)
+                sendREQ(subscriptionID: subID, filters: entry.filters, sinceProvider: entry.sinceProvider)
             }
         case "NOTICE":
             break

--- a/Sources/OnymIOS/Transport/Transport.swift
+++ b/Sources/OnymIOS/Transport/Transport.swift
@@ -104,10 +104,39 @@ protocol InboxTransport: Sendable {
     func connect(to endpoints: [TransportEndpoint]) async
     func disconnect() async
 
+    /// Tear down and rebuild every underlying connection, re-issuing all
+    /// live subscriptions. Unconditional by design: it exists for the
+    /// app-driven refresh triggers (return to foreground, regained
+    /// connectivity), where a fresh REQ is the only mechanism that
+    /// backfills events missed while the socket was dead or suspended —
+    /// probing first and skipping the rebuild on a healthy-*looking*
+    /// socket provably loses messages (design doc F3). Cheap by
+    /// construction: replays are `since`-bounded to the gap. Consumers'
+    /// subscription streams survive the rebuild.
+    func reconnect() async
+
     @discardableResult
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt
 
     func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox>
 
     func unsubscribe(inbox: TransportInboxID) async
+
+    /// Hot stream of the transport's connection state: `true` while at
+    /// least one endpoint is *confirmed live* (a frame has actually
+    /// arrived on its current socket), `false` otherwise. Emits the
+    /// current value on subscribe, then transitions. This is the ONLY
+    /// signal the presentation layer consumes from the transport — the
+    /// repository layer owns reconnecting; views only render the state.
+    nonisolated func connectionStateStream() -> AsyncStream<Bool>
+}
+
+extension InboxTransport {
+    /// Default for transports without a meaningful connection lifecycle
+    /// (in-process loopback, test fakes): permanently connected.
+    nonisolated func connectionStateStream() -> AsyncStream<Bool> {
+        AsyncStream { continuation in
+            continuation.yield(true)
+        }
+    }
 }

--- a/Sources/OnymIOS/Transport/TransportLifecycleRepository.swift
+++ b/Sources/OnymIOS/Transport/TransportLifecycleRepository.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Observation
+
+/// Owns the inbox transport's lifecycle end to end: the initial connect,
+/// the unconditional rebuild on app-lifecycle triggers (return to
+/// foreground, regained connectivity), and the connection-state signal.
+///
+/// Layering contract: this repository is the ONLY component that drives
+/// the transport, and `connectionSnapshots` is the ONLY thing the
+/// presentation layer consumes from it. No view code observes lifecycle
+/// notifications or calls `reconnect()` — the trigger streams are
+/// injected (the app shell passes `UIApplication`-notification and
+/// `NWPathMonitor` streams; tests pass hand-driven ones), so the
+/// repository itself is UIKit-free and the transport's lifetime is
+/// independent of any view's.
+///
+/// Note there is no "reconnect failed" event by design: the transport
+/// retries internally with escalating backoff and never gives up, so the
+/// honest presentation signal is the continuous connected/disconnected
+/// state — a failure shows as `false` persisting, and recovery flips it
+/// back without any extra machinery.
+actor TransportLifecycleRepository {
+    private let transport: any InboxTransport
+    private let foregroundSignals: AsyncStream<Void>
+    private let connectivitySignals: AsyncStream<Void>
+    private var triggerTasks: [Task<Void, Never>] = []
+    private var mirrorTask: Task<Void, Never>?
+    private var started = false
+
+    /// Latest known state, replayed to new subscribers. Optimistic
+    /// `true` before the first transport report so the UI doesn't flash
+    /// an offline indicator during a normal launch.
+    private var isConnected = true
+    private var continuations: [UUID: AsyncStream<Bool>.Continuation] = [:]
+
+    init(
+        transport: any InboxTransport,
+        foregroundSignals: AsyncStream<Void>,
+        connectivitySignals: AsyncStream<Void>
+    ) {
+        self.transport = transport
+        self.foregroundSignals = foregroundSignals
+        self.connectivitySignals = connectivitySignals
+    }
+
+    /// Connect to `endpoints` and begin owning the lifecycle. Returns
+    /// once the initial connect has been issued (callers that must
+    /// subscribe only after connect — the fan-out — can await this).
+    /// Idempotent.
+    func start(endpoints: [TransportEndpoint]) async {
+        guard !started else { return }
+        started = true
+
+        await transport.connect(to: endpoints)
+
+        // Mirror the transport's confirmed-live aggregate into the
+        // presentation-facing snapshots.
+        let stateStream = transport.connectionStateStream()
+        mirrorTask = Task { [weak self] in
+            for await connected in stateStream {
+                await self?.updateConnected(connected)
+            }
+        }
+
+        // Both triggers rebuild unconditionally: a fresh REQ is the only
+        // mechanism that backfills events missed while suspended, and
+        // the rebuild is cheap (since-bounded replay + pre-decrypt
+        // dedup). The streams are already edge-triggered/debounced at
+        // their sources.
+        let transport = self.transport
+        triggerTasks.append(Task { [foregroundSignals] in
+            for await _ in foregroundSignals {
+                // A yield buffered before stop()'s cancel can still
+                // resume the loop — never forward it.
+                guard !Task.isCancelled else { break }
+                await transport.reconnect()
+            }
+        })
+        triggerTasks.append(Task { [connectivitySignals] in
+            for await _ in connectivitySignals {
+                guard !Task.isCancelled else { break }
+                await transport.reconnect()
+            }
+        })
+    }
+
+    func stop() async {
+        for task in triggerTasks { task.cancel() }
+        triggerTasks.removeAll()
+        mirrorTask?.cancel()
+        mirrorTask = nil
+        started = false
+    }
+
+    /// Hot stream of the connection state for the presentation layer.
+    /// Replays the current value on subscribe.
+    nonisolated var connectionSnapshots: AsyncStream<Bool> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func updateConnected(_ connected: Bool) {
+        guard connected != isConnected else { return }
+        isConnected = connected
+        for continuation in continuations.values {
+            continuation.yield(connected)
+        }
+    }
+
+    private func subscribe(id: UUID, continuation: AsyncStream<Bool>.Continuation) {
+        continuations[id] = continuation
+        continuation.yield(isConnected)
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+}
+
+/// `@Observable` mirror of the repository's connection state for SwiftUI
+/// — the presentation layer's entire view of the transport. Mirrors the
+/// flow shape used across the app (`PendingInvitesFlow` etc.).
+@MainActor
+@Observable
+final class ConnectionStatusFlow {
+    /// `false` while no relay is confirmed live — drives the offline
+    /// indicator on the chats screen.
+    private(set) var isConnected = true
+
+    private let repository: TransportLifecycleRepository
+    private var streamTask: Task<Void, Never>?
+
+    init(repository: TransportLifecycleRepository) {
+        self.repository = repository
+    }
+
+    /// Idempotent.
+    func start() {
+        guard streamTask == nil else { return }
+        let snapshots = repository.connectionSnapshots
+        streamTask = Task { @MainActor [weak self] in
+            for await connected in snapshots {
+                self?.isConnected = connected
+            }
+        }
+    }
+
+    func stop() {
+        streamTask?.cancel()
+        streamTask = nil
+    }
+}

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -435,6 +435,7 @@ private final class CreateGroupFlowTestEnv {
 private struct FlowTestInboxTransport: InboxTransport {
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         PublishReceipt(messageID: "x", acceptedBy: 1)
     }

--- a/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupInteractorTests.swift
@@ -593,6 +593,7 @@ private actor ConfigurableInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         sends.append(Send(payload: payload, inbox: inbox))

--- a/Tests/OnymIOSTests/GroupStateRefreshTests.swift
+++ b/Tests/OnymIOSTests/GroupStateRefreshTests.swift
@@ -361,6 +361,7 @@ private actor VerifierRecordingInboxTransport: InboxTransport {
     private(set) var sends: Int = 0
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         sends += 1
         return PublishReceipt(messageID: "spy-\(sends)", acceptedBy: 1)

--- a/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
+++ b/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
@@ -216,6 +216,7 @@ private actor RecordingInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         PublishReceipt(messageID: UUID().uuidString, acceptedBy: 1)

--- a/Tests/OnymIOSTests/IntroInboxPumpTests.swift
+++ b/Tests/OnymIOSTests/IntroInboxPumpTests.swift
@@ -172,6 +172,7 @@ private actor PumpRecordingInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         PublishReceipt(messageID: UUID().uuidString, acceptedBy: 1)

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -493,6 +493,7 @@ private actor ApproverRecordingInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         sends.append((payload, inbox))

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -826,6 +826,7 @@ private actor RecordingInboxTransport: InboxTransport {
 
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
+    func reconnect() async {}
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         recordedSends.append(Record(payload: payload, inbox: inbox))

--- a/Tests/OnymIOSTests/Support/FakeInboxTransport.swift
+++ b/Tests/OnymIOSTests/Support/FakeInboxTransport.swift
@@ -27,6 +27,7 @@ actor FakeInboxTransport: InboxTransport {
     private(set) var connectedEndpoints: [TransportEndpoint] = []
     private(set) var disconnectCallCount = 0
     private(set) var unsubscribedInboxes: [TransportInboxID] = []
+    private(set) var subscribedInboxes: [TransportInboxID] = []
     private(set) var subscribeCallCount = 0
 
     // MARK: - InboxTransport
@@ -39,6 +40,15 @@ actor FakeInboxTransport: InboxTransport {
         disconnectCallCount += 1
         for cont in continuations.values { cont.finish() }
         continuations.removeAll()
+    }
+
+    private(set) var reconnectCallCount = 0
+
+    func reconnect() async {
+        // Nothing to rebuild (live subscriptions are driven via `emit`);
+        // counted so the lifecycle-repository tests can assert the
+        // trigger streams actually forward.
+        reconnectCallCount += 1
     }
 
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
@@ -93,6 +103,7 @@ actor FakeInboxTransport: InboxTransport {
         continuation: AsyncStream<InboundInbox>.Continuation
     ) {
         subscribeCallCount += 1
+        subscribedInboxes.append(inbox)
         continuations[inbox] = continuation
     }
 }


### PR DESCRIPTION
**1/4 of the reconnect work** (squashed restructure of #194 / #196-HWM / #197 / #201 for reviewability — no tests here by design; all coverage is in PR 4/4). Design doc: `~/Desktop/reconnect.md`.

Fixes the root problem: messages arrive only over live NIP-01 subscriptions, iOS backgrounding kills/half-opens the socket, and only a fresh REQ backfills what was missed.

- **`NostrRelayConnection` state machine**: generation-tokened connects; confirmed-live backoff (resets only when a frame arrives, cap 30 s); liveness monitor (match-nothing REQ → EOSE as pong; heals half-open sockets); `CLOSED` handled with the frame-immune `closedRebuilds` escalation (a persistently rejecting relay backs off, never hot-loops); stale-frame generation guard.
- **Single REQ, all filters** → 3× fewer relay subs (F8: strfry `maxSubsPerConnection=20` silently CLOSED the overflow).
- **`since`-bounded replay**: persisted per-inbox high-water mark, `since = HWM − 300 s` on every REQ, evaluated at send time — reconnects fetch the gap, never full history. Per-generation subIDs + stream-token unsubscribe close the re-subscribe races.
- **`TransportLifecycleRepository`** owns the lifecycle (connect + foreground/connectivity triggers via injected streams; UIKit-free). The view layer's only transport contact is `ConnectionStatusFlow.isConnected` → red **"Offline"** toolbar indicator (included here as this feature's user-facing surface).

Test-target changes are mechanical compile fixes only (`reconnect()` no-ops). Existing suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)