### PR TITLE
fix(group): tombstone consumed intro requests so replays can't resurrect them

### DIFF
--- a/Sources/OnymIOS/Group/IntroRequestStore.swift
+++ b/Sources/OnymIOS/Group/IntroRequestStore.swift
@@ -19,7 +19,14 @@ protocol IntroRequestStore: Sendable {
     func record(_ request: IntroRequest) async -> Bool
 
     /// Drop a request after the user has acted on it (Approve or
-    /// Decline) so it stops cluttering the surface.
+    /// Decline) so it stops cluttering the surface, and remember its
+    /// id so a replay can't resurrect it.
+    ///
+    /// Conformers MUST tombstone. `NostrInboxTransport`'s REQ carries
+    /// no `since` and no `limit`, so every relay reconnect re-delivers
+    /// the intro inbox in full. Dropping the row from `pending` alone
+    /// means the next replay re-records it and the user sees a request
+    /// they already handled.
     func consume(id: String) async
 
     /// Snapshot read used by tests + bootstrap reads. UI prefers
@@ -29,10 +36,16 @@ protocol IntroRequestStore: Sendable {
 
 actor InMemoryIntroRequestStore: IntroRequestStore {
     private var pending: [IntroRequest] = []
+    /// Event ids the user already acted on. Process-lifetime, matching
+    /// `pending`: a relaunch legitimately re-surfaces anything the user
+    /// never got round to (the type doc's contract), but within a
+    /// session an approved or declined row must stay gone.
+    private var consumed: Set<String> = []
     private var continuations: [UUID: AsyncStream<[IntroRequest]>.Continuation] = [:]
 
     @discardableResult
     func record(_ request: IntroRequest) async -> Bool {
+        if consumed.contains(request.id) { return false }
         if pending.contains(where: { $0.id == request.id }) { return false }
         pending.append(request)
         publish()
@@ -40,6 +53,10 @@ actor InMemoryIntroRequestStore: IntroRequestStore {
     }
 
     func consume(id: String) async {
+        // Tombstone unconditionally, even when the id isn't pending, so
+        // a tombstone can be laid ahead of a replay that hasn't landed
+        // yet.
+        consumed.insert(id)
         let before = pending.count
         pending.removeAll { $0.id == id }
         if pending.count != before { publish() }


### PR DESCRIPTION
`NostrInboxTransport`'s REQ sets neither `since` nor `limit`, so every relay reconnect re-delivers an intro inbox in full. `consume` only removed the row from `pending` and `record` only deduped against `pending`, so a replayed request the user had already approved or declined was re-recorded as if it were new.

Today that stays invisible: approving also revokes the intro key, so the replayed copy fails to decrypt in `decode` and never reaches the UI. The masking disappears the moment invite links become multi-use and the key outlives the first approval — hence fixing the store first, on its own terms.

`consume` now tombstones the event id unconditionally (even when the id isn't pending, so a tombstone can be laid ahead of a slow replay) and `record` rejects a tombstoned id. Process-lifetime, same posture as `pending`: a relaunch still re-surfaces anything the user never acted on.

**Base of the multi-use-invite-links stack.** It must land before or with the burn removal, never after — landing it later leaves a window where approved requests resurrect on relaunch.

Verified: full unit suite green (`-only-testing:OnymIOSTests`), `scripts/lint-secrets.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)