### PR TITLE
test: full coverage for the reconnect stack (4/4)

### DIFF
--- a/Tests/OnymIOSTests/BoundedReplayTests.swift
+++ b/Tests/OnymIOSTests/BoundedReplayTests.swift
@@ -1,0 +1,270 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-3 of the reconnect design: reconnect replays must be cheap so
+/// "always re-REQ" is safe. Covers the persisted high-water-mark store,
+/// the `since` bound applied at REQ-send time (initial + replay), the
+/// transport raising the mark as events arrive, and the durable
+/// seen-event-id dedup in the fan-out.
+final class BoundedReplayTests: XCTestCase {
+    private func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+    }
+
+    // MARK: - InboxHighWaterMarkStore
+
+    func test_hwmStore_unsetReturnsNil_raiseRoundTrips() {
+        let store = UserDefaultsInboxHighWaterMarkStore(defaults: isolatedDefaults())
+        XCTAssertNil(store.highWaterMark(inbox: "abc"))
+        store.raise(inbox: "abc", to: 1_700_000_000)
+        XCTAssertEqual(store.highWaterMark(inbox: "abc"), 1_700_000_000)
+    }
+
+    func test_hwmStore_neverLowers() {
+        let store = UserDefaultsInboxHighWaterMarkStore(defaults: isolatedDefaults())
+        store.raise(inbox: "abc", to: 2_000)
+        store.raise(inbox: "abc", to: 1_000)  // stale replayed event
+        XCTAssertEqual(store.highWaterMark(inbox: "abc"), 2_000)
+    }
+
+    func test_hwmStore_persistsAcrossInstances() {
+        let defaults = isolatedDefaults()
+        UserDefaultsInboxHighWaterMarkStore(defaults: defaults).raise(inbox: "abc", to: 42)
+        let reloaded = UserDefaultsInboxHighWaterMarkStore(defaults: defaults)
+        XCTAssertEqual(reloaded.highWaterMark(inbox: "abc"), 42)
+    }
+
+    func test_hwmStore_isPerInbox() {
+        let store = UserDefaultsInboxHighWaterMarkStore(defaults: isolatedDefaults())
+        store.raise(inbox: "a", to: 10)
+        XCTAssertNil(store.highWaterMark(inbox: "b"))
+    }
+
+    // MARK: - SeenEventIDStore
+
+    func test_seenStore_markAndContains() async {
+        let store = SeenEventIDStore(defaults: isolatedDefaults())
+        let seenBefore = await store.contains("e1")
+        XCTAssertFalse(seenBefore)
+        await store.markSeen("e1")
+        let seenAfter = await store.contains("e1")
+        XCTAssertTrue(seenAfter)
+    }
+
+    func test_seenStore_evictsOldestBeyondCapacity() async {
+        let store = SeenEventIDStore(defaults: isolatedDefaults(), capacity: 3)
+        for id in ["a", "b", "c", "d"] { await store.markSeen(id) }
+        let aSeen = await store.contains("a")
+        let dSeen = await store.contains("d")
+        XCTAssertFalse(aSeen, "oldest id must be evicted at capacity")
+        XCTAssertTrue(dSeen)
+    }
+
+    func test_seenStore_persistsAcrossInstances() async throws {
+        let defaults = isolatedDefaults()
+        let store = SeenEventIDStore(defaults: defaults, capacity: 10)
+        await store.markSeen("e1")
+        // Persistence is debounced ~1s; wait it out.
+        try await Task.sleep(for: .milliseconds(1400))
+        let reloaded = SeenEventIDStore(defaults: defaults, capacity: 10)
+        let seen = await reloaded.contains("e1")
+        XCTAssertTrue(seen, "seen ids must survive a relaunch")
+    }
+
+    // MARK: - Connection applies `since` at REQ-send time
+
+    func test_connection_sinceProvider_boundsInitialREQ() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: URL(string: "ws://127.0.0.1:\(try await relay.port())")!)
+        await conn.connect()
+
+        let stream = await conn.subscribe(
+            subscriptionID: "s1",
+            filters: [["kinds": [34113]], ["kinds": [24113]]],
+            sinceProvider: { 1_000 }
+        )
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await relay.waitForREQs(1)
+        let filters = relay.reqs(subID: "s1")[0]
+        XCTAssertEqual(filters.count, 2)
+        for filter in filters {
+            XCTAssertEqual(filter["since"] as? Int, 1_000, "every filter must carry the since bound")
+        }
+        await conn.disconnect()
+    }
+
+    func test_connection_sinceProvider_neverLowersExplicitSince() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: URL(string: "ws://127.0.0.1:\(try await relay.port())")!)
+        await conn.connect()
+
+        let stream = await conn.subscribe(
+            subscriptionID: "s1",
+            filters: [["kinds": [44114], "since": Int64(5_000)]],
+            sinceProvider: { 1_000 }
+        )
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await relay.waitForREQs(1)
+        let filter = relay.reqs(subID: "s1")[0][0]
+        XCTAssertEqual(filter["since"] as? Int, 5_000,
+                       "a stricter caller-supplied since must win")
+        await conn.disconnect()
+    }
+
+    func test_connection_replayREQ_usesCurrentProviderValue() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: URL(string: "ws://127.0.0.1:\(try await relay.port())")!)
+        await conn.connect()
+
+        // The provider reads mutable state — the replay must see the
+        // *current* value, not one frozen at subscribe time.
+        let hwm = UserDefaultsInboxHighWaterMarkStore(defaults: isolatedDefaults())
+        let stream = await conn.subscribe(
+            subscriptionID: "s1",
+            filters: [["kinds": [34113]]],
+            sinceProvider: { hwm.highWaterMark(inbox: "x") }
+        )
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+        XCTAssertNil(relay.reqs(subID: "s1")[0][0]["since"],
+                     "no mark yet: the cold-start REQ must be unbounded")
+
+        hwm.raise(inbox: "x", to: 9_000)
+        await conn.forceReconnect()
+        try await relay.waitForREQs(2)
+        XCTAssertEqual(relay.reqs(subID: "s1")[1][0]["since"] as? Int, 9_000,
+                       "the reconnect replay must be bounded by the current mark")
+        await conn.disconnect()
+    }
+
+    // MARK: - Transport raises the mark as events arrive
+
+    func test_inboxTransport_raisesHWMOnEvent() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let defaults = isolatedDefaults()
+        let hwm = UserDefaultsInboxHighWaterMarkStore(defaults: defaults)
+        let transport = NostrInboxTransport(
+            signerProvider: OnymNostrSignerProvider(),
+            highWaterMarks: hwm
+        )
+        let url = URL(string: "ws://127.0.0.1:\(try await relay.port())")!
+        await transport.connect(to: [TransportEndpoint(url: url)])
+
+        let inbox = TransportInboxID(rawValue: "abcd1234")
+        let stream = transport.subscribe(inbox: inbox)
+        let received = ReceivedBox()
+        let pump = Task { for await msg in stream { await received.append(msg.messageID) } }
+        defer { pump.cancel() }
+
+        try await relay.waitForREQs(1)
+        // The harness event's created_at is 1_700_000_000; content must
+        // be base64 for the transport to yield it. Push to the subID the
+        // transport actually REQ'd (generation-suffixed).
+        relay.push(LocalWebSocketRelay.eventFrame(
+            subID: relay.lastRecordedSubID()!, kind: 34113,
+            content: Data("hello".utf8).base64EncodedString(),
+            tag: ("d", "sep-inbox:abcd1234")
+        ))
+
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            if hwm.highWaterMark(inbox: "abcd1234") != nil { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(hwm.highWaterMark(inbox: "abcd1234"), 1_700_000_000,
+                       "an arriving event must raise the inbox's high-water mark")
+        await transport.disconnect()
+    }
+
+    // MARK: - Fan-out dedup
+
+    func test_fanout_dropsAlreadySeenEventBeforeDispatch() async throws {
+        // Two deliveries of the same event id (second relay / replay
+        // overlap) must dispatch exactly once.
+        let transport = FakeInboxTransport()
+        let identityRepo = IdentityRepository(
+            keychain: IdentityKeychainStore(testNamespace: "fanout-dedup-\(UUID().uuidString)")
+        )
+        _ = try await identityRepo.bootstrap()
+
+        let offer = try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x44, count: 32),
+            groupID: Data(repeating: 0x42, count: 32),
+            groupName: "G",
+            inviterAlias: "A"
+        )
+        let plaintext = try JSONEncoder().encode(offer)
+        let spy = SpyPendingInvitesForFanout()
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(mode: .fixed(plaintext)),
+            identities: identityRepo,
+            groupRepository: GroupRepository(store: SwiftDataGroupStore.inMemory()),
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: NoopChainStateForFanout(),
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            pendingInvites: spy
+        )
+
+        let fanout = InboxFanoutInteractor(
+            inboxTransport: transport,
+            identityRepository: identityRepo,
+            dispatcher: dispatcher,
+            seenEventIDs: SeenEventIDStore(defaults: isolatedDefaults())
+        )
+        let run = Task { await fanout.run() }
+        defer { run.cancel() }
+
+        // Wait for the fanout's subscription to land, then deliver the
+        // same event id twice.
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            let count = await transport.subscribeCallCount
+            if count >= 1 { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let inbox = await transport.subscribedInboxes.first
+        let message = InboundInbox(
+            inbox: inbox!, payload: Data("envelope".utf8),
+            receivedAt: Date(), messageID: "same-event-id"
+        )
+        await transport.emit(message)
+        try await Task.sleep(for: .milliseconds(300))
+        await transport.emit(message)
+        try await Task.sleep(for: .milliseconds(300))
+
+        let recorded = await spy.all()
+        XCTAssertEqual(recorded.count, 1, "a re-delivered event id must not re-dispatch")
+        await transport.finish()
+    }
+}
+
+// MARK: - Test doubles
+
+private actor ReceivedBox {
+    private var ids: [String] = []
+    func append(_ id: String) { ids.append(id) }
+    func all() -> [String] { ids }
+}
+
+private actor SpyPendingInvitesForFanout: PendingInvitesRecording {
+    private var recorded: [PendingInvite] = []
+    func record(_ invite: PendingInvite) async { recorded.append(invite) }
+    func all() -> [PendingInvite] { recorded }
+}
+
+private struct NoopChainStateForFanout: ChainStateReading {
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        throw URLError(.unsupportedURL)
+    }
+}

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -437,6 +437,138 @@ final class ChatThreadViewControllerTests: XCTestCase {
         RunLoop.current.run(until: Date(timeIntervalSinceNow: seconds))
     }
 
