### PR TITLE
fix(transport): bind relay receive loop to its socket + honor disconnect

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -33,6 +33,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Onym uses the camera to scan invite-key QR codes when you add someone to a group.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Info.plist
+++ b/Info.plist
@@ -33,15 +33,6 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<!-- Export compliance. Onym uses non-exempt encryption (end-to-end
-	     message/media encryption with AES-256-GCM + X25519, beyond
-	     HTTPS), so this is `true`. The app ships only industry-standard,
-	     publicly documented algorithms — it qualifies for US License
-	     Exception ENC (ECCN 5D992.c, mass market) via a self-classification
-	     report, and needs a French encryption declaration to be sold in
-	     France. See docs/compliance/. -->
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Onym uses the camera to scan invite-key QR codes when you add someone to a group.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Sources/OnymIOS/Chats/ChatReceiptSender.swift
+++ b/Sources/OnymIOS/Chats/ChatReceiptSender.swift
@@ -5,40 +5,46 @@ import Foundation
 /// Injected into the dispatcher (delivered receipts on receive) and the
 /// chat thread (read receipts on view). Best-effort: a failed seal or
 /// send is swallowed — a missing receipt only costs a check mark, never
-/// correctness.
+/// correctness. Returns whether the transport accepted the publish so
+/// the dispatcher can latch `deliveredAckSent` only on success and
+/// retry the receipt on the next inbox replay otherwise.
 protocol ChatReceiptSending: Sendable {
+    @discardableResult
     func send(
         kind: ChatReceiptPayload.Kind,
         messageIDs: [UUID],
         groupID: Data,
         to recipientInboxKey: Data
-    ) async
+    ) async -> Bool
 }
 
 /// Default no-op so the dispatcher's many test constructions don't have
 /// to thread a receipt sender they don't exercise (same posture as
