### PR TITLE
feat(group): invite links never expire and are revoked by hand

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,22 +1,6 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    " — they can find it in ": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " — they can find it in "
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " — они смогут её найти в "
-          }
-        }
-      }
-    },
     " · published on Stellar so anyone can verify it’s real.": {
       "extractionState": "stale",
       "localizations": {
@@ -34,50 +18,18 @@
         }
       }
     },
-    "—": {
+    " — they can find it in ": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "—"
+            "value": " — they can find it in "
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "—"
-          }
-        }
-      }
-    },
-    ", or share a QR code from there.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ", or share a QR code from there."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ", или поделитесь QR-кодом оттуда."
-          }
-        }
-      }
-    },
-    "·": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "·"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "·"
+            "value": " — они смогут её найти в "
           }
         }
       }
@@ -98,22 +50,6 @@
         }
       }
     },
-    "(you)": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(you)"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(вы)"
-          }
-        }
-      }
-    },
     "%@": {
       "localizations": {
         "en": {
@@ -130,18 +66,18 @@
         }
       }
     },
-    "%@ · ": {
+    "%@ %@ so far": {
       "localizations": {
         "en": {
           "stringUnit": {
-            "state": "translated",
-            "value": "%@ · "
+            "state": "new",
+            "value": "%1$@ %2$@ so far"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ · "
+            "value": "пока %1$@ %2$@"
           }
         }
       }
@@ -158,22 +94,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$@ (%2$@)"
-          }
-        }
-      }
-    },
-    "%@ %@ so far": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@ %2$@ so far"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "пока %1$@ %2$@"
           }
         }
       }
@@ -226,6 +146,39 @@
         }
       }
     },
+    "%@ · ": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · "
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · "
+          }
+        }
+      }
+    },
+    "%@%%": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%%"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%%"
+          }
+        }
+      }
+    },
     "%@. ": {
       "localizations": {
         "en": {
@@ -258,102 +211,34 @@
         }
       }
     },
-    "%@%%": {
-      "extractionState": "stale",
+    "(you)": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@%%"
+            "value": "(you)"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@%%"
+            "value": "(вы)"
           }
         }
       }
     },
-    "© 2026 · Onym Foundation": {
+    ", or share a QR code from there.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "© 2026 · Onym Foundation"
+            "value": ", or share a QR code from there."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "© 2026 · Onym Foundation"
-          }
-        }
-      }
-    },
-    "▲": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "▲"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "▲"
-          }
-        }
-      }
-    },
-    "✈": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "✈"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "✈"
-          }
-        }
-      }
-    },
-    "🎉 Hello, builder. Want to contribute?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "🎉 Hello, builder. Want to contribute?"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "🎉 Привет, разработчик. Хотите помочь проекту?"
-          }
-        }
-      }
-    },
-    "🐳": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "🐳"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "🐳"
+            "value": ", или поделитесь QR-кодом оттуда."
           }
         }
       }
@@ -390,22 +275,6 @@
         }
       }
     },
-    "Active": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Активная"
-          }
-        }
-      }
-    },
     "ACTIVE": {
       "localizations": {
         "ru": {
@@ -418,22 +287,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "ACTIVE"
-          }
-        }
-      }
-    },
-    "Active identity": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active identity"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Активная личность"
           }
         }
       }
@@ -455,6 +308,38 @@
         }
       }
     },
+    "Active": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активная"
+          }
+        }
+      }
+    },
+    "Active identity": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active identity"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активная личность"
+          }
+        }
+      }
+    },
     "Add": {
       "localizations": {
         "en": {
@@ -467,22 +352,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Добавить"
-          }
-        }
-      }
-    },
-    "Add a greeting, group rules, or policy…": {
-      "localizations": {
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Добавьте приветствие, правила или политику группы…"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add a greeting, group rules, or policy…"
           }
         }
       }
@@ -500,6 +369,38 @@
           "stringUnit": {
             "state": "translated",
             "value": "Добавить свой URL"
+          }
+        }
+      }
+    },
+    "Add Identity": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Identity"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить личность"
+          }
+        }
+      }
+    },
+    "Add a greeting, group rules, or policy…": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавьте приветствие, правила или политику группы…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a greeting, group rules, or policy…"
           }
         }
       }
@@ -533,22 +434,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add identity"
-          }
-        }
-      }
-    },
-    "Add Identity": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Identity"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Добавить личность"
           }
         }
       }
@@ -785,6 +670,70 @@
         }
       }
     },
+    "BLS": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLS"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLS"
+          }
+        }
+      }
+    },
+    "BLS %@": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLS %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLS %@"
+          }
+        }
+      }
+    },
+    "BLS %@…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLS %@…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLS %@…"
+          }
+        }
+      }
+    },
+    "BLS12-381": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLS12-381"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLS12-381"
+          }
+        }
+      }
+    },
     "Back up keys": {
       "extractionState": "stale",
       "localizations": {
@@ -885,70 +834,6 @@
         }
       }
     },
-    "BLS": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLS"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLS"
-          }
-        }
-      }
-    },
-    "BLS %@": {
-      "localizations": {
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLS %@"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLS %@"
-          }
-        }
-      }
-    },
-    "BLS %@…": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLS %@…"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLS %@…"
-          }
-        }
-      }
-    },
-    "BLS12-381": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLS12-381"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLS12-381"
-          }
-        }
-      }
-    },
     "Bring your own contract": {
       "localizations": {
         "en": {
@@ -1043,6 +928,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Создано людьми, которые считают приватность правом.\nВыпущено под лицензией MIT."
+          }
+        }
+      }
+    },
+    "CONTRACT · %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CONTRACT · %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "КОНТРАКТ · %@"
           }
         }
       }
@@ -1197,22 +1098,6 @@
         }
       }
     },
-    "CONTRACT · %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CONTRACT · %@"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "КОНТРАКТ · %@"
-          }
-        }
-      }
-    },
     "Contract deployed": {
       "extractionState": "stale",
       "localizations": {
@@ -1329,6 +1214,23 @@
         }
       }
     },
+    "Create Group": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Group"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать группу"
+          }
+        }
+      }
+    },
     "Create a group & share a link": {
       "localizations": {
         "ru": {
@@ -1358,23 +1260,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Создайте сквозно зашифрованную группу с якорем в Stellar."
-          }
-        }
-      }
-    },
-    "Create Group": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create Group"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Создать группу"
           }
         }
       }
@@ -1427,22 +1312,6 @@
         }
       }
     },
-    "Decline": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Decline"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отклонить"
-          }
-        }
-      }
-    },
     "DEFAULT": {
       "localizations": {
         "en": {
@@ -1455,6 +1324,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "ПО УМОЛЧАНИЮ"
+          }
+        }
+      }
+    },
+    "Decline": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decline"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отклонить"
           }
         }
       }
@@ -1540,6 +1425,22 @@
         }
       }
     },
+    "Direct invites": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direct invites"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Персональные приглашения"
+          }
+        }
+      }
+    },
     "Dismiss": {
       "localizations": {
         "en": {
@@ -1556,22 +1457,6 @@
         }
       }
     },
-    "Don’t have their key? ": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Don’t have their key? "
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Нет их ключа? "
-          }
-        }
-      }
-    },
     "Done": {
       "localizations": {
         "en": {
@@ -1584,6 +1469,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Готово"
+          }
+        }
+      }
+    },
+    "Don’t have their key? ": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don’t have their key? "
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет их ключа? "
           }
         }
       }
@@ -1733,6 +1634,22 @@
         }
       }
     },