+    // MARK: - New-message awareness (pill + deferred scroll)
+
+    /// Mount a controller with a long thread, cold-opened at the bottom,
+    /// then scrolled up to the top — the "user is reading history" state
+    /// the pill exists for.
+    private func scrolledUpController(messageCount: Int = 40) -> (ChatThreadViewController, UITableView, [ChatMessage]) {
+        let vc = mountedController()
+        let msgs = (0..<messageCount).map {
+            incoming(sender: "aa".repeated(48), body: "message \($0)", at: TimeInterval($0))
+        }
+        vc.update(messages: msgs)
+        let table = layoutTable(in: vc)
+        pumpMainRunLoop()  // cold open completes; hasAppliedFirstSnapshot set
+        table.contentOffset = .zero
+        table.layoutIfNeeded()
+        XCTAssertFalse(vc.isNearBottom, "precondition: the user is scrolled up")
+        return (vc, table, msgs)
+    }
+
+    private func newMessagesPill(in vc: UIViewController) -> UIButton? {
+        find(in: vc.view) { $0.accessibilityIdentifier == "chat.newMessagesPill" } as? UIButton
+    }
+
+    func test_newMessagesPill_hiddenInitially() {
+        let vc = mountedController()
+        vc.update(messages: [makeMessage(body: "hi", direction: .incoming)])
+        _ = layoutTable(in: vc)
+        pumpMainRunLoop()
+        XCTAssertTrue(newMessagesPill(in: vc)?.isHidden ?? false)
+    }
+
+    func test_incomingWhileScrolledUp_showsPillWithCount() {
+        let (vc, _, msgs) = scrolledUpController()
+        vc.update(messages: msgs + [
+            incoming(sender: "bb".repeated(48), body: "new 1", at: 100),
+            incoming(sender: "bb".repeated(48), body: "new 2", at: 101),
+        ])
+        pumpMainRunLoop()
+        let pill = newMessagesPill(in: vc)
+        XCTAssertEqual(pill?.isHidden, false,
+                       "incoming messages while scrolled up must surface the pill")
+        XCTAssertTrue(pill?.configuration?.title?.contains("2") ?? false,
+                      "the pill must carry the unseen count")
+        XCTAssertFalse(vc.isNearBottom,
+                       "the scroll position must NOT be yanked while reading history")
+    }
+
+    func test_pillCount_accumulatesAcrossUpdates() {
+        let (vc, _, msgs) = scrolledUpController()
+        let first = msgs + [incoming(sender: "bb".repeated(48), body: "new 1", at: 100)]
+        vc.update(messages: first)
+        pumpMainRunLoop(0.05)
+        vc.update(messages: first + [incoming(sender: "bb".repeated(48), body: "new 2", at: 101)])
+        pumpMainRunLoop(0.05)
+        XCTAssertTrue(newMessagesPill(in: vc)?.configuration?.title?.contains("2") ?? false,
+                      "unseen count must accumulate until the bottom is reached")
+    }
+
+    func test_reachingBottom_clearsPill() {
+        let (vc, table, msgs) = scrolledUpController()
+        vc.update(messages: msgs + [incoming(sender: "bb".repeated(48), body: "new", at: 100)])
+        pumpMainRunLoop(0.05)
+        XCTAssertEqual(newMessagesPill(in: vc)?.isHidden, false)
+
+        vc.scrollToBottom(animated: false)
+        table.layoutIfNeeded()
+        vc.scrollViewDidScroll(table)
+        XCTAssertEqual(newMessagesPill(in: vc)?.isHidden, true,
+                       "reaching the bottom must clear the pill")
+    }
+
+    func test_pillTap_scrollsToBottomAndHides() {
+        let (vc, table, msgs) = scrolledUpController()
+        vc.update(messages: msgs + [incoming(sender: "bb".repeated(48), body: "new", at: 100)])
+        pumpMainRunLoop(0.05)
+        let pill = newMessagesPill(in: vc)!
+        XCTAssertFalse(pill.isHidden)
+
+        pill.sendActions(for: .touchUpInside)
+        // The tap scrolls animated from ~40 rows up — give the scroll
+        // animation time to settle before asserting the landing spot.
+        pumpMainRunLoop(0.6)
+        table.layoutIfNeeded()
+        XCTAssertTrue(pill.isHidden)
+        XCTAssertTrue(vc.isNearBottom, "tapping the pill must land on the latest message")
+    }
+
+    func test_incomingNearBottom_autoScrolls_noPill() {
+        let vc = mountedController()
+        let msgs = (0..<40).map {
+            incoming(sender: "aa".repeated(48), body: "message \($0)", at: TimeInterval($0))
+        }
+        vc.update(messages: msgs)
+        _ = layoutTable(in: vc)
+        pumpMainRunLoop()  // cold open → at bottom
+
+        vc.update(messages: msgs + [incoming(sender: "bb".repeated(48), body: "new", at: 100)])
+        pumpMainRunLoop()
+        XCTAssertTrue(newMessagesPill(in: vc)?.isHidden ?? false,
+                      "near-bottom arrivals auto-scroll; the pill must not appear")
+        XCTAssertTrue(vc.isNearBottom, "the fresh message must be pulled into view")
+    }
+
+    /// The reported field bug: a message lands while the app can't
+    /// scroll (backgrounded / mid-foreground-transition). The scroll must
+    /// be deferred — and flushed the moment the app becomes active, so
+    /// the message is on screen when the user is.
+    func test_arrivalWhileNotScrollable_deferredAndFlushedOnBecomeActive() {
+        let vc = mountedController()
+        let msgs = (0..<40).map {
+            incoming(sender: "aa".repeated(48), body: "message \($0)", at: TimeInterval($0))
+        }
+        vc.update(messages: msgs)
+        let table = layoutTable(in: vc)
+        pumpMainRunLoop()  // cold open → at bottom
+        XCTAssertTrue(vc.isNearBottom)
+
+        vc.canScrollNow = { false }  // "backgrounded"
+        vc.update(messages: msgs + [incoming(sender: "bb".repeated(48), body: "bg message", at: 100)])
+        pumpMainRunLoop()
+        XCTAssertTrue(vc.pendingScrollToBottom,
+                      "an arrival that can't scroll now must arm the deferred scroll")
+
+        vc.canScrollNow = { true }  // "foregrounded"
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        pumpMainRunLoop()
+        table.layoutIfNeeded()
+        XCTAssertFalse(vc.pendingScrollToBottom, "didBecomeActive must flush the deferred scroll")
+        XCTAssertTrue(vc.isNearBottom,
+                      "the message received while away must be on screen after foregrounding")
+    }
+
     // MARK: - Sender differentiation (run grouping + name headers)
 
     func test_runGrouping_headerOnlyAtStartOfSameSenderRun() {

--- a/Tests/OnymIOSTests/DispatchLanesTests.swift
+++ b/Tests/OnymIOSTests/DispatchLanesTests.swift
@@ -1,0 +1,300 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-5 of the reconnect design: invitation / group-state payloads ride
+/// a serial slow lane so a backlog of chain-verifying handlers can never
+/// starve live chat (F6). Chat messages and receipts stay inline.
+final class DispatchLanesTests: XCTestCase {
+    private let owner = IdentityID()
+
+    // MARK: - SerialDispatchLane
+
+    func test_lane_runsJobsInFIFOOrder() async {
+        let lane = SerialDispatchLane()
+        let box = OrderBox()
+        for i in 0..<20 {
+            await lane.enqueue { await box.append(i) }
+        }
+        await lane.drain()
+        let order = await box.all()
+        XCTAssertEqual(order, Array(0..<20), "slow-lane jobs must run strictly FIFO")
+    }
+
+    func test_lane_enqueueDoesNotBlockOnRunningJob() async {
+        let lane = SerialDispatchLane()
+        let gate = Gate()
+        await lane.enqueue { await gate.wait() }  // job that blocks until opened
+
+        // Enqueueing behind a blocked job must return immediately.
+        let start = Date()
+        await lane.enqueue {}
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.5,
+                          "enqueue must never wait for running jobs")
+        await gate.open()
+        await lane.drain()
+    }
+
+    func test_lane_drainWaitsForChainedJobs() async {
+        let lane = SerialDispatchLane()
+        let box = OrderBox()
+        await lane.enqueue {
+            await box.append(1)
+            // A running job enqueues a successor (the chat retry shape).
+            await lane.enqueue { await box.append(2) }
+        }
+        await lane.drain()
+        let order = await box.all()
+        XCTAssertEqual(order, [1, 2], "drain must also cover jobs enqueued by running jobs")
+    }
+
+    // MARK: - Starvation: slow payloads must not delay chat
+
+    func test_chatMessage_isNotStarvedBySlowGroupStateWork() async throws {
+        // A refresh request whose handler stalls (models a slow chain
+        // read) is dispatched first; the chat message dispatched right
+        // after must land in the repository without waiting for it.
+        let group = TestGroupFactory.group(owner: owner)
+        let groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        _ = await groups.insert(group.chatGroup)
+        let messages = MessageRepository(store: SwiftDataMessageStore.inMemory())
+
+        let refresh = TestGroupFactory.refreshRequest(group: group)
+        let chat = TestGroupFactory.chatMessagePayload(group: group, body: "live message")
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .scripted([
+                Data("refresh-envelope".utf8): try JSONEncoder().encode(refresh),
+                Data("chat-envelope".utf8): try JSONEncoder().encode(chat),
+            ]),
+            senderEd25519PublicKey: group.senderEd25519
+        )
+        let stalledRefresher = StallingRefresher(stallSeconds: 2)
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentitiesForLanes(),
+            groupRepository: groups,
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: ThrowingChainStateForLanes(),
+            messageRepository: messages,
+            groupStateRefresher: stalledRefresher
+        )
+
+        // Slow payload first — it occupies the slow lane for ~2s.
+        await dispatcher.dispatch(
+            messageID: "m-refresh", ownerIdentityID: owner,
+            payload: Data("refresh-envelope".utf8), receivedAt: Date()
+        )
+        // Chat message next — must not wait behind it.
+        let start = Date()
+        await dispatcher.dispatch(
+            messageID: "m-chat", ownerIdentityID: owner,
+            payload: Data("chat-envelope".utf8), receivedAt: Date()
+        )
+        let dispatchLatency = Date().timeIntervalSince(start)
+
+        let persisted = await messages.currentMessages(
+            groupID: group.chatGroup.id, owner: owner
+        )
+        XCTAssertEqual(persisted.map(\.body), ["live message"],
+                       "the chat message must be persisted immediately")
+        XCTAssertLessThan(dispatchLatency, 1.0,
+                          "chat dispatch must not stall behind slow group-state work")
+        await dispatcher.drainSlowLane()
+    }
+
+    // MARK: - Group-not-found retry through the slow lane
+
+    func test_chatArrivingBeforeGroupMaterializes_isRetriedAfterSlowLane() async throws {
+        // The lane-split race: a chat message reaches the fast lane while
+        // the work that materializes its group is still queued in the
+        // slow lane. The retry must run AFTER that work and persist.
+        let group = TestGroupFactory.group(owner: owner)
+        let groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        let messages = MessageRepository(store: SwiftDataMessageStore.inMemory())
+
+        let refresh = TestGroupFactory.refreshRequest(group: group)
+        let chat = TestGroupFactory.chatMessagePayload(group: group, body: "raced ahead")
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .scripted([
+                Data("materialize-envelope".utf8): try JSONEncoder().encode(refresh),
+                Data("chat-envelope".utf8): try JSONEncoder().encode(chat),
+            ]),
+            senderEd25519PublicKey: group.senderEd25519
+        )
+        // A "refresher" that materializes the group when it runs —
+        // standing in for the invitation handler occupying the slow lane.
+        let materializer = MaterializingRefresher(groups: groups, group: group.chatGroup)
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: StubIdentitiesForLanes(),
+            groupRepository: groups,
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: ThrowingChainStateForLanes(),
+            messageRepository: messages,
+            groupStateRefresher: materializer
+        )
+
+        // Slow lane: the group-materializing work.
+        await dispatcher.dispatch(
+            messageID: "m-mat", ownerIdentityID: owner,
+            payload: Data("materialize-envelope".utf8), receivedAt: Date()
+        )
+        // Fast lane: the chat message — group doesn't exist yet.
+        await dispatcher.dispatch(
+            messageID: "m-chat", ownerIdentityID: owner,
+            payload: Data("chat-envelope".utf8), receivedAt: Date()
+        )
+        await dispatcher.drainSlowLane()
+
+        let persisted = await messages.currentMessages(
+            groupID: group.chatGroup.id, owner: owner
+        )
+        XCTAssertEqual(persisted.map(\.body), ["raced ahead"],
+                       "the retry must land once the slow lane materializes the group")
+    }
+
+    func test_chatForGenuinelyUnknownGroup_isDroppedAfterOneRetry() async throws {
+        let group = TestGroupFactory.group(owner: owner)
+        let messages = MessageRepository(store: SwiftDataMessageStore.inMemory())
+        let chat = TestGroupFactory.chatMessagePayload(group: group, body: "stale")
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(try JSONEncoder().encode(chat)),
+                senderEd25519PublicKey: group.senderEd25519
+            ),
+            identities: StubIdentitiesForLanes(),
+            groupRepository: GroupRepository(store: SwiftDataGroupStore.inMemory()),
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: ThrowingChainStateForLanes(),
+            messageRepository: messages
+        )
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m1", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let persisted = await messages.currentMessages(
+            groupID: group.chatGroup.id, owner: owner
+        )
+        XCTAssertTrue(persisted.isEmpty, "no group after the retry ⇒ drop, no infinite loop")
+    }
+}
+
+// MARK: - Test doubles
+
+/// Shared factory for a group + a matching signed chat payload, so the
+/// insider-spoof guards pass.
+private enum TestGroupFactory {
+    struct Made {
+        let chatGroup: ChatGroup
+        let senderBlsHex: String
+        let senderEd25519: Data
+    }
+
+    static func group(owner: IdentityID) -> Made {
+        let senderBlsHex = String(repeating: "11", count: 48)
+        let senderEd25519 = Data(repeating: 0xED, count: 32)
+        let groupID = Data(repeating: 0x42, count: 32)
+        let group = ChatGroup(
+            id: groupID.map { String(format: "%02x", $0) }.joined(),
+            ownerIdentityID: owner,
+            name: "Lane Group",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [],
+            memberProfiles: [
+                senderBlsHex: MemberProfile(
+                    alias: "Alice",
+                    inboxPublicKey: Data(repeating: 0x10, count: 32),
+                    sendingPubkey: senderEd25519
+                )
+            ],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: true
+        )
+        return Made(chatGroup: group, senderBlsHex: senderBlsHex, senderEd25519: senderEd25519)
+    }
+
+    static func chatMessagePayload(group: Made, body: String) -> ChatMessagePayload {
+        ChatMessagePayload(
+            version: 1,
+            messageID: UUID(),
+            groupID: group.chatGroup.groupIDData,
+            senderBlsPubkeyHex: group.senderBlsHex,
+            sentAtMillis: 1_700_000_000_000,
+            replyToMessageID: nil,
+            variant: .tyranny(body: body)
+        )
+    }
+
+    static func refreshRequest(group: Made) -> GroupStateRefreshRequest {
+        try! GroupStateRefreshRequest(
+            groupID: group.chatGroup.groupIDData,
+            requesterInboxPublicKey: Data(repeating: 0x21, count: 32),
+            requesterBlsPublicKey: Data(repeating: 0x31, count: 48)
+        )
+    }
+}
+
+private struct StubIdentitiesForLanes: IdentitiesProviding {
+    func currentIdentities() async -> [IdentitySummary] { [] }
+}
+
+private struct ThrowingChainStateForLanes: ChainStateReading {
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        throw URLError(.unsupportedURL)
+    }
+}
+
+/// Refresher that stalls — models a slow chain read occupying the lane.
+private struct StallingRefresher: GroupStateRefreshing {
+    let stallSeconds: Double
+    func deferVerification(invitation: GroupInvitationPayload, ownerIdentityID: IdentityID) async {}
+    func handleRefreshRequest(
+        _ request: GroupStateRefreshRequest,
+        ownerIdentityID: IdentityID,
+        requesterEd25519: Data?
+    ) async {
+        try? await Task.sleep(for: .seconds(stallSeconds))
+    }
+}
+
+/// Refresher that materializes a group when it runs — stands in for the
+/// invitation handler in the slow lane.
+private struct MaterializingRefresher: GroupStateRefreshing {
+    let groups: GroupRepository
+    let group: ChatGroup
+    func deferVerification(invitation: GroupInvitationPayload, ownerIdentityID: IdentityID) async {}
+    func handleRefreshRequest(
+        _ request: GroupStateRefreshRequest,
+        ownerIdentityID: IdentityID,
+        requesterEd25519: Data?
+    ) async {
+        _ = await groups.insert(group)
+    }
+}
+
+private actor OrderBox {
+    private var values: [Int] = []
+    func append(_ value: Int) { values.append(value) }
+    func all() -> [Int] { values }
+}
+
+private actor Gate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+    func open() {
+        isOpen = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+}

