### PR TITLE
feat(group): one reusable invite link per group instead of one per share

### DIFF
--- a/Sources/OnymIOS/Group/IntroCapability.swift
+++ b/Sources/OnymIOS/Group/IntroCapability.swift
@@ -219,6 +219,15 @@ struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
         let e = JSONEncoder()
         // Default `.base64` + matches Android `Base64.getEncoder()`.
         e.dataEncodingStrategy = .base64
+        // `JSONEncoder` does not guarantee key order without this, so
+        // one capability could encode to two different link strings.
+        // That matters now that invite links are multi-use and the
+        // share screen re-surfaces the *same* capability on every
+        // entry: without sorting, the user sees the URL change even
+        // though the underlying key hasn't. Decoding is key-order
+        // agnostic on both platforms, so previously-shared links are
+        // unaffected.
+        e.outputFormatting = .sortedKeys
         return e
     }()
 

--- a/Sources/OnymIOS/Group/IntroKeyEntry.swift
+++ b/Sources/OnymIOS/Group/IntroKeyEntry.swift
@@ -15,9 +15,19 @@ import Foundation
 /// - `groupId` is the on-chain `group_id` the invite is for —
 ///   needed when the inviter's app surfaces "Bob wants to join
 ///   <group>?" so it can render the group's name.
-/// - `createdAt` drives optional expiration UI (later PRs may
-///   prune invites older than N days).
+/// - `createdAt` drives both the enforced TTL (`lifetime`) and the
+///   share screen's reuse-or-mint decision.
 struct IntroKeyEntry: Equatable, Sendable {
+    /// How long a minted invite link stays honored — 24 hours per
+    /// issue onymchat/onym-ios#111. Mirrors onym-android's
+    /// `IntroKeyEntry.LIFETIME_MILLIS`.
+    ///
+    /// This window is the only bound on a link: it is redeemable by
+    /// any number of joiners until it expires. Nothing retires a key
+    /// early — `KeychainIntroKeyStore` filters expired entries out at
+    /// its single read point, and neither Approve nor Decline revokes.
+    static let lifetime: TimeInterval = 24 * 60 * 60
+
     let introPublicKey: Data
     let introPrivateKey: Data
     let ownerIdentityID: IdentityID
@@ -42,5 +52,18 @@ struct IntroKeyEntry: Equatable, Sendable {
         self.ownerIdentityID = ownerIdentityID
         self.groupId = groupId
         self.createdAt = createdAt
+    }
+
+    /// `true` while this entry is still inside its 24h window.
+    ///
+    /// `KeychainIntroKeyStore.loadAll` enforces the same rule at its
+    /// single read point, with the matching strict comparison so the
+    /// two boundaries can't drift. `InviteIntroducer.currentOrMint`
+    /// re-checks here rather than trusting the store, which keeps the
+    /// reuse-or-mint decision a pure function of the entry and a clock
+    /// — and therefore reachable from `InMemoryIntroKeyStore`, which
+    /// has no TTL of its own.
+    func isLive(at now: Date) -> Bool {
+        now.timeIntervalSince(createdAt) < Self.lifetime
     }
 }

--- a/Sources/OnymIOS/Group/InviteIntroducer.swift
+++ b/Sources/OnymIOS/Group/InviteIntroducer.swift
@@ -10,10 +10,23 @@ import CryptoKit
 /// the Keychain write is the dominant cost (single `SecItemUpdate`).
 /// Cheap enough for the foreground tap handler to await directly.
 ///
