### PR TITLE
feat(inbox): dedup + re-delivery handling — seen-ids, dispatch lanes, invite ledger (2/4)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -34,6 +34,40 @@
         }
       }
     },
+    "Group": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Группа"
+          }
+        }
+      }
+    },
+    "Invited by %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invited by %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пригласил(а) %@"
+          }
+        }
+      }
+    },
     "Not connected to a relay": {
       "extractionState": "manual",
       "localizations": {
@@ -64,6 +98,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Не в сети"
+          }
+        }
+      }
+    },
+    "Request sent — awaiting approval": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request sent — awaiting approval"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запрос отправлен — ожидает одобрения"
           }
         }
       }

--- a/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
+++ b/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
@@ -20,17 +20,26 @@ struct InboxFanoutInteractor: Sendable {
     /// Coalescing window — multiple identity changes within this many
     /// milliseconds collapse into one re-subscribe.
     let debounceMilliseconds: UInt64
+    /// Durable dedup by Nostr event id, consulted BEFORE the dispatcher
+    /// decrypts. Re-delivered events (HWM slack overlap, multi-relay,
+    /// reconnect replay) cost a set lookup instead of a decrypt + chain
+    /// read. Marked seen only after a dispatch completes, so a crash
+    /// midway re-delivers rather than loses. nil disables dedup (tests
+    /// that assert re-delivery behavior).
+    let seenEventIDs: SeenEventIDStore?
 
     init(
         inboxTransport: any InboxTransport,
         identityRepository: IdentityRepository,
         dispatcher: IncomingMessageDispatcher,
-        debounceMilliseconds: UInt64 = 250
+        debounceMilliseconds: UInt64 = 250,
+        seenEventIDs: SeenEventIDStore? = nil
     ) {
         self.inboxTransport = inboxTransport
         self.identityRepository = identityRepository
         self.dispatcher = dispatcher
         self.debounceMilliseconds = debounceMilliseconds
+        self.seenEventIDs = seenEventIDs
     }
 
     /// Run until cancelled. Subscribes to every identity's inbox tag
@@ -38,7 +47,8 @@ struct InboxFanoutInteractor: Sendable {
     func run() async {
         let subscriptions = ActiveSubscriptions(
             inboxTransport: inboxTransport,
-            dispatcher: dispatcher
+            dispatcher: dispatcher,
+            seenEventIDs: seenEventIDs
         )
 
         // Apply the current identity set immediately on launch (the
@@ -107,11 +117,17 @@ struct InboxFanoutInteractor: Sendable {
 private actor ActiveSubscriptions {
     private let inboxTransport: any InboxTransport
     private let dispatcher: IncomingMessageDispatcher
+    private let seenEventIDs: SeenEventIDStore?
     private var live: [IdentityID: (tag: TransportInboxID, task: Task<Void, Never>)] = [:]
 
-    init(inboxTransport: any InboxTransport, dispatcher: IncomingMessageDispatcher) {
+    init(
+        inboxTransport: any InboxTransport,
+        dispatcher: IncomingMessageDispatcher,
+        seenEventIDs: SeenEventIDStore?
+    ) {
         self.inboxTransport = inboxTransport
         self.dispatcher = dispatcher
+        self.seenEventIDs = seenEventIDs
     }
 
     func apply(_ wanted: Set<IdentityID>, tagsByID: [IdentityID: TransportInboxID]) async {
@@ -130,15 +146,25 @@ private actor ActiveSubscriptions {
             // `InvitationEnvelopeDecrypting` so cross-identity envelopes
             // decrypt under the right per-identity X25519 key, even if
             // the user has switched to a different identity.
-            let task = Task { [dispatcher, id] in
+            let task = Task { [dispatcher, seenEventIDs, id] in
                 for await message in stream {
                     if Task.isCancelled { break }
+                    // Dedup BEFORE decrypt: a re-delivered event (slack
+                    // overlap, second relay, reconnect replay) is a set
+                    // lookup, not a decrypt + possible chain read.
+                    if let seenEventIDs,
+                       await seenEventIDs.contains(message.messageID) {
+                        continue
+                    }
                     await dispatcher.dispatch(
                         messageID: message.messageID,
                         ownerIdentityID: id,
                         payload: message.payload,
                         receivedAt: message.receivedAt
                     )
+                    // Mark AFTER dispatch: a crash mid-processing means
+                    // re-delivery (idempotent), never loss.
+                    await seenEventIDs?.markSeen(message.messageID)
                 }
             }
             live[id] = (tag, task)

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -78,6 +78,21 @@ struct IncomingMessageDispatcher: Sendable {
     /// raises a message to `.read` when this device also sends read
     /// receipts. Defaulted to `true` (the shipping default).
     var readReceiptsEnabled: @Sendable () -> Bool = { true }
+    /// The slow lane: FIFO, serial, non-blocking-to-enqueue. Every
+    /// invitation / group-state payload runs here so a backlog of
+    /// chain-verifying handlers can never starve live chat (F6). One
+    /// lane per dispatcher instance; the struct's copies share it
+    /// (actor reference), preserving FIFO across the app's single
+    /// dispatcher.
+    var slowLane = SerialDispatchLane()
+    /// Durable per-(owner, group) invite dispositions. Consulted before
+    /// queueing a `GroupInviteOfferPayload`: a relay retains the offer
+    /// and re-serves it on every re-subscribe, so once the user has
+    /// requested / declined / joined, re-deliveries must be dropped at
+    /// the door — otherwise the offer "blinks" back into the inbox
+    /// forever. Defaulted to a no-op for the same reason as
+    /// `pendingInvites`.
+    var inviteDispositions: any InviteDispositionStoring = NoopInviteDispositionStore()
 
     func dispatch(
         messageID: String,
@@ -94,111 +109,132 @@ struct IncomingMessageDispatcher: Sendable {
             envelopeBytes: payload,
             asIdentity: ownerIdentityID
         ) else {
-            await fallThrough(
-                messageID: messageID,
-                ownerIdentityID: ownerIdentityID,
-                payload: payload,
-                receivedAt: receivedAt
-            )
+            // Undecryptable ciphertext lands in the opaque invitations
+            // queue — invitation domain, so it rides the slow lane.
+            await slowLane.enqueue { [self] in
+                await fallThrough(
+                    messageID: messageID,
+                    ownerIdentityID: ownerIdentityID,
+                    payload: payload,
+                    receivedAt: receivedAt
+                )
+            }
             return
         }
 
-        // Fast path 0: GroupInviteOfferPayload — a push invitation.
-        // Decoded + queued for the user's explicit Accept; it carries
-        // no epoch / commitment / roster, so it never materializes a
-        // group or touches the on-chain commitment. Tried first
-        // because its required `inviter_alias` + `intro_pub` keys are
-        // unique to this type — no other inbox payload decodes as one.
+        // ── Lane routing ────────────────────────────────────────────
+        // Chat messages + receipts are handled INLINE (fast lane): pure
+        // local work, milliseconds. Everything invitation / group-state
+        // shaped goes through `slowLane` (FIFO, serial): those handlers
+        // may hit the relayer for a chain read, and processing them
+        // inline meant a backlog of replayed invitations stalled live
+        // chat for minutes (F6). The fan-out's serial loop returns
+        // immediately for slow payloads; relative order WITHIN the slow
+        // family is preserved by the lane's FIFO guarantee.
+
+        // Slow: GroupInviteOfferPayload — a push invitation. Decoded +
+        // queued for the user's explicit Accept; carries no epoch /
+        // commitment / roster, so it never materializes a group. Tried
+        // first because its required `inviter_alias` + `intro_pub` keys
+        // are unique to this type.
         if let offer = try? JSONDecoder().decode(
             GroupInviteOfferPayload.self,
             from: envelope.plaintext
         ) {
-            await recordOffer(
-                offer,
-                messageID: messageID,
-                ownerIdentityID: ownerIdentityID,
-                receivedAt: receivedAt
-            )
+            await slowLane.enqueue { [self] in
+                await recordOffer(
+                    offer,
+                    messageID: messageID,
+                    ownerIdentityID: ownerIdentityID,
+                    receivedAt: receivedAt
+                )
+            }
             return
         }
 
-        // Fast path 0.5: GroupStateRefreshRequest — a member asking the
-        // admin for the current group state (Option 2 verify-at-current).
+        // Slow: GroupStateRefreshRequest — a member asking the admin for
+        // the current group state (Option 2 verify-at-current).
         // Admin-side; delegated to the verifier, which gates on the
         // requester being a current member before disclosing the salt.
         if let refresh = try? JSONDecoder().decode(
             GroupStateRefreshRequest.self,
             from: envelope.plaintext
         ) {
-            await groupStateRefresher.handleRefreshRequest(
-                refresh,
-                ownerIdentityID: ownerIdentityID,
-                requesterEd25519: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await groupStateRefresher.handleRefreshRequest(
+                    refresh,
+                    ownerIdentityID: ownerIdentityID,
+                    requesterEd25519: senderKey
+                )
+            }
             return
         }
 
-        // Fast path 1: MemberAnnouncementPayload — incremental roster
-        // delta for an existing local group.
+        // Slow: MemberAnnouncementPayload — incremental roster delta for
+        // an existing local group (may verify against the chain).
         if let announcement = try? JSONDecoder().decode(
             MemberAnnouncementPayload.self,
             from: envelope.plaintext
         ) {
-            await applyAnnouncement(
-                announcement,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await applyAnnouncement(
+                    announcement,
+                    senderEd25519PublicKey: senderKey
+                )
+            }
             return
         }
 
-        // Fast path 1.5: GroupAvatarPayload — admin updated the group
-        // photo. Group-state delta like the announcement above; its
-        // unique `avatar_*` keys keep it from decoding as a chat
-        // message (which shares version / group_id / sender).
+        // Slow: GroupAvatarPayload — admin updated the group photo.
+        // Group-state delta; its unique `avatar_*` keys keep it from
+        // decoding as a chat message. Local-only work, but it rides the
+        // slow lane so group-state mutations stay mutually ordered.
         if let avatarMsg = try? JSONDecoder().decode(
             GroupAvatarPayload.self,
             from: envelope.plaintext
         ) {
-            await applyAvatar(
-                avatarMsg,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await applyAvatar(avatarMsg, senderEd25519PublicKey: senderKey)
+            }
             return
         }
 
-        // Fast path 1.6: GroupNamePayload — admin renamed the group.
-        // Group-state delta like the avatar above; its unique `name_*`
-        // keys keep it from decoding as any other payload.
+        // Slow: GroupNamePayload — admin renamed the group. Same
+        // ordering rationale as the avatar above.
         if let nameMsg = try? JSONDecoder().decode(
             GroupNamePayload.self,
             from: envelope.plaintext
         ) {
-            await applyName(
-                nameMsg,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await applyName(nameMsg, senderEd25519PublicKey: senderKey)
+            }
             return
         }
 
-        // Fast path 2: GroupInvitationPayload — materialize a local
-        // group under `ownerIdentityID`. Skips the invitations queue
-        // because the group is now visible in the chat list.
+        // Slow: GroupInvitationPayload — materialize a local group under
+        // `ownerIdentityID` (chain-verifies the snapshot commitment).
         if let invitation = try? JSONDecoder().decode(
             GroupInvitationPayload.self,
             from: envelope.plaintext
         ) {
-            await materializeGroup(
-                invitation,
-                ownerIdentityID: ownerIdentityID,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey
-            )
+            let senderKey = envelope.senderEd25519PublicKey
+            await slowLane.enqueue { [self] in
+                await materializeGroup(
+                    invitation,
+                    ownerIdentityID: ownerIdentityID,
+                    senderEd25519PublicKey: senderKey
+                )
+            }
             return
         }
 
-        // Fast path: chat receipt — a peer acking one of OUR messages
-        // as delivered / read. Wire-shape-disjoint from every other
-        // payload (unique `kind` + `message_ids` keys), so this `try?`
-        // decode can't steal a different payload.
+        // Fast: chat receipt — a peer acking one of OUR messages as
+        // delivered / read. Wire-shape-disjoint from every other payload
+        // (unique `kind` + `message_ids` keys). Pure local status flip.
         if let receipt = try? JSONDecoder().decode(
             ChatReceiptPayload.self,
             from: envelope.plaintext
@@ -207,10 +243,11 @@ struct IncomingMessageDispatcher: Sendable {
             return
         }
 
-        // Fast path 3: ChatMessagePayload — body of the chat thread.
-        // Verifies the envelope's Ed25519 signer matches the claimed
-        // sender's `MemberProfile.sendingPubkey` (insider-spoof
-        // defense, PR 3), then persists via `messageRepository`.
+        // Fast: ChatMessagePayload — body of the chat thread. Verifies
+        // the envelope's Ed25519 signer matches the claimed sender's
+        // `MemberProfile.sendingPubkey` (insider-spoof defense), then
+        // persists via `messageRepository`. Never waits behind the slow
+        // lane — this is the latency-critical path.
         if let chatMessage = try? JSONDecoder().decode(
             ChatMessagePayload.self,
             from: envelope.plaintext
@@ -223,13 +260,22 @@ struct IncomingMessageDispatcher: Sendable {
             return
         }
 
-        // Plaintext didn't match any known payload — fall through.
-        await fallThrough(
-            messageID: messageID,
-            ownerIdentityID: ownerIdentityID,
-            payload: payload,
-            receivedAt: receivedAt
-        )
+        // Plaintext didn't match any known payload — fall through to the
+        // opaque invitations queue (invitation domain → slow lane).
+        await slowLane.enqueue { [self] in
+            await fallThrough(
+                messageID: messageID,
+                ownerIdentityID: ownerIdentityID,
+                payload: payload,
+                receivedAt: receivedAt
+            )
+        }
+    }
+
+    /// Test seam: wait for every slow-lane job enqueued so far (plus any
+    /// they chain, e.g. the chat retry) to finish.
+    func drainSlowLane() async {
+        await slowLane.drain()
     }
 
     /// Queue a decoded push offer for the user's explicit Accept.
@@ -242,6 +288,39 @@ struct IncomingMessageDispatcher: Sendable {
         ownerIdentityID: IdentityID,
         receivedAt: Date
     ) async {
+        // Disposition gate: once this (owner, group) invite has been
+        // requested / declined / joined, a re-delivered offer (the relay
+        // re-serves retained events on every re-subscribe, possibly
+        // under a fresh event id) is dropped at the door. Without this
+        // the offer re-enters the pending list and the materialized-
+        // group consumer removes it again — the "blinking invite" loop.
+        switch await inviteDispositions.disposition(
+            owner: ownerIdentityID, groupID: offer.groupID
+        ) {
+        case .requested, .declined, .joined:
+            return
+        case .offered, nil:
+            break
+        }
+
+        // Belt for the joined case the ledger may not have seen (e.g. a
+        // group materialized before this ledger existed): a local group
+        // for this (owner, group) means the invite is spent.
+        let alreadyJoined = await groupRepository.currentGroups().contains {
+            $0.groupIDData == offer.groupID && $0.ownerIdentityID == ownerIdentityID
+        }
+        if alreadyJoined {
+            await inviteDispositions.record(
+                .joined, owner: ownerIdentityID, groupID: offer.groupID,
+                groupName: offer.groupName, inviterAlias: offer.inviterAlias
+            )
+            return
+        }
+
+        await inviteDispositions.record(
+            .offered, owner: ownerIdentityID, groupID: offer.groupID,
+            groupName: offer.groupName, inviterAlias: offer.inviterAlias
+        )
         await pendingInvites.record(PendingInvite(
             id: messageID,
             ownerIdentityID: ownerIdentityID,
@@ -736,7 +815,8 @@ struct IncomingMessageDispatcher: Sendable {
     private func persistChatMessage(
         _ payload: ChatMessagePayload,
         ownerIdentityID: IdentityID,
-        senderEd25519PublicKey: Data?
+        senderEd25519PublicKey: Data?,
+        allowRetry: Bool = true
     ) async {
         // Envelope must have been signed — anonymous chat messages
         // are not part of the v1 trust model.
@@ -751,6 +831,23 @@ struct IncomingMessageDispatcher: Sendable {
         guard let group = groups.first(where: {
             $0.id == groupIDHex && $0.ownerIdentityID == ownerIdentityID
         }) else {
+            // The group may be *about to* exist: with the lane split, a
+            // chat message can race ahead of the invitation that
+            // materializes its group (the invitation rides the slow
+            // lane). Retry once BEHIND the slow lane's current queue —
+            // if a materializing invitation is in flight, the retry runs
+            // after it and the message lands; otherwise it's a genuine
+            // stale delivery and the retry drops it like before.
+            if allowRetry {
+                await slowLane.enqueue { [self] in
+                    await persistChatMessage(
+                        payload,
+                        ownerIdentityID: ownerIdentityID,
+                        senderEd25519PublicKey: senderEd25519PublicKey,
+                        allowRetry: false
+                    )
+                }
+            }
             return
         }
 

--- a/Sources/OnymIOS/Inbox/InviteDispositionLedger.swift
+++ b/Sources/OnymIOS/Inbox/InviteDispositionLedger.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+/// What this device has already decided about a group invite, keyed by
+/// the *logical* invite `(owner identity, group id)` — deliberately not
+/// the Nostr event id, so a re-broadcast offer under a fresh event id
+/// for a group the user already acted on is still recognized.
+enum InviteDisposition: String, Codable, Sendable {
+    /// Offer surfaced, awaiting the user's Accept / Dismiss.
+    case offered
+    /// User accepted: a join request was sent, awaiting the admin's
+    /// approval. Survives relaunch — the UI shows an honest
+    /// "request sent, awaiting approval" row instead of re-offering.
+    case requested
+    /// User dismissed the offer. Sticky: re-delivered offers stay dropped.
+    case declined
+    /// The group materialized locally — the invite is spent.
+    case joined
+
+    /// Monotonic rank: a disposition only ever moves forward, so a
+    /// re-delivered stale offer can never resurrect a handled invite.
+    /// `requested` and `declined` share a rank (mutually exclusive user
+    /// choices); `joined` is terminal.
+    var rank: Int {
+        switch self {
+        case .offered: return 0
+        case .requested, .declined: return 1
+        case .joined: return 2
+        }
+    }
+}
+
+/// One ledger row, carrying enough display metadata to render the
+/// "awaiting approval" surface without the original offer event.
+struct InviteDispositionEntry: Codable, Equatable, Sendable, Identifiable {
+    let ownerIdentityID: String
+    let groupIDHex: String
+    var state: InviteDisposition
+    var groupName: String?
+    var inviterAlias: String?
+    var updatedAt: Date
+
+    var id: String { "\(ownerIdentityID)|\(groupIDHex)" }
+}
+
+/// Narrow write/read seam the dispatcher depends on (mirrors
+/// `PendingInvitesRecording`).
+protocol InviteDispositionStoring: Sendable {
+    func disposition(owner: IdentityID, groupID: Data) async -> InviteDisposition?
+    func record(
+        _ state: InviteDisposition,
+        owner: IdentityID,
+        groupID: Data,
+        groupName: String?,
+        inviterAlias: String?
+    ) async
+}
+
+/// Persisted, per-identity-filtered ledger of invite dispositions.
+/// The durable "I already handled this" record the relay can't provide:
+/// a Nostr relay is a store, not a queue — it may re-serve an invite
+/// offer forever, so the client must own the disposition state. Mirrors
+/// the snapshot/filter shape of `PendingInvitesStore`.
+actor InviteDispositionLedger: InviteDispositionStoring {
+    private let defaults: UserDefaults
+    private var entries: [String: InviteDispositionEntry]
+    private var currentIdentity: IdentityID?
+    private var continuations: [UUID: AsyncStream<[InviteDispositionEntry]>.Continuation] = [:]
+    private static let key = "app.onym.ios.inbox.inviteDispositions"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.key),
+           let decoded = try? JSONDecoder().decode([InviteDispositionEntry].self, from: data) {
+            self.entries = Dictionary(uniqueKeysWithValues: decoded.map { ($0.id, $0) })
+        } else {
+            self.entries = [:]
+        }
+    }
+
+    // MARK: - InviteDispositionStoring
+
+    func disposition(owner: IdentityID, groupID: Data) -> InviteDisposition? {
+        entries[Self.entryID(owner: owner, groupID: groupID)]?.state
+    }
+
+    /// Record a disposition. Monotonic: writes that don't advance the
+    /// rank are ignored (a re-delivered offer can't downgrade
+    /// `requested` back to `offered`). Metadata is refreshed when
+    /// provided so later states keep the best-known display strings.
+    func record(
+        _ state: InviteDisposition,
+        owner: IdentityID,
+        groupID: Data,
+        groupName: String?,
+        inviterAlias: String?
+    ) {
+        let id = Self.entryID(owner: owner, groupID: groupID)
+        if var existing = entries[id] {
+            guard state.rank > existing.state.rank else {
+                // Same-or-lower rank: keep the state, still absorb
+                // fresher metadata (e.g. a renamed group on a re-offer).
+                var changed = false
+                if let groupName, existing.groupName != groupName {
+                    existing.groupName = groupName; changed = true
+                }
+                if let inviterAlias, existing.inviterAlias != inviterAlias {
+                    existing.inviterAlias = inviterAlias; changed = true
+                }
+                if changed { entries[id] = existing; persistAndPublish() }
+                return
+            }
+            existing.state = state
+            existing.updatedAt = Date()
+            if let groupName { existing.groupName = groupName }
+            if let inviterAlias { existing.inviterAlias = inviterAlias }
+            entries[id] = existing
+        } else {
+            entries[id] = InviteDispositionEntry(
+                ownerIdentityID: owner.rawValue.uuidString,
+                groupIDHex: Self.hex(groupID),
+                state: state,
+                groupName: groupName,
+                inviterAlias: inviterAlias,
+                updatedAt: Date()
+            )
+        }
+        persistAndPublish()
+    }
+
+    // MARK: - Identity scoping (mirrors PendingInvitesStore)
+
+    func setCurrentIdentity(_ id: IdentityID?) {
+        currentIdentity = id
+        publish()
+    }
+
+    /// Cascade for the identity-removal flow.
+    func removeForOwner(_ id: IdentityID) {
+        let owner = id.rawValue.uuidString
+        let before = entries.count
+        entries = entries.filter { $0.value.ownerIdentityID != owner }
+        if entries.count != before { persistAndPublish() }
+    }
+
+    /// Hot stream of the current identity's entries, newest first.
+    nonisolated var snapshots: AsyncStream<[InviteDispositionEntry]> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    static func entryID(owner: IdentityID, groupID: Data) -> String {
+        "\(owner.rawValue.uuidString)|\(hex(groupID))"
+    }
+
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func subscribe(
+        id: UUID,
+        continuation: AsyncStream<[InviteDispositionEntry]>.Continuation
+    ) {
+        continuations[id] = continuation
+        continuation.yield(filtered())
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func filtered() -> [InviteDispositionEntry] {
+        guard let currentIdentity else { return [] }
+        let owner = currentIdentity.rawValue.uuidString
+        return entries.values
+            .filter { $0.ownerIdentityID == owner }
+            .sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    private func persistAndPublish() {
+        if let data = try? JSONEncoder().encode(Array(entries.values)) {
+            defaults.set(data, forKey: Self.key)
+        }
+        publish()
+    }
+
+    private func publish() {
+        let snapshot = filtered()
+        for continuation in continuations.values { continuation.yield(snapshot) }
+    }
+}
+
+/// Default for the dispatcher's seam: records nothing, reports nothing —
+/// existing tests construct dispatchers without threading a ledger.
+struct NoopInviteDispositionStore: InviteDispositionStoring {
+    func disposition(owner: IdentityID, groupID: Data) async -> InviteDisposition? { nil }
+    func record(
+        _ state: InviteDisposition,
+        owner: IdentityID,
+        groupID: Data,
+        groupName: String?,
+        inviterAlias: String?
+    ) async {}
+}

--- a/Sources/OnymIOS/Inbox/PendingInvitesFlow.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesFlow.swift
@@ -18,6 +18,12 @@ import Observation
 final class PendingInvitesFlow {
     /// Pending invites for the current identity, newest first.
     var pending: [PendingInvite] = []
+    /// Accepted-but-unapproved invites for the current identity — the
+    /// durable "Request sent · awaiting approval" rows. Sourced from the
+    /// disposition ledger, so they survive relaunch instead of vanishing
+    /// (and can't be accepted twice); each clears when its group
+    /// materializes (→ `.joined`).
+    var awaitingApproval: [InviteDispositionEntry] = []
     /// Groups that were accepted but couldn't be verified at an exact
     /// epoch yet — awaiting (or unable to get) the current state from
     /// the admin. Surfaced so the user knows a join is in flight or
@@ -38,6 +44,11 @@ final class PendingInvitesFlow {
     private let store: PendingInvitesStore
     private let verificationStore: PendingVerificationStore
     private let groupRepository: GroupRepository
+    /// Durable (owner, group) dispositions — written on accept / dismiss
+    /// / group-materialize; read by the dispatcher to drop re-delivered
+    /// offers and by this flow for the awaiting-approval rows. nil keeps
+    /// the pre-ledger behavior (existing tests).
+    private let dispositions: InviteDispositionLedger?
     /// Mirrors `JoinFlow`'s injected `submitRequest` — seals + sends a
     /// `JoinRequestPayload` for the given capability. Returns the
     /// sender outcome so the flow can surface errors.
@@ -52,6 +63,7 @@ final class PendingInvitesFlow {
     private var streamingTask: Task<Void, Never>?
     private var verifyingTask: Task<Void, Never>?
     private var groupWatchTask: Task<Void, Never>?
+    private var ledgerTask: Task<Void, Never>?
 
     init(
         store: PendingInvitesStore,
@@ -59,7 +71,8 @@ final class PendingInvitesFlow {
         groupRepository: GroupRepository,
         submitJoin: @escaping @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome,
         displayLabel: @escaping @MainActor () -> String,
-        retryVerification: @escaping @Sendable (String) async -> Void
+        retryVerification: @escaping @Sendable (String) async -> Void,
+        dispositions: InviteDispositionLedger? = nil
     ) {
         self.store = store
         self.verificationStore = verificationStore
@@ -67,6 +80,7 @@ final class PendingInvitesFlow {
         self.submitJoin = submitJoin
         self.displayLabel = displayLabel
         self.retryVerification = retryVerification
+        self.dispositions = dispositions
     }
 
     func isInFlight(_ id: String) -> Bool { inFlightIDs.contains(id) }
@@ -95,13 +109,38 @@ final class PendingInvitesFlow {
                 self.verifying = snapshot
             }
         }
+        // Awaiting-approval rows: mirror the ledger's requested entries.
+        if let dispositions {
+            let dstream = dispositions.snapshots
+            ledgerTask = Task { @MainActor [weak self] in
+                for await entries in dstream {
+                    guard let self else { break }
+                    self.awaitingApproval = entries.filter { $0.state == .requested }
+                }
+            }
+        }
         let groups = groupRepository.snapshots
         let store = self.store
+        let dispositions = self.dispositions
         groupWatchTask = Task {
             for await groups in groups {
                 await store.consumeForMaterializedGroups(
                     Set(groups.map(\.groupIDData))
                 )
+                // A materialized group spends its invite: record .joined
+                // so re-delivered offers stay dropped and the awaiting-
+                // approval row clears.
+                if let dispositions {
+                    for group in groups {
+                        await dispositions.record(
+                            .joined,
+                            owner: group.ownerIdentityID,
+                            groupID: group.groupIDData,
+                            groupName: group.name,
+                            inviterAlias: nil
+                        )
+                    }
+                }
             }
         }
     }
@@ -113,6 +152,8 @@ final class PendingInvitesFlow {
         verifyingTask = nil
         groupWatchTask?.cancel()
         groupWatchTask = nil
+        ledgerTask?.cancel()
+        ledgerTask = nil
     }
 
     /// Retry a verification that got stuck because the admin was
@@ -142,6 +183,7 @@ final class PendingInvitesFlow {
         lastError = nil
         let label = displayLabel()
         let submitJoin = self.submitJoin
+        let dispositions = self.dispositions
         Task { @MainActor [weak self] in
             let outcome = await submitJoin(capability, label)
             guard let self else { return }
@@ -149,6 +191,23 @@ final class PendingInvitesFlow {
             switch outcome {
             case .sent:
                 self.requestedIDs.insert(id)
+                // Durable: the accept survives relaunch as an
+                // "awaiting approval" row, and the dispatcher drops
+                // re-delivered offers for this (owner, group) from now
+                // on — the invite can never blink back or be accepted
+                // twice.
+                if let dispositions {
+                    await dispositions.record(
+                        .requested,
+                        owner: invite.ownerIdentityID,
+                        groupID: invite.groupID,
+                        groupName: invite.groupName,
+                        inviterAlias: invite.inviterAlias
+                    )
+                    // The offer card is superseded by the durable
+                    // awaiting-approval row.
+                    await self.store.consume(id: id)
+                }
             case .noIdentityLoaded:
                 self.lastError = "Sign in first."
             case .transportFailed(let reason):
@@ -158,10 +217,25 @@ final class PendingInvitesFlow {
     }
 
     /// Drop an invite the user doesn't want. Local-only — no NACK to
-    /// the admin (their outstanding intro key just goes unused).
+    /// the admin (their outstanding intro key just goes unused). The
+    /// declined disposition is durable, so the relay re-serving the
+    /// offer can't resurrect it.
     func dismiss(_ id: String) {
         let store = self.store
-        Task { await store.consume(id: id) }
+        let dispositions = self.dispositions
+        let invite = pending.first(where: { $0.id == id })
+        Task {
+            if let dispositions, let invite {
+                await dispositions.record(
+                    .declined,
+                    owner: invite.ownerIdentityID,
+                    groupID: invite.groupID,
+                    groupName: invite.groupName,
+                    inviterAlias: invite.inviterAlias
+                )
+            }
+            await store.consume(id: id)
+        }
     }
 
     func dismissError() { lastError = nil }

--- a/Sources/OnymIOS/Inbox/PendingInvitesView.swift
+++ b/Sources/OnymIOS/Inbox/PendingInvitesView.swift
@@ -15,7 +15,8 @@ struct PendingInvitesView: View {
                 if let error = flow.lastError {
                     errorBanner(error)
                 }
-                if flow.pending.isEmpty && flow.verifying.isEmpty {
+                if flow.pending.isEmpty && flow.verifying.isEmpty
+                    && flow.awaitingApproval.isEmpty {
                     emptyState
                 } else {
                     inviteList
@@ -86,6 +87,9 @@ struct PendingInvitesView: View {
                 ForEach(flow.verifying) { entry in
                     verifyingCard(entry)
                 }
+                ForEach(flow.awaitingApproval) { entry in
+                    awaitingApprovalCard(entry)
+                }
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
@@ -130,6 +134,36 @@ struct PendingInvitesView: View {
         .background(OnymTokens.surface)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .accessibilityIdentifier("pending_invites.verifying.\(entry.groupIDHex)")
+    }
+
+    /// An accepted invite whose join request is with the admin. Durable
+    /// (ledger-backed): survives relaunch, can't be re-accepted, clears
+    /// on its own the moment the admin approves and the group
+    /// materializes.
+    private func awaitingApprovalCard(_ entry: InviteDispositionEntry) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(entry.groupName?.isEmpty == false ? entry.groupName! : String(localized: "Group"))
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            HStack(spacing: 8) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text3)
+                Text("Request sent \u{2014} awaiting approval")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            if let inviter = entry.inviterAlias, !inviter.isEmpty {
+                Text("Invited by \(inviter)")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text3)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(OnymTokens.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .accessibilityIdentifier("pending_invites.awaiting.\(entry.groupIDHex)")
     }
 
     private func inviteCard(_ invite: PendingInvite) -> some View {

--- a/Sources/OnymIOS/Inbox/SeenEventIDStore.swift
+++ b/Sources/OnymIOS/Inbox/SeenEventIDStore.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Durable, bounded record of Nostr event ids that have already been
+/// fully dispatched. The inbox fan-out consults it *before* decrypting,
+/// so re-delivered events — the HWM slack window, the same event from
+/// multiple relays, a reconnect's replay — cost a set lookup instead of
+/// an X25519/AES-GCM decrypt and a possible chain read.
+///
+/// Ids are marked seen only *after* a dispatch completes: a crash midway
+/// re-delivers (all dispatch paths are idempotent) rather than losing the
+/// event. Eviction is insertion-ordered FIFO with a fixed capacity —
+/// events older than the window are already excluded by the HWM `since`
+/// bound, so the set only needs to cover the recent overlap.
+///
+/// Persistence is debounced (bursty replays write once, not per event);
+/// losing the tail of unsaved marks on a kill is harmless — the events
+/// re-dispatch idempotently next launch.
+actor SeenEventIDStore {
+    private let defaults: UserDefaults
+    private let capacity: Int
+    private var order: [String]
+    private var members: Set<String>
+    private var persistScheduled = false
+    private static let key = "app.onym.ios.inbox.seenEventIDs"
+    private static let persistDebounce: Duration = .seconds(1)
+
+    init(defaults: UserDefaults = .standard, capacity: Int = 4096) {
+        self.defaults = defaults
+        self.capacity = capacity
+        let stored = defaults.stringArray(forKey: Self.key) ?? []
+        self.order = Array(stored.suffix(capacity))
+        self.members = Set(order)
+    }
+
+    func contains(_ id: String) -> Bool {
+        members.contains(id)
+    }
+
+    func markSeen(_ id: String) {
+        guard !members.contains(id) else { return }
+        members.insert(id)
+        order.append(id)
+        if order.count > capacity {
+            let evicted = order.removeFirst()
+            members.remove(evicted)
+        }
+        schedulePersist()
+    }
+
+    private func schedulePersist() {
+        guard !persistScheduled else { return }
+        persistScheduled = true
+        Task {
+            try? await Task.sleep(for: Self.persistDebounce)
+            self.persistNow()
+        }
+    }
+
+    private func persistNow() {
+        persistScheduled = false
+        defaults.set(order, forKey: Self.key)
+    }
+}

--- a/Sources/OnymIOS/Inbox/SerialDispatchLane.swift
+++ b/Sources/OnymIOS/Inbox/SerialDispatchLane.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// FIFO serial execution lane: jobs run strictly in enqueue order, one
+/// at a time, without blocking the enqueuer. Implemented as a chain of
+/// Tasks — each new job awaits the previous tail before running.
+///
+/// This is the dispatcher's *slow lane*: invitation / group-state
+/// payloads (which may hit the relayer for a chain read) are enqueued
+/// here so a backlog of them can never starve live chat delivery — the
+/// fan-out's `for await → dispatch` loop returns immediately for slow
+/// payloads instead of stalling behind a network round-trip per event
+/// (design doc F6: an invitation-spammed device queued live messages
+/// behind minutes of chain reads).
+actor SerialDispatchLane {
+    private var tail: Task<Void, Never>?
+    private var enqueuedCount = 0
+
+    /// Append a job. Returns immediately; the job runs after every job
+    /// enqueued before it has finished.
+    func enqueue(_ job: @escaping @Sendable () async -> Void) {
+        enqueuedCount += 1
+        let previous = tail
+        tail = Task {
+            await previous?.value
+            await job()
+        }
+    }
+
+    /// Suspend until everything enqueued so far — including jobs that
+    /// running jobs enqueue (e.g. the chat group-not-found retry) — has
+    /// finished. Test seam; production code never needs a barrier.
+    func drain() async {
+        while true {
+            let snapshot = enqueuedCount
+            guard let current = tail else { return }
+            await current.value
+            if enqueuedCount == snapshot { return }
+        }
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -19,6 +19,7 @@ struct OnymIOSApp: App {
     private let incomingInvitations: IncomingInvitationsRepository
     private let pendingInvitesStore: PendingInvitesStore
     private let pendingVerificationStore: PendingVerificationStore
+    private let inviteDispositionLedger: InviteDispositionLedger
     private let groupStateVerifier: GroupStateVerifier
     private let introKeyStore: any IntroKeyStore
     private let introRequestStore: any IntroRequestStore
@@ -325,6 +326,13 @@ struct OnymIOSApp: App {
         // identical to the deeplink join path.
         let pendingInvitesStore = PendingInvitesStore()
         self.pendingInvitesStore = pendingInvitesStore
+        // Durable (owner, group) invite dispositions — the "I already
+        // handled this" record a relay can't provide (it re-serves
+        // retained offers on every re-subscribe). Written by the invites
+        // flow (accept/dismiss/joined), read by the dispatcher to drop
+        // re-delivered offers at the door.
+        let inviteDispositionLedger = InviteDispositionLedger()
+        self.inviteDispositionLedger = inviteDispositionLedger
         // Verify-at-current (Option 2): stale snapshots defer here; the
         // verifier asks the admin for current state and surfaces a
         // "couldn't verify" state if the admin is offline.
@@ -366,7 +374,8 @@ struct OnymIOSApp: App {
             },
             retryVerification: { [groupStateVerifier] groupIDHex in
                 await groupStateVerifier.retry(groupIDHex: groupIDHex)
-            }
+            },
+            dispositions: inviteDispositionLedger
         )
 
         self.dependencies = AppDependencies(
@@ -573,6 +582,7 @@ struct OnymIOSApp: App {
                         await incomingInvitations.setCurrentIdentity(initialID)
                         await pendingInvitesStore.setCurrentIdentity(initialID)
                         await pendingVerificationStore.setCurrentIdentity(initialID)
+                        await inviteDispositionLedger.setCurrentIdentity(initialID)
                     }
                 }
                 .task {
@@ -583,6 +593,7 @@ struct OnymIOSApp: App {
                         await incomingInvitations.setCurrentIdentity(id)
                         await pendingInvitesStore.setCurrentIdentity(id)
                         await pendingVerificationStore.setCurrentIdentity(id)
+                        await inviteDispositionLedger.setCurrentIdentity(id)
                     }
                 }
                 .task {
@@ -596,6 +607,7 @@ struct OnymIOSApp: App {
                         await incomingInvitations.removeForOwner(removed)
                         await pendingInvitesStore.removeForOwner(removed)
                         await pendingVerificationStore.removeForOwner(removed)
+                        await inviteDispositionLedger.removeForOwner(removed)
                         // Cascade-wipe the removed identity's intro
                         // privkeys so an attacker who restores a
                         // backup post-removal can't decrypt
@@ -649,12 +661,17 @@ struct OnymIOSApp: App {
                             identity: identityRepository,
                             inboxTransport: inboxTransport
                         ),
-                        readReceiptsEnabled: { ReadReceiptsPreference.isEnabled }
+                        readReceiptsEnabled: { ReadReceiptsPreference.isEnabled },
+                        inviteDispositions: inviteDispositionLedger
                     )
                     let fanout = InboxFanoutInteractor(
                         inboxTransport: inboxTransport,
                         identityRepository: identityRepository,
-                        dispatcher: dispatcher
+                        dispatcher: dispatcher,
+                        // Durable event-id dedup: replay overlap and
+                        // multi-relay duplicates are dropped before
+                        // decrypt (marked seen only post-dispatch).
+                        seenEventIDs: SeenEventIDStore()
                     )
                     await fanout.run()
                 }

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -78,7 +78,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -103,7 +103,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-reply",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -128,7 +128,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -151,7 +151,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -173,7 +173,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: Data(repeating: 0xBB, count: 32)  // not Alice
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -195,7 +195,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: nil
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -219,7 +219,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: otherIdentity,
             payload: Data("envelope".utf8),
@@ -285,7 +285,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             plaintext: try JSONEncoder().encode(payload),
             envelopeSigner: secondSenderEd25519
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-multi",
             ownerIdentityID: secondIdentity,
             payload: Data("envelope".utf8),
@@ -313,13 +313,13 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         )
 
         // Same message delivered twice (Nostr re-delivery, etc.).
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: envelopeBytes,
             receivedAt: Date()
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1-retry",
             ownerIdentityID: owner,
             payload: envelopeBytes,
@@ -383,7 +383,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519,
             receiptSender: spy
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -408,7 +408,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             plaintext: try JSONEncoder().encode(receipt),
             envelopeSigner: senderEd25519
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "rcpt-1", ownerIdentityID: owner,
             payload: Data("envelope".utf8), receivedAt: Date()
         )
@@ -429,7 +429,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519,
             readReceiptsEnabled: { false }
         )
-        await off.dispatch(messageID: "r", ownerIdentityID: owner,
+        await off.dispatchAndDrain(messageID: "r", ownerIdentityID: owner,
                            payload: Data("e".utf8), receivedAt: Date())
         var stored = await messages.currentMessages(groupID: groupIDHex, owner: owner)
         XCTAssertEqual(stored.first { $0.id == idOff }?.status, .delivered,
@@ -441,7 +441,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeSigner: senderEd25519,
             readReceiptsEnabled: { true }
         )
-        await on.dispatch(messageID: "r2", ownerIdentityID: owner,
+        await on.dispatchAndDrain(messageID: "r2", ownerIdentityID: owner,
                           payload: Data("e".utf8), receivedAt: Date())
         stored = await messages.currentMessages(groupID: groupIDHex, owner: owner)
         XCTAssertEqual(stored.first { $0.id == idOff }?.status, .read)

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -70,7 +70,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-1",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -106,7 +106,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-2",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -152,7 +152,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-3",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -196,7 +196,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-trust-ok",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -238,7 +238,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-trust-bad",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -282,7 +282,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-unsigned",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -328,7 +328,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-adminless-member",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -372,7 +372,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-adminless-nonmember",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -415,7 +415,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-adminless-unsigned",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -452,7 +452,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "name-adminless-nonmember",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -490,7 +490,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "avatar-adminless-nonmember",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -526,7 +526,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "name-adminless-member",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -561,7 +561,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "avatar-ok",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -595,7 +595,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "name-ok",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -626,7 +626,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "name-imposter",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -660,7 +660,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "avatar-imposter",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -693,7 +693,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "avatar-clear",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -745,7 +745,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-cap",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -780,7 +780,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-no-commitment",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -825,7 +825,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-onchain-mismatch",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -862,7 +862,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-internal-mismatch",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -917,7 +917,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             chainState: chainState,
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-announce-mismatch",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -967,7 +967,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-mat",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1016,7 +1016,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-legacy",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1055,7 +1055,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-race",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1082,7 +1082,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-4",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1111,7 +1111,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-5",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1280,7 +1280,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             pendingInvites: spy
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-offer",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1333,7 +1333,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupStateRefresher: refresher
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-stale",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),
@@ -1380,9 +1380,9 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(messageID: "mat-1", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "mat-1", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
-        await dispatcher.dispatch(messageID: "mat-1-replay", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "mat-1-replay", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
 
         let after = await groups.currentGroups()
@@ -1426,7 +1426,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupStateRefresher: refresher
         )
 
-        await dispatcher.dispatch(messageID: "mat-throw", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "mat-throw", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
 
         let after = await groups.currentGroups()
@@ -1477,7 +1477,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupStateRefresher: refresher
         )
 
-        await dispatcher.dispatch(messageID: "mat-behind", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "mat-behind", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
 
         let after = await groups.currentGroups()
@@ -1523,7 +1523,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
         )
 
-        await dispatcher.dispatch(messageID: "ann-known", ownerIdentityID: owner,
+        await dispatcher.dispatchAndDrain(messageID: "ann-known", ownerIdentityID: owner,
                                   payload: Data("envelope".utf8), receivedAt: Date())
 
         XCTAssertEqual(chainState.calls.count, 0,
@@ -1555,7 +1555,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             groupStateRefresher: refresher
         )
 
-        await dispatcher.dispatch(
+        await dispatcher.dispatchAndDrain(
             messageID: "msg-refresh",
             ownerIdentityID: owner,
             payload: Data("envelope".utf8),

--- a/Tests/OnymIOSTests/Support/DispatcherTestHelpers.swift
+++ b/Tests/OnymIOSTests/Support/DispatcherTestHelpers.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import OnymIOS
+
+extension IncomingMessageDispatcher {
+    /// Dispatch and then wait for the slow lane to finish — restores the
+    /// pre-lane synchronous-effects contract most dispatcher tests were
+    /// written against: after this returns, invitation / group-state
+    /// side effects (and any chained retries) have been applied.
+    func dispatchAndDrain(
+        messageID: String,
+        ownerIdentityID: IdentityID,
+        payload: Data,
+        receivedAt: Date
+    ) async {
+        await dispatch(
+            messageID: messageID,
+            ownerIdentityID: ownerIdentityID,
+            payload: payload,
+            receivedAt: receivedAt
+        )
+        await drainSlowLane()
+    }
+}


### PR DESCRIPTION
**2/4 of the reconnect work** (squashed restructure of #196-dedup / #198 / #199 — no tests here by design; coverage in PR 4/4).

The relay is a store, not a queue: it re-serves retained events on every re-subscribe. With reconnects frequent-by-design (1/4), the client owns:

- **`SeenEventIDStore`** — durable event-id dedup checked in the fan-out *before decrypt* (marked seen only *after* dispatch: crash ⇒ re-delivery, never loss).
- **Dispatch lanes** — chat/receipts inline; invitation/group-state payloads ride a FIFO `SerialDispatchLane`, so a chain-verifying backlog can't starve live chat (F6). Chat-before-group race handled with a single retry queued behind the slow lane.
- **`InviteDispositionLedger`** — persisted, keyed by the *logical* invite `(owner, groupID)`; monotonic `offered → requested|declined → joined`. Kills the blinking invite, makes Accept durable ("Request sent — awaiting approval" row, no double-accept), Dismiss sticky.

Test-target changes are mechanical only (`dispatchAndDrain` migration preserving the existing tests' synchronous-effects contract). Existing suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)