--- a/Tests/OnymIOSTests/InviteDispositionLedgerTests.swift
+++ b/Tests/OnymIOSTests/InviteDispositionLedgerTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-6 of the reconnect design: a Nostr relay may re-serve an invite
+/// offer forever, so the client owns a durable record of what the user
+/// already decided. Covers the ledger's monotonic state machine +
+/// persistence, and the dispatcher's drop-at-the-door enforcement.
+final class InviteDispositionLedgerTests: XCTestCase {
+    private let owner = IdentityID()
+    private let groupID = Data(repeating: 0x42, count: 32)
+
+    private func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+    }
+
+    // MARK: - Ledger semantics
+
+    func test_record_isMonotonic_reofferCannotDowngradeRequested() async {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: "G", inviterAlias: "A")
+        await ledger.record(.offered, owner: owner, groupID: groupID, groupName: "G", inviterAlias: "A")
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .requested, "a re-delivered offer must not downgrade requested")
+    }
+
+    func test_joined_isTerminal() async {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.joined, owner: owner, groupID: groupID, groupName: "G", inviterAlias: nil)
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: "G", inviterAlias: nil)
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .joined)
+    }
+
+    func test_declinedThenJoined_upgrades() async {
+        // The admin's approval can land after a local dismiss — joined
+        // always wins.
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.declined, owner: owner, groupID: groupID, groupName: "G", inviterAlias: nil)
+        await ledger.record(.joined, owner: owner, groupID: groupID, groupName: "G", inviterAlias: nil)
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .joined)
+    }
+
+    func test_persistsAcrossInstances() async {
+        let defaults = isolatedDefaults()
+        let ledger = InviteDispositionLedger(defaults: defaults)
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: "Maple", inviterAlias: "Alice")
+
+        let reloaded = InviteDispositionLedger(defaults: defaults)
+        let state = await reloaded.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .requested, "an accepted invite must survive relaunch")
+    }
+
+    func test_removeForOwner_cascades() async {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        let otherOwner = IdentityID()
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: nil, inviterAlias: nil)
+        await ledger.record(.requested, owner: otherOwner, groupID: groupID, groupName: nil, inviterAlias: nil)
+
+        await ledger.removeForOwner(owner)
+        let removed = await ledger.disposition(owner: owner, groupID: groupID)
+        let kept = await ledger.disposition(owner: otherOwner, groupID: groupID)
+        XCTAssertNil(removed)
+        XCTAssertEqual(kept, .requested, "other identities' rows must be untouched")
+    }
+
+    func test_snapshots_filterByCurrentIdentity() async throws {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        let otherOwner = IdentityID()
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: "Mine", inviterAlias: nil)
+        await ledger.record(.requested, owner: otherOwner, groupID: groupID, groupName: "Theirs", inviterAlias: nil)
+        await ledger.setCurrentIdentity(owner)
+
+        var iterator = ledger.snapshots.makeAsyncIterator()
+        let snapshot = await iterator.next()
+        XCTAssertEqual(snapshot?.map(\.groupName), ["Mine"])
+    }
+
+    // MARK: - Dispatcher enforcement
+
+    private func makeDispatcher(
+        ledger: InviteDispositionLedger,
+        spy: LedgerSpyPendingInvites,
+        groups: GroupRepository = GroupRepository(store: SwiftDataGroupStore.inMemory()),
+        offer: GroupInviteOfferPayload
+    ) throws -> IncomingMessageDispatcher {
+        IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(try JSONEncoder().encode(offer))
+            ),
+            identities: LedgerStubIdentities(),
+            groupRepository: groups,
+            invitationsRepository: IncomingInvitationsRepository(store: SwiftDataInvitationStore.inMemory()),
+            chainState: LedgerThrowingChainState(),
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory()),
+            pendingInvites: spy,
+            inviteDispositions: ledger
+        )
+    }
+
+    private func makeOffer() throws -> GroupInviteOfferPayload {
+        try GroupInviteOfferPayload(
+            introPublicKey: Data(repeating: 0x44, count: 32),
+            groupID: groupID,
+            groupName: "Maple Garden",
+            inviterAlias: "Alice"
+        )
+    }
+
+    func test_freshOffer_isQueuedAndRecordedOffered() async throws {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        let spy = LedgerSpyPendingInvites()
+        let dispatcher = try makeDispatcher(ledger: ledger, spy: spy, offer: makeOffer())
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m1", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let recorded = await spy.all()
+        XCTAssertEqual(recorded.count, 1)
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .offered)
+    }
+
+    func test_redeliveredOffer_afterRequested_isDropped() async throws {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.requested, owner: owner, groupID: groupID, groupName: nil, inviterAlias: nil)
+        let spy = LedgerSpyPendingInvites()
+        let dispatcher = try makeDispatcher(ledger: ledger, spy: spy, offer: makeOffer())
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m-redelivered", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let recorded = await spy.all()
+        XCTAssertTrue(recorded.isEmpty,
+                      "an offer for an already-requested invite must be dropped at the door")
+    }
+
+    func test_redeliveredOffer_afterDeclined_isDropped() async throws {
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        await ledger.record(.declined, owner: owner, groupID: groupID, groupName: nil, inviterAlias: nil)
+        let spy = LedgerSpyPendingInvites()
+        let dispatcher = try makeDispatcher(ledger: ledger, spy: spy, offer: makeOffer())
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m-redelivered", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let recorded = await spy.all()
+        XCTAssertTrue(recorded.isEmpty, "declined is sticky across re-deliveries")
+    }
+
+    func test_offerForLocallyExistingGroup_isDroppedAndMarkedJoined() async throws {
+        // The blink loop's root case: the group already materialized;
+        // the re-served offer must be dropped and the ledger updated so
+        // even the group's later deletion can't resurrect the offer.
+        let ledger = InviteDispositionLedger(defaults: isolatedDefaults())
+        let groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        _ = await groups.insert(ChatGroup(
+            id: groupID.map { String(format: "%02x", $0) }.joined(),
+            ownerIdentityID: owner,
+            name: "Maple Garden",
+            groupSecret: Data(repeating: 0x55, count: 32),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            members: [], memberProfiles: [:],
+            epoch: 0, salt: Data(repeating: 0x66, count: 32),
+            commitment: nil, tier: .small, groupType: .tyranny,
+            adminPubkeyHex: nil, adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: true
+        ))
+        let spy = LedgerSpyPendingInvites()
+        let dispatcher = try makeDispatcher(ledger: ledger, spy: spy, groups: groups, offer: makeOffer())
+
+        await dispatcher.dispatchAndDrain(
+            messageID: "m1", ownerIdentityID: owner,
+            payload: Data("envelope".utf8), receivedAt: Date()
+        )
+        let recorded = await spy.all()
+        XCTAssertTrue(recorded.isEmpty, "an offer for a joined group must never re-enter the inbox")
+        let state = await ledger.disposition(owner: owner, groupID: groupID)
+        XCTAssertEqual(state, .joined)
+    }
+}
+
+// MARK: - Test doubles
+
+private actor LedgerSpyPendingInvites: PendingInvitesRecording {
+    private var recorded: [PendingInvite] = []
+    func record(_ invite: PendingInvite) async { recorded.append(invite) }
+    func all() -> [PendingInvite] { recorded }
+}
+
+private struct LedgerStubIdentities: IdentitiesProviding {
+    func currentIdentities() async -> [IdentitySummary] { [] }
+}
+
+private struct LedgerThrowingChainState: ChainStateReading {
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        throw URLError(.unsupportedURL)
+    }
+}

