### PR TITLE
feat(chat): view-layer message visibility — deferred scroll, new-messages pill, render-acked receipts (3/4)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -34,6 +34,59 @@
         }
       }
     },
+    "%lld new messages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld new message"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld new messages"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld новое сообщение"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld новых сообщения"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld новых сообщений"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld новых сообщений"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "Group": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -126,7 +126,8 @@ struct ChatThreadView: View {
             voiceLoader: voiceLoader,
             pendingMedia: pendingMedia.map { (id: $0.id, thumbnail: $0.thumbnail) },
             onSendMedia: { handleSendPendingMedia() },
-            onRemovePendingMedia: { id in pendingMedia.removeAll { $0.id == id } }
+            onRemovePendingMedia: { id in pendingMedia.removeAll { $0.id == id } },
+            onMessagesSeen: handleMessagesSeen
         )
         // One combined picker for photos + videos. Each pick is classified
         // in `onChange` by its content type.
@@ -255,25 +256,37 @@ struct ChatThreadView: View {
             else { return }
             for await snapshot in messageRepository.snapshots(groupID: groupID, owner: owner) {
                 messages = snapshot
-                // Read receipts: the thread is on-screen (this task is
-                // tied to its lifetime), so any incoming message here is
-                // "read". Gated by the symmetric setting, batched per
-                // sender, and de-duped via `ackedReadIDs`.
-                await sendReadReceipts(for: snapshot)
-                // Clear the chat-list unread badge: mark the group read up
-                // to the newest message the user is now looking at. No-op
-                // in the repo when it isn't newer than the stored marker.
-                if let newest = snapshot.map(\.sentAt).max() {
-                    await chatsFlow.markRead(groupID: groupID, upTo: newest)
-                }
+                // NB: read receipts + unread-badge clearing deliberately
+                // do NOT happen here. A snapshot reaching this task only
+                // proves the data arrived — not that a person saw it
+                // (app may be backgrounded, message below the fold).
+                // Both are driven by `handleMessagesSeen`, fed by the
+                // controller when bubbles are actually rendered on an
+                // active screen.
             }
         }
     }
 