+    "Generate new link": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate new link"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать новую ссылку"
+          }
+        }
+      }
+    },
     "Generate with AI": {
       "extractionState": "stale",
       "localizations": {
@@ -1762,6 +1679,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Генерируется доказательство и обновляется обязательство в блокчейне. Обычно занимает несколько секунд."
+          }
+        }
+      }
+    },
+    "Generating…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generating…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создаём…"
           }
         }
       }
@@ -1865,22 +1798,6 @@
         }
       }
     },
-    "i": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "i"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "i"
-          }
-        }
-      }
-    },
     "I'll do this later": {
       "localizations": {
         "en": {
@@ -1913,38 +1830,6 @@
         }
       }
     },
-    "Inbox %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inbox %@"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Входящие %@"
-          }
-        }
-      }
-    },
-    "inbox key": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "inbox key"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ключ входящих"
-          }
-        }
-      }
-    },
     "INVITATION": {
       "localizations": {
         "ru": {
@@ -1957,6 +1842,39 @@
           "stringUnit": {
             "state": "translated",
             "value": "INVITATION"
+          }
+        }
+      }
+    },
+    "INVITE KEY": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "INVITE KEY"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "КЛЮЧ ПРИГЛАШЕНИЯ"
+          }
+        }
+      }
+    },
+    "Inbox %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inbox %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Входящие %@"
           }
         }
       }
@@ -2010,23 +1928,6 @@
         }
       }
     },
-    "INVITE KEY": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "INVITE KEY"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "КЛЮЧ ПРИГЛАШЕНИЯ"
-          }
-        }
-      }
-    },
     "Invite people from the chat to see them here.": {
       "localizations": {
         "en": {
@@ -2039,22 +1940,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Пригласите людей в чат — они появятся здесь."
-          }
-        }
-      }
-    },
-    "invited you to “%@”": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "invited you to “%@”"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "пригласил вас в «%@»"
           }
         }
       }
@@ -2124,6 +2009,23 @@
         }
       }
     },
+    "MEMBERS": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MEMBERS"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "УЧАСТНИКИ"
+          }
+        }
+      }
+    },
     "Mainnet": {
       "extractionState": "stale",
       "localizations": {
@@ -2153,23 +2055,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Участники"
-          }
-        }
-      }
-    },
-    "MEMBERS": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MEMBERS"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "УЧАСТНИКИ"
           }
         }
       }
@@ -2455,6 +2340,22 @@
         }
       }
     },
+    "No response yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No response yet"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока нет ответа"
+          }
+        }
+      }
+    },
     "No servers configured. Media can't be sent or received.": {
       "localizations": {
         "ru": {
@@ -2516,22 +2417,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Это не то слово. Проверьте фразу и повторите попытку."
-          }
-        }
-      }
-    },
-    "npub": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "npub"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "npub"
           }
         }
       }
@@ -2616,71 +2501,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Onym"
-          }
-        }
-      }
-    },
-    "onym · open · anonymous · onchain": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "onym · open · anonymous · onchain"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "onym · открыто · анонимно · в блокчейне"
-          }
-        }
-      }
-    },
-    "onymchat/onym-contracts": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "onymchat/onym-contracts"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "onymchat/onym-contracts"
-          }
-        }
-      }
-    },
-    "onymchat/onym-relayer": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "onymchat/onym-relayer"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "onymchat/onym-relayer"
-          }
-        }
-      }
-    },
-    "open · anonymous · onchain": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "open · anonymous · onchain"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "открыто · анонимно · в блокчейне"
           }
         }
       }
@@ -3016,22 +2836,6 @@
         }
       }
     },
-    "Remove identity": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove identity"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Удалить личность"
-          }
-        }
-      }
-    },
     "Remove Photo": {
       "extractionState": "stale",
       "localizations": {
@@ -3045,6 +2849,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Удалить фото"
+          }
+        }
+      }
+    },
+    "Remove identity": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove identity"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить личность"
           }
         }
       }
@@ -3162,6 +2982,22 @@
         }
       }
     },
+    "Revoke": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revoke"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отозвать"
+          }
+        }
+      }
+    },
     "Run a relayer for yourself, your team, or your org. End-to-end encryption stays intact — Onym never sees your messages.": {
       "localizations": {
         "en": {
@@ -3194,6 +3030,22 @@
         }
       }
     },
+    "SX": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SX"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SX"
+          }
+        }
+      }
+    },
     "Save": {
       "localizations": {
         "ru": {
@@ -3206,6 +3058,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Save"
+          }
+        }
+      }
+    },
+    "Scan QR": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan QR"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сканировать QR"
           }
         }
       }
@@ -3240,22 +3108,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сканировать QR приглашения"
-          }
-        }
-      }
-    },
-    "Scan QR": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan QR"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сканировать QR"
           }
         }
       }
@@ -3387,6 +3239,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Отправляем запрос…"
+          }
+        }
+      }
+    },
+    "Sent when you created the group. Each one can still be used to request to join.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent when you created the group. Each one can still be used to request to join."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отправлены при создании группы. По каждому из них всё ещё можно запросить вступление."
           }
         }
       }
@@ -3602,35 +3470,19 @@
         }
       }
     },
-    "SX": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SX"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SX"
-          }
-        }
-      }
-    },
-    "Tap “Use this contract” to anchor new %@ chats here. Existing chats keep their current contract.": {
+    "TBA": {
       "extractionState": "stale",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tap “Use this contract” to anchor new %@ chats here. Existing chats keep their current contract."
+            "value": "TBA"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Нажмите «Использовать этот контракт», чтобы привязывать новые чаты %@ здесь. Существующие чаты сохранят свой текущий контракт."
+            "value": "СКОРО"
           }
         }
       }
@@ -3651,19 +3503,19 @@
         }
       }
     },
-    "TBA": {
+    "Tap “Use this contract” to anchor new %@ chats here. Existing chats keep their current contract.": {
       "extractionState": "stale",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "TBA"
+            "value": "Tap “Use this contract” to anchor new %@ chats here. Existing chats keep their current contract."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "СКОРО"
+            "value": "Нажмите «Использовать этот контракт», чтобы привязывать новые чаты %@ здесь. Существующие чаты сохранят свой текущий контракт."
           }
         }
       }
@@ -3697,6 +3549,38 @@
           "stringUnit": {
             "state": "translated",
             "value": "Это не QR-код приглашения в группу Onym. Попросите администратора показать QR-код приглашения из списка участников группы."
+          }
+        }
+      }
+    },
+    "The host may be offline, or this invite may no longer work. Ask them for a new link.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The host may be offline, or this invite may no longer work. Ask them for a new link."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Возможно, владелец группы не в сети или это приглашение больше не действует. Попросите новую ссылку."
+          }
+        }
+      }
+    },
+    "The old link stops working. Anyone still holding it won't be told.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The old link stops working. Anyone still holding it won't be told."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Старая ссылка перестанет работать. Тех, у кого она осталась, об этом не уведомят."
           }
         }
       }
@@ -3813,12 +3697,13 @@
         }
       }
     },
-    "Try again": {
+    "Try Again": {
+      "extractionState": "stale",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Try again"
+            "value": "Try Again"
           }
         },
         "ru": {
@@ -3829,13 +3714,12 @@
         }
       }
     },
-    "Try Again": {
-      "extractionState": "stale",
+    "Try again": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Try Again"
+            "value": "Try again"
           }
         },
         "ru": {
@@ -3994,22 +3878,6 @@
         }
       }
     },