--- a/Tests/OnymIOSTests/NetworkPathMonitorTests.swift
+++ b/Tests/OnymIOSTests/NetworkPathMonitorTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import OnymIOS
+
+/// Unit tests for `ConnectivityRegainDetector` — the emission policy
+/// behind `NetworkPathMonitor`. The two field-proven failure modes it
+/// must prevent: a reconnect storm from satisfied→satisfied path churn
+/// (design doc F2), and a swallowed regain after a launch-offline start.
+final class NetworkPathMonitorTests: XCTestCase {
+    func test_baselineCallbackNeverEmits() {
+        let detector = ConnectivityRegainDetector(cooldown: 0)
+        XCTAssertFalse(detector.shouldEmit(satisfied: true),
+                       "the first (baseline) callback must not emit")
+    }
+
+    func test_offlineLaunchThenRegain_emits() {
+        // Launch offline → connectivity arrives. The one-shot-latch
+        // design swallowed this; the edge detector must fire.
+        let detector = ConnectivityRegainDetector(cooldown: 0)
+        XCTAssertFalse(detector.shouldEmit(satisfied: false))  // baseline, offline
+        XCTAssertTrue(detector.shouldEmit(satisfied: true), "offline→online must emit")
+    }
+
+    func test_satisfiedChurn_doesNotEmit() {
+        let detector = ConnectivityRegainDetector(cooldown: 0)
+        _ = detector.shouldEmit(satisfied: true)  // baseline, online
+        XCTAssertFalse(detector.shouldEmit(satisfied: true),
+                       "interface churn while satisfied must not emit (reconnect storm)")
+        XCTAssertFalse(detector.shouldEmit(satisfied: true))
+    }
+
+    func test_dropAndRegain_emitsOnce() {
+        let detector = ConnectivityRegainDetector(cooldown: 0)
+        _ = detector.shouldEmit(satisfied: true)   // baseline
+        XCTAssertFalse(detector.shouldEmit(satisfied: false))
+        XCTAssertTrue(detector.shouldEmit(satisfied: true))
+        XCTAssertFalse(detector.shouldEmit(satisfied: true), "no re-emit while staying satisfied")
+    }
+
+    func test_flapping_isCoalescedWithinCooldown() {
+        var now = Date(timeIntervalSince1970: 1_000)
+        let detector = ConnectivityRegainDetector(cooldown: 3, now: { now })
+        _ = detector.shouldEmit(satisfied: true)   // baseline online
+
+        now = now.addingTimeInterval(0.1)
+        _ = detector.shouldEmit(satisfied: false)
+        XCTAssertTrue(detector.shouldEmit(satisfied: true), "first regain emits")
+
+        // A rapid flap inside the cooldown is swallowed.
+        now = now.addingTimeInterval(0.5)
+        _ = detector.shouldEmit(satisfied: false)
+        XCTAssertFalse(detector.shouldEmit(satisfied: true),
+                       "a regain within the cooldown must be coalesced")
+
+        // After the cooldown lapses, a regain emits again.
+        now = now.addingTimeInterval(5)
+        _ = detector.shouldEmit(satisfied: false)
+        XCTAssertTrue(detector.shouldEmit(satisfied: true))
+    }
+}
+
+/// Transport-level: `InboxTransport.reconnect()` must rebuild the socket,
+/// replay the REQ, and thereby backfill an event stored while away — the
+/// full foreground-refresh path minus the app trigger.
+final class NostrInboxTransportReconnectTests: XCTestCase {
+    func test_reconnect_rebuildsAndBackfillsStoredEvent() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let transport = NostrInboxTransport(
+            signerProvider: OnymNostrSignerProvider(),
+            highWaterMarks: UserDefaultsInboxHighWaterMarkStore(
+                defaults: UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+            )
+        )
+        let url = URL(string: "ws://127.0.0.1:\(try await relay.port())")!
+        await transport.connect(to: [TransportEndpoint(url: url)])
+
+        let inbox = TransportInboxID(rawValue: "cafe0001")
+        let received = ReceivedMessages()
+        let stream = transport.subscribe(inbox: inbox)
+        let pump = Task { for await msg in stream { await received.append(msg.messageID) } }
+        defer { pump.cancel() }
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        // Arrives while "backgrounded": stored on the relay, never
+        // pushed live to this socket. Keyed to the subID the transport
+        // actually REQ'd (generation-suffixed) — a reconnect replays the
+        // same subscription id.
+        relay.store(subID: relay.lastRecordedSubID()!, eventJSON: LocalWebSocketRelay.eventObjectJSON(
+            kind: 34113,
+            content: Data("missed".utf8).base64EncodedString(),
+            tag: ("d", "sep-inbox:cafe0001")
+        ))
+
+        await transport.reconnect()
+        try await relay.waitForConnections(2)
+        try await relay.waitForREQs(2)
+
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            let count = await received.count()
+            if count >= 1 { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let ids = await received.all()
+        XCTAssertEqual(ids.count, 1,
+                       "reconnect() must re-REQ so the relay backfills the missed event")
+        await transport.disconnect()
+    }
+}
+
+private actor ReceivedMessages {
+    private var ids: [String] = []
+    func append(_ id: String) { ids.append(id) }
+    func all() -> [String] { ids }
+    func count() -> Int { ids.count }
+}