-/// `pendingInvites` / `groupStateRefresher`).
+/// `pendingInvites` / `groupStateRefresher`). Reports `false` — nothing
+/// was sent, so nothing should be latched as acked.
 struct NoopChatReceiptSender: ChatReceiptSending {
+    @discardableResult
     func send(
         kind: ChatReceiptPayload.Kind,
         messageIDs: [UUID],
         groupID: Data,
         to recipientInboxKey: Data
-    ) async {}
+    ) async -> Bool { false }
 }
 
 struct ChatReceiptSender: ChatReceiptSending {
     let identity: IdentityRepository
     let inboxTransport: any InboxTransport
 
+    @discardableResult
     func send(
         kind: ChatReceiptPayload.Kind,
         messageIDs: [UUID],
         groupID: Data,
         to recipientInboxKey: Data
-    ) async {
-        guard !messageIDs.isEmpty else { return }
-        guard let active = await identity.currentIdentity() else { return }
+    ) async -> Bool {
+        guard !messageIDs.isEmpty else { return false }
+        guard let active = await identity.currentIdentity() else { return false }
         let myBlsHex = active.blsPublicKey.map { String(format: "%02x", $0) }.joined()
         let payload = ChatReceiptPayload(
             version: 1,
@@ -49,9 +55,9 @@ struct ChatReceiptSender: ChatReceiptSending {
         )
         guard let bytes = try? JSONEncoder().encode(payload),
               let sealed = try? await identity.sealInvitation(payload: bytes, to: recipientInboxKey)
-        else { return }
+        else { return false }
         let tag = TransportInboxID(rawValue: Self.inboxTag(from: recipientInboxKey))
-        _ = try? await inboxTransport.send(sealed, to: tag)
+        return (try? await inboxTransport.send(sealed, to: tag)) != nil
     }
 
     /// Same derivation as `SendMessageInteractor` / `IntroInboxPump`.

--- a/Sources/OnymIOS/Chats/MessageRepository.swift
+++ b/Sources/OnymIOS/Chats/MessageRepository.swift
@@ -47,10 +47,10 @@ actor MessageRepository {
     /// to `MessageStore.insertOrUpdate`). Receive-side replays and
     /// outgoing status flips both flow through here.
     @discardableResult
-    func insert(_ message: ChatMessage) async -> Bool {
-        let inserted = await store.insertOrUpdate(message)
+    func insert(_ message: ChatMessage) async -> MessageInsertOutcome {
+        let outcome = await store.insertOrUpdate(message)
         await refresh(ThreadKey(groupID: message.groupID, owner: message.ownerIdentityID))
-        return inserted
+        return outcome
     }
 
     /// Flip an outgoing message's status (pending → sent / failed).

--- a/Sources/OnymIOS/Chats/MessageRepository.swift
+++ b/Sources/OnymIOS/Chats/MessageRepository.swift
@@ -53,6 +53,25 @@ actor MessageRepository {
         return outcome
     }
 
+    /// Whether the delivered receipt for one incoming row still needs
+    /// to be sent — `true` until `markDeliveredAckSent` latches it.
+    /// See `MessageStore.needsDeliveredAck`.
+    func needsDeliveredAck(id: UUID, owner: IdentityID) async -> Bool {
+        await store.needsDeliveredAck(
+            id: id,
+            ownerIDString: owner.rawValue.uuidString
+        )
+    }
+
+    /// Latch one row's delivered receipt as successfully sent. No
+    /// snapshot refresh — the flag never renders.
+    func markDeliveredAckSent(id: UUID, owner: IdentityID) async {
+        await store.markDeliveredAckSent(
+            id: id,
+            ownerIDString: owner.rawValue.uuidString
+        )
+    }
+
     /// Flip an outgoing message's status (pending → sent / failed).
     /// Hot path for the send pipeline so we don't round-trip the
     /// whole row through the encryption boundary. `failureReason`

--- a/Sources/OnymIOS/Chats/MessageStore.swift
+++ b/Sources/OnymIOS/Chats/MessageStore.swift
@@ -1,5 +1,23 @@
 import Foundation
 
+/// Result of `MessageStore.insertOrUpdate`. `.updated` (the benign
+/// replay / status-flip path) and `.failed` (nothing persisted) both
+/// mean "not a new row", but callers gating side effects must tell
+/// them apart: the delivered receipt is skipped for a replayed
+/// duplicate yet must ALSO be withheld on failure so the sender's
+/// relay copy is still replayed — and re-attempted — on the next
+/// reconnect, rather than acked for a message this device never
+/// stored.
+enum MessageInsertOutcome: Sendable, Equatable {
+    /// New row persisted.
+    case inserted
+    /// A row with the same `(id, owner)` already existed and was
+    /// updated in place.
+    case updated
+    /// Nothing was persisted — encode or save failed.
+    case failed
+}
+
 /// Persistence seam for chat messages. Async surface mirrors
 /// `GroupStore` so a concrete implementation can serialise writes on
 /// its own queue without forcing callers onto a specific actor.
@@ -33,11 +51,10 @@ protocol MessageStore: Sendable {
 
     /// Idempotent on the composite `(message.id, ownerIdentityID)`.
     /// New row → insert. Same id+owner → update in place; used both
-    /// for receive-side replays (no-op result on the second insert)
+    /// for receive-side replays (`.updated` on the second insert)
     /// and outgoing status transitions (pending → sent / failed).
-    /// Returns `true` on insert, `false` on update.
     @discardableResult
-    func insertOrUpdate(_ message: ChatMessage) async -> Bool
+    func insertOrUpdate(_ message: ChatMessage) async -> MessageInsertOutcome
 
     /// Flip just the status column (and the failure-reason column that
     /// travels with it — non-nil when flipping to `.failed`, nil

--- a/Sources/OnymIOS/Chats/MessageStore.swift
+++ b/Sources/OnymIOS/Chats/MessageStore.swift
@@ -56,6 +56,19 @@ protocol MessageStore: Sendable {
     @discardableResult
     func insertOrUpdate(_ message: ChatMessage) async -> MessageInsertOutcome
 
+    /// `true` while the row exists and its delivered receipt hasn't
+    /// been successfully handed to the transport yet. The dispatcher
+    /// consults this on replayed (`.updated`) rows so a receipt that
+    /// failed to send (relay unreachable at receive time) is retried
+    /// on the next inbox replay instead of being lost forever.
+    /// `false` for unknown rows.
+    func needsDeliveredAck(id: UUID, ownerIDString: String) async -> Bool
+
+    /// Latch the delivered receipt as sent for one row. Called only
+    /// after the transport accepted the receipt publish. No-op for
+    /// unknown rows.
+    func markDeliveredAckSent(id: UUID, ownerIDString: String) async
+
     /// Flip just the status column (and the failure-reason column that
     /// travels with it — non-nil when flipping to `.failed`, nil
     /// otherwise so a retry's pending flip clears the stale reason).

--- a/Sources/OnymIOS/Chats/PersistedMessage.swift
+++ b/Sources/OnymIOS/Chats/PersistedMessage.swift
@@ -55,6 +55,15 @@ final class PersistedMessage {
     /// optional, so adding it is a SwiftData lightweight migration
     /// over the existing store — same shape as `replyToMessageIDString`.
     var failureReasonRaw: String?
+    /// `true` once the delivered receipt for this incoming row was
+    /// successfully handed to the transport. The receipt send is
+    /// fire-and-forget with no outbox, so relay-reconnect replays are
+    /// the only retry — the dispatcher re-acks a replayed row until
+    /// this flips, then stays silent (re-acking every replay snowballed
+    /// receipt storms; see `persistChatMessage`). Plain (one bit) and
+    /// optional for lightweight migration; nil reads as `false`.
+    /// Meaningless for outgoing rows.
+    var deliveredAckSent: Bool?
 
     var encryptedSenderBlsPubkeyHex: Data
     var encryptedBody: Data
@@ -89,6 +98,7 @@ final class PersistedMessage {
         groupTypeRaw: String,
         replyToMessageIDString: String?,
         failureReasonRaw: String?,
+        deliveredAckSent: Bool? = nil,
         encryptedSenderBlsPubkeyHex: Data,
         encryptedBody: Data,
         encryptedAttachmentJSON: Data? = nil,
@@ -105,6 +115,7 @@ final class PersistedMessage {
         self.groupTypeRaw = groupTypeRaw
         self.replyToMessageIDString = replyToMessageIDString
         self.failureReasonRaw = failureReasonRaw
+        self.deliveredAckSent = deliveredAckSent
         self.encryptedSenderBlsPubkeyHex = encryptedSenderBlsPubkeyHex
         self.encryptedBody = encryptedBody
         self.encryptedAttachmentJSON = encryptedAttachmentJSON

--- a/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
+++ b/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
@@ -156,7 +156,15 @@ actor SwiftDataMessageStore: MessageStore {
             existing.encryptedVideoAttachmentJSON = encoded.encryptedVideoAttachmentJSON
             existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON
             existing.encryptedVoiceAttachmentJSON = encoded.encryptedVoiceAttachmentJSON
-            try? context.save()
+            do {
+                try context.save()
+            } catch {
+                // Discard the half-mutated row so the context reflects
+                // what's actually on disk; `.failed` keeps the enum's
+                // "nothing was persisted" promise on this path too.
+                context.rollback()
+                return .failed
+            }
             return .updated
         }
 
@@ -170,6 +178,29 @@ actor SwiftDataMessageStore: MessageStore {
             return .failed
         }
         return .inserted
+    }
+
+    func needsDeliveredAck(id: UUID, ownerIDString: String) -> Bool {
+        guard let row = fetchRow(id: id, ownerIDString: ownerIDString) else {
+            return false
+        }
+        return row.deliveredAckSent != true
+    }
+
+    func markDeliveredAckSent(id: UUID, ownerIDString: String) {
+        guard let row = fetchRow(id: id, ownerIDString: ownerIDString) else {
+            return
+        }
+        row.deliveredAckSent = true
+        try? context.save()
+    }
+
+    private func fetchRow(id: UUID, ownerIDString: String) -> PersistedMessage? {
+        let key = id.uuidString
+        let descriptor = FetchDescriptor<PersistedMessage>(
+            predicate: #Predicate { $0.id == key && $0.ownerIdentityIDString == ownerIDString }
+        )
+        return try? context.fetch(descriptor).first
     }
 
     func updateStatus(id: UUID, ownerIDString: String, status: MessageStatus, failureReason: SendFailureReason?) {

--- a/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
+++ b/Sources/OnymIOS/Chats/SwiftDataMessageStore.swift
@@ -129,8 +129,8 @@ actor SwiftDataMessageStore: MessageStore {
     }
 
     @discardableResult
-    func insertOrUpdate(_ message: ChatMessage) -> Bool {
-        guard let encoded = try? Self.encode(message) else { return false }
+    func insertOrUpdate(_ message: ChatMessage) -> MessageInsertOutcome {
+        guard let encoded = try? Self.encode(message) else { return .failed }
 
         let id = message.id.uuidString
         let owner = encoded.ownerIdentityIDString
@@ -157,12 +157,19 @@ actor SwiftDataMessageStore: MessageStore {
             existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON
             existing.encryptedVoiceAttachmentJSON = encoded.encryptedVoiceAttachmentJSON
             try? context.save()
-            return false
+            return .updated
         }
 
         context.insert(encoded)
-        try? context.save()
-        return true
+        do {
+            try context.save()
+        } catch {
+            // Roll the orphaned in-memory insert back out so the
+            // next attempt (inbox replay) starts from a clean context.
+            context.delete(encoded)
+            return .failed
+        }
+        return .inserted
     }
 
     func updateStatus(id: UUID, ownerIDString: String, status: MessageStatus, failureReason: SendFailureReason?) {

--- a/Sources/OnymIOS/Group/IntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/IntroKeyStore.swift
@@ -56,4 +56,20 @@ protocol IntroKeyStore: Sendable {
     /// here so adding/revoking an invite immediately re-balances the
     /// transport subscription set.
     nonisolated func entriesStream(forOwner ownerIdentityID: IdentityID) -> AsyncStream<[IntroKeyEntry]>
+
+    /// Launch-time garbage collection: drop every entry whose owner is
+    /// not in `owners`. `deleteForOwner` only fires for identities
+    /// removed through the app — identities orphaned by an app
+    /// delete/reinstall never cascade, and their intro keys would keep
+    /// consuming a relay subscription slot each forever. Returns the
+    /// count of entries removed.
+    @discardableResult
+    func pruneOwners(keeping owners: Set<IdentityID>) async -> Int
+}
+
+extension IntroKeyStore {
+    /// Default no-op so lightweight conformers (test doubles) don't
+    /// need GC behavior.
+    @discardableResult
+    func pruneOwners(keeping owners: Set<IdentityID>) async -> Int { 0 }
 }

--- a/Sources/OnymIOS/Group/IntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/IntroKeyStore.swift
@@ -62,14 +62,9 @@ protocol IntroKeyStore: Sendable {
     /// removed through the app — identities orphaned by an app
     /// delete/reinstall never cascade, and their intro keys would keep
     /// consuming a relay subscription slot each forever. Returns the
-    /// count of entries removed.
+    /// count of entries removed. No default implementation on purpose:
+    /// a real store that forgot GC would otherwise compile fine and
+    /// silently never collect.
     @discardableResult
     func pruneOwners(keeping owners: Set<IdentityID>) async -> Int
-}
-
-extension IntroKeyStore {
-    /// Default no-op so lightweight conformers (test doubles) don't
-    /// need GC behavior.
-    @discardableResult
-    func pruneOwners(keeping owners: Set<IdentityID>) async -> Int { 0 }
 }

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -21,13 +21,14 @@ actor KeychainIntroKeyStore: IntroKeyStore {
     static let serviceDefault = "app.onym.ios.intro_keys"
     static let account = "blob"
 
-    /// Invite links are short-lived capabilities: entries older than
-    /// this are expired — invisible to `find`/`listForOwner`/streams
-    /// (so the intro pump stops subscribing their inboxes, which each
-    /// cost a relay REQ slot) and compacted out on the next write.
-    /// Without a TTL, every link ever shared kept an inbox subscribed
-    /// forever.
-    static let entryTTL: TimeInterval = 30 * 24 * 60 * 60
+    /// How long an invite link is honored after minting. 24 hours per
+    /// issue onymchat/onym-ios#111 (shrink the leak window of a
+    /// forwarded or screenshotted link) — matches onym-android's
+    /// `IntroKeyEntry.LIFETIME_MILLIS`. Expired entries are invisible
+    /// to `find`/`listForOwner`/streams (so the intro pump stops
+    /// subscribing their inboxes, which each cost a relay REQ slot)
+    /// and compact out of the blob on the next write.
+    static let entryTTL: TimeInterval = 24 * 60 * 60
 
     private let service: String
     /// Per-owner subscriber continuations. Mutations re-emit the

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -36,6 +36,10 @@ actor KeychainIntroKeyStore: IntroKeyStore {
     /// filtered+sorted snapshot to every subscriber whose owner
     /// matches.
     private var continuations: [IdentityID: [UUID: AsyncStream<[IntroKeyEntry]>.Continuation]] = [:]
+    /// Reentrancy latch: `loadAll()` publishes when it compacts, and
+    /// `publish` itself calls `loadAll()` — the latch stops that inner
+    /// load from re-entering the compaction path.
+    private var compacting = false
 
     init(testNamespace: String? = nil) {
         if let testNamespace, !testNamespace.isEmpty {
@@ -178,8 +182,20 @@ actor KeychainIntroKeyStore: IntroKeyStore {
         // Compact immediately: expired rows carry intro PRIVATE keys,
         // and a read-only workload would otherwise leave them at rest
         // indefinitely waiting for a mutation to rewrite the blob.
-        if live.count != entries.count {
+        // Publish for the expired entries' owners so a live session's
+        // intro pump drops their relay REQ slots too — but note this
+        // still only runs when *something* touches the store; a fully
+        // quiet session keeps its slots until the next access or
+        // launch.
+        if live.count != entries.count, !compacting {
+            compacting = true
             writeAll(live)
+            let expiredOwners = Set(
+                entries.filter { $0.createdAtMillis <= cutoff }
+                    .compactMap { IdentityID($0.ownerIdentityID) }
+            )
+            for owner in expiredOwners { publish(forOwner: owner) }
+            compacting = false
         }
         return live
     }

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -27,7 +27,8 @@ actor KeychainIntroKeyStore: IntroKeyStore {
     /// `IntroKeyEntry.LIFETIME_MILLIS`. Expired entries are invisible
     /// to `find`/`listForOwner`/streams (so the intro pump stops
     /// subscribing their inboxes, which each cost a relay REQ slot)
-    /// and compact out of the blob on the next write.
+    /// and are compacted out of the blob by the load that first sees
+    /// them expired.
     static let entryTTL: TimeInterval = 24 * 60 * 60
 
     private let service: String
@@ -171,10 +172,16 @@ actor KeychainIntroKeyStore: IntroKeyStore {
         // fail to deliver and the inviter re-shares.
         let entries = (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
         // TTL filter at the single load point so expired entries are
-        // invisible to every reader; the next writeAll compacts them
-        // out of the blob.
+        // invisible to every reader.
         let cutoff = Int64((Date().timeIntervalSince1970 - Self.entryTTL) * 1000)
-        return entries.filter { $0.createdAtMillis > cutoff }
+        let live = entries.filter { $0.createdAtMillis > cutoff }
+        // Compact immediately: expired rows carry intro PRIVATE keys,
+        // and a read-only workload would otherwise leave them at rest
+        // indefinitely waiting for a mutation to rewrite the blob.
+        if live.count != entries.count {
+            writeAll(live)
+        }
+        return live
     }
 
     private func writeAll(_ entries: [StoredIntroKey]) {

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -21,6 +21,14 @@ actor KeychainIntroKeyStore: IntroKeyStore {
     static let serviceDefault = "app.onym.ios.intro_keys"
     static let account = "blob"
 
+    /// Invite links are short-lived capabilities: entries older than
+    /// this are expired — invisible to `find`/`listForOwner`/streams
+    /// (so the intro pump stops subscribing their inboxes, which each
+    /// cost a relay REQ slot) and compacted out on the next write.
+    /// Without a TTL, every link ever shared kept an inbox subscribed
+    /// forever.
+    static let entryTTL: TimeInterval = 30 * 24 * 60 * 60
+
     private let service: String
     /// Per-owner subscriber continuations. Mutations re-emit the
     /// filtered+sorted snapshot to every subscriber whose owner
@@ -81,6 +89,20 @@ actor KeychainIntroKeyStore: IntroKeyStore {
             publish(forOwner: ownerIdentityID)
         }
         return removed
+    }
+
+    @discardableResult
+    func pruneOwners(keeping owners: Set<IdentityID>) async -> Int {
+        let keep = Set(owners.map { $0.rawValue.uuidString })
+        var current = loadAll()
+        let orphaned = current.filter { !keep.contains($0.ownerIdentityID) }
+        guard !orphaned.isEmpty else { return 0 }
+        current.removeAll { !keep.contains($0.ownerIdentityID) }
+        writeAll(current)
+        for owner in Set(orphaned.compactMap { IdentityID($0.ownerIdentityID) }) {
+            publish(forOwner: owner)
+        }
+        return orphaned.count
     }
 
     nonisolated func entriesStream(forOwner ownerIdentityID: IdentityID) -> AsyncStream<[IntroKeyEntry]> {
@@ -146,7 +168,12 @@ actor KeychainIntroKeyStore: IntroKeyStore {
         // because this store holds ephemeral per-invite keys; if we
         // lose them, the worst that happens is in-flight invites
         // fail to deliver and the inviter re-shares.
-        return (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
+        let entries = (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
+        // TTL filter at the single load point so expired entries are
+        // invisible to every reader; the next writeAll compacts them
+        // out of the blob.
+        let cutoff = Int64((Date().timeIntervalSince1970 - Self.entryTTL) * 1000)
+        return entries.filter { $0.createdAtMillis > cutoff }
     }
 
     private func writeAll(_ entries: [StoredIntroKey]) {

--- a/Sources/OnymIOS/Identity/IdentitiesFlow.swift
+++ b/Sources/OnymIOS/Identity/IdentitiesFlow.swift
@@ -53,7 +53,7 @@ final class IdentitiesFlow {
     /// can fire on every view appear without leaking subscribers.
     func start() async {
         guard streamingTask == nil else { return }
-        let initialIdentities = await repository.currentIdentities()
+        let initialIdentities = (try? await repository.currentIdentities()) ?? []
         identities = initialIdentities
         currentID = await repository.currentSelectedID()
 

--- a/Sources/OnymIOS/Identity/IdentitiesProviding.swift
+++ b/Sources/OnymIOS/Identity/IdentitiesProviding.swift
@@ -7,5 +7,5 @@ import Foundation
 /// `InvitationEnvelopeDecrypting` pattern: tests substitute a canned
 /// list, production conforms `IdentityRepository` directly.
 protocol IdentitiesProviding: Sendable {
-    func currentIdentities() async -> [IdentitySummary]
+    func currentIdentities() async throws -> [IdentitySummary]
 }

--- a/Sources/OnymIOS/Identity/IdentityKeychainStore.swift
+++ b/Sources/OnymIOS/Identity/IdentityKeychainStore.swift
@@ -48,6 +48,14 @@ struct IdentityKeychainStore: Sendable {
     /// back doesn't need to remember it.
     static let account = "current"
 
+    /// Service-name prefix for quarantined items. Deliberately NOT an
+    /// extension of `servicePrefix` so `list()`/`read()` can never see
+    /// a quarantined identity. Items land here instead of being
+    /// destroyed when `reconcileFreshInstall()` decides they're
+    /// orphans of a deleted install — that verdict rests on soft
+    /// UserDefaults signals, so the key material must survive it.
+    static let quarantineServicePrefix = "app.onym.ios.identity-quarantine."
+
     /// Optional injection seam for tests — production uses the default
     /// init which targets the real Keychain. Tests pass a `serviceSuffix`
     /// override that namespaces test runs and lets `wipeAll` clean up
@@ -149,25 +157,17 @@ struct IdentityKeychainStore: Sendable {
         }
     }
 
-    /// Drop every per-identity item — used by tests in `tearDown` and
-    /// (eventually) the user-facing "reset all identities" flow.
+    /// Drop every per-identity item, active AND quarantined — used by
+    /// tests in `tearDown` and (eventually) the user-facing "reset all
+    /// identities" flow.
     func wipeAll() throws {
-        let prefix = servicePrefix(for: testNamespace)
-        let listQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecReturnAttributes as String: true,
-            kSecMatchLimit as String: kSecMatchLimitAll,
+        let prefixes = [
+            servicePrefix(for: testNamespace),
+            quarantinePrefix(for: testNamespace),
         ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(listQuery as CFDictionary, &result)
-        if status == errSecItemNotFound { return }
-        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
-            if status == errSecSuccess { return }
-            throw IdentityError.keychainRead(status)
-        }
-        for attrs in items {
+        for attrs in try listAllItems() {
             guard let service = attrs[kSecAttrService as String] as? String,
-                  service.hasPrefix(prefix)
+                  prefixes.contains(where: { service.hasPrefix($0) })
             else { continue }
             let deleteQuery: [String: Any] = [
                 kSecClass as String: kSecClassGenericPassword,
@@ -181,13 +181,89 @@ struct IdentityKeychainStore: Sendable {
         }
     }
 
+    /// Move every active per-identity item into the quarantine
+    /// namespace instead of destroying it. Quarantined items are
+    /// invisible to `list()`/`read()` (the picker, the inbox fan-out)
+    /// but the secret material stays at rest, so a wrong "fresh
+    /// install" verdict is recoverable rather than fatal.
+    func quarantineAll() throws {
+        let activePrefix = servicePrefix(for: testNamespace)
+        let targetPrefix = quarantinePrefix(for: testNamespace)
+        for attrs in try listAllItems() {
+            guard let service = attrs[kSecAttrService as String] as? String,
+                  service.hasPrefix(activePrefix)
+            else { continue }
+            let suffix = String(service.dropFirst(activePrefix.count))
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: Self.account,
+            ]
+            let rename: [String: Any] = [
+                kSecAttrService as String: targetPrefix + suffix,
+            ]
+            let status = SecItemUpdate(query as CFDictionary, rename as CFDictionary)
+            if status == errSecDuplicateItem {
+                // A previous quarantine of this same id already holds a
+                // copy — keeping it is enough; drop the active twin.
+                let deleteStatus = SecItemDelete(query as CFDictionary)
+                guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                    throw IdentityError.keychainDelete(deleteStatus)
+                }
+                continue
+            }
+            guard status == errSecSuccess || status == errSecItemNotFound else {
+                throw IdentityError.keychainWrite(status)
+            }
+        }
+    }
+
+    /// Every quarantined identity id — surfaced so a future recovery /
+    /// support flow can offer them back to the user.
+    func listQuarantined() throws -> [IdentityID] {
+        let prefix = quarantinePrefix(for: testNamespace)
+        return try listAllItems().compactMap { attrs in
+            guard let service = attrs[kSecAttrService as String] as? String,
+                  service.hasPrefix(prefix)
+            else { return nil }
+            return IdentityID(String(service.dropFirst(prefix.count)))
+        }
+    }
+
     // MARK: - Private
+
+    /// One `SecItemCopyMatching` over every generic-password item;
+    /// callers filter by service prefix. Returns `[]` when the
+    /// keychain is empty.
+    private func listAllItems() throws -> [[String: Any]] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return [] }
+        guard status == errSecSuccess else {
+            throw IdentityError.keychainRead(status)
+        }
+        return (result as? [[String: Any]]) ?? []
+    }
 
     /// Per-identity service name. Tests override the prefix via
     /// `testNamespace` so concurrent test runs don't stomp on each
     /// other's keychain entries.
     private func service(for id: IdentityID) -> String {
         servicePrefix(for: testNamespace) + id.rawValue.uuidString
+    }
+
+    /// Quarantine analogue of `servicePrefix(for:)` — same namespacing
+    /// rule so tests quarantine into their own sandbox too.
+    private func quarantinePrefix(for namespace: String?) -> String {
+        if let namespace, !namespace.isEmpty {
+            return "\(Self.quarantineServicePrefix)\(namespace)."
+        }
+        return Self.quarantineServicePrefix
     }
 
     /// Returns the prefix used to list/match per-identity items. The

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -39,6 +39,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     private var orderedIDs: [IdentityID] = []
     private var currentID: IdentityID?
     private var loaded = false
+    /// Non-nil while a first load is in flight — see `ensureLoaded()`.
+    private var loadTask: Task<Void, any Error>?
 
     private var snapshotContinuations: [UUID: AsyncStream<Identity?>.Continuation] = [:]
     private var identitiesContinuations: [UUID: AsyncStream<[IdentitySummary]>.Continuation] = [:]
@@ -540,6 +542,27 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// stored selection no longer exists.
     private func ensureLoaded() async throws {
         guard !loaded else { return }
+        // Single-flight: `performLoad()` suspends (the protected-data
+        // check hops to the MainActor), and actor reentrancy would let
+        // two first-callers interleave across that gap — both passing
+        // the `loaded` guard, both resetting state, both appending
+        // every identity twice. The app hits exactly that shape at
+        // launch: `bootstrap()` and the intro-prune's
+        // `currentIdentities()` are sibling `.task`s. First caller
+        // creates the load; everyone else awaits the same task.
+        if let inFlight = loadTask {
+            try await inFlight.value
+            return
+        }
+        let task = Task { try await self.performLoad() }
+        loadTask = task
+        // Creator clears the slot on success AND failure — a failed
+        // load must not wedge every future call on a dead task.
+        defer { loadTask = nil }
+        try await task.value
+    }
+
+    private func performLoad() async throws {
         // A previous attempt may have thrown mid-loop; start every
         // attempt from a clean slate so a retry can't double-append.
         cache.removeAll()

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -536,7 +536,11 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// stored selection no longer exists.
     private func ensureLoaded() throws {
         guard !loaded else { return }
-        loaded = true
+        // A previous attempt may have thrown mid-loop; start every
+        // attempt from a clean slate so a retry can't double-append.
+        cache.removeAll()
+        names.removeAll()
+        orderedIDs.removeAll()
         try reconcileFreshInstall()
         let ids = try keychain.list()
         // Stable order — UUIDs sort lexically. The picker also re-sorts
@@ -556,6 +560,11 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
             currentID = orderedIDs.first
             if currentID != nil { persistSelection() }
         }
+        // Only a fully-successful load marks the repo loaded. Flipping
+        // the flag up front would let a keychain error strand the repo
+        // "loaded" but empty — a retried bootstrap() then mints a
+        // duplicate identity while the real ones still sit on disk.
+        loaded = true
     }
 
     /// Keychain items survive app uninstall while UserDefaults dies
@@ -569,13 +578,21 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// - no marker, selection set  → update of an existing install:
     ///   stamp the marker, keep everything
     /// - no marker, no selection   → fresh install: any identity items
-    ///   in the keychain are orphans of a deleted install — wipe them.
-    ///   The user's path back to an identity is the recovery phrase,
-    ///   not an invisible keychain remnant.
+    ///   in the keychain are orphans of a deleted install — quarantine
+    ///   them out of the active namespace.
+    ///
+    /// Quarantine, never wipe: both signals live in UserDefaults,
+    /// whose file protection is weaker than the identity items'
+    /// (`CompleteUntilFirstUserAuthentication` vs
+    /// `AfterFirstUnlockThisDeviceOnly`), so a pre-first-unlock launch
+    /// or a corrupted defaults DB can read as "fresh install" while
+    /// real keys sit in the keychain. A wrong verdict must cost a
+    /// hidden identity (recoverable via mnemonic or a future
+    /// quarantine-recovery flow), not destroyed key material.
     private func reconcileFreshInstall() throws {
         guard !installMarker.exists() else { return }
         if selectionStore.load() == nil {
-            try keychain.wipeAll()
+            try keychain.quarantineAll()
         }
         installMarker.set()
     }

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -221,9 +221,13 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     }
 
     /// Snapshot of every identity, ordered by insertion. View-safe
-    /// (no secret material).
-    func currentIdentities() -> [IdentitySummary] {
-        orderedIDs.compactMap(summary(for:))
+    /// (no secret material). Loads from the Keychain on first access
+    /// and throws on load failure so callers can tell "no identities"
+    /// apart from "not loaded yet" — destructive callers (intro-key
+    /// pruning) must not treat a failed load as an empty list.
+    func currentIdentities() throws -> [IdentitySummary] {
+        try ensureLoaded()
+        return orderedIDs.compactMap(summary(for:))
     }
 
     /// One-shot accessor for the currently-selected identity's BLS Fr

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import Foundation
 import OnymSDK
+import UIKit
 
 /// Owns every on-device identity. All Keychain I/O and OnymSDK calls
 /// happen here; views observe `identitiesStream` + `currentIdentityID`
@@ -29,6 +30,7 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     private let keychain: IdentityKeychainStore
     private let selectionStore: SelectedIdentityStore
     private let installMarker: InstallMarker
+    private let protectedData: ProtectedDataAvailability
 
     /// In-memory cache of every identity loaded from the keychain.
     /// Repopulated lazily on first access via `ensureLoaded()`.
@@ -46,11 +48,13 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     init(
         keychain: IdentityKeychainStore = IdentityKeychainStore(),
         selectionStore: SelectedIdentityStore = .userDefaults,
-        installMarker: InstallMarker = .userDefaults
+        installMarker: InstallMarker = .userDefaults,
+        protectedData: ProtectedDataAvailability = .uiApplication
     ) {
         self.keychain = keychain
         self.selectionStore = selectionStore
         self.installMarker = installMarker
+        self.protectedData = protectedData
     }
 
     // MARK: - Bootstrap / lifecycle
@@ -59,8 +63,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// generates a default-named one. Returns the currently-selected
     /// identity (post-bootstrap there's always one selected).
     @discardableResult
-    func bootstrap() throws -> Identity {
-        try ensureLoaded()
+    func bootstrap() async throws -> Identity {
+        try await ensureLoaded()
         if cache.isEmpty {
             let id = try addLocked(name: nil, mnemonic: nil)
             currentID = id
@@ -82,8 +86,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// phrase or generates a fresh one when nil. The new identity
     /// becomes current iff there was no current identity before.
     @discardableResult
-    func add(name: String? = nil, mnemonic: String? = nil) throws -> IdentityID {
-        try ensureLoaded()
+    func add(name: String? = nil, mnemonic: String? = nil) async throws -> IdentityID {
+        try await ensureLoaded()
         let id = try addLocked(name: name, mnemonic: mnemonic)
         if currentID == nil {
             currentID = id
@@ -96,8 +100,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// Switch the currently-selected identity. Calls with an unknown
     /// `id` are no-ops (defensive — UI should never present an ID
     /// that isn't in the picker).
-    func select(_ id: IdentityID) throws {
-        try ensureLoaded()
+    func select(_ id: IdentityID) async throws {
+        try await ensureLoaded()
         guard cache[id] != nil else { return }
         guard currentID != id else { return }
         currentID = id
@@ -109,8 +113,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// cache, picks a new current (next in order, or nil if it was the
     /// last). Subscribers of `identityRemoved` get notified so they
     /// can wipe identity-scoped state (chats, messages — PR-3).
-    func remove(_ id: IdentityID) throws {
-        try ensureLoaded()
+    func remove(_ id: IdentityID) async throws {
+        try await ensureLoaded()
         guard cache[id] != nil else { return }
         try keychain.wipe(id)
         cache.removeValue(forKey: id)
@@ -135,8 +139,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     ///
     /// - Throws: `IdentityError.identityNotLoaded` if `id` doesn't exist
     ///   on this device.
-    func rename(_ id: IdentityID, newName: String) throws {
-        try ensureLoaded()
+    func rename(_ id: IdentityID, newName: String) async throws {
+        try await ensureLoaded()
         let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return }
         guard var snapshot = try keychain.read(id) else {
@@ -154,11 +158,11 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// first — preserves the legacy single-slot `restore` semantic so
     /// existing tests + the recovery-phrase backup flow keep working.
     @discardableResult
-    func restore(mnemonic: String) throws -> Identity {
+    func restore(mnemonic: String) async throws -> Identity {
         guard Bip39.isValidMnemonic(mnemonic) else {
             throw IdentityError.invalidMnemonic
         }
-        try ensureLoaded()
+        try await ensureLoaded()
         for id in orderedIDs { try keychain.wipe(id) }
         let removed = orderedIDs
         cache.removeAll()
@@ -177,8 +181,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     }
 
     /// Wipe every identity. Subscribers receive nil.
-    func wipe() throws {
-        try ensureLoaded()
+    func wipe() async throws {
+        try await ensureLoaded()
         for id in orderedIDs { try keychain.wipe(id) }
         let removed = orderedIDs
         cache.removeAll()
@@ -225,8 +229,8 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// and throws on load failure so callers can tell "no identities"
     /// apart from "not loaded yet" — destructive callers (intro-key
     /// pruning) must not treat a failed load as an empty list.
-    func currentIdentities() throws -> [IdentitySummary] {
-        try ensureLoaded()
+    func currentIdentities() async throws -> [IdentitySummary] {
+        try await ensureLoaded()
         return orderedIDs.compactMap(summary(for:))
     }
 
@@ -534,14 +538,14 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// Resolves the previously-selected identity from
     /// `selectionStore`; falls back to the first identity if the
     /// stored selection no longer exists.
-    private func ensureLoaded() throws {
+    private func ensureLoaded() async throws {
         guard !loaded else { return }
         // A previous attempt may have thrown mid-loop; start every
         // attempt from a clean slate so a retry can't double-append.
         cache.removeAll()
         names.removeAll()
         orderedIDs.removeAll()
-        try reconcileFreshInstall()
+        try await reconcileFreshInstall()
         let ids = try keychain.list()
         // Stable order — UUIDs sort lexically. The picker also re-sorts
         // by name, so this is just a determinism guarantee for the
@@ -589,8 +593,15 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     /// real keys sit in the keychain. A wrong verdict must cost a
     /// hidden identity (recoverable via mnemonic or a future
     /// quarantine-recovery flow), not destroyed key material.
-    private func reconcileFreshInstall() throws {
+    private func reconcileFreshInstall() async throws {
         guard !installMarker.exists() else { return }
+        // Both inputs live in a plist that's unreadable before the
+        // first post-boot unlock — they'd silently read as "fresh
+        // install" while real keys sit in the keychain. Defer the
+        // verdict to a launch that can actually read them; nothing is
+        // lost, the identity items can't be read or renamed while
+        // locked either.
+        guard await protectedData.isAvailable() else { return }
         if selectionStore.load() == nil {
             try keychain.quarantineAll()
         }
@@ -848,6 +859,28 @@ struct SelectedIdentityStore: Sendable {
         }
         init(value: IdentityID?) { _value = value }
     }
+}
+
+/// Seam over "has the user unlocked the device since boot". The
+/// fresh-install verdict in `reconcileFreshInstall()` reads two
+/// UserDefaults values whose plist is
+/// `NSFileProtectionCompleteUntilFirstUserAuthentication` — before the
+/// first unlock both silently read as empty, indistinguishable from a
+/// genuine fresh install. Gating the reconcile on this signal defers
+/// the verdict to a launch where the inputs are actually readable.
+/// Async because the authoritative API
+/// (`UIApplication.isProtectedDataAvailable`) is main-actor-isolated;
+/// the repository hops there once, at first load. Injected so tests
+/// (and any future extension target, where `UIApplication.shared` is
+/// unavailable) can substitute a constant.
+struct ProtectedDataAvailability: Sendable {
+    let isAvailable: @Sendable () async -> Bool
+
+    static let uiApplication = ProtectedDataAvailability {
+        await MainActor.run { UIApplication.shared.isProtectedDataAvailable }
+    }
+
+    static let always = ProtectedDataAvailability { true }
 }
 
 /// First-run marker distinguishing a fresh install from a relaunch.

--- a/Sources/OnymIOS/Identity/IdentityRepository.swift
+++ b/Sources/OnymIOS/Identity/IdentityRepository.swift
@@ -28,6 +28,7 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
 
     private let keychain: IdentityKeychainStore
     private let selectionStore: SelectedIdentityStore
+    private let installMarker: InstallMarker
 
     /// In-memory cache of every identity loaded from the keychain.
     /// Repopulated lazily on first access via `ensureLoaded()`.
@@ -44,10 +45,12 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
 
     init(
         keychain: IdentityKeychainStore = IdentityKeychainStore(),
-        selectionStore: SelectedIdentityStore = .userDefaults
+        selectionStore: SelectedIdentityStore = .userDefaults,
+        installMarker: InstallMarker = .userDefaults
     ) {
         self.keychain = keychain
         self.selectionStore = selectionStore
+        self.installMarker = installMarker
     }
 
     // MARK: - Bootstrap / lifecycle
@@ -530,6 +533,7 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
     private func ensureLoaded() throws {
         guard !loaded else { return }
         loaded = true
+        try reconcileFreshInstall()
         let ids = try keychain.list()
         // Stable order — UUIDs sort lexically. The picker also re-sorts
         // by name, so this is just a determinism guarantee for the
@@ -548,6 +552,28 @@ actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelopeSealin
             currentID = orderedIDs.first
             if currentID != nil { persistSelection() }
         }
+    }
+
+    /// Keychain items survive app uninstall while UserDefaults dies
+    /// with the container — so identities from every previous install
+    /// silently resurrect into the picker and the inbox fan-out.
+    /// "Install marker absent" alone can't distinguish a fresh install
+    /// from an app UPDATE that predates the marker, so the persisted
+    /// identity selection doubles as the legacy-install signal:
+    ///
+    /// - marker present            → normal launch, nothing to do
+    /// - no marker, selection set  → update of an existing install:
+    ///   stamp the marker, keep everything
+    /// - no marker, no selection   → fresh install: any identity items
+    ///   in the keychain are orphans of a deleted install — wipe them.
+    ///   The user's path back to an identity is the recovery phrase,
+    ///   not an invisible keychain remnant.
+    private func reconcileFreshInstall() throws {
+        guard !installMarker.exists() else { return }
+        if selectionStore.load() == nil {
+            try keychain.wipeAll()
+        }
+        installMarker.set()
     }
 
     /// Mints a fresh BIP39 identity (or restores from `mnemonic` when
@@ -799,7 +825,43 @@ struct SelectedIdentityStore: Sendable {
             get { lock.withLock { _value } }
             set { lock.withLock { _value = newValue } }
         }
-        init(value: IdentityID?) { self._value = value }
+        init(value: IdentityID?) { _value = value }
+    }
+}
+
+/// First-run marker distinguishing a fresh install from a relaunch.
+/// Lives in UserDefaults precisely BECAUSE UserDefaults dies with the
+/// app container on uninstall while keychain items do not — "marker
+/// absent" is the fresh-install signal `reconcileFreshInstall()` keys
+/// off.
+struct InstallMarker: Sendable {
+    let exists: @Sendable () -> Bool
+    let set: @Sendable () -> Void
+
+    static let userDefaults: InstallMarker = {
+        let key = "app.onym.ios.identity.installMarker"
+        return InstallMarker(
+            exists: { UserDefaults.standard.bool(forKey: key) },
+            set: { UserDefaults.standard.set(true, forKey: key) }
+        )
+    }()
+
+    static func inMemory(initiallySet: Bool = false) -> InstallMarker {
+        let box = BoolBox(value: initiallySet)
+        return InstallMarker(
+            exists: { box.value },
+            set: { box.value = true }
+        )
+    }
+
+    private final class BoolBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value: Bool
+        var value: Bool {
+            get { lock.withLock { _value } }
+            set { lock.withLock { _value = newValue } }
+        }
+        init(value: Bool) { _value = value }
     }
 }
 

--- a/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
+++ b/Sources/OnymIOS/Inbox/InboxFanoutInteractor.swift
@@ -44,7 +44,7 @@ struct InboxFanoutInteractor: Sendable {
         // Apply the current identity set immediately on launch (the
         // identitiesStream replays the current value on subscribe but
         // only delivers it once we await the first element).
-        let initial = await identityRepository.currentIdentities()
+        let initial = (try? await identityRepository.currentIdentities()) ?? []
         await subscriptions.apply(
             Set(initial.map(\.id)),
             tagsByID: Self.tagsByID(initial)

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -819,21 +819,44 @@ struct IncomingMessageDispatcher: Sendable {
 
         // Ack the sender: delivered now (it only reveals a device
         // received the ciphertext). Read receipts are sent later, when
-        // the user opens the thread. Only for a NEWLY stored message:
-        // `.updated` is a relay-reconnect replay (re-acking every
-        // replayed message published a receipt per historical message
-        // on every launch, each becoming a new stored event in the
-        // sender's inbox — snowballing replays for both sides), and
-        // `.failed` stored nothing, so acking would tell the sender
-        // "delivered" about a message this device lost; staying silent
-        // leaves the relay copy to retry on the next inbox replay.
-        guard outcome == .inserted else { return }
-        await receiptSender.send(
+        // the user opens the thread. The receipt send is fire-and-
+        // forget with no outbox, so inbox replays are its only retry —
+        // gate on the persisted `deliveredAckSent` latch, not on
+        // "newly inserted":
+        // - `.inserted` → first sight, ack.
+        // - `.updated` → replay; ack ONLY if no earlier attempt
+        //   succeeded (re-acking every replay published a receipt per
+        //   historical message on every launch, each becoming a new
+        //   stored event in the sender's inbox — snowballing replays
+        //   for both sides).
+        // - `.failed` → nothing stored; acking would tell the sender
+        //   "delivered" about a message this device lost. Stay silent
+        //   so the relay copy retries on the next replay.
+        let needsAck: Bool
+        switch outcome {
+        case .inserted:
+            needsAck = true
+        case .updated:
+            needsAck = await messageRepository.needsDeliveredAck(
+                id: message.id,
+                owner: message.ownerIdentityID
+            )
+        case .failed:
+            needsAck = false
+        }
+        guard needsAck else { return }
+        let accepted = await receiptSender.send(
             kind: .delivered,
             messageIDs: [payload.messageID],
             groupID: payload.groupID,
             to: senderProfile.inboxPublicKey
         )
+        if accepted {
+            await messageRepository.markDeliveredAckSent(
+                id: message.id,
+                owner: message.ownerIdentityID
+            )
+        }
     }
 
     /// Apply an inbound receipt: raise the acked outgoing messages to

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -552,7 +552,7 @@ struct IncomingMessageDispatcher: Sendable {
     private func selfMemberProfileEntry(
         for identityID: IdentityID
     ) async -> (key: String, value: MemberProfile)? {
-        let summaries = await identities.currentIdentities()
+        let summaries = (try? await identities.currentIdentities()) ?? []
         guard let me = summaries.first(where: { $0.id == identityID }) else {
             return nil
         }

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -815,11 +815,16 @@ struct IncomingMessageDispatcher: Sendable {
             // (`ChatVoiceLoader`).
             voiceAttachment: payload.voiceAttachment
         )
-        await messageRepository.insert(message)
+        let inserted = await messageRepository.insert(message)
 
-        // Ack the sender: delivered now (unconditional — it only reveals
-        // a device received the ciphertext). Read receipts are sent
-        // later, when the user opens the thread.
+        // Ack the sender: delivered now (it only reveals a device
+        // received the ciphertext). Read receipts are sent later, when
+        // the user opens the thread. Only for a NEWLY stored message —
+        // relay reconnects replay the full inbox, and re-acking every
+        // replayed message published a receipt per historical message
+        // on every launch, each becoming a new stored event in the
+        // sender's inbox (snowballing replays for both sides).
+        guard inserted else { return }
         await receiptSender.send(
             kind: .delivered,
             messageIDs: [payload.messageID],

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -815,16 +815,19 @@ struct IncomingMessageDispatcher: Sendable {
             // (`ChatVoiceLoader`).
             voiceAttachment: payload.voiceAttachment
         )
-        let inserted = await messageRepository.insert(message)
+        let outcome = await messageRepository.insert(message)
 
         // Ack the sender: delivered now (it only reveals a device
         // received the ciphertext). Read receipts are sent later, when
-        // the user opens the thread. Only for a NEWLY stored message —
-        // relay reconnects replay the full inbox, and re-acking every
+        // the user opens the thread. Only for a NEWLY stored message:
+        // `.updated` is a relay-reconnect replay (re-acking every
         // replayed message published a receipt per historical message
         // on every launch, each becoming a new stored event in the
-        // sender's inbox (snowballing replays for both sides).
-        guard inserted else { return }
+        // sender's inbox — snowballing replays for both sides), and
+        // `.failed` stored nothing, so acking would tell the sender
+        // "delivered" about a message this device lost; staying silent
+        // leaves the relay copy to retry on the next inbox replay.
+        guard outcome == .inserted else { return }
         await receiptSender.send(
             kind: .delivered,
             messageIDs: [payload.messageID],

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -633,6 +633,14 @@ struct OnymIOSApp: App {
                     // the outer task restarts via .task { } onChange
                     // semantics in a follow-up. For V1, single-active-
                     // identity pump is sufficient.
+                    // GC intro keys whose owner identity no longer
+                    // exists (identity removed without the cascade
+                    // firing, or orphaned by an app delete/reinstall —
+                    // the keychain blob outlives the app container).
+                    // Each stale entry costs a relay subscription slot
+                    // through this pump, forever.
+                    let owners = Set(await identityRepository.currentIdentities().map(\.id))
+                    await introKeyStore.pruneOwners(keeping: owners)
                     let pump = IntroInboxPump(
                         inboxTransport: inboxTransport,
                         store: introRequestStore

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -639,8 +639,13 @@ struct OnymIOSApp: App {
                     // the keychain blob outlives the app container).
                     // Each stale entry costs a relay subscription slot
                     // through this pump, forever.
-                    let owners = Set(await identityRepository.currentIdentities().map(\.id))
-                    await introKeyStore.pruneOwners(keeping: owners)
+                    // Skip the prune when the identity load fails —
+                    // an orphaned key surviving until next launch is
+                    // recoverable; pruning against a partial identity
+                    // list would wipe live invite-link inboxes.
+                    if let identities = try? await identityRepository.currentIdentities() {
+                        await introKeyStore.pruneOwners(keeping: Set(identities.map(\.id)))
+                    }
                     let pump = IntroInboxPump(
                         inboxTransport: inboxTransport,
                         store: introRequestStore

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -642,8 +642,15 @@ struct OnymIOSApp: App {
                     // Skip the prune when the identity load fails —
                     // an orphaned key surviving until next launch is
                     // recoverable; pruning against a partial identity
-                    // list would wipe live invite-link inboxes.
-                    if let identities = try? await identityRepository.currentIdentities() {
+                    // list would wipe live invite-link inboxes. Also
+                    // skip on a successful-but-EMPTY load (fresh
+                    // install post-quarantine, or bootstrap losing the
+                    // race): with zero identities the pump subscribes
+                    // nothing anyway, and pruning would permanently
+                    // destroy intro keys whose quarantined owners a
+                    // recovery flow could still bring back.
+                    if let identities = try? await identityRepository.currentIdentities(),
+                       !identities.isEmpty {
                         await introKeyStore.pruneOwners(keeping: Set(identities.map(\.id)))
                     }
                     let pump = IntroInboxPump(

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Nostr-relay-backed `InboxTransport`. Each `send` builds a kind-34113
@@ -98,9 +99,15 @@ final class NostrInboxTransport: InboxTransport {
     fileprivate actor State {
         private var connections: [URL: NostrRelayConnection] = [:]
         private var activeSubscriptions: [TransportInboxID: Task<Void, Never>] = [:]
+        /// Monotonic counter baked into every subscription id. A
+        /// resubscribe for the same inbox cancels the old stream, whose
+        /// `onTermination` sends CLOSE for *its* id — with a fixed id
+        /// that CLOSE would tear down the replacement REQ and silence
+        /// the inbox until the next resubscribe. Same scheme as
+        /// `NostrMessageTransport.subscriptionGeneration`.
+        private var subscriptionGeneration: UInt64 = 0
 
         func connect(to endpoints: [TransportEndpoint]) async {
-            TransportLog.log("inbox transport: connect to \(endpoints.count) endpoints (\(connections.count) already connected)")
             for endpoint in endpoints {
                 if connections[endpoint.url] == nil {
                     let conn = NostrRelayConnection(url: endpoint.url)
@@ -155,7 +162,6 @@ final class NostrInboxTransport: InboxTransport {
             let accepted = outcomes.filter {
                 if case .accepted = $0 { return true } else { return false }
             }.count
-            TransportLog.log("inbox send id=\(event.id.prefix(8)): accepted by \(accepted)/\(conns.count) relays")
             if accepted > 0 { return accepted }
 
             let anyRejected = outcomes.contains {
@@ -176,10 +182,12 @@ final class NostrInboxTransport: InboxTransport {
             continuation: AsyncStream<InboundInbox>.Continuation
         ) {
             activeSubscriptions[inbox]?.cancel()
-            let subID = "inbox-\(inbox.rawValue)"
+            subscriptionGeneration += 1
+            // NIP-01 caps subscription ids at 64 chars; the raw inbox
+            // pubkey is already 64, so ship a truncated digest instead.
+            let subID = "inbox-\(Self.subIDHash(inbox.rawValue))-\(subscriptionGeneration)"
             let filters = NostrInboxTransport.subscriptionFilters(inbox: inbox.rawValue)
             let conns = Array(connections.values)
-            TransportLog.log("inbox subscribe \(inbox.rawValue.prefix(12)): 1 REQ (\(filters.count) filters) × \(conns.count) relays")
 
             // All filter shapes ride in ONE REQ per relay: relays cap
             // concurrent REQs per connection (strfry rejects overflow with
@@ -193,10 +201,8 @@ final class NostrInboxTransport: InboxTransport {
                             for await event in stream {
                                 guard !Task.isCancelled else { break }
                                 guard let payload = Data(base64Encoded: event.content) else {
-                                    TransportLog.log("inbox \(inbox.rawValue.prefix(12)): event \(event.id.prefix(8)) DROPPED, content not base64")
                                     continue
                                 }
-                                TransportLog.log("inbox \(inbox.rawValue.prefix(12)): yielding event \(event.id.prefix(8)) (\(payload.count)B)")
                                 let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
                                 continuation.yield(InboundInbox(
                                     inbox: inbox,
@@ -213,9 +219,18 @@ final class NostrInboxTransport: InboxTransport {
         }
 
         func unsubscribe(inbox: TransportInboxID) {
-            TransportLog.log("inbox unsubscribe \(inbox.rawValue.prefix(12))")
             activeSubscriptions[inbox]?.cancel()
             activeSubscriptions.removeValue(forKey: inbox)
+        }
+
+        /// First 16 hex chars of SHA-256 — collision-safe for the
+        /// handful of inboxes one client subscribes to, and short
+        /// enough to leave room for the generation suffix.
+        private static func subIDHash(_ inbox: String) -> String {
+            SHA256.hash(data: Data(inbox.utf8))
+                .prefix(8)
+                .map { String(format: "%02x", $0) }
+                .joined()
         }
     }
 }

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -100,6 +100,7 @@ final class NostrInboxTransport: InboxTransport {
         private var activeSubscriptions: [TransportInboxID: Task<Void, Never>] = [:]
 
         func connect(to endpoints: [TransportEndpoint]) async {
+            TransportLog.log("inbox transport: connect to \(endpoints.count) endpoints (\(connections.count) already connected)")
             for endpoint in endpoints {
                 if connections[endpoint.url] == nil {
                     let conn = NostrRelayConnection(url: endpoint.url)
@@ -154,6 +155,7 @@ final class NostrInboxTransport: InboxTransport {
             let accepted = outcomes.filter {
                 if case .accepted = $0 { return true } else { return false }
             }.count
+            TransportLog.log("inbox send id=\(event.id.prefix(8)): accepted by \(accepted)/\(conns.count) relays")
             if accepted > 0 { return accepted }
 
             let anyRejected = outcomes.contains {
@@ -177,6 +179,7 @@ final class NostrInboxTransport: InboxTransport {
             let subIDBase = "inbox-\(inbox.rawValue)"
             let filters = NostrInboxTransport.subscriptionFilters(inbox: inbox.rawValue)
             let conns = Array(connections.values)
+            TransportLog.log("inbox subscribe \(inbox.rawValue.prefix(12)): \(filters.count) filters × \(conns.count) relays")
 
             let task = Task {
                 await withTaskGroup(of: Void.self) { group in
@@ -187,7 +190,11 @@ final class NostrInboxTransport: InboxTransport {
                                 let stream = await conn.subscribe(subscriptionID: filterSubID, filter: filter)
                                 for await event in stream {
                                     guard !Task.isCancelled else { break }
-                                    guard let payload = Data(base64Encoded: event.content) else { continue }
+                                    guard let payload = Data(base64Encoded: event.content) else {
+                                        TransportLog.log("inbox \(inbox.rawValue.prefix(12)): event \(event.id.prefix(8)) DROPPED, content not base64")
+                                        continue
+                                    }
+                                    TransportLog.log("inbox \(inbox.rawValue.prefix(12)): yielding event \(event.id.prefix(8)) (\(payload.count)B) from sub \(filterSubID)")
                                     let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
                                     continuation.yield(InboundInbox(
                                         inbox: inbox,
@@ -205,6 +212,7 @@ final class NostrInboxTransport: InboxTransport {
         }
 
         func unsubscribe(inbox: TransportInboxID) {
+            TransportLog.log("inbox unsubscribe \(inbox.rawValue.prefix(12))")
             activeSubscriptions[inbox]?.cancel()
             activeSubscriptions.removeValue(forKey: inbox)
         }

--- a/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrInboxTransport.swift
@@ -176,33 +176,34 @@ final class NostrInboxTransport: InboxTransport {
             continuation: AsyncStream<InboundInbox>.Continuation
         ) {
             activeSubscriptions[inbox]?.cancel()
-            let subIDBase = "inbox-\(inbox.rawValue)"
+            let subID = "inbox-\(inbox.rawValue)"
             let filters = NostrInboxTransport.subscriptionFilters(inbox: inbox.rawValue)
             let conns = Array(connections.values)
-            TransportLog.log("inbox subscribe \(inbox.rawValue.prefix(12)): \(filters.count) filters × \(conns.count) relays")
+            TransportLog.log("inbox subscribe \(inbox.rawValue.prefix(12)): 1 REQ (\(filters.count) filters) × \(conns.count) relays")
 
+            // All filter shapes ride in ONE REQ per relay: relays cap
+            // concurrent REQs per connection (strfry rejects overflow with
+            // "too many concurrent REQs"), and one REQ also makes the relay
+            // dedup events that match several of the overlapping filters.
             let task = Task {
                 await withTaskGroup(of: Void.self) { group in
                     for conn in conns {
-                        for (index, filter) in filters.enumerated() {
-                            group.addTask {
-                                let filterSubID = "\(subIDBase)-\(index)"
-                                let stream = await conn.subscribe(subscriptionID: filterSubID, filter: filter)
-                                for await event in stream {
-                                    guard !Task.isCancelled else { break }
-                                    guard let payload = Data(base64Encoded: event.content) else {
-                                        TransportLog.log("inbox \(inbox.rawValue.prefix(12)): event \(event.id.prefix(8)) DROPPED, content not base64")
-                                        continue
-                                    }
-                                    TransportLog.log("inbox \(inbox.rawValue.prefix(12)): yielding event \(event.id.prefix(8)) (\(payload.count)B) from sub \(filterSubID)")
-                                    let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
-                                    continuation.yield(InboundInbox(
-                                        inbox: inbox,
-                                        payload: payload,
-                                        receivedAt: received,
-                                        messageID: event.id
-                                    ))
+                        group.addTask {
+                            let stream = await conn.subscribe(subscriptionID: subID, filters: filters)
+                            for await event in stream {
+                                guard !Task.isCancelled else { break }
+                                guard let payload = Data(base64Encoded: event.content) else {
+                                    TransportLog.log("inbox \(inbox.rawValue.prefix(12)): event \(event.id.prefix(8)) DROPPED, content not base64")
+                                    continue
                                 }
+                                TransportLog.log("inbox \(inbox.rawValue.prefix(12)): yielding event \(event.id.prefix(8)) (\(payload.count)B)")
+                                let received = Date(timeIntervalSince1970: TimeInterval(event.displayMilliseconds) / 1000.0)
+                                continuation.yield(InboundInbox(
+                                    inbox: inbox,
+                                    payload: payload,
+                                    receivedAt: received,
+                                    messageID: event.id
+                                ))
                             }
                         }
                     }

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -1,25 +1,6 @@
 import Foundation
 import os.log
 
-/// TEMPORARY transport diagnostics for the device live-delivery bug.
-/// Emits nothing in release builds. Remove once resolved.
-/// Uses print() rather than os Logger because the scheme runs with
-/// OS_ACTIVITY_MODE=disable, which suppresses os_log in Xcode's console.
-enum TransportLog {
-    #if DEBUG
-    private static let timestamp: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "HH:mm:ss.SSS"
-        return f
-    }()
-    #endif
-    static func log(_ message: @autoclosure () -> String) {
-        #if DEBUG
-        print("🔌 \(timestamp.string(from: Date())) \(message())")
-        #endif
-    }
-}
-
 /// Persistent WebSocket connection to a single Nostr relay. Owns the
 /// REQ/EVENT/EOSE/OK/CLOSE framing and is the only place in the
 /// transport layer that touches `URLSessionWebSocketTask`. Reconnect with
@@ -67,11 +48,7 @@ actor NostrRelayConnection {
 
     func connect() {
         desiredConnected = true
-        guard webSocketTask == nil else {
-            TransportLog.log("connect \(url.absoluteString): skipped, socket already exists")
-            return
-        }
-        TransportLog.log("connect \(url.absoluteString): opening socket, will replay \(subscriptions.count) subs")
+        guard webSocketTask == nil else { return }
         let task = session.webSocketTask(with: url)
         self.webSocketTask = task
         task.resume()
@@ -94,7 +71,6 @@ actor NostrRelayConnection {
     }
 
     func disconnect() {
-        TransportLog.log("disconnect \(url.absoluteString)")
         desiredConnected = false
         pingTask?.cancel()
         pingTask = nil
@@ -130,8 +106,6 @@ actor NostrRelayConnection {
     /// before the send so a fast OK can never be missed.
     func publishAndAwaitOK(event: NostrEvent) async throws -> Bool {
         let eventID = event.id
-        TransportLog.log("publish \(eventID.prefix(8)) → \(url.absoluteString): awaiting OK")
-
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, any Error>) in
             self.pendingOKContinuations[eventID] = continuation
 
@@ -154,14 +128,12 @@ actor NostrRelayConnection {
 
     private func timeoutPendingOK(eventID: String) {
         if let continuation = pendingOKContinuations.removeValue(forKey: eventID) {
-            TransportLog.log("publish \(eventID.prefix(8)) → \(url.absoluteString): no OK in 5s, assuming accepted")
             continuation.resume(returning: true)
         }
     }
 
     private func failPendingOK(eventID: String, error: any Error) {
         if let continuation = pendingOKContinuations.removeValue(forKey: eventID) {
-            TransportLog.log("publish \(eventID.prefix(8)) → \(url.absoluteString): send failed: \(error)")
             continuation.resume(throwing: error)
         }
     }
@@ -198,7 +170,6 @@ actor NostrRelayConnection {
     }
 
     func unsubscribe(subscriptionID: String) {
-        TransportLog.log("CLOSE \(subscriptionID) → \(url.absoluteString)")
         subscriptions.removeValue(forKey: subscriptionID)
         let frame: [Any] = ["CLOSE", subscriptionID]
         if let data = try? JSONSerialization.data(withJSONObject: frame),
@@ -216,16 +187,7 @@ actor NostrRelayConnection {
               let string = String(data: data, encoding: .utf8)
         else { return }
         Task {
-            guard let task = webSocketTask else {
-                TransportLog.log("REQ \(subscriptionID) → \(url.absoluteString): DROPPED, no socket")
-                return
-            }
-            do {
-                try await task.send(.string(string))
-                TransportLog.log("REQ \(subscriptionID) → \(url.absoluteString): sent \(string)")
-            } catch {
-                TransportLog.log("REQ \(subscriptionID) → \(url.absoluteString): send FAILED: \(error)")
-            }
+            try? await webSocketTask?.send(.string(string))
         }
     }
 
@@ -242,8 +204,6 @@ actor NostrRelayConnection {
     /// the same CFNetwork use-after-free family as the `sendPing` crash
     /// documented above `startHeartbeat()`.
     private func receiveLoop(task: URLSessionWebSocketTask) async {
-        TransportLog.log("receiveLoop \(url.absoluteString): started")
-        defer { TransportLog.log("receiveLoop \(url.absoluteString): exited") }
         while isConnected, webSocketTask === task {
             do {
                 let message = try await task.receive()
@@ -261,10 +221,9 @@ actor NostrRelayConnection {
                 }
                 handleMessage(text)
             } catch {
-                guard webSocketTask === task else {
-                    TransportLog.log("receiveLoop \(url.absoluteString): stale loop erred (\(error)), yielding to successor")
-                    return
-                }
+                // A stale loop's socket erred after it was replaced —
+                // the successor owns reconnect now.
+                guard webSocketTask === task else { return }
                 pingTask?.cancel()
                 pingTask = nil
                 isConnected = false
@@ -275,14 +234,11 @@ actor NostrRelayConnection {
                     Self.maxReconnectDelay,
                     Self.baseReconnectDelay * pow(2.0, Double(min(reconnectAttempts - 1, 6)))
                 )
-                TransportLog.log("receiveLoop \(url.absoluteString): receive failed (\(error)), attempt \(reconnectAttempts), reconnecting in \(delay)s")
                 try? await Task.sleep(for: .seconds(delay))
                 // disconnect() may have run during the backoff sleep —
-                // a dropped connection must stay dropped.
-                guard desiredConnected, webSocketTask == nil else {
-                    TransportLog.log("receiveLoop \(url.absoluteString): reconnect abandoned (desired=\(desiredConnected), socketExists=\(webSocketTask != nil))")
-                    return
-                }
+                // a dropped connection must stay dropped. A non-nil
+                // socket means an externally-created successor exists.
+                guard desiredConnected, webSocketTask == nil else { return }
                 connect()
                 return
             }
@@ -315,25 +271,38 @@ actor NostrRelayConnection {
     }
 
     private static let probeTimeout: TimeInterval = 10
+    private static let probePollSlice: TimeInterval = 0.5
     private static let probeREQ = #"["REQ","__hb",{"ids":["0000000000000000000000000000000000000000000000000000000000000000"],"limit":1}]"#
+    private static let probeCLOSE = #"["CLOSE","__hb"]"#
 
     /// Send the probe REQ and report whether *any* frame arrived while
     /// waiting — the EOSE it provokes, or ordinary traffic, both prove
-    /// the receive path is alive.
+    /// the receive path is alive. Polls in short slices so a frame that
+    /// is already flowing ends the probe immediately instead of holding
+    /// the full timeout. The probe REQ is CLOSEd on exit — relays cap
+    /// concurrent REQs per connection, and an open `__hb` would pin one
+    /// of those slots for the socket's whole lifetime.
     private func probeLiveness() async -> Bool {
         guard let task = webSocketTask, task.state == .running else {
-            TransportLog.log("probe \(url.absoluteString): no running socket (state=\(webSocketTask?.state.rawValue ?? -1))")
             return false
         }
         let sentAt = ContinuousClock.now
         try? await task.send(.string(Self.probeREQ))
-        try? await Task.sleep(for: .seconds(Self.probeTimeout))
-        // Socket was replaced while waiting — the reconnect that did it
-        // started a fresh heartbeat, which owns liveness now.
-        guard webSocketTask === task else { return true }
-        let alive = lastFrameAt > sentAt
-        TransportLog.log("probe \(url.absoluteString): \(alive ? "alive" : "DEAD — no frame within \(Self.probeTimeout)s")")
-        return alive
+        defer {
+            Task { try? await task.send(.string(Self.probeCLOSE)) }
+        }
+        let deadline = sentAt.advanced(by: .seconds(Self.probeTimeout))
+        while ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .seconds(Self.probePollSlice))
+            // Heartbeat torn down mid-probe — don't spin out the rest
+            // of the window (a cancelled sleep returns immediately).
+            if Task.isCancelled { return true }
+            // Socket was replaced while waiting — the reconnect that
+            // did it started a fresh heartbeat, which owns liveness now.
+            guard webSocketTask === task else { return true }
+            if lastFrameAt > sentAt { return true }
+        }
+        return false
     }
 
     /// Cancelling the socket makes the pending `receive()` throw, so the
@@ -357,46 +326,32 @@ actor NostrRelayConnection {
         guard let data = text.data(using: .utf8),
               let array = try? JSONSerialization.jsonObject(with: data) as? [Any],
               let kind = array.first as? String
-        else {
-            TransportLog.log("frame ← \(url.absoluteString): unparseable (\(text.utf8.count) bytes)")
-            return
-        }
+        else { return }
 
         switch kind {
         case "EVENT":
             guard array.count >= 3,
                   let subID = array[1] as? String,
                   let eventObj = array[2] as? [String: Any]
-            else {
-                TransportLog.log("EVENT ← \(url.absoluteString): malformed frame")
-                return
-            }
-            let event = parseEvent(eventObj)
-            let matched = subscriptions[subID] != nil
-            TransportLog.log("EVENT ← \(url.absoluteString): sub=\(subID) id=\((eventObj["id"] as? String)?.prefix(8) ?? "?") parsed=\(event != nil) subKnown=\(matched)")
-            if let event,
+            else { return }
+            if let event = parseEvent(eventObj),
                let (_, callback) = subscriptions[subID]
             {
                 callback(event)
             }
-        case "EOSE":
-            TransportLog.log("EOSE ← \(url.absoluteString): sub=\(array.count >= 2 ? "\(array[1])" : "?")")
         case "OK":
             if array.count >= 3,
                let eventID = array[1] as? String,
                let accepted = array[2] as? Bool {
                 if let continuation = pendingOKContinuations.removeValue(forKey: eventID) {
-                    TransportLog.log("OK ← \(url.absoluteString): id=\(eventID.prefix(8)) accepted=\(accepted)")
                     continuation.resume(returning: accepted)
-                } else {
-                    TransportLog.log("OK ← \(url.absoluteString): id=\(eventID.prefix(8)) accepted=\(accepted), nothing pending")
                 }
                 onOKCallback?(eventID, accepted)
             }
-        case "NOTICE":
-            TransportLog.log("NOTICE ← \(url.absoluteString): \(array.count >= 2 ? "\(array[1])" : text)")
+        case "EOSE", "NOTICE":
+            break
         default:
-            TransportLog.log("frame ← \(url.absoluteString): unhandled kind=\(kind)")
+            break
         }
     }
 

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -262,8 +262,9 @@ actor NostrRelayConnection {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(Self.pingInterval))
                 guard !Task.isCancelled, let self else { break }
-                guard await self.probeLiveness() else {
-                    await self.teardownDeadSocket()
+                guard let socket = await self.currentSocket() else { break }
+                guard await self.probeLiveness(of: socket) else {
+                    await self.teardownDeadSocket(socket)
                     break
                 }
             }
@@ -275,17 +276,28 @@ actor NostrRelayConnection {
     private static let probeREQ = #"["REQ","__hb",{"ids":["0000000000000000000000000000000000000000000000000000000000000000"],"limit":1}]"#
     private static let probeCLOSE = #"["CLOSE","__hb"]"#
 
-    /// Send the probe REQ and report whether *any* frame arrived while
-    /// waiting — the EOSE it provokes, or ordinary traffic, both prove
-    /// the receive path is alive. Polls in short slices so a frame that
-    /// is already flowing ends the probe immediately instead of holding
-    /// the full timeout. The probe REQ is CLOSEd on exit — relays cap
-    /// concurrent REQs per connection, and an open `__hb` would pin one
-    /// of those slots for the socket's whole lifetime.
-    private func probeLiveness() async -> Bool {
-        guard let task = webSocketTask, task.state == .running else {
-            return false
-        }
+    /// The socket the heartbeat should probe this round, captured on
+    /// the actor so probe + teardown act on one pinned reference.
+    private func currentSocket() -> URLSessionWebSocketTask? {
+        webSocketTask
+    }
+
+    /// Send the probe REQ on `task` and report whether *any* frame
+    /// arrived while waiting — the EOSE it provokes, or ordinary
+    /// traffic, both prove the receive path is alive. Polls in short
+    /// slices so a frame that is already flowing ends the probe
+    /// immediately instead of holding the full timeout. The probe REQ
+    /// is CLOSEd on exit — relays cap concurrent REQs per connection,
+    /// and an open `__hb` would pin one of those slots for the
+    /// socket's whole lifetime. During the probe window the connection
+    /// briefly uses one extra slot; that's safe even at the relay's
+    /// cap, because an over-limit REQ is *answered* (strfry replies
+    /// CLOSED/NOTICE) and any reply frame satisfies the probe — only a
+    /// relay that silently drops over-cap REQs could produce a false
+    /// dead verdict, and keeping the subscription count below cap
+    /// (one-REQ-per-inbox + intro-key TTL/GC) is the real guard there.
+    private func probeLiveness(of task: URLSessionWebSocketTask) async -> Bool {
+        guard task.state == .running else { return false }
         let sentAt = ContinuousClock.now
         try? await task.send(.string(Self.probeREQ))
         defer {
@@ -308,9 +320,13 @@ actor NostrRelayConnection {
     /// Cancelling the socket makes the pending `receive()` throw, so the
     /// receive loop's error path runs the shared backoff + reconnect
     /// (which also replays subscriptions, fetching whatever the dead
-    /// socket missed).
-    private func teardownDeadSocket() {
-        webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
+    /// socket missed). Tears down only the socket the probe actually
+    /// judged: a reconnect may have installed a successor between the
+    /// verdict and this call, and cancelling that one would be the
+    /// foreign-cancel pattern `receiveLoop(task:)` exists to prevent.
+    private func teardownDeadSocket(_ task: URLSessionWebSocketTask) {
+        guard webSocketTask === task else { return }
+        task.cancel(with: .abnormalClosure, reason: nil)
     }
 
     /// Reject incoming frames over 1 MB so a malicious relay can't

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -17,6 +17,10 @@ actor NostrRelayConnection {
     private var pendingOKContinuations: [String: CheckedContinuation<Bool, any Error>] = [:]
     private var pingTask: Task<Void, Never>?
     private var onOKCallback: ((String, Bool) -> Void)?
+    /// Sticky connection intent. Set by `connect()`/`disconnect()` and
+    /// checked by a receive loop waking from its backoff sleep, so an
+    /// explicitly dropped connection can never resurrect itself.
+    private var desiredConnected = false
 
     func setOnOK(_ callback: @escaping (String, Bool) -> Void) {
         onOKCallback = callback
@@ -39,13 +43,13 @@ actor NostrRelayConnection {
     }
 
     func connect() {
+        desiredConnected = true
         guard webSocketTask == nil else { return }
         let task = session.webSocketTask(with: url)
         self.webSocketTask = task
         task.resume()
         isConnected = true
-        reconnectAttempts = 0
-        Task { await receiveLoop() }
+        Task { await receiveLoop(task: task) }
         startHeartbeat()
 
         for (subID, (filter, _)) in subscriptions {
@@ -63,6 +67,7 @@ actor NostrRelayConnection {
     }
 
     func disconnect() {
+        desiredConnected = false
         pingTask?.cancel()
         pingTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
@@ -174,11 +179,21 @@ actor NostrRelayConnection {
         }
     }
 
-    private func receiveLoop() async {
-        while isConnected {
-            guard let task = webSocketTask else { break }
+    /// Each loop is bound to the socket it was spawned for and exits the
+    /// moment `webSocketTask` no longer points at it. Exactly one loop
+    /// ever calls `receive()` on a given socket, and a stale loop can
+    /// never cancel a successor's socket while a receive is pending —
+    /// the same CFNetwork use-after-free family as the `sendPing` crash
+    /// documented above `startHeartbeat()`.
+    private func receiveLoop(task: URLSessionWebSocketTask) async {
+        while isConnected, webSocketTask === task {
             do {
                 let message = try await task.receive()
+                // A delivered frame proves the connection is healthy.
+                // Resetting here instead of in connect() keeps the
+                // backoff escalating for a relay that dies during the
+                // handshake, rather than retrying it every second.
+                reconnectAttempts = 0
                 let text: String
                 switch message {
                 case .string(let s): text = s
@@ -187,10 +202,11 @@ actor NostrRelayConnection {
                 }
                 handleMessage(text)
             } catch {
+                guard webSocketTask === task else { return }
                 pingTask?.cancel()
                 pingTask = nil
                 isConnected = false
-                webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
+                task.cancel(with: .abnormalClosure, reason: nil)
                 webSocketTask = nil
                 reconnectAttempts += 1
                 let delay = min(
@@ -198,6 +214,9 @@ actor NostrRelayConnection {
                     Self.baseReconnectDelay * pow(2.0, Double(min(reconnectAttempts - 1, 6)))
                 )
                 try? await Task.sleep(for: .seconds(delay))
+                // disconnect() may have run during the backoff sleep —
+                // a dropped connection must stay dropped.
+                guard desiredConnected, webSocketTask == nil else { return }
                 connect()
                 return
             }

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -21,6 +21,10 @@ actor NostrRelayConnection {
     /// checked by a receive loop waking from its backoff sleep, so an
     /// explicitly dropped connection can never resurrect itself.
     private var desiredConnected = false
+    /// Instant of the last frame the receive loop delivered. The
+    /// heartbeat compares this against its probe time to detect sockets
+    /// that died without erroring (NAT drop, suspended-app wake).
+    private var lastFrameAt = ContinuousClock.now
 
     func setOnOK(_ callback: @escaping (String, Bool) -> Void) {
         onOKCallback = callback
@@ -189,6 +193,7 @@ actor NostrRelayConnection {
         while isConnected, webSocketTask === task {
             do {
                 let message = try await task.receive()
+                lastFrameAt = ContinuousClock.now
                 // A delivered frame proves the connection is healthy.
                 // Resetting here instead of in connect() keeps the
                 // backoff escalating for a relay that dies during the
@@ -223,23 +228,54 @@ actor NostrRelayConnection {
         }
     }
 
-    /// Heartbeat sends a no-op `["CLOSE","__hb"]` instead of using
-    /// `URLSessionWebSocketTask.sendPing`. The CFNetwork ping handler has
-    /// a known crash where the pong fires on an internal queue after the
-    /// task is cancelled and dereferences a freed `nw_connection`. A
-    /// plain `.send()` doesn't have that path — if the connection is
-    /// dead, the send throws and the receive loop reconnects.
+    /// Heartbeat probes liveness with a request/response round trip
+    /// instead of `URLSessionWebSocketTask.sendPing`. The CFNetwork ping
+    /// handler has a known crash where the pong fires on an internal
+    /// queue after the task is cancelled and dereferences a freed
+    /// `nw_connection`. A fire-and-forget `.send()` isn't enough either:
+    /// on a NAT-dropped or suspend-killed socket the send buffers
+    /// locally and "succeeds" while nothing can ever arrive, so the
+    /// receive loop hangs forever without an error. The probe is a REQ
+    /// whose filter can't match anything (impossible event id), which
+    /// NIP-01 requires the relay to answer with an immediate EOSE —
+    /// silence past the timeout means the socket is dead.
     private func startHeartbeat() {
         pingTask?.cancel()
         pingTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(Self.pingInterval))
-                guard !Task.isCancelled else { break }
-                guard let task = await self?.webSocketTask,
-                      task.state == .running else { break }
-                try? await task.send(.string("[\"CLOSE\",\"__hb\"]"))
+                guard !Task.isCancelled, let self else { break }
+                guard await self.probeLiveness() else {
+                    await self.teardownDeadSocket()
+                    break
+                }
             }
         }
+    }
+
+    private static let probeTimeout: TimeInterval = 10
+    private static let probeREQ = #"["REQ","__hb",{"ids":["0000000000000000000000000000000000000000000000000000000000000000"],"limit":1}]"#
+
+    /// Send the probe REQ and report whether *any* frame arrived while
+    /// waiting — the EOSE it provokes, or ordinary traffic, both prove
+    /// the receive path is alive.
+    private func probeLiveness() async -> Bool {
+        guard let task = webSocketTask, task.state == .running else { return false }
+        let sentAt = ContinuousClock.now
+        try? await task.send(.string(Self.probeREQ))
+        try? await Task.sleep(for: .seconds(Self.probeTimeout))
+        // Socket was replaced while waiting — the reconnect that did it
+        // started a fresh heartbeat, which owns liveness now.
+        guard webSocketTask === task else { return true }
+        return lastFrameAt > sentAt
+    }
+
+    /// Cancelling the socket makes the pending `receive()` throw, so the
+    /// receive loop's error path runs the shared backoff + reconnect
+    /// (which also replays subscriptions, fetching whatever the dead
+    /// socket missed).
+    private func teardownDeadSocket() {
+        webSocketTask?.cancel(with: .abnormalClosure, reason: nil)
     }
 
     /// Reject incoming frames over 1 MB so a malicious relay can't

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -3,14 +3,19 @@ import os.log
 
 /// TEMPORARY transport diagnostics for the device live-delivery bug.
 /// Emits nothing in release builds. Remove once resolved.
+/// Uses print() rather than os Logger because the scheme runs with
+/// OS_ACTIVITY_MODE=disable, which suppresses os_log in Xcode's console.
 enum TransportLog {
     #if DEBUG
-    private static let logger = Logger(subsystem: "app.onym.ios", category: "TransportDebug")
+    private static let timestamp: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
     #endif
     static func log(_ message: @autoclosure () -> String) {
         #if DEBUG
-        let text = message()
-        logger.debug("🔌 \(text, privacy: .public)")
+        print("🔌 \(timestamp.string(from: Date())) \(message())")
         #endif
     }
 }

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -1,6 +1,20 @@
 import Foundation
 import os.log
 
+/// TEMPORARY transport diagnostics for the device live-delivery bug.
+/// Emits nothing in release builds. Remove once resolved.
+enum TransportLog {
+    #if DEBUG
+    private static let logger = Logger(subsystem: "app.onym.ios", category: "TransportDebug")
+    #endif
+    static func log(_ message: @autoclosure () -> String) {
+        #if DEBUG
+        let text = message()
+        logger.debug("🔌 \(text, privacy: .public)")
+        #endif
+    }
+}
+
 /// Persistent WebSocket connection to a single Nostr relay. Owns the
 /// REQ/EVENT/EOSE/OK/CLOSE framing and is the only place in the
 /// transport layer that touches `URLSessionWebSocketTask`. Reconnect with
@@ -48,7 +62,11 @@ actor NostrRelayConnection {
 
     func connect() {
         desiredConnected = true
-        guard webSocketTask == nil else { return }
+        guard webSocketTask == nil else {
+            TransportLog.log("connect \(url.absoluteString): skipped, socket already exists")
+            return
+        }
+        TransportLog.log("connect \(url.absoluteString): opening socket, will replay \(subscriptions.count) subs")
         let task = session.webSocketTask(with: url)
         self.webSocketTask = task
         task.resume()
@@ -71,6 +89,7 @@ actor NostrRelayConnection {
     }
 
     func disconnect() {
+        TransportLog.log("disconnect \(url.absoluteString)")
         desiredConnected = false
         pingTask?.cancel()
         pingTask = nil
@@ -106,6 +125,7 @@ actor NostrRelayConnection {
     /// before the send so a fast OK can never be missed.
     func publishAndAwaitOK(event: NostrEvent) async throws -> Bool {
         let eventID = event.id
+        TransportLog.log("publish \(eventID.prefix(8)) → \(url.absoluteString): awaiting OK")
 
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, any Error>) in
             self.pendingOKContinuations[eventID] = continuation
@@ -129,12 +149,14 @@ actor NostrRelayConnection {
 
     private func timeoutPendingOK(eventID: String) {
         if let continuation = pendingOKContinuations.removeValue(forKey: eventID) {
+            TransportLog.log("publish \(eventID.prefix(8)) → \(url.absoluteString): no OK in 5s, assuming accepted")
             continuation.resume(returning: true)
         }
     }
 
     private func failPendingOK(eventID: String, error: any Error) {
         if let continuation = pendingOKContinuations.removeValue(forKey: eventID) {
+            TransportLog.log("publish \(eventID.prefix(8)) → \(url.absoluteString): send failed: \(error)")
             continuation.resume(throwing: error)
         }
     }
@@ -158,6 +180,7 @@ actor NostrRelayConnection {
     }
 
     func unsubscribe(subscriptionID: String) {
+        TransportLog.log("CLOSE \(subscriptionID) → \(url.absoluteString)")
         subscriptions.removeValue(forKey: subscriptionID)
         let frame: [Any] = ["CLOSE", subscriptionID]
         if let data = try? JSONSerialization.data(withJSONObject: frame),
@@ -174,7 +197,18 @@ actor NostrRelayConnection {
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
               let string = String(data: data, encoding: .utf8)
         else { return }
-        Task { try? await webSocketTask?.send(.string(string)) }
+        Task {
+            guard let task = webSocketTask else {
+                TransportLog.log("REQ \(subscriptionID) → \(url.absoluteString): DROPPED, no socket")
+                return
+            }
+            do {
+                try await task.send(.string(string))
+                TransportLog.log("REQ \(subscriptionID) → \(url.absoluteString): sent \(string)")
+            } catch {
+                TransportLog.log("REQ \(subscriptionID) → \(url.absoluteString): send FAILED: \(error)")
+            }
+        }
     }
 
     private func replaySubscriptions() {
@@ -190,6 +224,8 @@ actor NostrRelayConnection {
     /// the same CFNetwork use-after-free family as the `sendPing` crash
     /// documented above `startHeartbeat()`.
     private func receiveLoop(task: URLSessionWebSocketTask) async {
+        TransportLog.log("receiveLoop \(url.absoluteString): started")
+        defer { TransportLog.log("receiveLoop \(url.absoluteString): exited") }
         while isConnected, webSocketTask === task {
             do {
                 let message = try await task.receive()
@@ -207,7 +243,10 @@ actor NostrRelayConnection {
                 }
                 handleMessage(text)
             } catch {
-                guard webSocketTask === task else { return }
+                guard webSocketTask === task else {
+                    TransportLog.log("receiveLoop \(url.absoluteString): stale loop erred (\(error)), yielding to successor")
+                    return
+                }
                 pingTask?.cancel()
                 pingTask = nil
                 isConnected = false
@@ -218,10 +257,14 @@ actor NostrRelayConnection {
                     Self.maxReconnectDelay,
                     Self.baseReconnectDelay * pow(2.0, Double(min(reconnectAttempts - 1, 6)))
                 )
+                TransportLog.log("receiveLoop \(url.absoluteString): receive failed (\(error)), attempt \(reconnectAttempts), reconnecting in \(delay)s")
                 try? await Task.sleep(for: .seconds(delay))
                 // disconnect() may have run during the backoff sleep —
                 // a dropped connection must stay dropped.
-                guard desiredConnected, webSocketTask == nil else { return }
+                guard desiredConnected, webSocketTask == nil else {
+                    TransportLog.log("receiveLoop \(url.absoluteString): reconnect abandoned (desired=\(desiredConnected), socketExists=\(webSocketTask != nil))")
+                    return
+                }
                 connect()
                 return
             }
@@ -260,14 +303,19 @@ actor NostrRelayConnection {
     /// waiting — the EOSE it provokes, or ordinary traffic, both prove
     /// the receive path is alive.
     private func probeLiveness() async -> Bool {
-        guard let task = webSocketTask, task.state == .running else { return false }
+        guard let task = webSocketTask, task.state == .running else {
+            TransportLog.log("probe \(url.absoluteString): no running socket (state=\(webSocketTask?.state.rawValue ?? -1))")
+            return false
+        }
         let sentAt = ContinuousClock.now
         try? await task.send(.string(Self.probeREQ))
         try? await Task.sleep(for: .seconds(Self.probeTimeout))
         // Socket was replaced while waiting — the reconnect that did it
         // started a fresh heartbeat, which owns liveness now.
         guard webSocketTask === task else { return true }
-        return lastFrameAt > sentAt
+        let alive = lastFrameAt > sentAt
+        TransportLog.log("probe \(url.absoluteString): \(alive ? "alive" : "DEAD — no frame within \(Self.probeTimeout)s")")
+        return alive
     }
 
     /// Cancelling the socket makes the pending `receive()` throw, so the
@@ -291,34 +339,46 @@ actor NostrRelayConnection {
         guard let data = text.data(using: .utf8),
               let array = try? JSONSerialization.jsonObject(with: data) as? [Any],
               let kind = array.first as? String
-        else { return }
+        else {
+            TransportLog.log("frame ← \(url.absoluteString): unparseable (\(text.utf8.count) bytes)")
+            return
+        }
 
         switch kind {
         case "EVENT":
             guard array.count >= 3,
                   let subID = array[1] as? String,
                   let eventObj = array[2] as? [String: Any]
-            else { return }
-            if let event = parseEvent(eventObj),
+            else {
+                TransportLog.log("EVENT ← \(url.absoluteString): malformed frame")
+                return
+            }
+            let event = parseEvent(eventObj)
+            let matched = subscriptions[subID] != nil
+            TransportLog.log("EVENT ← \(url.absoluteString): sub=\(subID) id=\((eventObj["id"] as? String)?.prefix(8) ?? "?") parsed=\(event != nil) subKnown=\(matched)")
+            if let event,
                let (_, callback) = subscriptions[subID]
             {
                 callback(event)
             }
         case "EOSE":
-            break
+            TransportLog.log("EOSE ← \(url.absoluteString): sub=\(array.count >= 2 ? "\(array[1])" : "?")")
         case "OK":
             if array.count >= 3,
                let eventID = array[1] as? String,
                let accepted = array[2] as? Bool {
                 if let continuation = pendingOKContinuations.removeValue(forKey: eventID) {
+                    TransportLog.log("OK ← \(url.absoluteString): id=\(eventID.prefix(8)) accepted=\(accepted)")
                     continuation.resume(returning: accepted)
+                } else {
+                    TransportLog.log("OK ← \(url.absoluteString): id=\(eventID.prefix(8)) accepted=\(accepted), nothing pending")
                 }
                 onOKCallback?(eventID, accepted)
             }
         case "NOTICE":
-            break
+            TransportLog.log("NOTICE ← \(url.absoluteString): \(array.count >= 2 ? "\(array[1])" : text)")
         default:
-            break
+            TransportLog.log("frame ← \(url.absoluteString): unhandled kind=\(kind)")
         }
     }
 

--- a/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
+++ b/Sources/OnymIOS/Transport/Nostr/NostrRelayConnection.swift
@@ -30,7 +30,7 @@ actor NostrRelayConnection {
     let url: URL
     private var webSocketTask: URLSessionWebSocketTask?
     private let session: URLSession
-    private var subscriptions: [String: ([String: Any], (NostrEvent) -> Void)] = [:]
+    private var subscriptions: [String: ([[String: Any]], (NostrEvent) -> Void)] = [:]
     private(set) var isConnected = false
     private var reconnectAttempts = 0
     private var pendingOKContinuations: [String: CheckedContinuation<Bool, any Error>] = [:]
@@ -79,8 +79,8 @@ actor NostrRelayConnection {
         Task { await receiveLoop(task: task) }
         startHeartbeat()
 
-        for (subID, (filter, _)) in subscriptions {
-            sendREQ(subscriptionID: subID, filter: filter)
+        for (subID, (filters, _)) in subscriptions {
+            sendREQ(subscriptionID: subID, filters: filters)
         }
 
         // URLSessionWebSocketTask exposes no reliable onOpen callback. Replay
@@ -170,8 +170,21 @@ actor NostrRelayConnection {
         subscriptionID: String,
         filter: [String: Any]
     ) -> AsyncStream<NostrEvent> {
+        subscribe(subscriptionID: subscriptionID, filters: [filter])
+    }
+
+    /// A single REQ carries every filter (NIP-01 allows it), so one
+    /// subscription slot is consumed on the relay no matter how many
+    /// filter shapes a caller needs — relays cap concurrent REQs per
+    /// connection (strfry defaults to 20) and reject the overflow.
+    /// The relay also dedups matches within one REQ, so overlapping
+    /// filters no longer deliver the same event several times.
+    func subscribe(
+        subscriptionID: String,
+        filters: [[String: Any]]
+    ) -> AsyncStream<NostrEvent> {
         let stream = AsyncStream<NostrEvent> { continuation in
-            subscriptions[subscriptionID] = (filter, { event in
+            subscriptions[subscriptionID] = (filters, { event in
                 continuation.yield(event)
             })
             continuation.onTermination = { @Sendable _ in
@@ -180,7 +193,7 @@ actor NostrRelayConnection {
                 }
             }
         }
-        sendREQ(subscriptionID: subscriptionID, filter: filter)
+        sendREQ(subscriptionID: subscriptionID, filters: filters)
         return stream
     }
 
@@ -197,8 +210,8 @@ actor NostrRelayConnection {
 
     // MARK: - Private
 
-    private func sendREQ(subscriptionID: String, filter: [String: Any]) {
-        let frame: [Any] = ["REQ", subscriptionID, filter]
+    private func sendREQ(subscriptionID: String, filters: [[String: Any]]) {
+        let frame: [Any] = ["REQ", subscriptionID] + filters
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
               let string = String(data: data, encoding: .utf8)
         else { return }
@@ -217,8 +230,8 @@ actor NostrRelayConnection {
     }
 
     private func replaySubscriptions() {
-        for (subID, (filter, _)) in subscriptions {
-            sendREQ(subscriptionID: subID, filter: filter)
+        for (subID, (filters, _)) in subscriptions {
+            sendREQ(subscriptionID: subID, filters: filters)
         }
     }
 

--- a/Tests/OnymIOSTests/IdentityRepositoryFreshInstallTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryFreshInstallTests.swift
@@ -119,6 +119,38 @@ final class IdentityRepositoryFreshInstallTests: XCTestCase {
         XCTAssertTrue(marker.exists())
     }
 
+    /// Regression: the protected-data check suspends inside the first
+    /// load, and actor reentrancy let two concurrent first-callers
+    /// (the app's sibling `bootstrap()` / `currentIdentities()`
+    /// launch tasks) interleave across it — appending every identity
+    /// twice. The slow availability closure below holds the window
+    /// open; the single-flight load must keep the list exact.
+    func test_concurrentFirstLoads_doNotDuplicateIdentities() async throws {
+        _ = try await seedIdentities()
+        let selected = try keychain.list().first
+
+        let repo = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(initial: selected),
+            installMarker: .inMemory(initiallySet: false),
+            protectedData: ProtectedDataAvailability(isAvailable: {
+                try? await Task.sleep(for: .milliseconds(100))
+                return true
+            })
+        )
+
+        async let first = repo.bootstrap()
+        async let second = repo.currentIdentities()
+        _ = try await first
+        _ = try await second
+
+        let summaries = try await repo.currentIdentities()
+        XCTAssertEqual(summaries.count, 2,
+                       "concurrent first loads must not double-append identities")
+        XCTAssertEqual(Set(summaries.map(\.id)).count, 2,
+                       "every picker entry is distinct")
+    }
+
     /// Quarantining twice (fresh install verdict on two consecutive
     /// launches) must not throw on the duplicate items.
     func test_quarantineAll_idempotentAcrossRepeatedVerdicts() async throws {

--- a/Tests/OnymIOSTests/IdentityRepositoryFreshInstallTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryFreshInstallTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import OnymIOS
+
+/// `reconcileFreshInstall()` — the launch-time verdict that decides
+/// whether keychain identities are orphans of a deleted install. The
+/// wrong verdict used to destroy key material; it now quarantines, and
+/// these tests pin every branch: fresh install, app update, normal
+/// launch, and the deferred pre-first-unlock case.
+final class IdentityRepositoryFreshInstallTests: XCTestCase {
+    private var keychain: IdentityKeychainStore!
+
+    override func setUp() {
+        super.setUp()
+        keychain = IdentityKeychainStore(
+            testNamespace: "fresh-\(UUID().uuidString)"
+        )
+    }
+
+    override func tearDown() {
+        try? keychain.wipeAll()
+        keychain = nil
+        super.tearDown()
+    }
+
+    /// No marker, no selection → fresh install: keychain leftovers are
+    /// quarantined (never destroyed) and bootstrap mints a new identity.
+    func test_freshInstall_quarantinesOrphansAndMintsNewIdentity() async throws {
+        let orphans = try await seedIdentities()
+
+        let repo = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(),
+            installMarker: .inMemory(initiallySet: false),
+            protectedData: .always
+        )
+        let minted = try await repo.bootstrap()
+
+        let active = try await repo.currentIdentities()
+        XCTAssertEqual(active.count, 1, "only the freshly-minted identity is active")
+        XCTAssertFalse(orphans.contains(minted.blsPublicKey),
+                       "the minted identity is new, not a resurrected orphan")
+        XCTAssertEqual(try keychain.list().count, 1,
+                       "orphans are out of the active namespace")
+        XCTAssertEqual(try keychain.listQuarantined().count, 2,
+                       "orphans are quarantined — key material preserved, never wiped")
+    }
+
+    /// No marker but a persisted selection → app update predating the
+    /// marker: everything is kept and the marker is stamped.
+    func test_appUpdate_keepsIdentitiesAndStampsMarker() async throws {
+        _ = try await seedIdentities()
+        let selected = try keychain.list().first
+        let marker = InstallMarker.inMemory(initiallySet: false)
+
+        let repo = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(initial: selected),
+            installMarker: marker,
+            protectedData: .always
+        )
+        _ = try await repo.bootstrap()
+
+        let active = try await repo.currentIdentities()
+        XCTAssertEqual(active.count, 2, "an app update must keep every identity")
+        XCTAssertEqual(try keychain.listQuarantined(), [])
+        XCTAssertTrue(marker.exists(), "the update launch stamps the marker")
+    }
+
+    /// Marker present → normal launch, reconcile is a no-op.
+    func test_markerPresent_keepsIdentities() async throws {
+        _ = try await seedIdentities()
+
+        let repo = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(),
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
+        )
+        _ = try await repo.bootstrap()
+
+        let active = try await repo.currentIdentities()
+        XCTAssertEqual(active.count, 2)
+        XCTAssertEqual(try keychain.listQuarantined(), [])
+    }
+
+    /// Protected data unavailable (pre-first-unlock launch): the
+    /// fresh-install signals are unreadable, so the verdict is
+    /// deferred — nothing quarantined, marker left unstamped so a
+    /// later unlocked launch re-runs the reconcile with real inputs.
+    func test_protectedDataUnavailable_defersReconcile() async throws {
+        _ = try await seedIdentities()
+        let marker = InstallMarker.inMemory(initiallySet: false)
+
+        let locked = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(),
+            installMarker: marker,
+            protectedData: ProtectedDataAvailability(isAvailable: { false })
+        )
+        _ = try await locked.bootstrap()
+
+        let active = try await locked.currentIdentities()
+        XCTAssertEqual(active.count, 2,
+                       "no verdict while the signals are unreadable — identities stay")
+        XCTAssertEqual(try keychain.listQuarantined(), [])
+        XCTAssertFalse(marker.exists(),
+                       "the marker must not be stamped off unreadable inputs")
+
+        // Next launch, device unlocked: the deferred verdict lands.
+        let unlocked = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(),
+            installMarker: marker,
+            protectedData: .always
+        )
+        _ = try await unlocked.bootstrap()
+        XCTAssertEqual(try keychain.listQuarantined().count, 2,
+                       "the reconcile runs on the first launch that can read its inputs")
+        XCTAssertTrue(marker.exists())
+    }
+
+    /// Quarantining twice (fresh install verdict on two consecutive
+    /// launches) must not throw on the duplicate items.
+    func test_quarantineAll_idempotentAcrossRepeatedVerdicts() async throws {
+        _ = try await seedIdentities()
+        try keychain.quarantineAll()
+        _ = try await seedIdentities(names: ["Third"])
+
+        XCTAssertNoThrow(try keychain.quarantineAll())
+        XCTAssertEqual(try keychain.list(), [])
+        XCTAssertEqual(try keychain.listQuarantined().count, 3)
+    }
+
+    // MARK: - Helpers
+
+    /// Seeds identities through a marker-set repo (no reconcile) and
+    /// returns their BLS pubkeys for identity comparison.
+    private func seedIdentities(names: [String] = ["Personal", "Work"]) async throws -> Set<Data> {
+        let seeder = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(),
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
+        )
+        for name in names {
+            _ = try await seeder.add(name: name)
+        }
+        return Set(try await seeder.currentIdentities().map(\.blsPublicKey))
+    }
+}

--- a/Tests/OnymIOSTests/IdentityRepositoryMultiIdentityTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryMultiIdentityTests.swift
@@ -32,7 +32,7 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
         // `IdentityRepositoryTests.test_bootstrap_freshInstall_…`.
         // onym:allow-secret-read
         XCTAssertNotNil(identity.recoveryPhrase)
-        let summaries = await repo.currentIdentities()
+        let summaries = try await repo.currentIdentities()
         XCTAssertEqual(summaries.count, 1)
         XCTAssertEqual(summaries[0].name, "Identity",
                        "first auto-bootstrapped identity uses the bare 'Identity' name")
@@ -42,7 +42,7 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
         let first = try await repo.bootstrap()
         let secondID = try await repo.add(name: "Work")
 
-        let summaries = await repo.currentIdentities()
+        let summaries = try await repo.currentIdentities()
         XCTAssertEqual(summaries.count, 2)
         XCTAssertEqual(Set(summaries.map(\.name)), ["Identity", "Work"])
 
@@ -56,7 +56,7 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
     func test_add_namesGetTrimmed_andEmptyFallsBackToSlotDefault() async throws {
         _ = try await repo.bootstrap()
         let id = try await repo.add(name: "   ")
-        let summary = await repo.currentIdentities().first(where: { $0.id == id })
+        let summary = try await repo.currentIdentities().first(where: { $0.id == id })
         XCTAssertEqual(summary?.name, "Identity 2",
                        "whitespace-only names must fall back to the slot default")
     }
@@ -74,7 +74,7 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
         XCTAssertEqual(switched, secondID)
 
         let current = try await XCTUnwrapAsync(await repo.currentIdentity())
-        let summary = await repo.currentIdentities().first(where: { $0.id == secondID })
+        let summary = try await repo.currentIdentities().first(where: { $0.id == secondID })
         XCTAssertEqual(current.blsPublicKey, summary?.blsPublicKey)
     }
 
@@ -107,7 +107,7 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
         let removed = await removedTask.value
         XCTAssertEqual(removed, secondID)
 
-        let summaries = await repo.currentIdentities()
+        let summaries = try await repo.currentIdentities()
         XCTAssertEqual(summaries.count, 1, "one identity remains after removal")
         let current = try await XCTUnwrapAsync(await repo.currentIdentity())
         XCTAssertEqual(current.blsPublicKey, summaries[0].blsPublicKey,
@@ -119,7 +119,7 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
         try await repo.remove(onlyID)
         let current = await repo.currentIdentity()
         XCTAssertNil(current, "no identities → no current")
-        let summaries = await repo.currentIdentities()
+        let summaries = try await repo.currentIdentities()
         XCTAssertEqual(summaries, [])
     }
 
@@ -157,10 +157,30 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
         let revived = IdentityRepository(keychain: keychain, selectionStore: selectionStore)
         _ = try await revived.bootstrap()
         let current = try await XCTUnwrapAsync(await revived.currentIdentity())
-        let summaries = await revived.currentIdentities()
+        let summaries = try await revived.currentIdentities()
         let secondSummary = summaries.first(where: { $0.id == secondID })
         XCTAssertEqual(current.blsPublicKey, secondSummary?.blsPublicKey,
                        "previously-selected ID must come back as current")
+    }
+
+    func test_currentIdentities_asFirstCall_loadsFromKeychain() async throws {
+        // Seed the keychain via a first repo instance.
+        _ = try await repo.bootstrap()
+        _ = try await repo.add(name: "Work")
+        let selected = await repo.currentSelectedID()
+
+        // A fresh repo whose FIRST call is `currentIdentities()` must
+        // load from the keychain, not return the empty pre-load
+        // snapshot. The app's intro-key prune races `bootstrap()` and
+        // treats this as the complete owner set — an empty answer
+        // there wipes every pending invite-link inbox.
+        let fresh = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(initial: selected)
+        )
+        let summaries = try await fresh.currentIdentities()
+        XCTAssertEqual(summaries.count, 2,
+                       "first-call snapshot must reflect keychain contents")
     }
 
     // MARK: - Helpers

--- a/Tests/OnymIOSTests/IdentityRepositoryMultiIdentityTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryMultiIdentityTests.swift
@@ -12,7 +12,12 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
     override func setUp() {
         super.setUp()
         keychain = IdentityKeychainStore(testNamespace: "multi-\(UUID().uuidString)")
-        repo = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        repo = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(),
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
+        )
     }
 
     override func tearDown() {
@@ -154,7 +159,12 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
         // Create a fresh repo against the same keychain — selection
         // should be restored from the persisted store.
         let selectionStore = SelectedIdentityStore.inMemory(initial: secondID)
-        let revived = IdentityRepository(keychain: keychain, selectionStore: selectionStore)
+        let revived = IdentityRepository(
+            keychain: keychain,
+            selectionStore: selectionStore,
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
+        )
         _ = try await revived.bootstrap()
         let current = try await XCTUnwrapAsync(await revived.currentIdentity())
         let summaries = try await revived.currentIdentities()
@@ -176,7 +186,9 @@ final class IdentityRepositoryMultiIdentityTests: XCTestCase {
         // there wipes every pending invite-link inbox.
         let fresh = IdentityRepository(
             keychain: keychain,
-            selectionStore: .inMemory(initial: selected)
+            selectionStore: .inMemory(initial: selected),
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
         )
         let summaries = try await fresh.currentIdentities()
         XCTAssertEqual(summaries.count, 2,

--- a/Tests/OnymIOSTests/IdentityRepositoryTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryTests.swift
@@ -210,7 +210,7 @@ final class IdentityRepositoryTests: XCTestCase {
 
         try await repo.rename(firstID, newName: "Personal")
 
-        let summaries = await repo.currentIdentities()
+        let summaries = try await repo.currentIdentities()
         XCTAssertEqual(summaries.first { $0.id == firstID }?.name, "Personal")
         XCTAssertEqual(summaries.first { $0.id == secondID }?.name, "Work")
         let selected = await repo.currentSelectedID()
@@ -228,7 +228,7 @@ final class IdentityRepositoryTests: XCTestCase {
             selectionStore: .inMemory()
         )
         _ = try await freshRepo.bootstrap()
-        let reloaded = await freshRepo.currentIdentities()
+        let reloaded = try await freshRepo.currentIdentities()
         XCTAssertEqual(reloaded.first { $0.id == firstID }?.name, "Personal")
         XCTAssertEqual(reloaded.first { $0.id == secondID }?.name, "Work")
     }
@@ -236,7 +236,7 @@ final class IdentityRepositoryTests: XCTestCase {
     func test_rename_trimsWhitespace() async throws {
         let id = try await repo.add(name: "Original")
         try await repo.rename(id, newName: "  Padded   ")
-        let summaries = await repo.currentIdentities()
+        let summaries = try await repo.currentIdentities()
         XCTAssertEqual(summaries.first { $0.id == id }?.name, "Padded")
     }
 
@@ -244,7 +244,7 @@ final class IdentityRepositoryTests: XCTestCase {
         let id = try await repo.add(name: "Keep")
         try await repo.rename(id, newName: "   ")
         try await repo.rename(id, newName: "")
-        let summaries = await repo.currentIdentities()
+        let summaries = try await repo.currentIdentities()
         XCTAssertEqual(summaries.first { $0.id == id }?.name, "Keep")
     }
 

--- a/Tests/OnymIOSTests/IdentityRepositoryTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryTests.swift
@@ -17,7 +17,9 @@ final class IdentityRepositoryTests: XCTestCase {
         )
         repo = IdentityRepository(
             keychain: keychain,
-            selectionStore: .inMemory()
+            selectionStore: .inMemory(),
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
         )
     }
 
@@ -104,7 +106,11 @@ final class IdentityRepositoryTests: XCTestCase {
         let first = try await repo.bootstrap()
 
         // Fresh repo against the same Keychain — should load, not regenerate.
-        let secondRepo = IdentityRepository(keychain: keychain)
+        let secondRepo = IdentityRepository(
+            keychain: keychain,
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
+        )
         let loaded = try await secondRepo.bootstrap()
 
         XCTAssertEqual(first, loaded)
@@ -225,7 +231,9 @@ final class IdentityRepositoryTests: XCTestCase {
         // Survives a full reload from disk.
         let freshRepo = IdentityRepository(
             keychain: keychain,
-            selectionStore: .inMemory()
+            selectionStore: .inMemory(),
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
         )
         _ = try await freshRepo.bootstrap()
         let reloaded = try await freshRepo.currentIdentities()

--- a/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
+++ b/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
@@ -53,7 +53,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
         // Seed two identities BEFORE running.
         _ = try await identity.bootstrap()                      // Identity 1
         _ = try await identity.add(name: "Work")                // Identity 2
-        let summaries = await identity.currentIdentities()
+        let summaries = try await identity.currentIdentities()
         XCTAssertEqual(summaries.count, 2)
 
         let transport = RecordingInboxTransport()
@@ -103,7 +103,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
     func test_removingIdentity_triggersUnsubscribe() async throws {
         _ = try await identity.bootstrap()
         let workID = try await identity.add(name: "Work")
-        let summaries = await identity.currentIdentities()
+        let summaries = try await identity.currentIdentities()
         let workSummary = try XCTUnwrap(summaries.first(where: { $0.id == workID }))
 
         let transport = RecordingInboxTransport()
@@ -132,7 +132,7 @@ final class InboxFanoutInteractorTests: XCTestCase {
 
     func test_inboundMessage_landsInRepository() async throws {
         let activeIdentity = try await identity.bootstrap()
-        let summaries = await identity.currentIdentities()
+        let summaries = try await identity.currentIdentities()
         let summary = try XCTUnwrap(
             summaries.first(where: { $0.blsPublicKey == activeIdentity.blsPublicKey })
         )

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -397,6 +397,58 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
                        "delivered receipt must be addressed to the message sender's inbox")
     }
 
+    func test_replayedChatMessage_retriesDeliveredReceiptUntilAccepted() async throws {
+        let payload = makePayload(body: "hi")
+        let spy = SpyChatReceiptSender()
+        await spy.setAccepts(false)  // relay unreachable on first receive
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519,
+            receiptSender: spy
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        await spy.setAccepts(true)  // relay back for the replay
+        await dispatcher.dispatch(
+            messageID: "msg-1-replay",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let sends = await spy.sends
+        XCTAssertEqual(sends.count, 2,
+                       "a replay must retry the receipt while no send has been accepted")
+    }
+
+    func test_replayedChatMessage_doesNotReackOnceReceiptAccepted() async throws {
+        let payload = makePayload(body: "hi")
+        let spy = SpyChatReceiptSender()
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519,
+            receiptSender: spy
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-1-replay",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let sends = await spy.sends
+        XCTAssertEqual(sends.count, 1,
+                       "an accepted receipt must latch — replays never re-ack (receipt-storm regression)")
+    }
+
     func test_receipt_delivered_raisesOutgoingMessageToDelivered() async throws {
         let outgoingID = UUID()
         await seedOutgoing(id: outgoingID, status: .sent)
@@ -467,13 +519,20 @@ private actor SpyChatReceiptSender: ChatReceiptSending {
         let recipientInboxKey: Data
     }
     private(set) var sends: [Sent] = []
+    /// Whether the spy reports the publish as accepted — `false`
+    /// simulates an unreachable relay so tests can drive the
+    /// replay-retries-unacked-receipt path.
+    var accepts = true
+    func setAccepts(_ value: Bool) { accepts = value }
+    @discardableResult
     func send(
         kind: ChatReceiptPayload.Kind,
         messageIDs: [UUID],
         groupID: Data,
         to recipientInboxKey: Data
-    ) async {
+    ) async -> Bool {
         sends.append(Sent(kind: kind, messageIDs: messageIDs, groupID: groupID, recipientInboxKey: recipientInboxKey))
+        return accepts
     }
 }
 

--- a/Tests/OnymIOSTests/KeychainIntroKeyStoreTests.swift
+++ b/Tests/OnymIOSTests/KeychainIntroKeyStoreTests.swift
@@ -1,0 +1,134 @@
+import Security
+import XCTest
+@testable import OnymIOS
+
+/// TTL + GC behavior of the production intro-key store. These paths
+/// hide/destroy intro PRIVATE keys, so they get coverage in the PR
+/// that introduces them rather than the stack-final test PR. Hits the
+/// real Keychain under a per-test namespace, same rationale as
+/// `IdentityKeychainStoreTests`.
+final class KeychainIntroKeyStoreTests: XCTestCase {
+    private var namespace: String!
+    private var store: KeychainIntroKeyStore!
+    private let ownerA = IdentityID()
+    private let ownerB = IdentityID()
+
+    override func setUp() {
+        super.setUp()
+        namespace = "tests-\(UUID().uuidString)"
+        store = KeychainIntroKeyStore(testNamespace: namespace)
+    }
+
+    override func tearDown() async throws {
+        await store.wipeAll()
+        store = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - TTL
+
+    func test_expiredEntry_invisibleToReads() async {
+        await store.save(makeEntry(owner: ownerA, age: KeychainIntroKeyStore.entryTTL + 60))
+        let fresh = makeEntry(owner: ownerA)
+        await store.save(fresh)
+
+        let listed = await store.listForOwner(ownerA)
+        XCTAssertEqual(listed.map(\.introPublicKey), [fresh.introPublicKey],
+                       "entries past the 24h TTL must be invisible to listForOwner")
+    }
+
+    func test_expiredEntry_compactsOutOfBlobOnFirstRead() async {
+        let fresh = makeEntry(owner: ownerA)
+        await store.save(fresh)
+        await store.save(makeEntry(owner: ownerB, age: KeychainIntroKeyStore.entryTTL + 60))
+        // No subscribers → save's publish no-ops without reading, so
+        // the expired row really is at rest now.
+        XCTAssertEqual(rawEntryCount(), 2)
+
+        _ = await store.listForOwner(ownerA)
+
+        XCTAssertEqual(rawEntryCount(), 1,
+                       "the read that first sees an expired intro privkey must rewrite the blob without it")
+    }
+
+    func test_expiredEntry_streamSnapshotExcludesIt() async {
+        await store.save(makeEntry(owner: ownerB, age: KeychainIntroKeyStore.entryTTL + 60))
+
+        var iterator = store.entriesStream(forOwner: ownerB).makeAsyncIterator()
+        let snapshot = await iterator.next()
+
+        XCTAssertEqual(snapshot, [],
+                       "the intro pump must never see an expired entry's inbox")
+        XCTAssertEqual(rawEntryCount(), 0,
+                       "subscribing triggered the read → the expired privkey is gone at rest too")
+    }
+
+    // MARK: - pruneOwners
+
+    func test_pruneOwners_dropsOrphanedOwnersOnly() async {
+        let kept = makeEntry(owner: ownerA)
+        await store.save(kept)
+        await store.save(makeEntry(owner: ownerB))
+
+        let removed = await store.pruneOwners(keeping: [ownerA])
+
+        XCTAssertEqual(removed, 1)
+        let aEntries = await store.listForOwner(ownerA)
+        let bEntries = await store.listForOwner(ownerB)
+        XCTAssertEqual(aEntries.map(\.introPublicKey), [kept.introPublicKey],
+                       "a kept owner's entries survive the prune")
+        XCTAssertEqual(bEntries, [], "an orphaned owner's entries are gone")
+    }
+
+    func test_pruneOwners_publishesEmptySnapshotToOrphanedOwnersStream() async {
+        let orphaned = makeEntry(owner: ownerB)
+        await store.save(orphaned)
+        var iterator = store.entriesStream(forOwner: ownerB).makeAsyncIterator()
+        let initial = await iterator.next()
+        XCTAssertEqual(initial?.map(\.introPublicKey), [orphaned.introPublicKey])
+
+        await store.pruneOwners(keeping: [ownerA])
+
+        let afterPrune = await iterator.next()
+        XCTAssertEqual(afterPrune, [],
+                       "the pump must be told to drop the pruned owner's inbox subscriptions")
+    }
+
+    func test_pruneOwners_noOrphans_isNoOp() async {
+        await store.save(makeEntry(owner: ownerA))
+        let removed = await store.pruneOwners(keeping: [ownerA])
+        XCTAssertEqual(removed, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeEntry(owner: IdentityID, age: TimeInterval = 0) -> IntroKeyEntry {
+        IntroKeyEntry(
+            introPublicKey: Data((0..<32).map { _ in UInt8.random(in: 0...255) }),
+            introPrivateKey: Data((0..<32).map { _ in UInt8.random(in: 0...255) }),
+            ownerIdentityID: owner,
+            groupId: Data(repeating: 7, count: 32),
+            createdAt: Date().addingTimeInterval(-age)
+        )
+    }
+
+    /// Reads the store's blob straight out of the Keychain and counts
+    /// its rows — the only way to assert compaction *at rest* rather
+    /// than just read-side filtering.
+    private func rawEntryCount() -> Int {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "\(KeychainIntroKeyStore.serviceDefault).\(namespace!)",
+            kSecAttrAccount as String: KeychainIntroKeyStore.account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let entries = object["entries"] as? [Any]
+        else { return 0 }
+        return entries.count
+    }
+}

--- a/Tests/OnymIOSTests/MessageRepositoryTests.swift
+++ b/Tests/OnymIOSTests/MessageRepositoryTests.swift
@@ -444,6 +444,19 @@ private actor InMemoryMessageStore: MessageStore {
         return isNew ? .inserted : .updated
     }
 
+    private var ackedKeys: Set<Key> = []
+
+    func needsDeliveredAck(id: UUID, ownerIDString: String) -> Bool {
+        guard let owner = IdentityID(ownerIDString) else { return false }
+        let key = Key(id: id, owner: owner)
+        return rows[key] != nil && !ackedKeys.contains(key)
+    }
+
+    func markDeliveredAckSent(id: UUID, ownerIDString: String) {
+        guard let owner = IdentityID(ownerIDString) else { return }
+        ackedKeys.insert(Key(id: id, owner: owner))
+    }
+
     func updateStatus(id: UUID, ownerIDString: String, status: MessageStatus, failureReason: SendFailureReason?) {
         guard let owner = IdentityID(ownerIDString) else { return }
         let key = Key(id: id, owner: owner)

--- a/Tests/OnymIOSTests/MessageRepositoryTests.swift
+++ b/Tests/OnymIOSTests/MessageRepositoryTests.swift
@@ -41,8 +41,8 @@ final class MessageRepositoryTests: XCTestCase {
         _ = await iterator.next()  // initial empty
 
         let msg = makeMessage(groupID: groupA, body: "hello")
-        let inserted = await repo.insert(msg)
-        XCTAssertTrue(inserted)
+        let outcome = await repo.insert(msg)
+        XCTAssertEqual(outcome, .inserted)
 
         let next = await iterator.next()
         XCTAssertEqual(next?.count, 1)
@@ -437,11 +437,11 @@ private actor InMemoryMessageStore: MessageStore {
     }
 
     @discardableResult
-    func insertOrUpdate(_ message: ChatMessage) -> Bool {
+    func insertOrUpdate(_ message: ChatMessage) -> MessageInsertOutcome {
         let key = Key(id: message.id, owner: message.ownerIdentityID)
         let isNew = rows[key] == nil
         rows[key] = message
-        return isNew
+        return isNew ? .inserted : .updated
     }
 
     func updateStatus(id: UUID, ownerIDString: String, status: MessageStatus, failureReason: SendFailureReason?) {

--- a/Tests/OnymIOSTests/Support/InMemoryIntroKeyStore.swift
+++ b/Tests/OnymIOSTests/Support/InMemoryIntroKeyStore.swift
@@ -43,6 +43,17 @@ actor InMemoryIntroKeyStore: IntroKeyStore {
         return removed
     }
 
+    @discardableResult
+    func pruneOwners(keeping owners: Set<IdentityID>) async -> Int {
+        let orphaned = entries.filter { !owners.contains($0.ownerIdentityID) }
+        guard !orphaned.isEmpty else { return 0 }
+        entries.removeAll { !owners.contains($0.ownerIdentityID) }
+        for owner in Set(orphaned.map(\.ownerIdentityID)) {
+            publish(forOwner: owner)
+        }
+        return orphaned.count
+    }
+
     nonisolated func entriesStream(forOwner ownerIdentityID: IdentityID) -> AsyncStream<[IntroKeyEntry]> {
         AsyncStream { continuation in
             let id = UUID()

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -36,8 +36,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             status: .pending
         )
 
-        let inserted = await store.insertOrUpdate(msg)
-        XCTAssertTrue(inserted)
+        let outcome = await store.insertOrUpdate(msg)
+        XCTAssertEqual(outcome, .inserted)
 
         let listed = await store.list(groupID: groupID, ownerIDString: owner.rawValue.uuidString)
         XCTAssertEqual(listed.count, 1)
@@ -173,8 +173,9 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             replyToMessageID: nil,
             groupType: .tyranny
         )
-        let inserted = await store.insertOrUpdate(updated)
-        XCTAssertFalse(inserted, "second insert on same id+owner must report update, not insert")
+        let outcome = await store.insertOrUpdate(updated)
+        XCTAssertEqual(outcome, .updated,
+                       "second insert on same id+owner must report update, not insert")
 
         let listed = await store.list(groupID: msg.groupID, ownerIDString: kOwner.rawValue.uuidString)
         XCTAssertEqual(listed.count, 1)
@@ -198,11 +199,11 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             body: "mine", direction: .incoming
         )
 
-        let insertedA = await store.insertOrUpdate(outgoing)
-        let insertedB = await store.insertOrUpdate(incoming)
-        XCTAssertTrue(insertedA)
-        XCTAssertTrue(insertedB,
-                      "second owner is a fresh insert, not an in-place overwrite")
+        let outcomeA = await store.insertOrUpdate(outgoing)
+        let outcomeB = await store.insertOrUpdate(incoming)
+        XCTAssertEqual(outcomeA, .inserted)
+        XCTAssertEqual(outcomeB, .inserted,
+                       "second owner is a fresh insert, not an in-place overwrite")
 
         let aRows = await store.list(groupID: groupID, ownerIDString: ownerA.rawValue.uuidString)
         let bRows = await store.list(groupID: groupID, ownerIDString: ownerB.rawValue.uuidString)

--- a/project.yml
+++ b/project.yml
@@ -56,6 +56,19 @@ targets:
         # About screen ships a stale value forever.
         CFBundleShortVersionString: $(MARKETING_VERSION)
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        # Export compliance. Onym uses non-exempt encryption (end-to-end
+        # message/media encryption with AES-256-GCM + X25519, beyond
+        # HTTPS), so this is `true`. The app ships only industry-standard,
+        # publicly documented algorithms — it qualifies for US License
+        # Exception ENC (ECCN 5D992.c, mass market) via a
+        # self-classification report, and needs a French encryption
+        # declaration to be sold in France. See docs/compliance/.
+        # Without this key App Store Connect re-prompts the compliance
+        # questionnaire on every upload. It MUST live here, not in
+        # Info.plist directly — the plist is xcodegen output and a
+        # hand-edit is silently dropped on the next regenerate (that's
+        # how 71fbb75's key got lost once already).
+        ITSAppUsesNonExemptEncryption: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: true
           UISceneConfigurations: {}


### PR DESCRIPTION
Started as one crash fix, grew into a transport-reliability series as each fix exposed the next issue on-device. One commit per problem:

## 1. EXC_BAD_ACCESS in handleMessage (task-frame corruption)
Fault address 0x10 = null array-buffer + count offset: the async task's heap frame was corrupted by cancel-during-receive churn in the reconnect path racing CFNetwork's receive completion (same UAF family as the sendPing crash documented in-file). Amplified by three reconnect bugs: backoff pinned at 1s (`connect()` reset the counter), stale receive loops cancelling a successor's socket, and `disconnect()` not surviving a backoff sleep. Fix: `receiveLoop(task:)` is bound to its socket (one loop per socket, no foreign cancels), sticky `desiredConnected`, backoff resets on successful receive only.

## 2. Device stops receiving live events (zombie sockets)
Backgrounding/lock kills the NAT path while the socket looks locally alive — `receive()` hangs forever, the old fire-and-forget heartbeat couldn't tell. Heartbeat is now probe-and-verify: track `lastFrameAt`, send a REQ that can't match anything (NIP-01 obliges an immediate EOSE), no frame within 10s ⇒ cancel the socket and recover through the normal reconnect + subscription replay.

## 3. Temporary DEBUG diagnostics
`TransportLog` (print-based — the scheme's `OS_ACTIVITY_MODE=disable` mutes os_log) covering connection lifecycle, REQ/CLOSE, every inbound frame, publish/OK outcomes, probe verdicts. ~~Remove after the dust settles.~~ **Removed** in the review round — it printed whole REQ frames including inbox pubkeys.

## 4. Relay rejected most subscriptions ("too many concurrent REQs")
3 filter shapes × ~25 inboxes = ~75 REQs vs strfry's ~20/connection cap; rejected inboxes had no live subscription (the "messages only on app start" symptom). One REQ now carries all filters per inbox (3× fewer slots) and the relay dedups overlapping matches (kills 2-3× duplicate delivery).

## 5. Receipt storm on every launch
Relay reconnects replay the full inbox; `persistChatMessage` acked every replayed message unconditionally — a receipt publish per historical message per launch, each becoming a new stored event on the other side (snowballing replays). Receipts now fire only for newly inserted messages.

## 6. Stale keychain state inflating the subscription count
The ~25 inboxes were mostly intro-key inboxes (one per invite link ever shared, no expiry) plus keychain items surviving reinstall. Fixes: 24-hour TTL on intro keys, matching Android per #111 (filtered at the single load point; the load that first sees an expired row compacts the blob); launch-time `pruneOwners` GC for intro keys whose owner identity no longer exists; fresh-install reconciliation in `IdentityRepository` (no install marker AND no persisted selection ⇒ orphaned identity items are **quarantined** into a separate keychain namespace, never destroyed — app updates are detected via the existing selection and only stamped).

## 7. Review follow-ups (#4822757300, #4822779117)
- `currentIdentities()` now throws and calls `ensureLoaded()` first, so the intro-key prune racing `bootstrap()` can no longer see an empty pre-load snapshot and wipe every pending invite-link inbox; the prune site skips on load failure.
- `ensureLoaded()` marks the repo loaded only after a fully-successful load (a thrown keychain error no longer strands an empty "loaded" repo whose retried `bootstrap()` mints a duplicate identity).
- `reconcileFreshInstall()` quarantines instead of `wipeAll()` — both of its signals are UserDefaults (weaker file protection than the identity items), so a wrong verdict must cost a hidden identity, not destroyed key material.
- Inbox subscription ids carry a monotonic generation (a resubscribe's old-stream `onTermination` no longer CLOSEs the replacement REQ) and use a hashed inbox (under NIP-01's 64-char cap).
- The `__hb` probe REQ is CLOSEd after the probe window; `probeLiveness()` polls in 0.5s slices and exits on the first frame.
- `insertOrUpdate` returns `.inserted`/`.updated`/`.failed` — a persistence failure is no longer indistinguishable from a replayed duplicate, and stays un-acked so the relay copy retries on the next replay.

## 8. Review follow-ups, round 2 (#4822938510)
- Delivered receipts regained a retry path: `PersistedMessage` carries a `deliveredAckSent` latch, `ChatReceiptSender` reports whether the transport accepted the publish, and the dispatcher acks on `.inserted` *or* an un-latched replay — a receipt lost to an unreachable relay retries on the next inbox replay, while an acked message never re-acks (receipt-storm fix intact; both directions tested).
- `reconcileFreshInstall()` is gated on an injected `ProtectedDataAvailability` seam (`UIApplication.isProtectedDataAvailable`): pre-first-unlock launches defer the verdict instead of misreading unreadable UserDefaults as "fresh install".
- `teardownDeadSocket(_:)` cancels only the socket the probe judged, guarded by `webSocketTask === task`.
- TTL compaction publishes the affected owners' streams so a live session's intro pump releases expired REQ slots; the launch prune skips an empty identity set (post-quarantine, pruning would destroy intro keys a recovery flow could still revive).
- The update branch of `insertOrUpdate` mirrors the insert branch's `do/catch` — a failed save rolls back and reports `.failed`.
- Tests in this PR for the secret-hiding paths (quarantine branches incl. deferred verdict, TTL invisibility + at-rest compaction, `pruneOwners`), and identity tests now inject `installMarker`/`protectedData` so they're order-independent.
- Not changed: the `__hb` probe's transient extra REQ slot — an over-limit REQ is answered (CLOSED/NOTICE) and any reply frame satisfies the probe, so a rejected probe still proves liveness; assumption documented at the probe.

Builds clean (`xcodebuild -scheme OnymIOS`, iphonesimulator); full `OnymIOSTests` suite passes (870 tests). Per review convention, the remaining tests land in the final PR of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