-    /// Emit `.read` receipts for incoming messages the user is now
-    /// looking at. No-op when the setting is off. Groups unacked
-    /// incoming IDs by sender and ships one receipt per sender to that
-    /// sender's inbox key (resolved from the group's member profiles).
+    /// Render-acknowledged "seen" handler: the controller reports
+    /// incoming messages whose bubbles were actually painted on an
+    /// active screen. Ship `.read` receipts for them and clear the
+    /// chat-list unread badge up to the newest seen message — both now
+    /// mean what they say.
+    private func handleMessagesSeen(_ seen: [ChatMessage]) {
+        let chatsFlow = chatsFlow
+        let groupID = groupID
+        Task {
+            await sendReadReceipts(for: seen)
+            if let newest = seen.map(\.sentAt).max() {
+                await chatsFlow.markRead(groupID: groupID, upTo: newest)
+            }
+        }
+    }
+
+    /// Emit `.read` receipts for incoming messages the user has now
+    /// seen. No-op when the setting is off. Groups unacked incoming IDs
+    /// by sender and ships one receipt per sender to that sender's
+    /// inbox key (resolved from the group's member profiles).
     private func sendReadReceipts(for snapshot: [ChatMessage]) async {
         guard ReadReceiptsPreference.isEnabled else { return }
         guard let group = chatsFlow.groups.first(where: { $0.id == groupID }) else { return }
@@ -400,6 +413,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let pendingMedia: [(id: UUID, thumbnail: UIImage)]
     let onSendMedia: () -> Void
     let onRemovePendingMedia: (UUID) -> Void
+    let onMessagesSeen: ([ChatMessage]) -> Void
 
     func makeUIViewController(context: Context) -> ChatThreadViewController {
         let vc = ChatThreadViewController()
@@ -447,6 +461,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         vc.voiceLoader = voiceLoader
         vc.onSendMedia = onSendMedia
         vc.onRemovePendingMedia = onRemovePendingMedia
+        vc.onMessagesSeen = onMessagesSeen
         vc.update(memberProfiles: memberProfiles)
         vc.update(invitationMessage: invitationMessage)
         vc.update(messages: messages)

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -59,8 +59,43 @@ final class ChatThreadViewController: UIViewController {
     var onSendMedia: (() -> Void)?
     /// Fired when the ✕ on a staged item is tapped (host drops it).
     var onRemovePendingMedia: ((UUID) -> Void)?
+    /// Fired with incoming messages whose bubbles have actually been
+    /// rendered on screen while the app is active — the host sends
+    /// `.read` receipts and clears the unread badge from here. This is
+    /// deliberately NOT the data stream: receipting from snapshot
+    /// processing marked messages "read" that were never painted (app
+    /// backgrounded, thread below the fold), telling senders a lie.
+    /// Each message is reported at most once per controller lifetime.
+    var onMessagesSeen: (([ChatMessage]) -> Void)?
+    /// Incoming message ids already reported through `onMessagesSeen`.
+    private var reportedSeenIDs: Set<UUID> = []
 
     private let tableView = UITableView()
+    /// Floating "N new messages" affordance, shown above the input panel
+    /// when incoming messages land while the user is scrolled up in
+    /// history — auto-scrolling would yank them away from what they're
+    /// reading, but the arrival must still be user-visible. Tapping
+    /// scrolls to the bottom; reaching the bottom by hand clears it too.
+    private let newMessagesPill = UIButton(type: .system)
+    /// Incoming messages that arrived while the user was away from the
+    /// bottom — the pill's count. Reset whenever the bottom is reached.
+    private var unseenIncomingCount = 0
+    /// Deferred auto-scroll: set when a fresh message wants the scroll
+    /// pulled to the bottom but the view can't scroll reliably right now
+    /// (app backgrounded / mid-foreground-transition / view not in a
+    /// window — exactly where the reconnect backfill lands). Flushed on
+    /// `viewDidAppear` and `didBecomeActiveNotification`, so a message
+    /// received while backgrounded is on screen the moment the user is.
+    private(set) var pendingScrollToBottom = false
+    /// Whether a scroll performed right now will actually stick. UIKit
+    /// quietly drops scroll-to-row work applied while the app isn't
+    /// active or the view isn't in a window. Injectable so tests can
+    /// drive the deferred path without a real app lifecycle.
+    lazy var canScrollNow: () -> Bool = { [weak self] in
+        guard let self, let view = self.viewIfLoaded else { return false }
+        return view.window != nil
+            && UIApplication.shared.applicationState == .active
+    }
     /// The group's invitation message, surfaced in the empty state.
     private var invitationMessage: String?
     /// Rich empty state (invitation + members + privacy points), hosted
@@ -118,7 +153,18 @@ final class ChatThreadViewController: UIViewController {
         buildTableView()
         buildInputPanel()
         layout()
+        buildNewMessagesPill()
         configureDataSource()
+
+        // A backfilled message can land while the app is backgrounded or
+        // mid-foreground-transition, where a scroll won't stick — flush
+        // the deferred scroll the moment the app is actually active.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
 
         // The input panel rides the keyboard up via the
         // `keyboardLayoutGuide` constraint, which shrinks the message
@@ -148,6 +194,45 @@ final class ChatThreadViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         installFullWidthPopGesture()
+        flushPendingScrollToBottom()
+        reportVisibleIncomingMessages()
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        flushPendingScrollToBottom()
+        reportVisibleIncomingMessages()
+    }
+
+    /// Perform a deferred scroll-to-bottom (see `pendingScrollToBottom`).
+    /// Non-animated: the user is just arriving; the latest message should
+    /// simply already be there, like it is after a relaunch.
+    private func flushPendingScrollToBottom() {
+        guard pendingScrollToBottom else { return }
+        pendingScrollToBottom = false
+        tableView.layoutIfNeeded()
+        scrollToBottom(animated: false)
+    }
+
+    /// Report incoming messages whose cells are on screen right now —
+    /// but only when they're genuinely visible to a person: view in a
+    /// window AND the app active. Called from every point where
+    /// visibility can change (apply completion, scroll, foreground,
+    /// appear); cheap and idempotent, deduped via `reportedSeenIDs`.
+    func reportVisibleIncomingMessages() {
+        guard canScrollNow() else { return }
+        guard let visiblePaths = tableView.indexPathsForVisibleRows,
+              !visiblePaths.isEmpty else { return }
+        var newlySeen: [ChatMessage] = []
+        for path in visiblePaths {
+            guard path.row < orderedMessages.count else { continue }
+            let message = orderedMessages[path.row]
+            guard message.direction == .incoming,
+                  !reportedSeenIDs.contains(message.id) else { continue }
+            reportedSeenIDs.insert(message.id)
+            newlySeen.append(message)
+        }
+        guard !newlySeen.isEmpty else { return }
+        onMessagesSeen?(newlySeen)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -249,6 +334,12 @@ final class ChatThreadViewController: UIViewController {
             guard let prior = messagesByID[msg.id], prior != msg else { return nil }
             return msg.id
         }
+        // Incoming rows this update introduces (computed against the
+        // *previous* messagesByID) — drives the "N new messages" pill
+        // when the user is scrolled up and auto-scroll would be rude.
+        let newIncomingCount = sorted.count(where: { msg in
+            msg.direction == .incoming && messagesByID[msg.id] == nil
+        })
         messagesByID = Dictionary(uniqueKeysWithValues: sorted.map { ($0.id, $0) })
         orderedMessages = sorted
         rebuildSenderDisplays()
@@ -277,8 +368,29 @@ final class ChatThreadViewController: UIViewController {
                 self.jumpToBottomForColdOpen()
                 self.hasAppliedFirstSnapshot = true
             } else if wasNearBottom && sorted.count > previousCount {
-                self.scrollToBottom(animated: true)
+                if self.canScrollNow() {
+                    self.scrollToBottom(animated: true)
+                } else {
+                    // Backgrounded / mid-foreground-transition / not in a
+                    // window: a scroll now would be silently dropped and
+                    // the fresh message would sit below the fold —
+                    // delivered but invisible. Defer; `viewDidAppear` /
+                    // `didBecomeActive` flushes it.
+                    self.pendingScrollToBottom = true
+                }
             }
+            // Whatever the scroll decision, the set of on-screen bubbles
+            // may have changed — report what a person can now see.
+            self.reportVisibleIncomingMessages()
+        }
+
+        // The user is scrolled up in history and new incoming messages
+        // just landed: don't yank the scroll — surface the arrival with
+        // the pill instead. (Own outgoing sends keep today's behavior:
+        // no pill, no scroll unless near bottom.)
+        if !isFirstApply, !wasNearBottom, newIncomingCount > 0 {
+            unseenIncomingCount += newIncomingCount
+            showNewMessagesPill(count: unseenIncomingCount)
         }
     }
 
@@ -483,12 +595,66 @@ final class ChatThreadViewController: UIViewController {
         tableView.scrollToRow(at: lastIndex, at: .bottom, animated: animated)
     }
 
+    // MARK: - New-messages pill
+
+    private func buildNewMessagesPill() {
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = UIColor(OnymTokens.surface3)
+        config.baseForegroundColor = UIColor(OnymTokens.text)
+        config.cornerStyle = .capsule
+        config.image = UIImage(systemName: "chevron.down")
+        config.preferredSymbolConfigurationForImage =
+            UIImage.SymbolConfiguration(pointSize: 11, weight: .semibold)
+        config.imagePadding = 6
+        config.contentInsets = NSDirectionalEdgeInsets(
+            top: 8, leading: 14, bottom: 8, trailing: 14
+        )
+        newMessagesPill.configuration = config
+        newMessagesPill.layer.shadowColor = UIColor.black.cgColor
+        newMessagesPill.layer.shadowOpacity = 0.18
+        newMessagesPill.layer.shadowRadius = 10
+        newMessagesPill.layer.shadowOffset = CGSize(width: 0, height: 4)
+        newMessagesPill.accessibilityIdentifier = "chat.newMessagesPill"
+        newMessagesPill.isHidden = true
+        newMessagesPill.addTarget(self, action: #selector(newMessagesPillTapped), for: .touchUpInside)
+
+        newMessagesPill.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(newMessagesPill)
+        NSLayoutConstraint.activate([
+            newMessagesPill.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            newMessagesPill.bottomAnchor.constraint(equalTo: inputPanel.topAnchor, constant: -12),
+        ])
+    }
+
+    private func showNewMessagesPill(count: Int) {
+        var config = newMessagesPill.configuration
+        config?.title = String(localized: "\(count) new messages")
+        newMessagesPill.configuration = config
+        newMessagesPill.isHidden = false
+    }
+
+    /// Hide the pill and forget the unseen count — the user has reached
+    /// (or jumped to) the bottom, so everything is seen.
+    private func clearNewMessagesPill() {
+        unseenIncomingCount = 0
+        newMessagesPill.isHidden = true
+    }
+
+    @objc private func newMessagesPillTapped() {
+        clearNewMessagesPill()
+        tableView.layoutIfNeeded()
+        scrollToBottom(animated: true)
+    }
+
     // MARK: - Table view (message list)
 
     private func buildTableView() {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.backgroundColor = UIColor(OnymTokens.bg)
         tableView.separatorStyle = .none
+        // Scroll tracking for the new-messages pill: reaching the bottom
+        // (by hand or via the pill) clears the unseen count.
+        tableView.delegate = self
         // Hidden until the cold open is positioned at the bottom, so the
         // user never sees the initial top→bottom scroll. Revealed by
         // `jumpToBottomForColdOpen` once the latest message is in place.
@@ -730,6 +896,19 @@ final class ChatThreadViewController: UIViewController {
         handleSend(body)
     }
     #endif
+}
+
+extension ChatThreadViewController: UITableViewDelegate {
+    /// Scrolling changes what's visible: clear the new-messages pill
+    /// once the user reaches the bottom (by hand, pill tap, or
+    /// auto-scroll), and report newly on-screen incoming bubbles for
+    /// read-receipting.
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if !newMessagesPill.isHidden, isNearBottom {
+            clearNewMessagesPill()
+        }
+        reportVisibleIncomingMessages()
+    }
 }
 
 extension ChatThreadViewController: UIGestureRecognizerDelegate {

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -21,13 +21,30 @@ struct RootView: View {
     let dependencies: AppDependencies
 
     @State private var selectedTab: RootTab = .chats
+    // Held in @State so they survive RootView body re-evaluations. Built
+    // inline in `body` before, a fresh ChatsFlow was minted on every
+    // re-render; `.task { flow.start() }` keys off the view's identity
+    // and does NOT re-fire for the replacement instance, so an unstarted
+    // (empty) flow backed the chat list until a tab switch forced `.task`
+    // to run again — the "chat list empty until I visit Settings and come
+    // back" bug (design doc F5). A view must tolerate body re-evaluation;
+    // owning the flows here makes their subscriptions durable.
+    @State private var chatsFlow: ChatsFlow
+    @State private var searchChatsFlow: ChatsFlow
+
+    @MainActor
+    init(dependencies: AppDependencies) {
+        self.dependencies = dependencies
+        _chatsFlow = State(initialValue: dependencies.makeChatsFlow())
+        _searchChatsFlow = State(initialValue: dependencies.makeChatsFlow())
+    }
 
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: .chats) {
                 NavigationStack {
                     ChatsView(
-                        flow: dependencies.makeChatsFlow(),
+                        flow: chatsFlow,
                         identitiesFlow: dependencies.identitiesFlow,
                         connectionStatusFlow: dependencies.connectionStatusFlow,
                         approveRequestsFlow: dependencies.approveRequestsFlow,
@@ -65,7 +82,7 @@ struct RootView: View {
                 NavigationStack {
                     SearchView(
                         messageRepository: dependencies.messageRepository,
-                        chatsFlow: dependencies.makeChatsFlow(),
+                        chatsFlow: searchChatsFlow,
                         identitiesFlow: dependencies.identitiesFlow,
                         sendMessageInteractor: dependencies.sendMessageInteractor,
                         chatReceiptSender: dependencies.chatReceiptSender,


### PR DESCRIPTION
**3/4 of the reconnect work** (squashed restructure of #195 / #200 + the RootView ownership fix from #197 — no tests here by design; coverage in PR 4/4).

Delivery isn't done until the user can see it:

- **Deferred auto-scroll** — a message backfilled on foreground was persisted but below the fold (the scroll ran while the app wasn't active and UIKit dropped it). Now armed as `pendingScrollToBottom` and flushed on `viewDidAppear`/`didBecomeActive`: on screen the moment you are.
- **"N new messages" pill** — arrivals while scrolled up never yank the scroll; a capsule shows the unseen count, tap jumps to latest, reaching the bottom clears it. Invariant: every arriving message is either on screen or announced.
- **Render-acknowledged read receipts + badge** (F7) — `.read` and `markRead` now fire from actually-rendered-on-an-active-screen (`onMessagesSeen`), not from data processing. "Delivered" = persisted; "read" = a person saw it.
- **RootView `@State`-owned flows** (F5) — no more minting `ChatsFlow` inline in `body`.

Existing suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)