### PR TITLE
feat(group): invite links are multi-use — approve/decline stop burning them

### DIFF
--- a/Sources/OnymIOS/Group/IntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/IntroKeyStore.swift
@@ -14,7 +14,8 @@ import Foundation
 ///     payload.
 ///  4. On Approve, sender seals the existing
 ///     `GroupInvitationPayload` to the joiner's identity inbox key.
-///     `revoke` is called to retire the intro slot.
+///     The intro key is NOT retired: one link serves many joiners
+///     until `IntroKeyEntry.lifetime` expires.
 ///
 /// Owner-scoping: every entry carries an `IdentityID`. Removing an
 /// identity cascades a `deleteForOwner` so we don't leak intro
@@ -38,9 +39,15 @@ protocol IntroKeyStore: Sendable {
     /// list reads here.
     func listForOwner(_ ownerIdentityID: IdentityID) async -> [IntroKeyEntry]
 
-    /// Single-entry deletion. Called after a request is accepted +
-    /// sealed → the intro slot is no longer useful. No-op if the
-    /// pubkey isn't present.
+    /// Single-entry deletion. **No production caller** since invite
+    /// links went multi-use: Approve and Decline both leave the key
+    /// alive so the rest of the link's holders can still join, and
+    /// expiry is handled by the TTL filter in the store's read path.
+    ///
+    /// Retained as the seam a future "kill this link" affordance would
+    /// use, and because the store must be able to destroy one intro
+    /// *private* key on demand. Exercised by `InviteIntroducerTests`.
+    /// No-op if the pubkey isn't present.
     func revoke(introPublicKey: Data) async
 
     /// Cascade for the identity-removal flow. Returns the count of

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -26,10 +26,13 @@ protocol JoinRequestApproving: Sendable {
 ///     Approve?" prompts.
 ///  3. On Approve → seals the existing `GroupInvitationPayload`
 ///     (built from the local `ChatGroup`) to the joiner's identity
-///     inbox key, ships via `inboxTransport.send`, revokes the
-///     intro key. The pump from PR-3 stops listening on that intro
-///     tag within one emission window.
-///  4. On Decline → drop the request, revoke the intro key. No
+///     inbox key and ships via `inboxTransport.send`. The intro key
+///     is deliberately NOT retired: invite links are multi-use, so
+///     the same `IntroKeyEntry` must keep decrypting requests from
+///     everyone else the inviter shared the link with. The link's
+///     only bound is `IntroKeyEntry.lifetime` (24h).
+///  4. On Decline → drop that one request. Nothing else: the link
+///     stays live so declining Bob can't silently lock out Carol. No
 ///     NACK to the joiner; their JoinScreen times out gracefully.
 actor JoinRequestApprover: JoinRequestApproving {
 
@@ -115,6 +118,10 @@ actor JoinRequestApprover: JoinRequestApproving {
     private let makeContractTransport: @Sendable (URL) -> any SEPContractTransport
 
     private var pendingValue: [PendingRequest] = []
+    /// Surviving pending-row id → every raw `IntroRequest.id` that
+    /// collapsed into it (the winner included). Rebuilt by `refresh`,
+    /// read by `consumeRequestAndSiblings`.
+    private var collapsedRequestIDs: [String: [String]] = [:]
     private var pendingContinuations: [UUID: AsyncStream<[PendingRequest]>.Continuation] = [:]
     private var decryptFailures: Int = 0
     private var collectorTask: Task<Void, Never>?
@@ -230,7 +237,10 @@ actor JoinRequestApprover: JoinRequestApproving {
     ///      (members, commitment, epoch, salt), seal + ship the
     ///      `GroupInvitationPayload` (with new state) to the joiner,
     ///      fanout `MemberAnnouncementPayload` (also with new state)
-    ///      to existing members, revoke intro key + consume request.
+    ///      to existing members, consume the request. The intro key
+    ///      survives — see the type doc.
+    ///   8. A joiner already in `group.members` skips steps 2-6
+    ///      entirely and only gets the current snapshot re-shipped.
     ///
     /// Failures at the proof / anchor steps return without mutating
     /// any local state or consuming the request, so the admin can
@@ -255,10 +265,36 @@ actor JoinRequestApprover: JoinRequestApproving {
             return .unknownGroup
         }
 
+        // Re-join recovery path: this joiner is ALREADY in the group's
+        // cryptographic roster. They reinstalled and lost local state,
+        // the relay replayed an old request on this still-live intro
+        // tag, or an earlier approve anchored and then failed at
+        // seal+ship. Extending the Merkle tree again would push a
+        // duplicate leaf and burn an epoch for nothing, so skip the
+        // anchor and just re-seal + re-ship the current invitation.
+        //
+        // Keyed on `members` — the roster `anchorTyrannyJoin` actually
+        // mutates — and not on `memberProfiles`, which is an
+        // independent app-level directory that can hold entries with no
+        // corresponding leaf. A nil BLS pubkey yields false, preserving
+        // today's behaviour exactly: Tyranny already short-circuits to
+        // `.outdatedJoinerClient`, and the ship-only path already gates
+        // its side effects on `if let blsPub`.
+        //
+        // This also hardens the double-tapped-Approve race.
+        // `performApprove` reads its row from `pendingValue`, which the
+        // collector only refreshes asynchronously, so two taps can both
+        // find it. `enqueue` serializes them, so the second pass reads
+        // the roster the first pass persisted and degrades to a safe
+        // re-ship instead of a duplicate leaf.
+        let alreadyInRoster = req.joinerBlsPublicKey.map { blsPub in
+            group.members.contains { $0.publicKeyCompressed == blsPub }
+        } ?? false
+
         // PR-13a admin-anchor path is Tyranny-only. Other types fall
         // through to the pre-PR-13 ship-only flow at the bottom.
         var anchored = group
-        if group.groupType == .tyranny {
+        if group.groupType == .tyranny, !alreadyInRoster {
             switch await anchorTyrannyJoin(
                 req: req,
                 group: group,
@@ -333,6 +369,9 @@ actor JoinRequestApprover: JoinRequestApproving {
         // already updated by the anchor step. Both side-effects only
         // run when the joiner shipped a BLS pubkey.
         if let blsPub = req.joinerBlsPublicKey {
+            // Idempotent on the BLS hex key. On the re-join path this is
+            // the whole point of still calling it: a reinstalled joiner
+            // has a new inbox pubkey, and future fanouts read it here.
             await recordJoiner(
                 in: anchored,
                 blsPub: blsPub,
@@ -340,19 +379,28 @@ actor JoinRequestApprover: JoinRequestApproving {
                 sendingPub: req.joinerSendingPublicKey,
                 alias: req.joinerDisplayLabel
             )
-            await broadcastJoin(
-                in: anchored,
-                joinerBlsPub: blsPub,
-                joinerInboxPub: req.joinerInboxPublicKey,
-                joinerSendingPub: req.joinerSendingPublicKey,
-                joinerAlias: req.joinerDisplayLabel
-            )
+            // Skip the fanout on the re-join path. Every peer already
+            // holds this member's profile, and the receive side bails on
+            // a known non-revoked BLS hex before doing anything, so the
+            // broadcast would be N seals + N relay publishes with no
+            // effect on any recipient.
+            if !alreadyInRoster {
+                await broadcastJoin(
+                    in: anchored,
+                    joinerBlsPub: blsPub,
+                    joinerInboxPub: req.joinerInboxPublicKey,
+                    joinerSendingPub: req.joinerSendingPublicKey,
+                    joinerAlias: req.joinerDisplayLabel
+                )
+            }
         }
-        // Best-effort cleanup.
-        if let introPub = await findIntroPub(forRequestID: requestId) {
-            await introKeyStore.revoke(introPublicKey: introPub)
-        }
-        await introRequestStore.consume(id: requestId)
+        // Drop this request and its collapsed siblings. The intro key is
+        // intentionally left alive: one invite link is redeemable by
+        // many joiners inside its 24h TTL, and revoking here would make
+        // `decode` return nil for every other joiner's pending request
+        // — their rows would vanish from the approval surface with no
+        // explanation.
+        await consumeRequestAndSiblings(requestId)
         return .sent
     }
 
@@ -616,13 +664,18 @@ actor JoinRequestApprover: JoinRequestApproving {
         }
     }
 
-    /// Decline a pending request: drop it + revoke the intro slot.
+    /// Decline a pending request: drop that one request and its
+    /// collapsed siblings, and nothing else.
+    ///
+    /// The invite link stays live until `IntroKeyEntry.lifetime`
+    /// expires. A decline is a judgement about one requester, not about
+    /// the link — declining Bob must not silently lock out Carol, who
+    /// is holding the same shared link. There is deliberately no "kill
+    /// this link" action; the 24h TTL is the only bound.
+    ///
     /// No NACK to the joiner — their JoinScreen times out.
     func decline(requestId: String) async {
-        if let introPub = await findIntroPub(forRequestID: requestId) {
-            await introKeyStore.revoke(introPublicKey: introPub)
-        }
-        await introRequestStore.consume(id: requestId)
+        await consumeRequestAndSiblings(requestId)
     }
 
     // MARK: - Private
@@ -653,12 +706,21 @@ actor JoinRequestApprover: JoinRequestApproving {
         // rows and approving/declining one leaves the siblings behind —
         // which reads as "the buttons don't work". Keep the most recently
         // received copy, positioned at the first-seen index.
+        //
+        // Note this re-decodes every raw request on every emission, so a
+        // row's continued existence depends on its intro key still being
+        // findable. That is now stable for the link's full 24h life —
+        // before invite links went multi-use, approving one joiner
+        // revoked the key and made every sibling joiner's row silently
+        // disappear.
         var collapsed: [String: (request: PendingRequest, receivedAt: Date)] = [:]
+        var siblings: [String: [String]] = [:]
         var order: [String] = []
         for r in raw {
             guard let p = await decode(r) else { continue }
             let identity = p.joinerBlsPublicKey ?? p.joinerInboxPublicKey
             let key = Self.hex(identity) + ":" + Self.hex(p.groupId)
+            siblings[key, default: []].append(r.id)
             if let existing = collapsed[key] {
                 if r.receivedAt > existing.receivedAt {
                     collapsed[key] = (p, r.receivedAt)
@@ -669,7 +731,24 @@ actor JoinRequestApprover: JoinRequestApproving {
             }
         }
         pendingValue = order.compactMap { collapsed[$0]?.request }
+        // Surviving row id → every raw request that collapsed into it.
+        // Approve / Decline consume the whole set: dropping only the
+        // winner would let a sibling resurface as a fresh row on the
+        // very next emission, which reads as "the buttons don't work".
+        collapsedRequestIDs = order.reduce(into: [:]) { acc, key in
+            guard let winner = collapsed[key]?.request else { return }
+            acc[winner.id] = siblings[key] ?? [winner.id]
+        }
         publishPending()
+    }
+
+    /// Drop the request behind `requestId` plus every sibling copy that
+    /// collapsed into the same pending row. The intro key is
+    /// deliberately left alive — see the type doc.
+    private func consumeRequestAndSiblings(_ requestId: String) async {
+        for id in collapsedRequestIDs[requestId] ?? [requestId] {
+            await introRequestStore.consume(id: id)
+        }
     }
 
     private static func hex(_ data: Data) -> String {
@@ -726,12 +805,5 @@ actor JoinRequestApprover: JoinRequestApproving {
             groupId: payload.groupId,
             groupName: groupName
         )
-    }
-
-    /// `PendingRequest` doesn't carry the introPub (intentional —
-    /// UI never needs it). Resolve via the raw store on demand.
-    private func findIntroPub(forRequestID id: String) async -> Data? {
-        let raw = await introRequestStore.current()
-        return raw.first { $0.id == id }?.targetIntroPublicKey
     }
 }

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -88,7 +88,7 @@ final class JoinRequestApproverTests: XCTestCase {
 
     // MARK: - approve happy path
 
-    func test_approve_sendsSealedInviteAndConsumesRequest() async throws {
+    func test_approve_sendsSealedInvite_consumesRequest_keepsIntroKeyLive() async throws {
         let env = try await seedEnvironment()
 
         // Pump once: collector reads the seeded request, decodes,
@@ -104,12 +104,15 @@ final class JoinRequestApproverTests: XCTestCase {
         XCTAssertNotNil(toJoiner,
                         "approve must send to the joiner's inbox tag")
 
-        // Request consumed + intro key revoked.
+        // Request consumed, but the link stays usable.
         let remaining = await introRequestStore.current()
         XCTAssertTrue(remaining.isEmpty,
                       "approved request must be consumed from the store")
         let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNil(intro, "intro key must be revoked after approve")
+        XCTAssertNotNil(
+            intro,
+            "intro key must survive approve — one link is redeemable by many joiners"
+        )
     }
 
     // MARK: - duplicate collapse
@@ -168,9 +171,13 @@ final class JoinRequestApproverTests: XCTestCase {
         } else {
             XCTFail("expected .transportFailed, got \(outcome)")
         }
-        let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNotNil(intro,
-                        "intro key must NOT be revoked when transport rejects — caller may retry")
+        // Asserting the intro key survives here is now vacuous — nothing
+        // revokes on any path. The guarantee this path still owes is
+        // that the request stays available so the admin can retry:
+        // `performApprove` returns before consuming it.
+        let remaining = await introRequestStore.current()
+        XCTAssertEqual(remaining.count, 1,
+                       "a transport-rejected request must stay in the store for retry")
     }
 
     // MARK: - PR 4: recordJoiner side effect
@@ -306,7 +313,7 @@ final class JoinRequestApproverTests: XCTestCase {
 
     // MARK: - decline
 
-    func test_decline_dropsRequestAndRevokesKey() async throws {
+    func test_decline_dropsOnlyThatRequest_leavesLinkLive() async throws {
         let env = try await seedEnvironment()
         await env.approver.pumpOnce()
 
@@ -316,7 +323,10 @@ final class JoinRequestApproverTests: XCTestCase {
         XCTAssertTrue(remaining.isEmpty,
                       "declined request must be consumed")
         let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNil(intro, "intro key revoked even on decline")
+        XCTAssertNotNil(
+            intro,
+            "declining one joiner must not kill the link for everyone else holding it"
+        )
         let sends = await transport.sends
         XCTAssertTrue(sends.isEmpty,
                       "decline ships no envelopes")


### PR DESCRIPTION
Stacked on #210. **This is the behavioural change; the two below it are the groundwork.**

An invite link was killed by the first Approve *or* Decline. That gave three bad behaviours:

- **It was already accidentally multi-use.** Two joiners who both send before the first approval both decode, both render as rows, and both can be approved — `performApprove` never re-validated the intro key. "Single use" was a race, not a guarantee.
- **Declining one stranger silently killed the link for everyone else** holding it.
- **After the first approval every other pending joiner's row vanished** with no explanation, because `decode` could no longer find the key.

Make it deliberate. Approve and Decline no longer revoke; a link stays redeemable by any number of joiners until `IntroKeyEntry.lifetime` (24h) retires it. Every join is still gated by an explicit admin tap.

### Three supporting changes fall out of that

**Sibling consumption.** `refresh` collapses copies of one joiner's request into a single row, but Approve/Decline consumed only the tapped id. Dropping only the winner let a sibling resurface on the next emission, which reads as "the buttons don't work". The burn used to hide this by making the siblings undecodable.

**Already-in-roster guard.** A joiner already in `group.members` skips the chain anchor and only gets the current snapshot re-shipped. Without it, a relay replay or a reinstalled joiner re-tapping the link would push a duplicate leaf into the Merkle tree and burn an epoch. Keyed on `members` — the roster the anchor actually mutates — not on `memberProfiles`, which is an independent directory that can hold entries with no leaf. This also makes the long-standing double-tapped-Approve race safe: the second pass reads the roster the first persisted and degrades to a harmless re-ship.

**Fanout skip.** `broadcastJoin` is skipped on the re-join path: every peer already holds the profile and `applyAnnouncement` bails on a known non-revoked BLS hex, so the fanout would be N seals and N publishes for nothing. ⚠️ The Android PR deliberately **keeps** the fanout there, on the grounds that it is the only thing that heals peers after an approve that anchored and then failed at seal+ship. Both arguments are sound — worth settling on one behaviour for both platforms in review rather than shipping the split.

`findIntroPub` loses both call sites and goes. `revoke` stays on the `IntroKeyStore` protocol with a doc saying it has no production caller and why — it is the seam a future "kill this link" affordance needs, and that comment is the guard against someone reinstating the burn.

### Security posture delta

A leaked or screenshotted link used to be worth at most one join attempt, closed by the first tap. It is now a **24-hour open request channel**: anyone holding it can queue unlimited join requests. Nothing is granted without an explicit Approve and the link carries no group secret, so this is a nuisance/DoS surface rather than an access grant — but it is new, and there is no cap on the pending list. A cap or rate window is a reasonable follow-up.

Two other follow-ups worth filing: `SepTier.maxMembers` is enforced nowhere in the join path, and unlimited-use links make overflow plausible for the first time; and the link now silently rotates at 24h while the UI *looks* stable, which is more surprising than when every visit rotated.

Verified: full unit suite green, `scripts/lint-secrets.py` clean. New coverage lands in the test PR on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)