### PR TITLE
test(group): cover multi-use invite links end to end

### DIFF
--- a/Tests/OnymIOSTests/IntroInboxPumpTests.swift
+++ b/Tests/OnymIOSTests/IntroInboxPumpTests.swift
@@ -144,6 +144,49 @@ final class IntroInboxPumpTests: XCTestCase {
         runTask.cancel()
     }
 
+    // MARK: - IntroRequestStore consume tombstone
+
+    func test_record_afterConsume_isRejected_soRelayReplayCannotResurrect() async {
+        let store = InMemoryIntroRequestStore()
+        let request = IntroRequest(
+            id: "evt-1",
+            targetIntroPublicKey: Data(repeating: 0xA1, count: 32),
+            payload: Data([0x01, 0x02]),
+            receivedAt: Date()
+        )
+
+        let recorded = await store.record(request)
+        XCTAssertTrue(recorded)
+        await store.consume(id: request.id)
+
+        // The relay REQ carries no `since`/`limit`, so every reconnect
+        // re-delivers the whole inbox. A handled request must not come
+        // back.
+        let reRecorded = await store.record(request)
+        XCTAssertFalse(reRecorded, "a consumed event id must never be re-recorded")
+        let remaining = await store.current()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_consume_unknownId_stillTombstones_soALateReplayIsRejected() async {
+        let store = InMemoryIntroRequestStore()
+
+        // Tombstone laid before the replay lands — the ordering the
+        // pump can actually produce when a consume races a reconnect.
+        await store.consume(id: "evt-never-seen")
+
+        let late = IntroRequest(
+            id: "evt-never-seen",
+            targetIntroPublicKey: Data(repeating: 0xA1, count: 32),
+            payload: Data([0x03]),
+            receivedAt: Date()
+        )
+        let recordedLate = await store.record(late)
+        XCTAssertFalse(recordedLate)
+        let remaining = await store.current()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func waitFor(

--- a/Tests/OnymIOSTests/InviteIntroducerTests.swift
+++ b/Tests/OnymIOSTests/InviteIntroducerTests.swift
@@ -136,4 +136,153 @@ final class InviteIntroducerTests: XCTestCase {
         XCTAssertNotNil(entry)
         XCTAssertEqual(entry?.createdAt, frozen)
     }
+
+    // MARK: - currentOrMint (multi-use links)
+
+    func test_currentOrMint_noLiveKeyForGroup_mintsAndPersistsOne() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let cap = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed.first?.introPublicKey, cap.introPublicKey)
+    }
+
+    func test_currentOrMint_twiceForSameGroup_returnsSameKey_persistsOneEntry() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let first = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let second = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(first.introPublicKey, second.introPublicKey)
+        // The count is what stops this from being "returns the same
+        // link but still writes a row".
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
+    }
+
+    func test_currentOrMint_differentGroups_doNotShareAKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let g1 = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let g2 = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: other)
+
+        XCTAssertNotEqual(g1.introPublicKey, g2.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 2)
+    }
+
+    func test_currentOrMint_expiredKey_mintsAFreshOne() async throws {
+        let store = InMemoryIntroKeyStore()
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+        // Two introducers because `now` is injected at init; they share
+        // the store, so the second sees the first's (expired) entry.
+        let early = InviteIntroducer(store: store, now: { t0 })
+        let late = InviteIntroducer(
+            store: store,
+            now: { t0.addingTimeInterval(IntroKeyEntry.lifetime + 60) }
+        )
+
+        let first = try await early.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let second = try await late.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(first.introPublicKey, second.introPublicKey)
+    }
+
+    func test_currentOrMint_atExactlyLifetime_isTreatedAsExpired() async throws {
+        let store = InMemoryIntroKeyStore()
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+        let early = InviteIntroducer(store: store, now: { t0 })
+        // Pins the strict comparison in `isLive(at:)` against
+        // `KeychainIntroKeyStore.loadAll`'s cutoff so the two
+        // boundaries can't drift apart.
+        let atBoundary = InviteIntroducer(
+            store: store,
+            now: { t0.addingTimeInterval(IntroKeyEntry.lifetime) }
+        )
+
+        let first = try await early.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let second = try await atBoundary.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(first.introPublicKey, second.introPublicKey)
+    }
+
+    func test_currentOrMint_doesNotReuseAnotherIdentitysLiveKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // The intro pump only subscribes the *active* identity's tags,
+        // so reusing Bob's key for Alice would hand out a link nobody
+        // is listening on.
+        let bobCap = try await introducer.currentOrMint(
+            ownerIdentityID: bob, groupId: sampleGroupId
+        )
+        let aliceCap = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(bobCap.introPublicKey, aliceCap.introPublicKey)
+        let aliceKeys = await store.listForOwner(alice)
+        let bobKeys = await store.listForOwner(bob)
+        XCTAssertEqual(aliceKeys.count, 1)
+        XCTAssertEqual(bobKeys.count, 1)
+    }
+
+    func test_currentOrMint_rejectsWrongSizedGroupId_withoutTouchingTheStore() async {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        do {
+            _ = try await introducer.currentOrMint(
+                ownerIdentityID: alice,
+                groupId: Data(repeating: 0x01, count: 16)
+            )
+            XCTFail("expected IntroducerError.invalidGroupID")
+        } catch IntroducerError.invalidGroupID {
+            // expected
+        } catch {
+            XCTFail("expected IntroducerError.invalidGroupID, got \(error)")
+        }
+
+        let listed = await store.listForOwner(alice)
+        XCTAssertTrue(listed.isEmpty)
+    }
+
+    func test_mint_alwaysMintsFresh_evenWhenALiveKeyExists() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // Locks in the two-entry-point split: collapsing `mint` into
+        // `currentOrMint` would silently break the create-time offers'
+        // 1:1 request-to-invitee mapping.
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let fresh = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        XCTAssertNotEqual(shared.introPublicKey, fresh.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 2)
+    }
 }

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -334,6 +334,253 @@ final class JoinRequestApproverTests: XCTestCase {
 
     // MARK: - Test fixture builder
 
+    // MARK: - multi-use links
+
+    func test_approve_joinerA_thenJoinerBOnTheSameIntroKey_bothJoin() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        var pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 2, "two joiners on one link are two rows")
+
+        let firstOutcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(firstOutcome, .sent)
+
+        // The link survives the first approval — this is the whole
+        // feature. Before, `revoke` here made B's request undecodable
+        // and B's row silently vanished.
+        let intro = await introKeyStore.find(introPublicKey: env.introPub)
+        XCTAssertNotNil(intro, "approving A must not burn the link B is holding")
+
+        await env.approver.pumpOnce()
+        pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "A consumed, B still standing")
+        XCTAssertEqual(pending.first?.joinerBlsPublicKey, second.blsPub)
+
+        let secondOutcome = await env.approver.approve(requestId: second.requestID)
+        XCTAssertEqual(secondOutcome, .sent)
+
+        let snapshotGroup = await groups.currentGroups()
+        let group = try XCTUnwrap(
+            snapshotGroup.first { $0.groupIDData == env.groupID }
+        )
+        XCTAssertEqual(group.members.count, 3, "admin + both joiners")
+        XCTAssertEqual(group.epoch, 2, "each joiner is its own anchor")
+        XCTAssertEqual(contractTransport.calls.count, 2, "two real anchors, not one")
+
+        let sends = await transport.sends
+        XCTAssertNotNil(sends.first { $0.inbox == env.expectedJoinerTag })
+        XCTAssertNotNil(sends.first { $0.inbox == second.expectedTag })
+    }
+
+    func test_decline_joinerA_leavesJoinerBApprovable() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        await env.approver.decline(requestId: env.requestID)
+        await env.approver.pumpOnce()
+
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "declining A must not drop B")
+        XCTAssertEqual(pending.first?.joinerBlsPublicKey, second.blsPub)
+
+        let outcome = await env.approver.approve(requestId: second.requestID)
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(contractTransport.calls.count, 1)
+    }
+
+    func test_pumpOnce_twoDifferentJoinersOnOneIntroKey_yieldTwoPendingRows() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        // The collapse key is per joiner identity, not per intro key.
+        // Over-merging here would silently drop invitees and neuter the
+        // whole feature.
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 2)
+        XCTAssertEqual(
+            Set(pending.compactMap(\.joinerBlsPublicKey)),
+            Set([env.joinerBlsPub, second.blsPub])
+        )
+    }
+
+    func test_approve_consumesEveryCollapsedSibling() async throws {
+        let env = try await seedEnvironment()
+        // Two more copies of the SAME joiner's request, as a retry or a
+        // relay replay under fresh ephemeral keys would produce.
+        for _ in 0..<2 {
+            await introRequestStore.record(IntroRequest(
+                id: "req-\(UUID().uuidString)",
+                targetIntroPublicKey: env.introPub,
+                payload: env.sealedPayload,
+                receivedAt: Date().addingTimeInterval(30)
+            ))
+        }
+        await env.approver.pumpOnce()
+
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "one joiner is one row")
+        let winner = try XCTUnwrap(pending.first?.id)
+
+        let outcome = await env.approver.approve(requestId: winner)
+        XCTAssertEqual(outcome, .sent)
+
+        // Consuming only the winner would leave the siblings behind to
+        // resurface on the next emission.
+        let leftover = await introRequestStore.current()
+        XCTAssertTrue(leftover.isEmpty, "every collapsed sibling must be consumed")
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    func test_decline_consumesEveryCollapsedSibling() async throws {
+        let env = try await seedEnvironment()
+        await introRequestStore.record(IntroRequest(
+            id: "req-\(UUID().uuidString)",
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(30)
+        ))
+        await env.approver.pumpOnce()
+        let rows = await pendingRows(env.approver)
+        let winner = try XCTUnwrap(rows.first?.id)
+
+        await env.approver.decline(requestId: winner)
+
+        let leftover = await introRequestStore.current()
+        XCTAssertTrue(leftover.isEmpty)
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    func test_approvedRequest_replayedByRelay_doesNotReappearAsPending() async throws {
+        let env = try await seedEnvironment()
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .sent)
+
+        // Every relay reconnect replays the inbox in full — the REQ
+        // carries no `since` and no `limit`. The intro key is still
+        // live now, so without the consume-tombstone this decodes again
+        // and the admin sees a request they already approved.
+        let reRecorded = await introRequestStore.record(IntroRequest(
+            id: env.requestID,
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(120)
+        ))
+        XCTAssertFalse(reRecorded, "a consumed event id must not be re-recorded")
+
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    // MARK: - re-join recovery
+
+    func test_approve_joinerAlreadyInRoster_skipsAnchor_reshipsInvitation() async throws {
+        let env = try await seedEnvironment()
+        await env.approver.pumpOnce()
+        let firstOutcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(firstOutcome, .sent)
+        XCTAssertEqual(contractTransport.calls.count, 1)
+        let snapshotAfterfirst = await groups.currentGroups()
+        let afterFirst = try XCTUnwrap(
+            snapshotAfterfirst.first { $0.groupIDData == env.groupID }
+        )
+
+        // Same joiner, fresh event id: a reinstall, or a replay landing
+        // on the still-live link.
+        let replayID = "req-\(UUID().uuidString)"
+        await introRequestStore.record(IntroRequest(
+            id: replayID,
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(60)
+        ))
+        await env.approver.pumpOnce()
+
+        let replayOutcome = await env.approver.approve(requestId: replayID)
+        XCTAssertEqual(replayOutcome, .sent)
+
+        // No second anchor: re-adding an existing member would push a
+        // duplicate leaf into the tree and burn an epoch.
+        XCTAssertEqual(contractTransport.calls.count, 1, "re-join must not re-anchor")
+        let proveCalls = await proofGenerator.proveUpdateCalls
+        XCTAssertEqual(proveCalls, 1,
+                       "the guard must sit before the proof, not after it")
+
+        let snapshotAftersecond = await groups.currentGroups()
+        let afterSecond = try XCTUnwrap(
+            snapshotAftersecond.first { $0.groupIDData == env.groupID }
+        )
+        XCTAssertEqual(afterSecond.epoch, afterFirst.epoch)
+        XCTAssertEqual(afterSecond.members.count, afterFirst.members.count)
+        XCTAssertEqual(afterSecond.commitment, afterFirst.commitment)
+
+        // But the joiner did get the snapshot again — that's the point.
+        let sends = await transport.sends
+        XCTAssertEqual(
+            sends.filter { $0.inbox == env.expectedJoinerTag }.count, 2,
+            "the re-join path must re-ship the current invitation"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Replay the approver's current pending snapshot. `pending` is a
+    /// hot stream that yields the snapshot to each new subscriber, so
+    /// one `next()` is a point-in-time read.
+    private func pendingRows(
+        _ approver: JoinRequestApprover
+    ) async -> [JoinRequestApprover.PendingRequest] {
+        var iterator = approver.pending.makeAsyncIterator()
+        return await iterator.next() ?? []
+    }
+
+    private struct SecondJoiner {
+        let requestID: String
+        let blsPub: Data
+        let expectedTag: TransportInboxID
+    }
+
+    /// Seal a second joiner's `JoinRequestPayload` to the *same* intro
+    /// pubkey and record it under a fresh event id — two people
+    /// redeeming one shared multi-use link.
+    private func seedSecondJoiner(on env: Env) async throws -> SecondJoiner {
+        let blsPub = Data(repeating: 0x1A, count: 48)
+        let inboxPub = Data(repeating: 0x1C, count: 32)
+        let payload = try JoinRequestPayload(
+            joinerInboxPublicKey: inboxPub,
+            joinerBlsPublicKey: blsPub,
+            joinerLeafHash: Data(repeating: 0x1B, count: 32),
+            joinerSendingPublicKey: Data(repeating: 0x1D, count: 32),
+            joinerDisplayLabel: "Joiner Carol",
+            groupId: env.groupID
+        )
+        let sealed = try await identity.sealInvitation(
+            payload: try JSONEncoder().encode(payload),
+            to: env.introPub
+        )
+        let requestID = "req-\(UUID().uuidString)"
+        await introRequestStore.record(IntroRequest(
+            id: requestID,
+            targetIntroPublicKey: env.introPub,
+            payload: sealed,
+            receivedAt: Date().addingTimeInterval(10)
+        ))
+        return SecondJoiner(
+            requestID: requestID,
+            blsPub: blsPub,
+            expectedTag: TransportInboxID(rawValue: ApproverInboxTag.from(inboxPub))
+        )
+    }
+
     private struct Env {
         let approver: JoinRequestApprover
         let requestID: String


### PR DESCRIPTION
Stacked on #211. 888 tests green (+17).

The headline case: joiner A is approved, then joiner B's request on the *same* intro key still decodes and still approves. Final state is three members, epoch 2 and two distinct chain invocations, so the second join is a real anchor and not a silent no-op.

Also pinned:

- Declining A leaves B approvable — a decline is about one requester, not about the link.
- Two different joiners on one key stay two rows. Over-merging the collapse key here would silently drop invitees and neuter the feature.
- Approve and Decline consume every collapsed sibling, so a retry copy can't resurface as a fresh row.
- A replayed already-approved request is rejected by the store's tombstone. **This one fails without #209.**
- The re-join path ships the snapshot again with no anchor, no epoch bump and no commitment change, and asserts `proveUpdateCalls == 1` so the guard can't drift to after the proof.
- `currentOrMint` reuses inside the window, mints past it, treats the exact boundary as expired (pinning the strict comparison against the store's own cutoff), never crosses identities, and leaves `mint` always-fresh for the offer path.

Note for reviewers: `XCTUnwrap` and the `XCTAssert*` family take autoclosures, which can't carry an `await`, so the async reads are hoisted into lets throughout. That is why the new tests read more verbosely than the surrounding file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)