--- a/Tests/OnymIOSTests/NostrRelayConnectionTests.swift
+++ b/Tests/OnymIOSTests/NostrRelayConnectionTests.swift
@@ -1,0 +1,379 @@
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for `NostrRelayConnection`'s lifecycle state machine,
+/// driven against a loopback WebSocket relay (`LocalWebSocketRelay`).
+/// Regression coverage for the field failure modes in the reconnect
+/// design doc: dead-until-relaunch (F1), missed-backfill-on-foreground
+/// (F3), silently-CLOSED subscriptions (F8), and half-open sockets the
+/// error path can't see.
+final class NostrRelayConnectionTests: XCTestCase {
+    /// One subscription = one REQ frame carrying all of its filters —
+    /// never one REQ per filter (relay `maxSubsPerConnection` caps).
+    func testSubscribeSendsSingleREQWithAllFilters() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+
+        let filters: [[String: Any]] = [
+            ["kinds": [34113], "#d": ["sep-inbox:abc"]],
+            ["kinds": [34113], "#t": ["abc"]],
+            ["kinds": [24113], "#t": ["abc"]],
+        ]
+        _ = await conn.subscribe(subscriptionID: "inbox-abc", filters: filters)
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+        // Give a straggler REQ a beat to show up if the code regressed
+        // to one-REQ-per-filter.
+        try await Task.sleep(for: .milliseconds(150))
+
+        let recorded = relay.reqs(subID: "inbox-abc")
+        XCTAssertEqual(recorded.count, 1, "exactly one REQ for the subscription")
+        XCTAssertEqual(recorded[0].count, 3, "the single REQ carries all three filters")
+        await conn.disconnect()
+    }
+
+    /// A subscription established before a server-side drop must resume
+    /// delivering after the passive error-path reconnect — no external
+    /// trigger.
+    func testSubscriptionResumesAfterServerDrop() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            baseReconnectDelay: 0.1,
+            maxReconnectDelay: 0.5
+        )
+        await conn.connect()
+
+        let collector = EventCollector()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await event in stream { await collector.append(event) } }
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        relay.push(LocalWebSocketRelay.eventFrame(
+            subID: "sub1", kind: 34113, content: "first", tag: ("t", "x")
+        ))
+        try await collector.waitForCount(1)
+
+        relay.dropCurrentConnection()
+        try await relay.waitForConnections(2, timeout: 6)
+
+        relay.push(LocalWebSocketRelay.eventFrame(
+            subID: "sub1", kind: 34113, content: "second", tag: ("t", "x")
+        ))
+        try await collector.waitForCount(2, timeout: 6)
+
+        let contents = await collector.contents()
+        XCTAssertEqual(contents, ["first", "second"])
+        await conn.disconnect()
+    }
+
+    /// The canonical background→foreground bug (design doc F3): a message
+    /// stored on the relay while the client was away arrives only via the
+    /// fresh REQ's backfill. `forceReconnect()` must rebuild AND re-REQ —
+    /// no live push happens in this test at all.
+    func testForceReconnectBackfillsEventStoredWhileAway() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+
+        let collector = EventCollector()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await event in stream { await collector.append(event) } }
+        defer { pump.cancel() }
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        // Arrives at the relay while the client is "suspended": stored,
+        // never pushed live to this socket.
+        relay.store(subID: "sub1", eventJSON: LocalWebSocketRelay.eventObjectJSON(
+            kind: 34113, content: "missed-while-bg", tag: ("d", "sep-inbox:abc")
+        ))
+
+        let reqsBefore = relay.reqCount()
+        await conn.forceReconnect()
+        try await relay.waitForConnections(2)
+        try await relay.waitForREQs(reqsBefore + 1)
+        try await collector.waitForCount(1)
+
+        let contents = await collector.contents()
+        XCTAssertEqual(contents, ["missed-while-bg"],
+                       "the rebuilt connection's REQ must backfill the missed event")
+        await conn.disconnect()
+    }
+
+    /// Half-open socket (design doc F1): the peer goes silent without
+    /// closing, `receive()` never throws, so only the liveness monitor
+    /// can notice. With test-scale timings it must rebuild on its own.
+    func testLivenessMonitorHealsSilentSocket() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        relay.autoRespondEOSE = false  // silent peer: no EOSE, no replies
+
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            pingInterval: 0.1,
+            livenessTimeout: 0.3,
+            baseReconnectDelay: 0.05,
+            maxReconnectDelay: 0.2
+        )
+        await conn.connect()
+        _ = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+
+        try await relay.waitForConnections(1)
+        // No traffic at all — staleness must fire and rebuild.
+        let reconnected = try await relay.waitForConnections(2, timeout: 3)
+        XCTAssertGreaterThanOrEqual(reconnected, 2)
+        await conn.disconnect()
+    }
+
+    /// A healthy relay that answers the liveness probe (EOSE) keeps the
+    /// connection alive — no spurious rebuilds from the staleness check.
+    func testProbeAnsweredKeepsConnectionAlive() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            pingInterval: 0.1,
+            livenessTimeout: 0.3,
+            baseReconnectDelay: 0.05,
+            maxReconnectDelay: 0.2
+        )
+        await conn.connect()
+        _ = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+
+        try await relay.waitForConnections(1)
+        // Several liveness windows pass; probe EOSEs keep it alive.
+        try await Task.sleep(for: .seconds(1))
+        XCTAssertEqual(relay.connectionCount(), 1,
+                       "a probe-answering relay must not trigger rebuilds")
+        await conn.disconnect()
+    }
+
+    /// First `CLOSED` for a subscription re-issues its REQ once (design
+    /// doc F8: a silently rejected subscription must be retried, not
+    /// ignored).
+    func testCLOSEDTriggersOneResubscribe() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await _ in stream {} }  // hold the subscription live
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        relay.sendCLOSED(subID: "sub1")
+        try await relay.waitForREQs(2)
+
+        XCTAssertEqual(relay.reqs(subID: "sub1").count, 2, "CLOSED must re-REQ the subscription")
+        XCTAssertEqual(relay.connectionCount(), 1, "a single CLOSED must not rebuild the connection")
+        await conn.disconnect()
+    }
+
+    /// A second `CLOSED` for the same subscription — with no intervening
+    /// EOSE/EVENT proving the retry stuck — means the rejection is
+    /// persistent: escalate to a full rebuild (visible recovery) instead
+    /// of retrying forever or going silently deaf. The relay is silent
+    /// (no EOSE) so the retry's acceptance-decay doesn't clear the flag.
+    func testRepeatedCLOSEDRebuildsConnection() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        relay.autoRespondEOSE = false
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            baseReconnectDelay: 0.05,
+            maxReconnectDelay: 0.2
+        )
+        await conn.connect()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await _ in stream {} }  // hold the subscription live
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        relay.sendCLOSED(subID: "sub1")
+        try await relay.waitForREQs(2)
+        relay.sendCLOSED(subID: "sub1")
+
+        try await relay.waitForConnections(2, timeout: 4)
+        // The rebuilt connection replays the subscription.
+        try await relay.waitForREQs(3, timeout: 4)
+        await conn.disconnect()
+    }
+
+    /// A relay that persistently rejects the subscription (every REQ →
+    /// CLOSED) must back off, not hot-loop: the relay's own CLOSED
+    /// frames must not count as "confirmed live" and reset the backoff.
+    /// With base 0.05 s / cap 0.4 s over a 1.5 s window, escalating
+    /// backoff yields a handful of rebuilds; the naive reset-on-frame
+    /// behavior yields 15+ at a steady ~20 Hz-equivalent.
+    func testPersistentlyRejectedSubscription_backsOffInsteadOfHotLooping() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        relay.autoCLOSESubscriptions = true
+
+        let conn = NostrRelayConnection(
+            url: try await relay.wsURL(),
+            baseReconnectDelay: 0.05,
+            maxReconnectDelay: 0.4
+        )
+        await conn.connect()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await Task.sleep(for: .seconds(1.5))
+        let rebuilds = relay.connectionCount()
+        XCTAssertGreaterThanOrEqual(rebuilds, 2, "rebuild attempts must continue")
+        XCTAssertLessThanOrEqual(rebuilds, 8,
+                                 "persistent CLOSED must escalate backoff, not hot-loop (~1 Hz+)")
+        await conn.disconnect()
+    }
+
+    /// Benign, isolated CLOSEDs must not accumulate into a rebuild: an
+    /// EOSE for the re-issued REQ proves it stuck and decays the sub's
+    /// retried flag, so a second CLOSED much later gets a fresh retry.
+    func testIsolatedCLOSEDs_decayAfterAcceptedREQ_noRebuild() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+        let stream = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+        let pump = Task { for await _ in stream {} }
+        defer { pump.cancel() }
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        relay.sendCLOSED(subID: "sub1")
+        try await relay.waitForREQs(2)  // retry — auto-answered with EOSE
+        try await Task.sleep(for: .milliseconds(200))  // EOSE decays the flag
+
+        relay.sendCLOSED(subID: "sub1")
+        try await relay.waitForREQs(3)  // a fresh retry, NOT a rebuild
+
+        XCTAssertEqual(relay.connectionCount(), 1,
+                       "isolated CLOSEDs with accepted retries in between must never rebuild")
+        await conn.disconnect()
+    }
+
+    /// `CLOSED` for an unknown subscription (e.g. one we already
+    /// unsubscribed) is ignored — no retry, no rebuild.
+    func testCLOSEDForUnknownSubIsIgnored() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let conn = NostrRelayConnection(url: try await relay.wsURL())
+        await conn.connect()
+        _ = await conn.subscribe(subscriptionID: "sub1", filters: [["kinds": [34113]]])
+
+        try await relay.waitForConnections(1)
+        try await relay.waitForREQs(1)
+
+        relay.sendCLOSED(subID: "no-such-sub")
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(relay.reqCount(), 1)
+        XCTAssertEqual(relay.connectionCount(), 1)
+        await conn.disconnect()
+    }
+}
+
+/// Transport-level: re-subscribing an inbox must not let the OLD
+/// stream's asynchronous `onTermination` CLOSE tear down the NEW
+/// subscription (the generation-token pattern `NostrMessageTransport`
+/// pioneered, now applied to the inbox transport).
+final class NostrInboxTransportResubscribeTests: XCTestCase {
+    func test_resubscribeSameInbox_usesFreshSubID_andStaysLive() async throws {
+        let relay = try LocalWebSocketRelay()
+        defer { relay.stop() }
+        let transport = NostrInboxTransport(signerProvider: OnymNostrSignerProvider())
+        let url = URL(string: "ws://127.0.0.1:\(try await relay.port())")!
+        await transport.connect(to: [TransportEndpoint(url: url)])
+
+        let inbox = TransportInboxID(rawValue: "beef0001")
+        let first = transport.subscribe(inbox: inbox)
+        let firstPump = Task { for await _ in first {} }
+        try await relay.waitForREQs(1)
+
+        // Re-subscribe (identity rebalance / pump restart shape). The
+        // old stream terminates asynchronously and sends CLOSE for ITS
+        // subID — which must not be the new one's.
+        let second = transport.subscribe(inbox: inbox)
+        let received = ResubscribeBox()
+        let secondPump = Task { for await msg in second { await received.append(msg.messageID) } }
+        defer { secondPump.cancel() }
+        firstPump.cancel()
+        try await relay.waitForREQs(2)
+        // Give the old stream's onTermination CLOSE time to land (the
+        // bug window this test exists for).
+        try await Task.sleep(for: .milliseconds(300))
+
+        // The two REQs must carry DISTINCT subIDs — that's the whole fix.
+        let subIDs = relay.recordedSubIDs()
+        XCTAssertEqual(subIDs.count, 2)
+        XCTAssertEqual(Set(subIDs).count, 2, "re-subscribe must mint a fresh subID")
+
+        // The new subscription must still be live: push an event to the
+        // SECOND recorded subID and assert delivery.
+        relay.push(LocalWebSocketRelay.eventFrame(
+            subID: relay.lastRecordedSubID()!,
+            kind: 34113,
+            content: Data("still alive".utf8).base64EncodedString(),
+            tag: ("d", "sep-inbox:beef0001")
+        ))
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            if await received.count() >= 1 { break }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let count = await received.count()
+        XCTAssertEqual(count, 1,
+                       "the re-subscribed inbox must survive the old stream's CLOSE")
+        await transport.disconnect()
+    }
+}
+
+private actor ResubscribeBox {
+    private var ids: [String] = []
+    func append(_ id: String) { ids.append(id) }
+    func count() -> Int { ids.count }
+}
+
+// MARK: - Helpers
+
+private extension LocalWebSocketRelay {
+    func wsURL() async throws -> URL {
+        URL(string: "ws://127.0.0.1:\(try await port())")!
+    }
+}
+
+/// Actor sink for events pumped off a subscription stream, with a poll
+/// helper so tests can await a target count without racing the stream.
+private actor EventCollector {
+    private var events: [NostrEvent] = []
+
+    func append(_ event: NostrEvent) { events.append(event) }
+    func contents() -> [String] { events.map(\.content) }
+    private func count() -> Int { events.count }
+
+    func waitForCount(_ target: Int, timeout: TimeInterval = 3) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if count() >= target { return }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        throw CollectorError.timeout
+    }
+
+    enum CollectorError: Error { case timeout }
+}