-    "wants to join “%@”": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "wants to join “%@”"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "хочет вступить в «%@»"
-          }
-        }
-      }
-    },
     "Write down these %@ words in order. You'll confirm three of them on the next screen.": {
       "localizations": {
         "en": {
@@ -4091,6 +3959,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Запишите их. Храните офлайн. Эта фраза восстанавливает ваши ключи Nostr, Stellar и BLS на любом устройстве."
+          }
+        }
+      }
+    },
+    "You can leave this screen open — if they approve, the chat still appears.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can leave this screen open — if they approve, the chat still appears."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Можно не закрывать этот экран — если заявку одобрят, чат появится сам."
           }
         }
       }
@@ -4220,6 +4104,266 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ваш релеер — ваши правила"
+          }
+        }
+      }
+    },
+    "i": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "i"
+          }
+        }
+      }
+    },
+    "inbox key": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inbox key"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ключ входящих"
+          }
+        }
+      }
+    },
+    "invited you to “%@”": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "invited you to “%@”"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "пригласил вас в «%@»"
+          }
+        }
+      }
+    },
+    "npub": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "npub"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "npub"
+          }
+        }
+      }
+    },
+    "onym · open · anonymous · onchain": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onym · open · anonymous · onchain"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onym · открыто · анонимно · в блокчейне"
+          }
+        }
+      }
+    },
+    "onymchat/onym-contracts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onymchat/onym-contracts"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onymchat/onym-contracts"
+          }
+        }
+      }
+    },
+    "onymchat/onym-relayer": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onymchat/onym-relayer"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "onymchat/onym-relayer"
+          }
+        }
+      }
+    },
+    "open · anonymous · onchain": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "open · anonymous · onchain"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "открыто · анонимно · в блокчейне"
+          }
+        }
+      }
+    },
+    "wants to join “%@”": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wants to join “%@”"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "хочет вступить в «%@»"
+          }
+        }
+      }
+    },
+    "© 2026 · Onym Foundation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "© 2026 · Onym Foundation"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "© 2026 · Onym Foundation"
+          }
+        }
+      }
+    },
+    "·": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·"
+          }
+        }
+      }
+    },
+    "—": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
+          }
+        }
+      }
+    },
+    "▲": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "▲"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "▲"
+          }
+        }
+      }
+    },
+    "✈": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✈"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✈"
+          }
+        }
+      }
+    },
+    "🎉 Hello, builder. Want to contribute?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "🎉 Hello, builder. Want to contribute?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "🎉 Привет, разработчик. Хотите помочь проекту?"
+          }
+        }
+      }
+    },
+    "🐳": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "🐳"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "🐳"
           }
         }
       }

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -720,9 +720,14 @@ struct CreateGroupInteractor: Sendable {
     /// Mint a per-invitee intro key and ship a durable
     /// `GroupInviteOfferPayload` to each invitee's inbox. Reuses the
     /// inbox seal+send path, but the payload grants nothing: it carries
-    /// only the reply channel + display context, so it never expires
-    /// and never anchors anyone. The invitee turns it into a join
-    /// request on accept; the admin anchors only on explicit approve.
+    /// only the reply channel + display context, and never anchors
+    /// anyone. The invitee turns it into a join request on accept; the
+    /// admin anchors only on explicit approve.
+    ///
+    /// Each key is labelled with the invitee's inbox fingerprint so it
+    /// shows up as a named row on the group's invite list. Without a
+    /// label these would be anonymous, and since nothing expires any
+    /// more, the list is the only way they ever get retired.
     private func sendOffers(
         to invitees: [Data],
         ownerIdentityID: IdentityID,
@@ -734,13 +739,16 @@ struct CreateGroupInteractor: Sendable {
         for (index, inboxKey) in invitees.enumerated() {
             // One fresh intro key per invitee → granular revoke and a
             // clean 1:1 mapping from an inbound join request back to
-            // the person the admin meant to invite.
+            // the person the admin meant to invite. Deliberately `mint`
+            // and not `currentOrMint`: sharing the group's link key
+            // here would collapse that mapping.
             let capability: IntroCapability
             do {
                 capability = try await introducer.mint(
                     ownerIdentityID: ownerIdentityID,
                     groupId: groupID,
-                    groupName: groupName
+                    groupName: groupName,
+                    label: IntroKeyEntry.fingerprint(of: inboxKey)
                 )
             } catch {
                 throw CreateGroupError.invitationSendFailed(

--- a/Sources/OnymIOS/Group/IntroKeyEntry.swift
+++ b/Sources/OnymIOS/Group/IntroKeyEntry.swift
@@ -15,31 +15,29 @@ import Foundation
 /// - `groupId` is the on-chain `group_id` the invite is for —
 ///   needed when the inviter's app surfaces "Bob wants to join
 ///   <group>?" so it can render the group's name.
-/// - `createdAt` drives both the enforced TTL (`lifetime`) and the
-///   share screen's reuse-or-mint decision.
+/// - `createdAt` is display-only: "shared 3 days ago" on the invite
+///   list. Invite links do not expire; they live until revoked.
+/// - `label` distinguishes the group's shared link (nil) from a
+///   create-time offer minted for one specific invitee (their alias
+///   or key fingerprint), so the invite list can say *which* invite a
+///   row is before you revoke it.
 struct IntroKeyEntry: Equatable, Sendable {
-    /// How long a minted invite link stays honored — 24 hours per
-    /// issue onymchat/onym-ios#111. Mirrors onym-android's
-    /// `IntroKeyEntry.LIFETIME_MILLIS`.
-    ///
-    /// This window is the only bound on a link: it is redeemable by
-    /// any number of joiners until it expires. Nothing retires a key
-    /// early — `KeychainIntroKeyStore` filters expired entries out at
-    /// its single read point, and neither Approve nor Decline revokes.
-    static let lifetime: TimeInterval = 24 * 60 * 60
-
     let introPublicKey: Data
     let introPrivateKey: Data
     let ownerIdentityID: IdentityID
     let groupId: Data
     let createdAt: Date
+    /// nil == the group's shared link. Non-nil == a create-time offer
+    /// aimed at one invitee.
+    let label: String?
 
     init(
         introPublicKey: Data,
         introPrivateKey: Data,
         ownerIdentityID: IdentityID,
         groupId: Data,
-        createdAt: Date
+        createdAt: Date,
+        label: String? = nil
     ) {
         precondition(introPublicKey.count == 32,
                      "introPublicKey: expected 32 bytes, got \(introPublicKey.count)")
@@ -52,18 +50,13 @@ struct IntroKeyEntry: Equatable, Sendable {
         self.ownerIdentityID = ownerIdentityID
         self.groupId = groupId
         self.createdAt = createdAt
+        self.label = label
     }
 
-    /// `true` while this entry is still inside its 24h window.
-    ///
-    /// `KeychainIntroKeyStore.loadAll` enforces the same rule at its
-    /// single read point, with the matching strict comparison so the
-    /// two boundaries can't drift. `InviteIntroducer.currentOrMint`
-    /// re-checks here rather than trusting the store, which keeps the
-    /// reuse-or-mint decision a pure function of the entry and a clock
-    /// — and therefore reachable from `InMemoryIntroKeyStore`, which
-    /// has no TTL of its own.
-    func isLive(at now: Date) -> Bool {
-        now.timeIntervalSince(createdAt) < Self.lifetime
+    /// Short, stable, human-comparable stand-in for an invitee with no
+    /// alias — the first 4 bytes of their inbox key, matching the
+    /// fingerprint shape the approval screen already shows.
+    static func fingerprint(of inboxPublicKey: Data) -> String {
+        inboxPublicKey.prefix(4).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/OnymIOS/Group/InviteIntroducer.swift
+++ b/Sources/OnymIOS/Group/InviteIntroducer.swift
@@ -13,11 +13,11 @@ import CryptoKit
 /// **Two entry points, deliberately**:
 ///  - `currentOrMint` — the shared-link path. Hands back the
 ///    identity's existing live key for the group when there is one,
-///    minting only when there isn't. Invite links are multi-use: one
-///    keypair serves every joiner who redeems the link inside
-///    `IntroKeyEntry.lifetime`, so re-opening the share screen must
-///    return the same link rather than stacking a fresh relay REQ slot
-///    per visit.
+///    minting only when there isn't. Invite links are multi-use and
+///    do not expire: one keypair serves every joiner who redeems the
+///    link until the inviter revokes it, so re-opening the share
+///    screen must return the same link rather than stacking a fresh
+///    relay REQ slot per visit.
 ///  - `mint` — always a fresh keypair. `CreateGroupInteractor`'s
 ///    create-time offers want one key per invitee so an inbound join
 ///    request maps 1:1 back to the person the admin meant to invite.
@@ -25,8 +25,8 @@ import CryptoKit
 /// **Why a keypair per link instead of one per identity**: the intro
 /// key is the only thing that can decrypt requests aimed at it, so
 /// scoping it to one group means a leaked link exposes that group's
-/// request channel and nothing else — and expiry retires it without
-/// touching any other invite.
+/// request channel and nothing else — and revoking it retires that
+/// one link without touching any other invite.
 actor InviteIntroducer {
     private let store: any IntroKeyStore
     private let now: @Sendable () -> Date
@@ -48,10 +48,14 @@ actor InviteIntroducer {
     ///   - groupName: optional plaintext name surfaced in the deeplink
     ///     for the joiner's preview. Pass nil for groups whose name
     ///     is sensitive (deeplink transits cleartext channels).
+    ///   - label: nil for the group's shared link; the invitee's
+    ///     alias or key fingerprint for a create-time offer, so the
+    ///     invite list can name the row.
     func mint(
         ownerIdentityID: IdentityID,
         groupId: Data,
-        groupName: String? = nil
+        groupName: String? = nil,
+        label: String? = nil
     ) async throws -> IntroCapability {
         guard groupId.count == 32 else {
             throw IntroducerError.invalidGroupID(actualSize: groupId.count)
@@ -69,7 +73,8 @@ actor InviteIntroducer {
             introPrivateKey: privBytes,
             ownerIdentityID: ownerIdentityID,
             groupId: groupId,
-            createdAt: now()
+            createdAt: now(),
+            label: label
         ))
 
         return try IntroCapability(
@@ -80,16 +85,14 @@ actor InviteIntroducer {
     }
 
     /// The group's current invite capability for `ownerIdentityID`,
-    /// minting one only when no live key exists.
+    /// minting one only when the group has no link yet.
     ///
-    /// Invite links are multi-use, so the share screen is a view onto
-    /// the group's live link rather than a link factory: re-entering it
-    /// must surface the same link instead of leaving a trail of live
-    /// intro slots, each costing a relay REQ slot until it ages out.
-    ///
-    /// Reuse deliberately does not re-stamp `createdAt`. The 24h cap is
-    /// absolute per link, not a sliding window, so a link that has been
-    /// circulating for 23 hours still goes dark in one.
+    /// Invite links are multi-use and never expire, so the share screen
+    /// is a view onto the group's live link rather than a link factory:
+    /// re-entering it must surface the same link instead of leaving a
+    /// trail of live intro slots, each costing a relay REQ slot for as
+    /// long as it exists. Rotating is an explicit user action —
+    /// `rotate`, behind "Generate new link".
     ///
     /// Scoped to `ownerIdentityID` on purpose: `IntroInboxPump` is
     /// wired to `entriesStream(forOwner: activeID)`, so it only listens
@@ -112,9 +115,12 @@ actor InviteIntroducer {
             throw IntroducerError.invalidGroupID(actualSize: groupId.count)
         }
 
-        let reference = now()
+        // `label == nil` is the shared link. Offer keys are minted for
+        // one named invitee and must never be handed out as the group's
+        // link — the common create-with-invitees flow lands on the
+        // share screen with the last invitee's key as the newest entry.
         let live = await store.listForOwner(ownerIdentityID).first {
-            $0.groupId == groupId && $0.isLive(at: reference)
+            $0.groupId == groupId && $0.label == nil
         }
         if let live {
             return try IntroCapability(
@@ -129,6 +135,67 @@ actor InviteIntroducer {
             groupId: groupId,
             groupName: groupName
         )
+    }
+
+    /// Replace the group's shared link: mint a fresh keypair, then
+    /// revoke every other key this identity holds for the group.
+    ///
+    /// This is what "Generate new link" does. Since links no longer
+    /// expire, rotating is the only way a leaked or over-shared link
+    /// stops working — and rotating rather than plain-revoking leaves
+    /// the inviter with a link they can still hand out.
+    ///
+    /// Mint-then-revoke, not the reverse: if the process dies between
+    /// the two, the group is left with two working links rather than
+    /// none. An extra live link is a nuisance the user can rotate
+    /// again; zero links with a joiner mid-flow is a dead end.
+    ///
+    /// Revocation is local. There is no way to tell the relay or the
+    /// people holding the old link — they simply stop being able to
+    /// reach anyone, because this device stops subscribing to that
+    /// intro tag and is the only holder of the private key.
+    @discardableResult
+    func rotate(
+        ownerIdentityID: IdentityID,
+        groupId: Data,
+        groupName: String? = nil
+    ) async throws -> IntroCapability {
+        guard groupId.count == 32 else {
+            throw IntroducerError.invalidGroupID(actualSize: groupId.count)
+        }
+
+        // Only the shared link rotates. Per-invitee offer keys are
+        // revoked individually from the invite list.
+        let superseded = await store.listForOwner(ownerIdentityID)
+            .filter { $0.groupId == groupId && $0.label == nil }
+            .map(\.introPublicKey)
+
+        let fresh = try await mint(
+            ownerIdentityID: ownerIdentityID,
+            groupId: groupId,
+            groupName: groupName
+        )
+
+        for pub in superseded where pub != fresh.introPublicKey {
+            await store.revoke(introPublicKey: pub)
+        }
+        return fresh
+    }
+
+    /// Kill one specific link. Used by the per-row revoke on the
+    /// invite list — chiefly for the create-time offer keys, which
+    /// have no other way to be retired now that nothing expires.
+    func revoke(introPublicKey: Data) async {
+        await store.revoke(introPublicKey: introPublicKey)
+    }
+
+    /// Every live invite this identity holds for the group,
+    /// newest-first. Backs the invite list on the share screen.
+    func liveInvites(
+        ownerIdentityID: IdentityID,
+        groupId: Data
+    ) async -> [IntroKeyEntry] {
+        await store.listForOwner(ownerIdentityID).filter { $0.groupId == groupId }
     }
 }
 

--- a/Sources/OnymIOS/Group/JoinFlow.swift
+++ b/Sources/OnymIOS/Group/JoinFlow.swift
@@ -50,6 +50,12 @@ final class JoinFlow {
         case ready(IntroCapability)
         case sending
         case awaitingApproval
+        /// The request went out and nothing came back for
+        /// `unansweredAfter`. Not a failure — the host may simply be
+        /// offline — but invite links can now be revoked, and a
+        /// revoked link is indistinguishable from a slow host from
+        /// here. Saying so beats an indefinite spinner.
+        case unanswered
         case approved(ChatGroup)
         case failed(reason: String)
     }
@@ -67,17 +73,24 @@ final class JoinFlow {
 
     private var sendTask: Task<Void, Never>?
     private var watcherTask: Task<Void, Never>?
+    private var unansweredTask: Task<Void, Never>?
+    /// How long this flow waits before flipping to `.unanswered`, or
+    /// nil to never flip. Injected so tests can drive the timeout in
+    /// milliseconds instead of sitting out the real 90 seconds.
+    private let unansweredAfter: Duration?
 
     init(
         capability: IntroCapability,
         suggestedDisplayLabel: String,
         submitRequest: @escaping @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome,
-        groupRepository: GroupRepository
+        groupRepository: GroupRepository,
+        unansweredAfter: Duration? = JoinFlow.unansweredAfter
     ) {
         self.capability = capability
         self.suggestedDisplayLabel = suggestedDisplayLabel
         self.submitRequest = submitRequest
         self.groupRepository = groupRepository
+        self.unansweredAfter = unansweredAfter
         self.state = .ready(capability)
         startWatcher()
     }
@@ -86,6 +99,16 @@ final class JoinFlow {
     // capture `[weak self]` so they exit gracefully on deallocation
     // without needing main-actor-isolated cancellation in `deinit`
     // (which Swift's strict concurrency checking would flag).
+
+    /// How long to wait on `awaitingApproval` before telling the user
+    /// nothing has come back.
+    ///
+    /// Deliberately generous: approval is a human action plus a
+    /// multi-second proof and a chain round-trip on the host's device,
+    /// so anything short would cry wolf on a host who is simply
+    /// thinking. The watcher stays live afterwards — a late approval
+    /// still flips straight to `.approved`.
+    static let unansweredAfter: Duration = .seconds(90)
 
     /// Ship the join request. No-op if a previous `send` is in flight
     /// (debounce — protects against double-tap on the primary
@@ -111,11 +134,26 @@ final class JoinFlow {
             switch outcome {
             case .sent:
                 self.state = .awaitingApproval
+                self.startUnansweredTimer()
             case .noIdentityLoaded:
                 self.state = .failed(reason: "Sign in first.")
             case .transportFailed(let reason):
                 self.state = .failed(reason: "Couldn't send: \(reason)")
             }
+        }
+    }
+
+    /// Flip to `.unanswered` if nothing has landed by the deadline.
+    /// Cancelled implicitly by the flow going away; a late approval
+    /// overwrites the state via the watcher either way.
+    private func startUnansweredTimer() {
+        guard let unansweredAfter else { return }
+        unansweredTask?.cancel()
+        unansweredTask = Task { [weak self] in
+            try? await Task.sleep(for: unansweredAfter)
+            guard let self, !Task.isCancelled else { return }
+            guard case .awaitingApproval = self.state else { return }
+            self.state = .unanswered
         }
     }
 
@@ -130,6 +168,9 @@ final class JoinFlow {
                     continue
                 }
                 if case .approved = self.state { continue }  // terminal
+                // Beats `.unanswered` too: a late approval is still an
+                // approval.
+                self.unansweredTask?.cancel()
                 self.state = .approved(match)
             }
         }

--- a/Sources/OnymIOS/Group/JoinView.swift
+++ b/Sources/OnymIOS/Group/JoinView.swift
@@ -135,6 +135,31 @@ struct JoinView: View {
             }
             .padding(.top, 24)
             .accessibilityIdentifier("join.awaiting_approval")
+        case .unanswered:
+            VStack(spacing: 12) {
+                Image(systemName: "clock.badge.questionmark")
+                    .font(.system(size: 36))
+                    .foregroundStyle(OnymTokens.text2)
+                Text("No response yet")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                // Two very different causes, indistinguishable from
+                // here: the host is offline, or they replaced the link
+                // and this one is dead. Revocation is silent by design
+                // — nothing tells the holder — so name both.
+                Text("The host may be offline, or this invite may no longer work. Ask them for a new link.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                Text("You can leave this screen open — if they approve, the chat still appears.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+            .padding(.top, 24)
+            .accessibilityIdentifier("join.unanswered")
         case .approved(let group):
             VStack(spacing: 12) {
                 Image(systemName: "checkmark.seal.fill")

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -21,31 +21,11 @@ actor KeychainIntroKeyStore: IntroKeyStore {
     static let serviceDefault = "app.onym.ios.intro_keys"
     static let account = "blob"
 
-    /// How long an invite link is honored after minting. 24 hours per
-    /// issue onymchat/onym-ios#111 (shrink the leak window of a
-    /// forwarded or screenshotted link) — matches onym-android's
-    /// `IntroKeyEntry.LIFETIME_MILLIS`. Expired entries are invisible
-    /// to `find`/`listForOwner`/streams (so the intro pump stops
-    /// subscribing their inboxes, which each cost a relay REQ slot)
-    /// and are compacted out of the blob by the load that first sees
-    /// them expired.
-    ///
-    /// This window is the *only* bound on a link: inside it, one link
-    /// is redeemable by any number of joiners. Homed on
-    /// `IntroKeyEntry` so the introducer's reuse-or-mint decision and
-    /// this store's read filter can't drift apart.
-    static let entryTTL: TimeInterval = IntroKeyEntry.lifetime
-
     private let service: String
     /// Per-owner subscriber continuations. Mutations re-emit the
     /// filtered+sorted snapshot to every subscriber whose owner
     /// matches.
     private var continuations: [IdentityID: [UUID: AsyncStream<[IntroKeyEntry]>.Continuation]] = [:]
-    /// Reentrancy latch: `loadAll()` publishes when it compacts, and
-    /// `publish` itself calls `loadAll()` — the latch stops that inner
-    /// load from re-entering the compaction path.
-    private var compacting = false
-
     init(testNamespace: String? = nil) {
         if let testNamespace, !testNamespace.isEmpty {
             self.service = "\(Self.serviceDefault).\(testNamespace)"
@@ -176,33 +156,14 @@ actor KeychainIntroKeyStore: IntroKeyStore {
         let status = SecItemCopyMatching(q as CFDictionary, &result)
         guard status == errSecSuccess, let data = result as? Data else { return [] }
         // Corrupted blob → discard rather than crash. Acceptable
-        // because this store holds ephemeral per-invite keys; if we
-        // lose them, the worst that happens is in-flight invites
-        // fail to deliver and the inviter re-shares.
-        let entries = (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
-        // TTL filter at the single load point so expired entries are
-        // invisible to every reader.
-        let cutoff = Int64((Date().timeIntervalSince1970 - Self.entryTTL) * 1000)
-        let live = entries.filter { $0.createdAtMillis > cutoff }
-        // Compact immediately: expired rows carry intro PRIVATE keys,
-        // and a read-only workload would otherwise leave them at rest
-        // indefinitely waiting for a mutation to rewrite the blob.
-        // Publish for the expired entries' owners so a live session's
-        // intro pump drops their relay REQ slots too — but note this
-        // still only runs when *something* touches the store; a fully
-        // quiet session keeps its slots until the next access or
-        // launch.
-        if live.count != entries.count, !compacting {
-            compacting = true
-            writeAll(live)
-            let expiredOwners = Set(
-                entries.filter { $0.createdAtMillis <= cutoff }
-                    .compactMap { IdentityID($0.ownerIdentityID) }
-            )
-            for owner in expiredOwners { publish(forOwner: owner) }
-            compacting = false
-        }
-        return live
+        // because this store holds per-invite keys; if we lose them,
+        // the worst that happens is in-flight invites fail to deliver
+        // and the inviter re-shares.
+        //
+        // No time-based filtering: invite links do not expire. An entry
+        // lives until the inviter revokes it, or their identity goes
+        // away via `deleteForOwner` / `pruneOwners`.
+        return (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
     }
 
     private func writeAll(_ entries: [StoredIntroKey]) {
@@ -241,6 +202,11 @@ private struct StoredIntroKey: Codable {
     let ownerIdentityID: String
     let groupId: Data
     let createdAtMillis: Int64
+    /// Added after the initial release, so it MUST stay optional: the
+    /// blob decode is `(try? decode)?.entries ?? []`, and a
+    /// non-optional field would make every pre-existing invite fail to
+    /// decode and silently vanish on upgrade.
+    let label: String?
 
     enum CodingKeys: String, CodingKey {
         case introPub = "intro_pub"
@@ -248,6 +214,7 @@ private struct StoredIntroKey: Codable {
         case ownerIdentityID = "owner_identity_id"
         case groupId = "group_id"
         case createdAtMillis = "created_at_millis"
+        case label
     }
 
     init(from entry: IntroKeyEntry) {
@@ -256,6 +223,7 @@ private struct StoredIntroKey: Codable {
         self.ownerIdentityID = entry.ownerIdentityID.rawValue.uuidString
         self.groupId = entry.groupId
         self.createdAtMillis = Int64(entry.createdAt.timeIntervalSince1970 * 1000)
+        self.label = entry.label
     }
 
     func toEntry() -> IntroKeyEntry? {
@@ -267,7 +235,8 @@ private struct StoredIntroKey: Codable {
             introPrivateKey: introPriv,
             ownerIdentityID: owner,
             groupId: groupId,
-            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000)
+            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000),
+            label: label
         )
     }
 }

--- a/Sources/OnymIOS/Group/ShareInviteFlow.swift
+++ b/Sources/OnymIOS/Group/ShareInviteFlow.swift
@@ -25,6 +25,16 @@ final class ShareInviteFlow: Identifiable {
         case failed(reason: String)
     }
 
+    /// One revokable invite on the list. `introPublicKey` is the
+    /// revoke handle; it never reaches the screen.
+    struct InviteRow: Equatable, Identifiable, Sendable {
+        let introPublicKey: Data
+        let label: String
+        let createdAt: Date
+
+        var id: Data { introPublicKey }
+    }
+
     /// Drives `.sheet(item:)` from a single source of truth.
     /// `.sheet(isPresented:)` paired with a separate optional-flow
     /// `@State` raced on first present — the content closure read
@@ -32,6 +42,18 @@ final class ShareInviteFlow: Identifiable {
     nonisolated var id: ObjectIdentifier { ObjectIdentifier(self) }
 
     private(set) var state: State = .idle
+
+    /// Other live invites for this group — the create-time offer keys,
+    /// each aimed at one invitee. The group's shared link is `state`,
+    /// not a row here. Empty for a group created without invitees.
+    ///
+    /// Nothing expires any more, so this list is the only way these
+    /// ever get retired.
+    private(set) var otherInvites: [InviteRow] = []
+
+    /// Set while a rotate is in flight so the UI can disable the
+    /// button — rotating twice in a row would strand a live key.
+    private(set) var isRotating = false
 
     private let identity: IdentityRepository
     private let introducer: InviteIntroducer
@@ -79,8 +101,72 @@ final class ShareInviteFlow: Identifiable {
                 groupName: group.name
             )
             state = .ready(link: cap.toAppLink(), groupName: group.name)
+            await refreshOtherInvites(ownerIdentityID: activeID, groupId: group.groupIDData)
         } catch {
             state = .failed(reason: "\(error)")
         }
+    }
+
+    /// Replace the group's shared link. The old one stops working the
+    /// moment the intro pump drops its subscription — there is no way
+    /// to notify anyone already holding it, so this is the "my link
+    /// leaked" escape hatch, not a polite hand-off.
+    func rotateLink(groupID: String) {
+        Task { await rotateLinkAsync(groupID: groupID) }
+    }
+
+    private func rotateLinkAsync(groupID: String) async {
+        guard !isRotating else { return }
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }) else {
+            state = .failed(reason: "Group not found on this device")
+            return
+        }
+        guard let activeID = await identity.currentSelectedID() else {
+            state = .failed(reason: "No identity selected")
+            return
+        }
+        isRotating = true
+        defer { isRotating = false }
+        do {
+            let cap = try await introducer.rotate(
+                ownerIdentityID: activeID,
+                groupId: group.groupIDData,
+                groupName: group.name
+            )
+            state = .ready(link: cap.toAppLink(), groupName: group.name)
+        } catch {
+            state = .failed(reason: "\(error)")
+        }
+    }
+
+    /// Retire one per-invitee offer key.
+    func revoke(_ row: InviteRow, groupID: String) {
+        Task { await revokeAsync(row, groupID: groupID) }
+    }
+
+    private func revokeAsync(_ row: InviteRow, groupID: String) async {
+        await introducer.revoke(introPublicKey: row.introPublicKey)
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }),
+              let activeID = await identity.currentSelectedID()
+        else { return }
+        await refreshOtherInvites(ownerIdentityID: activeID, groupId: group.groupIDData)
+    }
+
+    private func refreshOtherInvites(ownerIdentityID: IdentityID, groupId: Data) async {
+        // `label == nil` is the group's shared link, which the screen
+        // already renders as the QR + link; only the named per-invitee
+        // offers belong on the list.
+        otherInvites = await introducer
+            .liveInvites(ownerIdentityID: ownerIdentityID, groupId: groupId)
+            .compactMap { entry in
+                guard let label = entry.label else { return nil }
+                return InviteRow(
+                    introPublicKey: entry.introPublicKey,
+                    label: label,
+                    createdAt: entry.createdAt
+                )
+            }
     }
 }

--- a/Sources/OnymIOS/Group/ShareInviteView.swift
+++ b/Sources/OnymIOS/Group/ShareInviteView.swift
@@ -49,6 +49,74 @@ struct ShareInviteView: View {
         .onAppear { flow.mintFor(groupID: groupID) }
     }
 
+    /// "Generate new link" — rotate. Links never expire, so this is
+    /// the only way a leaked or over-shared one stops working. Framed
+    /// as generate-a-new-one rather than revoke because it always
+    /// leaves the user holding a working link.
+    private var rotateButton: some View {
+        Button {
+            copied = false
+            flow.rotateLink(groupID: groupID)
+        } label: {
+            HStack(spacing: 8) {
+                if flow.isRotating {
+                    ProgressView().controlSize(.small)
+                }
+                Text(flow.isRotating ? "Generating…" : "Generate new link")
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .foregroundStyle(OnymTokens.text2)
+        }
+        .disabled(flow.isRotating)
+        .accessibilityIdentifier("share_invite.rotate_button")
+        .overlay(alignment: .bottom) {
+            Text("The old link stops working. Anyone still holding it won't be told.")
+                .font(.system(size: 11))
+                .foregroundStyle(OnymTokens.text2)
+                .multilineTextAlignment(.center)
+                .offset(y: 16)
+        }
+        .padding(.bottom, 20)
+    }
+
+    /// The create-time offers, one per invitee. Nothing expires, so
+    /// this list is the only way they are ever retired.
+    @ViewBuilder
+    private var otherInvitesSection: some View {
+        if !flow.otherInvites.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Direct invites")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("Sent when you created the group. Each one can still be used to request to join.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(OnymTokens.text2)
+
+                ForEach(flow.otherInvites) { row in
+                    HStack {
+                        Text(row.label)
+                            .font(.system(size: 13, design: .monospaced))
+                            .foregroundStyle(OnymTokens.text)
+                        Spacer()
+                        Button("Revoke") {
+                            flow.revoke(row, groupID: groupID)
+                        }
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.red)
+                        .accessibilityIdentifier("share_invite.revoke_button.\(row.label)")
+                    }
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 12)
+                    .background(OnymTokens.surface2,
+                                in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityIdentifier("share_invite.other_invites")
+        }
+    }
+
     private var topBar: some View {
         HStack {
             Spacer().frame(width: 60)
@@ -131,6 +199,9 @@ struct ShareInviteView: View {
                 // capability aloud in Release.
                 .accessibilityValue(link)
                 #endif
+
+                rotateButton
+                otherInvitesSection
             }
             .padding(.top, 24)
         case .failed(let reason):

--- a/Tests/OnymIOSTests/InviteIntroducerTests.swift
+++ b/Tests/OnymIOSTests/InviteIntroducerTests.swift
@@ -185,47 +185,136 @@ final class InviteIntroducerTests: XCTestCase {
         XCTAssertEqual(listed.count, 2)
     }
 
-    func test_currentOrMint_expiredKey_mintsAFreshOne() async throws {
+    func test_currentOrMint_neverExpires_soAnAncientKeyIsStillReused() async throws {
         let store = InMemoryIntroKeyStore()
         let t0 = Date(timeIntervalSince1970: 1_700_000_000)
-        // Two introducers because `now` is injected at init; they share
-        // the store, so the second sees the first's (expired) entry.
         let early = InviteIntroducer(store: store, now: { t0 })
-        let late = InviteIntroducer(
+        // A year later. Invite links have no TTL — only `rotate` or
+        // `revoke` retires one.
+        let muchLater = InviteIntroducer(
             store: store,
-            now: { t0.addingTimeInterval(IntroKeyEntry.lifetime + 60) }
+            now: { t0.addingTimeInterval(365 * 24 * 60 * 60) }
         )
 
         let first = try await early.currentOrMint(
             ownerIdentityID: alice, groupId: sampleGroupId
         )
-        let second = try await late.currentOrMint(
+        let second = try await muchLater.currentOrMint(
             ownerIdentityID: alice, groupId: sampleGroupId
         )
 
-        XCTAssertNotEqual(first.introPublicKey, second.introPublicKey)
+        XCTAssertEqual(first.introPublicKey, second.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
     }
 
-    func test_currentOrMint_atExactlyLifetime_isTreatedAsExpired() async throws {
+    // MARK: - rotate / revoke
+
+    func test_rotate_mintsAFreshKey_andRetiresTheOldOne() async throws {
         let store = InMemoryIntroKeyStore()
-        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
-        let early = InviteIntroducer(store: store, now: { t0 })
-        // Pins the strict comparison in `isLive(at:)` against
-        // `KeychainIntroKeyStore.loadAll`'s cutoff so the two
-        // boundaries can't drift apart.
-        let atBoundary = InviteIntroducer(
-            store: store,
-            now: { t0.addingTimeInterval(IntroKeyEntry.lifetime) }
-        )
+        let introducer = InviteIntroducer(store: store)
 
-        let first = try await early.currentOrMint(
+        let old = try await introducer.currentOrMint(
             ownerIdentityID: alice, groupId: sampleGroupId
         )
-        let second = try await atBoundary.currentOrMint(
+        let new = try await introducer.rotate(
             ownerIdentityID: alice, groupId: sampleGroupId
         )
 
-        XCTAssertNotEqual(first.introPublicKey, second.introPublicKey)
+        XCTAssertNotEqual(old.introPublicKey, new.introPublicKey)
+        let foundOld = await store.find(introPublicKey: old.introPublicKey)
+        XCTAssertNil(foundOld, "the superseded link must stop decrypting requests")
+        let foundNew = await store.find(introPublicKey: new.introPublicKey)
+        XCTAssertNotNil(foundNew)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1, "rotate must not leave the old slot behind")
+    }
+
+    func test_rotate_thenCurrentOrMint_returnsTheRotatedKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        let rotated = try await introducer.rotate(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let resolved = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(rotated.introPublicKey, resolved.introPublicKey)
+    }
+
+    func test_rotate_leavesOtherGroupsAlone() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let untouched = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: other
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        _ = try await introducer.rotate(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        let foundUntouched = await store.find(introPublicKey: untouched.introPublicKey)
+        XCTAssertNotNil(foundUntouched)
+    }
+
+    func test_rotate_doesNotRetireLabelledOfferKeys() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // Per-invitee offers are revoked one at a time from the invite
+        // list; rotating the shared link must not sweep them away.
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        _ = try await introducer.rotate(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        let foundOffer = await store.find(introPublicKey: offer.introPublicKey)
+        XCTAssertNotNil(foundOffer)
+    }
+
+    func test_currentOrMint_ignoresLabelledOfferKeys() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // The create-with-invitees flow lands on the share screen with
+        // the last invitee's offer key as the newest entry. Handing
+        // that out as the group's link would collapse the 1:1
+        // request-to-invitee mapping.
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(offer.introPublicKey, shared.introPublicKey)
+    }
+
+    func test_liveInvites_listsEveryKeyForTheGroup() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: other)
+
+        let live = await introducer.liveInvites(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(Set(live.map(\.introPublicKey)),
+                       Set([shared.introPublicKey, offer.introPublicKey]))
+        XCTAssertEqual(live.first(where: { $0.label == "aabbccdd" })?.introPublicKey,
+                       offer.introPublicKey)
     }
 
     func test_currentOrMint_doesNotReuseAnotherIdentitysLiveKey() async throws {

--- a/Tests/OnymIOSTests/JoinFlowTests.swift
+++ b/Tests/OnymIOSTests/JoinFlowTests.swift
@@ -102,7 +102,11 @@ final class JoinFlowTests: XCTestCase {
 
     private func harness(
         outcome: JoinRequestSender.Outcome,
-        seedGroups: [ChatGroup] = []
+        seedGroups: [ChatGroup] = [],
+        // Nil by default so the existing suite keeps observing
+        // `.awaitingApproval`; the timer gets its own tests, which
+        // pass milliseconds rather than sitting out the real 90s.
+        unansweredAfter: Duration? = nil
     ) async throws -> Env {
         let store = JoinTestableInMemoryGroupStore()
         await store.preload(seedGroups)
@@ -116,7 +120,8 @@ final class JoinFlowTests: XCTestCase {
                 counter.bump()
                 return outcome
             },
-            groupRepository: repo
+            groupRepository: repo,
+            unansweredAfter: unansweredAfter
         )
         return Env(flow: flow, repo: repo, counter: counter)
     }
@@ -159,6 +164,43 @@ final class JoinFlowTests: XCTestCase {
         XCTFail("waitFor predicate never became true within \(timeout)s",
                 file: file, line: line)
     }
+
+    // MARK: - unanswered
+
+    func test_awaitingApproval_afterTheTimeout_flipsToUnanswered() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: .milliseconds(50))
+
+        env.flow.send(displayLabel: "alice")
+
+        // A revoked link is indistinguishable from a slow host here, so
+        // the joiner gets told rather than left on an endless spinner.
+        try await waitFor { env.flow.state.isUnanswered }
+    }
+
+    func test_approvalArrivingAfterTheTimeout_stillWins() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: .milliseconds(50))
+        env.flow.send(displayLabel: "alice")
+        try await waitFor { env.flow.state.isUnanswered }
+
+        // The watcher stays live past the timeout — `.unanswered` is a
+        // hint, not a terminal state.
+        _ = await env.repo.insert(makeGroup(groupID: groupIdRaw, owner: alice))
+
+        try await waitFor {
+            if case .approved = env.flow.state { return true }
+            return false
+        }
+    }
+
+    func test_unansweredAfterNil_neverLeavesAwaitingApproval() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: nil)
+
+        env.flow.send(displayLabel: "alice")
+        try await waitFor { env.flow.state.isAwaitingApproval }
+        try? await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertTrue(env.flow.state.isAwaitingApproval)
+    }
 }
 
 // MARK: - State helpers
@@ -171,6 +213,9 @@ private extension JoinFlow.State {
     }
     var isApproved: Bool { if case .approved = self { return true } else { return false } }
     var isFailed: Bool { if case .failed = self { return true } else { return false } }
+    var isUnanswered: Bool {
+        if case .unanswered = self { return true } else { return false }
+    }
 }
 
 // MARK: - Test doubles

--- a/Tests/OnymIOSTests/KeychainIntroKeyStoreTests.swift
+++ b/Tests/OnymIOSTests/KeychainIntroKeyStoreTests.swift
@@ -25,42 +25,53 @@ final class KeychainIntroKeyStoreTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // MARK: - TTL
+    // MARK: - no expiry
 
-    func test_expiredEntry_invisibleToReads() async {
-        await store.save(makeEntry(owner: ownerA, age: KeychainIntroKeyStore.entryTTL + 60))
+    func test_oldEntry_staysVisibleAndAtRest() async {
+        // Invite links do not expire. An entry minted long ago is as
+        // usable as one minted a second ago; only `revoke` retires it.
+        let ancient = makeEntry(owner: ownerA, age: 400 * 24 * 60 * 60)
+        await store.save(ancient)
         let fresh = makeEntry(owner: ownerA)
         await store.save(fresh)
 
         let listed = await store.listForOwner(ownerA)
-        XCTAssertEqual(listed.map(\.introPublicKey), [fresh.introPublicKey],
-                       "entries past the 24h TTL must be invisible to listForOwner")
+        XCTAssertEqual(Set(listed.map(\.introPublicKey)),
+                       Set([ancient.introPublicKey, fresh.introPublicKey]))
+        let foundAncient = await store.find(introPublicKey: ancient.introPublicKey)
+        XCTAssertNotNil(foundAncient)
+        XCTAssertEqual(rawEntryCount(), 2, "reads must not silently drop rows")
     }
 
-    func test_expiredEntry_compactsOutOfBlobOnFirstRead() async {
-        let fresh = makeEntry(owner: ownerA)
-        await store.save(fresh)
-        await store.save(makeEntry(owner: ownerB, age: KeychainIntroKeyStore.entryTTL + 60))
-        // No subscribers → save's publish no-ops without reading, so
-        // the expired row really is at rest now.
-        XCTAssertEqual(rawEntryCount(), 2)
+    func test_revokedEntry_disappearsFromReadsAndFromTheBlob() async {
+        let doomed = makeEntry(owner: ownerA, age: 400 * 24 * 60 * 60)
+        await store.save(doomed)
+        let kept = makeEntry(owner: ownerA)
+        await store.save(kept)
 
-        _ = await store.listForOwner(ownerA)
+        await store.revoke(introPublicKey: doomed.introPublicKey)
 
-        XCTAssertEqual(rawEntryCount(), 1,
-                       "the read that first sees an expired intro privkey must rewrite the blob without it")
+        let listed = await store.listForOwner(ownerA)
+        XCTAssertEqual(listed.map(\.introPublicKey), [kept.introPublicKey])
+        let foundDoomed = await store.find(introPublicKey: doomed.introPublicKey)
+        XCTAssertNil(foundDoomed)
+        // The row held an intro PRIVATE key; revoke must remove it at
+        // rest, not just hide it from reads.
+        XCTAssertEqual(rawEntryCount(), 1)
     }
 
-    func test_expiredEntry_streamSnapshotExcludesIt() async {
-        await store.save(makeEntry(owner: ownerB, age: KeychainIntroKeyStore.entryTTL + 60))
+    func test_revoke_publishesToTheOwnersStream_soThePumpDropsTheInbox() async {
+        let doomed = makeEntry(owner: ownerB)
+        await store.save(doomed)
 
         var iterator = store.entriesStream(forOwner: ownerB).makeAsyncIterator()
-        let snapshot = await iterator.next()
+        _ = await iterator.next()  // initial snapshot
 
-        XCTAssertEqual(snapshot, [],
-                       "the intro pump must never see an expired entry's inbox")
-        XCTAssertEqual(rawEntryCount(), 0,
-                       "subscribing triggered the read → the expired privkey is gone at rest too")
+        await store.revoke(introPublicKey: doomed.introPublicKey)
+        let afterRevoke = await iterator.next()
+
+        XCTAssertEqual(afterRevoke, [],
+                       "the intro pump must stop subscribing a revoked inbox")
     }
 
     // MARK: - pruneOwners


### PR DESCRIPTION
Stacked on #212. Reverses the TTL decision from earlier in this stack: links now live until the inviter retires them.

### Why the TTL goes

The 24h expiry (onymchat/onym-ios#111) was a blunt instrument. It closed leaked links you never noticed, but it also silently killed links you were still using — and it was enforced as a **lazy purge at the store's read point, not a timer**, so a quiet session kept its relay subscriptions past expiry anyway. It gave neither a reliable guarantee nor a good experience.

### What replaces it

**Rotate.** "Generate new link" on the share screen mints a fresh keypair and revokes the group's previous shared key. Mint-then-revoke, not the reverse: if the process dies between the two, the group has two working links rather than none. An extra live link is a nuisance you can rotate again; zero links with a joiner mid-flow is a dead end.

**A visible list of everything else.** The create-time offer keys — one per invitee from `sendOffers` — now carry a `label` and appear as named rows with a per-row Revoke. They had **no UI at all** before, so removing the TTL without this would leave every group creation trailing permanent, invisible, unrevokable relay subscriptions. This is the piece that makes "no TTL" actually safe.

**A guard so the two never mix.** `currentOrMint` and `rotate` only consider the unlabelled shared link. The common create-with-invitees flow lands on the share screen with the last invitee's offer key as the newest entry for the group, and handing that out as the group's link would collapse the 1:1 request-to-invitee mapping.

### Storage compatibility

`IntroKeyEntry.label` is **optional** in the stored blob deliberately. The decode is `(try? decode)?.entries ?? []`, so a non-optional addition would make every pre-existing invite fail to decode and vanish on upgrade.

### The joiner had to be handled too

Revocation is local and silent — there is no way to tell the relay or the people holding the old link. With expiry gone, revoke becomes the main way links die, so leaving the joiner on "Keep this screen open" forever was no longer acceptable. `JoinFlow` gains an `unanswered` state after 90s, naming both causes (host offline, or the invite no longer works) since they are genuinely indistinguishable from there. The watcher stays live, so a late approval still flips to `.approved` — there's a test for exactly that. 90s is deliberately generous: approval is a human tap plus a multi-second proof and a chain round-trip.

The timeout is injectable. On Android that's load-bearing (`runTest`'s virtual clock skips `delay`, so a hard-coded value fires instantly in every test that just wants to observe `awaitingApproval`); iOS mirrors it so the timer is testable in milliseconds instead of sitting out 90 real seconds.

### Coverage

`KeychainIntroKeyStoreTests`' three expiry tests become three lifecycle tests: an ancient entry stays usable, revoke removes it from reads *and* from the blob at rest (it holds an intro private key), and revoke re-emits to the owner's stream so the pump drops the inbox. Plus rotate/revoke/liveInvites on the introducer and three join-timeout tests. 896 green.

Nine new strings, en and ru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)