### PR TITLE
chore: rename app to Onym Chat

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Onym</string>
+	<string>Onym Chat</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -38,7 +38,7 @@ targets:
     info:
       path: Info.plist
       properties:
-        CFBundleDisplayName: Onym
+        CFBundleDisplayName: Onym Chat
         # `$(...)` is Xcode's build-setting substitution, NOT xcodegen
         # env interpolation — these strings end up verbatim in
         # Info.plist and Xcode resolves them per build. The


### PR DESCRIPTION
## Summary
- Rename the app's home-screen display name from **Onym** to **Onym Chat** (`CFBundleDisplayName`)
- Change made in `project.yml` (the source of truth); `Info.plist` regenerated via `./generate-xcodeproj.sh`

No changes to bundle identifier, product name, or URL schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)