--- a/Tests/OnymIOSTests/RenderAckedSeenTests.swift
+++ b/Tests/OnymIOSTests/RenderAckedSeenTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-7 of the reconnect design (F7): `.read` receipts and unread-badge
+/// clearing must be driven by *actual on-screen rendering*, not by data
+/// processing. `ChatThreadViewController.onMessagesSeen` fires only for
+/// incoming bubbles that are visible while the view is in a window and
+/// the app active — and each message at most once.
+@MainActor
+final class RenderAckedSeenTests: XCTestCase {
+    private func mountedController() -> ChatThreadViewController {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 800))
+        let vc = ChatThreadViewController()
+        window.rootViewController = vc
+        window.isHidden = false
+        return vc
+    }
+
+    private func incoming(_ body: String, at seconds: TimeInterval) -> ChatMessage {
+        ChatMessage(
+            id: UUID(), groupID: String(repeating: "aa", count: 32),
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: String(repeating: "11", count: 48), body: body,
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
+            direction: .incoming, status: .received,
+            replyToMessageID: nil, groupType: .tyranny
+        )
+    }
+
+    private func outgoing(_ body: String, at seconds: TimeInterval) -> ChatMessage {
+        ChatMessage(
+            id: UUID(), groupID: String(repeating: "aa", count: 32),
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: String(repeating: "22", count: 48), body: body,
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000 + seconds),
+            direction: .outgoing, status: .sent,
+            replyToMessageID: nil, groupType: .tyranny
+        )
+    }
+
+    private func pump(_ seconds: TimeInterval = 0.3) {
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: seconds))
+    }
+
+    func test_visibleIncomingMessages_areReportedSeen_once() {
+        let vc = mountedController()
+        var seen: [ChatMessage] = []
+        vc.onMessagesSeen = { seen.append(contentsOf: $0) }
+
+        let msgs = [incoming("one", at: 0), incoming("two", at: 1)]
+        vc.update(messages: msgs)
+        vc.view.layoutIfNeeded()
+        pump()
+
+        XCTAssertEqual(Set(seen.map(\.id)), Set(msgs.map(\.id)),
+                       "visible incoming bubbles must be reported seen")
+
+        // Re-report triggers (scroll, appear) must not duplicate.
+        seen.removeAll()
+        vc.reportVisibleIncomingMessages()
+        XCTAssertTrue(seen.isEmpty, "each message is reported at most once")
+    }
+
+    func test_outgoingMessages_areNeverReportedSeen() {
+        let vc = mountedController()
+        var seen: [ChatMessage] = []
+        vc.onMessagesSeen = { seen.append(contentsOf: $0) }
+
+        vc.update(messages: [outgoing("mine", at: 0), incoming("theirs", at: 1)])
+        vc.view.layoutIfNeeded()
+        pump()
+
+        XCTAssertEqual(seen.map(\.body), ["theirs"],
+                       "own outgoing messages are not read-receipt subjects")
+    }
+
+    func test_nothingReported_whileNotVisible_reportedOnBecomeActive() {
+        let vc = mountedController()
+        var seen: [ChatMessage] = []
+        vc.onMessagesSeen = { seen.append(contentsOf: $0) }
+        vc.canScrollNow = { false }  // "backgrounded": not user-visible
+
+        vc.update(messages: [incoming("bg message", at: 0)])
+        vc.view.layoutIfNeeded()
+        pump()
+        XCTAssertTrue(seen.isEmpty,
+                      "a message rendered while backgrounded must NOT be marked read (F7)")
+
+        // Foreground: now a person can actually see it.
+        vc.canScrollNow = { true }
+        NotificationCenter.default.post(
+            name: UIApplication.didBecomeActiveNotification, object: nil
+        )
+        pump()
+        XCTAssertEqual(seen.map(\.body), ["bg message"],
+                       "the message must be reported once the app is active and it's on screen")
+    }
+
+    func test_messageBelowTheFold_reportedOnlyWhenScrolledIntoView() {
+        let vc = mountedController()
+        var seen: [ChatMessage] = []
+        vc.onMessagesSeen = { seen.append(contentsOf: $0) }
+
+        // Long thread: cold open lands at the bottom, so the OLDEST
+        // messages are off screen.
+        let msgs = (0..<60).map { incoming("m\($0)", at: TimeInterval($0)) }
+        vc.update(messages: msgs)
+        vc.view.layoutIfNeeded()
+        pump()
+
+        let table = vc.view.subviews.compactMap { $0 as? UITableView }.first
+            ?? vc.view.subviews.flatMap(\.subviews).compactMap { $0 as? UITableView }.first!
+        XCTAssertFalse(seen.contains { $0.body == "m0" },
+                       "a bubble below/above the fold is not seen")
+        let initiallySeen = Set(seen.map(\.id))
+
+        // Scroll to the top — the oldest bubbles become visible.
+        table.setContentOffset(.zero, animated: false)
+        table.layoutIfNeeded()
+        vc.reportVisibleIncomingMessages()
+        pump(0.1)
+
+        XCTAssertTrue(seen.contains { $0.body == "m0" },
+                      "scrolling a bubble on screen must report it seen")
+        XCTAssertGreaterThan(seen.count, initiallySeen.count)
+    }
+}

