### PR TITLE
feat(group): multi-use invite links with explicit revocation (squashed)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1540,6 +1540,22 @@
         }
       }
     },
+    "Direct invites": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direct invites"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Персональные приглашения"
+          }
+        }
+      }
+    },
     "Dismiss": {
       "localizations": {
         "en": {
@@ -1733,6 +1749,22 @@
         }
       }
     },
+    "Generate new link": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate new link"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать новую ссылку"
+          }
+        }
+      }
+    },
     "Generate with AI": {
       "extractionState": "stale",
       "localizations": {
@@ -1762,6 +1794,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Генерируется доказательство и обновляется обязательство в блокчейне. Обычно занимает несколько секунд."
+          }
+        }
+      }
+    },
+    "Generating…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generating…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создаём…"
           }
         }
       }
@@ -2455,6 +2503,22 @@
         }
       }
     },
+    "No response yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No response yet"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока нет ответа"
+          }
+        }
+      }
+    },
     "No servers configured. Media can't be sent or received.": {
       "localizations": {
         "ru": {
@@ -2516,6 +2580,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Это не то слово. Проверьте фразу и повторите попытку."
+          }
+        }
+      }
+    },
+    "Older link": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Older link"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Старая ссылка"
           }
         }
       }
@@ -3162,6 +3242,22 @@
         }
       }
     },
+    "Revoke": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revoke"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отозвать"
+          }
+        }
+      }
+    },
     "Run a relayer for yourself, your team, or your org. End-to-end encryption stays intact — Onym never sees your messages.": {
       "localizations": {
         "en": {
@@ -3387,6 +3483,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Отправляем запрос…"
+          }
+        }
+      }
+    },
+    "Sent when you created the group. Each one can still be used to request to join.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent when you created the group. Each one can still be used to request to join."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отправлены при создании группы. По каждому из них всё ещё можно запросить вступление."
           }
         }
       }
@@ -3701,6 +3813,38 @@
         }
       }
     },
+    "The host may be offline, or this invite may no longer work. Ask them for a new link.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The host may be offline, or this invite may no longer work. Ask them for a new link."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Возможно, владелец группы не в сети или это приглашение больше не действует. Попросите новую ссылку."
+          }
+        }
+      }
+    },
+    "The old link stops working. Anyone still holding it won't be told.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The old link stops working. Anyone still holding it won't be told."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Старая ссылка перестанет работать. Тех, у кого она осталась, об этом не уведомят."
+          }
+        }
+      }
+    },
     "The phrase is generated on-device and never sent off the device.": {
       "localizations": {
         "en": {
@@ -3990,6 +4134,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ждём одобрения от хоста…"
+          }
+        }
+      }
+    },
+    "You can leave this screen open — if they approve, the chat still appears.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can leave this screen open — if they approve, the chat still appears."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Можно не закрывать этот экран — если заявку одобрят, чат появится сам."
           }
         }
       }

