### PR TITLE
Member removal from Founder groups, with groupSecret rotation

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -34,6 +34,102 @@
         }
       }
     },
+    "Couldn't remove the member": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't remove the member"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось удалить участника"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
+          }
+        }
+      }
+    },
+    "Remove %@?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove %@?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить %@?"
+          }
+        }
+      }
+    },
+    "Remove member": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove member"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить участника"
+          }
+        }
+      }
+    },
+    "They will no longer receive this group's messages. The group key will be rotated for everyone else.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "They will no longer receive this group's messages. The group key will be rotated for everyone else."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Участник больше не будет получать сообщения этой группы. Ключ группы будет обновлён для остальных."
+          }
+        }
+      }
+    },
+    "You were removed from this group": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You were removed from this group"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вас удалили из этой группы"
+          }
+        }
+      }
+    },
     "—": {
       "localizations": {
         "en": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -34,6 +34,22 @@
         }
       }
     },
+    "Couldn't reach the network. Check your connection and try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't reach the network. Check your connection and try again."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось подключиться к сети. Проверьте соединение и попробуйте ещё раз."
+          }
+        }
+      }
+    },
     "Couldn't remove the member": {
       "localizations": {
         "en": {
@@ -46,6 +62,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Не удалось удалить участника"
+          }
+        }
+      }
+    },
+    "Only the group's founder can remove members.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only the group's founder can remove members."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалять участников может только основатель группы."
           }
         }
       }
@@ -94,6 +126,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Удалить участника"
+          }
+        }
+      }
+    },
+    "Something went wrong. Try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something went wrong. Try again."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что-то пошло не так. Попробуйте ещё раз."
           }
         }
       }

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -61,4 +61,16 @@ struct AppDependencies {
     /// `GroupNamePayload` out to members. Backs the admin-only rename
     /// affordance in `ChatMembersView`.
     let setGroupName: @MainActor (_ groupIDHex: String, _ name: String) async -> Void
+    /// Admin removes a member from a Tyranny group: anchors the
+    /// shrunken roster on chain (epoch bump + salt/groupSecret
+    /// rotation), tombstones the victim locally, and fans a
+    /// `MemberRemovalPayload` out to every member (the victim's copy
+    /// omits the rotated secrets). Backs the admin-only remove
+    /// affordance in `ChatMembersView`. Routed through
+    /// `JoinRequestApprover.removeMember` so it serializes with
+    /// in-flight approvals.
+    let removeGroupMember: @MainActor (
+        _ groupIDHex: String,
+        _ victimBlsHex: String
+    ) async -> JoinRequestApprover.RemoveOutcome
 }