--- a/Tests/OnymIOSTests/Support/LocalWebSocketRelay.swift
+++ b/Tests/OnymIOSTests/Support/LocalWebSocketRelay.swift
@@ -1,0 +1,251 @@
+import CryptoKit
+import Foundation
+import Network
+
+/// Minimal in-process WebSocket server for transport tests. Not a real
+/// Nostr relay — just enough NIP-01 to drive `NostrRelayConnection`:
+///
+///  - accepts connections (keeps the most recent one), counts them
+///  - records every `["REQ", subID, filter...]` (excluding the client's
+///    internal liveness probe) so tests can assert REQ replay and filter
+///    shape
+///  - "stores" events per subID and replays them (+ EOSE) on each REQ,
+///    like a real relay's backfill-on-subscribe
+///  - auto-answers every REQ (including the liveness probe) with EOSE —
+///    disable via `autoRespondEOSE = false` to model a silent/half-open
+///    peer for liveness tests
+///  - can inject `["CLOSED", subID, reason]` and hard-drop the socket
+final class LocalWebSocketRelay: @unchecked Sendable {
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "test.ws.relay")
+    private let lock = NSLock()
+    private var current: NWConnection?
+    private var acceptedCount = 0
+    /// Recorded REQs in arrival order: (subID, filters). Probe excluded.
+    private var recordedREQs: [(subID: String, filters: [[String: Any]])] = []
+    /// Events "stored" on the relay, keyed by the subID they replay under.
+    private var storedBySubID: [String: [String]] = [:]
+    /// Backing storage for the response-mode flags; written by test
+    /// threads, read on the listener queue — lock-guarded.
+    private var _autoRespondEOSE = true
+    private var _autoCLOSESubscriptions = false
+
+    /// When false, the relay answers nothing at all (no EOSE, no stored
+    /// replay) — a healthy-looking but silent peer.
+    var autoRespondEOSE: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _autoRespondEOSE }
+        set { lock.lock(); defer { lock.unlock() }; _autoRespondEOSE = newValue }
+    }
+
+    /// When true, every non-probe REQ is answered with
+    /// `["CLOSED", subID, …]` — a relay that persistently rejects the
+    /// subscription (e.g. a maxSubsPerConnection cap).
+    var autoCLOSESubscriptions: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _autoCLOSESubscriptions }
+        set { lock.lock(); defer { lock.unlock() }; _autoCLOSESubscriptions = newValue }
+    }
+
+    init() throws {
+        let params = NWParameters.tcp
+        let ws = NWProtocolWebSocket.Options()
+        ws.autoReplyPing = true
+        params.defaultProtocolStack.applicationProtocols.insert(ws, at: 0)
+        listener = try NWListener(using: params, on: .any)
+
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else { return }
+            self.lock.lock()
+            self.acceptedCount += 1
+            self.current = connection
+            self.lock.unlock()
+            connection.start(queue: self.queue)
+            self.receive(on: connection)
+        }
+        listener.start(queue: queue)
+    }
+
+    // MARK: - Observation
+
+    /// The OS-assigned loopback port (listener start is asynchronous).
+    func port() async throws -> UInt16 {
+        try await poll(timeout: 2) {
+            guard let p = listener.port?.rawValue, p != 0 else { return nil }
+            return p
+        }
+    }
+
+    /// Connections accepted so far. A reconnect shows up as an increment.
+    func connectionCount() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return acceptedCount
+    }
+
+    /// Non-probe REQs seen so far.
+    func reqCount() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return recordedREQs.count
+    }
+
+    /// Non-probe REQs recorded for one subscription id, in order.
+    func reqs(subID: String) -> [[[String: Any]]] {
+        lock.lock(); defer { lock.unlock() }
+        return recordedREQs.filter { $0.subID == subID }.map(\.filters)
+    }
+
+    /// All recorded (non-probe) subscription ids, in arrival order.
+    func recordedSubIDs() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return recordedREQs.map(\.subID)
+    }
+
+    /// The most recently REQ'd (non-probe) subscription id.
+    func lastRecordedSubID() -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return recordedREQs.last?.subID
+    }
+
+    @discardableResult
+    func waitForConnections(_ count: Int, timeout: TimeInterval = 3) async throws -> Int {
+        try await poll(timeout: timeout) { connectionCount() >= count ? connectionCount() : nil }
+    }
+
+    @discardableResult
+    func waitForREQs(_ count: Int, timeout: TimeInterval = 3) async throws -> Int {
+        try await poll(timeout: timeout) { reqCount() >= count ? reqCount() : nil }
+    }
+
+    // MARK: - Driving
+
+    /// Send a raw text frame to the current connection.
+    func push(_ text: String) {
+        lock.lock(); let conn = current; lock.unlock()
+        guard let conn else { return }
+        let meta = NWProtocolWebSocket.Metadata(opcode: .text)
+        let context = NWConnection.ContentContext(identifier: "send", metadata: [meta])
+        conn.send(
+            content: Data(text.utf8),
+            contentContext: context,
+            isComplete: true,
+            completion: .contentProcessed { _ in }
+        )
+    }
+
+    /// "Store" an event on the relay: replayed (before EOSE) on every
+    /// subsequent REQ for `subID` — models a message that arrived while
+    /// the client was away and must be backfilled on re-subscribe.
+    func store(subID: String, eventJSON: String) {
+        lock.lock(); storedBySubID[subID, default: []].append(eventJSON); lock.unlock()
+    }
+
+    /// Inject a relay-side subscription termination.
+    func sendCLOSED(subID: String, reason: String = "error: too many concurrent REQs") {
+        push("[\"CLOSED\",\"\(subID)\",\"\(reason)\"]")
+    }
+
+    /// Hard-drop the current connection — the client's `receive()` errors
+    /// and its reconnect path must rebuild.
+    func dropCurrentConnection() {
+        lock.lock(); let conn = current; current = nil; lock.unlock()
+        conn?.forceCancel()
+    }
+
+    func stop() {
+        listener.cancel()
+        lock.lock(); let conn = current; current = nil; lock.unlock()
+        conn?.forceCancel()
+    }
+
+    // MARK: - Private
+
+    private func receive(on connection: NWConnection) {
+        connection.receiveMessage { [weak self] data, _, isComplete, error in
+            guard let self, error == nil else { return }
+            // Re-arm FIRST: a non-final or unparseable frame must not
+            // silently kill the read loop mid-test.
+            self.receive(on: connection)
+            guard isComplete, let data else { return }
+            self.handleFrame(data, on: connection)
+        }
+    }
+
+    /// Record + answer a client `REQ`; drain everything else.
+    private func handleFrame(_ data: Data, on connection: NWConnection) {
+        guard
+            let array = try? JSONSerialization.jsonObject(with: data) as? [Any],
+            array.count >= 2,
+            (array[0] as? String) == "REQ",
+            let subID = array[1] as? String
+        else { return }
+        let filters = array.dropFirst(2).compactMap { $0 as? [String: Any] }
+
+        lock.lock()
+        if subID != "__onym_hb" {
+            recordedREQs.append((subID: subID, filters: filters))
+        }
+        let stored = storedBySubID[subID] ?? []
+        let respond = _autoRespondEOSE
+        let reject = _autoCLOSESubscriptions && subID != "__onym_hb"
+        lock.unlock()
+
+        if reject {
+            push("[\"CLOSED\",\"\(subID)\",\"error: too many concurrent REQs\"]")
+            return
+        }
+        guard respond else { return }
+        for eventJSON in stored {
+            push("[\"EVENT\",\"\(subID)\",\(eventJSON)]")
+        }
+        push("[\"EOSE\",\"\(subID)\"]")
+    }
+
+    /// Async poll that yields between checks (never blocks a cooperative
+    /// pool thread the way `Thread.sleep` would).
+    private func poll<T>(timeout: TimeInterval, _ probe: () -> T?) async throws -> T {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let value = probe() { return value }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        throw RelayError.timeout
+    }
+
+    enum RelayError: Error { case timeout }
+
+    // MARK: - Event construction
+
+    /// A full `["EVENT", subID, {...}]` frame whose event id is a valid
+    /// NIP-01 hash of its fields (so `parseEvent`'s `verifyEventID()`
+    /// accepts it). The signature is throwaway — the client verifies the
+    /// id, not the signature, at this layer.
+    static func eventFrame(subID: String, kind: Int, content: String, tag: (String, String)) -> String {
+        let event = eventObjectJSON(kind: kind, content: content, tag: tag)
+        return "[\"EVENT\",\"\(subID)\",\(event)]"
+    }
+
+    /// The bare event object (no frame wrapper) for `store(subID:eventJSON:)`.
+    /// The pubkey is derived from `content`, so distinct contents make
+    /// distinct events with distinct ids — mirroring the app's
+    /// ephemeral-pubkey-per-send design.
+    static func eventObjectJSON(kind: Int, content: String, tag: (String, String)) -> String {
+        let pubkey = String(
+            SHA256.hash(data: Data(content.utf8))
+                .map { String(format: "%02x", $0) }.joined().prefix(64)
+        )
+        let createdAt = 1_700_000_000
+        let tags = [[tag.0, tag.1]]
+        let canonical: [Any] = [0, pubkey, createdAt, kind, tags, content]
+        let serialized = try! JSONSerialization.data(withJSONObject: canonical, options: [])
+        let id = Data(SHA256.hash(data: serialized)).map { String(format: "%02x", $0) }.joined()
+        let event: [String: Any] = [
+            "id": id,
+            "pubkey": pubkey,
+            "created_at": createdAt,
+            "kind": kind,
+            "tags": tags,
+            "content": content,
+            "sig": String(repeating: "0", count: 128),
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: event, options: [])
+        return String(data: data, encoding: .utf8)!
+    }
+}