-/// **Why one keypair per invite instead of one per identity**: per-
-/// link revocation. The inviter can stop listening on a specific
-/// intro tag → that link goes silent without affecting other
-/// outstanding invites. A leaked link only burns its own slot.
+/// **Two entry points, deliberately**:
+///  - `currentOrMint` — the shared-link path. Hands back the
+///    identity's existing live key for the group when there is one,
+///    minting only when there isn't. Invite links are multi-use: one
+///    keypair serves every joiner who redeems the link inside
+///    `IntroKeyEntry.lifetime`, so re-opening the share screen must
+///    return the same link rather than stacking a fresh relay REQ slot
+///    per visit.
+///  - `mint` — always a fresh keypair. `CreateGroupInteractor`'s
+///    create-time offers want one key per invitee so an inbound join
+///    request maps 1:1 back to the person the admin meant to invite.
+///
+/// **Why a keypair per link instead of one per identity**: the intro
+/// key is the only thing that can decrypt requests aimed at it, so
+/// scoping it to one group means a leaked link exposes that group's
+/// request channel and nothing else — and expiry retires it without
+/// touching any other invite.
 actor InviteIntroducer {
     private let store: any IntroKeyStore
     private let now: @Sendable () -> Date
@@ -61,6 +74,58 @@ actor InviteIntroducer {
 
         return try IntroCapability(
             introPublicKey: pubBytes,
+            groupId: groupId,
+            groupName: groupName
+        )
+    }
+
+    /// The group's current invite capability for `ownerIdentityID`,
+    /// minting one only when no live key exists.
+    ///
+    /// Invite links are multi-use, so the share screen is a view onto
+    /// the group's live link rather than a link factory: re-entering it
+    /// must surface the same link instead of leaving a trail of live
+    /// intro slots, each costing a relay REQ slot until it ages out.
+    ///
+    /// Reuse deliberately does not re-stamp `createdAt`. The 24h cap is
+    /// absolute per link, not a sliding window, so a link that has been
+    /// circulating for 23 hours still goes dark in one.
+    ///
+    /// Scoped to `ownerIdentityID` on purpose: `IntroInboxPump` is
+    /// wired to `entriesStream(forOwner: activeID)`, so it only listens
+    /// on the *active* identity's intro inboxes. Handing back a key
+    /// another identity minted would produce a link nobody is
+    /// subscribed to. Two identities sharing one group each get their
+    /// own key; that's correct, not duplication.
+    ///
+    /// - Note: `store.listForOwner` is contractually newest-first, so
+    ///   the first match is the freshest key for the group.
+    func currentOrMint(
+        ownerIdentityID: IdentityID,
+        groupId: Data,
+        groupName: String? = nil
+    ) async throws -> IntroCapability {
+        // Checked ahead of the store read so a malformed id can't cause
+        // a pointless `listForOwner` pass, and so the throw is the same
+        // whichever branch would have run.
+        guard groupId.count == 32 else {
+            throw IntroducerError.invalidGroupID(actualSize: groupId.count)
+        }
+
+        let reference = now()
+        let live = await store.listForOwner(ownerIdentityID).first {
+            $0.groupId == groupId && $0.isLive(at: reference)
+        }
+        if let live {
+            return try IntroCapability(
+                introPublicKey: live.introPublicKey,
+                groupId: groupId,
+                groupName: groupName
+            )
+        }
+
+        return try await mint(
+            ownerIdentityID: ownerIdentityID,
             groupId: groupId,
             groupName: groupName
         )

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -29,7 +29,12 @@ actor KeychainIntroKeyStore: IntroKeyStore {
     /// subscribing their inboxes, which each cost a relay REQ slot)
     /// and are compacted out of the blob by the load that first sees
     /// them expired.
-    static let entryTTL: TimeInterval = 24 * 60 * 60
+    ///
+    /// This window is the *only* bound on a link: inside it, one link
+    /// is redeemable by any number of joiners. Homed on
+    /// `IntroKeyEntry` so the introducer's reuse-or-mint decision and
+    /// this store's read filter can't drift apart.
+    static let entryTTL: TimeInterval = IntroKeyEntry.lifetime
 
     private let service: String
     /// Per-owner subscriber continuations. Mutations re-emit the

--- a/Sources/OnymIOS/Group/ShareInviteFlow.swift
+++ b/Sources/OnymIOS/Group/ShareInviteFlow.swift
@@ -2,15 +2,17 @@ import Foundation
 import Observation
 
 /// Drives the post-create "Share invite" surface. Owns one piece of
-/// state — the share link for the just-minted invite — and exposes
-/// one intent (`mintFor`) to refresh / re-mint.
+/// state — the group's share link — and exposes one intent
+/// (`mintFor`) to load or refresh it.
 ///
-/// Why minting is decoupled from the view's first appearance:
-/// minting is a side effect (writes to `IntroKeyStore`); doing it
-/// in `.onAppear` ties it to view lifecycle (re-entries would mint
-/// twice). This flow holds the side effect off the view tree where
-/// it belongs. The view calls `mintFor` exactly once on appear,
-/// re-mint requires an explicit "Generate new link" tap.
+/// Why resolving the link is decoupled from the view's first
+/// appearance: it touches `IntroKeyStore`, and doing that in
+/// `.onAppear` ties a store write to view lifecycle. This flow holds
+/// the side effect off the view tree where it belongs.
+///
+/// Re-entry is cheap and idempotent — invite links are multi-use, so
+/// `InviteIntroducer.currentOrMint` hands back the group's existing
+/// live key instead of stacking a new one per visit.
 ///
 /// Mirrors onym-android's `ShareInviteViewModel.kt`.
 @MainActor
@@ -45,10 +47,11 @@ final class ShareInviteFlow: Identifiable {
         self.groupRepository = groupRepository
     }
 
-    /// Mint a fresh capability for the group with hex id `groupID` and
-    /// surface the share link. Idempotent for repeated taps from the
-    /// same screen — re-mints a fresh keypair so each share goes
-    /// through a distinct intro slot (per-link revocation friendly).
+    /// Resolve the share link for the group with hex id `groupID` and
+    /// surface it. Idempotent: repeated calls (screen re-entry, Retry
+    /// tap) return the *same* link while the group's intro key is
+    /// inside its 24h `IntroKeyEntry.lifetime`, and only mint a fresh
+    /// keypair once that key has expired. One link, many joiners.
     ///
     /// If `groupID` does not resolve to a local group (race between
     /// persistence + navigation, or a stale deeplink back into share)
@@ -70,7 +73,7 @@ final class ShareInviteFlow: Identifiable {
         }
         state = .minting
         do {
-            let cap = try await introducer.mint(
+            let cap = try await introducer.currentOrMint(
                 ownerIdentityID: activeID,
                 groupId: group.groupIDData,
                 groupName: group.name

--- a/Sources/OnymIOS/Group/ShareInviteView.swift
+++ b/Sources/OnymIOS/Group/ShareInviteView.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 
 /// Post-create surface. The just-created group is identified by hex
-/// `groupID`; the flow resolves it from the repository, mints a
-/// fresh deeplink capability, and surfaces the link. The user
+/// `groupID`; the flow resolves it from the repository, resolves the
+/// group's deeplink capability, and surfaces the link. The user
 /// shares via the system share sheet, copies it, or skips.
 ///
-/// Mints exactly once per screen entry — re-entry (after Done →
-/// back) re-mints with a fresh intro keypair so the previous share
-/// stays revocable independently.
+/// Loads the link on each screen entry, which is idempotent: the
+/// invite link is multi-use, so the flow hands back the group's
+/// existing live capability rather than minting a new keypair per
+/// visit. A QR code the user already screenshotted keeps working.
 struct ShareInviteView: View {
     let groupID: String
     @Bindable var flow: ShareInviteFlow

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -82,7 +82,7 @@ final class ShareInviteFlowTests: XCTestCase {
         XCTAssertEqual(listed.count, 0)
     }
 
-    func test_mintFor_calledTwice_mintsTwoIndependentKeypairs() async throws {
+    func test_mintFor_fromASecondFlowOverTheSameStore_reusesTheLiveLink() async throws {
         let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
         _ = try await identity.bootstrap()
         let resolved = await identity.currentSelectedID()
@@ -94,35 +94,41 @@ final class ShareInviteFlowTests: XCTestCase {
         let groupRepo = GroupRepository(store: store, currentIdentityID: owner)
         let introKeyStore = InMemoryIntroKeyStore()
         let introducer = InviteIntroducer(store: introKeyStore)
-        let flow = ShareInviteFlow(
+
+        // Two separate flows over one store, not two calls on one flow.
+        // That's the real production path — `ChatMembersView` builds a
+        // fresh flow per toolbar tap — and it's deterministic: the
+        // second flow starts `.idle`, so waiting for `.ready` genuinely
+        // awaits its resolution rather than observing the first flow's
+        // already-`.ready` state.
+        let first = ShareInviteFlow(
             identity: identity,
             introducer: introducer,
             groupRepository: groupRepo
         )
-
-        flow.mintFor(groupID: group.id)
-        try await waitFor { flow.state.isReady }
-        guard case .ready(let firstLink, _) = flow.state else {
+        first.mintFor(groupID: group.id)
+        try await waitFor { first.state.isReady }
+        guard case .ready(let firstLink, _) = first.state else {
             return XCTFail("expected first .ready")
         }
 
-        flow.mintFor(groupID: group.id)
-        // Wait for the link to actually change (the second mint emits
-        // `.minting` then `.ready` again).
-        try await waitFor {
-            if case .ready(let link, _) = flow.state, link != firstLink { return true }
-            return false
-        }
-        guard case .ready(let secondLink, _) = flow.state else {
+        let second = ShareInviteFlow(
+            identity: identity,
+            introducer: introducer,
+            groupRepository: groupRepo
+        )
+        second.mintFor(groupID: group.id)
+        try await waitFor { second.state.isReady }
+        guard case .ready(let secondLink, _) = second.state else {
             return XCTFail("expected second .ready")
         }
 
-        // Per-link revocation depends on this — re-shares cannot
-        // collapse to the same intro slot or revoking one would kill
-        // the other.
-        XCTAssertNotEqual(firstLink, secondLink, "two shares should produce different links")
+        // Invite links are multi-use, so the share screen is a view onto
+        // the group's live link, not a link factory. Re-entry must not
+        // leave a trail of live intro slots.
+        XCTAssertEqual(firstLink, secondLink, "re-entry should surface the same link")
         let listed = await introKeyStore.listForOwner(owner)
-        XCTAssertEqual(listed.count, 2)
+        XCTAssertEqual(listed.count, 1, "reuse must not persist a second intro slot")
     }
 
     func test_state_transitionsThroughMinting() async throws {


### PR DESCRIPTION
Stacked on #209.

Every entry into the share screen minted a fresh intro keypair, so a group accumulated a new live link — and a new relay REQ slot — per visit, each valid for the full 24h TTL. That made sense while a link was burned on first use; it does not once links are multi-use.

`InviteIntroducer.currentOrMint` returns the identity's newest live key for the group and mints only when there isn't one. `ShareInviteFlow` uses it. `mint` is untouched: `CreateGroupInteractor.sendOffers` still wants one key per invitee so an inbound request maps 1:1 back to the intended person.

Two details worth review attention:

- Reuse deliberately does **not** re-stamp `createdAt`. The 24h cap is absolute per link, not a sliding window, so a link circulating for 23 hours still goes dark in one.
- The liveness predicate is `IntroKeyEntry.isLive(at:)` rather than trusting the store's filter. That keeps the decision a pure function of the entry and a clock, and therefore reachable from `InMemoryIntroKeyStore`, which has no TTL of its own. `KeychainIntroKeyStore.entryTTL` now aliases `IntroKeyEntry.lifetime` so the two boundaries can't drift.

Scoping to the owning identity is deliberate: the intro pump subscribes only the active identity's tags, so reusing another identity's key would hand out a link nobody is listening on.

Also includes a genuine bug this surfaced. `JSONEncoder` makes no key-order guarantee, so one capability could serialize to two different link strings run-to-run. Invisible while every share minted a fresh key; very visible once the screen re-surfaces the *same* capability. `.sortedKeys` makes the encoding a pure function of the capability; decoding is key-order agnostic on both platforms, so links already in circulation keep working.

The test that asserted the old behaviour (`mintFor_calledTwice_mintsTwoIndependentKeypairs`) is replaced by a reuse assertion driven through two separate flows over one store — the real production path, since `ChatMembersView` builds a fresh flow per toolbar tap.

Verified: full unit suite green, `scripts/lint-secrets.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)