--- a/Sources/OnymIOS/Chats/ChatInputPanelView.swift
+++ b/Sources/OnymIOS/Chats/ChatInputPanelView.swift
@@ -39,6 +39,16 @@ final class ChatInputPanelView: UIView {
     /// Whether any media is staged in the preview strip.
     private var hasPendingMedia = false
 
+    /// Removed-from-group lockout. When `true` every input control
+    /// (attach / text field / mic / send) is hidden and a centered
+    /// "You were removed from this group" banner takes the composer's
+    /// place — the thread stays readable, nothing can be sent. Driven
+    /// by `ChatThreadViewController.update(membershipRevoked:)` from
+    /// the live `ChatGroup.membershipRevoked`.
+    private var membershipRevoked = false
+    /// The banner label shown while `membershipRevoked` is set.
+    private let removedLabel = UILabel()
+
     /// Invoked when the user taps the reply banner's cancel button.
     /// The host clears its armed reply target and calls
     /// `clearReplyBanner()`.
@@ -247,7 +257,43 @@ final class ChatInputPanelView: UIView {
         attachButton.accessibilityLabel = "Attach photo or video"
         addSubview(attachButton)
 
+        // Removed-from-group banner — replaces the whole input row
+        // while `membershipRevoked` is set.
+        removedLabel.text = String(localized: "You were removed from this group")
+        removedLabel.font = .preferredFont(forTextStyle: .subheadline)
+        removedLabel.adjustsFontForContentSizeCategory = true
+        removedLabel.textColor = UIColor(OnymTokens.text2)
+        removedLabel.textAlignment = .center
+        removedLabel.numberOfLines = 1
+        removedLabel.adjustsFontSizeToFitWidth = true
+        removedLabel.isHidden = true
+        removedLabel.translatesAutoresizingMaskIntoConstraints = false
+        removedLabel.accessibilityIdentifier = "chat.input.removed_banner"
+        addSubview(removedLabel)
+
         buildRecordingOverlay()
+    }
+
+    /// Swap the composer between its normal state and the removed-
+    /// from-group lockout. Idempotent; the panel keeps its height (the
+    /// hidden text view still drives the constraints) so the message
+    /// list doesn't jump.
+    func setMembershipRevoked(_ revoked: Bool) {
+        guard revoked != membershipRevoked else { return }
+        membershipRevoked = revoked
+        attachButton.isHidden = revoked
+        textView.isHidden = revoked
+        placeholderLabel.isHidden = revoked || !text.isEmpty
+        removedLabel.isHidden = !revoked
+        if revoked {
+            textView.resignFirstResponder()
+            sendButton.isHidden = true
+            micButton.isHidden = true
+            recordingOverlay.isHidden = true
+        } else {
+            // Re-derive the send/mic toggle from the composer content.
+            refreshAfterTextChange()
+        }
     }
 
     /// The record-time overlay that covers the text field: a pulsing red
@@ -530,6 +576,12 @@ final class ChatInputPanelView: UIView {
             micButton.widthAnchor.constraint(equalToConstant: 40),
             micButton.heightAnchor.constraint(equalToConstant: 40),
 
+            // Removed-from-group banner — centered over the (hidden)
+            // input row, so the panel keeps the same height.
+            removedLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            removedLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            removedLabel.centerYAnchor.constraint(equalTo: textView.centerYAnchor),
+
             // Record-time overlay sits exactly over the text field.
             recordingOverlay.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
             recordingOverlay.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
@@ -640,6 +692,14 @@ final class ChatInputPanelView: UIView {
         // Staged media alone is enough to send (no caption required).
         let hasContent = !trimmed.isEmpty || hasPendingMedia
         sendButton.isEnabled = hasContent
+        // Removed-from-group lockout: every control stays hidden — the
+        // banner owns the panel until `setMembershipRevoked(false)`.
+        if membershipRevoked {
+            sendButton.isHidden = true
+            micButton.isHidden = true
+            placeholderLabel.isHidden = true
+            return
+        }
         // Right-side toggle: mic when the composer is empty, send otherwise.
         // While recording, the mic stays put (the finger is on it) and the
         // overlay covers the field regardless.

--- a/Sources/OnymIOS/Chats/ChatMembersView.swift
+++ b/Sources/OnymIOS/Chats/ChatMembersView.swift
@@ -35,10 +35,20 @@ struct ChatMembersView: View {
     @State private var showRename = false
     @State private var renameText = ""
     /// The member awaiting the remove confirmation dialog, if any.
+    ///
+    /// This and the two states below are `@State` on a view instance
+    /// bound to ONE `groupID`, so removal UI state is group-scoped by
+    /// construction: a failure on group A can never pop an alert over
+    /// group B's screen, and removals on different groups may run
+    /// concurrently (each screen has its own slot; the approver's
+    /// `approvalChain` serializes the anchors underneath). This is the
+    /// iOS analogue of Android's keyed `removalsInFlight` /
+    /// `removalErrors` maps on its app-scoped ChatsViewModel.
     @State private var memberToRemove: MemberRow?
     /// BLS hex of the member whose removal is in flight (the
     /// multi-second PLONK prove + anchor round-trip) — the row shows a
-    /// spinner and further removals are disabled until it resolves.
+    /// spinner and further removals on THIS group are disabled until
+    /// it resolves.
     @State private var removalInFlightBlsHex: String?
     /// Non-`.sent` removal outcome, surfaced in an alert.
     @State private var removalErrorText: String?
@@ -325,7 +335,7 @@ struct ChatMembersView: View {
 
             // Removed members are tombstoned in the map but no longer
             // part of the group — count only the active ones.
-            let activeCount = group.memberProfiles.values.filter { !$0.revoked }.count
+            let activeCount = group.activeMemberProfiles.count
             Text("\(activeCount) member\(activeCount == 1 ? "" : "s")")
                 .font(.system(size: 12))
                 .foregroundStyle(OnymTokens.text3)
@@ -458,10 +468,9 @@ struct ChatMembersView: View {
 
     private func rows(for group: ChatGroup) -> [MemberRow] {
         let activeKey = activeBlsHex
-        return group.memberProfiles
-            // Removed members are tombstoned in the map (so message
-            // rendering keeps their alias) but hidden from the roster.
-            .filter { !$0.value.revoked }
+        // Removed members are tombstoned in the map (so message
+        // rendering keeps their alias) but hidden from the roster.
+        return group.activeMemberProfiles
             .map { (key, profile) in
                 MemberRow(
                     id: key,

--- a/Sources/OnymIOS/Chats/ChatMembersView.swift
+++ b/Sources/OnymIOS/Chats/ChatMembersView.swift
@@ -24,11 +24,24 @@ struct ChatMembersView: View {
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
     let setGroupAvatar: @MainActor (String, Data?) async -> Void
     let setGroupName: @MainActor (String, String) async -> Void
+    /// Admin removes a member: anchors the shrunken roster on chain,
+    /// rotates the group secret, tombstones the victim, fans the
+    /// removal out. Returns the outcome so non-`.sent` failures can
+    /// surface in the error alert.
+    let removeMember: @MainActor (String, String) async -> JoinRequestApprover.RemoveOutcome
 
     @State private var shareInviteFlow: ShareInviteFlow?
     /// Drives the admin-only rename alert.
     @State private var showRename = false
     @State private var renameText = ""
+    /// The member awaiting the remove confirmation dialog, if any.
+    @State private var memberToRemove: MemberRow?
+    /// BLS hex of the member whose removal is in flight (the
+    /// multi-second PLONK prove + anchor round-trip) — the row shows a
+    /// spinner and further removals are disabled until it resolves.
+    @State private var removalInFlightBlsHex: String?
+    /// Non-`.sent` removal outcome, surfaced in an alert.
+    @State private var removalErrorText: String?
 
     var body: some View {
         Group {
@@ -76,6 +89,35 @@ struct ChatMembersView: View {
                 flow: flow,
                 onDone: { shareInviteFlow = nil }
             )
+        }
+        .confirmationDialog(
+            Text(removalDialogTitle),
+            isPresented: Binding(
+                get: { memberToRemove != nil },
+                set: { if !$0 { memberToRemove = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: memberToRemove
+        ) { row in
+            Button("Remove", role: .destructive) {
+                beginRemoval(row)
+            }
+            .accessibilityIdentifier("members.remove_confirm")
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text("They will no longer receive this group's messages. The group key will be rotated for everyone else.")
+        }
+        .alert(
+            "Couldn't remove the member",
+            isPresented: Binding(
+                get: { removalErrorText != nil },
+                set: { if !$0 { removalErrorText = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+                .accessibilityIdentifier("members.remove_error")
+        } message: {
+            Text(removalErrorText ?? "")
         }
         .alert("Rename group", isPresented: $showRename) {
             TextField("Group name", text: $renameText)
@@ -210,6 +252,45 @@ struct ChatMembersView: View {
     /// because only their broadcast passes the receiver's admin check.
     private var canChangeName: Bool { canShareInvite }
 
+    /// Same admin gate again: only the Tyranny admin can remove a
+    /// member, because only they can prove the on-chain
+    /// `update_commitment` that makes the removal real.
+    private var canRemoveMembers: Bool { canShareInvite }
+
+    /// Title for the remove confirmation dialog — names the member so
+    /// a mis-tap can't silently remove the wrong person.
+    private var removalDialogTitle: String {
+        String(
+            format: String(localized: "Remove %@?"),
+            memberToRemove?.displayAlias ?? ""
+        )
+    }
+
+    /// Kick off the removal for a confirmed row: mark the row
+    /// in-flight (spinner), run the anchor + fanout, surface a
+    /// non-`.sent` outcome in the error alert. Roster/count updates
+    /// flow back reactively through `chatsFlow.groups`.
+    private func beginRemoval(_ row: MemberRow) {
+        guard removalInFlightBlsHex == nil else { return }
+        removalInFlightBlsHex = row.blsHex
+        let groupID = groupID
+        let removeMember = removeMember
+        Task {
+            let outcome = await removeMember(groupID, row.blsHex)
+            removalInFlightBlsHex = nil
+            if outcome != .sent {
+                removalErrorText = Self.describe(outcome)
+            }
+        }
+    }
+
+    /// Short diagnostic line for the error alert's message. The alert
+    /// title carries the user-meaningful part; this pins down which
+    /// gate failed (mirrors the Android toast's outcome dump).
+    private static func describe(_ outcome: JoinRequestApprover.RemoveOutcome) -> String {
+        String(describing: outcome)
+    }
+
     private func list(for group: ChatGroup) -> some View {
         ScrollView {
             if let message = group.invitationMessage,
@@ -235,7 +316,10 @@ struct ChatMembersView: View {
             .padding(.horizontal, 16)
             .padding(.top, 12)
 
-            Text("\(group.memberProfiles.count) member\(group.memberProfiles.count == 1 ? "" : "s")")
+            // Removed members are tombstoned in the map but no longer
+            // part of the group — count only the active ones.
+            let activeCount = group.memberProfiles.values.filter { !$0.revoked }.count
+            Text("\(activeCount) member\(activeCount == 1 ? "" : "s")")
                 .font(.system(size: 12))
                 .foregroundStyle(OnymTokens.text3)
                 .padding(.top, 8)
@@ -287,6 +371,29 @@ struct ChatMembersView: View {
                     .foregroundStyle(OnymTokens.text3)
             }
             Spacer(minLength: 0)
+            // Admin-only remove affordance (never on the admin's own
+            // row — the chain rejects self-removal anyway). While the
+            // multi-second prove + anchor runs, the row shows a
+            // spinner and other rows' buttons are disabled.
+            if canRemoveMembers && !row.isSelf {
+                if removalInFlightBlsHex == row.blsHex {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(OnymTokens.text3)
+                } else {
+                    Button(role: .destructive) {
+                        memberToRemove = row
+                    } label: {
+                        Image(systemName: "person.fill.xmark")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Color.red)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(removalInFlightBlsHex != nil)
+                    .accessibilityLabel("Remove member")
+                    .accessibilityIdentifier("members.remove_button.\(row.blsHex)")
+                }
+            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -345,6 +452,9 @@ struct ChatMembersView: View {
     private func rows(for group: ChatGroup) -> [MemberRow] {
         let activeKey = activeBlsHex
         return group.memberProfiles
+            // Removed members are tombstoned in the map (so message
+            // rendering keeps their alias) but hidden from the roster.
+            .filter { !$0.value.revoked }
             .map { (key, profile) in
                 MemberRow(
                     id: key,

--- a/Sources/OnymIOS/Chats/ChatMembersView.swift
+++ b/Sources/OnymIOS/Chats/ChatMembersView.swift
@@ -279,16 +279,23 @@ struct ChatMembersView: View {
             let outcome = await removeMember(groupID, row.blsHex)
             removalInFlightBlsHex = nil
             if outcome != .sent {
-                removalErrorText = Self.describe(outcome)
+                removalErrorText = Self.removalErrorText(outcome)
             }
         }
     }
 
-    /// Short diagnostic line for the error alert's message. The alert
-    /// title carries the user-meaningful part; this pins down which
-    /// gate failed (mirrors the Android toast's outcome dump).
-    private static func describe(_ outcome: JoinRequestApprover.RemoveOutcome) -> String {
-        String(describing: outcome)
+    /// Maps a removal failure to user-facing copy. The approver
+    /// surfaces the typed outcome; localization happens here. Mirrors
+    /// `removalErrorText` from onym-android's `ChatMembersScreen.kt`.
+    private static func removalErrorText(_ outcome: JoinRequestApprover.RemoveOutcome) -> String {
+        switch outcome {
+        case .notAdminOfThisGroup:
+            return String(localized: "Only the group's founder can remove members.")
+        case .noActiveRelayer, .noContractBinding, .transportFailed, .anchorRejected:
+            return String(localized: "Couldn't reach the network. Check your connection and try again.")
+        default:
+            return String(localized: "Something went wrong. Try again.")
+        }
     }
 
     private func list(for group: ChatGroup) -> some View {

--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -377,8 +377,7 @@ struct ChatThreadView: View {
     /// a new joiner updates the bar live as the announcement lands.
     /// Tombstoned (removed) members don't count.
     private var currentMemberCount: Int {
-        chatsFlow.groups.first { $0.id == groupID }?
-            .memberProfiles.values.filter { !$0.revoked }.count ?? 0
+        chatsFlow.groups.first { $0.id == groupID }?.activeMemberProfiles.count ?? 0
     }
 
     /// Member profiles for the current group, keyed by BLS pubkey hex.

--- a/Sources/OnymIOS/Chats/ChatThreadView.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadView.swift
@@ -29,6 +29,9 @@ struct ChatThreadView: View {
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
     let setGroupAvatar: @MainActor (String, Data?) async -> Void
     let setGroupName: @MainActor (String, String) async -> Void
+    /// Admin removes a member (anchor + rotate + fan out). Threaded
+    /// down to `ChatMembersView`'s remove affordance.
+    let removeGroupMember: @MainActor (String, String) async -> JoinRequestApprover.RemoveOutcome
     /// Fetches + decrypts image attachments for the bubbles + viewer.
     let imageLoader: ChatImageLoader
     /// Fetches + decrypts video blobs for the full-screen player.
@@ -69,6 +72,7 @@ struct ChatThreadView: View {
         ChatThreadControllerBridge(
             memberProfiles: currentMemberProfiles,
             invitationMessage: currentInvitationMessage,
+            membershipRevoked: currentMembershipRevoked,
             messages: messages,
             onSendTapped: { body, replyToMessageID in
                 // Fire-and-forget. `SendMessageInteractor` does the
@@ -240,7 +244,8 @@ struct ChatThreadView: View {
                 identitiesFlow: identitiesFlow,
                 makeShareInviteFlow: makeShareInviteFlow,
                 setGroupAvatar: setGroupAvatar,
-                setGroupName: setGroupName
+                setGroupName: setGroupName,
+                removeMember: removeGroupMember
             )
         }
         // Per-thread subscription. `task(id:)` cancels + restarts when
@@ -277,6 +282,9 @@ struct ChatThreadView: View {
     private func sendReadReceipts(for snapshot: [ChatMessage]) async {
         guard ReadReceiptsPreference.isEnabled else { return }
         guard let group = chatsFlow.groups.first(where: { $0.id == groupID }) else { return }
+        // Removed from this group: don't announce read activity into a
+        // roster that no longer trusts (or wants to hear from) us.
+        guard !group.membershipRevoked else { return }
         var bySender: [String: [UUID]] = [:]
         for message in snapshot
         where message.direction == .incoming && !ackedReadIDs.contains(message.id) {
@@ -284,7 +292,10 @@ struct ChatThreadView: View {
         }
         guard !bySender.isEmpty else { return }
         for (senderHex, ids) in bySender {
-            guard let inbox = group.memberProfiles[senderHex]?.inboxPublicKey else { continue }
+            // Skip tombstoned senders — never seal to a revoked inbox.
+            guard let profile = group.memberProfiles[senderHex],
+                  !profile.revoked else { continue }
+            let inbox = profile.inboxPublicKey
             await chatReceiptSender.send(
                 kind: .read,
                 messageIDs: ids,
@@ -364,8 +375,10 @@ struct ChatThreadView: View {
     /// Drives the title subtitle ("N members"). Reads from the same
     /// `chatsFlow.groups` source as the name so an admin admitting
     /// a new joiner updates the bar live as the announcement lands.
+    /// Tombstoned (removed) members don't count.
     private var currentMemberCount: Int {
-        chatsFlow.groups.first { $0.id == groupID }?.memberProfiles.count ?? 0
+        chatsFlow.groups.first { $0.id == groupID }?
+            .memberProfiles.values.filter { !$0.revoked }.count ?? 0
     }
 
     /// Member profiles for the current group, keyed by BLS pubkey hex.
@@ -380,11 +393,20 @@ struct ChatThreadView: View {
     private var currentInvitationMessage: String? {
         chatsFlow.groups.first { $0.id == groupID }?.invitationMessage
     }
+
+    /// Whether the admin removed this identity from the group. Drives
+    /// the composer's "you were removed" lockout — reads from the same
+    /// live `chatsFlow.groups` source as the name so the composer
+    /// swaps the moment the removal payload lands.
+    private var currentMembershipRevoked: Bool {
+        chatsFlow.groups.first { $0.id == groupID }?.membershipRevoked ?? false
+    }
 }
 
 private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let memberProfiles: [String: MemberProfile]
     let invitationMessage: String?
+    let membershipRevoked: Bool
     let messages: [ChatMessage]
     let onSendTapped: (String, UUID?) -> Void
     let onRetryRequested: (UUID) -> Void
@@ -425,6 +447,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         // reads the profiles to resolve names.
         vc.update(memberProfiles: memberProfiles)
         vc.update(invitationMessage: invitationMessage)
+        vc.update(membershipRevoked: membershipRevoked)
         vc.update(messages: messages)
         vc.setPendingMedia(pendingMedia)
         return vc
@@ -449,6 +472,7 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         vc.onRemovePendingMedia = onRemovePendingMedia
         vc.update(memberProfiles: memberProfiles)
         vc.update(invitationMessage: invitationMessage)
+        vc.update(membershipRevoked: membershipRevoked)
         vc.update(messages: messages)
         vc.setPendingMedia(pendingMedia)
     }

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -521,6 +521,11 @@ final class ChatThreadViewController: UIViewController {
     /// metadata (invitation + member aliases).
     private func makeEmptyState() -> ChatEmptyStateView {
         let names = memberProfiles.values
+            // Removed members are tombstoned in place — the intro
+            // body enumerates only active membership. (The full map
+            // stays on `memberProfiles` so message rendering keeps
+            // resolving a removed member's alias.)
+            .filter { !$0.revoked }
             .map { $0.alias.trimmingCharacters(in: .whitespacesAndNewlines) }
             .map { $0.isEmpty ? "(unnamed)" : $0 }
             .sorted { $0.lowercased() < $1.lowercased() }

--- a/Sources/OnymIOS/Chats/ChatThreadViewController.swift
+++ b/Sources/OnymIOS/Chats/ChatThreadViewController.swift
@@ -536,6 +536,21 @@ final class ChatThreadViewController: UIViewController {
         emptyStateHost.rootView = makeEmptyState()
     }
 
+    /// Push the group's removed-from-group state in. When `true` the
+    /// composer's input controls are swapped for a "You were removed
+    /// from this group" banner — the thread stays readable but nothing
+    /// can be sent. Called by the SwiftUI wrapper on every render (from
+    /// the live `ChatGroup.membershipRevoked`); no-op when unchanged.
+    func update(membershipRevoked: Bool) {
+        guard membershipRevoked != self.membershipRevoked else { return }
+        self.membershipRevoked = membershipRevoked
+        inputPanel.setMembershipRevoked(membershipRevoked)
+    }
+
+    /// Mirror of the group's `membershipRevoked`, kept so the wrapper's
+    /// per-render pushes are cheap no-ops.
+    private var membershipRevoked = false
+
     private func configureDataSource() {
         dataSource = UITableViewDiffableDataSource<Section, UUID>(
             tableView: tableView

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -21,6 +21,7 @@ struct ChatsView: View {
     let makeJoinFlow: @MainActor (IntroCapability) -> JoinFlow
     let setGroupAvatar: @MainActor (String, Data?) async -> Void
     let setGroupName: @MainActor (String, String) async -> Void
+    let removeGroupMember: @MainActor (String, String) async -> JoinRequestApprover.RemoveOutcome
 
     @State private var showCreateGroup = false
     @State private var showScanner = false
@@ -301,6 +302,7 @@ struct ChatsView: View {
                 makeShareInviteFlow: makeShareInviteFlow,
                 setGroupAvatar: setGroupAvatar,
                 setGroupName: setGroupName,
+                removeGroupMember: removeGroupMember,
                 imageLoader: imageLoader,
                 videoLoader: videoLoader,
                 voiceLoader: voiceLoader

--- a/Sources/OnymIOS/Chats/ChatsView.swift
+++ b/Sources/OnymIOS/Chats/ChatsView.swift
@@ -372,7 +372,9 @@ private struct ChatsRow: View {
         if let preview = item.latestPreview, !preview.isEmpty {
             return preview
         }
-        let count = group.memberProfiles.count
+        // Removed members are tombstoned in place — count only active
+        // membership.
+        let count = group.activeMemberProfiles.count
         let memberText: String?
         switch count {
         case 0:  memberText = nil

--- a/Sources/OnymIOS/Chats/SendMessageInteractor.swift
+++ b/Sources/OnymIOS/Chats/SendMessageInteractor.swift
@@ -49,6 +49,10 @@ actor SendMessageInteractor {
         /// creator's own profile was never recorded (shouldn't happen
         /// post-PR-3) or when the active identity switched mid-flight.
         case senderNotAMember
+        /// The admin removed this identity from the group
+        /// (`ChatGroup.membershipRevoked`) — the thread is read-only.
+        /// Defense-in-depth behind the UI's disabled composer.
+        case removedFromGroup
         /// Caller-side guard. Empty bodies are technically valid on
         /// the wire (the payload encodes them) but the interactor
         /// refuses to ship them — a no-op send would burn a relay
@@ -121,6 +125,10 @@ actor SendMessageInteractor {
         }) else {
             throw SendError.unknownGroup
         }
+        // The admin removed this identity from the group — the thread
+        // is read-only. Defense-in-depth behind the UI's removed-state
+        // composer banner.
+        guard !group.membershipRevoked else { throw SendError.removedFromGroup }
 
         let myBlsHex = active.blsPublicKey
             .map { String(format: "%02x", $0) }.joined()
@@ -175,6 +183,9 @@ actor SendMessageInteractor {
         // we mark `.sent` if at least one relay accepted any envelope.
         let recipients = group.memberProfiles
             .filter { $0.key != myBlsHex }
+            // Removed members are tombstoned in place — never seal a
+            // new message to a revoked inbox.
+            .filter { !$0.value.revoked }
             .map { $0.value.inboxPublicKey }
 
         let (finalStatus, failureReason) = await fanOut(
@@ -230,6 +241,7 @@ actor SendMessageInteractor {
         }) else {
             throw SendError.unknownGroup
         }
+        guard !group.membershipRevoked else { throw SendError.removedFromGroup }
         let myBlsHex = active.blsPublicKey.map { String(format: "%02x", $0) }.joined()
         guard group.memberProfiles[myBlsHex] != nil else {
             throw SendError.senderNotAMember
@@ -300,6 +312,9 @@ actor SendMessageInteractor {
 
         let recipients = group.memberProfiles
             .filter { $0.key != myBlsHex }
+            // Removed members are tombstoned in place — never seal a
+            // new message to a revoked inbox.
+            .filter { !$0.value.revoked }
             .map { $0.value.inboxPublicKey }
         let finalStatus = await uploadAndFanOut(
             blobs: [(sealed.blob, "image/jpeg")],
@@ -337,6 +352,7 @@ actor SendMessageInteractor {
         }) else {
             throw SendError.unknownGroup
         }
+        guard !group.membershipRevoked else { throw SendError.removedFromGroup }
         let myBlsHex = active.blsPublicKey.map { String(format: "%02x", $0) }.joined()
         guard group.memberProfiles[myBlsHex] != nil else {
             throw SendError.senderNotAMember
@@ -427,6 +443,9 @@ actor SendMessageInteractor {
 
         let recipients = group.memberProfiles
             .filter { $0.key != myBlsHex }
+            // Removed members are tombstoned in place — never seal a
+            // new message to a revoked inbox.
+            .filter { !$0.value.revoked }
             .map { $0.value.inboxPublicKey }
         // Poster first (small, so the recipient's bubble renders quickly),
         // then the video.
@@ -473,6 +492,7 @@ actor SendMessageInteractor {
         }) else {
             throw SendError.unknownGroup
         }
+        guard !group.membershipRevoked else { throw SendError.removedFromGroup }
         let myBlsHex = active.blsPublicKey.map { String(format: "%02x", $0) }.joined()
         guard group.memberProfiles[myBlsHex] != nil else {
             throw SendError.senderNotAMember
@@ -565,6 +585,9 @@ actor SendMessageInteractor {
 
         let recipients = group.memberProfiles
             .filter { $0.key != myBlsHex }
+            // Removed members are tombstoned in place — never seal a
+            // new message to a revoked inbox.
+            .filter { !$0.value.revoked }
             .map { $0.value.inboxPublicKey }
         let finalStatus = await uploadAndFanOut(
             blobs: uploads, payload: payload, recipients: recipients,
@@ -599,6 +622,7 @@ actor SendMessageInteractor {
         }) else {
             throw SendError.unknownGroup
         }
+        guard !group.membershipRevoked else { throw SendError.removedFromGroup }
         let myBlsHex = active.blsPublicKey.map { String(format: "%02x", $0) }.joined()
         guard group.memberProfiles[myBlsHex] != nil else {
             throw SendError.senderNotAMember
@@ -669,6 +693,9 @@ actor SendMessageInteractor {
 
         let recipients = group.memberProfiles
             .filter { $0.key != myBlsHex }
+            // Removed members are tombstoned in place — never seal a
+            // new message to a revoked inbox.
+            .filter { !$0.value.revoked }
             .map { $0.value.inboxPublicKey }
         let finalStatus = await uploadAndFanOut(
             blobs: [(sealed.blob, "audio/mp4")],
@@ -706,6 +733,9 @@ actor SendMessageInteractor {
         guard let group = groups.first(where: {
             $0.id == groupID && $0.ownerIdentityID == activeID
         }) else { return }
+        // Retrying into a group we were removed from would only burn a
+        // relay publish; receivers drop it anyway.
+        guard !group.membershipRevoked else { return }
 
         let messages = await messageRepository.currentMessages(
             groupID: groupID,
@@ -763,6 +793,9 @@ actor SendMessageInteractor {
 
         let recipients = group.memberProfiles
             .filter { $0.key != myBlsHex }
+            // Removed members are tombstoned in place — never seal a
+            // new message to a revoked inbox.
+            .filter { !$0.value.revoked }
             .map { $0.value.inboxPublicKey }
 
         _ = await uploadAndFanOut(

--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -24,7 +24,10 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     /// 32-byte shared secret. Used for `topicTag` derivation and message
     /// key HKDF — both still TBD on iOS, but the value must be sealed
     /// into the invitation now so receivers can rebuild the same key.
-    let groupSecret: Data
+    /// Mutable because a member removal rotates it: the admin mints a
+    /// fresh secret and remaining members swap to it via
+    /// `MemberRemovalPayload.groupSecretNew`.
+    var groupSecret: Data
     let createdAt: Date
 
     var members: [GovernanceMember]
@@ -33,13 +36,12 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     /// Populated for the creator at group-create time and extended as
     /// joiners are admitted (post-PR fanout).
     ///
-    /// Independent of `members`: V1 group rosters are static
-    /// on-chain (`update_commitment` is post-V1 in the SEP
-    /// contracts), so a joiner is "in the group" at the app level —
-    /// receiving messages, listed in the chat detail — without yet
-    /// being a `GovernanceMember` in the cryptographic Merkle tree.
-    /// `members` is the on-chain truth; `memberProfiles` is the
-    /// app-level "who am I talking to" directory. They may diverge.
+    /// Independent of `members`: that's the on-chain Merkle-tree
+    /// roster, advanced by the admin's `update_commitment` on every
+    /// join / removal. `memberProfiles` is the app-level "who am I
+    /// talking to" directory (aliases, inbox keys, tombstones). The
+    /// two usually agree but may briefly diverge while a roster
+    /// mutation propagates.
     var memberProfiles: [String: MemberProfile]
     var epoch: UInt64
     var salt: Data
@@ -89,6 +91,15 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     /// accepting, and persisted here as the group's intro. `nil` = none.
     /// Defaulted so existing construction sites need no change.
     var invitationMessage: String? = nil
+
+    /// `true` once this device's owner has been removed from the group
+    /// by the admin (a self-targeting `MemberRemovalPayload` landed).
+    /// The thread stays readable but the composer is replaced by a
+    /// "you were removed" banner and `SendMessageInteractor` refuses
+    /// sends. Local-only — never on the wire; defaulted so existing
+    /// construction sites need no change. Mirrors
+    /// `ChatGroup.membershipRevoked` from onym-android.
+    var membershipRevoked: Bool = false
 
     /// Group ID as the raw 32-byte payload (parsed back from `id`).
     /// Used directly when building chain payloads + invitations.

--- a/Sources/OnymIOS/Group/ChatGroup.swift
+++ b/Sources/OnymIOS/Group/ChatGroup.swift
@@ -101,6 +101,14 @@ struct ChatGroup: Identifiable, Equatable, Sendable {
     /// `ChatGroup.membershipRevoked` from onym-android.
     var membershipRevoked: Bool = false
 
+    /// `memberProfiles` minus tombstoned (removed) members — what the
+    /// UI means by "the members": counts, rosters, alias enumerations.
+    /// Message-rendering alias lookups keep using the full map so a
+    /// removed member's past messages still show their name.
+    var activeMemberProfiles: [String: MemberProfile] {
+        memberProfiles.filter { !$0.value.revoked }
+    }
+
     /// Group ID as the raw 32-byte payload (parsed back from `id`).
     /// Used directly when building chain payloads + invitations.
     var groupIDData: Data {

--- a/Sources/OnymIOS/Group/GroupAvatarBroadcaster.swift
+++ b/Sources/OnymIOS/Group/GroupAvatarBroadcaster.swift
@@ -49,6 +49,8 @@ actor GroupAvatarBroadcaster {
         for (memberKey, profile) in group.memberProfiles {
             // Skip self — the admin already applied the change locally.
             if let adminKey, memberKey == adminKey { continue }
+            // Removed members get nothing — tombstoned in place.
+            if profile.revoked { continue }
             guard let sealed = try? await identity.sealInvitation(
                 payload: payloadBytes,
                 to: profile.inboxPublicKey
@@ -90,6 +92,8 @@ actor GroupAvatarBroadcaster {
         for (memberKey, profile) in group.memberProfiles {
             // Skip self — the admin already applied the change locally.
             if let adminKey, memberKey == adminKey { continue }
+            // Removed members get nothing — tombstoned in place.
+            if profile.revoked { continue }
             guard let sealed = try? await identity.sealInvitation(
                 payload: payloadBytes,
                 to: profile.inboxPublicKey

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -332,6 +332,28 @@ actor JoinRequestApprover: JoinRequestApproving {
             }
         }
 
+        // Record the joiner BEFORE building the invitation snapshot.
+        // Ordering is load-bearing for RE-admission: the joiner's own
+        // entry is still the tombstone from their earlier removal, so
+        // the `!revoked` filter below would drop it off the wire, the
+        // receiver would materialize with a nil
+        // `MemberProfile.statusEpoch`, and the next relay replay of
+        // that old removal would re-lock their composer for good.
+        // Recording first un-revokes + epoch-stamps the entry so it
+        // survives the filter and carries its status marker across.
+        // Skipped when the joiner shipped a pre-PR-4 request — no
+        // stable cross-device key to record under.
+        let joinerBlsPub = req.joinerBlsPublicKey
+        if let joinerBlsPub {
+            anchored = await recordJoiner(
+                in: anchored,
+                blsPub: joinerBlsPub,
+                inboxPub: req.joinerInboxPublicKey,
+                sendingPub: req.joinerSendingPublicKey,
+                alias: req.joinerDisplayLabel
+            )
+        }
+
         let invite = GroupInvitationPayload(
             version: 1,
             groupID: anchored.groupIDData,
@@ -391,22 +413,13 @@ actor JoinRequestApprover: JoinRequestApproving {
         guard receipt.acceptedBy >= 1 else {
             return .transportFailed("no relay accepted the invitation")
         }
-        // Record the joiner in the local group's view-facing roster
-        // (alias / inbox-pub) so the admin sees their alias in the
-        // UI. The cryptographic roster (`anchored.members`) was
-        // already updated by the anchor step. Both side-effects only
-        // run when the joiner shipped a BLS pubkey.
-        if let blsPub = req.joinerBlsPublicKey {
-            await recordJoiner(
-                in: anchored,
-                blsPub: blsPub,
-                inboxPub: req.joinerInboxPublicKey,
-                sendingPub: req.joinerSendingPublicKey,
-                alias: req.joinerDisplayLabel
-            )
+        // The joiner is already recorded above (before the invitation
+        // snapshot — see the ordering comment there). Announce them to
+        // the existing members from the post-record snapshot.
+        if let joinerBlsPub {
             await broadcastJoin(
                 in: anchored,
-                joinerBlsPub: blsPub,
+                joinerBlsPub: joinerBlsPub,
                 joinerInboxPub: req.joinerInboxPublicKey,
                 joinerSendingPub: req.joinerSendingPublicKey,
                 joinerAlias: req.joinerDisplayLabel
@@ -863,13 +876,20 @@ actor JoinRequestApprover: JoinRequestApproving {
     /// alias + inbox-pub. Re-inserting through `GroupRepository`
     /// goes through `SwiftDataGroupStore.insertOrUpdate`, which
     /// updates the row in place rather than minting a new one.
+    ///
+    /// Returns the updated snapshot so the caller can build the
+    /// invitation + announcement from state that already includes the
+    /// joiner — for a RE-admission that's what un-revokes the entry and
+    /// stamps its `MemberProfile.statusEpoch` before the `!revoked`
+    /// filter runs.
+    @discardableResult
     private func recordJoiner(
         in group: ChatGroup,
         blsPub: Data,
         inboxPub: Data,
         sendingPub: Data,
         alias: String
-    ) async {
+    ) async -> ChatGroup {
         let key = blsPub.map { String(format: "%02x", $0) }.joined()
         var updated = group
         updated.memberProfiles[key] = MemberProfile(
@@ -884,6 +904,7 @@ actor JoinRequestApprover: JoinRequestApproving {
             statusEpoch: group.epoch
         )
         await groupRepository.insert(updated)
+        return updated
     }
 
     /// Build a `MemberAnnouncementPayload` for the new joiner and

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -758,9 +758,23 @@ actor JoinRequestApprover: JoinRequestApproving {
     }
 
     /// One sealed envelope per recipient, sequential, failures
-    /// swallowed (inbox replay + the on-chain gate make convergence
-    /// eventual). The victim's copy is encoded WITHOUT the rotated
+    /// swallowed. The victim's copy is encoded WITHOUT the rotated
     /// secrets — build both wire bodies once, outside the loop.
+    ///
+    /// ## Recovery path for a missed envelope
+    ///
+    /// If a recipient's send fails here (no relay accepted it), inbox
+    /// replay can NOT redeliver — the envelope never reached a relay.
+    /// That member's local state stays on the pre-removal epoch +
+    /// groupSecret until something triggers a
+    /// `GroupStateRefreshRequest` toward the admin (whose reply
+    /// carries the full current snapshot). They remain SAFE in the
+    /// meantime — the removal is already anchored and the victim
+    /// can't read anything new — but they'll keep the victim in their
+    /// local roster and keep sealing messages to the victim's inbox
+    /// until they converge. A proactive resend queue is a known
+    /// follow-up.
+    ///
     /// Mirrors `GroupMemberRemover.broadcastRemoval` from onym-android.
     private func broadcastRemoval(
         in group: ChatGroup,

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -348,7 +348,14 @@ actor JoinRequestApprover: JoinRequestApproving {
             // peers + admin by name from the moment they land. The
             // joiner's own profile gets backfilled by the receiver's
             // materializer from their active identity.
-            memberProfiles: anchored.memberProfiles.isEmpty ? nil : anchored.memberProfiles,
+            // Tombstoned (removed) members are filtered out: a fresh
+            // joiner has no history to render and no replayed
+            // announcements to dedup, so ex-members' aliases + keys
+            // would be pure disclosure (see MemberProfile.revoked).
+            memberProfiles: {
+                let active = anchored.memberProfiles.filter { !$0.value.revoked }
+                return active.isEmpty ? nil : active
+            }(),
             // Tyranny invitees only get the full snapshot here (the
             // create-time offer carries nothing), so this is where the
             // group photo reaches them.
@@ -742,7 +749,13 @@ actor JoinRequestApprover: JoinRequestApproving {
         anchored.epoch = group.epoch + 1
         anchored.salt = saltNew
         anchored.groupSecret = groupSecretNew
-        anchored.memberProfiles[victimHex] = victimProfile.withRevoked(true)
+        anchored.memberProfiles[victimHex] = victimProfile.withStatus(
+            revoked: true,
+            // Removal epoch — lets receive-side tombstone decisions
+            // stay order-independent under relay replay
+            // (MemberProfile.statusEpoch).
+            statusEpoch: group.epoch + 1
+        )
         await groupRepository.insert(anchored)
 
         // ─── fan out (best-effort) ───────────────────────────────────
@@ -862,7 +875,13 @@ actor JoinRequestApprover: JoinRequestApproving {
         updated.memberProfiles[key] = MemberProfile(
             alias: alias,
             inboxPublicKey: inboxPub,
-            sendingPubkey: sendingPub
+            sendingPubkey: sendingPub,
+            // (Re-)admission epoch — overwrites any tombstone's
+            // statusEpoch so out-of-order removal replays on OTHER
+            // devices are refused for this member. Uses the
+            // post-anchor group snapshot's epoch (the same value the
+            // announcement fanout claims).
+            statusEpoch: group.epoch
         )
         await groupRepository.insert(updated)
     }

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -103,6 +103,43 @@ actor JoinRequestApprover: JoinRequestApproving {
         case anchorRejected(String)
     }
 
+    /// Outcome of `removeMember`. Mirrors `GroupMemberRemover.Outcome`
+    /// from onym-android.
+    enum RemoveOutcome: Equatable, Sendable {
+        /// Anchored on chain, persisted locally, fanned out (best-effort).
+        case sent
+        /// No group with this id under the active identity.
+        case unknownGroup
+        /// No identity selected.
+        case noIdentityLoaded
+        /// Removal only exists for Tyranny groups.
+        case notTyrannyGroup
+        /// Active identity isn't this group's admin.
+        case notAdminOfThisGroup
+        /// The admin can't remove themself.
+        case cannotRemoveSelf
+        /// BLS hex not present in `ChatGroup.memberProfiles`.
+        case unknownMember
+        /// The member's profile is already tombstoned.
+        case alreadyRemoved
+        /// Present in the app-level directory but missing from the
+        /// on-chain `ChatGroup.members` roster — the tree can't be
+        /// shrunk around a leaf that was never in it. (Directory and
+        /// roster are allowed to diverge; removal is the first flow
+        /// that needs them to agree.)
+        case memberNotInRoster
+        /// `RelayerRepository.selectURL()` returned nil.
+        case noActiveRelayer
+        /// No deployed Tyranny contract for the active network.
+        case noContractBinding
+        /// `Tyranny.proveUpdate` failed.
+        case proofFailed(String)
+        /// Relayer accepted the POST but the contract rejected.
+        case anchorRejected(String)
+        /// Local/transport failure outside the prove+anchor leg.
+        case transportFailed(String)
+    }
+
     private let identity: IdentityRepository
     private let introKeyStore: any IntroKeyStore
     private let introRequestStore: any IntroRequestStore
@@ -118,16 +155,18 @@ actor JoinRequestApprover: JoinRequestApproving {
     private var pendingContinuations: [UUID: AsyncStream<[PendingRequest]>.Continuation] = [:]
     private var decryptFailures: Int = 0
     private var collectorTask: Task<Void, Never>?
-    /// Serializes `approve` calls. Each approval reads `group.epoch`,
-    /// proves an `update_commitment` from it, submits, then persists
-    /// `epoch + 1`. The actor re-enters at the multi-second prove /
-    /// submit awaits, so two overlapping approvals would both read the
-    /// same stale epoch — the chain accepts the first and rejects the
-    /// second as a stale-epoch replay (the loser's join silently
-    /// fails). Chaining each approval onto the previous one's
-    /// completion guarantees the read-prove-submit-persist critical
-    /// section runs to completion before the next begins.
-    private var approvalChain: Task<ApproveOutcome, Never>?
+    /// Serializes `approve` AND `removeMember` calls. Each one reads
+    /// `group.epoch`, proves an `update_commitment` from it, submits,
+    /// then persists `epoch + 1`. The actor re-enters at the
+    /// multi-second prove / submit awaits, so two overlapping
+    /// mutations would both read the same stale epoch — the chain
+    /// accepts the first and rejects the second as a stale-epoch
+    /// replay (the loser silently fails). Chaining each operation onto
+    /// the previous one's completion guarantees the
+    /// read-prove-submit-persist critical section runs to completion
+    /// before the next begins. Type-erased to `Void` so approvals and
+    /// removals share one chain (they mutate the same group state).
+    private var approvalChain: Task<Void, Never>?
 
     init(
         identity: IdentityRepository,
@@ -202,19 +241,37 @@ actor JoinRequestApprover: JoinRequestApproving {
         await refresh(from: raw)
     }
 
-    /// Public entry point. Serializes onto any in-flight approval via
-    /// `approvalChain` so each on-chain `update_commitment` reads the
-    /// epoch the previous approval persisted, then defers to
-    /// `performApprove` for the actual anchor flow. The read-and-assign
-    /// of `approvalChain` is synchronous (no `await` between), so
-    /// overlapping callers chain deterministically.
+    /// Public entry point. Serializes onto any in-flight approval /
+    /// removal via `approvalChain` so each on-chain `update_commitment`
+    /// reads the epoch the previous operation persisted, then defers to
+    /// `performApprove` for the actual anchor flow.
     func approve(requestId: String) async -> ApproveOutcome {
-        let previous = approvalChain
-        let task = Task { () -> ApproveOutcome in
-            _ = await previous?.value
-            return await self.performApprove(requestId: requestId)
+        await enqueue { await self.performApprove(requestId: requestId) }
+    }
+
+    /// Remove `victimBlsHex` (lowercase 96-char BLS pubkey hex) from
+    /// `groupIDHex`, with groupSecret rotation. Serialized through the
+    /// same `approvalChain` as `approve` — both are
+    /// read-prove-anchor-persist on the same group and must not
+    /// interleave. See `performRemove` for the flow.
+    func removeMember(groupIDHex: String, victimBlsHex: String) async -> RemoveOutcome {
+        await enqueue {
+            await self.performRemove(groupIDHex: groupIDHex, victimBlsHex: victimBlsHex)
         }
-        approvalChain = task
+    }
+
+    /// Chain `op` onto the previous group-mutating operation. The
+    /// read-and-assign of `approvalChain` is synchronous (no `await`
+    /// between), so overlapping callers chain deterministically.
+    private func enqueue<T: Sendable>(
+        _ op: @escaping @Sendable () async -> T
+    ) async -> T {
+        let previous = approvalChain
+        let task = Task { () -> T in
+            _ = await previous?.value
+            return await op()
+        }
+        approvalChain = Task { _ = await task.value }
         return await task.value
     }
 
@@ -504,6 +561,274 @@ actor JoinRequestApprover: JoinRequestApproving {
         return .ok(updated)
     }
 
+    /// Admin-side "remove member from a Tyranny group" flow, with
+    /// groupSecret rotation. Ordering is anchor → persist → fan out
+    /// (mirrors `performApprove`):
+    ///
+    ///  1. Shrink the roster, prove the Tyranny `update_commitment`
+    ///     over the new Merkle root, submit to the relayer. Epoch
+    ///     bumps, salt rotates, and — unlike a join — a **fresh random
+    ///     groupSecret** is generated so the removed member holds no
+    ///     post-removal member-only secret.
+    ///  2. Persist the advanced local state (roster minus victim, the
+    ///     victim's `MemberProfile` tombstoned via `revoked = true` —
+    ///     never deleted, so past-message rendering and dedup keep
+    ///     working).
+    ///  3. Fan a `MemberRemovalPayload` out per recipient,
+    ///     best-effort: remaining members receive the variant carrying
+    ///     `group_secret_new` + `salt_new`; the victim receives the
+    ///     secret-free variant (they learn the fact, never the
+    ///     secrets).
+    ///
+    /// The fanout is deliberately OFF the critical path: once the
+    /// chain anchor lands and local state persists, the removal is
+    /// real — a member that misses the payload converges later via
+    /// inbox replay. (stellar-mls postmortem lesson: never block the
+    /// security-critical leg on courtesy delivery.)
+    ///
+    /// Mirrors `GroupMemberRemover.remove` from onym-android (where a
+    /// shared `Mutex` stands in for this actor's `approvalChain`).
+    private func performRemove(
+        groupIDHex: String,
+        victimBlsHex: String
+    ) async -> RemoveOutcome {
+        let victimHex = victimBlsHex.lowercased()
+        let activeID = await identity.currentSelectedID()
+        let groups = await groupRepository.currentGroups()
+        // Scope to the active identity's copy — the same on-chain
+        // group id can belong to two local identities, and only the
+        // admin's copy holds the authority to shrink the roster.
+        guard let group = groups.first(where: {
+            $0.id.lowercased() == groupIDHex.lowercased()
+                && (activeID == nil || $0.ownerIdentityID == activeID)
+        }) else { return .unknownGroup }
+        guard activeID != nil else { return .noIdentityLoaded }
+
+        guard group.groupType == .tyranny else { return .notTyrannyGroup }
+        guard let adminPubkeyHex = group.adminPubkeyHex?.lowercased() else {
+            return .notAdminOfThisGroup
+        }
+        guard victimHex != adminPubkeyHex else { return .cannotRemoveSelf }
+
+        guard let victimProfile = group.memberProfiles[victimHex] else {
+            return .unknownMember
+        }
+        guard !victimProfile.revoked else { return .alreadyRemoved }
+
+        let victimBytes = ChatGroup.bytes(fromHex: victimHex)
+        guard group.members.contains(where: {
+            $0.publicKeyCompressed == victimBytes
+        }) else { return .memberNotInRoster }
+
+        // ─── chain-anchor leg (mirrors anchorTyrannyJoin) ────────────
+        guard let relayerURL = await relayers.selectURL() else {
+            return .noActiveRelayer
+        }
+        let activeNetwork = networkPreference.current()
+        let anchorKey = AnchorSelectionKey(
+            network: activeNetwork.contractNetwork,
+            type: .tyranny
+        )
+        guard let binding = await contracts.binding(for: anchorKey) else {
+            return .noContractBinding
+        }
+
+        let adminBytes = ChatGroup.bytes(fromHex: adminPubkeyHex)
+        guard let adminIndexOld = group.members.firstIndex(where: {
+            $0.publicKeyCompressed == adminBytes
+        }) else {
+            return .transportFailed("admin not in members roster")
+        }
+
+        // Removal preserves the existing lex order — filtering can't
+        // reorder an already-sorted roster.
+        let newMembers = group.members.filter {
+            $0.publicKeyCompressed != victimBytes
+        }
+        let memberRootNew: Data
+        do {
+            memberRootNew = try GroupCommitmentBuilder.computeMerkleRoot(
+                members: newMembers,
+                tier: group.tier
+            )
+        } catch {
+            return .proofFailed("merkle_root: \(error)")
+        }
+        let saltNew = GroupCommitmentBuilder.generateSalt()
+        // Fresh random groupSecret — the whole point of the rotation:
+        // the victim keeps the OLD secret, which stops mattering the
+        // moment the remaining members switch.
+        let groupSecretNew: Data
+        do {
+            groupSecretNew = try SecureRandom.data(32)
+        } catch {
+            return .transportFailed("random: \(error)")
+        }
+
+        let blsSecret: Data
+        do {
+            // onym:allow-secret-read
+            blsSecret = try await identity.blsSecretKey()
+        } catch {
+            return .transportFailed("bls_secret: \(error)")
+        }
+
+        // Same pre-flight as the approver: confirm the active identity
+        // actually IS the admin before handing the secret to the
+        // prover — catches "user switched identities" cleanly.
+        let activePubFromSecret: Data
+        do {
+            activePubFromSecret = try GroupCommitmentBuilder.computePublicKey(
+                secretKey: blsSecret
+            )
+        } catch {
+            return .transportFailed("derive_pub: \(error)")
+        }
+        guard activePubFromSecret == group.members[adminIndexOld].publicKeyCompressed else {
+            return .notAdminOfThisGroup
+        }
+
+        let proofInput = GroupProofUpdateInput(
+            groupType: .tyranny,
+            tier: group.tier,
+            oldMembers: group.members,
+            adminBlsSecretKey: blsSecret,
+            adminIndexOld: adminIndexOld,
+            epochOld: group.epoch,
+            memberRootNew: memberRootNew,
+            groupID: group.groupIDData,
+            saltOld: group.salt,
+            saltNew: saltNew
+        )
+        let proof: GroupUpdateProof
+        do {
+            proof = try proofGenerator.proveUpdate(proofInput)
+        } catch let err as GroupProofGeneratorError {
+            return .proofFailed(err.localizedDescription)
+        } catch {
+            return .proofFailed(String(describing: error))
+        }
+
+        let transport = makeContractTransport(relayerURL)
+        let client = SEPContractClient(
+            contractID: binding.contractID,
+            contractType: .tyranny,
+            network: activeNetwork.sepNetwork,
+            transport: transport
+        )
+        let response: SEPSubmissionResponse
+        do {
+            response = try await client.updateCommitmentTyranny(
+                TyrannyUpdateCommitmentPayload(
+                    groupID: group.groupIDData,
+                    proof: proof.proof,
+                    publicInputs: proof.publicInputs
+                )
+            )
+        } catch {
+            return .transportFailed("anchor: \(error)")
+        }
+        guard response.accepted else {
+            return .anchorRejected(response.message ?? "(no message)")
+        }
+
+        // ─── persist ─────────────────────────────────────────────────
+        // The anchor landed: the removal is now the on-chain truth.
+        // Persist BEFORE fanning out so a crash mid-fanout can't lose
+        // the transition (peers converge via inbox replay).
+        var anchored = group
+        anchored.members = newMembers
+        anchored.commitment = proof.commitmentNew
+        anchored.epoch = group.epoch + 1
+        anchored.salt = saltNew
+        anchored.groupSecret = groupSecretNew
+        anchored.memberProfiles[victimHex] = victimProfile.withRevoked(true)
+        await groupRepository.insert(anchored)
+
+        // ─── fan out (best-effort) ───────────────────────────────────
+        await broadcastRemoval(
+            in: anchored,
+            victimHex: victimHex,
+            victimProfile: victimProfile,
+            adminHex: adminPubkeyHex,
+            groupSecretNew: groupSecretNew,
+            saltNew: saltNew
+        )
+        return .sent
+    }
+
+    /// One sealed envelope per recipient, sequential, failures
+    /// swallowed (inbox replay + the on-chain gate make convergence
+    /// eventual). The victim's copy is encoded WITHOUT the rotated
+    /// secrets — build both wire bodies once, outside the loop.
+    /// Mirrors `GroupMemberRemover.broadcastRemoval` from onym-android.
+    private func broadcastRemoval(
+        in group: ChatGroup,
+        victimHex: String,
+        victimProfile: MemberProfile,
+        adminHex: String,
+        groupSecretNew: Data,
+        saltNew: Data
+    ) async {
+        guard let commitment = group.commitment else { return }
+        let sentAt = Int64(Date().timeIntervalSince1970 * 1000)
+        let memberBytes: Data
+        let victimBytes: Data
+        do {
+            let memberPayload = try MemberRemovalPayload(
+                version: 1,
+                groupID: group.groupIDData,
+                removedBlsHex: victimHex,
+                commitment: commitment,
+                epoch: group.epoch,
+                sentAtMillis: sentAt,
+                groupSecretNew: groupSecretNew,
+                saltNew: saltNew
+            )
+            let victimPayload = try MemberRemovalPayload(
+                version: 1,
+                groupID: group.groupIDData,
+                removedBlsHex: victimHex,
+                commitment: commitment,
+                epoch: group.epoch,
+                sentAtMillis: sentAt
+            )
+            memberBytes = try JSONEncoder().encode(memberPayload)
+            victimBytes = try JSONEncoder().encode(victimPayload)
+        } catch {
+            // Encode failures can't happen for sizes the caller
+            // already validated — but skipping fanout beats crashing
+            // after the anchor landed.
+            return
+        }
+
+        for (memberKey, profile) in group.memberProfiles {
+            if memberKey == adminHex { continue } // self
+            let body: Data
+            if memberKey == victimHex {
+                body = victimBytes
+            } else {
+                if profile.revoked { continue } // earlier tombstones
+                body = memberBytes
+            }
+            let inboxKey = memberKey == victimHex
+                ? victimProfile.inboxPublicKey
+                : profile.inboxPublicKey
+            let sealed: Data
+            do {
+                sealed = try await identity.sealInvitation(payload: body, to: inboxKey)
+            } catch {
+                continue
+            }
+            let tag = TransportInboxID(
+                rawValue: IntroInboxPump.inboxTag(from: inboxKey)
+            )
+            // Receipts discarded — fan-out is best-effort; the on-chain
+            // anchor is the truth and inbox replay backfills stragglers.
+            _ = try? await inboxTransport.send(sealed, to: tag)
+        }
+    }
+
     /// Insert/update the joiner's `MemberProfile` on the local
     /// group. Idempotent — a second approval for the same joiner
     /// (e.g. they re-tap the link before the inviter notices the
@@ -593,9 +918,11 @@ actor JoinRequestApprover: JoinRequestApproving {
 
         for (memberKey, profile) in group.memberProfiles {
             // Skip self (admin already knows) + the new joiner
-            // (covered by the GroupInvitationPayload above).
+            // (covered by the GroupInvitationPayload above) + removed
+            // members (tombstoned in place — their inbox gets nothing).
             if memberKey == joinerKey { continue }
             if let adminKey, memberKey == adminKey { continue }
+            if profile.revoked { continue }
 
             let sealed: Data
             do {

--- a/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
+++ b/Sources/OnymIOS/Group/MemberAnnouncementPayload.swift
@@ -72,12 +72,13 @@ struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
 
     /// One member's directory entry. App-level only — the
     /// cryptographic Poseidon leaf hash is intentionally absent.
-    /// V1 group rosters are static on-chain (the joiner is not yet a
-    /// member of the Merkle tree; `update_commitment` is post-V1
-    /// scope in the SEP contracts), so the leaf hash is meaningless
-    /// to ship today. When on-chain joiner ceremonies land, a
-    /// `leaf_hash` field can return via a non-failing
-    /// `decodeIfPresent` decoder without breaking older receivers.
+    /// The joiner's leaf reaches receivers through the full roster in
+    /// `GroupInvitationPayload.members` (the admin anchors the
+    /// `update_commitment` before fanning this announcement out), so
+    /// re-shipping it here would just be a second copy to keep
+    /// consistent. If a leaner delta ever needs it, a `leaf_hash`
+    /// field can land via a non-failing `decodeIfPresent` decoder
+    /// without breaking older receivers.
     ///
     /// `blsPub` is still carried as the **stable cross-device
     /// identifier**: it's HKDF-derived from the joiner's identity

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -7,10 +7,10 @@ import Foundation
 /// the peer's lowercase BLS pubkey hex.
 ///
 /// Distinct from `GovernanceMember`: that's the on-chain Merkle-tree
-/// roster (V1: creator only, static). `MemberProfile` covers the
-/// app-level "who's in this conversation" set, which V1 grows as
-/// joiners are admitted even though the on-chain roster doesn't
-/// change.
+/// roster (advanced by the admin's `update_commitment` as joiners are
+/// admitted / members are removed). `MemberProfile` covers the
+/// app-level "who's in this conversation" set — aliases and inbox
+/// keys the cryptographic roster doesn't carry.
 ///
 /// Trust: `alias` is self-asserted by its owner — never load-bearing.
 /// Surfaces should always offer the member's BLS-pubkey fingerprint
@@ -30,17 +30,29 @@ struct MemberProfile: Codable, Equatable, Hashable, Sendable {
     /// against this so an insider can't forge another member's
     /// `senderBlsPubkeyHex` claim.
     let sendingPubkey: Data
+    /// Tombstone for a member removed from the group. A revoked
+    /// profile stays in the map so past-message alias rendering and
+    /// BLS-fingerprint lookups keep working, but every trust surface
+    /// treats the member as gone: sender-auth paths reject their
+    /// envelopes, fanout loops skip their inbox, and the members UI
+    /// hides the row. Decoded with `decodeIfPresent ?? false` so
+    /// legacy persisted JSON and pre-removal wire payloads decode as
+    /// active members; always encoded (Android decoders default the
+    /// same way). Mirrors `MemberProfile.revoked` from onym-android.
+    let revoked: Bool
 
     enum CodingKeys: String, CodingKey {
         case alias
         case inboxPublicKey = "inbox_public_key"
         case sendingPubkey = "sending_pubkey"
+        case revoked
     }
 
-    init(alias: String, inboxPublicKey: Data, sendingPubkey: Data) {
+    init(alias: String, inboxPublicKey: Data, sendingPubkey: Data, revoked: Bool = false) {
         self.alias = alias
         self.inboxPublicKey = inboxPublicKey
         self.sendingPubkey = sendingPubkey
+        self.revoked = revoked
     }
 
     /// The wire-side decode boundary. `MemberProfile` ships inside
@@ -67,6 +79,19 @@ struct MemberProfile: Codable, Equatable, Hashable, Sendable {
         self.alias = alias
         self.inboxPublicKey = inbox
         self.sendingPubkey = sending
+        self.revoked = try c.decodeIfPresent(Bool.self, forKey: .revoked) ?? false
+    }
+
+    /// Copy of this profile with the tombstone flipped. Value-type
+    /// mirror of Android's `copy(revoked = true)` — the apply paths
+    /// tombstone in place, never delete.
+    func withRevoked(_ revoked: Bool) -> MemberProfile {
+        MemberProfile(
+            alias: alias,
+            inboxPublicKey: inboxPublicKey,
+            sendingPubkey: sendingPubkey,
+            revoked: revoked
+        )
     }
 }
 

--- a/Sources/OnymIOS/Group/MemberProfile.swift
+++ b/Sources/OnymIOS/Group/MemberProfile.swift
@@ -39,20 +39,56 @@ struct MemberProfile: Codable, Equatable, Hashable, Sendable {
     /// legacy persisted JSON and pre-removal wire payloads decode as
     /// active members; always encoded (Android decoders default the
     /// same way). Mirrors `MemberProfile.revoked` from onym-android.
+    ///
+    /// ## Retention & disclosure
+    ///
+    /// Tombstones live for the group's lifetime on devices that knew
+    /// the member — they're what makes removal apply idempotently and
+    /// order-independently under relay replay. They are deliberately
+    /// NOT shipped to brand-new joiners (`JoinRequestApprover` filters
+    /// them out of the invitation snapshot): a new member has no
+    /// history to render and no replayed announcements to dedup, so
+    /// disclosing ex-members' aliases + keys to them buys nothing.
+    /// Existing members DO receive them via `GroupStateVerifier`
+    /// refresh replies (convergence needs them). Bounded-retention GC
+    /// is an explicit follow-up.
     let revoked: Bool
+    /// Epoch of the LAST membership-status change known for this
+    /// member — the removal epoch when tombstoning, the (re-)admission
+    /// epoch when admitting. `nil` for profiles that predate this
+    /// field or whose status never changed.
+    ///
+    /// Why it exists: relay dispatch order is arrival order, not epoch
+    /// order. A single group-level epoch guard can't distinguish "a
+    /// stale removal I already superseded" from "an out-of-order
+    /// removal I haven't seen yet" — a removal at epoch 5 replayed
+    /// after one at epoch 6 must STILL tombstone its victim, while a
+    /// removal at epoch 5 replayed after that member's epoch-7
+    /// re-admission must NOT. Per-member status epochs make the
+    /// tombstone decision order-independent while
+    /// epoch / salt / groupSecret remain strictly converge-forward.
+    let statusEpoch: UInt64?
 
     enum CodingKeys: String, CodingKey {
         case alias
         case inboxPublicKey = "inbox_public_key"
         case sendingPubkey = "sending_pubkey"
         case revoked
+        case statusEpoch = "status_epoch"
     }
 
-    init(alias: String, inboxPublicKey: Data, sendingPubkey: Data, revoked: Bool = false) {
+    init(
+        alias: String,
+        inboxPublicKey: Data,
+        sendingPubkey: Data,
+        revoked: Bool = false,
+        statusEpoch: UInt64? = nil
+    ) {
         self.alias = alias
         self.inboxPublicKey = inboxPublicKey
         self.sendingPubkey = sendingPubkey
         self.revoked = revoked
+        self.statusEpoch = statusEpoch
     }
 
     /// The wire-side decode boundary. `MemberProfile` ships inside
@@ -80,17 +116,21 @@ struct MemberProfile: Codable, Equatable, Hashable, Sendable {
         self.inboxPublicKey = inbox
         self.sendingPubkey = sending
         self.revoked = try c.decodeIfPresent(Bool.self, forKey: .revoked) ?? false
+        self.statusEpoch = try c.decodeIfPresent(UInt64.self, forKey: .statusEpoch)
     }
 
-    /// Copy of this profile with the tombstone flipped. Value-type
-    /// mirror of Android's `copy(revoked = true)` — the apply paths
+    /// Copy of this profile with the membership status replaced —
+    /// tombstone flag plus the epoch that status change happened at.
+    /// Value-type mirror of Android's
+    /// `copy(revoked = …, statusEpoch = …)` — the apply paths
     /// tombstone in place, never delete.
-    func withRevoked(_ revoked: Bool) -> MemberProfile {
+    func withStatus(revoked: Bool, statusEpoch: UInt64?) -> MemberProfile {
         MemberProfile(
             alias: alias,
             inboxPublicKey: inboxPublicKey,
             sendingPubkey: sendingPubkey,
-            revoked: revoked
+            revoked: revoked,
+            statusEpoch: statusEpoch
         )
     }
 }

--- a/Sources/OnymIOS/Group/MemberRemovalPayload.swift
+++ b/Sources/OnymIOS/Group/MemberRemovalPayload.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+/// Plaintext payload the admin seals (via
+/// `IdentityRepository.sealInvitation`, X25519 + AES-GCM, signed by
+/// the admin's Ed25519 stellar key) and ships to every member's inbox
+/// after removing a member from a Tyranny group. Tells receivers
+/// "this person is no longer in the group — tombstone them and (for
+/// remaining members) rotate to the fresh group secret".
+///
+/// ## Two audience variants of the same type
+///
+/// The admin encodes this payload twice per removal:
+///
+///  - **Remaining members** get the full variant: `groupSecretNew` +
+///    `saltNew` carry the rotated secrets so their local group state
+///    stays coherent (and any future key derivation from
+///    `ChatGroup.groupSecret` excludes the removed member).
+///  - **The removed member** gets the secret-free variant — both
+///    optional fields omitted from the wire entirely (`encodeIfPresent`
+///    drops the keys, not just the values). The victim learns *that*
+///    they were removed, never the post-removal secrets. This mirrors
+///    the `SEPRemovalNotice` / `SEPRekeyEnvelope` split from
+///    stellar-mls collapsed into one type, safe here because every
+///    payload is per-recipient sealed anyway.
+///
+/// ## Trust
+///
+/// Receivers MUST cross-check the outer `SealedEnvelope`'s verified
+/// `senderEd25519PublicKey` against the group's stored
+/// `adminEd25519PubkeyHex` (the dispatcher's
+/// `isAuthorizedGroupMutation` gate) AND verify `commitment + epoch`
+/// against the on-chain state before mutating local state. That logic
+/// lives in the dispatcher — this type is a pure value carrier.
+///
+/// ## Wire disjointness
+///
+/// Every REQUIRED key is prefixed `removal_` so the dispatcher's
+/// trial-decode chain can never confuse this payload with any of the
+/// other inbox payloads in either direction (crucially:
+/// `removal_group_id` not `group_id`, `group_secret_new` not
+/// `group_secret`).
+///
+/// ## Versioning
+///
+/// `removal_version = 1` is the only shape receivers handle today.
+/// Future fields land via non-failing `decodeIfPresent` decoders.
+///
+/// ## Cross-platform parity
+///
+/// Mirrors `MemberRemovalPayload.kt` from onym-android — the wire
+/// format was authored there first; this file mirrors the snake_case
+/// keys + base64 `Data` encoding (Swift `JSONEncoder`'s `.base64`
+/// default + Kotlin's `Base64.getEncoder()` produce the same bytes).
+struct MemberRemovalPayload: Codable, Equatable, Sendable {
+    let version: Int
+    /// 32-byte group ID — receivers cross-check against their local
+    /// `ChatGroup.groupIDData` and drop removals for groups they
+    /// don't know about.
+    let groupID: Data
+    /// Lowercase 96-char BLS pubkey hex of the removed member — the
+    /// stable cross-device identifier, and the dedup key into
+    /// `ChatGroup.memberProfiles`. A receiver whose own BLS key
+    /// matches is the removal target.
+    let removedBlsHex: String
+    /// 32-byte Poseidon commitment of the post-removal tree, as
+    /// anchored on chain by the admin's `update_commitment`.
+    let commitment: Data
+    /// Post-removal epoch (`epoch_old + 1`). Verified against the
+    /// on-chain entry with the same converge-forward gate as member
+    /// announcements.
+    let epoch: UInt64
+    /// Admin's wall clock at send time (informational — receivers
+    /// order by arrival, and idempotency keys off epoch).
+    let sentAtMillis: Int64
+    /// Rotated 32-byte group secret. Remaining-members variant only —
+    /// NEVER present on the copy sealed to the removed member.
+    let groupSecretNew: Data?
+    /// Rotated 32-byte salt matching the post-removal commitment.
+    /// Remaining-members variant only, like `groupSecretNew`.
+    let saltNew: Data?
+
+    enum CodingKeys: String, CodingKey {
+        case version = "removal_version"
+        case groupID = "removal_group_id"
+        case removedBlsHex = "removal_member_bls_hex"
+        case commitment = "removal_commitment"
+        case epoch = "removal_epoch"
+        case sentAtMillis = "removal_sent_at_millis"
+        case groupSecretNew = "group_secret_new"
+        case saltNew = "salt_new"
+    }
+
+    init(
+        version: Int,
+        groupID: Data,
+        removedBlsHex: String,
+        commitment: Data,
+        epoch: UInt64,
+        sentAtMillis: Int64,
+        groupSecretNew: Data? = nil,
+        saltNew: Data? = nil
+    ) throws {
+        try Self.validate(
+            groupID: groupID,
+            removedBlsHex: removedBlsHex,
+            commitment: commitment,
+            groupSecretNew: groupSecretNew,
+            saltNew: saltNew
+        )
+        self.version = version
+        self.groupID = groupID
+        self.removedBlsHex = removedBlsHex
+        self.commitment = commitment
+        self.epoch = epoch
+        self.sentAtMillis = sentAtMillis
+        self.groupSecretNew = groupSecretNew
+        self.saltNew = saltNew
+    }
+
+    /// The wire-side decode boundary — validate sizes at decode like
+    /// `MemberProfile` / `MemberAnnouncementPayload` so a wrong-sized
+    /// key can never become local group state.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try c.decode(Int.self, forKey: .version)
+        let groupID = try c.decode(Data.self, forKey: .groupID)
+        let removedBlsHex = try c.decode(String.self, forKey: .removedBlsHex)
+        let commitment = try c.decode(Data.self, forKey: .commitment)
+        let epoch = try c.decode(UInt64.self, forKey: .epoch)
+        let sentAtMillis = try c.decode(Int64.self, forKey: .sentAtMillis)
+        let groupSecretNew = try c.decodeIfPresent(Data.self, forKey: .groupSecretNew)
+        let saltNew = try c.decodeIfPresent(Data.self, forKey: .saltNew)
+        try Self.validate(
+            groupID: groupID,
+            removedBlsHex: removedBlsHex,
+            commitment: commitment,
+            groupSecretNew: groupSecretNew,
+            saltNew: saltNew
+        )
+        self.version = version
+        self.groupID = groupID
+        self.removedBlsHex = removedBlsHex
+        self.commitment = commitment
+        self.epoch = epoch
+        self.sentAtMillis = sentAtMillis
+        self.groupSecretNew = groupSecretNew
+        self.saltNew = saltNew
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(version, forKey: .version)
+        try c.encode(groupID, forKey: .groupID)
+        try c.encode(removedBlsHex, forKey: .removedBlsHex)
+        try c.encode(commitment, forKey: .commitment)
+        try c.encode(epoch, forKey: .epoch)
+        try c.encode(sentAtMillis, forKey: .sentAtMillis)
+        // The victim's copy must omit the keys ENTIRELY (not encode
+        // them as null) — `encodeIfPresent` matches Android's
+        // `encodeDefaults = false` posture.
+        try c.encodeIfPresent(groupSecretNew, forKey: .groupSecretNew)
+        try c.encodeIfPresent(saltNew, forKey: .saltNew)
+    }
+
+    private static func validate(
+        groupID: Data,
+        removedBlsHex: String,
+        commitment: Data,
+        groupSecretNew: Data?,
+        saltNew: Data?
+    ) throws {
+        guard groupID.count == 32 else {
+            throw MemberRemovalPayloadError.shape(
+                "groupID: expected 32 bytes, got \(groupID.count)"
+            )
+        }
+        guard removedBlsHex.count == 96 else {
+            throw MemberRemovalPayloadError.shape(
+                "removedBlsHex: expected 96 hex chars, got \(removedBlsHex.count)"
+            )
+        }
+        guard commitment.count == 32 else {
+            throw MemberRemovalPayloadError.shape(
+                "commitment: expected 32 bytes, got \(commitment.count)"
+            )
+        }
+        if let secret = groupSecretNew, secret.count != 32 {
+            throw MemberRemovalPayloadError.shape(
+                "groupSecretNew: expected 32 bytes, got \(secret.count)"
+            )
+        }
+        if let salt = saltNew, salt.count != 32 {
+            throw MemberRemovalPayloadError.shape(
+                "saltNew: expected 32 bytes, got \(salt.count)"
+            )
+        }
+    }
+}
+
+enum MemberRemovalPayloadError: Error, Equatable {
+    case shape(String)
+}

--- a/Sources/OnymIOS/Group/PersistedGroup.swift
+++ b/Sources/OnymIOS/Group/PersistedGroup.swift
@@ -51,6 +51,12 @@ final class PersistedGroup {
     /// and optional so SwiftData's lightweight migration lands the column
     /// on existing rows without a wipe; `nil` = never opened.
     var lastReadAt: Date?
+    /// `true` once the admin removed this device's owner from the group
+    /// (`ChatGroup.membershipRevoked`). Plain (a single local-only flag,
+    /// like `isPublishedOnChain`) and optional so SwiftData's lightweight
+    /// migration lands the column on existing rows without a wipe;
+    /// `nil` decodes to `false`.
+    var membershipRevoked: Bool?
 
     var encryptedName: Data
     var encryptedGroupSecret: Data
@@ -83,6 +89,7 @@ final class PersistedGroup {
         groupTypeRaw: String,
         isPublishedOnChain: Bool,
         lastReadAt: Date? = nil,
+        membershipRevoked: Bool? = nil,
         encryptedName: Data,
         encryptedGroupSecret: Data,
         encryptedMembersJSON: Data,
@@ -102,6 +109,7 @@ final class PersistedGroup {
         self.groupTypeRaw = groupTypeRaw
         self.isPublishedOnChain = isPublishedOnChain
         self.lastReadAt = lastReadAt
+        self.membershipRevoked = membershipRevoked
         self.encryptedName = encryptedName
         self.encryptedGroupSecret = encryptedGroupSecret
         self.encryptedMembersJSON = encryptedMembersJSON

--- a/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
+++ b/Sources/OnymIOS/Group/SwiftDataGroupStore.swift
@@ -88,6 +88,7 @@ actor SwiftDataGroupStore: GroupStore {
             existing.tierRaw = encoded.tierRaw
             existing.groupTypeRaw = encoded.groupTypeRaw
             existing.isPublishedOnChain = encoded.isPublishedOnChain
+            existing.membershipRevoked = encoded.membershipRevoked
             existing.encryptedName = encoded.encryptedName
             existing.encryptedGroupSecret = encoded.encryptedGroupSecret
             existing.encryptedMembersJSON = encoded.encryptedMembersJSON
@@ -174,6 +175,7 @@ actor SwiftDataGroupStore: GroupStore {
             groupTypeRaw: group.groupType.rawValue,
             isPublishedOnChain: group.isPublishedOnChain,
             lastReadAt: group.lastReadAt,
+            membershipRevoked: group.membershipRevoked,
             encryptedName: try StorageEncryption.encrypt(group.name),
             encryptedGroupSecret: try StorageEncryption.encrypt(group.groupSecret),
             encryptedMembersJSON: try StorageEncryption.encrypt(membersJSON),
@@ -238,7 +240,11 @@ actor SwiftDataGroupStore: GroupStore {
             isPublishedOnChain: row.isPublishedOnChain,
             avatarJPEG: avatarJPEG,
             lastReadAt: row.lastReadAt,
-            invitationMessage: invitationMessage
+            invitationMessage: invitationMessage,
+            // Rows migrated in before the column existed read as
+            // "still a member" — the removal payload re-applies via
+            // inbox replay if that's ever wrong.
+            membershipRevoked: row.membershipRevoked ?? false
         )
     }
 }

--- a/Sources/OnymIOS/Inbox/GroupStateVerifier.swift
+++ b/Sources/OnymIOS/Inbox/GroupStateVerifier.swift
@@ -237,6 +237,11 @@ actor GroupStateVerifier: GroupStateRefreshing {
         // forged request can't redirect the salt elsewhere.
         let key = Self.hex(request.requesterBlsPublicKey)
         guard let profile = group.memberProfiles[key] else { return }
+        // A removed (tombstoned) member is no longer entitled to the
+        // salt/groupSecret-bearing snapshot — the rotated secrets are
+        // exactly what removal takes away from them. Likewise never
+        // answer from a group WE were removed from (stale authority).
+        guard !profile.revoked, !group.membershipRevoked else { return }
         guard let requesterEd25519, requesterEd25519 == profile.sendingPubkey else { return }
         guard request.requesterInboxPublicKey == profile.inboxPublicKey else { return }
 

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -78,6 +78,32 @@ struct IncomingMessageDispatcher: Sendable {
     /// raises a message to `.read` when this device also sends read
     /// receipts. Defaulted to `true` (the shipping default).
     var readReceiptsEnabled: @Sendable () -> Bool = { true }
+    /// Base delay before re-checking the chain for a removal whose
+    /// claimed epoch is ahead of our read (see `applyRemoval`). Must
+    /// exceed `CachingChainStateReader`'s 10s TTL or the retry
+    /// re-reads the same cached entry. Attempt N waits N × this.
+    var removalRetryDelayNanos: UInt64 = 12_000_000_000
+    /// How many delayed re-attempts a chain-behind removal gets before
+    /// this delivery gives up (the next inbox replay retries from
+    /// scratch). `0` disables retries entirely.
+    var removalMaxRetries: Int = 2
+    /// Test seam for the retry delay — production sleeps for real;
+    /// tests inject a no-op so the bounded-retry loop runs instantly.
+    var removalRetrySleep: @Sendable (UInt64) async -> Void = { nanos in
+        try? await Task.sleep(nanoseconds: nanos)
+    }
+    /// Test seam for how a retry attempt is scheduled. Production
+    /// fire-and-forgets a `Task` so a 12–24s wait never blocks the
+    /// inbox pump; tests inject `{ await $0() }` so `dispatch` only
+    /// returns once the retries have run to completion.
+    var removalRetryScheduler: @Sendable (@escaping @Sendable () async -> Void) async -> Void = { work in
+        Task { await work() }
+    }
+    /// Dedup registry for scheduled removal retries — a relay
+    /// re-delivery during the delay window must not stack a second
+    /// timer for the same removal. Reference type so every copy of
+    /// this value-type dispatcher shares one registry.
+    var removalRetries = RemovalRetryRegistry()
 
     func dispatch(
         messageID: String,
@@ -134,6 +160,25 @@ struct IncomingMessageDispatcher: Sendable {
                 refresh,
                 ownerIdentityID: ownerIdentityID,
                 requesterEd25519: envelope.senderEd25519PublicKey
+            )
+            return
+        }
+
+        // Fast path 0.7: MemberRemovalPayload — the admin removed a
+        // member (possibly us). Its required `removal_*` keys are
+        // unique to this type, so the trial-decode is unambiguous.
+        // Tried before the announcement branch: a removal is the only
+        // subtractive roster mutation and must never be mistaken for
+        // an additive one.
+        if let removal = try? JSONDecoder().decode(
+            MemberRemovalPayload.self,
+            from: envelope.plaintext
+        ) {
+            await applyRemoval(
+                removal,
+                ownerIdentityID: ownerIdentityID,
+                senderEd25519PublicKey: envelope.senderEd25519PublicKey,
+                attempt: 0
             )
             return
         }
@@ -595,8 +640,10 @@ struct IncomingMessageDispatcher: Sendable {
         // Admin-less governance: the verified signer must belong to a
         // current member (`memberProfiles` is keyed by BLS hex, but
         // `sendingPubkey` is the Ed25519 that signs every envelope).
+        // Tombstoned (revoked) members are no longer CURRENT members —
+        // their signature stops authorizing mutations.
         return group.memberProfiles.values.contains {
-            $0.sendingPubkey == senderEd25519PublicKey
+            !$0.revoked && $0.sendingPubkey == senderEd25519PublicKey
         }
     }
 
@@ -633,9 +680,13 @@ struct IncomingMessageDispatcher: Sendable {
         // re-delivered on each launch — bailing here keeps those replays
         // from each firing a `get_commitment` against the relayer (the
         // launch-time storm). Cheap, local, and idempotent.
+        // A tombstoned (revoked) profile does NOT dedup: the admin may
+        // have re-admitted a previously-removed member, and that
+        // announcement must overwrite the tombstone (revoked = false
+        // via the fresh MemberProfile below).
         let key = payload.newMember.blsPub
             .map { String(format: "%02x", $0) }.joined()
-        if group.memberProfiles[key] != nil { return }
+        if let existing = group.memberProfiles[key], !existing.revoked { return }
 
         // PR 9 + H-2 trust check: the verified envelope signer must be
         // the group's known admin, or — for admin-less groups — a
@@ -661,6 +712,158 @@ struct IncomingMessageDispatcher: Sendable {
             sendingPubkey: payload.newMember.sendingPub
         )
         await groupRepository.insert(updated)
+    }
+
+    /// Apply an inbound `MemberRemovalPayload`.
+    ///
+    /// Two apply shapes, split on whether the removal names *us*:
+    ///
+    ///  - **Self (victim device):** flip `ChatGroup.membershipRevoked`.
+    ///    History, profiles, and secrets stay untouched (the victim's
+    ///    payload variant carries no new secrets anyway); the UI swaps
+    ///    the composer for a "you were removed" banner.
+    ///  - **Remaining member:** tombstone the victim's `MemberProfile`
+    ///    (`revoked = true` — never deleted), drop them from the
+    ///    on-chain `ChatGroup.members` roster, and advance
+    ///    epoch / commitment / salt / groupSecret to the payload's
+    ///    post-removal values. From this point every fanout excludes
+    ///    the victim's inbox and every trust gate rejects their key.
+    ///
+    /// Order of gates (cheapest first, mirroring `applyAnnouncement`):
+    /// group lookup → idempotency (relays replay the full inbox on
+    /// every reconnect — bail BEFORE any chain read) → admin-Ed25519
+    /// authorization → on-chain converge-forward check.
+    ///
+    /// ## Chain-behind retry
+    ///
+    /// A removal usually lands seconds after the admin anchors, while
+    /// `CachingChainStateReader` may serve a ≤10s-old entry — the
+    /// chain read looks *behind* the claimed epoch. For announcements
+    /// that case is a plain drop (later activity backfills); a dropped
+    /// removal would leave the victim trusted, so instead we re-check
+    /// after `removalRetryDelayNanos` (then 2×) — each attempt past
+    /// the cache TTL. After `removalMaxRetries` the payload is dropped
+    /// for THIS delivery; the next inbox replay retries from scratch,
+    /// so the removal is never permanently lost.
+    ///
+    /// Mirrors `applyRemoval` from onym-android's
+    /// `IncomingMessageDispatcher.kt`.
+    private func applyRemoval(
+        _ payload: MemberRemovalPayload,
+        ownerIdentityID: IdentityID,
+        senderEd25519PublicKey: Data?,
+        attempt: Int
+    ) async {
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: {
+            $0.groupIDData == payload.groupID && $0.ownerIdentityID == ownerIdentityID
+        }) else { return }
+        guard group.groupType == .tyranny else { return }
+
+        let victimHex = payload.removedBlsHex.lowercased()
+        let summaries = (try? await identities.currentIdentities()) ?? []
+        let selfHex = summaries.first(where: { $0.id == ownerIdentityID })?
+            .blsPublicKey
+            .map { String(format: "%02x", $0) }.joined()
+        let isSelf = selfHex != nil && selfHex == victimHex
+
+        // Idempotency BEFORE any chain read (launch-storm pattern —
+        // see applyAnnouncement).
+        if isSelf && group.membershipRevoked { return }
+        if !isSelf,
+           let existing = group.memberProfiles[victimHex],
+           existing.revoked, group.epoch >= payload.epoch {
+            return
+        }
+
+        // Trust gate: only the stored admin may shrink the roster.
+        guard isAuthorizedGroupMutation(
+            group: group,
+            senderEd25519PublicKey: senderEd25519PublicKey
+        ) else { return }
+
+        // On-chain converge-forward gate (same posture as
+        // verifyTyrannyAnnouncement: no roster recompute, the anchor
+        // is the strong check). chain ahead → accept (we missed
+        // updates; the admin-signed removal is still legitimate),
+        // exact epoch → byte-verify, chain behind → bounded retry.
+        let onchain: SEPCommitmentEntry
+        do {
+            onchain = try await chainState.tyrannyCommitment(groupID: payload.groupID)
+        } catch {
+            // Unreachable relayer is not evidence of forgery, but
+            // accepting unverified would let a stolen admin key
+            // shrink rosters offline. Retry like chain-behind.
+            await scheduleRemovalRetry(
+                payload,
+                ownerIdentityID: ownerIdentityID,
+                senderEd25519PublicKey: senderEd25519PublicKey,
+                attempt: attempt
+            )
+            return
+        }
+        if onchain.epoch < payload.epoch {
+            await scheduleRemovalRetry(
+                payload,
+                ownerIdentityID: ownerIdentityID,
+                senderEd25519PublicKey: senderEd25519PublicKey,
+                attempt: attempt
+            )
+            return
+        }
+        if onchain.epoch == payload.epoch, onchain.commitment != payload.commitment {
+            return
+        }
+
+        if isSelf {
+            var updated = group
+            updated.membershipRevoked = true
+            await groupRepository.insert(updated)
+            return
+        }
+
+        let victimBytes = ChatGroup.bytes(fromHex: victimHex)
+        var updated = group
+        updated.members.removeAll { $0.publicKeyCompressed == victimBytes }
+        if let victimProfile = updated.memberProfiles[victimHex] {
+            updated.memberProfiles[victimHex] = victimProfile.withRevoked(true)
+        }
+        updated.epoch = payload.epoch
+        updated.commitment = payload.commitment
+        updated.salt = payload.saltNew ?? group.salt
+        // The victim's own copy carries no secrets; a remaining member
+        // that somehow received it keeps the old material and converges
+        // via the admin's refresh path.
+        updated.groupSecret = payload.groupSecretNew ?? group.groupSecret
+        await groupRepository.insert(updated)
+    }
+
+    /// Schedule one delayed `applyRemoval` re-attempt, deduped so a
+    /// relay re-delivery inside the delay window can't stack timers.
+    private func scheduleRemovalRetry(
+        _ payload: MemberRemovalPayload,
+        ownerIdentityID: IdentityID,
+        senderEd25519PublicKey: Data?,
+        attempt: Int
+    ) async {
+        guard attempt < removalMaxRetries else { return }
+        let groupIDHex = payload.groupID.map { String(format: "%02x", $0) }.joined()
+        let key = "\(groupIDHex):\(payload.removedBlsHex.lowercased()):\(payload.epoch)"
+        guard await removalRetries.begin(key) else { return }
+        let dispatcher = self
+        let delay = removalRetryDelayNanos * UInt64(attempt + 1)
+        let sleep = removalRetrySleep
+        let registry = removalRetries
+        await removalRetryScheduler {
+            await sleep(delay)
+            await registry.end(key)
+            await dispatcher.applyRemoval(
+                payload,
+                ownerIdentityID: ownerIdentityID,
+                senderEd25519PublicKey: senderEd25519PublicKey,
+                attempt: attempt + 1
+            )
+        }
     }
 
     /// Apply an inbound group-photo update to the matching local group.
@@ -761,6 +964,11 @@ struct IncomingMessageDispatcher: Sendable {
         guard let senderProfile = group.memberProfiles[senderKey] else {
             return
         }
+
+        // Removed members are tombstoned, not deleted — their key
+        // still resolves, so the trust chain must check the flag:
+        // a removed member's post-removal sends are dropped here.
+        guard !senderProfile.revoked else { return }
 
         // Insider-spoof check: the verified envelope signer must match
         // the stored Ed25519 for the claimed BLS member. Without this,
@@ -882,5 +1090,25 @@ struct IncomingMessageDispatcher: Sendable {
                 owner: ownerIdentityID
             )
         }
+    }
+}
+
+/// Dedup keys of member-removal retries currently scheduled, so a
+/// relay re-delivery during the delay window can't stack a second
+/// timer for the same removal (see
+/// `IncomingMessageDispatcher.scheduleRemovalRetry`). An actor —
+/// the value-type dispatcher shares one reference across its copies.
+/// Mirrors `pendingRemovalRetries` from onym-android's dispatcher.
+actor RemovalRetryRegistry {
+    private var pending: Set<String> = []
+
+    /// Register `key`. Returns `false` when a retry for it is already
+    /// scheduled — the caller must not stack another timer.
+    func begin(_ key: String) -> Bool {
+        pending.insert(key).inserted
+    }
+
+    func end(_ key: String) {
+        pending.remove(key)
     }
 }

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -104,6 +104,16 @@ struct IncomingMessageDispatcher: Sendable {
     /// timer for the same removal. Reference type so every copy of
     /// this value-type dispatcher shares one registry.
     var removalRetries = RemovalRetryRegistry()
+    /// Serializes `applyRemoval`'s read-modify-write. The retry chain
+    /// runs OFF the inbox pump, so a retry firing at t=12s can
+    /// interleave with the pump applying a second removal for the same
+    /// group: both read the same snapshot, both mutate their copy, and
+    /// the later `insert` wins — silently losing one tombstone, the
+    /// exact failure the retry exists to prevent. `GroupRepository` is
+    /// an actor but only serializes each individual call, so the guard
+    /// has to live here, spanning read→write. Reference type for the
+    /// same reason as `removalRetries`.
+    var removalApplyLock = RemovalApplyLock()
 
     func dispatch(
         messageID: String,
@@ -367,18 +377,39 @@ struct IncomingMessageDispatcher: Sendable {
         // self if we can resolve our own identity. The "wire first"
         // ordering means a sender that mistakenly includes us under
         // our own BLS key gets overwritten by our locally-trusted
-        // alias + inbox pub — the receiver's view of itself wins. The
-        // wire entry's statusEpoch is PRESERVED through the overwrite:
-        // a re-admitted member's own status marker is what refuses a
-        // replayed stale self-removal — erasing it would re-lock the
-        // composer on the next inbox replay.
+        // alias + inbox pub — the receiver's view of itself wins. Our
+        // own statusEpoch is preserved from the wire when present, else
+        // DEFAULTED to the invitation's epoch: being in a snapshot at
+        // epoch N means every removal at or before N is stale for us.
+        // Without that default a re-admitted member whose entry didn't
+        // ship (pre-record snapshots, legacy senders) would materialize
+        // with a nil marker and the next replay of their old removal
+        // would re-lock the composer for good.
         var profiles = invitation.memberProfiles ?? [:]
-        if let selfEntry = await selfMemberProfileEntry(for: ownerIdentityID) {
+        let selfEntry = await selfMemberProfileEntry(for: ownerIdentityID)
+        if let selfEntry {
             profiles[selfEntry.key] = selfEntry.value.withStatus(
                 revoked: selfEntry.value.revoked,
-                statusEpoch: profiles[selfEntry.key]?.statusEpoch
+                statusEpoch: profiles[selfEntry.key]?.statusEpoch ?? invitation.epoch
             )
         }
+
+        // Preserve a prior removal unless this snapshot post-dates it.
+        // materializeGroup rebuilds the row from scratch, so any
+        // accepted invitation would otherwise clear membershipRevoked —
+        // leaving the exact-epoch chain gate as the only thing between
+        // a stale (or stale-peer-answered refresh) invitation and an
+        // unlocked composer.
+        let priorRemovalEpoch: UInt64? = await {
+            let existing = await groupRepository.currentGroups().first {
+                $0.groupIDData == invitation.groupID && $0.ownerIdentityID == ownerIdentityID
+            }
+            guard let existing, existing.membershipRevoked else { return nil }
+            return selfEntry
+                .flatMap { existing.memberProfiles[$0.key]?.statusEpoch }
+                ?? existing.epoch
+        }()
+        let stillRevoked = priorRemovalEpoch.map { invitation.epoch <= $0 } ?? false
 
         // Stamp the inviting envelope's Ed25519 pubkey as the
         // group's admin signing key. PR 9 uses this on every
@@ -420,7 +451,8 @@ struct IncomingMessageDispatcher: Sendable {
             // can still fill it in.
             avatarJPEG: invitation.avatar,
             // The group's invitation/intro, as the sender wrote it.
-            invitationMessage: invitation.invitationMessage
+            invitationMessage: invitation.invitationMessage,
+            membershipRevoked: stillRevoked
         )
         await groupRepository.insert(group)
     }
@@ -816,6 +848,29 @@ struct IncomingMessageDispatcher: Sendable {
         ownerIdentityID: IdentityID,
         senderEd25519PublicKey: Data?
     ) async -> RemovalApplyResult {
+        // Held across the whole read→write body, released before the
+        // caller's retry delay (each attempt re-acquires) — see
+        // `removalApplyLock`. Nothing between acquire and release can
+        // throw or be cancelled out from under us (no `try`, no
+        // cancellation-aware suspension), so the release always runs.
+        await removalApplyLock.acquire()
+        let result = await applyRemovalLocked(
+            payload,
+            ownerIdentityID: ownerIdentityID,
+            senderEd25519PublicKey: senderEd25519PublicKey
+        )
+        await removalApplyLock.release()
+        return result
+    }
+
+    /// `applyRemoval`'s body — always called under
+    /// `removalApplyLock` so the snapshot read and the write can't
+    /// interleave with a concurrent removal for the same group.
+    private func applyRemovalLocked(
+        _ payload: MemberRemovalPayload,
+        ownerIdentityID: IdentityID,
+        senderEd25519PublicKey: Data?
+    ) async -> RemovalApplyResult {
         let groups = await groupRepository.currentGroups()
         guard let group = groups.first(where: {
             $0.groupIDData == payload.groupID && $0.ownerIdentityID == ownerIdentityID
@@ -891,15 +946,21 @@ struct IncomingMessageDispatcher: Sendable {
 
         var updated = group
         // Tombstone effect — order-independent (see the doc comment).
-        if tombstoneApplies {
+        // The leaf also goes whenever we accept the state advance: in
+        // the directory/roster-divergence case (no local profile for
+        // the victim, the receive-side twin of `.memberNotInRoster`)
+        // the anchored commitment we're adopting is over the SHRUNKEN
+        // tree, so keeping the leaf would leave the local roster
+        // disagreeing with the commitment we just stored.
+        if tombstoneApplies || advancesState {
             let victimBytes = ChatGroup.bytes(fromHex: victimHex)
             updated.members.removeAll { $0.publicKeyCompressed == victimBytes }
-            if let victimProfile {
-                updated.memberProfiles[victimHex] = victimProfile.withStatus(
-                    revoked: true,
-                    statusEpoch: payload.epoch
-                )
-            }
+        }
+        if tombstoneApplies, let victimProfile {
+            updated.memberProfiles[victimHex] = victimProfile.withStatus(
+                revoked: true,
+                statusEpoch: payload.epoch
+            )
         }
         // Group-state effect — strictly converge-forward. The victim's
         // own copy carries no secrets; a remaining member that somehow
@@ -1216,6 +1277,34 @@ struct IncomingMessageDispatcher: Sendable {
 /// `IncomingMessageDispatcher.scheduleRemovalRetry`). An actor —
 /// the value-type dispatcher shares one reference across its copies.
 /// Mirrors `pendingRemovalRetries` from onym-android's dispatcher.
+/// Async mutex guarding `IncomingMessageDispatcher.applyRemoval`'s
+/// read-modify-write. Ownership transfers straight to the next waiter
+/// on `release`, so acquisitions are FIFO and no two removal applies
+/// for the same device can interleave between the snapshot read and
+/// the persist. Mirrors `removalApplyMutex` from onym-android's
+/// dispatcher (Kotlin's `Mutex.withLock`).
+actor RemovalApplyLock {
+    private var isHeld = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        guard isHeld else {
+            isHeld = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            isHeld = false
+        } else {
+            // Hand ownership to the next waiter — `isHeld` stays true.
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
 actor RemovalRetryRegistry {
     private var pending: Set<String> = []
 

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -367,10 +367,17 @@ struct IncomingMessageDispatcher: Sendable {
         // self if we can resolve our own identity. The "wire first"
         // ordering means a sender that mistakenly includes us under
         // our own BLS key gets overwritten by our locally-trusted
-        // alias + inbox pub — the receiver's view of itself wins.
+        // alias + inbox pub — the receiver's view of itself wins. The
+        // wire entry's statusEpoch is PRESERVED through the overwrite:
+        // a re-admitted member's own status marker is what refuses a
+        // replayed stale self-removal — erasing it would re-lock the
+        // composer on the next inbox replay.
         var profiles = invitation.memberProfiles ?? [:]
         if let selfEntry = await selfMemberProfileEntry(for: ownerIdentityID) {
-            profiles[selfEntry.key] = selfEntry.value
+            profiles[selfEntry.key] = selfEntry.value.withStatus(
+                revoked: selfEntry.value.revoked,
+                statusEpoch: profiles[selfEntry.key]?.statusEpoch
+            )
         }
 
         // Stamp the inviting envelope's Ed25519 pubkey as the
@@ -708,7 +715,13 @@ struct IncomingMessageDispatcher: Sendable {
         updated.memberProfiles[key] = MemberProfile(
             alias: payload.newMember.alias,
             inboxPublicKey: payload.newMember.inboxPub,
-            sendingPubkey: payload.newMember.sendingPub
+            sendingPubkey: payload.newMember.sendingPub,
+            // Stamp the (re-)admission epoch so an out-of-order
+            // REMOVAL replayed later (with a lower epoch) can't
+            // re-tombstone this member — see
+            // `MemberProfile.statusEpoch`. Nil only from legacy
+            // senders that omit `epoch`, which never race removals.
+            statusEpoch: payload.epoch
         )
         await groupRepository.insert(updated)
     }
@@ -739,20 +752,34 @@ struct IncomingMessageDispatcher: Sendable {
     ///    the victim's inbox and every trust gate rejects their key.
     ///
     /// Order of gates (cheapest first, mirroring `applyAnnouncement`):
-    /// group lookup → fail-closed admin requirement → local
-    /// converge-forward guard (BEFORE any chain read — relays replay
-    /// the full inbox on every reconnect) → self classification →
+    /// group lookup → fail-closed admin requirement → self
+    /// classification → local applicability check (BEFORE any chain
+    /// read — relays replay the full inbox on every reconnect) →
     /// admin-Ed25519 authorization → on-chain converge-forward check.
     ///
-    /// ## Local converge-forward guard
+    /// ## Two independently-guarded effects
     ///
-    /// `group.epoch >= payload.epoch` drops the payload outright: a
-    /// removal may only ever advance local state. Without this, a
-    /// relay-replayed removal envelope arriving AFTER the member was
-    /// re-admitted would pass the on-chain "ahead → accept" branch and
-    /// roll epoch / salt / groupSecret back to the old rotated values
-    /// while re-tombstoning the re-admitted member. It also makes
-    /// re-delivery idempotent without any per-profile bookkeeping.
+    /// Relay dispatch order is ARRIVAL order, not epoch order — an
+    /// offline device can receive "remove B (epoch 6)" before
+    /// "remove A (epoch 5)". A single group-level epoch guard would
+    /// drop the epoch-5 removal forever, leaving A trusted. So the
+    /// apply decomposes:
+    ///
+    ///  - **Group-state advance** (epoch / commitment / salt /
+    ///    groupSecret): strictly converge-forward — only when
+    ///    `payload.epoch > group.epoch`. Never rolls backward, which
+    ///    keeps the re-admission replay from restoring old secrets.
+    ///  - **Tombstone** (per-member, order-independent): applies when
+    ///    this removal is NEWER than the member's last known status
+    ///    change (`MemberProfile.statusEpoch`) — so a stale-but-unseen
+    ///    removal still lands, while a removal replayed after that
+    ///    member's later re-admission is refused. The victim's
+    ///    `ChatGroup.members` leaf is subtracted together with the
+    ///    tombstone (a member removed at epoch 5 is not in ANY later
+    ///    tree unless re-admitted, which resets statusEpoch).
+    ///
+    /// A payload where NEITHER effect applies is dropped before any
+    /// chain read — that's the idempotency for relay re-delivery.
     ///
     /// ## Fail closed on a missing admin key
     ///
@@ -781,10 +808,6 @@ struct IncomingMessageDispatcher: Sendable {
         // otherwise fall back to any-current-member.)
         guard group.adminEd25519PubkeyHex != nil else { return .done }
 
-        // Local converge-forward guard — see the doc comment. Cheap,
-        // local, and BEFORE any chain read (launch-storm pattern).
-        guard group.epoch < payload.epoch else { return .done }
-
         // Self classification. If we can't resolve our own BLS key we
         // can't tell which branch is safe — drop rather than let the
         // victim's own device take the remaining-member branch and
@@ -797,7 +820,21 @@ struct IncomingMessageDispatcher: Sendable {
             .map({ String(format: "%02x", $0) }).joined()
         else { return .done }
         let isSelf = selfHex == victimHex
-        if isSelf && group.membershipRevoked { return .done }
+
+        // Local applicability — BEFORE any chain read (launch-storm
+        // pattern). Which effects would this payload have?
+        let victimProfile = group.memberProfiles[victimHex]
+        let advancesState = payload.epoch > group.epoch
+        let tombstoneApplies: Bool = {
+            guard !isSelf, let victimProfile, !victimProfile.revoked else { return false }
+            return victimProfile.statusEpoch.map { payload.epoch > $0 } ?? true
+        }()
+        let selfApplies: Bool = {
+            guard isSelf, !group.membershipRevoked else { return false }
+            return (victimProfile?.statusEpoch).map { payload.epoch > $0 } ?? true
+        }()
+        if isSelf && !selfApplies { return .done }
+        if !isSelf && !tombstoneApplies && !advancesState { return .done }
 
         // Trust gate: only the stored admin may shrink the roster.
         guard isAuthorizedGroupMutation(
@@ -825,25 +862,36 @@ struct IncomingMessageDispatcher: Sendable {
         }
 
         if isSelf {
+            // Victim device: mark and keep everything else untouched.
+            // (No state advance from the secret-free victim variant.)
             var updated = group
             updated.membershipRevoked = true
             await groupRepository.insert(updated)
             return .done
         }
 
-        let victimBytes = ChatGroup.bytes(fromHex: victimHex)
         var updated = group
-        updated.members.removeAll { $0.publicKeyCompressed == victimBytes }
-        if let victimProfile = updated.memberProfiles[victimHex] {
-            updated.memberProfiles[victimHex] = victimProfile.withRevoked(true)
+        // Tombstone effect — order-independent (see the doc comment).
+        if tombstoneApplies {
+            let victimBytes = ChatGroup.bytes(fromHex: victimHex)
+            updated.members.removeAll { $0.publicKeyCompressed == victimBytes }
+            if let victimProfile {
+                updated.memberProfiles[victimHex] = victimProfile.withStatus(
+                    revoked: true,
+                    statusEpoch: payload.epoch
+                )
+            }
         }
-        updated.epoch = payload.epoch
-        updated.commitment = payload.commitment
-        updated.salt = payload.saltNew ?? group.salt
-        // The victim's own copy carries no secrets; a remaining member
-        // that somehow received it keeps the old material and converges
-        // via the admin's refresh path.
-        updated.groupSecret = payload.groupSecretNew ?? group.groupSecret
+        // Group-state effect — strictly converge-forward. The victim's
+        // own copy carries no secrets; a remaining member that somehow
+        // received it keeps the old material and converges via the
+        // admin's refresh path.
+        if advancesState {
+            updated.epoch = payload.epoch
+            updated.commitment = payload.commitment
+            updated.salt = payload.saltNew ?? group.salt
+            updated.groupSecret = payload.groupSecretNew ?? group.groupSecret
+        }
         await groupRepository.insert(updated)
         return .done
     }

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -692,7 +692,26 @@ struct IncomingMessageDispatcher: Sendable {
         // via the fresh MemberProfile below).
         let key = payload.newMember.blsPub
             .map { String(format: "%02x", $0) }.joined()
-        if let existing = group.memberProfiles[key], !existing.revoked { return }
+        let existing = group.memberProfiles[key]
+        if let existing, !existing.revoked { return }
+
+        // Re-admission guard. A tombstoned profile is resurrected ONLY
+        // by an announcement provably newer than the removal that
+        // tombstoned it (`MemberProfile.statusEpoch`). Every relay
+        // reconnect replays the member's ORIGINAL admission event;
+        // without this, that stale announcement clears the tombstone and
+        // re-trusts a removed member (their own removal replay would
+        // usually re-apply, but the trust window is real and closes only
+        // while that envelope is still replayable). An announcement with
+        // no epoch on the wire can't prove it's newer — keep the
+        // tombstone.
+        if let existing, existing.revoked {
+            guard let announcedEpoch = payload.epoch else { return }
+            if let removedAtEpoch = existing.statusEpoch,
+               announcedEpoch <= removedAtEpoch {
+                return
+            }
+        }
 
         // PR 9 + H-2 trust check: the verified envelope signer must be
         // the group's known admin, or — for admin-less groups — a
@@ -928,7 +947,12 @@ struct IncomingMessageDispatcher: Sendable {
         guard removalMaxRetries > 0 else { return }
 
         let groupIDHex = payload.groupID.map { String(format: "%02x", $0) }.joined()
-        let key = "\(groupIDHex):\(payload.removedBlsHex.lowercased()):\(payload.epoch)"
+        // Owner-scoped: the same on-chain group can be held by two local
+        // identities, each with its own row and its own delivery. An
+        // unscoped key would let the first identity's claim starve the
+        // second's retry entirely.
+        let key = "\(ownerIdentityID.rawValue.uuidString):\(groupIDHex):"
+            + "\(payload.removedBlsHex.lowercased()):\(payload.epoch)"
         guard await removalRetries.begin(key) else { return }
 
         let dispatcher = self
@@ -1040,6 +1064,15 @@ struct IncomingMessageDispatcher: Sendable {
         }) else {
             return
         }
+
+        // We were removed from this group: refuse new traffic even
+        // though a stale peer can still seal to our unchanged inbox key
+        // until they converge (their fanout skips us only once they
+        // apply the removal). Symmetric with the send-side
+        // `.removedFromGroup` gate — the thread is read-only history
+        // from the moment the removal lands. Also suppresses the
+        // delivered receipt below, so we don't advertise reachability.
+        guard !group.membershipRevoked else { return }
 
         // Sender must be a known member. `memberProfiles` is keyed by
         // lowercase BLS pubkey hex; normalize the payload's claim

--- a/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
+++ b/Sources/OnymIOS/Inbox/IncomingMessageDispatcher.swift
@@ -174,11 +174,10 @@ struct IncomingMessageDispatcher: Sendable {
             MemberRemovalPayload.self,
             from: envelope.plaintext
         ) {
-            await applyRemoval(
+            await applyRemovalWithRetry(
                 removal,
                 ownerIdentityID: ownerIdentityID,
-                senderEd25519PublicKey: envelope.senderEd25519PublicKey,
-                attempt: 0
+                senderEd25519PublicKey: envelope.senderEd25519PublicKey
             )
             return
         }
@@ -714,6 +713,16 @@ struct IncomingMessageDispatcher: Sendable {
         await groupRepository.insert(updated)
     }
 
+    /// Result of one `applyRemoval` pass.
+    private enum RemovalApplyResult {
+        /// Applied, or dropped for a terminal reason — do not retry.
+        case done
+        /// The chain read was behind the claimed epoch (or the
+        /// relayer was unreachable) — worth re-checking after the
+        /// cache TTL.
+        case chainBehind
+    }
+
     /// Apply an inbound `MemberRemovalPayload`.
     ///
     /// Two apply shapes, split on whether the removal names *us*:
@@ -730,63 +739,77 @@ struct IncomingMessageDispatcher: Sendable {
     ///    the victim's inbox and every trust gate rejects their key.
     ///
     /// Order of gates (cheapest first, mirroring `applyAnnouncement`):
-    /// group lookup → idempotency (relays replay the full inbox on
-    /// every reconnect — bail BEFORE any chain read) → admin-Ed25519
-    /// authorization → on-chain converge-forward check.
+    /// group lookup → fail-closed admin requirement → local
+    /// converge-forward guard (BEFORE any chain read — relays replay
+    /// the full inbox on every reconnect) → self classification →
+    /// admin-Ed25519 authorization → on-chain converge-forward check.
     ///
-    /// ## Chain-behind retry
+    /// ## Local converge-forward guard
     ///
-    /// A removal usually lands seconds after the admin anchors, while
-    /// `CachingChainStateReader` may serve a ≤10s-old entry — the
-    /// chain read looks *behind* the claimed epoch. For announcements
-    /// that case is a plain drop (later activity backfills); a dropped
-    /// removal would leave the victim trusted, so instead we re-check
-    /// after `removalRetryDelayNanos` (then 2×) — each attempt past
-    /// the cache TTL. After `removalMaxRetries` the payload is dropped
-    /// for THIS delivery; the next inbox replay retries from scratch,
-    /// so the removal is never permanently lost.
+    /// `group.epoch >= payload.epoch` drops the payload outright: a
+    /// removal may only ever advance local state. Without this, a
+    /// relay-replayed removal envelope arriving AFTER the member was
+    /// re-admitted would pass the on-chain "ahead → accept" branch and
+    /// roll epoch / salt / groupSecret back to the old rotated values
+    /// while re-tombstoning the re-admitted member. It also makes
+    /// re-delivery idempotent without any per-profile bookkeeping.
+    ///
+    /// ## Fail closed on a missing admin key
+    ///
+    /// Groups materialized from an unsigned invitation envelope store
+    /// `adminEd25519PubkeyHex == nil`. `isAuthorizedGroupMutation`'s
+    /// any-current-member fallback is tolerable for additive
+    /// announcements, but a subtractive op would let any member evict
+    /// any other member from every peer's local view — so removal
+    /// requires the stored admin key, full stop.
     ///
     /// Mirrors `applyRemoval` from onym-android's
     /// `IncomingMessageDispatcher.kt`.
     private func applyRemoval(
         _ payload: MemberRemovalPayload,
         ownerIdentityID: IdentityID,
-        senderEd25519PublicKey: Data?,
-        attempt: Int
-    ) async {
+        senderEd25519PublicKey: Data?
+    ) async -> RemovalApplyResult {
         let groups = await groupRepository.currentGroups()
         guard let group = groups.first(where: {
             $0.groupIDData == payload.groupID && $0.ownerIdentityID == ownerIdentityID
-        }) else { return }
-        guard group.groupType == .tyranny else { return }
+        }) else { return .done }
+        guard group.groupType == .tyranny else { return .done }
 
+        // Subtractive ops fail CLOSED without a stored admin key —
+        // see the doc comment. (isAuthorizedGroupMutation would
+        // otherwise fall back to any-current-member.)
+        guard group.adminEd25519PubkeyHex != nil else { return .done }
+
+        // Local converge-forward guard — see the doc comment. Cheap,
+        // local, and BEFORE any chain read (launch-storm pattern).
+        guard group.epoch < payload.epoch else { return .done }
+
+        // Self classification. If we can't resolve our own BLS key we
+        // can't tell which branch is safe — drop rather than let the
+        // victim's own device take the remaining-member branch and
+        // delete itself from its own roster. (Production always wires
+        // the identities provider; this is the fallback posture.)
         let victimHex = payload.removedBlsHex.lowercased()
         let summaries = (try? await identities.currentIdentities()) ?? []
-        let selfHex = summaries.first(where: { $0.id == ownerIdentityID })?
+        guard let selfHex = summaries.first(where: { $0.id == ownerIdentityID })?
             .blsPublicKey
-            .map { String(format: "%02x", $0) }.joined()
-        let isSelf = selfHex != nil && selfHex == victimHex
-
-        // Idempotency BEFORE any chain read (launch-storm pattern —
-        // see applyAnnouncement).
-        if isSelf && group.membershipRevoked { return }
-        if !isSelf,
-           let existing = group.memberProfiles[victimHex],
-           existing.revoked, group.epoch >= payload.epoch {
-            return
-        }
+            .map({ String(format: "%02x", $0) }).joined()
+        else { return .done }
+        let isSelf = selfHex == victimHex
+        if isSelf && group.membershipRevoked { return .done }
 
         // Trust gate: only the stored admin may shrink the roster.
         guard isAuthorizedGroupMutation(
             group: group,
             senderEd25519PublicKey: senderEd25519PublicKey
-        ) else { return }
+        ) else { return .done }
 
         // On-chain converge-forward gate (same posture as
         // verifyTyrannyAnnouncement: no roster recompute, the anchor
         // is the strong check). chain ahead → accept (we missed
         // updates; the admin-signed removal is still legitimate),
-        // exact epoch → byte-verify, chain behind → bounded retry.
+        // exact epoch → byte-verify, chain behind → caller retries.
         let onchain: SEPCommitmentEntry
         do {
             onchain = try await chainState.tyrannyCommitment(groupID: payload.groupID)
@@ -794,32 +817,18 @@ struct IncomingMessageDispatcher: Sendable {
             // Unreachable relayer is not evidence of forgery, but
             // accepting unverified would let a stolen admin key
             // shrink rosters offline. Retry like chain-behind.
-            await scheduleRemovalRetry(
-                payload,
-                ownerIdentityID: ownerIdentityID,
-                senderEd25519PublicKey: senderEd25519PublicKey,
-                attempt: attempt
-            )
-            return
+            return .chainBehind
         }
-        if onchain.epoch < payload.epoch {
-            await scheduleRemovalRetry(
-                payload,
-                ownerIdentityID: ownerIdentityID,
-                senderEd25519PublicKey: senderEd25519PublicKey,
-                attempt: attempt
-            )
-            return
-        }
+        if onchain.epoch < payload.epoch { return .chainBehind }
         if onchain.epoch == payload.epoch, onchain.commitment != payload.commitment {
-            return
+            return .done
         }
 
         if isSelf {
             var updated = group
             updated.membershipRevoked = true
             await groupRepository.insert(updated)
-            return
+            return .done
         }
 
         let victimBytes = ChatGroup.bytes(fromHex: victimHex)
@@ -836,33 +845,60 @@ struct IncomingMessageDispatcher: Sendable {
         // via the admin's refresh path.
         updated.groupSecret = payload.groupSecretNew ?? group.groupSecret
         await groupRepository.insert(updated)
+        return .done
     }
 
-    /// Schedule one delayed `applyRemoval` re-attempt, deduped so a
-    /// relay re-delivery inside the delay window can't stack timers.
-    private func scheduleRemovalRetry(
+    /// One initial `applyRemoval` pass plus a bounded retry loop for
+    /// the chain-behind case.
+    ///
+    /// A removal usually lands seconds after the admin anchors, while
+    /// `CachingChainStateReader` may serve a ≤10s-old entry — the
+    /// chain read looks *behind* the claimed epoch. For announcements
+    /// that case is a plain drop (later activity backfills); a dropped
+    /// removal would leave the victim trusted, so we re-check after
+    /// `removalRetryDelayNanos` (then 2×) — each attempt past the
+    /// cache TTL. After `removalMaxRetries` the payload is dropped for
+    /// THIS delivery; the next inbox replay retries from scratch, so
+    /// the removal is never permanently lost.
+    ///
+    /// The dedup key is held for the WHOLE retry loop — including the
+    /// network-bound `applyRemoval` re-attempts — so a relay
+    /// re-delivery at any point while a retry chain is live can't
+    /// stack a parallel chain. It's released when the loop ends, so a
+    /// later replay gets a fresh retry budget.
+    private func applyRemovalWithRetry(
         _ payload: MemberRemovalPayload,
         ownerIdentityID: IdentityID,
-        senderEd25519PublicKey: Data?,
-        attempt: Int
+        senderEd25519PublicKey: Data?
     ) async {
-        guard attempt < removalMaxRetries else { return }
+        let first = await applyRemoval(
+            payload,
+            ownerIdentityID: ownerIdentityID,
+            senderEd25519PublicKey: senderEd25519PublicKey
+        )
+        guard first == .chainBehind else { return }
+        guard removalMaxRetries > 0 else { return }
+
         let groupIDHex = payload.groupID.map { String(format: "%02x", $0) }.joined()
         let key = "\(groupIDHex):\(payload.removedBlsHex.lowercased()):\(payload.epoch)"
         guard await removalRetries.begin(key) else { return }
+
         let dispatcher = self
-        let delay = removalRetryDelayNanos * UInt64(attempt + 1)
+        let maxRetries = removalMaxRetries
+        let baseDelay = removalRetryDelayNanos
         let sleep = removalRetrySleep
         let registry = removalRetries
         await removalRetryScheduler {
-            await sleep(delay)
+            for attempt in 1...maxRetries {
+                await sleep(baseDelay * UInt64(attempt))
+                let result = await dispatcher.applyRemoval(
+                    payload,
+                    ownerIdentityID: ownerIdentityID,
+                    senderEd25519PublicKey: senderEd25519PublicKey
+                )
+                if result != .chainBehind { break }
+            }
             await registry.end(key)
-            await dispatcher.applyRemoval(
-                payload,
-                ownerIdentityID: ownerIdentityID,
-                senderEd25519PublicKey: senderEd25519PublicKey,
-                attempt: attempt + 1
-            )
         }
     }
 

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -446,6 +446,12 @@ struct OnymIOSApp: App {
             },
             setGroupName: { groupIDHex, name in
                 await groupAvatarBroadcaster.setName(groupIDHex: groupIDHex, name: name)
+            },
+            removeGroupMember: { groupIDHex, victimBlsHex in
+                await joinRequestApprover.removeMember(
+                    groupIDHex: groupIDHex,
+                    victimBlsHex: victimBlsHex
+                )
             }
         )
     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -41,7 +41,8 @@ struct RootView: View {
                         makeShareInviteFlow: dependencies.makeShareInviteFlow,
                         makeJoinFlow: dependencies.makeJoinFlow,
                         setGroupAvatar: dependencies.setGroupAvatar,
-                        setGroupName: dependencies.setGroupName
+                        setGroupName: dependencies.setGroupName,
+                        removeGroupMember: dependencies.removeGroupMember
                     )
                 }
             }
@@ -71,6 +72,7 @@ struct RootView: View {
                         makeShareInviteFlow: dependencies.makeShareInviteFlow,
                         setGroupAvatar: dependencies.setGroupAvatar,
                         setGroupName: dependencies.setGroupName,
+                        removeGroupMember: dependencies.removeGroupMember,
                         imageLoader: dependencies.imageLoader,
                         videoLoader: dependencies.videoLoader,
                         voiceLoader: dependencies.voiceLoader

--- a/Sources/OnymIOS/Search/SearchView.swift
+++ b/Sources/OnymIOS/Search/SearchView.swift
@@ -18,6 +18,7 @@ struct SearchView: View {
     let makeShareInviteFlow: @MainActor () -> ShareInviteFlow
     let setGroupAvatar: @MainActor (String, Data?) async -> Void
     let setGroupName: @MainActor (String, String) async -> Void
+    let removeGroupMember: @MainActor (String, String) async -> JoinRequestApprover.RemoveOutcome
     let imageLoader: ChatImageLoader
     let videoLoader: ChatVideoLoader
     let voiceLoader: ChatVoiceLoader
@@ -46,6 +47,7 @@ struct SearchView: View {
                 makeShareInviteFlow: makeShareInviteFlow,
                 setGroupAvatar: setGroupAvatar,
                 setGroupName: setGroupName,
+                removeGroupMember: removeGroupMember,
                 imageLoader: imageLoader,
                 videoLoader: videoLoader,
                 voiceLoader: voiceLoader,

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -331,6 +331,44 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
                        "second delivery of the same message id must be a no-op")
     }
 
+    func test_chatMessage_droppedAndUnacked_whenWeWereRemovedFromTheGroup() async throws {
+        // A stale peer can still seal to our unchanged inbox key until
+        // they apply the removal. Once membershipRevoked is set the
+        // thread is read-only history: drop the message AND send no
+        // delivered receipt (which would advertise reachability).
+        let seeded = await groups.currentGroups()
+        var revoked = try XCTUnwrap(seeded.first { $0.id == groupIDHex })
+        revoked.membershipRevoked = true
+        _ = await groups.insert(revoked)
+
+        let spy = SpyChatReceiptSender()
+        // Counting store so "didn't fall through to the legacy queue"
+        // is observable (the shared repo's snapshots filter by a
+        // current identity this fixture never sets).
+        let queueStore = CountingInvitationStore()
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(makePayload(body: "after removal")),
+            envelopeSigner: senderEd25519,
+            receiptSender: spy,
+            invitationsRepository: IncomingInvitationsRepository(store: queueStore)
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-after-removal",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex, owner: owner)
+        XCTAssertTrue(stored.isEmpty,
+                      "a removed member must not persist new group traffic")
+        let sends = await spy.sends
+        XCTAssertTrue(sends.isEmpty, "no delivered receipt from a revoked membership")
+        // Not a legacy-queue candidate either — it decoded fine.
+        let queued = await queueStore.count
+        XCTAssertEqual(queued, 0)
+    }
+
     // MARK: - Helpers
 
     private func makePayload(
@@ -355,7 +393,8 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         plaintext: Data,
         envelopeSigner: Data?,
         receiptSender: any ChatReceiptSending = NoopChatReceiptSender(),
-        readReceiptsEnabled: @escaping @Sendable () -> Bool = { true }
+        readReceiptsEnabled: @escaping @Sendable () -> Bool = { true },
+        invitationsRepository: IncomingInvitationsRepository? = nil
     ) -> IncomingMessageDispatcher {
         let decrypter = FakeInvitationEnvelopeDecrypter(
             mode: .fixed(plaintext),
@@ -365,7 +404,7 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             envelopeDecrypter: decrypter,
             identities: StubIdentities(summaries: []),
             groupRepository: groups,
-            invitationsRepository: invitations,
+            invitationsRepository: invitationsRepository ?? invitations,
             chainState: chainState,
             messageRepository: messages,
             receiptSender: receiptSender,
@@ -507,6 +546,30 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             direction: .outgoing, status: status,
             replyToMessageID: nil, groupType: .tyranny
         ))
+    }
+}
+
+/// Minimal `InvitationStore` that just counts saved rows — lets a test
+/// assert a decoded-but-dropped payload did NOT fall through to the
+/// legacy invitations queue.
+private actor CountingInvitationStore: InvitationStore {
+    private var rows: [String: IncomingInvitationRecord] = [:]
+
+    var count: Int { rows.count }
+
+    func list() -> [IncomingInvitationRecord] { Array(rows.values) }
+
+    @discardableResult
+    func save(_ record: IncomingInvitationRecord) -> Bool {
+        guard rows[record.id] == nil else { return false }
+        rows[record.id] = record
+        return true
+    }
+
+    func updateStatus(id: String, status: IncomingInvitationStatus) {}
+    func delete(id: String) { rows.removeValue(forKey: id) }
+    func deleteOwner(_ ownerIDString: String) {
+        rows = rows.filter { $0.value.ownerIdentityID.rawValue.uuidString != ownerIDString }
     }
 }
 

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
@@ -1,0 +1,426 @@
+import XCTest
+@testable import OnymIOS
+
+/// Behavioral tests for the `IncomingMessageDispatcher` member-removal
+/// fast path: remaining-member apply (tombstone + secret rotation),
+/// self-removal (`ChatGroup.membershipRevoked`), the admin-signature
+/// gate, the on-chain converge-forward check, idempotent re-delivery,
+/// and the chain-behind bounded retry.
+///
+/// Mirrors `IncomingMessageDispatcherRemovalTest.kt` from
+/// onym-android. The retry cases inject an inline scheduler + no-op
+/// sleep so the 12s/24s production delays never run in tests.
+@MainActor
+final class IncomingMessageDispatcherRemovalTests: XCTestCase {
+
+    private let groupID = Data(repeating: 0xAA, count: 32)
+
+    private let adminSending = Data(repeating: 0x10, count: 32)
+    private var adminSendingHex: String { String(repeating: "10", count: 32) }
+
+    private let victimBls = Data(repeating: 0xBB, count: 48)
+    private var victimHex: String { String(repeating: "bb", count: 48) }
+    private let otherBls = Data(repeating: 0xCC, count: 48)
+    private var otherHex: String { String(repeating: "cc", count: 48) }
+
+    private let oldSecret = Data(repeating: 0x01, count: 32)
+    private let oldSalt = Data(repeating: 0x02, count: 32)
+    private let newSecret = Data(repeating: 0x03, count: 32)
+    private let newSalt = Data(repeating: 0x04, count: 32)
+    private let newCommitment = Data(repeating: 0x05, count: 32)
+
+    private var groups: GroupRepository!
+    private var invitations: IncomingInvitationsRepository!
+    private var owner: IdentityID!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        invitations = IncomingInvitationsRepository(store: InMemoryInvitationStore())
+        owner = IdentityID()
+        await groups.setCurrentIdentity(owner)
+        _ = await groups.insert(makeGroup())
+    }
+
+    override func tearDown() async throws {
+        groups = nil
+        invitations = nil
+        owner = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - remaining-member apply
+
+    func test_removal_remainingMember_tombstonesAndRotatesSecrets() async throws {
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(payload: payloadForMembers(), reader: reader)
+        await dispatch(dispatcher)
+
+        let updated = try await currentGroup()
+        // Tombstoned, not deleted.
+        let victim = try XCTUnwrap(updated.memberProfiles[victimHex])
+        XCTAssertTrue(victim.revoked)
+        // Other member untouched.
+        XCTAssertEqual(updated.memberProfiles[otherHex]?.revoked, false)
+        // Subtracted from the on-chain roster.
+        XCTAssertFalse(updated.members.contains { $0.publicKeyCompressed == victimBls })
+        // Rotated state applied.
+        XCTAssertEqual(updated.epoch, 2)
+        XCTAssertEqual(updated.groupSecret, newSecret)
+        XCTAssertEqual(updated.salt, newSalt)
+        XCTAssertEqual(updated.commitment, newCommitment)
+        XCTAssertFalse(updated.membershipRevoked)
+    }
+
+    func test_removal_selfTarget_setsMembershipRevokedAndKeepsSecrets() async throws {
+        // The receiving identity IS the victim; their payload variant
+        // carries no secrets.
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForVictim(),
+            identities: [selfSummary()],
+            reader: reader
+        )
+        await dispatch(dispatcher)
+
+        let updated = try await currentGroup()
+        XCTAssertTrue(updated.membershipRevoked)
+        // Nothing else moved: history-preserving, secrets untouched.
+        XCTAssertEqual(updated.epoch, 1)
+        XCTAssertEqual(updated.groupSecret, oldSecret)
+        XCTAssertEqual(updated.salt, oldSalt)
+        XCTAssertEqual(updated.members.count, 2)
+        XCTAssertEqual(updated.memberProfiles[victimHex]?.revoked, false)
+    }
+
+    // MARK: - trust gates
+
+    func test_removal_droppedWhenSignerIsNotAdmin() async throws {
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            senderPub: Data(repeating: 0x77, count: 32),  // not the admin key
+            reader: reader
+        )
+        await dispatch(dispatcher)
+        try await assertUntouched()
+        XCTAssertEqual(reader.calls, 0, "auth gate precedes the chain read")
+    }
+
+    func test_removal_droppedWhenNoSigner() async throws {
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            senderPub: nil,
+            reader: reader
+        )
+        await dispatch(dispatcher)
+        try await assertUntouched()
+    }
+
+    func test_removal_droppedOnExactEpochCommitmentMismatch() async throws {
+        let reader = SequencedChainReader([entry(Data(repeating: 0x66, count: 32), epoch: 2)])
+        let dispatcher = try makeDispatcher(payload: payloadForMembers(), reader: reader)
+        await dispatch(dispatcher)
+        try await assertUntouched()
+        XCTAssertEqual(reader.calls, 1)
+    }
+
+    func test_removal_acceptedWhenChainAhead() async throws {
+        // Chain moved past the removal epoch (later joins landed) —
+        // the admin-signed removal is still legitimate history.
+        let reader = SequencedChainReader([entry(Data(repeating: 0x66, count: 32), epoch: 7)])
+        let dispatcher = try makeDispatcher(payload: payloadForMembers(), reader: reader)
+        await dispatch(dispatcher)
+        let updated = try await currentGroup()
+        XCTAssertEqual(updated.memberProfiles[victimHex]?.revoked, true)
+    }
+
+    func test_removal_acceptedOnExactEpochCommitmentMatch() async throws {
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(payload: payloadForMembers(), reader: reader)
+        await dispatch(dispatcher)
+        let updated = try await currentGroup()
+        XCTAssertEqual(updated.memberProfiles[victimHex]?.revoked, true)
+    }
+
+    func test_removal_chainBehindWithZeroRetries_isDropped() async throws {
+        let reader = SequencedChainReader([entry(Data(repeating: 0x66, count: 32), epoch: 1)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            reader: reader,
+            maxRetries: 0
+        )
+        await dispatch(dispatcher)
+        try await assertUntouched()
+        XCTAssertEqual(reader.calls, 1)
+    }
+
+    // MARK: - chain-behind retry
+
+    func test_removal_chainBehind_retriesAndAppliesOnceChainCatchesUp() async throws {
+        // First read: chain still at the pre-removal epoch (the
+        // caching reader's ≤10s-stale entry). Second read: caught up.
+        let reader = SequencedChainReader([
+            entry(Data(repeating: 0x66, count: 32), epoch: 1),
+            entry(newCommitment, epoch: 2),
+        ])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            reader: reader,
+            inlineRetries: true
+        )
+        await dispatch(dispatcher)
+
+        let updated = try await currentGroup()
+        XCTAssertEqual(updated.memberProfiles[victimHex]?.revoked, true)
+        XCTAssertEqual(reader.calls, 2)
+    }
+
+    func test_removal_chainStuckBehind_givesUpAfterMaxRetries() async throws {
+        let reader = SequencedChainReader([entry(Data(repeating: 0x66, count: 32), epoch: 1)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            reader: reader,
+            inlineRetries: true
+        )
+        await dispatch(dispatcher)
+
+        try await assertUntouched()
+        // Initial attempt + removalMaxRetries (2) = 3 chain reads.
+        XCTAssertEqual(reader.calls, 3)
+    }
+
+    func test_removal_chainReadThrows_retriesLikeChainBehind() async throws {
+        // An unreachable relayer is not evidence of forgery, but a
+        // stolen admin key must not shrink rosters offline — the read
+        // failure retries (and here recovers on the second attempt).
+        let reader = SequencedChainReader(
+            [entry(newCommitment, epoch: 2)],
+            failuresBeforeFirstEntry: 1
+        )
+        let dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            reader: reader,
+            inlineRetries: true
+        )
+        await dispatch(dispatcher)
+        let updated = try await currentGroup()
+        XCTAssertEqual(updated.memberProfiles[victimHex]?.revoked, true)
+        XCTAssertEqual(reader.calls, 2)
+    }
+
+    // MARK: - idempotency
+
+    func test_removal_redeliveryBailsBeforeChainRead() async throws {
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(payload: payloadForMembers(), reader: reader)
+        await dispatch(dispatcher, messageID: "m1")
+        await dispatch(dispatcher, messageID: "m2")
+
+        // Second delivery must not have hit the relayer (launch-storm
+        // protection) — one read total.
+        XCTAssertEqual(reader.calls, 1)
+        let updated = try await currentGroup()
+        XCTAssertEqual(updated.memberProfiles[victimHex]?.revoked, true)
+    }
+
+    func test_removal_selfRedeliveryBailsWhenAlreadyRevoked() async throws {
+        var revoked = makeGroup()
+        revoked.membershipRevoked = true
+        _ = await groups.insert(revoked)
+
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForVictim(),
+            identities: [selfSummary()],
+            reader: reader
+        )
+        await dispatch(dispatcher)
+        XCTAssertEqual(reader.calls, 0)
+    }
+
+    // MARK: - helpers
+
+    private func currentGroup() async throws -> ChatGroup {
+        let all = await groups.currentGroups()
+        return try XCTUnwrap(all.first { $0.groupIDData == groupID })
+    }
+
+    private func assertUntouched() async throws {
+        let group = try await currentGroup()
+        XCTAssertEqual(group.memberProfiles[victimHex]?.revoked, false)
+        XCTAssertEqual(group.epoch, 1)
+        XCTAssertEqual(group.groupSecret, oldSecret)
+        XCTAssertFalse(group.membershipRevoked)
+    }
+
+    private func dispatch(
+        _ dispatcher: IncomingMessageDispatcher,
+        messageID: String = "m1"
+    ) async {
+        await dispatcher.dispatch(
+            messageID: messageID,
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+    }
+
+    private func makeDispatcher(
+        payload: MemberRemovalPayload,
+        senderPub: Data? = Data(repeating: 0x10, count: 32),
+        identities: [IdentitySummary] = [],
+        reader: SequencedChainReader,
+        maxRetries: Int = 2,
+        inlineRetries: Bool = false
+    ) throws -> IncomingMessageDispatcher {
+        let plaintext = try JSONEncoder().encode(payload)
+        let decrypter = FakeInvitationEnvelopeDecrypter(
+            mode: .fixed(plaintext),
+            senderEd25519PublicKey: senderPub
+        )
+        var dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: decrypter,
+            identities: RemovalStubIdentities(summaries: identities),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: reader,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        dispatcher.removalMaxRetries = maxRetries
+        // No real 12s sleeps in tests.
+        dispatcher.removalRetrySleep = { _ in }
+        if inlineRetries {
+            // Run the retry inline so `dispatch` only returns once the
+            // bounded-retry loop has completed.
+            dispatcher.removalRetryScheduler = { work in await work() }
+        }
+        return dispatcher
+    }
+
+    private func selfSummary() -> IdentitySummary {
+        IdentitySummary(
+            id: owner,
+            name: "Me",
+            blsPublicKey: victimBls,
+            inboxPublicKey: Data(repeating: 0x21, count: 32),
+            sendingPublicKey: Data(repeating: 0x22, count: 32)
+        )
+    }
+
+    private func entry(_ commitment: Data, epoch: UInt64) -> SEPCommitmentEntry {
+        SEPCommitmentEntry(
+            commitment: commitment,
+            epoch: epoch,
+            timestamp: 0,
+            tier: 0,
+            active: nil
+        )
+    }
+
+    private func payloadForMembers() throws -> MemberRemovalPayload {
+        try MemberRemovalPayload(
+            version: 1,
+            groupID: groupID,
+            removedBlsHex: victimHex,
+            commitment: newCommitment,
+            epoch: 2,
+            sentAtMillis: 1_000,
+            groupSecretNew: newSecret,
+            saltNew: newSalt
+        )
+    }
+
+    private func payloadForVictim() throws -> MemberRemovalPayload {
+        try MemberRemovalPayload(
+            version: 1,
+            groupID: groupID,
+            removedBlsHex: victimHex,
+            commitment: newCommitment,
+            epoch: 2,
+            sentAtMillis: 1_000
+        )
+    }
+
+    private func makeGroup() -> ChatGroup {
+        ChatGroup(
+            id: groupID.map { String(format: "%02x", $0) }.joined(),
+            ownerIdentityID: owner,
+            name: "Family",
+            groupSecret: oldSecret,
+            createdAt: Date(timeIntervalSince1970: 0),
+            members: [
+                GovernanceMember(
+                    publicKeyCompressed: victimBls,
+                    leafHash: Data(repeating: 0x0B, count: 32)
+                ),
+                GovernanceMember(
+                    publicKeyCompressed: otherBls,
+                    leafHash: Data(repeating: 0x0C, count: 32)
+                ),
+            ],
+            memberProfiles: [
+                victimHex: MemberProfile(
+                    alias: "Victim",
+                    inboxPublicKey: Data(repeating: 0x31, count: 32),
+                    sendingPubkey: Data(repeating: 0x32, count: 32)
+                ),
+                otherHex: MemberProfile(
+                    alias: "Other",
+                    inboxPublicKey: Data(repeating: 0x41, count: 32),
+                    sendingPubkey: Data(repeating: 0x42, count: 32)
+                ),
+            ],
+            epoch: 1,
+            salt: oldSalt,
+            commitment: Data(repeating: 0x50, count: 32),
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: String(repeating: "de", count: 48),
+            adminEd25519PubkeyHex: adminSendingHex,
+            isPublishedOnChain: true
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+/// Programmable chain reader: serves `entries` in order, repeating the
+/// last one, counting calls. Optionally throws for the first
+/// `failuresBeforeFirstEntry` calls (unreachable-relayer simulation).
+private final class SequencedChainReader: ChainStateReading, @unchecked Sendable {
+    private let lock = NSLock()
+    private let entries: [SEPCommitmentEntry]
+    private let failuresBeforeFirstEntry: Int
+    private var _calls = 0
+
+    var calls: Int { lock.withLock { _calls } }
+
+    init(_ entries: [SEPCommitmentEntry], failuresBeforeFirstEntry: Int = 0) {
+        self.entries = entries
+        self.failuresBeforeFirstEntry = failuresBeforeFirstEntry
+    }
+
+    func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
+        try lock.withLock {
+            let call = _calls
+            _calls += 1
+            if call < failuresBeforeFirstEntry {
+                throw ChainReadError.noActiveRelayer
+            }
+            let index = min(call - failuresBeforeFirstEntry, entries.count - 1)
+            return entries[index]
+        }
+    }
+}
+
+private actor RemovalStubIdentities: IdentitiesProviding {
+    private let summaries: [IdentitySummary]
+
+    init(summaries: [IdentitySummary]) {
+        self.summaries = summaries
+    }
+
+    func currentIdentities() -> [IdentitySummary] { summaries }
+}

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
@@ -323,6 +323,143 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
         XCTAssertEqual(reader.calls, 0)
     }
 
+    func test_removal_chainBehindRetryIsScopedPerOwnerIdentity() async throws {
+        // Two local identities hold the same on-chain group. Both get
+        // the removal, both see a chain-behind read. An unscoped retry
+        // key would let the first identity's claim starve the second's
+        // retry budget entirely.
+        let secondOwner = IdentityID()
+        _ = await groups.insert(makeGroup(ownedBy: secondOwner))
+
+        let reader = SequencedChainReader([entry(Data(repeating: 0x66, count: 32), epoch: 1)])
+        // A gate instead of a sleep: both retry chains park inside it,
+        // so the second dispatch runs while the first chain still holds
+        // its dedup key — the starvation an unscoped key would cause.
+        let gate = RetryGate()
+        let chains = RetryTaskBag()
+        var dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            identities: [
+                nonVictimSelf(),
+                IdentitySummary(
+                    id: secondOwner,
+                    name: "Me2",
+                    blsPublicKey: Data(repeating: 0x98, count: 48),
+                    inboxPublicKey: Data(repeating: 0x23, count: 32),
+                    sendingPublicKey: Data(repeating: 0x24, count: 32)
+                ),
+            ],
+            reader: reader
+        )
+        dispatcher.removalRetrySleep = { _ in await gate.wait() }
+        dispatcher.removalRetryScheduler = { work in
+            await chains.add(Task { await work() })
+        }
+
+        await dispatch(dispatcher, messageID: "m1")
+        await dispatcher.dispatch(
+            messageID: "m2",
+            ownerIdentityID: secondOwner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        await gate.openGate()
+        await chains.waitAll()
+
+        // Per owner: 1 initial read + removalMaxRetries (2) = 3, so 6
+        // total. An unscoped key would starve owner 2 at 4.
+        XCTAssertEqual(reader.calls, 6)
+    }
+
+    // MARK: - announcement re-admission guard
+
+    func test_announcement_staleAdmissionReplay_doesNotResurrectRemovedMember() async throws {
+        // The victim's ORIGINAL admission announcement is re-delivered
+        // on every relay reconnect. It must NOT clear the tombstone —
+        // its epoch predates the removal that set it.
+        await seedTombstonedVictim(groupEpoch: 2, statusEpoch: 2)
+
+        await dispatchAnnouncement(epoch: 1, chainEpoch: 2)
+
+        let group = try await currentGroup()
+        XCTAssertEqual(group.memberProfiles[victimHex]?.revoked, true,
+                       "stale admission must not resurrect a removed member")
+    }
+
+    func test_announcement_newerReadmission_clearsTombstone() async throws {
+        // The legitimate case: the admin re-admits the member, so the
+        // announcement's epoch is NEWER than the removal's.
+        await seedTombstonedVictim(groupEpoch: 2, statusEpoch: 2)
+
+        await dispatchAnnouncement(epoch: 3, chainEpoch: 3)
+
+        let group = try await currentGroup()
+        let profile = try XCTUnwrap(group.memberProfiles[victimHex])
+        XCTAssertFalse(profile.revoked, "re-admission must clear the tombstone")
+        XCTAssertEqual(profile.statusEpoch, 3)
+    }
+
+    func test_announcement_withoutEpoch_doesNotResurrectRemovedMember() async throws {
+        // A legacy sender ships no epoch — we can't prove the
+        // announcement is newer than the removal, so keep the tombstone.
+        await seedTombstonedVictim(groupEpoch: 1, statusEpoch: 2)
+
+        await dispatchAnnouncement(epoch: nil, chainEpoch: 2)
+
+        let group = try await currentGroup()
+        XCTAssertEqual(group.memberProfiles[victimHex]?.revoked, true)
+    }
+
+    /// Seed the fixture group with the victim already tombstoned.
+    private func seedTombstonedVictim(groupEpoch: UInt64, statusEpoch: UInt64) async {
+        var group = makeGroup()
+        group.epoch = groupEpoch
+        group.memberProfiles[victimHex] = group.memberProfiles[victimHex]?
+            .withStatus(revoked: true, statusEpoch: statusEpoch)
+        _ = await groups.insert(group)
+    }
+
+    /// Dispatch a victim-readmitting `MemberAnnouncementPayload`
+    /// through a fresh dispatcher.
+    private func dispatchAnnouncement(epoch: UInt64?, chainEpoch: UInt64) async {
+        let commitment = Data(repeating: 0x90, count: 32)
+        guard let announcement = try? MemberAnnouncementPayload(
+            version: 1,
+            groupId: groupID,
+            newMember: try MemberAnnouncementPayload.AnnouncedMember(
+                blsPub: victimBls,
+                inboxPub: Data(repeating: 0x31, count: 32),
+                alias: "Victim",
+                sendingPub: Data(repeating: 0x32, count: 32)
+            ),
+            adminAlias: "Admin",
+            commitment: epoch == nil ? nil : commitment,
+            epoch: epoch
+        ),
+              let plaintext = try? JSONEncoder().encode(announcement)
+        else {
+            XCTFail("couldn't build the announcement fixture")
+            return
+        }
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(plaintext),
+                senderEd25519PublicKey: adminSending
+            ),
+            identities: RemovalStubIdentities(summaries: [nonVictimSelf()]),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: SequencedChainReader([entry(commitment, epoch: chainEpoch)]),
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        await dispatcher.dispatch(
+            messageID: "a1",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+    }
+
     func test_removal_failsClosedWhenGroupHasNoStoredAdminKey() async throws {
         // A group materialized from an unsigned invitation stores no
         // admin Ed25519. isAuthorizedGroupMutation's any-current-member
@@ -514,10 +651,13 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
         )
     }
 
-    private func makeGroup() -> ChatGroup {
+    /// The fixture group. `ownedBy` lets a test seed a SECOND local
+    /// identity's row for the same on-chain group id (the real store is
+    /// composite-keyed on `(id, owner)`, like production).
+    private func makeGroup(ownedBy customOwner: IdentityID? = nil) -> ChatGroup {
         ChatGroup(
             id: groupID.map { String(format: "%02x", $0) }.joined(),
-            ownerIdentityID: owner,
+            ownerIdentityID: customOwner ?? owner,
             name: "Family",
             groupSecret: oldSecret,
             createdAt: Date(timeIntervalSince1970: 0),
@@ -583,6 +723,39 @@ private final class SequencedChainReader: ChainStateReading, @unchecked Sendable
             let index = min(call - failuresBeforeFirstEntry, entries.count - 1)
             return entries[index]
         }
+    }
+}
+
+/// One-shot gate standing in for the retry delay: every parked chain
+/// suspends in `wait()` until the test calls `openGate()`, so two retry
+/// chains can be in flight simultaneously (which is what makes the
+/// dedup-key scoping observable).
+private actor RetryGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func openGate() {
+        isOpen = true
+        let parked = waiters
+        waiters.removeAll()
+        for waiter in parked { waiter.resume() }
+    }
+}
+
+/// Collects the spawned retry chains so a test can await them instead
+/// of racing the fire-and-forget `Task`s.
+private actor RetryTaskBag {
+    private var tasks: [Task<Void, Never>] = []
+    func add(_ task: Task<Void, Never>) { tasks.append(task) }
+    func waitAll() async {
+        let pending = tasks
+        tasks.removeAll()
+        for task in pending { await task.value }
     }
 }
 

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
@@ -299,28 +299,306 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
     }
 
     func test_removal_replayAfterOwnReadmission_doesNotRelockComposer() async throws {
-        // Victim device: removed, then re-admitted (fresh invitation
-        // stamps their own profile's statusEpoch). A replayed stale
-        // self-removal must not re-set membershipRevoked.
-        var readmitted = makeGroup()
-        readmitted.membershipRevoked = false
-        readmitted.epoch = 3
-        readmitted.memberProfiles[victimHex] = readmitted.memberProfiles[victimHex]?
-            .withStatus(revoked: false, statusEpoch: 3)
-        _ = await groups.insert(readmitted)
+        // Victim device: removed at epoch 2, then re-admitted. A
+        // replayed stale self-removal must not re-set
+        // membershipRevoked.
+        //
+        // The post-readmission state here is produced by DISPATCHING a
+        // real re-admission invitation (the path the admin's approve
+        // actually drives), not hand-written — an earlier version of
+        // this test stamped `statusEpoch` itself and therefore passed
+        // while the real path shipped a nil marker and re-locked the
+        // composer for good.
 
-        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
-        let dispatcher = try makeDispatcher(
-            payload: payloadForVictim(),
-            identities: [selfSummary()],
-            reader: reader
+        // 1. Removed at epoch 2 (self branch → membershipRevoked).
+        let removalReader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        await dispatch(
+            try makeDispatcher(
+                payload: payloadForVictim(),
+                identities: [selfSummary()],
+                reader: removalReader
+            ),
+            messageID: "m1"
         )
-        await dispatch(dispatcher)
+        let afterRemoval = try await currentGroup()
+        XCTAssertTrue(afterRemoval.membershipRevoked)
+
+        // 2. Re-admitted at epoch 3: the admin's approve records the
+        //    joiner BEFORE building the snapshot, so the invitation
+        //    carries our own un-revoked, epoch-stamped profile.
+        try await dispatchInvitation(
+            epoch: 3,
+            members: readmitMembers,
+            profiles: [
+                victimHex: MemberProfile(
+                    alias: "Victim",
+                    inboxPublicKey: Data(repeating: 0x31, count: 32),
+                    sendingPubkey: Data(repeating: 0x32, count: 32),
+                    revoked: false,
+                    statusEpoch: 3
+                ),
+                otherHex: MemberProfile(
+                    alias: "Other",
+                    inboxPublicKey: Data(repeating: 0x41, count: 32),
+                    sendingPubkey: Data(repeating: 0x42, count: 32)
+                ),
+            ]
+        )
+
+        let readmitted = try await currentGroup()
+        XCTAssertFalse(readmitted.membershipRevoked,
+                       "re-admission must unlock the thread")
+        XCTAssertEqual(readmitted.memberProfiles[victimHex]?.statusEpoch, 3,
+                       "our own profile must carry the admission epoch after materialize")
+
+        // 3. Relay replays the OLD epoch-2 removal.
+        let replayReader = SequencedChainReader([entry(newCommitment, epoch: 3)])
+        await dispatch(
+            try makeDispatcher(
+                payload: payloadForVictim(),
+                identities: [selfSummary()],
+                reader: replayReader
+            ),
+            messageID: "m2"
+        )
 
         let final = try await currentGroup()
         XCTAssertFalse(final.membershipRevoked,
                        "stale self-removal must not re-lock the thread")
-        XCTAssertEqual(reader.calls, 0)
+        XCTAssertEqual(replayReader.calls, 0,
+                       "local guard fires before any chain read")
+    }
+
+    func test_invitation_withoutOwnProfile_defaultsStatusEpochSoReplayCannotRelock() async throws {
+        // Belt-and-braces for the sender side: if a re-admission
+        // snapshot omits OUR profile (legacy sender, or an admin build
+        // that filters tombstones before recording the re-joiner),
+        // materializeGroup must still default our statusEpoch to the
+        // invitation's epoch — being in a snapshot at epoch N means
+        // every removal at or before N is stale for us. Without the
+        // default our marker is nil, `selfApplies` is true, and the
+        // replayed removal re-locks the thread permanently.
+        await dispatch(
+            try makeDispatcher(
+                payload: payloadForVictim(),
+                identities: [selfSummary()],
+                reader: SequencedChainReader([entry(newCommitment, epoch: 2)])
+            ),
+            messageID: "m1"
+        )
+        let afterRemoval = try await currentGroup()
+        XCTAssertTrue(afterRemoval.membershipRevoked)
+
+        // Re-admission snapshot at epoch 3 that ships only the OTHER
+        // member's profile — ours is absent from the wire.
+        try await dispatchInvitation(
+            epoch: 3,
+            members: readmitMembers,
+            profiles: [
+                otherHex: MemberProfile(
+                    alias: "Other",
+                    inboxPublicKey: Data(repeating: 0x41, count: 32),
+                    sendingPubkey: Data(repeating: 0x42, count: 32)
+                ),
+            ]
+        )
+
+        let readmitted = try await currentGroup()
+        XCTAssertFalse(readmitted.membershipRevoked)
+        XCTAssertEqual(readmitted.memberProfiles[victimHex]?.statusEpoch, 3,
+                       "self statusEpoch must default to the invitation epoch")
+
+        // The stale epoch-2 removal replays and must be refused.
+        await dispatch(
+            try makeDispatcher(
+                payload: payloadForVictim(),
+                identities: [selfSummary()],
+                reader: SequencedChainReader([entry(newCommitment, epoch: 3)])
+            ),
+            messageID: "m2"
+        )
+        let afterReplay = try await currentGroup()
+        XCTAssertFalse(afterReplay.membershipRevoked,
+                       "replayed removal must not re-lock after re-admission")
+    }
+
+    func test_removal_withoutLocalProfile_stillSubtractsTheLeafWithTheStateAdvance() async throws {
+        // Directory/roster divergence (the receive-side twin of
+        // `.memberNotInRoster`): the victim is in our `members` tree but
+        // has no local `MemberProfile`, so no tombstone applies. We
+        // still accept the state advance — and the commitment we adopt
+        // is over the SHRUNKEN tree, so the leaf has to go with it or
+        // the stored roster disagrees with the stored commitment.
+        var divergent = makeGroup()
+        divergent.memberProfiles.removeValue(forKey: victimHex)
+        _ = await groups.insert(divergent)
+
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        await dispatch(try makeDispatcher(payload: payloadForMembers(), reader: reader))
+
+        let updated = try await currentGroup()
+        XCTAssertFalse(updated.members.contains { $0.publicKeyCompressed == victimBls },
+                       "the leaf must be subtracted alongside the adopted commitment")
+        XCTAssertEqual(updated.epoch, 2)
+        XCTAssertEqual(updated.commitment, newCommitment)
+        XCTAssertNil(updated.memberProfiles[victimHex],
+                     "no profile to tombstone — the directory stays as it was")
+    }
+
+    func test_concurrentRemovals_forOneGroup_bothTombstonesSurvive() async throws {
+        // The retry chain runs OFF the inbox pump, so two applies for
+        // the same group can be in flight at once. Without a lock
+        // spanning read→write they both read the same snapshot and the
+        // later persist clobbers the earlier tombstone — the exact
+        // failure the retry exists to prevent. The gated reader parks
+        // both reads so the interleaving is deterministic.
+        // ONE dispatcher instance, two inbound envelopes — exactly the
+        // production shape (`OnymIOSApp` builds a single dispatcher for
+        // the inbox pump; the retry path re-enters that same value, and
+        // the lock is a reference so every copy shares it).
+        let gate = RetryGate()
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)], gate: gate)
+        let victimEnvelope = Data("envelope-victim".utf8)
+        let otherEnvelope = Data("envelope-other".utf8)
+        let otherRemoval = try MemberRemovalPayload(
+            version: 1,
+            groupID: groupID,
+            removedBlsHex: otherHex,
+            commitment: newCommitment,
+            epoch: 2,
+            sentAtMillis: 2_000,
+            groupSecretNew: newSecret,
+            saltNew: newSalt
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .scripted([
+                    victimEnvelope: try JSONEncoder().encode(payloadForMembers()),
+                    otherEnvelope: try JSONEncoder().encode(otherRemoval),
+                ]),
+                senderEd25519PublicKey: adminSending
+            ),
+            identities: RemovalStubIdentities(summaries: [nonVictimSelf()]),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: reader,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+
+        let first = Task {
+            await dispatcher.dispatch(
+                messageID: "c1", ownerIdentityID: self.owner,
+                payload: victimEnvelope, receivedAt: Date()
+            )
+        }
+        let second = Task {
+            await dispatcher.dispatch(
+                messageID: "c2", ownerIdentityID: self.owner,
+                payload: otherEnvelope, receivedAt: Date()
+            )
+        }
+        // Let both reach their chain read (or, under the lock, let the
+        // second park on `acquire`) before releasing the reads.
+        for _ in 0..<50 { await Task.yield() }
+        await gate.openGate()
+        _ = await first.value
+        _ = await second.value
+
+        let final = try await currentGroup()
+        XCTAssertEqual(final.memberProfiles[victimHex]?.revoked, true,
+                       "the first removal's tombstone must not be clobbered")
+        XCTAssertEqual(final.memberProfiles[otherHex]?.revoked, true,
+                       "the second removal's tombstone must not be clobbered")
+    }
+
+    func test_invitation_staleSnapshotDoesNotUnlockRemovedMember() async throws {
+        // materializeGroup rebuilds the row from scratch, so without a
+        // guard ANY accepted invitation clears membershipRevoked — e.g.
+        // a stale peer answering a refresh request. A snapshot at or
+        // before the removal's epoch must not unlock the composer.
+        await dispatch(
+            try makeDispatcher(
+                payload: payloadForVictim(),
+                identities: [selfSummary()],
+                reader: SequencedChainReader([entry(newCommitment, epoch: 2)])
+            ),
+            messageID: "m1"
+        )
+        let afterRemoval = try await currentGroup()
+        XCTAssertTrue(afterRemoval.membershipRevoked)
+
+        // A snapshot from BEFORE the removal (epoch 1).
+        try await dispatchInvitation(epoch: 1, members: [], profiles: nil)
+
+        let afterStale = try await currentGroup()
+        XCTAssertTrue(afterStale.membershipRevoked,
+                      "a stale snapshot must not unlock a removed member")
+    }
+
+    /// Roster the re-admission snapshots ship (both original leaves —
+    /// the victim is back in the tree).
+    private var readmitMembers: [GovernanceMember] {
+        [
+            GovernanceMember(
+                publicKeyCompressed: victimBls,
+                leafHash: Data(repeating: 0x0B, count: 32)
+            ),
+            GovernanceMember(
+                publicKeyCompressed: otherBls,
+                leafHash: Data(repeating: 0x0C, count: 32)
+            ),
+        ]
+    }
+
+    /// Dispatch a real `GroupInvitationPayload` for the fixture group
+    /// through a fresh dispatcher. The commitment is the REAL Poseidon
+    /// value for `(members, epoch, salt)` and the chain stub is seeded
+    /// at that exact epoch, so the Tyranny invitation verifier accepts
+    /// (iOS recomputes the commitment via the SDK — no best-effort
+    /// bypass like Android's nullable chain reader).
+    private func dispatchInvitation(
+        epoch: UInt64,
+        members: [GovernanceMember],
+        profiles: [String: MemberProfile]?
+    ) async throws {
+        let salt = Data(repeating: 0xA2, count: 32)
+        let commitment = try IncomingMessageDispatcherTests.makeRealTyrannyCommitment(
+            members: members,
+            epoch: epoch,
+            salt: salt,
+            tier: .small
+        )
+        let invitation = GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0xA1, count: 32),
+            name: "Family",
+            members: members,
+            epoch: epoch,
+            salt: salt,
+            commitment: commitment,
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.tyranny.rawValue,
+            adminPubkeyHex: String(repeating: "de", count: 48),
+            memberProfiles: profiles
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(try JSONEncoder().encode(invitation)),
+                senderEd25519PublicKey: adminSending
+            ),
+            identities: RemovalStubIdentities(summaries: [selfSummary()]),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: SequencedChainReader([entry(commitment, epoch: epoch)]),
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        await dispatcher.dispatch(
+            messageID: "i-\(epoch)",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
     }
 
     func test_removal_chainBehindRetryIsScopedPerOwnerIdentity() async throws {
@@ -704,25 +982,35 @@ private final class SequencedChainReader: ChainStateReading, @unchecked Sendable
     private let lock = NSLock()
     private let entries: [SEPCommitmentEntry]
     private let failuresBeforeFirstEntry: Int
+    /// When set, every read parks here before returning — lets a test
+    /// hold two applies inside their read-modify-write window at once.
+    private let gate: RetryGate?
     private var _calls = 0
 
     var calls: Int { lock.withLock { _calls } }
 
-    init(_ entries: [SEPCommitmentEntry], failuresBeforeFirstEntry: Int = 0) {
+    init(
+        _ entries: [SEPCommitmentEntry],
+        failuresBeforeFirstEntry: Int = 0,
+        gate: RetryGate? = nil
+    ) {
         self.entries = entries
         self.failuresBeforeFirstEntry = failuresBeforeFirstEntry
+        self.gate = gate
     }
 
     func tyrannyCommitment(groupID: Data) async throws -> SEPCommitmentEntry {
-        try lock.withLock {
+        let result: Result<SEPCommitmentEntry, Error> = lock.withLock {
             let call = _calls
             _calls += 1
             if call < failuresBeforeFirstEntry {
-                throw ChainReadError.noActiveRelayer
+                return .failure(ChainReadError.noActiveRelayer)
             }
             let index = min(call - failuresBeforeFirstEntry, entries.count - 1)
-            return entries[index]
+            return .success(entries[index])
         }
+        await gate?.wait()
+        return try result.get()
     }
 }
 

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
@@ -225,9 +225,12 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
         XCTAssertEqual(group.memberProfiles[victimHex]?.revoked, true)
 
         // 2. Re-admission: the announcement path resets the tombstone
-        //    (local epoch stays at 2 — announcements don't carry state).
+        //    and stamps the admission epoch (local group epoch stays at
+        //    2 — announcements don't carry group state). Mirrors what
+        //    applyAnnouncement writes.
         let postReadmissionSecret = Data(repeating: 0x71, count: 32)
-        group.memberProfiles[victimHex] = group.memberProfiles[victimHex]?.withRevoked(false)
+        group.memberProfiles[victimHex] = group.memberProfiles[victimHex]?
+            .withStatus(revoked: false, statusEpoch: 3)
         group.groupSecret = postReadmissionSecret
         _ = await groups.insert(group)
 
@@ -245,6 +248,79 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
         XCTAssertEqual(final.epoch, 2)
         // And the replay never even hit the chain (local guard fires first).
         XCTAssertEqual(reader.calls, 1)
+    }
+
+    func test_removal_outOfOrderDelivery_tombstonesBothWithoutRollingStateBack() async throws {
+        // Relay dispatch order is ARRIVAL order: an offline device can
+        // receive "remove other (epoch 3)" before "remove victim
+        // (epoch 2)". Both must land — a single group-epoch guard would
+        // drop the epoch-2 removal forever and leave the victim trusted.
+        let laterCommitment = Data(repeating: 0x80, count: 32)
+        let laterSecret = Data(repeating: 0x81, count: 32)
+        let laterSalt = Data(repeating: 0x82, count: 32)
+        let laterRemoval = try MemberRemovalPayload(
+            version: 1,
+            groupID: groupID,
+            removedBlsHex: otherHex,
+            commitment: laterCommitment,
+            epoch: 3,
+            sentAtMillis: 2_000,
+            groupSecretNew: laterSecret,
+            saltNew: laterSalt
+        )
+        // Chain is at the latest epoch throughout (both removals are
+        // already anchored by the time this device reconnects).
+        let reader = SequencedChainReader([entry(laterCommitment, epoch: 3)])
+
+        // Newest-first replay: epoch 3 lands, advancing state.
+        let laterDispatcher = try makeDispatcher(payload: laterRemoval, reader: reader)
+        await dispatch(laterDispatcher, messageID: "m1")
+        let afterLater = try await currentGroup()
+        XCTAssertEqual(afterLater.memberProfiles[otherHex]?.revoked, true)
+        XCTAssertEqual(afterLater.epoch, 3)
+
+        // Then the older epoch-2 removal arrives.
+        let earlierDispatcher = try makeDispatcher(payload: payloadForMembers(), reader: reader)
+        await dispatch(earlierDispatcher, messageID: "m2")
+
+        let final = try await currentGroup()
+        // BOTH members tombstoned + dropped from the on-chain roster.
+        XCTAssertEqual(final.memberProfiles[victimHex]?.revoked, true,
+                       "stale-but-unseen removal must still tombstone")
+        XCTAssertEqual(final.memberProfiles[otherHex]?.revoked, true)
+        XCTAssertFalse(final.members.contains { $0.publicKeyCompressed == victimBls })
+        XCTAssertFalse(final.members.contains { $0.publicKeyCompressed == otherBls })
+        // Group state stays at the NEWER removal's values — the older
+        // payload must not roll epoch / secrets backward.
+        XCTAssertEqual(final.epoch, 3)
+        XCTAssertEqual(final.groupSecret, laterSecret)
+        XCTAssertEqual(final.salt, laterSalt)
+        XCTAssertEqual(final.commitment, laterCommitment)
+    }
+
+    func test_removal_replayAfterOwnReadmission_doesNotRelockComposer() async throws {
+        // Victim device: removed, then re-admitted (fresh invitation
+        // stamps their own profile's statusEpoch). A replayed stale
+        // self-removal must not re-set membershipRevoked.
+        var readmitted = makeGroup()
+        readmitted.membershipRevoked = false
+        readmitted.epoch = 3
+        readmitted.memberProfiles[victimHex] = readmitted.memberProfiles[victimHex]?
+            .withStatus(revoked: false, statusEpoch: 3)
+        _ = await groups.insert(readmitted)
+
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForVictim(),
+            identities: [selfSummary()],
+            reader: reader
+        )
+        await dispatch(dispatcher)
+
+        let final = try await currentGroup()
+        XCTAssertFalse(final.membershipRevoked,
+                       "stale self-removal must not re-lock the thread")
+        XCTAssertEqual(reader.calls, 0)
     }
 
     func test_removal_failsClosedWhenGroupHasNoStoredAdminKey() async throws {

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherRemovalTests.swift
@@ -210,6 +210,88 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
         XCTAssertEqual(reader.calls, 2)
     }
 
+    // MARK: - review regressions
+
+    func test_removal_replayAfterReadmission_doesNotRollStateBack() async throws {
+        // 1. Removal (epoch 2) applies.
+        let reader = SequencedChainReader([
+            entry(newCommitment, epoch: 2),
+            // Later reads: chain moved on past the re-admission.
+            entry(Data(repeating: 0x70, count: 32), epoch: 3),
+        ])
+        let dispatcher = try makeDispatcher(payload: payloadForMembers(), reader: reader)
+        await dispatch(dispatcher, messageID: "m1")
+        var group = try await currentGroup()
+        XCTAssertEqual(group.memberProfiles[victimHex]?.revoked, true)
+
+        // 2. Re-admission: the announcement path resets the tombstone
+        //    (local epoch stays at 2 — announcements don't carry state).
+        let postReadmissionSecret = Data(repeating: 0x71, count: 32)
+        group.memberProfiles[victimHex] = group.memberProfiles[victimHex]?.withRevoked(false)
+        group.groupSecret = postReadmissionSecret
+        _ = await groups.insert(group)
+
+        // 3. The relay replays the OLD epoch-2 removal envelope. The
+        //    chain (epoch 3) is ahead — without the local
+        //    converge-forward guard this would re-tombstone the member
+        //    and roll groupSecret/epoch back to the removal values.
+        await dispatch(dispatcher, messageID: "m2")
+
+        let final = try await currentGroup()
+        XCTAssertEqual(final.memberProfiles[victimHex]?.revoked, false,
+                       "re-admitted member must stay active")
+        XCTAssertEqual(final.groupSecret, postReadmissionSecret,
+                       "post-readmission secret must survive the replay")
+        XCTAssertEqual(final.epoch, 2)
+        // And the replay never even hit the chain (local guard fires first).
+        XCTAssertEqual(reader.calls, 1)
+    }
+
+    func test_removal_failsClosedWhenGroupHasNoStoredAdminKey() async throws {
+        // A group materialized from an unsigned invitation stores no
+        // admin Ed25519. isAuthorizedGroupMutation's any-current-member
+        // fallback must NOT apply to a subtractive op — a member's
+        // valid signature is not authority to evict another member.
+        let memberSending = Data(repeating: 0x42, count: 32)
+        var group = makeGroup()
+        group.adminEd25519PubkeyHex = nil
+        group.memberProfiles[otherHex] = MemberProfile(
+            alias: "Other",
+            inboxPublicKey: Data(repeating: 0x41, count: 32),
+            sendingPubkey: memberSending
+        )
+        _ = await groups.insert(group)
+
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            senderPub: memberSending,  // valid CURRENT member signature
+            reader: reader
+        )
+        await dispatch(dispatcher)
+
+        let after = try await currentGroup()
+        XCTAssertEqual(after.memberProfiles[victimHex]?.revoked, false)
+        XCTAssertEqual(after.epoch, 1)
+        XCTAssertEqual(reader.calls, 0, "fails closed before any chain read")
+    }
+
+    func test_removal_droppedWhenSelfUnresolvable() async throws {
+        // No resolvable self identity → can't classify self vs
+        // remaining-member. The safe posture is drop (previously the
+        // victim's own device would take the remaining-member branch
+        // and delete itself).
+        let reader = SequencedChainReader([entry(newCommitment, epoch: 2)])
+        let dispatcher = try makeDispatcher(
+            payload: payloadForMembers(),
+            identities: [],
+            reader: reader
+        )
+        await dispatch(dispatcher)
+        try await assertUntouched()
+        XCTAssertEqual(reader.calls, 0)
+    }
+
     // MARK: - idempotency
 
     func test_removal_redeliveryBailsBeforeChainRead() async throws {
@@ -270,7 +352,7 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
     private func makeDispatcher(
         payload: MemberRemovalPayload,
         senderPub: Data? = Data(repeating: 0x10, count: 32),
-        identities: [IdentitySummary] = [],
+        identities: [IdentitySummary]? = nil,
         reader: SequencedChainReader,
         maxRetries: Int = 2,
         inlineRetries: Bool = false
@@ -282,7 +364,7 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
         )
         var dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter: decrypter,
-            identities: RemovalStubIdentities(summaries: identities),
+            identities: RemovalStubIdentities(summaries: identities ?? [nonVictimSelf()]),
             groupRepository: groups,
             invitationsRepository: invitations,
             chainState: reader,
@@ -304,6 +386,19 @@ final class IncomingMessageDispatcherRemovalTests: XCTestCase {
             id: owner,
             name: "Me",
             blsPublicKey: victimBls,
+            inboxPublicKey: Data(repeating: 0x21, count: 32),
+            sendingPublicKey: Data(repeating: 0x22, count: 32)
+        )
+    }
+
+    /// Default self-identity: a non-victim member, so the dispatcher
+    /// can classify the removal (an unresolvable self now DROPS —
+    /// see `test_removal_droppedWhenSelfUnresolvable`).
+    private func nonVictimSelf() -> IdentitySummary {
+        IdentitySummary(
+            id: owner,
+            name: "Me",
+            blsPublicKey: Data(repeating: 0x99, count: 48),
             inboxPublicKey: Data(repeating: 0x21, count: 32),
             sendingPublicKey: Data(repeating: 0x22, count: 32)
         )

--- a/Tests/OnymIOSTests/JoinRequestApproverRemovalTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverRemovalTests.swift
@@ -1,0 +1,459 @@
+import CryptoKit
+import XCTest
+import OnymSDK
+@testable import OnymIOS
+
+/// Behavioral tests for `JoinRequestApprover.removeMember` — the
+/// admin-side "remove member from a Tyranny group" flow with
+/// groupSecret rotation. Gate tests short-circuit before the prover;
+/// the happy path + anchor-rejected cases run the REAL
+/// `Tyranny.proveUpdate` on the `.small` tier (pattern:
+/// `GroupProofGeneratorTests`) against a stub contract transport.
+///
+/// Mirrors the behavioral shape of onym-android's
+/// `GroupMemberRemoverTest`.
+@MainActor
+final class JoinRequestApproverRemovalTests: XCTestCase {
+
+    private var keychain: IdentityKeychainStore!
+    private var identity: IdentityRepository!
+    private var groups: GroupRepository!
+    private var transport: RemovalRecordingInboxTransport!
+    private var relayers: RelayerRepository!
+    private var contracts: ContractsRepository!
+    private var contractTransport: RemovalStubContractTransport!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        keychain = IdentityKeychainStore(testNamespace: "remover-\(UUID().uuidString)")
+        identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+        transport = RemovalRecordingInboxTransport()
+        contractTransport = RemovalStubContractTransport()
+
+        relayers = RelayerRepository(
+            fetcher: FakeKnownRelayersFetcher(mode: .succeeds([])),
+            store: InMemoryRelayerSelectionStore()
+        )
+        _ = await relayers.addEndpoint(RelayerEndpoint(
+            name: "test",
+            url: URL(string: "https://relayer.test.example")!,
+            networks: ["testnet"]
+        ))
+        await relayers.setStrategy(.primary)
+        await relayers.setPrimary(url: URL(string: "https://relayer.test.example")!)
+
+        let manifest = ContractsManifest(
+            version: 1,
+            releases: [
+                ContractRelease(
+                    release: "v0.0.3",
+                    publishedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    contracts: [
+                        ContractEntry(
+                            network: .testnet,
+                            type: .tyranny,
+                            id: "CTYRANNYTEST00000000000000000000000000000000000000000000"
+                        )
+                    ]
+                )
+            ]
+        )
+        contracts = ContractsRepository(
+            fetcher: FakeContractsManifestFetcher(mode: .succeeds(manifest)),
+            store: InMemoryAnchorSelectionStore()
+        )
+        try? await contracts.refresh()
+    }
+
+    override func tearDown() async throws {
+        try? keychain?.wipeAll()
+        keychain = nil
+        identity = nil
+        groups = nil
+        transport = nil
+        relayers = nil
+        contracts = nil
+        contractTransport = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Gates
+
+    func test_remove_unknownGroup() async throws {
+        let env = try await seedEnvironment(insertGroup: false)
+        let outcome = await env.approver.removeMember(
+            groupIDHex: env.groupIDHex,
+            victimBlsHex: env.victimHex
+        )
+        XCTAssertEqual(outcome, .unknownGroup)
+    }
+
+    func test_remove_cannotRemoveSelf() async throws {
+        let env = try await seedEnvironment()
+        let outcome = await env.approver.removeMember(
+            groupIDHex: env.groupIDHex,
+            victimBlsHex: env.adminHex
+        )
+        XCTAssertEqual(outcome, .cannotRemoveSelf)
+    }
+
+    func test_remove_unknownMember() async throws {
+        let env = try await seedEnvironment()
+        let outcome = await env.approver.removeMember(
+            groupIDHex: env.groupIDHex,
+            victimBlsHex: String(repeating: "ff", count: 48)
+        )
+        XCTAssertEqual(outcome, .unknownMember)
+    }
+
+    func test_remove_alreadyRemoved() async throws {
+        let env = try await seedEnvironment(victimAlreadyRevoked: true)
+        let outcome = await env.approver.removeMember(
+            groupIDHex: env.groupIDHex,
+            victimBlsHex: env.victimHex
+        )
+        XCTAssertEqual(outcome, .alreadyRemoved)
+    }
+
+    func test_remove_memberNotInRoster() async throws {
+        // The peer is in `memberProfiles` (app-level directory) but not
+        // in the on-chain `members` roster — the tree can't be shrunk
+        // around a leaf that was never in it.
+        let env = try await seedEnvironment()
+        let outcome = await env.approver.removeMember(
+            groupIDHex: env.groupIDHex,
+            victimBlsHex: env.peerHex
+        )
+        XCTAssertEqual(outcome, .memberNotInRoster)
+    }
+
+    func test_remove_notAdminOfThisGroup_preflight() async throws {
+        // The stored group's admin roster entry doesn't match the
+        // active identity's derived BLS pub — the pre-flight must
+        // catch it before invoking the prover.
+        let env = try await seedEnvironment()
+        var group = try await currentGroup(env)
+        let bogusSecret = Self.fr(9)
+        let bogusAdmin = GovernanceMember(
+            publicKeyCompressed: try GroupCommitmentBuilder.computePublicKey(secretKey: bogusSecret),
+            leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: bogusSecret)
+        )
+        group.members = [bogusAdmin, env.victimMember]
+        group.adminPubkeyHex = bogusAdmin.publicKeyCompressed
+            .map { String(format: "%02x", $0) }.joined()
+        _ = await groups.insert(group)
+
+        let outcome = await env.approver.removeMember(
+            groupIDHex: env.groupIDHex,
+            victimBlsHex: env.victimHex
+        )
+        XCTAssertEqual(outcome, .notAdminOfThisGroup)
+        let sends = await transport.sends
+        XCTAssertTrue(sends.isEmpty, "no envelopes ship when the pre-flight fails")
+    }
+
+    // MARK: - Anchor rejected
+
+    func test_remove_anchorRejected_persistsNothing() async throws {
+        contractTransport.nextAccepted = false
+        let env = try await seedEnvironment()
+        let outcome = await env.approver.removeMember(
+            groupIDHex: env.groupIDHex,
+            victimBlsHex: env.victimHex
+        )
+        guard case .anchorRejected = outcome else {
+            XCTFail("expected .anchorRejected, got \(outcome)")
+            return
+        }
+        let after = try await currentGroup(env)
+        XCTAssertEqual(after.epoch, 0, "epoch must NOT advance when the anchor is rejected")
+        XCTAssertEqual(after.memberProfiles[env.victimHex]?.revoked, false)
+        XCTAssertEqual(after.groupSecret, Data(repeating: 0x55, count: 32))
+        XCTAssertEqual(after.members.count, 2)
+        let sends = await transport.sends
+        XCTAssertTrue(sends.isEmpty, "no envelopes ship when the chain rejects")
+    }
+
+    // MARK: - Happy path (real prover)
+
+    func test_remove_happyPath_anchorsPersistsAndFansOut() async throws {
+        let env = try await seedEnvironment()
+
+        let outcome = await env.approver.removeMember(
+            groupIDHex: env.groupIDHex,
+            victimBlsHex: env.victimHex
+        )
+        XCTAssertEqual(outcome, .sent)
+
+        // The relayer saw exactly one update_commitment.
+        XCTAssertEqual(contractTransport.calls.count, 1)
+
+        // ─── persisted state ────────────────────────────────────────
+        let after = try await currentGroup(env)
+        XCTAssertEqual(after.epoch, 1, "epoch advances by 1")
+        XCTAssertFalse(
+            after.members.contains { $0.publicKeyCompressed == env.victimMember.publicKeyCompressed },
+            "victim leaves the on-chain roster"
+        )
+        XCTAssertEqual(after.members.count, 1)
+        XCTAssertNotEqual(after.groupSecret, Data(repeating: 0x55, count: 32),
+                          "groupSecret rotates to fresh random bytes")
+        XCTAssertEqual(after.groupSecret.count, 32)
+        XCTAssertNotEqual(after.salt, Data(repeating: 0x66, count: 32), "salt rotates")
+        XCTAssertEqual(after.commitment?.count, 32)
+        // Victim tombstoned, NOT deleted; peer untouched.
+        XCTAssertEqual(after.memberProfiles[env.victimHex]?.revoked, true)
+        XCTAssertEqual(after.memberProfiles[env.peerHex]?.revoked, false)
+
+        // ─── fanout ─────────────────────────────────────────────────
+        // Two envelopes: victim (secret-free) + peer (with secrets);
+        // the admin's own inbox is skipped.
+        let sends = await transport.sends
+        XCTAssertEqual(sends.count, 2)
+
+        let victimTag = Self.inboxTag(env.victimInboxPub)
+        let peerTag = Self.inboxTag(env.peerInboxPub)
+
+        let victimSend = try XCTUnwrap(sends.first { $0.inbox.rawValue == victimTag })
+        let victimPayload = try Self.open(
+            envelope: victimSend.payload,
+            with: env.victimInboxKey
+        )
+        XCTAssertEqual(victimPayload.removedBlsHex, env.victimHex)
+        XCTAssertEqual(victimPayload.epoch, 1)
+        XCTAssertEqual(victimPayload.commitment, after.commitment)
+        XCTAssertNil(victimPayload.groupSecretNew, "victim never learns the rotated secret")
+        XCTAssertNil(victimPayload.saltNew, "victim never learns the rotated salt")
+
+        let peerSend = try XCTUnwrap(sends.first { $0.inbox.rawValue == peerTag })
+        let peerPayload = try Self.open(
+            envelope: peerSend.payload,
+            with: env.peerInboxKey
+        )
+        XCTAssertEqual(peerPayload.removedBlsHex, env.victimHex)
+        XCTAssertEqual(peerPayload.epoch, 1)
+        XCTAssertEqual(peerPayload.commitment, after.commitment)
+        XCTAssertEqual(peerPayload.groupSecretNew, after.groupSecret,
+                       "remaining members receive the rotated secret")
+        XCTAssertEqual(peerPayload.saltNew, after.salt,
+                       "remaining members receive the rotated salt")
+    }
+
+    // MARK: - Fixture
+
+    private struct Env {
+        let approver: JoinRequestApprover
+        let groupIDHex: String
+        let adminHex: String
+        let victimHex: String
+        let victimMember: GovernanceMember
+        let victimInboxKey: Curve25519.KeyAgreement.PrivateKey
+        let victimInboxPub: Data
+        let peerHex: String
+        let peerInboxKey: Curve25519.KeyAgreement.PrivateKey
+        let peerInboxPub: Data
+    }
+
+    /// Bootstrap the admin identity and seed a two-leaf Tyranny group:
+    /// the admin (real keys, so `proveUpdate` succeeds) + a synthetic
+    /// victim member (canonical Fr leaf from a small test secret). A
+    /// third "peer" lives in `memberProfiles` only — the remaining-
+    /// member fanout target.
+    private func seedEnvironment(
+        insertGroup: Bool = true,
+        victimAlreadyRevoked: Bool = false
+    ) async throws -> Env {
+        let active = try await identity.bootstrap()
+        let maybeOwnerID = await identity.currentSelectedID()
+        let ownerID = try XCTUnwrap(maybeOwnerID)
+        // onym:allow-secret-read
+        let adminBlsSecret = try await identity.blsSecretKey()
+        let adminLeaf = try GroupCommitmentBuilder.computeLeafHash(secretKey: adminBlsSecret)
+        let adminHex = active.blsPublicKey.map { String(format: "%02x", $0) }.joined()
+
+        // Victim: synthetic-but-canonical member (leaf must be a valid
+        // Fr for the FFI merkle root, so derive it from a tiny secret).
+        let victimSecret = Self.fr(7)
+        let victimMember = GovernanceMember(
+            publicKeyCompressed: try GroupCommitmentBuilder.computePublicKey(secretKey: victimSecret),
+            leafHash: try GroupCommitmentBuilder.computeLeafHash(secretKey: victimSecret)
+        )
+        let victimHex = victimMember.publicKeyCompressed
+            .map { String(format: "%02x", $0) }.joined()
+        let victimInboxKey = Curve25519.KeyAgreement.PrivateKey()
+        let victimInboxPub = Data(victimInboxKey.publicKey.rawRepresentation)
+
+        // Peer: profile-only remaining member with a decryptable inbox.
+        let peerHex = String(repeating: "77", count: 48)
+        let peerInboxKey = Curve25519.KeyAgreement.PrivateKey()
+        let peerInboxPub = Data(peerInboxKey.publicKey.rawRepresentation)
+
+        let groupID = Self.fr(0x4242)
+        let groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
+
+        if insertGroup {
+            let adminMember = GovernanceMember(
+                publicKeyCompressed: active.blsPublicKey,
+                leafHash: adminLeaf
+            )
+            let members = [adminMember, victimMember].sorted {
+                $0.publicKeyCompressed.lexicographicallyPrecedes($1.publicKeyCompressed)
+            }
+            let group = ChatGroup(
+                id: groupIDHex,
+                ownerIdentityID: ownerID,
+                name: "Family",
+                groupSecret: Data(repeating: 0x55, count: 32),
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+                members: members,
+                memberProfiles: [
+                    adminHex: MemberProfile(
+                        alias: "Admin",
+                        inboxPublicKey: active.inboxPublicKey,
+                        sendingPubkey: active.stellarPublicKey
+                    ),
+                    victimHex: MemberProfile(
+                        alias: "Victim",
+                        inboxPublicKey: victimInboxPub,
+                        sendingPubkey: Data(repeating: 0xE1, count: 32),
+                        revoked: victimAlreadyRevoked
+                    ),
+                    peerHex: MemberProfile(
+                        alias: "Peer",
+                        inboxPublicKey: peerInboxPub,
+                        sendingPubkey: Data(repeating: 0xE2, count: 32)
+                    ),
+                ],
+                epoch: 0,
+                salt: Data(repeating: 0x66, count: 32),
+                commitment: Data(repeating: 0x77, count: 32),
+                tier: .small,
+                groupType: .tyranny,
+                adminPubkeyHex: adminHex,
+                adminEd25519PubkeyHex: nil,
+                isPublishedOnChain: true
+            )
+            _ = await groups.insert(group)
+        }
+
+        let chainTransport = contractTransport!
+        let approver = JoinRequestApprover(
+            identity: identity,
+            introKeyStore: InMemoryIntroKeyStore(),
+            introRequestStore: InMemoryIntroRequestStore(),
+            groupRepository: groups,
+            inboxTransport: transport,
+            relayers: relayers,
+            contracts: contracts,
+            networkPreference: RemovalStaticNetworkPreference(value: .testnet),
+            makeContractTransport: { _ in chainTransport }
+        )
+
+        return Env(
+            approver: approver,
+            groupIDHex: groupIDHex,
+            adminHex: adminHex,
+            victimHex: victimHex,
+            victimMember: victimMember,
+            victimInboxKey: victimInboxKey,
+            victimInboxPub: victimInboxPub,
+            peerHex: peerHex,
+            peerInboxKey: peerInboxKey,
+            peerInboxPub: peerInboxPub
+        )
+    }
+
+    private func currentGroup(_ env: Env) async throws -> ChatGroup {
+        let all = await groups.currentGroups()
+        return try XCTUnwrap(all.first { $0.id == env.groupIDHex })
+    }
+
+    // MARK: - Helpers
+
+    /// Decrypt a sealed removal envelope with the recipient's inbox
+    /// private key and decode the `MemberRemovalPayload`.
+    private static func open(
+        envelope: Data,
+        with key: Curve25519.KeyAgreement.PrivateKey
+    ) throws -> MemberRemovalPayload {
+        let plaintext = try IdentityRepository.decryptSealedEnvelope(
+            envelopeBytes: envelope,
+            recipientX25519PrivateKey: key
+        )
+        return try JSONDecoder().decode(MemberRemovalPayload.self, from: plaintext)
+    }
+
+    /// Mirror of `IntroInboxPump.inboxTag(from:)`.
+    private static func inboxTag(_ inboxPublicKey: Data) -> String {
+        var hasher = SHA256()
+        hasher.update(data: Data("sep-inbox-v1".utf8))
+        hasher.update(data: inboxPublicKey)
+        return hasher.finalize().prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// 32-byte BE encoding of a small u64 — a canonical Fr scalar.
+    private static func fr(_ value: UInt64) -> Data {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        for i in 0..<8 {
+            bytes[31 - i] = UInt8((value >> (i * 8)) & 0xFF)
+        }
+        return Data(bytes)
+    }
+}
+
+// MARK: - Test doubles
+
+/// Recording inbox transport — captures every send.
+private actor RemovalRecordingInboxTransport: InboxTransport {
+    private(set) var sends: [(payload: Data, inbox: TransportInboxID)] = []
+
+    func connect(to endpoints: [TransportEndpoint]) async {}
+    func disconnect() async {}
+
+    func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
+        sends.append((payload, inbox))
+        return PublishReceipt(messageID: UUID().uuidString, acceptedBy: 1)
+    }
+
+    nonisolated func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
+        AsyncStream { _ in }
+    }
+
+    func unsubscribe(inbox: TransportInboxID) async {}
+}
+
+/// Stub `SEPContractTransport` — records every invocation, returns
+/// `accepted = true` by default; tests flip `nextAccepted` to drive
+/// the rejected path.
+private final class RemovalStubContractTransport: SEPContractTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _nextAccepted = true
+    private var _calls: [String] = []
+
+    var nextAccepted: Bool {
+        get { lock.withLock { _nextAccepted } }
+        set { lock.withLock { _nextAccepted = newValue } }
+    }
+    var calls: [String] { lock.withLock { _calls } }
+
+    func invoke<Payload: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ invocation: SEPContractInvocation<Payload>,
+        responseType: Response.Type
+    ) async throws -> Response {
+        lock.withLock { _calls.append(invocation.function) }
+        let response = SEPSubmissionResponse(
+            accepted: nextAccepted,
+            transactionHash: nextAccepted ? "0xstubhash" : nil,
+            message: nextAccepted ? nil : "stub rejected"
+        )
+        let data = try JSONEncoder().encode(response)
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+}
+
+/// Static `NetworkPreferenceProviding` for tests.
+private struct RemovalStaticNetworkPreference: NetworkPreferenceProviding, Sendable {
+    let value: AppNetwork
+    func current() -> AppNetwork { value }
+}

--- a/Tests/OnymIOSTests/JoinRequestApproverRemovalTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverRemovalTests.swift
@@ -202,8 +202,11 @@ final class JoinRequestApproverRemovalTests: XCTestCase {
         XCTAssertEqual(after.groupSecret.count, 32)
         XCTAssertNotEqual(after.salt, Data(repeating: 0x66, count: 32), "salt rotates")
         XCTAssertEqual(after.commitment?.count, 32)
-        // Victim tombstoned, NOT deleted; peer untouched.
+        // Victim tombstoned, NOT deleted; peer untouched. The tombstone
+        // carries the removal epoch so receive-side decisions stay
+        // order-independent (MemberProfile.statusEpoch).
         XCTAssertEqual(after.memberProfiles[env.victimHex]?.revoked, true)
+        XCTAssertEqual(after.memberProfiles[env.victimHex]?.statusEpoch, 1)
         XCTAssertEqual(after.memberProfiles[env.peerHex]?.revoked, false)
 
         // ─── fanout ─────────────────────────────────────────────────

--- a/Tests/OnymIOSTests/MemberRemovalPayloadTests.swift
+++ b/Tests/OnymIOSTests/MemberRemovalPayloadTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import OnymIOS
+
+/// Round-trip vectors for `MemberRemovalPayload` plus trial-decode
+/// disjointness against every other inbox payload — the dispatcher's
+/// routing depends on no payload decoding as another.
+///
+/// Wire format authored on Android first (`MemberRemovalPayload.kt`);
+/// `test_decode_wireVector` decodes the exact wire shape Android's
+/// `MemberRemovalPayloadTest.decode_wireVector` freezes (same byte
+/// values, same base64 encoding).
+final class MemberRemovalPayloadTests: XCTestCase {
+
+    private let groupID = Data(repeating: 0xAA, count: 32)
+    private let victimHex = String(repeating: "bb", count: 48)
+    private let commitment = Data(repeating: 0xDD, count: 32)
+    private let secretNew = Data(repeating: 0x11, count: 32)
+    private let saltNew = Data(repeating: 0x22, count: 32)
+
+    private func memberVariant() throws -> MemberRemovalPayload {
+        try MemberRemovalPayload(
+            version: 1,
+            groupID: groupID,
+            removedBlsHex: victimHex,
+            commitment: commitment,
+            epoch: 3,
+            sentAtMillis: 1_700_000_000_000,
+            groupSecretNew: secretNew,
+            saltNew: saltNew
+        )
+    }
+
+    private func victimVariant() throws -> MemberRemovalPayload {
+        try MemberRemovalPayload(
+            version: 1,
+            groupID: groupID,
+            removedBlsHex: victimHex,
+            commitment: commitment,
+            epoch: 3,
+            sentAtMillis: 1_700_000_000_000
+        )
+    }
+
+    // MARK: - Round-trips
+
+    func test_roundTrip_memberVariant() throws {
+        let encoded = try JSONEncoder().encode(memberVariant())
+        let decoded = try JSONDecoder().decode(MemberRemovalPayload.self, from: encoded)
+        XCTAssertEqual(decoded, try memberVariant())
+        XCTAssertEqual(decoded.groupSecretNew, secretNew)
+        XCTAssertEqual(decoded.saltNew, saltNew)
+    }
+
+    func test_roundTrip_victimVariant_omitsSecretKeysEntirely() throws {
+        let encoded = try JSONEncoder().encode(victimVariant())
+        let text = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        // Not just null-valued — the keys must be absent from the wire.
+        XCTAssertFalse(text.contains("group_secret_new"))
+        XCTAssertFalse(text.contains("salt_new"))
+        let decoded = try JSONDecoder().decode(MemberRemovalPayload.self, from: encoded)
+        XCTAssertNil(decoded.groupSecretNew)
+        XCTAssertNil(decoded.saltNew)
+        XCTAssertEqual(decoded, try victimVariant())
+    }
+
+    // MARK: - Frozen wire vector (Android parity)
+
+    func test_decode_wireVector() throws {
+        // Frozen wire shape — Android's MemberRemovalPayloadTest
+        // encodes these exact values; both platforms must decode it.
+        let text = """
+        {
+          "removal_version": 1,
+          "removal_group_id": "\(groupID.base64EncodedString())",
+          "removal_member_bls_hex": "\(victimHex)",
+          "removal_commitment": "\(commitment.base64EncodedString())",
+          "removal_epoch": 3,
+          "removal_sent_at_millis": 1700000000000,
+          "group_secret_new": "\(secretNew.base64EncodedString())",
+          "salt_new": "\(saltNew.base64EncodedString())"
+        }
+        """
+        let decoded = try JSONDecoder().decode(
+            MemberRemovalPayload.self,
+            from: Data(text.utf8)
+        )
+        XCTAssertEqual(decoded, try memberVariant())
+    }
+
+    // MARK: - Trial-decode disjointness (both directions)
+
+    func test_removal_doesNotDecodeAsAnyOtherInboxPayload() throws {
+        let wire = try JSONEncoder().encode(memberVariant())
+        XCTAssertNil(try? JSONDecoder().decode(GroupInviteOfferPayload.self, from: wire))
+        XCTAssertNil(try? JSONDecoder().decode(GroupStateRefreshRequest.self, from: wire))
+        XCTAssertNil(try? JSONDecoder().decode(MemberAnnouncementPayload.self, from: wire))
+        XCTAssertNil(try? JSONDecoder().decode(GroupInvitationPayload.self, from: wire))
+        XCTAssertNil(try? JSONDecoder().decode(GroupAvatarPayload.self, from: wire))
+        XCTAssertNil(try? JSONDecoder().decode(GroupNamePayload.self, from: wire))
+        XCTAssertNil(try? JSONDecoder().decode(ChatReceiptPayload.self, from: wire))
+        XCTAssertNil(try? JSONDecoder().decode(ChatMessagePayload.self, from: wire))
+    }
+
+    func test_otherInboxPayloads_doNotDecodeAsRemoval() throws {
+        let announcement = try JSONEncoder().encode(
+            try MemberAnnouncementPayload(
+                version: 1,
+                groupId: groupID,
+                newMember: try MemberAnnouncementPayload.AnnouncedMember(
+                    blsPub: Data(repeating: 0xBB, count: 48),
+                    inboxPub: Data(repeating: 0xCC, count: 32),
+                    alias: "Bob",
+                    sendingPub: Data(repeating: 0xDE, count: 32)
+                ),
+                adminAlias: "Alice",
+                commitment: commitment,
+                epoch: 3
+            )
+        )
+        XCTAssertNil(try? JSONDecoder().decode(MemberRemovalPayload.self, from: announcement))
+
+        let invitation = try JSONEncoder().encode(
+            GroupInvitationPayload(
+                version: 1,
+                groupID: groupID,
+                groupSecret: secretNew,
+                name: "Family",
+                members: [],
+                epoch: 3,
+                salt: saltNew,
+                commitment: commitment,
+                tierRaw: SEPTier.small.rawValue,
+                groupTypeRaw: SEPGroupType.tyranny.rawValue,
+                adminPubkeyHex: victimHex
+            )
+        )
+        XCTAssertNil(try? JSONDecoder().decode(MemberRemovalPayload.self, from: invitation))
+    }
+
+    // MARK: - Shape validation
+
+    func test_init_rejectsWrongSizes() {
+        XCTAssertThrowsError(try MemberRemovalPayload(
+            version: 1, groupID: Data(repeating: 0xAA, count: 31),
+            removedBlsHex: victimHex, commitment: commitment,
+            epoch: 3, sentAtMillis: 0
+        ))
+        XCTAssertThrowsError(try MemberRemovalPayload(
+            version: 1, groupID: groupID,
+            removedBlsHex: "ab", commitment: commitment,
+            epoch: 3, sentAtMillis: 0
+        ))
+        XCTAssertThrowsError(try MemberRemovalPayload(
+            version: 1, groupID: groupID,
+            removedBlsHex: victimHex, commitment: Data(repeating: 0xDD, count: 16),
+            epoch: 3, sentAtMillis: 0
+        ))
+        XCTAssertThrowsError(try MemberRemovalPayload(
+            version: 1, groupID: groupID,
+            removedBlsHex: victimHex, commitment: commitment,
+            epoch: 3, sentAtMillis: 0,
+            groupSecretNew: Data(repeating: 0x11, count: 16)
+        ))
+        XCTAssertThrowsError(try MemberRemovalPayload(
+            version: 1, groupID: groupID,
+            removedBlsHex: victimHex, commitment: commitment,
+            epoch: 3, sentAtMillis: 0,
+            saltNew: Data(repeating: 0x22, count: 16)
+        ))
+    }
+
+    func test_decode_rejectsWrongSizedGroupID() throws {
+        let text = """
+        {
+          "removal_version": 1,
+          "removal_group_id": "\(Data(repeating: 0xAA, count: 16).base64EncodedString())",
+          "removal_member_bls_hex": "\(victimHex)",
+          "removal_commitment": "\(commitment.base64EncodedString())",
+          "removal_epoch": 3,
+          "removal_sent_at_millis": 1700000000000
+        }
+        """
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(MemberRemovalPayload.self, from: Data(text.utf8))
+        )
+    }
+}

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -80,6 +80,54 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         XCTAssertEqual(listed[0].memberProfiles, profiles)
     }
 
+    func test_insertOrUpdate_roundtripsRevokedProfileAndMembershipRevoked() async {
+        let victimHex = "33".repeated(48)
+        var group = makeGroup(
+            id: "ac".repeated(32),
+            name: "Removals",
+            memberProfiles: [
+                victimHex: MemberProfile(
+                    alias: "victim",
+                    inboxPublicKey: Data(repeating: 0xCC, count: 32),
+                    sendingPubkey: Data(repeating: 0xE3, count: 32),
+                    revoked: true
+                ),
+            ]
+        )
+        group.membershipRevoked = true
+        _ = await store.insertOrUpdate(group)
+
+        let listed = await store.list()
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed[0].memberProfiles[victimHex]?.revoked, true,
+                       "the tombstone must survive the encrypted round-trip")
+        XCTAssertTrue(listed[0].membershipRevoked)
+    }
+
+    func test_insertOrUpdate_membershipRevokedDefaultsFalse() async {
+        let group = makeGroup(id: "ad".repeated(32), name: "Active")
+        _ = await store.insertOrUpdate(group)
+
+        let listed = await store.list()
+        XCTAssertFalse(listed[0].membershipRevoked)
+        XCTAssertEqual(listed[0].memberProfiles.values.filter(\.revoked).count, 0)
+    }
+
+    /// Legacy persisted JSON (and pre-removal wire payloads) carry no
+    /// `revoked` key — they must decode as active members.
+    func test_memberProfile_legacyJSONWithoutRevokedKey_decodesAsActive() throws {
+        let legacy = """
+        {
+          "alias": "old-timer",
+          "inbox_public_key": "\(Data(repeating: 0xAA, count: 32).base64EncodedString())",
+          "sending_pubkey": "\(Data(repeating: 0xBB, count: 32).base64EncodedString())"
+        }
+        """
+        let decoded = try JSONDecoder().decode(MemberProfile.self, from: Data(legacy.utf8))
+        XCTAssertFalse(decoded.revoked)
+        XCTAssertEqual(decoded.alias, "old-timer")
+    }
+
     func test_insertOrUpdate_emptyProfilesRoundtripAsEmptyDict() async {
         let group = makeGroup(id: "cd".repeated(32), name: "No profiles")
         _ = await store.insertOrUpdate(group)

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -90,7 +90,8 @@ final class SwiftDataGroupStoreTests: XCTestCase {
                     alias: "victim",
                     inboxPublicKey: Data(repeating: 0xCC, count: 32),
                     sendingPubkey: Data(repeating: 0xE3, count: 32),
-                    revoked: true
+                    revoked: true,
+                    statusEpoch: 7
                 ),
             ]
         )
@@ -101,6 +102,8 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         XCTAssertEqual(listed.count, 1)
         XCTAssertEqual(listed[0].memberProfiles[victimHex]?.revoked, true,
                        "the tombstone must survive the encrypted round-trip")
+        XCTAssertEqual(listed[0].memberProfiles[victimHex]?.statusEpoch, 7,
+                       "the status epoch must survive the encrypted round-trip")
         XCTAssertTrue(listed[0].membershipRevoked)
     }
 
@@ -114,7 +117,8 @@ final class SwiftDataGroupStoreTests: XCTestCase {
     }
 
     /// Legacy persisted JSON (and pre-removal wire payloads) carry no
-    /// `revoked` key — they must decode as active members.
+    /// `revoked` / `status_epoch` keys — they must decode as active
+    /// members with no status marker.
     func test_memberProfile_legacyJSONWithoutRevokedKey_decodesAsActive() throws {
         let legacy = """
         {
@@ -125,7 +129,37 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         """
         let decoded = try JSONDecoder().decode(MemberProfile.self, from: Data(legacy.utf8))
         XCTAssertFalse(decoded.revoked)
+        XCTAssertNil(decoded.statusEpoch, "legacy profiles carry no status epoch")
         XCTAssertEqual(decoded.alias, "old-timer")
+    }
+
+    /// `status_epoch` round-trips through JSON both ways (wire parity
+    /// with Android's `MemberProfile.statusEpoch`).
+    func test_memberProfile_statusEpoch_roundTripsThroughJSON() throws {
+        let profile = MemberProfile(
+            alias: "peer",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: Data(repeating: 0xBB, count: 32),
+            revoked: false,
+            statusEpoch: 5
+        )
+        let encoded = try JSONEncoder().encode(profile)
+        let text = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertTrue(text.contains("\"status_epoch\":5"))
+        let decoded = try JSONDecoder().decode(MemberProfile.self, from: encoded)
+        XCTAssertEqual(decoded, profile)
+
+        // Nil status epoch omits the key entirely (wire-compatible
+        // with legacy decoders on both platforms).
+        let bare = MemberProfile(
+            alias: "peer",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: Data(repeating: 0xBB, count: 32)
+        )
+        let bareText = try XCTUnwrap(
+            String(data: try JSONEncoder().encode(bare), encoding: .utf8)
+        )
+        XCTAssertFalse(bareText.contains("status_epoch"))
     }
 
     func test_insertOrUpdate_emptyProfilesRoundtripAsEmptyDict() async {


### PR DESCRIPTION
## Summary

iOS twin of onymchat/onym-android#192 — the founder removes a member from a Tyranny group, expressed as the existing `update_commitment` over the shrunken roster, with **groupSecret rotation** delivered per-recipient.

- **Wire**: `MemberRemovalPayload` mirrors the Android-authored format exactly (`removal_*` required keys, trial-decode-disjoint from every other inbox payload). The victim's copy omits `group_secret_new`/`salt_new` entirely — the removed member learns the fact, never the secrets. Cross-platform parity is pinned by decoding Android's frozen wire vector in `MemberRemovalPayloadTests`.
- **Admin side**: `removeMember` on `JoinRequestApprover`, serialized through the same `approvalChain` as approvals (both are read-prove-anchor-persist; interleaving would prove against a stale epoch). Ordering: anchor → persist → best-effort fanout.
- **Tombstone, never delete**: `MemberProfile.revoked` keeps past-message rendering and dedup intact while chat sender auth, mutation auth, salt-bearing refresh replies, and all fanout loops reject/skip removed members. Re-admission overwrites the tombstone.
- **Victim device**: `ChatGroup.membershipRevoked` (defaulted optional SwiftData column — lightweight migration, no store wipe): history readable, `ChatInputPanelView` swaps to a localized "You were removed from this group" banner, `SendMessageInteractor` throws `.removedFromGroup`.
- **Receive side**: converge-forward chain verification plus a bounded 12s/24s retry when the cached chain read lags the just-landed anchor.
- **UI**: admin-only destructive remove button + confirmation dialog + in-flight spinner on `ChatMembersView`; en + ru catalog entries.

## Test plan

- [x] Full `OnymIOSTests` target green on the iPhone 17 Pro Max simulator (90 suites, 0 failures) — new: `MemberRemovalPayloadTests`, `IncomingMessageDispatcherRemovalTests` (incl. chain-behind retry + idempotency counting chain reads), `JoinRequestApproverRemovalTests` (real `Tyranny.proveUpdate` on `.small`; both fanout envelopes decrypted with real X25519 keys — victim copy proven secret-free); `SwiftDataGroupStoreTests` extended
- [ ] Cross-platform 3-member session with the onym-android sibling (remove one member; victim banner + send refusal, remaining members converse on the rotated secret, restarted device converges via inbox replay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)