--- a/Tests/OnymIOSTests/TransportLifecycleRepositoryTests.swift
+++ b/Tests/OnymIOSTests/TransportLifecycleRepositoryTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import OnymIOS
+
+/// PR-8 of the reconnect design: the transport's lifecycle belongs to
+/// the repository layer, not the view tree. The repository owns connect
+/// + every reconnect trigger (injected streams — no UIKit here), and the
+/// presentation layer's ONLY contact with the transport is the
+/// connection-state snapshot stream.
+final class TransportLifecycleRepositoryTests: XCTestCase {
+    private func makeSignals() -> (stream: AsyncStream<Void>, fire: () -> Void, finish: () -> Void) {
+        var continuation: AsyncStream<Void>.Continuation!
+        let stream = AsyncStream<Void> { continuation = $0 }
+        let cont = continuation!
+        return (stream, { cont.yield(()) }, { cont.finish() })
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 3,
+        _ condition: () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTFail("condition not met within \(timeout)s")
+    }
+
+    func test_start_connectsToEndpoints() async throws {
+        let transport = FakeInboxTransport()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: makeSignals().stream,
+            connectivitySignals: makeSignals().stream
+        )
+        let endpoint = TransportEndpoint(url: URL(string: "wss://relay.example")!)
+        await repo.start(endpoints: [endpoint])
+
+        let connected = await transport.connectedEndpoints
+        XCTAssertEqual(connected, [endpoint], "start() must issue the initial connect")
+        await repo.stop()
+    }
+
+    func test_foregroundSignal_triggersReconnect() async throws {
+        let transport = FakeInboxTransport()
+        let foreground = makeSignals()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: foreground.stream,
+            connectivitySignals: makeSignals().stream
+        )
+        await repo.start(endpoints: [])
+
+        foreground.fire()
+        try await waitUntil { await transport.reconnectCallCount >= 1 }
+
+        foreground.fire()
+        try await waitUntil { await transport.reconnectCallCount >= 2 }
+        await repo.stop()
+    }
+
+    func test_connectivitySignal_triggersReconnect() async throws {
+        let transport = FakeInboxTransport()
+        let connectivity = makeSignals()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: makeSignals().stream,
+            connectivitySignals: connectivity.stream
+        )
+        await repo.start(endpoints: [])
+
+        connectivity.fire()
+        try await waitUntil { await transport.reconnectCallCount >= 1 }
+        await repo.stop()
+    }
+
+    func test_connectionSnapshots_replayCurrentAndMirrorTransport() async throws {
+        // FakeInboxTransport uses the protocol's default state stream
+        // (permanently connected) — the repository must replay `true`
+        // on subscribe.
+        let transport = FakeInboxTransport()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: makeSignals().stream,
+            connectivitySignals: makeSignals().stream
+        )
+        await repo.start(endpoints: [])
+
+        var iterator = repo.connectionSnapshots.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first, true)
+        await repo.stop()
+    }
+
+    func test_stop_endsTriggerForwarding() async throws {
+        let transport = FakeInboxTransport()
+        let foreground = makeSignals()
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: foreground.stream,
+            connectivitySignals: makeSignals().stream
+        )
+        await repo.start(endpoints: [])
+        await repo.stop()
+
+        foreground.fire()
+        try await Task.sleep(for: .milliseconds(300))
+        let count = await transport.reconnectCallCount
+        XCTAssertEqual(count, 0, "a stopped repository must not forward triggers")
+    }
+
+    /// End-to-end state signal against the loopback relay: connected
+    /// flips true when a frame confirms the socket live, and false when
+    /// the relay dies while backoff retries run.
+    func test_connectionState_reflectsRelayLiveness() async throws {
+        let relay = try LocalWebSocketRelay()
+        let transport = NostrInboxTransport(
+            signerProvider: OnymNostrSignerProvider(),
+            highWaterMarks: UserDefaultsInboxTransportTestStore()
+        )
+        let url = URL(string: "ws://127.0.0.1:\(try await relay.port())")!
+
+        let repo = TransportLifecycleRepository(
+            transport: transport,
+            foregroundSignals: makeSignals().stream,
+            connectivitySignals: makeSignals().stream
+        )
+        await repo.start(endpoints: [TransportEndpoint(url: url)])
+
+        let states = StateBox()
+        let snapshots = repo.connectionSnapshots
+        let pump = Task { for await state in snapshots { await states.append(state) } }
+        defer { pump.cancel() }
+
+        // A subscription draws an EOSE — the confirming frame.
+        let stream = transport.subscribe(inbox: TransportInboxID(rawValue: "feed0001"))
+        let subPump = Task { for await _ in stream {} }
+        defer { subPump.cancel() }
+
+        try await waitUntil { await states.all().contains(true) }
+
+        // Kill the relay entirely: the receive error tears the socket
+        // down and reconnect attempts fail — state must flip false.
+        relay.stop()
+        try await waitUntil { await states.all().last == false }
+        await repo.stop()
+        await transport.disconnect()
+    }
+}
+
+private actor StateBox {
+    private var values: [Bool] = []
+    func append(_ value: Bool) { values.append(value) }
+    func all() -> [Bool] { values }
+}
+
+/// Isolated HWM store so the state test never touches shared defaults.
+private final class UserDefaultsInboxTransportTestStore: InboxHighWaterMarkStoring, @unchecked Sendable {
+    private let inner = UserDefaultsInboxHighWaterMarkStore(
+        defaults: UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+    )
+    func highWaterMark(inbox: String) -> Int64? { inner.highWaterMark(inbox: inbox) }
+    func raise(inbox: String, to createdAt: Int64) { inner.raise(inbox: inbox, to: createdAt) }
+}


### PR DESCRIPTION
**4/4 — every test for PRs 1–3 in one reviewable place**, plus the `LocalWebSocketRelay` loopback harness (REQ/filter/since recording, store-and-replay backfill, EOSE auto-reply, CLOSED injection + auto-CLOSE mode, hard-drop).

Coverage map in the commit message; highlights:
- the canonical **bg→fg missed-message repro** (stored event delivered purely by the rebuilt REQ's backfill)
- **CLOSED hot-loop regression** (persistently rejecting relay: rebuild count stays bounded)
- **starvation repro** (chat persists <1 s while a 2 s chain-read occupies the slow lane)
- **F7 repro** (rendered-while-backgrounded not marked read until `didBecomeActive`)

The union of PRs 1–4 is **verified byte-identical** to the previously reviewed 8-PR stack state (`git diff` empty against `transport/pr8-lifecycle-repository`). Full suite: **918 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)