--- a/Sources/OnymIOS/Group/CreateGroupInteractor.swift
+++ b/Sources/OnymIOS/Group/CreateGroupInteractor.swift
@@ -720,9 +720,8 @@ struct CreateGroupInteractor: Sendable {
     /// Mint a per-invitee intro key and ship a durable
     /// `GroupInviteOfferPayload` to each invitee's inbox. Reuses the
     /// inbox seal+send path, but the payload grants nothing: it carries
-    /// only the reply channel + display context, so it never expires
-    /// and never anchors anyone. The invitee turns it into a join
-    /// request on accept; the admin anchors only on explicit approve.
+    /// only the reply channel + display context, and never anchors
+    /// anyone. Labelled per invitee so the invite list can revoke it.
     private func sendOffers(
         to invitees: [Data],
         ownerIdentityID: IdentityID,
@@ -732,15 +731,15 @@ struct CreateGroupInteractor: Sendable {
         inviterAlias: String
     ) async throws {
         for (index, inboxKey) in invitees.enumerated() {
-            // One fresh intro key per invitee → granular revoke and a
-            // clean 1:1 mapping from an inbound join request back to
-            // the person the admin meant to invite.
+            // One key per invitee keeps the 1:1 map from request back
+            // to person; `currentOrMint` would collapse it.
             let capability: IntroCapability
             do {
                 capability = try await introducer.mint(
                     ownerIdentityID: ownerIdentityID,
                     groupId: groupID,
-                    groupName: groupName
+                    groupName: groupName,
+                    label: IntroKeyEntry.fingerprint(of: inboxKey)
                 )
             } catch {
                 throw CreateGroupError.invitationSendFailed(

--- a/Sources/OnymIOS/Group/HandledIntroRequestLog.swift
+++ b/Sources/OnymIOS/Group/HandledIntroRequestLog.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Durable record of intro-request event ids the user already acted on.
+///
+/// The REQ carries no `since`, so every cold start replays an intro
+/// inbox in full. The burn used to make those replays undecodable.
+///
+/// Scoped by intro pubkey, so `prune(keeping:)` bounds the set by the
+/// links that still exist. `maxEntries` backstops one busy link.
+protocol HandledIntroRequestLog: Sendable {
+    /// Event ids already acted on, for the reader's fast path.
+    func handledIDs() -> Set<String>
+    /// Remember `id`, attributed to the link it arrived on.
+    func record(id: String, introPublicKey: Data)
+    /// Drop tombstones whose link no longer exists.
+    func prune(keeping livePublicKeys: Set<Data>)
+}
+
+/// UserDefaults-backed: event ids are not secrets, so the Keychain
+/// would be over-rotation. Isolated `app.onym.ios.*` key prefix.
+struct UserDefaultsHandledIntroRequestLog: HandledIntroRequestLog, @unchecked Sendable {
+    /// Backstop for a busy link. Ids are 64-char hex, so this caps the
+    /// blob in the low hundreds of KB.
+    static let maxEntries = 2_000
+
+    private static let storageKey = "app.onym.ios.intro_requests.handled"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func handledIDs() -> Set<String> {
+        Set(load().map(\.id))
+    }
+
+    func record(id: String, introPublicKey: Data) {
+        var rows = load()
+        guard !rows.contains(where: { $0.id == id }) else { return }
+        rows.append(Row(id: id, introPub: introPublicKey))
+        // Oldest-first drop: a replay is likeliest to hit recent ids.
+        if rows.count > Self.maxEntries {
+            rows.removeFirst(rows.count - Self.maxEntries)
+        }
+        save(rows)
+    }
+
+    func prune(keeping livePublicKeys: Set<Data>) {
+        let rows = load()
+        let kept = rows.filter { livePublicKeys.contains($0.introPub) }
+        if kept.count != rows.count { save(kept) }
+    }
+
+    // MARK: - Private
+
+    private struct Row: Codable {
+        let id: String
+        let introPub: Data
+    }
+
+    private func load() -> [Row] {
+        guard let data = defaults.data(forKey: Self.storageKey) else { return [] }
+        // Corrupted blob → start over; one round of replays re-surfaces.
+        return (try? JSONDecoder().decode([Row].self, from: data)) ?? []
+    }
+
+    private func save(_ rows: [Row]) {
+        guard let data = try? JSONEncoder().encode(rows) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+}
+
+/// Test double, and the fallback when no durable log is wired.
+final class InMemoryHandledIntroRequestLog: HandledIntroRequestLog, @unchecked Sendable {
+    private let lock = NSLock()
+    private var rows: [String: Data] = [:]
+
+    init() {}
+
+    func handledIDs() -> Set<String> {
+        lock.withLock { Set(rows.keys) }
+    }
+
+    func record(id: String, introPublicKey: Data) {
+        lock.withLock { rows[id] = introPublicKey }
+    }
+
+    func prune(keeping livePublicKeys: Set<Data>) {
+        lock.withLock { rows = rows.filter { livePublicKeys.contains($0.value) } }
+    }
+}

--- a/Sources/OnymIOS/Group/IntroCapability.swift
+++ b/Sources/OnymIOS/Group/IntroCapability.swift
@@ -219,6 +219,9 @@ struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
         let e = JSONEncoder()
         // Default `.base64` + matches Android `Base64.getEncoder()`.
         e.dataEncodingStrategy = .base64
+        // Without this one capability can encode to two different
+        // link strings. Decoding is order-agnostic, so links keep working.
+        e.outputFormatting = .sortedKeys
         return e
     }()
 

--- a/Sources/OnymIOS/Group/IntroKeyEntry.swift
+++ b/Sources/OnymIOS/Group/IntroKeyEntry.swift
@@ -15,21 +15,25 @@ import Foundation
 /// - `groupId` is the on-chain `group_id` the invite is for —
 ///   needed when the inviter's app surfaces "Bob wants to join
 ///   <group>?" so it can render the group's name.
-/// - `createdAt` drives optional expiration UI (later PRs may
-///   prune invites older than N days).
+/// - `createdAt` is display-only; links live until revoked.
+/// - `label` is nil for the shared link, else the invitee's fingerprint.
 struct IntroKeyEntry: Equatable, Sendable {
     let introPublicKey: Data
     let introPrivateKey: Data
     let ownerIdentityID: IdentityID
     let groupId: Data
     let createdAt: Date
+    /// nil == the group's shared link. Non-nil == a create-time offer
+    /// aimed at one invitee.
+    let label: String?
 
     init(
         introPublicKey: Data,
         introPrivateKey: Data,
         ownerIdentityID: IdentityID,
         groupId: Data,
-        createdAt: Date
+        createdAt: Date,
+        label: String? = nil
     ) {
         precondition(introPublicKey.count == 32,
                      "introPublicKey: expected 32 bytes, got \(introPublicKey.count)")
@@ -42,5 +46,12 @@ struct IntroKeyEntry: Equatable, Sendable {
         self.ownerIdentityID = ownerIdentityID
         self.groupId = groupId
         self.createdAt = createdAt
+        self.label = label
+    }
+
+    /// First 4 bytes of the inbox key — same fingerprint shape the
+    /// approval screen shows.
+    static func fingerprint(of inboxPublicKey: Data) -> String {
+        inboxPublicKey.prefix(4).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/OnymIOS/Group/IntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/IntroKeyStore.swift
@@ -14,7 +14,8 @@ import Foundation
 ///     payload.
 ///  4. On Approve, sender seals the existing
 ///     `GroupInvitationPayload` to the joiner's identity inbox key.
-///     `revoke` is called to retire the intro slot.
+///     The intro key is NOT retired: one link serves many joiners
+///     until the inviter revokes it.
 ///
 /// Owner-scoping: every entry carries an `IdentityID`. Removing an
 /// identity cascades a `deleteForOwner` so we don't leak intro
@@ -38,9 +39,8 @@ protocol IntroKeyStore: Sendable {
     /// list reads here.
     func listForOwner(_ ownerIdentityID: IdentityID) async -> [IntroKeyEntry]
 
-    /// Single-entry deletion. Called after a request is accepted +
-    /// sealed → the intro slot is no longer useful. No-op if the
-    /// pubkey isn't present.
+    /// Single-entry deletion, behind "Generate new link" and the
+    /// per-row revoke. No-op if the pubkey isn't present.
     func revoke(introPublicKey: Data) async
 
     /// Cascade for the identity-removal flow. Returns the count of

--- a/Sources/OnymIOS/Group/IntroRequestStore.swift
+++ b/Sources/OnymIOS/Group/IntroRequestStore.swift
@@ -18,9 +18,13 @@ protocol IntroRequestStore: Sendable {
     @discardableResult
     func record(_ request: IntroRequest) async -> Bool
 
-    /// Drop a request after the user has acted on it (Approve or
-    /// Decline) so it stops cluttering the surface.
+    /// Drop a handled request and tombstone its id. Conformers MUST
+    /// tombstone durably: cold starts replay the inbox too.
     func consume(id: String) async
+
+    /// Drop tombstones for links that no longer exist, so the durable
+    /// set stays bounded by the live invites.
+    func pruneTombstones(keeping livePublicKeys: Set<Data>) async
 
     /// Snapshot read used by tests + bootstrap reads. UI prefers
     /// the stream.
@@ -29,10 +33,22 @@ protocol IntroRequestStore: Sendable {
 
 actor InMemoryIntroRequestStore: IntroRequestStore {
     private var pending: [IntroRequest] = []
+    /// Event ids already acted on, mirrored from `handledLog` so the
+    /// hot `record` path doesn't hit storage per inbound.
+    private var consumed: Set<String>
+    /// Durable half of the tombstone. Process-lifetime alone would let
+    /// every handled request re-decode on the next cold start.
+    private let handledLog: any HandledIntroRequestLog
     private var continuations: [UUID: AsyncStream<[IntroRequest]>.Continuation] = [:]
+
+    init(handledLog: any HandledIntroRequestLog = InMemoryHandledIntroRequestLog()) {
+        self.handledLog = handledLog
+        self.consumed = handledLog.handledIDs()
+    }
 
     @discardableResult
     func record(_ request: IntroRequest) async -> Bool {
+        if consumed.contains(request.id) { return false }
         if pending.contains(where: { $0.id == request.id }) { return false }
         pending.append(request)
         publish()
@@ -40,9 +56,22 @@ actor InMemoryIntroRequestStore: IntroRequestStore {
     }
 
     func consume(id: String) async {
+        // Unconditional, so a tombstone can be laid ahead of a replay
+        // that hasn't landed yet.
+        consumed.insert(id)
+        // Attribute to the link it arrived on so `pruneTombstones` can
+        // drop it when that link is retired.
+        if let raw = pending.first(where: { $0.id == id }) {
+            handledLog.record(id: id, introPublicKey: raw.targetIntroPublicKey)
+        }
         let before = pending.count
         pending.removeAll { $0.id == id }
         if pending.count != before { publish() }
+    }
+
+    func pruneTombstones(keeping livePublicKeys: Set<Data>) async {
+        handledLog.prune(keeping: livePublicKeys)
+        consumed = handledLog.handledIDs()
     }
 
     func current() async -> [IntroRequest] {

--- a/Sources/OnymIOS/Group/InviteIntroducer.swift
+++ b/Sources/OnymIOS/Group/InviteIntroducer.swift
@@ -10,13 +10,14 @@ import CryptoKit
 /// the Keychain write is the dominant cost (single `SecItemUpdate`).
 /// Cheap enough for the foreground tap handler to await directly.
 ///
-/// **Why one keypair per invite instead of one per identity**: per-
-/// link revocation. The inviter can stop listening on a specific
-/// intro tag → that link goes silent without affecting other
-/// outstanding invites. A leaked link only burns its own slot.
+/// `currentOrMint` reuses the group's shared link; `mint` is always
+/// fresh, for create-time offers needing one key per invitee.
 actor InviteIntroducer {
     private let store: any IntroKeyStore
     private let now: @Sendable () -> Date
+    /// In-flight shared-link mutation per group: both paths read the
+    /// store across an `await`, so the actor suspends between them.
+    private var inFlight: [String: Task<IntroCapability, Error>] = [:]
 
     init(store: any IntroKeyStore, now: @escaping @Sendable () -> Date = { Date() }) {
         self.store = store
@@ -35,10 +36,13 @@ actor InviteIntroducer {
     ///   - groupName: optional plaintext name surfaced in the deeplink
     ///     for the joiner's preview. Pass nil for groups whose name
     ///     is sensitive (deeplink transits cleartext channels).
+    ///   - label: nil for the shared link; the invitee's fingerprint
+    ///     for a create-time offer, so the invite list can name it.
     func mint(
         ownerIdentityID: IdentityID,
         groupId: Data,
-        groupName: String? = nil
+        groupName: String? = nil,
+        label: String? = nil
     ) async throws -> IntroCapability {
         guard groupId.count == 32 else {
             throw IntroducerError.invalidGroupID(actualSize: groupId.count)
@@ -56,7 +60,8 @@ actor InviteIntroducer {
             introPrivateKey: privBytes,
             ownerIdentityID: ownerIdentityID,
             groupId: groupId,
-            createdAt: now()
+            createdAt: now(),
+            label: label
         ))
 
         return try IntroCapability(
@@ -64,6 +69,105 @@ actor InviteIntroducer {
             groupId: groupId,
             groupName: groupName
         )
+    }
+
+    /// The group's shared link, minting only when it has none. Owner-
+    /// scoped: the pump only listens on the active identity's inboxes.
+    func currentOrMint(
+        ownerIdentityID: IdentityID,
+        groupId: Data,
+        groupName: String? = nil
+    ) async throws -> IntroCapability {
+        // Ahead of the store read so the throw is the same whichever
+        // branch would have run.
+        guard groupId.count == 32 else {
+            throw IntroducerError.invalidGroupID(actualSize: groupId.count)
+        }
+        return try await serializingLink(ownerIdentityID, groupId) {
+            // `label == nil` is the shared link. Create-with-invitees
+            // would otherwise hand out the last invitee's offer key.
+            let live = await self.store.listForOwner(ownerIdentityID).first {
+                $0.groupId == groupId && $0.label == nil
+            }
+            if let live {
+                return try IntroCapability(
+                    introPublicKey: live.introPublicKey,
+                    groupId: groupId,
+                    groupName: groupName
+                )
+            }
+            return try await self.mint(
+                ownerIdentityID: ownerIdentityID,
+                groupId: groupId,
+                groupName: groupName
+            )
+        }
+    }
+
+    /// Serialize the read-decide-write on a group's shared link, which
+    /// actor isolation alone doesn't cover across the store `await`.
+    private func serializingLink(
+        _ owner: IdentityID,
+        _ groupId: Data,
+        _ body: @escaping @Sendable () async throws -> IntroCapability
+    ) async throws -> IntroCapability {
+        let key = owner.rawValue.uuidString + ":"
+            + groupId.map { String(format: "%02x", $0) }.joined()
+        // Wait out any predecessor; its failure is not ours to handle.
+        while let running = inFlight[key] {
+            _ = try? await running.value
+            if inFlight[key] == running { inFlight[key] = nil }
+        }
+        let task = Task { try await body() }
+        inFlight[key] = task
+        defer { if inFlight[key] == task { inFlight[key] = nil } }
+        return try await task.value
+    }
+
+    /// "Generate new link": mint fresh, then revoke the old shared key.
+    /// That order, so a crash leaves two working links rather than none.
+    @discardableResult
+    func rotate(
+        ownerIdentityID: IdentityID,
+        groupId: Data,
+        groupName: String? = nil
+    ) async throws -> IntroCapability {
+        guard groupId.count == 32 else {
+            throw IntroducerError.invalidGroupID(actualSize: groupId.count)
+        }
+        return try await serializingLink(ownerIdentityID, groupId) {
+            // Only the shared link rotates; offer keys are revoked one
+            // at a time from the invite list.
+            let superseded = await self.store.listForOwner(ownerIdentityID)
+                .filter { $0.groupId == groupId && $0.label == nil }
+                .map(\.introPublicKey)
+
+            let fresh = try await self.mint(
+                ownerIdentityID: ownerIdentityID,
+                groupId: groupId,
+                groupName: groupName
+            )
+
+            for pub in superseded where pub != fresh.introPublicKey {
+                await self.store.revoke(introPublicKey: pub)
+            }
+            return fresh
+        }
+    }
+
+    /// Kill one link. Backs the per-row revoke, chiefly for offer keys
+    /// which have no other way to be retired.
+    func revoke(introPublicKey: Data) async {
+        await store.revoke(introPublicKey: introPublicKey)
+    }
+
+    /// Every live invite this identity holds for the group,
+    /// newest-first. Backs the invite list on the share screen.
+    func liveInvites(
+        ownerIdentityID: IdentityID,
+        groupId: Data
+    ) async -> [IntroKeyEntry] {
+        await store.listForOwner(ownerIdentityID).filter { $0.groupId == groupId }
     }
 }
 

--- a/Sources/OnymIOS/Group/JoinFlow.swift
+++ b/Sources/OnymIOS/Group/JoinFlow.swift
@@ -50,6 +50,9 @@ final class JoinFlow {
         case ready(IntroCapability)
         case sending
         case awaitingApproval
+        /// Nothing came back in time. Not a failure — a revoked link
+        /// and a slow host are indistinguishable from here.
+        case unanswered
         case approved(ChatGroup)
         case failed(reason: String)
     }
@@ -67,17 +70,23 @@ final class JoinFlow {
 
     private var sendTask: Task<Void, Never>?
     private var watcherTask: Task<Void, Never>?
+    private var unansweredTask: Task<Void, Never>?
+    /// Wait before flipping to `.unanswered`, nil to never flip.
+    /// Injected so tests drive it in milliseconds.
+    private let unansweredAfter: Duration?
 
     init(
         capability: IntroCapability,
         suggestedDisplayLabel: String,
         submitRequest: @escaping @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome,
-        groupRepository: GroupRepository
+        groupRepository: GroupRepository,
+        unansweredAfter: Duration? = JoinFlow.unansweredAfter
     ) {
         self.capability = capability
         self.suggestedDisplayLabel = suggestedDisplayLabel
         self.submitRequest = submitRequest
         self.groupRepository = groupRepository
+        self.unansweredAfter = unansweredAfter
         self.state = .ready(capability)
         startWatcher()
     }
@@ -86,6 +95,10 @@ final class JoinFlow {
     // capture `[weak self]` so they exit gracefully on deallocation
     // without needing main-actor-isolated cancellation in `deinit`
     // (which Swift's strict concurrency checking would flag).
+
+    /// Generous: approval is a human tap plus a proof and a chain
+    /// round-trip, so anything short cries wolf on a thinking host.
+    static let unansweredAfter: Duration = .seconds(90)
 
     /// Ship the join request. No-op if a previous `send` is in flight
     /// (debounce — protects against double-tap on the primary
@@ -98,7 +111,7 @@ final class JoinFlow {
             // tap will be guarded by the state check below anyway.)
         }
         switch state {
-        case .ready, .failed: break
+        case .ready, .failed, .unanswered: break
         default: return
         }
         sendTask = Task { [weak self, submitRequest, capability] in
@@ -111,11 +124,25 @@ final class JoinFlow {
             switch outcome {
             case .sent:
                 self.state = .awaitingApproval
+                self.startUnansweredTimer()
             case .noIdentityLoaded:
                 self.state = .failed(reason: "Sign in first.")
             case .transportFailed(let reason):
                 self.state = .failed(reason: "Couldn't send: \(reason)")
             }
+        }
+    }
+
+    /// Flip to `.unanswered` at the deadline. A late approval still
+    /// overwrites it via the watcher.
+    private func startUnansweredTimer() {
+        guard let unansweredAfter else { return }
+        unansweredTask?.cancel()
+        unansweredTask = Task { [weak self] in
+            try? await Task.sleep(for: unansweredAfter)
+            guard let self, !Task.isCancelled else { return }
+            guard case .awaitingApproval = self.state else { return }
+            self.state = .unanswered
         }
     }
 
@@ -130,6 +157,9 @@ final class JoinFlow {
                     continue
                 }
                 if case .approved = self.state { continue }  // terminal
+                // Beats `.unanswered` too: a late approval is still an
+                // approval.
+                self.unansweredTask?.cancel()
                 self.state = .approved(match)
             }
         }

--- a/Sources/OnymIOS/Group/JoinRequestApprover.swift
+++ b/Sources/OnymIOS/Group/JoinRequestApprover.swift
@@ -26,11 +26,8 @@ protocol JoinRequestApproving: Sendable {
 ///     Approve?" prompts.
 ///  3. On Approve → seals the existing `GroupInvitationPayload`
 ///     (built from the local `ChatGroup`) to the joiner's identity
-///     inbox key, ships via `inboxTransport.send`, revokes the
-///     intro key. The pump from PR-3 stops listening on that intro
-///     tag within one emission window.
-///  4. On Decline → drop the request, revoke the intro key. No
-///     NACK to the joiner; their JoinScreen times out gracefully.
+///     inbox key and ships it. The intro key is NOT retired.
+///  4. On Decline → drop that one request; the link stays live.
 actor JoinRequestApprover: JoinRequestApproving {
 
     /// UI-renderable view of one decrypted, awaiting-action request.
@@ -115,6 +112,9 @@ actor JoinRequestApprover: JoinRequestApproving {
     private let makeContractTransport: @Sendable (URL) -> any SEPContractTransport
 
     private var pendingValue: [PendingRequest] = []
+    /// Surviving row id → every raw id that collapsed into it.
+    /// Rebuilt by `refresh`, read by `consumeRequestAndSiblings`.
+    private var collapsedRequestIDs: [String: [String]] = [:]
     private var pendingContinuations: [UUID: AsyncStream<[PendingRequest]>.Continuation] = [:]
     private var decryptFailures: Int = 0
     private var collectorTask: Task<Void, Never>?
@@ -230,7 +230,8 @@ actor JoinRequestApprover: JoinRequestApproving {
     ///      (members, commitment, epoch, salt), seal + ship the
     ///      `GroupInvitationPayload` (with new state) to the joiner,
     ///      fanout `MemberAnnouncementPayload` (also with new state)
-    ///      to existing members, revoke intro key + consume request.
+    ///      to existing members, consume the request. The key survives.
+    ///   8. A joiner already in `members` skips 2-6; snapshot only.
     ///
     /// Failures at the proof / anchor steps return without mutating
     /// any local state or consuming the request, so the admin can
@@ -255,10 +256,16 @@ actor JoinRequestApprover: JoinRequestApproving {
             return .unknownGroup
         }
 
+        // Already in the roster (reinstall, replay, retry) — re-anchoring
+        // would duplicate a leaf. `members`, not `memberProfiles`.
+        let alreadyInRoster = req.joinerBlsPublicKey.map { blsPub in
+            group.members.contains { $0.publicKeyCompressed == blsPub }
+        } ?? false
+
         // PR-13a admin-anchor path is Tyranny-only. Other types fall
         // through to the pre-PR-13 ship-only flow at the bottom.
         var anchored = group
-        if group.groupType == .tyranny {
+        if group.groupType == .tyranny, !alreadyInRoster {
             switch await anchorTyrannyJoin(
                 req: req,
                 group: group,
@@ -333,6 +340,8 @@ actor JoinRequestApprover: JoinRequestApproving {
         // already updated by the anchor step. Both side-effects only
         // run when the joiner shipped a BLS pubkey.
         if let blsPub = req.joinerBlsPublicKey {
+            // Idempotent, and the point of the re-join path: a
+            // reinstalled joiner has a new inbox pubkey.
             await recordJoiner(
                 in: anchored,
                 blsPub: blsPub,
@@ -340,19 +349,21 @@ actor JoinRequestApprover: JoinRequestApproving {
                 sendingPub: req.joinerSendingPublicKey,
                 alias: req.joinerDisplayLabel
             )
-            await broadcastJoin(
-                in: anchored,
-                joinerBlsPub: blsPub,
-                joinerInboxPub: req.joinerInboxPublicKey,
-                joinerSendingPub: req.joinerSendingPublicKey,
-                joinerAlias: req.joinerDisplayLabel
-            )
+            // Skipped on re-join: receivers bail on a known BLS hex, so
+            // this would be N seals and N publishes for nothing.
+            if !alreadyInRoster {
+                await broadcastJoin(
+                    in: anchored,
+                    joinerBlsPub: blsPub,
+                    joinerInboxPub: req.joinerInboxPublicKey,
+                    joinerSendingPub: req.joinerSendingPublicKey,
+                    joinerAlias: req.joinerDisplayLabel
+                )
+            }
         }
-        // Best-effort cleanup.
-        if let introPub = await findIntroPub(forRequestID: requestId) {
-            await introKeyStore.revoke(introPublicKey: introPub)
-        }
-        await introRequestStore.consume(id: requestId)
+        // Drop the request and its siblings. The key stays alive, or
+        // every other joiner's row would silently vanish.
+        await consumeRequestAndSiblings(requestId)
         return .sent
     }
 
@@ -616,13 +627,10 @@ actor JoinRequestApprover: JoinRequestApproving {
         }
     }
 
-    /// Decline a pending request: drop it + revoke the intro slot.
-    /// No NACK to the joiner — their JoinScreen times out.
+    /// Drop that one request and its siblings, nothing else: a decline
+    /// judges one requester, not the link. No NACK to the joiner.
     func decline(requestId: String) async {
-        if let introPub = await findIntroPub(forRequestID: requestId) {
-            await introKeyStore.revoke(introPublicKey: introPub)
-        }
-        await introRequestStore.consume(id: requestId)
+        await consumeRequestAndSiblings(requestId)
     }
 
     // MARK: - Private
@@ -653,12 +661,15 @@ actor JoinRequestApprover: JoinRequestApproving {
         // rows and approving/declining one leaves the siblings behind —
         // which reads as "the buttons don't work". Keep the most recently
         // received copy, positioned at the first-seen index.
+        // Re-decodes each emission, so a row lives only while its key
+        // does — stable now that approve no longer revokes.
         var collapsed: [String: (request: PendingRequest, receivedAt: Date)] = [:]
+        var siblings: [String: [String]] = [:]
         var order: [String] = []
         for r in raw {
             guard let p = await decode(r) else { continue }
-            let identity = p.joinerBlsPublicKey ?? p.joinerInboxPublicKey
-            let key = Self.hex(identity) + ":" + Self.hex(p.groupId)
+            let key = Self.collapseKey(for: p)
+            siblings[key, default: []].append(r.id)
             if let existing = collapsed[key] {
                 if r.receivedAt > existing.receivedAt {
                     collapsed[key] = (p, r.receivedAt)
@@ -669,7 +680,40 @@ actor JoinRequestApprover: JoinRequestApproving {
             }
         }
         pendingValue = order.compactMap { collapsed[$0]?.request }
+        // Approve/Decline consume the whole set; dropping only the
+        // winner lets a sibling resurface on the next emission.
+        collapsedRequestIDs = order.reduce(into: [:]) { acc, key in
+            guard let winner = collapsed[key]?.request else { return }
+            acc[winner.id] = siblings[key] ?? [winner.id]
+        }
         publishPending()
+    }
+
+    /// Drop `requestId` plus every sibling that collapsed into its row.
+    /// The intro key is left alive — see the type doc.
+    private func consumeRequestAndSiblings(_ requestId: String) async {
+        var ids = Set(collapsedRequestIDs[requestId] ?? [requestId])
+        // The cached map is only as fresh as the last `refresh`, so
+        // re-derive against the live store before consuming.
+        if let target = pendingValue.first(where: { $0.id == requestId }) {
+            let key = Self.collapseKey(for: target)
+            for raw in await introRequestStore.current() {
+                guard let decoded = await decode(raw),
+                      Self.collapseKey(for: decoded) == key
+                else { continue }
+                ids.insert(raw.id)
+            }
+        }
+        for id in ids {
+            await introRequestStore.consume(id: id)
+        }
+    }
+
+    /// Same joiner, same group — the identity two copies of one logical
+    /// join share.
+    private static func collapseKey(for request: PendingRequest) -> String {
+        let identity = request.joinerBlsPublicKey ?? request.joinerInboxPublicKey
+        return hex(identity) + ":" + hex(request.groupId)
     }
 
     private static func hex(_ data: Data) -> String {
@@ -726,12 +770,5 @@ actor JoinRequestApprover: JoinRequestApproving {
             groupId: payload.groupId,
             groupName: groupName
         )
-    }
-
-    /// `PendingRequest` doesn't carry the introPub (intentional —
-    /// UI never needs it). Resolve via the raw store on demand.
-    private func findIntroPub(forRequestID id: String) async -> Data? {
-        let raw = await introRequestStore.current()
-        return raw.first { $0.id == id }?.targetIntroPublicKey
     }
 }

--- a/Sources/OnymIOS/Group/JoinView.swift
+++ b/Sources/OnymIOS/Group/JoinView.swift
@@ -135,6 +135,35 @@ struct JoinView: View {
             }
             .padding(.top, 24)
             .accessibilityIdentifier("join.awaiting_approval")
+        case .unanswered:
+            VStack(spacing: 12) {
+                Image(systemName: "clock.badge.questionmark")
+                    .font(.system(size: 36))
+                    .foregroundStyle(OnymTokens.text2)
+                Text("No response yet")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                // Host offline or link replaced — indistinguishable
+                // from here, since revocation is silent. Name both.
+                Text("The host may be offline, or this invite may no longer work. Ask them for a new link.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                Text("You can leave this screen open — if they approve, the chat still appears.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                Button("Try again") {
+                    flow.send(displayLabel: displayLabel)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 4)
+                .accessibilityIdentifier("join.retry_button")
+            }
+            .padding(.top, 24)
+            .accessibilityIdentifier("join.unanswered")
         case .approved(let group):
             VStack(spacing: 12) {
                 Image(systemName: "checkmark.seal.fill")

--- a/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
+++ b/Sources/OnymIOS/Group/KeychainIntroKeyStore.swift
@@ -21,26 +21,11 @@ actor KeychainIntroKeyStore: IntroKeyStore {
     static let serviceDefault = "app.onym.ios.intro_keys"
     static let account = "blob"
 
-    /// How long an invite link is honored after minting. 24 hours per
-    /// issue onymchat/onym-ios#111 (shrink the leak window of a
-    /// forwarded or screenshotted link) — matches onym-android's
-    /// `IntroKeyEntry.LIFETIME_MILLIS`. Expired entries are invisible
-    /// to `find`/`listForOwner`/streams (so the intro pump stops
-    /// subscribing their inboxes, which each cost a relay REQ slot)
-    /// and are compacted out of the blob by the load that first sees
-    /// them expired.
-    static let entryTTL: TimeInterval = 24 * 60 * 60
-
     private let service: String
     /// Per-owner subscriber continuations. Mutations re-emit the
     /// filtered+sorted snapshot to every subscriber whose owner
     /// matches.
     private var continuations: [IdentityID: [UUID: AsyncStream<[IntroKeyEntry]>.Continuation]] = [:]
-    /// Reentrancy latch: `loadAll()` publishes when it compacts, and
-    /// `publish` itself calls `loadAll()` — the latch stops that inner
-    /// load from re-entering the compaction path.
-    private var compacting = false
-
     init(testNamespace: String? = nil) {
         if let testNamespace, !testNamespace.isEmpty {
             self.service = "\(Self.serviceDefault).\(testNamespace)"
@@ -170,34 +155,9 @@ actor KeychainIntroKeyStore: IntroKeyStore {
         var result: AnyObject?
         let status = SecItemCopyMatching(q as CFDictionary, &result)
         guard status == errSecSuccess, let data = result as? Data else { return [] }
-        // Corrupted blob → discard rather than crash. Acceptable
-        // because this store holds ephemeral per-invite keys; if we
-        // lose them, the worst that happens is in-flight invites
-        // fail to deliver and the inviter re-shares.
-        let entries = (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
-        // TTL filter at the single load point so expired entries are
-        // invisible to every reader.
-        let cutoff = Int64((Date().timeIntervalSince1970 - Self.entryTTL) * 1000)
-        let live = entries.filter { $0.createdAtMillis > cutoff }
-        // Compact immediately: expired rows carry intro PRIVATE keys,
-        // and a read-only workload would otherwise leave them at rest
-        // indefinitely waiting for a mutation to rewrite the blob.
-        // Publish for the expired entries' owners so a live session's
-        // intro pump drops their relay REQ slots too — but note this
-        // still only runs when *something* touches the store; a fully
-        // quiet session keeps its slots until the next access or
-        // launch.
-        if live.count != entries.count, !compacting {
-            compacting = true
-            writeAll(live)
-            let expiredOwners = Set(
-                entries.filter { $0.createdAtMillis <= cutoff }
-                    .compactMap { IdentityID($0.ownerIdentityID) }
-            )
-            for owner in expiredOwners { publish(forOwner: owner) }
-            compacting = false
-        }
-        return live
+        // Corrupted blob → discard; the inviter re-shares. No
+        // time-based filter: entries live until revoked.
+        return (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
     }
 
     private func writeAll(_ entries: [StoredIntroKey]) {
@@ -236,6 +196,9 @@ private struct StoredIntroKey: Codable {
     let ownerIdentityID: String
     let groupId: Data
     let createdAtMillis: Int64
+    /// MUST stay optional: the decode is `(try? …) ?? []`, so a
+    /// required field would wipe every existing invite on upgrade.
+    let label: String?
 
     enum CodingKeys: String, CodingKey {
         case introPub = "intro_pub"
@@ -243,6 +206,7 @@ private struct StoredIntroKey: Codable {
         case ownerIdentityID = "owner_identity_id"
         case groupId = "group_id"
         case createdAtMillis = "created_at_millis"
+        case label
     }
 
     init(from entry: IntroKeyEntry) {
@@ -251,6 +215,7 @@ private struct StoredIntroKey: Codable {
         self.ownerIdentityID = entry.ownerIdentityID.rawValue.uuidString
         self.groupId = entry.groupId
         self.createdAtMillis = Int64(entry.createdAt.timeIntervalSince1970 * 1000)
+        self.label = entry.label
     }
 
     func toEntry() -> IntroKeyEntry? {
@@ -262,7 +227,8 @@ private struct StoredIntroKey: Codable {
             introPrivateKey: introPriv,
             ownerIdentityID: owner,
             groupId: groupId,
-            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000)
+            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000),
+            label: label
         )
     }
 }

--- a/Sources/OnymIOS/Group/ShareInviteFlow.swift
+++ b/Sources/OnymIOS/Group/ShareInviteFlow.swift
@@ -2,15 +2,11 @@ import Foundation
 import Observation
 
 /// Drives the post-create "Share invite" surface. Owns one piece of
-/// state — the share link for the just-minted invite — and exposes
-/// one intent (`mintFor`) to refresh / re-mint.
+/// state — the group's share link — and exposes one intent
+/// (`mintFor`) to load or refresh it.
 ///
-/// Why minting is decoupled from the view's first appearance:
-/// minting is a side effect (writes to `IntroKeyStore`); doing it
-/// in `.onAppear` ties it to view lifecycle (re-entries would mint
-/// twice). This flow holds the side effect off the view tree where
-/// it belongs. The view calls `mintFor` exactly once on appear,
-/// re-mint requires an explicit "Generate new link" tap.
+/// Re-entry is idempotent: `currentOrMint` returns the existing key
+/// rather than stacking a new one per visit.
 ///
 /// Mirrors onym-android's `ShareInviteViewModel.kt`.
 @MainActor
@@ -23,6 +19,16 @@ final class ShareInviteFlow: Identifiable {
         case failed(reason: String)
     }
 
+    /// One revokable invite. `label` is nil for a superseded shared
+    /// key; the view supplies the localized name for that case.
+    struct InviteRow: Equatable, Identifiable, Sendable {
+        let introPublicKey: Data
+        let label: String?
+        let createdAt: Date
+
+        var id: Data { introPublicKey }
+    }
+
     /// Drives `.sheet(item:)` from a single source of truth.
     /// `.sheet(isPresented:)` paired with a separate optional-flow
     /// `@State` raced on first present — the content closure read
@@ -30,6 +36,14 @@ final class ShareInviteFlow: Identifiable {
     nonisolated var id: ObjectIdentifier { ObjectIdentifier(self) }
 
     private(set) var state: State = .idle
+
+    /// Other live invites: the per-invitee offer keys, plus any
+    /// superseded shared key, so nothing is left unrevokable.
+    private(set) var otherInvites: [InviteRow] = []
+
+    /// Set while a rotate is in flight so the UI can disable the
+    /// button — rotating twice in a row would strand a live key.
+    private(set) var isRotating = false
 
     private let identity: IdentityRepository
     private let introducer: InviteIntroducer
@@ -45,10 +59,8 @@ final class ShareInviteFlow: Identifiable {
         self.groupRepository = groupRepository
     }
 
-    /// Mint a fresh capability for the group with hex id `groupID` and
-    /// surface the share link. Idempotent for repeated taps from the
-    /// same screen — re-mints a fresh keypair so each share goes
-    /// through a distinct intro slot (per-link revocation friendly).
+    /// Resolve and surface the group's share link. Idempotent: re-entry
+    /// returns the same link. One link, many joiners.
     ///
     /// If `groupID` does not resolve to a local group (race between
     /// persistence + navigation, or a stale deeplink back into share)
@@ -70,7 +82,41 @@ final class ShareInviteFlow: Identifiable {
         }
         state = .minting
         do {
-            let cap = try await introducer.mint(
+            let cap = try await introducer.currentOrMint(
+                ownerIdentityID: activeID,
+                groupId: group.groupIDData,
+                groupName: group.name
+            )
+            state = .ready(link: cap.toAppLink(), groupName: group.name)
+            await refreshOtherInvites(ownerIdentityID: activeID, groupId: group.groupIDData)
+        } catch {
+            state = .failed(reason: "\(error)")
+        }
+    }
+
+    /// Replace the shared link. Nobody holding the old one is told, so
+    /// this is the "my link leaked" escape hatch.
+    func rotateLink(groupID: String) {
+        Task { await rotateLinkAsync(groupID: groupID) }
+    }
+
+    private func rotateLinkAsync(groupID: String) async {
+        // Set before the first await, or a double-tap clears both this
+        // guard and `.disabled(flow.isRotating)` inside the window.
+        guard !isRotating else { return }
+        isRotating = true
+        defer { isRotating = false }
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }) else {
+            state = .failed(reason: "Group not found on this device")
+            return
+        }
+        guard let activeID = await identity.currentSelectedID() else {
+            state = .failed(reason: "No identity selected")
+            return
+        }
+        do {
+            let cap = try await introducer.rotate(
                 ownerIdentityID: activeID,
                 groupId: group.groupIDData,
                 groupName: group.name
@@ -79,5 +125,43 @@ final class ShareInviteFlow: Identifiable {
         } catch {
             state = .failed(reason: "\(error)")
         }
+    }
+
+    /// Retire one per-invitee offer key.
+    func revoke(_ row: InviteRow, groupID: String) {
+        Task { await revokeAsync(row, groupID: groupID) }
+    }
+
+    private func revokeAsync(_ row: InviteRow, groupID: String) async {
+        await introducer.revoke(introPublicKey: row.introPublicKey)
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }),
+              let activeID = await identity.currentSelectedID()
+        else { return }
+        await refreshOtherInvites(ownerIdentityID: activeID, groupId: group.groupIDData)
+    }
+
+    private func refreshOtherInvites(ownerIdentityID: IdentityID, groupId: Data) async {
+        let current = currentIntroPublicKey()
+        // Everything but the link on screen. A shared key stranded by a
+        // crash mid-rotate would otherwise be listed nowhere.
+        otherInvites = await introducer
+            .liveInvites(ownerIdentityID: ownerIdentityID, groupId: groupId)
+            .filter { $0.introPublicKey != current }
+            .map { entry in
+                InviteRow(
+                    introPublicKey: entry.introPublicKey,
+                    label: entry.label,
+                    createdAt: entry.createdAt
+                )
+            }
+    }
+
+    /// Intro pubkey behind the rendered link, so the list excludes it.
+    private func currentIntroPublicKey() -> Data? {
+        guard case .ready(let link, _) = state,
+              let cap = IntroCapability.fromLink(link)
+        else { return nil }
+        return cap.introPublicKey
     }
 }

--- a/Sources/OnymIOS/Group/ShareInviteView.swift
+++ b/Sources/OnymIOS/Group/ShareInviteView.swift
@@ -1,13 +1,11 @@
 import SwiftUI
 
 /// Post-create surface. The just-created group is identified by hex
-/// `groupID`; the flow resolves it from the repository, mints a
-/// fresh deeplink capability, and surfaces the link. The user
+/// `groupID`; the flow resolves it from the repository, resolves the
+/// group's deeplink capability, and surfaces the link. The user
 /// shares via the system share sheet, copies it, or skips.
 ///
-/// Mints exactly once per screen entry — re-entry (after Done →
-/// back) re-mints with a fresh intro keypair so the previous share
-/// stays revocable independently.
+/// Idempotent per entry — a QR already screenshotted keeps working.
 struct ShareInviteView: View {
     let groupID: String
     @Bindable var flow: ShareInviteFlow
@@ -46,6 +44,82 @@ struct ShareInviteView: View {
         }
         .background(OnymTokens.bg)
         .onAppear { flow.mintFor(groupID: groupID) }
+    }
+
+    /// Rotate. The only way a leaked link stops working, framed as
+    /// generate-a-new-one so the user always holds a working link.
+    private var rotateButton: some View {
+        Button {
+            copied = false
+            flow.rotateLink(groupID: groupID)
+        } label: {
+            HStack(spacing: 8) {
+                if flow.isRotating {
+                    ProgressView().controlSize(.small)
+                }
+                Text(flow.isRotating ? "Generating…" : "Generate new link")
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .foregroundStyle(OnymTokens.text2)
+        }
+        .disabled(flow.isRotating)
+        .accessibilityIdentifier("share_invite.rotate_button")
+        .overlay(alignment: .bottom) {
+            Text("The old link stops working. Anyone still holding it won't be told.")
+                .font(.system(size: 11))
+                .foregroundStyle(OnymTokens.text2)
+                .multilineTextAlignment(.center)
+                .offset(y: 16)
+        }
+        .padding(.bottom, 20)
+    }
+
+    /// The create-time offers, one per invitee. Nothing expires, so
+    /// this list is the only way they are ever retired.
+    @ViewBuilder
+    private var otherInvitesSection: some View {
+        if !flow.otherInvites.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Direct invites")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("Sent when you created the group. Each one can still be used to request to join.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(OnymTokens.text2)
+
+                ForEach(flow.otherInvites) { row in
+                    HStack {
+                        // A literal key so it localizes; a String
+                        // variable would render verbatim.
+                        if let label = row.label {
+                            Text(label)
+                                .font(.system(size: 13, design: .monospaced))
+                                .foregroundStyle(OnymTokens.text)
+                        } else {
+                            Text("Older link")
+                                .font(.system(size: 13))
+                                .foregroundStyle(OnymTokens.text)
+                        }
+                        Spacer()
+                        Button("Revoke") {
+                            flow.revoke(row, groupID: groupID)
+                        }
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.red)
+                        .accessibilityIdentifier(
+                            "share_invite.revoke_button.\(row.label ?? "superseded")"
+                        )
+                    }
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 12)
+                    .background(OnymTokens.surface2,
+                                in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityIdentifier("share_invite.other_invites")
+        }
     }
 
     private var topBar: some View {
@@ -130,6 +204,9 @@ struct ShareInviteView: View {
                 // capability aloud in Release.
                 .accessibilityValue(link)
                 #endif
+
+                rotateButton
+                otherInvitesSection
             }
             .padding(.top, 24)
         case .failed(let reason):

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -275,9 +275,11 @@ struct OnymIOSApp: App {
         let introKeyStore = KeychainIntroKeyStore()
         let inviteIntroducer = InviteIntroducer(store: introKeyStore)
         self.introKeyStore = introKeyStore
-        // Process-lifetime sink for inbound "request to join"
-        // envelopes. The sender-approval UI (PR-5+) consumes this.
-        self.introRequestStore = InMemoryIntroRequestStore()
+        // Sink for inbound "request to join" envelopes. Pending rows
+        // are process-lifetime; the handled-tombstones are durable.
+        self.introRequestStore = InMemoryIntroRequestStore(
+            handledLog: UserDefaultsHandledIntroRequestLog()
+        )
 
         // Single shared IdentitiesFlow so the toolbar picker on Chats
         // and the Settings → Identities screen observe the same state.
@@ -667,7 +669,23 @@ struct OnymIOSApp: App {
                             continue
                         }
                         let entries = introKeyStore.entriesStream(forOwner: activeID)
-                        currentTask = Task { await pump.run(entries: entries) }
+                        let store = introRequestStore
+                        // Tee the same snapshots the pump reconciles on,
+                        // so a retired link's tombstones go with it.
+                        let (forPump, pumpFeed) = AsyncStream.makeStream(of: [IntroKeyEntry].self)
+                        let tee = Task {
+                            for await snapshot in entries {
+                                await store.pruneTombstones(
+                                    keeping: Set(snapshot.map(\.introPublicKey))
+                                )
+                                pumpFeed.yield(snapshot)
+                            }
+                            pumpFeed.finish()
+                        }
+                        currentTask = Task {
+                            defer { tee.cancel() }
+                            await pump.run(entries: forPump)
+                        }
                     }
                     currentTask?.cancel()
                 }

--- a/Tests/OnymIOSTests/IntroInboxPumpTests.swift
+++ b/Tests/OnymIOSTests/IntroInboxPumpTests.swift
@@ -144,6 +144,102 @@ final class IntroInboxPumpTests: XCTestCase {
         runTask.cancel()
     }
 
+    // MARK: - IntroRequestStore consume tombstone
+
+    func test_record_afterConsume_isRejected_soRelayReplayCannotResurrect() async {
+        let store = InMemoryIntroRequestStore()
+        let request = IntroRequest(
+            id: "evt-1",
+            targetIntroPublicKey: Data(repeating: 0xA1, count: 32),
+            payload: Data([0x01, 0x02]),
+            receivedAt: Date()
+        )
+
+        let recorded = await store.record(request)
+        XCTAssertTrue(recorded)
+        await store.consume(id: request.id)
+
+        // The REQ has no `since`, so reconnects replay the whole inbox.
+        // A handled request must not come back.
+        let reRecorded = await store.record(request)
+        XCTAssertFalse(reRecorded, "a consumed event id must never be re-recorded")
+        let remaining = await store.current()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_consume_unknownId_stillTombstones_soALateReplayIsRejected() async {
+        let store = InMemoryIntroRequestStore()
+
+        // Tombstone laid before the replay lands — the ordering the
+        // pump can actually produce when a consume races a reconnect.
+        await store.consume(id: "evt-never-seen")
+
+        let late = IntroRequest(
+            id: "evt-never-seen",
+            targetIntroPublicKey: Data(repeating: 0xA1, count: 32),
+            payload: Data([0x03]),
+            receivedAt: Date()
+        )
+        let recordedLate = await store.record(late)
+        XCTAssertFalse(recordedLate)
+        let remaining = await store.current()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_tombstoneSurvivesRelaunch_soAHandledRequestStaysGone() async {
+        // A fresh store over the same durable log is what a cold start
+        // looks like. This is the case a process-lifetime set missed.
+        let log = InMemoryHandledIntroRequestLog()
+        let request = IntroRequest(
+            id: "evt-1",
+            targetIntroPublicKey: Data(repeating: 0xA1, count: 32),
+            payload: Data([0x01]),
+            receivedAt: Date()
+        )
+
+        let first = InMemoryIntroRequestStore(handledLog: log)
+        _ = await first.record(request)
+        await first.consume(id: request.id)
+
+        let relaunched = InMemoryIntroRequestStore(handledLog: log)
+        let reRecorded = await relaunched.record(request)
+
+        XCTAssertFalse(reRecorded, "a handled request must not return after relaunch")
+        let remaining = await relaunched.current()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_pruneTombstones_dropsRetiredLinks_keepsLiveOnes() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let livePub = Data(repeating: 0xA1, count: 32)
+        let retiredPub = Data(repeating: 0xB2, count: 32)
+        let store = InMemoryIntroRequestStore(handledLog: log)
+
+        for (id, pub) in [("evt-live", livePub), ("evt-retired", retiredPub)] {
+            _ = await store.record(IntroRequest(
+                id: id, targetIntroPublicKey: pub,
+                payload: Data([0x01]), receivedAt: Date()
+            ))
+            await store.consume(id: id)
+        }
+
+        // The retired link's tombstones go with it, so the set stays
+        // bounded by the invites that still exist.
+        await store.pruneTombstones(keeping: [livePub])
+
+        let after = InMemoryIntroRequestStore(handledLog: log)
+        let liveStillBlocked = await after.record(IntroRequest(
+            id: "evt-live", targetIntroPublicKey: livePub,
+            payload: Data([0x01]), receivedAt: Date()
+        ))
+        let retiredNowFree = await after.record(IntroRequest(
+            id: "evt-retired", targetIntroPublicKey: retiredPub,
+            payload: Data([0x01]), receivedAt: Date()
+        ))
+        XCTAssertFalse(liveStillBlocked)
+        XCTAssertTrue(retiredNowFree)
+    }
+
     // MARK: - Helpers
 
     private func waitFor(

--- a/Tests/OnymIOSTests/InviteIntroducerTests.swift
+++ b/Tests/OnymIOSTests/InviteIntroducerTests.swift
@@ -136,4 +136,274 @@ final class InviteIntroducerTests: XCTestCase {
         XCTAssertNotNil(entry)
         XCTAssertEqual(entry?.createdAt, frozen)
     }
+
+    // MARK: - currentOrMint (multi-use links)
+
+    func test_currentOrMint_noLiveKeyForGroup_mintsAndPersistsOne() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let cap = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed.first?.introPublicKey, cap.introPublicKey)
+    }
+
+    func test_currentOrMint_twiceForSameGroup_returnsSameKey_persistsOneEntry() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let first = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let second = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(first.introPublicKey, second.introPublicKey)
+        // The count is what stops this from being "returns the same
+        // link but still writes a row".
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
+    }
+
+    func test_currentOrMint_differentGroups_doNotShareAKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let g1 = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let g2 = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: other)
+
+        XCTAssertNotEqual(g1.introPublicKey, g2.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 2)
+    }
+
+    func test_currentOrMint_neverExpires_soAnAncientKeyIsStillReused() async throws {
+        let store = InMemoryIntroKeyStore()
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+        let early = InviteIntroducer(store: store, now: { t0 })
+        // A year later. Invite links have no TTL — only `rotate` or
+        // `revoke` retires one.
+        let muchLater = InviteIntroducer(
+            store: store,
+            now: { t0.addingTimeInterval(365 * 24 * 60 * 60) }
+        )
+
+        let first = try await early.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let second = try await muchLater.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(first.introPublicKey, second.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
+    }
+
+    // MARK: - rotate / revoke
+
+    func test_rotate_mintsAFreshKey_andRetiresTheOldOne() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let old = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let new = try await introducer.rotate(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(old.introPublicKey, new.introPublicKey)
+        let foundOld = await store.find(introPublicKey: old.introPublicKey)
+        XCTAssertNil(foundOld, "the superseded link must stop decrypting requests")
+        let foundNew = await store.find(introPublicKey: new.introPublicKey)
+        XCTAssertNotNil(foundNew)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1, "rotate must not leave the old slot behind")
+    }
+
+    func test_rotate_thenCurrentOrMint_returnsTheRotatedKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        let rotated = try await introducer.rotate(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let resolved = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(rotated.introPublicKey, resolved.introPublicKey)
+    }
+
+    func test_rotate_leavesOtherGroupsAlone() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let untouched = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: other
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        _ = try await introducer.rotate(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        let foundUntouched = await store.find(introPublicKey: untouched.introPublicKey)
+        XCTAssertNotNil(foundUntouched)
+    }
+
+    func test_rotate_doesNotRetireLabelledOfferKeys() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // Per-invitee offers are revoked one at a time from the invite
+        // list; rotating the shared link must not sweep them away.
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        _ = try await introducer.rotate(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        let foundOffer = await store.find(introPublicKey: offer.introPublicKey)
+        XCTAssertNotNil(foundOffer)
+    }
+
+    func test_currentOrMint_ignoresLabelledOfferKeys() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // Create-with-invitees leaves an offer key as the newest entry;
+        // handing it out would collapse the 1:1 mapping.
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(offer.introPublicKey, shared.introPublicKey)
+    }
+
+    func test_liveInvites_listsEveryKeyForTheGroup() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: other)
+
+        let live = await introducer.liveInvites(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(Set(live.map(\.introPublicKey)),
+                       Set([shared.introPublicKey, offer.introPublicKey]))
+        XCTAssertEqual(live.first(where: { $0.label == "aabbccdd" })?.introPublicKey,
+                       offer.introPublicKey)
+    }
+
+    func test_currentOrMint_doesNotReuseAnotherIdentitysLiveKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // The pump only subscribes the active identity's tags, so this
+        // would hand out a link nobody is listening on.
+        let bobCap = try await introducer.currentOrMint(
+            ownerIdentityID: bob, groupId: sampleGroupId
+        )
+        let aliceCap = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(bobCap.introPublicKey, aliceCap.introPublicKey)
+        let aliceKeys = await store.listForOwner(alice)
+        let bobKeys = await store.listForOwner(bob)
+        XCTAssertEqual(aliceKeys.count, 1)
+        XCTAssertEqual(bobKeys.count, 1)
+    }
+
+    func test_currentOrMint_rejectsWrongSizedGroupId_withoutTouchingTheStore() async {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        do {
+            _ = try await introducer.currentOrMint(
+                ownerIdentityID: alice,
+                groupId: Data(repeating: 0x01, count: 16)
+            )
+            XCTFail("expected IntroducerError.invalidGroupID")
+        } catch IntroducerError.invalidGroupID {
+            // expected
+        } catch {
+            XCTFail("expected IntroducerError.invalidGroupID, got \(error)")
+        }
+
+        let listed = await store.listForOwner(alice)
+        XCTAssertTrue(listed.isEmpty)
+    }
+
+    func test_mint_alwaysMintsFresh_evenWhenALiveKeyExists() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // Locks the two-entry-point split; collapsing them would break
+        // the offers' 1:1 mapping.
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let fresh = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        XCTAssertNotEqual(shared.introPublicKey, fresh.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 2)
+    }
+
+    // MARK: - concurrency
+
+    func test_currentOrMint_concurrentCalls_produceExactlyOneKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // `.onAppear` fires more than once per entry; the store read is
+        // an await, so unserialized this mints twice.
+        async let a = introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        async let b = introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        let (first, second) = try await (a, b)
+
+        XCTAssertEqual(first.introPublicKey, second.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1, "a second shared key would be unrevokable")
+    }
+
+    func test_rotate_concurrentWithCurrentOrMint_leavesOneSharedKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        async let rotated = introducer.rotate(ownerIdentityID: alice, groupId: sampleGroupId)
+        async let resolved = introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let (_, handedToCaller) = try await (rotated, resolved)
+
+        // The hazard is the value handed to the concurrent caller, not
+        // the end state: unserialized, it can be a link rotate revoked.
+        let stillLive = await store.find(introPublicKey: handedToCaller.introPublicKey)
+        XCTAssertNotNil(stillLive, "the caller was handed a link that was then revoked")
+        let shared = await store.listForOwner(alice).filter { $0.label == nil }
+        XCTAssertEqual(shared.count, 1)
+    }
 }

--- a/Tests/OnymIOSTests/JoinFlowTests.swift
+++ b/Tests/OnymIOSTests/JoinFlowTests.swift
@@ -102,7 +102,10 @@ final class JoinFlowTests: XCTestCase {
 
     private func harness(
         outcome: JoinRequestSender.Outcome,
-        seedGroups: [ChatGroup] = []
+        seedGroups: [ChatGroup] = [],
+        // Nil by default so the suite keeps observing
+        // `.awaitingApproval`; the timer has its own tests.
+        unansweredAfter: Duration? = nil
     ) async throws -> Env {
         let store = JoinTestableInMemoryGroupStore()
         await store.preload(seedGroups)
@@ -116,9 +119,23 @@ final class JoinFlowTests: XCTestCase {
                 counter.bump()
                 return outcome
             },
-            groupRepository: repo
+            groupRepository: repo,
+            unansweredAfter: unansweredAfter
         )
         return Env(flow: flow, repo: repo, counter: counter)
+    }
+
+    func test_unanswered_allowsResend_soItIsNotADeadEnd() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: .milliseconds(50))
+        env.flow.send(displayLabel: "alice")
+        try await waitFor { env.flow.state.isUnanswered }
+
+        // Without this, the copy's "ask for a new link" is the only
+        // exit and the Try again button does nothing.
+        env.flow.send(displayLabel: "alice")
+
+        try await waitFor { env.flow.state.isAwaitingApproval }
+        XCTAssertEqual(env.counter.value, 2, "the retry must actually re-submit")
     }
 
     // MARK: - Helpers
@@ -159,6 +176,43 @@ final class JoinFlowTests: XCTestCase {
         XCTFail("waitFor predicate never became true within \(timeout)s",
                 file: file, line: line)
     }
+
+    // MARK: - unanswered
+
+    func test_awaitingApproval_afterTheTimeout_flipsToUnanswered() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: .milliseconds(50))
+
+        env.flow.send(displayLabel: "alice")
+
+        // A revoked link is indistinguishable from a slow host here, so
+        // the joiner gets told rather than left on an endless spinner.
+        try await waitFor { env.flow.state.isUnanswered }
+    }
+
+    func test_approvalArrivingAfterTheTimeout_stillWins() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: .milliseconds(50))
+        env.flow.send(displayLabel: "alice")
+        try await waitFor { env.flow.state.isUnanswered }
+
+        // The watcher stays live past the timeout — `.unanswered` is a
+        // hint, not a terminal state.
+        _ = await env.repo.insert(makeGroup(groupID: groupIdRaw, owner: alice))
+
+        try await waitFor {
+            if case .approved = env.flow.state { return true }
+            return false
+        }
+    }
+
+    func test_unansweredAfterNil_neverLeavesAwaitingApproval() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: nil)
+
+        env.flow.send(displayLabel: "alice")
+        try await waitFor { env.flow.state.isAwaitingApproval }
+        try? await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertTrue(env.flow.state.isAwaitingApproval)
+    }
 }
 
 // MARK: - State helpers
@@ -171,6 +225,9 @@ private extension JoinFlow.State {
     }
     var isApproved: Bool { if case .approved = self { return true } else { return false } }
     var isFailed: Bool { if case .failed = self { return true } else { return false } }
+    var isUnanswered: Bool {
+        if case .unanswered = self { return true } else { return false }
+    }
 }
 
 // MARK: - Test doubles

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -88,7 +88,7 @@ final class JoinRequestApproverTests: XCTestCase {
 
     // MARK: - approve happy path
 
-    func test_approve_sendsSealedInviteAndConsumesRequest() async throws {
+    func test_approve_sendsSealedInvite_consumesRequest_keepsIntroKeyLive() async throws {
         let env = try await seedEnvironment()
 
         // Pump once: collector reads the seeded request, decodes,
@@ -104,12 +104,15 @@ final class JoinRequestApproverTests: XCTestCase {
         XCTAssertNotNil(toJoiner,
                         "approve must send to the joiner's inbox tag")
 
-        // Request consumed + intro key revoked.
+        // Request consumed, but the link stays usable.
         let remaining = await introRequestStore.current()
         XCTAssertTrue(remaining.isEmpty,
                       "approved request must be consumed from the store")
         let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNil(intro, "intro key must be revoked after approve")
+        XCTAssertNotNil(
+            intro,
+            "intro key must survive approve — one link is redeemable by many joiners"
+        )
     }
 
     // MARK: - duplicate collapse
@@ -168,9 +171,11 @@ final class JoinRequestApproverTests: XCTestCase {
         } else {
             XCTFail("expected .transportFailed, got \(outcome)")
         }
-        let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNotNil(intro,
-                        "intro key must NOT be revoked when transport rejects — caller may retry")
+        // Key survival is vacuous now. What this path still owes is
+        // that the request stays available for a retry.
+        let remaining = await introRequestStore.current()
+        XCTAssertEqual(remaining.count, 1,
+                       "a transport-rejected request must stay in the store for retry")
     }
 
     // MARK: - PR 4: recordJoiner side effect
@@ -306,7 +311,7 @@ final class JoinRequestApproverTests: XCTestCase {
 
     // MARK: - decline
 
-    func test_decline_dropsRequestAndRevokesKey() async throws {
+    func test_decline_dropsOnlyThatRequest_leavesLinkLive() async throws {
         let env = try await seedEnvironment()
         await env.approver.pumpOnce()
 
@@ -316,13 +321,257 @@ final class JoinRequestApproverTests: XCTestCase {
         XCTAssertTrue(remaining.isEmpty,
                       "declined request must be consumed")
         let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNil(intro, "intro key revoked even on decline")
+        XCTAssertNotNil(
+            intro,
+            "declining one joiner must not kill the link for everyone else holding it"
+        )
         let sends = await transport.sends
         XCTAssertTrue(sends.isEmpty,
                       "decline ships no envelopes")
     }
 
     // MARK: - Test fixture builder
+
+    // MARK: - multi-use links
+
+    func test_approve_joinerA_thenJoinerBOnTheSameIntroKey_bothJoin() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        var pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 2, "two joiners on one link are two rows")
+
+        let firstOutcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(firstOutcome, .sent)
+
+        // The whole feature. Before, revoking here made B's request
+        // undecodable and B's row silently vanished.
+        let intro = await introKeyStore.find(introPublicKey: env.introPub)
+        XCTAssertNotNil(intro, "approving A must not burn the link B is holding")
+
+        await env.approver.pumpOnce()
+        pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "A consumed, B still standing")
+        XCTAssertEqual(pending.first?.joinerBlsPublicKey, second.blsPub)
+
+        let secondOutcome = await env.approver.approve(requestId: second.requestID)
+        XCTAssertEqual(secondOutcome, .sent)
+
+        let snapshotGroup = await groups.currentGroups()
+        let group = try XCTUnwrap(
+            snapshotGroup.first { $0.groupIDData == env.groupID }
+        )
+        XCTAssertEqual(group.members.count, 3, "admin + both joiners")
+        XCTAssertEqual(group.epoch, 2, "each joiner is its own anchor")
+        XCTAssertEqual(contractTransport.calls.count, 2, "two real anchors, not one")
+
+        let sends = await transport.sends
+        XCTAssertNotNil(sends.first { $0.inbox == env.expectedJoinerTag })
+        XCTAssertNotNil(sends.first { $0.inbox == second.expectedTag })
+    }
+
+    func test_decline_joinerA_leavesJoinerBApprovable() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        await env.approver.decline(requestId: env.requestID)
+        await env.approver.pumpOnce()
+
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "declining A must not drop B")
+        XCTAssertEqual(pending.first?.joinerBlsPublicKey, second.blsPub)
+
+        let outcome = await env.approver.approve(requestId: second.requestID)
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(contractTransport.calls.count, 1)
+    }
+
+    func test_pumpOnce_twoDifferentJoinersOnOneIntroKey_yieldTwoPendingRows() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        // Collapse is per joiner, not per key; over-merging would
+        // silently drop invitees.
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 2)
+        XCTAssertEqual(
+            Set(pending.compactMap(\.joinerBlsPublicKey)),
+            Set([env.joinerBlsPub, second.blsPub])
+        )
+    }
+
+    func test_approve_consumesEveryCollapsedSibling() async throws {
+        let env = try await seedEnvironment()
+        // Two more copies of the SAME joiner's request, as a retry or a
+        // relay replay under fresh ephemeral keys would produce.
+        for _ in 0..<2 {
+            await introRequestStore.record(IntroRequest(
+                id: "req-\(UUID().uuidString)",
+                targetIntroPublicKey: env.introPub,
+                payload: env.sealedPayload,
+                receivedAt: Date().addingTimeInterval(30)
+            ))
+        }
+        await env.approver.pumpOnce()
+
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "one joiner is one row")
+        let winner = try XCTUnwrap(pending.first?.id)
+
+        let outcome = await env.approver.approve(requestId: winner)
+        XCTAssertEqual(outcome, .sent)
+
+        // Consuming only the winner would leave the siblings behind to
+        // resurface on the next emission.
+        let leftover = await introRequestStore.current()
+        XCTAssertTrue(leftover.isEmpty, "every collapsed sibling must be consumed")
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    func test_decline_consumesEveryCollapsedSibling() async throws {
+        let env = try await seedEnvironment()
+        await introRequestStore.record(IntroRequest(
+            id: "req-\(UUID().uuidString)",
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(30)
+        ))
+        await env.approver.pumpOnce()
+        let rows = await pendingRows(env.approver)
+        let winner = try XCTUnwrap(rows.first?.id)
+
+        await env.approver.decline(requestId: winner)
+
+        let leftover = await introRequestStore.current()
+        XCTAssertTrue(leftover.isEmpty)
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    func test_approvedRequest_replayedByRelay_doesNotReappearAsPending() async throws {
+        let env = try await seedEnvironment()
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .sent)
+
+        // Reconnects replay the inbox in full, and the key is still
+        // live — without the tombstone this decodes again.
+        let reRecorded = await introRequestStore.record(IntroRequest(
+            id: env.requestID,
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(120)
+        ))
+        XCTAssertFalse(reRecorded, "a consumed event id must not be re-recorded")
+
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    // MARK: - re-join recovery
+
+    func test_approve_joinerAlreadyInRoster_skipsAnchor_reshipsInvitation() async throws {
+        let env = try await seedEnvironment()
+        await env.approver.pumpOnce()
+        let firstOutcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(firstOutcome, .sent)
+        XCTAssertEqual(contractTransport.calls.count, 1)
+        let snapshotAfterfirst = await groups.currentGroups()
+        let afterFirst = try XCTUnwrap(
+            snapshotAfterfirst.first { $0.groupIDData == env.groupID }
+        )
+
+        // Same joiner, fresh event id: a reinstall, or a replay landing
+        // on the still-live link.
+        let replayID = "req-\(UUID().uuidString)"
+        await introRequestStore.record(IntroRequest(
+            id: replayID,
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(60)
+        ))
+        await env.approver.pumpOnce()
+
+        let replayOutcome = await env.approver.approve(requestId: replayID)
+        XCTAssertEqual(replayOutcome, .sent)
+
+        // No second anchor: re-adding an existing member would push a
+        // duplicate leaf into the tree and burn an epoch.
+        XCTAssertEqual(contractTransport.calls.count, 1, "re-join must not re-anchor")
+        let proveCalls = await proofGenerator.proveUpdateCalls
+        XCTAssertEqual(proveCalls, 1,
+                       "the guard must sit before the proof, not after it")
+
+        let snapshotAftersecond = await groups.currentGroups()
+        let afterSecond = try XCTUnwrap(
+            snapshotAftersecond.first { $0.groupIDData == env.groupID }
+        )
+        XCTAssertEqual(afterSecond.epoch, afterFirst.epoch)
+        XCTAssertEqual(afterSecond.members.count, afterFirst.members.count)
+        XCTAssertEqual(afterSecond.commitment, afterFirst.commitment)
+
+        // But the joiner did get the snapshot again — that's the point.
+        let sends = await transport.sends
+        XCTAssertEqual(
+            sends.filter { $0.inbox == env.expectedJoinerTag }.count, 2,
+            "the re-join path must re-ship the current invitation"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Point-in-time read: `pending` yields its snapshot to each new
+    /// subscriber, so one `next()` is enough.
+    private func pendingRows(
+        _ approver: JoinRequestApprover
+    ) async -> [JoinRequestApprover.PendingRequest] {
+        var iterator = approver.pending.makeAsyncIterator()
+        return await iterator.next() ?? []
+    }
+
+    private struct SecondJoiner {
+        let requestID: String
+        let blsPub: Data
+        let expectedTag: TransportInboxID
+    }
+
+    /// A second joiner sealed to the *same* intro pubkey — two people
+    /// redeeming one shared link.
+    private func seedSecondJoiner(on env: Env) async throws -> SecondJoiner {
+        let blsPub = Data(repeating: 0x1A, count: 48)
+        let inboxPub = Data(repeating: 0x1C, count: 32)
+        let payload = try JoinRequestPayload(
+            joinerInboxPublicKey: inboxPub,
+            joinerBlsPublicKey: blsPub,
+            joinerLeafHash: Data(repeating: 0x1B, count: 32),
+            joinerSendingPublicKey: Data(repeating: 0x1D, count: 32),
+            joinerDisplayLabel: "Joiner Carol",
+            groupId: env.groupID
+        )
+        let sealed = try await identity.sealInvitation(
+            payload: try JSONEncoder().encode(payload),
+            to: env.introPub
+        )
+        let requestID = "req-\(UUID().uuidString)"
+        await introRequestStore.record(IntroRequest(
+            id: requestID,
+            targetIntroPublicKey: env.introPub,
+            payload: sealed,
+            receivedAt: Date().addingTimeInterval(10)
+        ))
+        return SecondJoiner(
+            requestID: requestID,
+            blsPub: blsPub,
+            expectedTag: TransportInboxID(rawValue: ApproverInboxTag.from(inboxPub))
+        )
+    }
 
     private struct Env {
         let approver: JoinRequestApprover

--- a/Tests/OnymIOSTests/KeychainIntroKeyStoreTests.swift
+++ b/Tests/OnymIOSTests/KeychainIntroKeyStoreTests.swift
@@ -25,42 +25,53 @@ final class KeychainIntroKeyStoreTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // MARK: - TTL
+    // MARK: - no expiry
 
-    func test_expiredEntry_invisibleToReads() async {
-        await store.save(makeEntry(owner: ownerA, age: KeychainIntroKeyStore.entryTTL + 60))
+    func test_oldEntry_staysVisibleAndAtRest() async {
+        // Invite links do not expire. An entry minted long ago is as
+        // usable as one minted a second ago; only `revoke` retires it.
+        let ancient = makeEntry(owner: ownerA, age: 400 * 24 * 60 * 60)
+        await store.save(ancient)
         let fresh = makeEntry(owner: ownerA)
         await store.save(fresh)
 
         let listed = await store.listForOwner(ownerA)
-        XCTAssertEqual(listed.map(\.introPublicKey), [fresh.introPublicKey],
-                       "entries past the 24h TTL must be invisible to listForOwner")
+        XCTAssertEqual(Set(listed.map(\.introPublicKey)),
+                       Set([ancient.introPublicKey, fresh.introPublicKey]))
+        let foundAncient = await store.find(introPublicKey: ancient.introPublicKey)
+        XCTAssertNotNil(foundAncient)
+        XCTAssertEqual(rawEntryCount(), 2, "reads must not silently drop rows")
     }
 
-    func test_expiredEntry_compactsOutOfBlobOnFirstRead() async {
-        let fresh = makeEntry(owner: ownerA)
-        await store.save(fresh)
-        await store.save(makeEntry(owner: ownerB, age: KeychainIntroKeyStore.entryTTL + 60))
-        // No subscribers → save's publish no-ops without reading, so
-        // the expired row really is at rest now.
-        XCTAssertEqual(rawEntryCount(), 2)
+    func test_revokedEntry_disappearsFromReadsAndFromTheBlob() async {
+        let doomed = makeEntry(owner: ownerA, age: 400 * 24 * 60 * 60)
+        await store.save(doomed)
+        let kept = makeEntry(owner: ownerA)
+        await store.save(kept)
 
-        _ = await store.listForOwner(ownerA)
+        await store.revoke(introPublicKey: doomed.introPublicKey)
 
-        XCTAssertEqual(rawEntryCount(), 1,
-                       "the read that first sees an expired intro privkey must rewrite the blob without it")
+        let listed = await store.listForOwner(ownerA)
+        XCTAssertEqual(listed.map(\.introPublicKey), [kept.introPublicKey])
+        let foundDoomed = await store.find(introPublicKey: doomed.introPublicKey)
+        XCTAssertNil(foundDoomed)
+        // The row held an intro PRIVATE key; revoke must remove it at
+        // rest, not just hide it from reads.
+        XCTAssertEqual(rawEntryCount(), 1)
     }
 
-    func test_expiredEntry_streamSnapshotExcludesIt() async {
-        await store.save(makeEntry(owner: ownerB, age: KeychainIntroKeyStore.entryTTL + 60))
+    func test_revoke_publishesToTheOwnersStream_soThePumpDropsTheInbox() async {
+        let doomed = makeEntry(owner: ownerB)
+        await store.save(doomed)
 
         var iterator = store.entriesStream(forOwner: ownerB).makeAsyncIterator()
-        let snapshot = await iterator.next()
+        _ = await iterator.next()  // initial snapshot
 
-        XCTAssertEqual(snapshot, [],
-                       "the intro pump must never see an expired entry's inbox")
-        XCTAssertEqual(rawEntryCount(), 0,
-                       "subscribing triggered the read → the expired privkey is gone at rest too")
+        await store.revoke(introPublicKey: doomed.introPublicKey)
+        let afterRevoke = await iterator.next()
+
+        XCTAssertEqual(afterRevoke, [],
+                       "the intro pump must stop subscribing a revoked inbox")
     }
 
     // MARK: - pruneOwners

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -82,7 +82,7 @@ final class ShareInviteFlowTests: XCTestCase {
         XCTAssertEqual(listed.count, 0)
     }
 
-    func test_mintFor_calledTwice_mintsTwoIndependentKeypairs() async throws {
+    func test_mintFor_fromASecondFlowOverTheSameStore_reusesTheLiveLink() async throws {
         let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
         _ = try await identity.bootstrap()
         let resolved = await identity.currentSelectedID()
@@ -94,35 +94,36 @@ final class ShareInviteFlowTests: XCTestCase {
         let groupRepo = GroupRepository(store: store, currentIdentityID: owner)
         let introKeyStore = InMemoryIntroKeyStore()
         let introducer = InviteIntroducer(store: introKeyStore)
-        let flow = ShareInviteFlow(
+
+        // Two flows over one store: the real path (a fresh flow per
+        // tap) and deterministic, since the second starts `.idle`.
+        let first = ShareInviteFlow(
             identity: identity,
             introducer: introducer,
             groupRepository: groupRepo
         )
-
-        flow.mintFor(groupID: group.id)
-        try await waitFor { flow.state.isReady }
-        guard case .ready(let firstLink, _) = flow.state else {
+        first.mintFor(groupID: group.id)
+        try await waitFor { first.state.isReady }
+        guard case .ready(let firstLink, _) = first.state else {
             return XCTFail("expected first .ready")
         }
 
-        flow.mintFor(groupID: group.id)
-        // Wait for the link to actually change (the second mint emits
-        // `.minting` then `.ready` again).
-        try await waitFor {
-            if case .ready(let link, _) = flow.state, link != firstLink { return true }
-            return false
-        }
-        guard case .ready(let secondLink, _) = flow.state else {
+        let second = ShareInviteFlow(
+            identity: identity,
+            introducer: introducer,
+            groupRepository: groupRepo
+        )
+        second.mintFor(groupID: group.id)
+        try await waitFor { second.state.isReady }
+        guard case .ready(let secondLink, _) = second.state else {
             return XCTFail("expected second .ready")
         }
 
-        // Per-link revocation depends on this — re-shares cannot
-        // collapse to the same intro slot or revoking one would kill
-        // the other.
-        XCTAssertNotEqual(firstLink, secondLink, "two shares should produce different links")
+        // The share screen is a view onto the group's link, not a link
+        // factory; re-entry must not leave a trail of slots.
+        XCTAssertEqual(firstLink, secondLink, "re-entry should surface the same link")
         let listed = await introKeyStore.listForOwner(owner)
-        XCTAssertEqual(listed.count, 2)
+        XCTAssertEqual(listed.count, 1, "reuse must not persist a second intro slot")
     }
 
     func test_state_transitionsThroughMinting() async throws {
@@ -145,6 +146,76 @@ final class ShareInviteFlowTests: XCTestCase {
         flow.mintFor(groupID: group.id)
         try await waitFor { flow.state.isReady }
         XCTAssertTrue(flow.state.isReady)
+    }
+
+    func test_rotate_doubleTap_onlyRotatesOnce() async throws {
+        let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        _ = try await identity.bootstrap()
+        let resolved = await identity.currentSelectedID()
+        let owner = try XCTUnwrap(resolved)
+        let store = TestableInMemoryGroupStore()
+        let group = makeGroup(id: String(repeating: "ab", count: 32), name: "G", owner: owner)
+        await store.preload([group])
+        let introKeyStore = InMemoryIntroKeyStore()
+        let flow = ShareInviteFlow(
+            identity: identity,
+            introducer: InviteIntroducer(store: introKeyStore),
+            groupRepository: GroupRepository(store: store, currentIdentityID: owner)
+        )
+        flow.mintFor(groupID: group.id)
+        try await waitFor { flow.state.isReady }
+
+        // The guard has to bite before the first await, or the second
+        // tap slips through while `isRotating` is still false.
+        flow.rotateLink(groupID: group.id)
+        flow.rotateLink(groupID: group.id)
+        try await waitFor { flow.state.isReady && !flow.isRotating }
+
+        let shared = await introKeyStore.listForOwner(owner).filter { $0.label == nil }
+        XCTAssertEqual(shared.count, 1, "a second rotate would strand a live key")
+    }
+
+    func test_supersededSharedKey_isListedSoItCanBeRevoked() async throws {
+        let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        _ = try await identity.bootstrap()
+        let resolved = await identity.currentSelectedID()
+        let owner = try XCTUnwrap(resolved)
+        let store = TestableInMemoryGroupStore()
+        let group = makeGroup(id: String(repeating: "ab", count: 32), name: "G", owner: owner)
+        await store.preload([group])
+        let introKeyStore = InMemoryIntroKeyStore()
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // Two unlabelled keys is what a crash mid-rotate leaves. The
+        // older one used to be on no list: no revoke, live subscription.
+        let stranded = try await InviteIntroducer(store: introKeyStore, now: { t0 })
+            .mint(ownerIdentityID: owner, groupId: group.groupIDData)
+        let introducer = InviteIntroducer(
+            store: introKeyStore,
+            now: { t0.addingTimeInterval(60) }
+        )
+        let current = try await introducer.mint(
+            ownerIdentityID: owner, groupId: group.groupIDData
+        )
+        let flow = ShareInviteFlow(
+            identity: identity,
+            introducer: introducer,
+            groupRepository: GroupRepository(store: store, currentIdentityID: owner)
+        )
+        flow.mintFor(groupID: group.id)
+        try await waitFor { flow.state.isReady }
+        try await waitFor { !flow.otherInvites.isEmpty }
+
+        let row = try XCTUnwrap(flow.otherInvites.first)
+        XCTAssertEqual(flow.otherInvites.count, 1, "the rendered link is not a row")
+        XCTAssertEqual(row.introPublicKey, stranded.introPublicKey)
+        XCTAssertNotEqual(row.introPublicKey, current.introPublicKey)
+        XCTAssertNil(row.label, "a superseded key has no invitee name; the view names it")
+
+        flow.revoke(row, groupID: group.id)
+        try await waitFor { flow.otherInvites.isEmpty }
+        let gone = await introKeyStore.find(introPublicKey: stranded.introPublicKey)
+        XCTAssertNil(gone)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
**Draft — reading copy.** Same change as the #209 → #213 stack, squashed into one commit off `main` so the whole thing can be read as a single diff. Merge the stack, not this. Comments are condensed here (≤2 lines); the stack carries the long-form rationale.

Android twin: onymchat/onym-android#201.

### What changed

An invite link was killed by the first Approve *or* Decline, which was wrong three ways: it was already accidentally multi-use (two joiners racing the first approval both worked, because approve never re-validated the key); declining one stranger silently killed the link for everyone else; and after the first approval every other pending joiner's row vanished with no explanation.

Links are now deliberately multi-use, never expire, and are retired only by the inviter. Every join is still gated by an explicit tap.

- **Approve/Decline stop revoking**, and both consume the whole collapsed sibling set rather than just the tapped row.
- **A joiner already in `group.members`** skips the chain anchor and only gets the current snapshot re-shipped, so a replay or a reinstall can't push a duplicate leaf. Also makes the long-standing double-tapped-Approve race safe.
- **The share screen reuses the group's link** instead of minting one per visit; **"Generate new link"** rotates it — mint fresh, then revoke the old, in that order so a crash leaves two links rather than zero.
- **Create-time offer keys are labelled per invitee and listed with a per-row Revoke.** They had no UI before, so dropping the TTL without this would leave every group creation trailing permanent, invisible relay subscriptions.
- **Consumed request ids are tombstoned.** The relay REQ carries no `since`, so reconnects replay the whole inbox; the burn was the only thing hiding that.
- **`JoinFlow` gains an `unanswered` state** after 90s, since revocation is silent and a dead link is indistinguishable from a slow host.
- **`IntroCapability` encodes with sorted keys** — one capability could otherwise serialize to two different link strings.

### Security note

A leaked link used to be worth one join attempt, closed by the first tap. It is now an open request channel until noticed and rotated. Nothing is granted without an explicit Approve and the link carries no group secret, but the unsolicited-request surface is new and uncapped. Two follow-ups worth filing: no cap on pending requests, and `SepTier.maxMembers` is enforced nowhere in the join path.

896 tests green, secret lint clean. Nine new strings, en and ru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)