### PR TITLE
feat(moderation): OnymModeration package — domain, authority seams, DeviceCheck gate-check rail

### DIFF
--- a/Packages/OnymModeration/Package.swift
+++ b/Packages/OnymModeration/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OnymModeration",
+    platforms: [.iOS("18.0")],
+    products: [
+        .library(name: "OnymModeration", targets: ["OnymModeration"]),
+    ],
+    dependencies: [
+        .package(path: "../OnymFoundation"),
+    ],
+    targets: [
+        .target(
+            name: "OnymModeration",
+            dependencies: [
+                "OnymFoundation",
+            ]
+        ),
+    ]
+)

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityKey.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityKey.swift
@@ -1,0 +1,64 @@
+import Foundation
+import CryptoKit
+
+/// The one parser for authority signing keys. Both forms feed through
+/// it — the directory listing's base64 `operatorPublicKeyBase64` and the
+/// manifest's `onym:key:<hex>` `operator` field — so the fetcher can
+/// require the manifest to declare *byte-for-byte* the key the directory
+/// pins (`AuthorityManifestFetcher`), and verdict verification can key
+/// on that same parsed key (`VerdictValidator`). One parser, one trust
+/// root.
+public enum AuthorityKey {
+    /// Prefix of the spec's key-reference form, `onym:key:<hex>`.
+    public static let referencePrefix = "onym:key:"
+
+    /// Raw Ed25519 public key bytes from an `onym:key:<hex>` reference
+    /// (32 bytes, hex-encoded — the form mandates carry). Any other
+    /// shape throws: a reference this client can't parse is not a key it
+    /// can pin consent to.
+    public static func rawBytes(fromReference reference: String) throws -> Data {
+        guard reference.hasPrefix(referencePrefix) else {
+            throw ModerationError.keyInvalid("not an \(referencePrefix) reference")
+        }
+        let hex = reference.dropFirst(referencePrefix.count)
+        guard hex.count == 64, hex.allSatisfy(\.isHexDigit) else {
+            throw ModerationError.keyInvalid("\(referencePrefix) reference is not 32 hex-encoded bytes")
+        }
+        var bytes = Data(capacity: 32)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<next], radix: 16) else {
+                throw ModerationError.keyInvalid("\(referencePrefix) reference is not hex")
+            }
+            bytes.append(byte)
+            index = next
+        }
+        return bytes
+    }
+
+    /// Raw Ed25519 public key bytes from the directory listing's base64
+    /// encoding.
+    public static func rawBytes(fromBase64 base64: String) throws -> Data {
+        guard let bytes = Data(base64Encoded: base64), bytes.count == 32 else {
+            throw ModerationError.keyInvalid("operator key is not 32 base64-encoded bytes")
+        }
+        return bytes
+    }
+
+    public static func publicKey(fromReference reference: String) throws -> Curve25519.Signing.PublicKey {
+        try publicKey(rawBytes: rawBytes(fromReference: reference))
+    }
+
+    public static func publicKey(fromBase64 base64: String) throws -> Curve25519.Signing.PublicKey {
+        try publicKey(rawBytes: rawBytes(fromBase64: base64))
+    }
+
+    private static func publicKey(rawBytes: Data) throws -> Curve25519.Signing.PublicKey {
+        do {
+            return try Curve25519.Signing.PublicKey(rawRepresentation: rawBytes)
+        } catch {
+            throw ModerationError.keyInvalid("not an Ed25519 public key")
+        }
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifest.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifest.swift
@@ -50,8 +50,10 @@ public struct AuthorityManifest: Codable, Sendable, Equatable {
     /// mandates and verdicts.
     public let componentId: String
     public let seat: String
-    /// `onym:key:<authority-identity>` — the verdict/manifest signing
-    /// key. `operator` is the spec's field name.
+    /// `onym:key:<hex>` — the verdict/manifest signing key. `operator`
+    /// is the spec's field name. Not an independent trust root: the
+    /// fetcher requires it to equal the directory-pinned key byte for
+    /// byte (`AuthorityManifestFetcher`).
     public let operatorKey: String
     public let moderationProfileId: String
     public let violationClasses: [ViolationClass]
@@ -66,35 +68,42 @@ public struct AuthorityManifest: Codable, Sendable, Equatable {
     public let confidentiality: String?
     public let statistics: String?
     public let offers: [String]?
-    /// Bounds new mandates and new cases, not live process.
+    /// Bounds new mandates and new cases, not live process. Enforced at
+    /// consent by `AuthorityManifestValidator`.
     public let validUntil: Date
-    /// Authority signature over the manifest. Verified against the
-    /// directory-pinned operator key (see `AuthorityManifestFetcher`).
-    public let signature: String
 
     enum CodingKeys: String, CodingKey {
         case version, componentId, seat
         case operatorKey = "operator"
         case moderationProfileId, violationClasses, evidenceRules
         case reputationPolicy, newHolderAppeal, appellate
-        case confidentiality, statistics, offers, validUntil, signature
+        case confidentiality, statistics, offers, validUntil
     }
 
     public func violationClass(id: String) -> ViolationClass? {
         violationClasses.first { $0.classId == id }
     }
+
+    /// The authority's signing key, parsed from `operator` by the one
+    /// `AuthorityKey` parser the directory pin is checked with — so
+    /// verdict verification and the fetch-time pin key on the same
+    /// bytes.
+    public func operatorPublicKey() throws -> Curve25519.Signing.PublicKey {
+        try AuthorityKey.publicKey(fromReference: operatorKey)
+    }
 }
 
 /// The unit of consent: a decoded manifest together with the exact
 /// bytes it was fetched as. `manifestHash` — SHA-256 over those exact
-/// bytes — is what the mandate pins.
+/// bytes — is what the mandate pins, and those same bytes are what the
+/// authority's **detached** signature covers.
 ///
-/// Hashing the fetched bytes rather than a canonical re-encoding is
-/// deliberate: the draft spec defines no canonical JSON, hashing exact
-/// bytes matches the repo's `SignedAsset` model (signatures over exact
-/// bytes), and persisting `rawBytes` alongside the mandate keeps the
-/// consented terms displayable and re-verifiable even if the authority
-/// later edits the hosted file or disappears.
+/// Hashing (and signing) the fetched bytes rather than a canonical
+/// re-encoding is deliberate: the draft spec defines no canonical JSON,
+/// exact bytes match the repo's `SignedAsset` model, and persisting
+/// `rawBytes` alongside the mandate keeps the consented terms
+/// displayable and re-verifiable even if the authority later edits the
+/// hosted file or disappears.
 public struct SignedManifest: Sendable, Equatable {
     public let manifest: AuthorityManifest
     public let rawBytes: Data

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifest.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifest.swift
@@ -1,0 +1,113 @@
+import Foundation
+import CryptoKit
+
+/// One violation class from an authority manifest, with the five
+/// mandatory terms every class must declare (Moderation.md §5.2
+/// normative constraint 1). A class missing any term fails decode,
+/// which is exactly the spec's "invalid at mandate validation".
+public struct ViolationClass: Codable, Sendable, Equatable {
+    public let classId: String
+    /// Content address (hash-or-url) of the exact prohibited-content
+    /// definition the user consents to. Immutable once consented.
+    public let definition: String
+    public let responseWindow: ISO8601Duration
+    public let decisionDeadline: ISO8601Duration
+    public let banTerm: BanTerm
+    public let appealWindow: ISO8601Duration
+    public let appealEffect: AppealEffect
+    /// Statutory reporting the authority performs for this class
+    /// (declared for classes such as CSAM; absent elsewhere).
+    public let lawfulReporting: String?
+
+    public init(
+        classId: String,
+        definition: String,
+        responseWindow: ISO8601Duration,
+        decisionDeadline: ISO8601Duration,
+        banTerm: BanTerm,
+        appealWindow: ISO8601Duration,
+        appealEffect: AppealEffect,
+        lawfulReporting: String? = nil
+    ) {
+        self.classId = classId
+        self.definition = definition
+        self.responseWindow = responseWindow
+        self.decisionDeadline = decisionDeadline
+        self.banTerm = banTerm
+        self.appealWindow = appealWindow
+        self.appealEffect = appealEffect
+        self.lawfulReporting = lawfulReporting
+    }
+}
+
+/// A moderation authority's published, signed manifest (Moderation.md
+/// §5.2): the complete enumeration of its power. Everything the user
+/// consents to at mandate signing is in here or content-addressed
+/// from here.
+public struct AuthorityManifest: Codable, Sendable, Equatable {
+    public let version: Int
+    /// `onym:component:<authority-id>` — the authority's identity in
+    /// mandates and verdicts.
+    public let componentId: String
+    public let seat: String
+    /// `onym:key:<authority-identity>` — the verdict/manifest signing
+    /// key. `operator` is the spec's field name.
+    public let operatorKey: String
+    public let moderationProfileId: String
+    public let violationClasses: [ViolationClass]
+    public let evidenceRules: String?
+    public let reputationPolicy: String?
+    /// Procedure for a device's new owner — surfaced in the ban UX
+    /// (a mandatory appeal class, spec §5.7).
+    public let newHolderAppeal: String?
+    /// External appellate authority, or `"self"` for manifests with no
+    /// permanent class (spec §5.2 constraint 2).
+    public let appellate: String?
+    public let confidentiality: String?
+    public let statistics: String?
+    public let offers: [String]?
+    /// Bounds new mandates and new cases, not live process.
+    public let validUntil: Date
+    /// Authority signature over the manifest. Verified against the
+    /// directory-pinned operator key (see `AuthorityManifestFetcher`).
+    public let signature: String
+
+    enum CodingKeys: String, CodingKey {
+        case version, componentId, seat
+        case operatorKey = "operator"
+        case moderationProfileId, violationClasses, evidenceRules
+        case reputationPolicy, newHolderAppeal, appellate
+        case confidentiality, statistics, offers, validUntil, signature
+    }
+
+    public func violationClass(id: String) -> ViolationClass? {
+        violationClasses.first { $0.classId == id }
+    }
+}
+
+/// The unit of consent: a decoded manifest together with the exact
+/// bytes it was fetched as. `manifestHash` — SHA-256 over those exact
+/// bytes — is what the mandate pins.
+///
+/// Hashing the fetched bytes rather than a canonical re-encoding is
+/// deliberate: the draft spec defines no canonical JSON, hashing exact
+/// bytes matches the repo's `SignedAsset` model (signatures over exact
+/// bytes), and persisting `rawBytes` alongside the mandate keeps the
+/// consented terms displayable and re-verifiable even if the authority
+/// later edits the hosted file or disappears.
+public struct SignedManifest: Sendable, Equatable {
+    public let manifest: AuthorityManifest
+    public let rawBytes: Data
+    /// Lowercase hex SHA-256 of `rawBytes`.
+    public let manifestHash: String
+
+    public init(manifest: AuthorityManifest, rawBytes: Data) {
+        self.manifest = manifest
+        self.rawBytes = rawBytes
+        self.manifestHash = Self.hash(of: rawBytes)
+    }
+
+    public static func hash(of bytes: Data) -> String {
+        SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestFetcher.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestFetcher.swift
@@ -4,8 +4,9 @@ import os.log
 import OnymFoundation
 
 /// Fetches an authority's manifest as **exact bytes**, hashes them
-/// (that hash is what the mandate pins), decodes, and verifies the
-/// manifest's own signature against the directory-pinned operator key.
+/// (that hash is what the mandate pins), decodes, requires the declared
+/// `operator` to be the directory-pinned key, and verifies the
+/// authority's detached signature over those exact bytes.
 public protocol AuthorityManifestFetcher: Sendable {
     func fetch(_ listing: AuthorityListing) async throws -> SignedManifest
 }
@@ -48,50 +49,63 @@ public struct URLSessionAuthorityManifestFetcher: AuthorityManifestFetcher {
         guard manifest.componentId == listing.componentId else {
             throw ModerationError.manifestInvalid("componentId does not match the directory listing")
         }
-        try verifySignature(of: manifest, rawBytes: data, listing: listing)
+        let pinnedKey = try Self.directoryPinnedOperatorKey(for: manifest, listing: listing)
+        try await verifySignature(rawBytes: data, pinnedKey: pinnedKey, listing: listing)
         return SignedManifest(manifest: manifest, rawBytes: data)
     }
 
-    /// The manifest's `signature` field covers the manifest content;
-    /// with no canonical JSON in the draft spec we verify over the
-    /// fetched bytes with the signature field's value excised — the
-    /// same exact-bytes posture as `SignedAsset`, adapted for an
-    /// embedded (not detached) signature. PROVISIONAL like every
-    /// signing form here; soft mode accepts and logs until real
-    /// authorities sign (see `ModerationTrust`).
-    private func verifySignature(
-        of manifest: AuthorityManifest,
-        rawBytes: Data,
+    /// The manifest's declared `operator` must be the directory-pinned
+    /// key, byte for byte — otherwise a manifest could name its own
+    /// verdict-signing key and the directory pin would guard nothing.
+    /// Both sides go through the single `AuthorityKey` parser, which also
+    /// validates the `onym:key:` form.
+    static func directoryPinnedOperatorKey(
+        for manifest: AuthorityManifest,
         listing: AuthorityListing
-    ) throws {
-        let verified: Bool
-        if
-            let keyRaw = Data(base64Encoded: listing.operatorPublicKeyBase64),
-            let key = try? Curve25519.Signing.PublicKey(rawRepresentation: keyRaw),
-            let signature = Data(base64Encoded: manifest.signature),
-            let signedBytes = Self.bytesExcludingSignature(from: rawBytes, signature: manifest.signature)
-        {
-            verified = Ed25519DetachedSignatureVerifier(publicKey: key)
-                .isValid(signature: signature, for: signedBytes)
-        } else {
-            verified = false
+    ) throws -> Curve25519.Signing.PublicKey {
+        let declared: Data
+        do {
+            declared = try AuthorityKey.rawBytes(fromReference: manifest.operatorKey)
+        } catch {
+            throw ModerationError.manifestInvalid("operator is not a valid \(AuthorityKey.referencePrefix) reference")
         }
-        guard !verified else { return }
-        if enforceSignature {
-            Self.log.error("\(listing.componentId, privacy: .public): manifest signature did NOT verify; rejecting (enforcement ON)")
-            throw ModerationError.manifestInvalid("manifest signature did not verify")
+        let pinnedKey: Curve25519.Signing.PublicKey
+        do {
+            pinnedKey = try AuthorityKey.publicKey(fromBase64: listing.operatorPublicKeyBase64)
+        } catch {
+            throw ModerationError.manifestInvalid("directory listing carries no usable operator key")
         }
-        Self.log.warning("\(listing.componentId, privacy: .public): manifest signature did NOT verify; accepting anyway (enforcement OFF)")
+        guard declared == pinnedKey.rawRepresentation else {
+            throw ModerationError.manifestInvalid("operator does not match the directory-pinned key")
+        }
+        return pinnedKey
     }
 
-    /// Excise the signature value from the raw JSON text so the signed
-    /// content is byte-stable regardless of where the signature field
-    /// sits. Returns nil when the raw bytes aren't UTF-8 or don't
-    /// contain the signature value.
-    static func bytesExcludingSignature(from rawBytes: Data, signature: String) -> Data? {
-        guard let text = String(data: rawBytes, encoding: .utf8), text.contains(signature) else {
-            return nil
+    /// The authority signs the manifest's **exact bytes** with a
+    /// detached signature published alongside it at `<manifest-url>.sig`
+    /// — the same posture as `SignedAsset` elsewhere in the app. No
+    /// embedded signature, so nothing has to be excised from (or
+    /// re-encoded out of) the signed bytes. Soft mode accepts and logs
+    /// until real authorities sign (see `ModerationTrust`).
+    private func verifySignature(
+        rawBytes: Data,
+        pinnedKey: Curve25519.Signing.PublicKey,
+        listing: AuthorityListing
+    ) async throws {
+        do {
+            try await SignedAsset.verify(
+                assetData: rawBytes,
+                assetURL: listing.manifestURL,
+                session: session,
+                label: "manifest \(listing.componentId)",
+                verifier: Ed25519DetachedSignatureVerifier(publicKey: pinnedKey),
+                enforce: enforceSignature
+            )
+        } catch {
+            // `SignedAsset.verify` throws only under enforcement; soft
+            // mode logs there and returns.
+            Self.log.error("\(listing.componentId, privacy: .public): manifest signature did NOT verify; rejecting (enforcement ON)")
+            throw ModerationError.manifestInvalid("manifest signature did not verify: \(error)")
         }
-        return Data(text.replacingOccurrences(of: signature, with: "").utf8)
     }
 }

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestFetcher.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestFetcher.swift
@@ -1,0 +1,97 @@
+import Foundation
+import CryptoKit
+import os.log
+import OnymFoundation
+
+/// Fetches an authority's manifest as **exact bytes**, hashes them
+/// (that hash is what the mandate pins), decodes, and verifies the
+/// manifest's own signature against the directory-pinned operator key.
+public protocol AuthorityManifestFetcher: Sendable {
+    func fetch(_ listing: AuthorityListing) async throws -> SignedManifest
+}
+
+public struct URLSessionAuthorityManifestFetcher: AuthorityManifestFetcher {
+    private static let log = Logger(subsystem: "app.onym.ios", category: "ModerationManifest")
+
+    let session: URLSession
+    let decoder: JSONDecoder
+    let enforceSignature: Bool
+
+    public init(
+        session: URLSession = .shared,
+        decoder: JSONDecoder? = nil,
+        enforceSignature: Bool = ModerationTrust.enforceManifestSignatures
+    ) {
+        self.session = session
+        if let decoder {
+            self.decoder = decoder
+        } else {
+            let d = JSONDecoder()
+            d.dateDecodingStrategy = .iso8601
+            self.decoder = d
+        }
+        self.enforceSignature = enforceSignature
+    }
+
+    public func fetch(_ listing: AuthorityListing) async throws -> SignedManifest {
+        let (data, response) = try await session.data(from: listing.manifestURL)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(statusCode) else {
+            throw ModerationError.manifestInvalid("status \(statusCode)")
+        }
+        let manifest: AuthorityManifest
+        do {
+            manifest = try decoder.decode(AuthorityManifest.self, from: data)
+        } catch {
+            throw ModerationError.manifestInvalid("malformed manifest: \(error)")
+        }
+        guard manifest.componentId == listing.componentId else {
+            throw ModerationError.manifestInvalid("componentId does not match the directory listing")
+        }
+        try verifySignature(of: manifest, rawBytes: data, listing: listing)
+        return SignedManifest(manifest: manifest, rawBytes: data)
+    }
+
+    /// The manifest's `signature` field covers the manifest content;
+    /// with no canonical JSON in the draft spec we verify over the
+    /// fetched bytes with the signature field's value excised — the
+    /// same exact-bytes posture as `SignedAsset`, adapted for an
+    /// embedded (not detached) signature. PROVISIONAL like every
+    /// signing form here; soft mode accepts and logs until real
+    /// authorities sign (see `ModerationTrust`).
+    private func verifySignature(
+        of manifest: AuthorityManifest,
+        rawBytes: Data,
+        listing: AuthorityListing
+    ) throws {
+        let verified: Bool
+        if
+            let keyRaw = Data(base64Encoded: listing.operatorPublicKeyBase64),
+            let key = try? Curve25519.Signing.PublicKey(rawRepresentation: keyRaw),
+            let signature = Data(base64Encoded: manifest.signature),
+            let signedBytes = Self.bytesExcludingSignature(from: rawBytes, signature: manifest.signature)
+        {
+            verified = Ed25519DetachedSignatureVerifier(publicKey: key)
+                .isValid(signature: signature, for: signedBytes)
+        } else {
+            verified = false
+        }
+        guard !verified else { return }
+        if enforceSignature {
+            Self.log.error("\(listing.componentId, privacy: .public): manifest signature did NOT verify; rejecting (enforcement ON)")
+            throw ModerationError.manifestInvalid("manifest signature did not verify")
+        }
+        Self.log.warning("\(listing.componentId, privacy: .public): manifest signature did NOT verify; accepting anyway (enforcement OFF)")
+    }
+
+    /// Excise the signature value from the raw JSON text so the signed
+    /// content is byte-stable regardless of where the signature field
+    /// sits. Returns nil when the raw bytes aren't UTF-8 or don't
+    /// contain the signature value.
+    static func bytesExcludingSignature(from rawBytes: Data, signature: String) -> Data? {
+        guard let text = String(data: rawBytes, encoding: .utf8), text.contains(signature) else {
+            return nil
+        }
+        return Data(text.replacingOccurrences(of: signature, with: "").utf8)
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestValidator.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestValidator.swift
@@ -66,7 +66,9 @@ public struct AuthorityManifestValidator: Sendable {
     /// §5.2 constraint 2 in full: the appellate must be a component
     /// reference, and a component *other than the issuer*. Accepting any
     /// non-`"self"` string let a manifest name its own `componentId`
-    /// (or a non-component value) and still declare permanent bans.
+    /// (or a non-component value) and still declare permanent bans,
+    /// and a bare prefix check let `"onym:component:"` — a reference
+    /// naming nobody — stand in for a living forum.
     private static func requireExternalAppellate(
         of manifest: AuthorityManifest,
         forClasses permanentClasses: [String]
@@ -77,17 +79,33 @@ public struct AuthorityManifestValidator: Sendable {
                 "permanent ban term (\(classes)) requires an external appellate"
             )
         }
-        guard appellate.hasPrefix(Self.componentReferencePrefix) else {
+        // Parsed, not prefix-matched: `"onym:component:"` carries the
+        // prefix while naming nobody, and an appellate that resolves to
+        // no component can hear no appeal.
+        let appellateIdentifier: String
+        do {
+            appellateIdentifier = try ComponentReference.identifier(from: appellate)
+        } catch {
             throw ModerationError.manifestInvalid(
-                "permanent ban term (\(classes)) requires the appellate to be a \(Self.componentReferencePrefix) reference"
+                "permanent ban term (\(classes)) requires the appellate to be a valid \(ComponentReference.prefix) reference: \(appellate)"
             )
         }
-        guard appellate != manifest.componentId else {
+        // The issuer is parsed too: if its own `componentId` doesn't
+        // resolve, "the appellate differs from the issuer" can't be
+        // established, and silently passing would be the wrong
+        // failure direction for a permanent sanction.
+        let issuerIdentifier: String
+        do {
+            issuerIdentifier = try ComponentReference.identifier(from: manifest.componentId)
+        } catch {
+            throw ModerationError.manifestInvalid(
+                "permanent ban term (\(classes)) requires a valid issuer componentId: \(manifest.componentId)"
+            )
+        }
+        guard appellateIdentifier != issuerIdentifier else {
             throw ModerationError.manifestInvalid(
                 "permanent ban term (\(classes)) names the issuer as its own appellate"
             )
         }
     }
-
-    static let componentReferencePrefix = "onym:component:"
 }

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestValidator.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestValidator.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The manifest's **consent-time validity conditions** (Moderation.md
+/// §5.2), in one place. `AuthorityManifestFetcher` establishes
+/// authenticity (directory-pinned operator key, detached signature);
+/// this establishes that the terms are ones this client may consent to
+/// at all.
+///
+/// These are validity conditions, not UI concerns: `ModerationRepository`
+/// runs them before enrollment and mandate signing, so an invalid
+/// manifest can never end up pinned by a signed mandate — and keeping
+/// them here stops the rules from scattering across the consent path.
+public struct AuthorityManifestValidator: Sendable {
+    /// Moderation profiles this client implements. PROVISIONAL: the
+    /// draft spec doesn't fix the id string yet, so it lives in exactly
+    /// one place; a manifest declaring anything else is refused rather
+    /// than half-honored.
+    public static let defaultSupportedProfileIds: Set<String> = ["onym:profile:devicecheck"]
+
+    private let supportedProfileIds: Set<String>
+
+    public init(supportedProfileIds: Set<String> = AuthorityManifestValidator.defaultSupportedProfileIds) {
+        self.supportedProfileIds = supportedProfileIds
+    }
+
+    /// - Throws: `ModerationError` when this manifest may not be
+    ///   consented to now:
+    ///   - `validUntil` has passed — it bounds *new* mandates and cases,
+    ///     so an already-signed mandate keeps honoring its pinned terms;
+    ///   - `moderationProfileId` is a profile this client doesn't
+    ///     implement;
+    ///   - a class declares a `permanent` ban term without the external
+    ///     appellate §5.2 constraint 2 requires (`nil`, empty, or
+    ///     `"self"` is not an external appellate).
+    public func validateForConsent(_ signed: SignedManifest, now: Date) throws {
+        let manifest = signed.manifest
+        guard manifest.validUntil > now else {
+            throw ModerationError.manifestInvalid("manifest validUntil \(manifest.validUntil) has passed")
+        }
+        guard supportedProfileIds.contains(manifest.moderationProfileId) else {
+            throw ModerationError.unsupportedProfile(manifest.moderationProfileId)
+        }
+        let permanentClasses = manifest.violationClasses
+            .filter { $0.banTerm == .permanent }
+            .map(\.classId)
+        if !permanentClasses.isEmpty {
+            guard let appellate = manifest.appellate, !appellate.isEmpty, appellate != "self" else {
+                throw ModerationError.manifestInvalid(
+                    "permanent ban term (\(permanentClasses.joined(separator: ", "))) requires an external appellate"
+                )
+            }
+        }
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestValidator.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestValidator.swift
@@ -11,11 +11,15 @@ import Foundation
 /// manifest can never end up pinned by a signed mandate — and keeping
 /// them here stops the rules from scattering across the consent path.
 public struct AuthorityManifestValidator: Sendable {
-    /// Moderation profiles this client implements. PROVISIONAL: the
-    /// draft spec doesn't fix the id string yet, so it lives in exactly
-    /// one place; a manifest declaring anything else is refused rather
-    /// than half-honored.
-    public static let defaultSupportedProfileIds: Set<String> = ["onym:profile:devicecheck"]
+    /// Moderation profiles this client implements. The spec fixes this
+    /// string — Moderation.md §5.1 declares the profile's `profileId`
+    /// and §5.2 carries it as the manifest's `moderationProfileId` — so
+    /// a conforming manifest names exactly this. It lives in one place;
+    /// a manifest declaring anything else is refused rather than
+    /// half-honored.
+    public static let defaultSupportedProfileIds: Set<String> = [
+        "onym:moderation-profile:consent-bound-v1",
+    ]
 
     private let supportedProfileIds: Set<String>
 

--- a/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestValidator.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/AuthorityManifestValidator.swift
@@ -34,8 +34,14 @@ public struct AuthorityManifestValidator: Sendable {
     ///   - `moderationProfileId` is a profile this client doesn't
     ///     implement;
     ///   - a class declares a `permanent` ban term without the external
-    ///     appellate §5.2 constraint 2 requires (`nil`, empty, or
-    ///     `"self"` is not an external appellate).
+    ///     appellate §5.2 constraint 2 requires — it must be a
+    ///     `onym:component:` reference naming someone *other than* the
+    ///     issuer, since the rule exists so no permanent sanction
+    ///     depends on its issuer staying alive; or
+    ///   - `newHolderAppeal` is absent. Device marks survive resale, so
+    ///     §5.7 makes the new-holder path mandatory and the ban UX is
+    ///     required to display it — a manifest without one cannot
+    ///     deliver the remedy the user is consenting to.
     public func validateForConsent(_ signed: SignedManifest, now: Date) throws {
         let manifest = signed.manifest
         guard manifest.validUntil > now else {
@@ -44,15 +50,44 @@ public struct AuthorityManifestValidator: Sendable {
         guard supportedProfileIds.contains(manifest.moderationProfileId) else {
             throw ModerationError.unsupportedProfile(manifest.moderationProfileId)
         }
+        guard let newHolderAppeal = manifest.newHolderAppeal, !newHolderAppeal.isEmpty else {
+            throw ModerationError.manifestInvalid(
+                "manifest declares no newHolderAppeal path (mandatory — device marks outlive the device's owner)"
+            )
+        }
         let permanentClasses = manifest.violationClasses
             .filter { $0.banTerm == .permanent }
             .map(\.classId)
         if !permanentClasses.isEmpty {
-            guard let appellate = manifest.appellate, !appellate.isEmpty, appellate != "self" else {
-                throw ModerationError.manifestInvalid(
-                    "permanent ban term (\(permanentClasses.joined(separator: ", "))) requires an external appellate"
-                )
-            }
+            try Self.requireExternalAppellate(of: manifest, forClasses: permanentClasses)
         }
     }
+
+    /// §5.2 constraint 2 in full: the appellate must be a component
+    /// reference, and a component *other than the issuer*. Accepting any
+    /// non-`"self"` string let a manifest name its own `componentId`
+    /// (or a non-component value) and still declare permanent bans.
+    private static func requireExternalAppellate(
+        of manifest: AuthorityManifest,
+        forClasses permanentClasses: [String]
+    ) throws {
+        let classes = permanentClasses.joined(separator: ", ")
+        guard let appellate = manifest.appellate, !appellate.isEmpty, appellate != "self" else {
+            throw ModerationError.manifestInvalid(
+                "permanent ban term (\(classes)) requires an external appellate"
+            )
+        }
+        guard appellate.hasPrefix(Self.componentReferencePrefix) else {
+            throw ModerationError.manifestInvalid(
+                "permanent ban term (\(classes)) requires the appellate to be a \(Self.componentReferencePrefix) reference"
+            )
+        }
+        guard appellate != manifest.componentId else {
+            throw ModerationError.manifestInvalid(
+                "permanent ban term (\(classes)) names the issuer as its own appellate"
+            )
+        }
+    }
+
+    static let componentReferencePrefix = "onym:component:"
 }

--- a/Packages/OnymModeration/Sources/OnymModeration/CaseNotice.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/CaseNotice.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Notice of an opened case, served to the accused through the
+/// interface (Moderation.md §5.5). The interface must present it with
+/// the evidence, the consented class definition, and the response
+/// path; the case-open mark is procedural state and must not degrade
+/// service.
+public struct CaseNotice: Codable, Sendable, Equatable {
+    public let noticeVersion: Int
+    public let caseId: String
+    public let authority: String
+    public let accused: String
+    /// Hash of the accused's mandate.
+    public let mandateRef: String
+    public let classId: String
+    /// Hash of the disclosed items the case rests on.
+    public let evidenceSummary: String
+    public let responseDeadline: Date
+    public let decisionDeadline: Date
+    public let signature: String
+
+    public init(
+        noticeVersion: Int = 1,
+        caseId: String,
+        authority: String,
+        accused: String,
+        mandateRef: String,
+        classId: String,
+        evidenceSummary: String,
+        responseDeadline: Date,
+        decisionDeadline: Date,
+        signature: String
+    ) {
+        self.noticeVersion = noticeVersion
+        self.caseId = caseId
+        self.authority = authority
+        self.accused = accused
+        self.mandateRef = mandateRef
+        self.classId = classId
+        self.evidenceSummary = evidenceSummary
+        self.responseDeadline = responseDeadline
+        self.decisionDeadline = decisionDeadline
+        self.signature = signature
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ComponentReference.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ComponentReference.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The spec's component-reference form, `onym:component:<identifier>` —
+/// how manifests, mandates, and verdicts name authorities, interfaces,
+/// and appellates.
+///
+/// A parser rather than a prefix check, for the same reason
+/// `AuthorityKey` is one: `hasPrefix("onym:component:")` accepts the
+/// bare prefix, so `"onym:component:"` would pass as an appellate while
+/// naming nobody. A reference this client can't resolve to an
+/// identifier is not a component it can bind consent to.
+public enum ComponentReference {
+    public static let prefix = "onym:component:"
+
+    /// The identifier following the prefix.
+    ///
+    /// - Throws: `ModerationError.componentReferenceInvalid` when the
+    ///   prefix is absent, or the identifier is empty or blank —
+    ///   whitespace names no component either.
+    public static func identifier(from reference: String) throws -> String {
+        guard reference.hasPrefix(prefix) else {
+            throw ModerationError.componentReferenceInvalid("not an \(prefix) reference: \(reference)")
+        }
+        let identifier = String(reference.dropFirst(prefix.count))
+        guard !identifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ModerationError.componentReferenceInvalid("\(prefix) reference names no component")
+        }
+        guard !identifier.contains(where: \.isWhitespace) else {
+            throw ModerationError.componentReferenceInvalid("\(prefix) identifier contains whitespace")
+        }
+        return identifier
+    }
+
+    /// Whether two references name the same component. Parses both, so
+    /// a malformed reference is never "different from" anything by
+    /// accident.
+    public static func namesSameComponent(_ lhs: String, _ rhs: String) -> Bool {
+        guard let left = try? identifier(from: lhs), let right = try? identifier(from: rhs) else {
+            return false
+        }
+        return left == right
+    }
+
+    public static func reference(for identifier: String) -> String {
+        prefix + identifier
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/DeviceAttestationProvider.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/DeviceAttestationProvider.swift
@@ -1,0 +1,35 @@
+import Foundation
+import DeviceCheck
+
+/// Seam over the platform's device-attestation token source. The
+/// token proves "this app on this physical device" to the enforcement
+/// backend, which is the only party that can query Apple for the
+/// device's mark bits (the DeviceCheck key never ships in the app).
+public protocol DeviceAttestationProvider: Sendable {
+    /// False on the simulator and enterprise-signed builds
+    /// (profile §8.5). Callers must degrade toward
+    /// gate-check-required, never toward unmoderated operation.
+    var isSupported: Bool { get }
+    /// A fresh, ephemeral, unlinkable DeviceCheck token. Throws
+    /// `ModerationError.attestationUnavailable` when unsupported.
+    func generateToken() async throws -> Data
+}
+
+/// Production provider over `DCDevice`. Tokens are single-use and
+/// carry no device identifier — linkage to an enrollment exists only
+/// while (identity signature, token) travel together in one session
+/// (profile §5).
+public struct DCDeviceAttestationProvider: DeviceAttestationProvider {
+    public init() {}
+
+    public var isSupported: Bool {
+        DCDevice.current.isSupported
+    }
+
+    public func generateToken() async throws -> Data {
+        guard isSupported else {
+            throw ModerationError.attestationUnavailable
+        }
+        return try await DCDevice.current.generateToken()
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/EnforcementBackendClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/EnforcementBackendClient.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// The vendor-local enrollment identifier the mandate's
+/// `deviceBinding` carries. Issued by the backend — never derived
+/// from DeviceCheck tokens, which are ephemeral and unlinkable, so no
+/// global device identifier is ever created (profile §5).
+public struct DeviceEnrollment: Codable, Sendable, Equatable {
+    public let deviceBinding: String
+
+    public init(deviceBinding: String) {
+        self.deviceBinding = deviceBinding
+    }
+}
+
+/// One gate check as the client presents it: a fresh device token and
+/// an identity signature in the same session — the profile's only
+/// permitted token↔enrollment linkage, refreshed every session.
+public struct GateCheckRequest: Codable, Sendable, Equatable {
+    /// Fresh `DCDevice` token, or nil when attestation is unavailable
+    /// (simulator, enterprise build). The client NEVER fabricates a
+    /// token; a conforming backend never answers `.clear` to a nil
+    /// token (see `StubEnforcementBackendClient` for the one exception
+    /// and why).
+    public let deviceToken: Data?
+    public let userKey: String
+    /// Hash of the active mandate, when one exists.
+    public let mandateRef: String?
+    public let timestamp: Date
+    /// User-key signature binding token and timestamp into this
+    /// session. PROVISIONAL signing form — see
+    /// `GateCheckRequest.signedPayload`.
+    public let signature: Data
+
+    public init(deviceToken: Data?, userKey: String, mandateRef: String?, timestamp: Date, signature: Data) {
+        self.deviceToken = deviceToken
+        self.userKey = userKey
+        self.mandateRef = mandateRef
+        self.timestamp = timestamp
+        self.signature = signature
+    }
+
+    /// The bytes the user key signs: the token (empty when absent)
+    /// followed by the ISO 8601 timestamp. PROVISIONAL until the
+    /// enforcement backend's wire contract is specified.
+    public static func signedPayload(deviceToken: Data?, timestamp: Date) -> Data {
+        var payload = deviceToken ?? Data()
+        payload.append(Data(ISO8601DateFormatter().string(from: timestamp).utf8))
+        return payload
+    }
+}
+
+/// Why the backend (or local policy) demands a successful gate check
+/// before the app may operate.
+public enum CheckRequiredReason: String, Codable, Sendable, Equatable {
+    /// The presented token failed Apple-side validation.
+    case tokenInvalid
+    /// No attestation path on this device/build (simulator,
+    /// enterprise-signed) — profile §8.5 fails these toward
+    /// gate-check-required.
+    case attestationUnavailable
+    /// Bits are set but the session identity resolves no active
+    /// verdict — the holder is routed to the authority's
+    /// re-identification / new-holder procedure (profile §5).
+    case reidentificationRequired
+    /// Local policy: the offline grace window lapsed with no
+    /// successful check.
+    case offlineGraceExpired
+    /// Local policy: no successful check has ever completed.
+    case neverChecked
+}
+
+/// The ban state a gate check returns for display. The client renders
+/// this; it never computes ban state itself — the bits (read by the
+/// backend) are the sole authority, which is what survives reinstall.
+public struct BanState: Codable, Sendable, Equatable {
+    /// Hash of the governing verdict.
+    public let verdictRef: String
+    /// The verdict itself when the backend serves it; validated
+    /// client-side (`VerdictValidator`) before display.
+    public let verdict: Verdict?
+    public let authorityContact: String
+    /// Nil means permanent (appealable at the manifest's appellate
+    /// for as long as it is in force).
+    public let banExpires: Date?
+    public let appealURL: URL?
+    /// The new-holder procedure — mandatory in the ban UX (a silent
+    /// brick is nonconforming, profile §5).
+    public let newHolderURL: URL?
+
+    public init(
+        verdictRef: String,
+        verdict: Verdict? = nil,
+        authorityContact: String,
+        banExpires: Date? = nil,
+        appealURL: URL? = nil,
+        newHolderURL: URL? = nil
+    ) {
+        self.verdictRef = verdictRef
+        self.verdict = verdict
+        self.authorityContact = authorityContact
+        self.banExpires = banExpires
+        self.appealURL = appealURL
+        self.newHolderURL = newHolderURL
+    }
+}
+
+/// What the enforcement backend answered for this device, after
+/// reading the DeviceCheck bits and reconciling verdict state
+/// (profile §5–§6).
+public enum GateCheckResult: Codable, Sendable, Equatable {
+    /// Both bits clear (or never set — Apple's "bit state not found"
+    /// is the clean state).
+    case clear
+    /// bit0: operate normally, display the open case(s).
+    case caseOpen([CaseNotice])
+    /// bit1: refuse to operate, show the full ban UX.
+    case banned(BanState)
+    /// No trustworthy answer: re-present a token, or route to
+    /// re-identification.
+    case checkRequired(CheckRequiredReason)
+}
+
+/// The interface vendor's enforcement backend — the only party
+/// holding the Apple DeviceCheck key, therefore the only possible
+/// write/read path for device marks. Not deployed yet: the app ships
+/// against `StubEnforcementBackendClient`, and a future
+/// `URLSessionEnforcementBackendClient` (SEPContractTransport-style
+/// wire client) slots in behind this protocol untouched.
+///
+/// One protocol for enrollment, countersignature, and gate check
+/// because all three are the same service sharing auth and transport.
+public protocol EnforcementBackendClient: Sendable {
+    /// First-session enrollment at mandate signing: the (identity
+    /// signature, device token) pair is the only token↔enrollment
+    /// linkage. Returns the vendor-local `deviceBinding` the mandate
+    /// will carry.
+    func enrollDevice(token: Data?, userKey: String, signature: Data) async throws -> DeviceEnrollment
+
+    /// Interface countersignature over the user-signed mandate
+    /// (Moderation.md §5.3 — signed by the user, countersigned by
+    /// the interface).
+    func countersignMandate(_ mandate: ModerationMandate) async throws -> ModerationMandate
+
+    /// The launch/interval gate check (profile §5).
+    func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/EnforcementBackendClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/EnforcementBackendClient.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// The interface's countersignature over the mandate the user signed
+/// (Moderation.md §5.3). Deliberately just the signature: the client
+/// appends it to its own copy, so the countersigning round-trip cannot
+/// change any consented field.
+public struct InterfaceCountersignature: Codable, Sendable, Equatable {
+    /// Base64 detached signature over the mandate's `signingBytes()`.
+    public let signature: String
+
+    public init(signature: String) {
+        self.signature = signature
+    }
+}
+
 /// The vendor-local enrollment identifier the mandate's
 /// `deviceBinding` carries. Issued by the backend — never derived
 /// from DeviceCheck tokens, which are ephemeral and unlinkable, so no
@@ -9,6 +22,41 @@ public struct DeviceEnrollment: Codable, Sendable, Equatable {
 
     public init(deviceBinding: String) {
         self.deviceBinding = deviceBinding
+    }
+}
+
+/// First-session enrollment as the client presents it. Every field the
+/// signature covers is transmitted, so the backend can reconstruct the
+/// signed bytes and actually verify — see `signedPayload`.
+public struct EnrollmentRequest: Codable, Sendable, Equatable {
+    /// Fresh `DCDevice` token, or nil when attestation is unavailable.
+    /// The client never fabricates one.
+    public let deviceToken: Data?
+    public let userKey: String
+    public let timestamp: Date
+    /// User-key signature over `signedPayload(deviceToken:userKey:timestamp:)`.
+    public let signature: Data
+
+    public init(deviceToken: Data?, userKey: String, timestamp: Date, signature: Data) {
+        self.deviceToken = deviceToken
+        self.userKey = userKey
+        self.timestamp = timestamp
+        self.signature = signature
+    }
+
+    /// The bytes the user key signs, built from **exactly** the fields
+    /// this request transmits — the backend recomputes this from what
+    /// it received. Length-prefixed so no field boundary is ambiguous.
+    /// PROVISIONAL until the enforcement backend's wire contract is
+    /// specified.
+    public static func signedPayload(deviceToken: Data?, userKey: String, timestamp: Date) -> Data {
+        SignedSessionPayload.bytes(
+            context: "onym-moderation-enroll-v1",
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            mandateRef: nil
+        )
     }
 }
 
@@ -39,14 +87,66 @@ public struct GateCheckRequest: Codable, Sendable, Equatable {
         self.signature = signature
     }
 
-    /// The bytes the user key signs: the token (empty when absent)
-    /// followed by the ISO 8601 timestamp. PROVISIONAL until the
-    /// enforcement backend's wire contract is specified.
-    public static func signedPayload(deviceToken: Data?, timestamp: Date) -> Data {
-        var payload = deviceToken ?? Data()
-        payload.append(Data(ISO8601DateFormatter().string(from: timestamp).utf8))
+    /// The bytes the user key signs, built from **exactly** the fields
+    /// this request transmits — `mandateRef` included, so a signature
+    /// can't be replayed against a different mandate. PROVISIONAL until
+    /// the enforcement backend's wire contract is specified.
+    public static func signedPayload(
+        deviceToken: Data?,
+        userKey: String,
+        mandateRef: String?,
+        timestamp: Date
+    ) -> Data {
+        SignedSessionPayload.bytes(
+            context: "onym-moderation-gate-v1",
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            mandateRef: mandateRef
+        )
+    }
+}
+
+/// Shared construction for the session payloads the user key signs.
+/// Every field is length-prefixed and the payload is domain-separated
+/// by `context`, so no two field layouts can collide and an enrollment
+/// signature can never be replayed as a gate-check signature.
+enum SignedSessionPayload {
+    static func bytes(
+        context: String,
+        deviceToken: Data?,
+        userKey: String,
+        timestamp: Date,
+        mandateRef: String?
+    ) -> Data {
+        var payload = Data()
+        append(&payload, Data(context.utf8))
+        append(&payload, deviceToken ?? Data())
+        append(&payload, Data(userKey.utf8))
+        append(&payload, Data(ISO8601DateFormatter.moderation.string(from: timestamp).utf8))
+        append(&payload, Data((mandateRef ?? "").utf8))
         return payload
     }
+
+    /// Big-endian 32-bit length prefix, so concatenation is injective.
+    private static func append(_ payload: inout Data, _ field: Data) {
+        var length = UInt32(field.count).bigEndian
+        withUnsafeBytes(of: &length) { payload.append(contentsOf: $0) }
+        payload.append(field)
+    }
+}
+
+extension ISO8601DateFormatter {
+    /// One formatter configuration for signed payloads — the default
+    /// `ISO8601DateFormatter()` options are the stable subset (no
+    /// fractional seconds), pinned here so the signed bytes can't shift
+    /// with a caller's formatter settings.
+    static let moderation: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
 }
 
 /// Why the backend (or local policy) demands a successful gate check
@@ -67,6 +167,10 @@ public enum CheckRequiredReason: String, Codable, Sendable, Equatable {
     case offlineGraceExpired
     /// Local policy: no successful check has ever completed.
     case neverChecked
+    /// Local policy: the device clock now reads earlier than the last
+    /// successful check, so elapsed time can't be trusted to bound
+    /// staleness — the grace window is refused rather than extended.
+    case clockRollback
 }
 
 /// The ban state a gate check returns for display. The client renders
@@ -134,12 +238,17 @@ public protocol EnforcementBackendClient: Sendable {
     /// signature, device token) pair is the only token↔enrollment
     /// linkage. Returns the vendor-local `deviceBinding` the mandate
     /// will carry.
-    func enrollDevice(token: Data?, userKey: String, signature: Data) async throws -> DeviceEnrollment
+    func enrollDevice(_ request: EnrollmentRequest) async throws -> DeviceEnrollment
 
     /// Interface countersignature over the user-signed mandate
     /// (Moderation.md §5.3 — signed by the user, countersigned by
     /// the interface).
-    func countersignMandate(_ mandate: ModerationMandate) async throws -> ModerationMandate
+    ///
+    /// Returns **only the interface's signature**, never a rebuilt
+    /// mandate: the object the user signed is the consent record, and
+    /// handing back a full mandate would let a buggy or compromised
+    /// backend alter fields the user's signature no longer covers.
+    func countersignMandate(_ mandate: ModerationMandate) async throws -> InterfaceCountersignature
 
     /// The launch/interval gate check (profile §5).
     func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult

--- a/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
@@ -118,6 +118,8 @@ public actor GateCheckRepository {
     private var cached: GateStatus = .notMandated
     private var continuations: [UUID: AsyncStream<GateStatus>.Continuation] = [:]
     private var loopTask: Task<Void, Never>?
+    /// Monotonic tag for in-flight checks; stale completions are dropped.
+    private var generation: UInt64 = 0
 
     public init(
         attestation: any DeviceAttestationProvider,
@@ -173,14 +175,26 @@ public actor GateCheckRepository {
     // MARK: - Gate check
 
     /// Run one gate check now (launch, foreground, retry button).
+    ///
+    /// Actor isolation does not span the awaits below, so the cadence
+    /// loop and a foreground/retry call can be in flight together. Each
+    /// call takes a generation, and a completion whose generation is no
+    /// longer the newest is discarded — otherwise a slow `.clear` could
+    /// land after a fast `.banned` and reopen the app.
     public func checkNow() async {
+        generation &+= 1
+        let generation = generation
+
         guard let record = await moderation.activeMandateRecord() else {
+            guard generation == self.generation else { return }
             cached = .notMandated
             publish()
             return
         }
 
         let attempt = await performAttempt(for: record)
+        guard generation == self.generation else { return }
+
         let (status, persisted) = Self.derive(
             persisted: store.load(),
             attempt: attempt,
@@ -204,13 +218,19 @@ public actor GateCheckRepository {
 
         do {
             let timestamp = clock()
+            let mandateRef = try? record.mandate.mandateHash()
             let signature = try await signer.sign(
-                GateCheckRequest.signedPayload(deviceToken: token, timestamp: timestamp)
+                GateCheckRequest.signedPayload(
+                    deviceToken: token,
+                    userKey: record.mandate.user,
+                    mandateRef: mandateRef,
+                    timestamp: timestamp
+                )
             )
             let request = GateCheckRequest(
                 deviceToken: token,
                 userKey: record.mandate.user,
-                mandateRef: try? record.mandate.mandateHash(),
+                mandateRef: mandateRef,
                 timestamp: timestamp,
                 signature: signature
             )
@@ -228,7 +248,12 @@ public actor GateCheckRepository {
     ///   serving the last known state;
     /// - unreachable past grace → `.gateCheckRequired(.offlineGraceExpired)`,
     ///   persisted state kept (a later success overwrites it);
-    /// - unreachable with no history → `.gateCheckRequired(.neverChecked)`.
+    /// - unreachable with no history → `.gateCheckRequired(.neverChecked)`;
+    /// - unreachable with the clock behind `lastSuccessAt` →
+    ///   `.gateCheckRequired(.clockRollback)`. A negative age would
+    ///   otherwise satisfy the grace comparison forever, so winding the
+    ///   clock back and blocking only the backend would pin a cached
+    ///   `.clear` indefinitely.
     /// Degradation only ever moves toward blocking.
     public static func derive(
         persisted: PersistedGateState?,
@@ -243,7 +268,11 @@ public actor GateCheckRepository {
             guard let persisted else {
                 return (.gateCheckRequired(.neverChecked), nil)
             }
-            if now.timeIntervalSince(persisted.lastSuccessAt) <= policy.offlineGrace {
+            let age = now.timeIntervalSince(persisted.lastSuccessAt)
+            if age < 0 {
+                return (.gateCheckRequired(.clockRollback), persisted)
+            }
+            if age <= policy.offlineGrace {
                 return (status(for: persisted.lastResult), persisted)
             }
             return (.gateCheckRequired(.offlineGraceExpired), persisted)

--- a/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
@@ -76,6 +76,13 @@ public enum GateStatus: Sendable, Equatable {
     /// No active mandate yet — the consent gate applies, not this
     /// one. The protocol remains usable without a mandate; it's this
     /// interface that requires one.
+    ///
+    /// NOT an operational state and never an escape hatch: losing the
+    /// mandate routes to re-consent, after which a fresh gate check
+    /// re-reads the device bits. PR-3 owns the RootView gate composition
+    /// and must carry the invariant (with a test) that `.notMandated`
+    /// cannot reach the operational app, plus a `checkNow()` immediately
+    /// after consent.
     case notMandated
     /// Operating. Non-empty `openCases` renders the (non-blocking)
     /// case banner — the case-open mark must not degrade service.
@@ -133,12 +140,27 @@ public actor GateCheckRepository {
     // MARK: - Lifecycle
 
     /// Launch check + interval loop. Idempotent.
+    ///
+    /// Each sleep runs to a wall-clock deadline anchored on the previous
+    /// check rather than "interval after this check finished", so check
+    /// duration doesn't accumulate drift; a deadline already past (the
+    /// app was suspended across it) checks immediately and re-anchors.
+    /// This loop is the *cadence* floor only — PR-3 must additionally
+    /// call `checkNow()` on foreground, and should test a multi-day warm
+    /// resume.
     public func start() {
         guard loopTask == nil else { return }
-        loopTask = Task { [weak self, policy] in
+        loopTask = Task { [weak self, policy, clock] in
+            var due = clock()
             while !Task.isCancelled {
                 await self?.checkNow()
-                try? await Task.sleep(nanoseconds: UInt64(policy.interval * 1_000_000_000))
+                due = due.addingTimeInterval(policy.interval)
+                let delay = due.timeIntervalSince(clock())
+                if delay > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                } else {
+                    due = clock()
+                }
             }
         }
     }

--- a/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
@@ -1,0 +1,274 @@
+import Foundation
+
+/// The declared cadence from the DeviceCheck profile §5: gate check at
+/// launch and at least once per `interval`; a device that can't reach
+/// the backend operates on its last known state for `offlineGrace`,
+/// then degrades to gate-check-required.
+public struct GateCheckPolicy: Sendable, Equatable {
+    /// Default `P1D`.
+    public let interval: TimeInterval
+    /// Default `P3D`.
+    public let offlineGrace: TimeInterval
+
+    public static let `default` = GateCheckPolicy(
+        interval: 86_400,
+        offlineGrace: 3 * 86_400
+    )
+
+    public init(interval: TimeInterval, offlineGrace: TimeInterval) {
+        self.interval = interval
+        self.offlineGrace = offlineGrace
+    }
+}
+
+/// Last successful gate answer + when it landed. Persisted so a
+/// relaunch inside the grace window serves the last known state
+/// instead of blocking on the network.
+public struct PersistedGateState: Codable, Sendable, Equatable {
+    public let lastResult: GateCheckResult
+    public let lastSuccessAt: Date
+
+    public init(lastResult: GateCheckResult, lastSuccessAt: Date) {
+        self.lastResult = lastResult
+        self.lastSuccessAt = lastSuccessAt
+    }
+}
+
+public protocol GateStateStore: Sendable {
+    func load() -> PersistedGateState?
+    func save(_ state: PersistedGateState?)
+}
+
+/// `@unchecked Sendable`: `UserDefaults` is documented thread-safe
+/// but not formally `Sendable`.
+public struct UserDefaultsGateStateStore: GateStateStore, @unchecked Sendable {
+    private static let stateKey = "app.onym.ios.moderation.gateState"
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> PersistedGateState? {
+        guard let data = defaults.data(forKey: Self.stateKey) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(PersistedGateState.self, from: data)
+    }
+
+    public func save(_ state: PersistedGateState?) {
+        guard let state else {
+            defaults.removeObject(forKey: Self.stateKey)
+            return
+        }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(state) else { return }
+        defaults.set(data, forKey: Self.stateKey)
+    }
+}
+
+/// What the root of the app switches on. Every state except
+/// `.operational` with no open cases changes the UI; only `.banned`
+/// and `.gateCheckRequired` block it.
+public enum GateStatus: Sendable, Equatable {
+    /// No active mandate yet — the consent gate applies, not this
+    /// one. The protocol remains usable without a mandate; it's this
+    /// interface that requires one.
+    case notMandated
+    /// Operating. Non-empty `openCases` renders the (non-blocking)
+    /// case banner — the case-open mark must not degrade service.
+    case operational(openCases: [CaseNotice])
+    /// bit1: the app refuses to operate and shows the full ban UX.
+    case banned(BanState)
+    /// Blocking: no trustworthy gate answer (and grace exhausted).
+    case gateCheckRequired(CheckRequiredReason)
+}
+
+/// Owns the gate-check cadence: launch + interval checks, offline
+/// grace on the persisted last-known state, degradation toward
+/// blocking — never toward unmoderated operation. All state
+/// transitions go through the pure `derive` so the arithmetic is
+/// testable without actor plumbing.
+public actor GateCheckRepository {
+    /// Outcome of one contact attempt with the backend.
+    public enum AttemptOutcome: Sendable, Equatable {
+        case success(GateCheckResult)
+        /// Network failure / backend unreachable. NOT a backend
+        /// refusal — a reachable backend answers `.checkRequired`.
+        case unreachable
+    }
+
+    private let attestation: any DeviceAttestationProvider
+    private let backend: any EnforcementBackendClient
+    private let moderation: ModerationRepository
+    private let signer: any ModerationSigner
+    private let store: any GateStateStore
+    private let policy: GateCheckPolicy
+    private let clock: @Sendable () -> Date
+
+    private var cached: GateStatus = .notMandated
+    private var continuations: [UUID: AsyncStream<GateStatus>.Continuation] = [:]
+    private var loopTask: Task<Void, Never>?
+
+    public init(
+        attestation: any DeviceAttestationProvider,
+        backend: any EnforcementBackendClient,
+        moderation: ModerationRepository,
+        signer: any ModerationSigner,
+        store: any GateStateStore,
+        policy: GateCheckPolicy = .default,
+        clock: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.attestation = attestation
+        self.backend = backend
+        self.moderation = moderation
+        self.signer = signer
+        self.store = store
+        self.policy = policy
+        self.clock = clock
+    }
+
+    // MARK: - Lifecycle
+
+    /// Launch check + interval loop. Idempotent.
+    public func start() {
+        guard loopTask == nil else { return }
+        loopTask = Task { [weak self, policy] in
+            while !Task.isCancelled {
+                await self?.checkNow()
+                try? await Task.sleep(nanoseconds: UInt64(policy.interval * 1_000_000_000))
+            }
+        }
+    }
+
+    public func stop() {
+        loopTask?.cancel()
+        loopTask = nil
+    }
+
+    // MARK: - Gate check
+
+    /// Run one gate check now (launch, foreground, retry button).
+    public func checkNow() async {
+        guard let record = await moderation.activeMandateRecord() else {
+            cached = .notMandated
+            publish()
+            return
+        }
+
+        let attempt = await performAttempt(for: record)
+        let (status, persisted) = Self.derive(
+            persisted: store.load(),
+            attempt: attempt,
+            now: clock(),
+            policy: policy
+        )
+        store.save(persisted)
+        cached = status
+        publish()
+    }
+
+    private func performAttempt(for record: MandateRecord) async -> AttemptOutcome {
+        // The client never fabricates a token: unavailable attestation
+        // sends nil and lets the backend (or grace arithmetic) decide.
+        let token: Data?
+        if attestation.isSupported {
+            token = try? await attestation.generateToken()
+        } else {
+            token = nil
+        }
+
+        do {
+            let timestamp = clock()
+            let signature = try await signer.sign(
+                GateCheckRequest.signedPayload(deviceToken: token, timestamp: timestamp)
+            )
+            let request = GateCheckRequest(
+                deviceToken: token,
+                userKey: record.mandate.user,
+                mandateRef: try? record.mandate.mandateHash(),
+                timestamp: timestamp,
+                signature: signature
+            )
+            return .success(try await backend.gateCheck(request))
+        } catch {
+            return .unreachable
+        }
+    }
+
+    // MARK: - Cadence arithmetic (pure)
+
+    /// The profile-§5 rules as one pure function:
+    /// - success → status from the result; persist `{result, now}`;
+    /// - unreachable within `offlineGrace` of the last success → keep
+    ///   serving the last known state;
+    /// - unreachable past grace → `.gateCheckRequired(.offlineGraceExpired)`,
+    ///   persisted state kept (a later success overwrites it);
+    /// - unreachable with no history → `.gateCheckRequired(.neverChecked)`.
+    /// Degradation only ever moves toward blocking.
+    public static func derive(
+        persisted: PersistedGateState?,
+        attempt: AttemptOutcome,
+        now: Date,
+        policy: GateCheckPolicy
+    ) -> (GateStatus, PersistedGateState?) {
+        switch attempt {
+        case .success(let result):
+            return (status(for: result), PersistedGateState(lastResult: result, lastSuccessAt: now))
+        case .unreachable:
+            guard let persisted else {
+                return (.gateCheckRequired(.neverChecked), nil)
+            }
+            if now.timeIntervalSince(persisted.lastSuccessAt) <= policy.offlineGrace {
+                return (status(for: persisted.lastResult), persisted)
+            }
+            return (.gateCheckRequired(.offlineGraceExpired), persisted)
+        }
+    }
+
+    static func status(for result: GateCheckResult) -> GateStatus {
+        switch result {
+        case .clear:
+            return .operational(openCases: [])
+        case .caseOpen(let notices):
+            return .operational(openCases: notices)
+        case .banned(let state):
+            return .banned(state)
+        case .checkRequired(let reason):
+            return .gateCheckRequired(reason)
+        }
+    }
+
+    // MARK: - Read / stream
+
+    public func currentStatus() -> GateStatus { cached }
+
+    public nonisolated var snapshots: AsyncStream<GateStatus> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func subscribe(id: UUID, continuation: AsyncStream<GateStatus>.Continuation) {
+        continuations[id] = continuation
+        continuation.yield(cached)
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func publish() {
+        for continuation in continuations.values {
+            continuation.yield(cached)
+        }
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ISO8601Duration.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ISO8601Duration.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// The day-granular subset of ISO 8601 durations the moderation spec
+/// actually uses (`P1D`, `P3D`, `P30D`, `P365D`, …). Authority
+/// manifests declare every window in whole days; supporting the full
+/// ISO 8601 grammar (weeks, time components, fractions) would be
+/// untestable surface for values no conforming manifest emits.
+public struct ISO8601Duration: Sendable, Equatable, Hashable {
+    /// The exact string as consented to, e.g. `"P3D"`. Preserved
+    /// verbatim so terms render exactly as the manifest declared them.
+    public let raw: String
+    /// Whole days encoded by `raw`.
+    public let days: Int
+
+    public var timeInterval: TimeInterval { TimeInterval(days) * 86_400 }
+
+    public init(days: Int) {
+        self.raw = "P\(days)D"
+        self.days = days
+    }
+
+    /// Parse the `P<n>D` subset. Throws `ModerationError.invalidDuration`
+    /// on anything else — a manifest declaring windows this client can't
+    /// interpret must fail consent validation, not round to zero.
+    public init(parsing raw: String) throws {
+        guard raw.hasPrefix("P"), raw.hasSuffix("D"),
+              raw.count > 2,
+              let days = Int(raw.dropFirst().dropLast()),
+              days > 0
+        else {
+            throw ModerationError.invalidDuration(raw)
+        }
+        self.raw = raw
+        self.days = days
+    }
+}
+
+extension ISO8601Duration: Codable {
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        try self.init(parsing: raw)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(raw)
+    }
+}
+
+/// A violation class's ban term: a declared duration, or `permanent`
+/// (valid per spec §5.2 only on classes whose manifest names an
+/// external appellate — checked at consent, not here).
+public enum BanTerm: Sendable, Equatable, Hashable {
+    case permanent
+    case duration(ISO8601Duration)
+}
+
+extension BanTerm: Codable {
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        if raw == "permanent" {
+            self = .permanent
+        } else {
+            self = .duration(try ISO8601Duration(parsing: raw))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .permanent: try container.encode("permanent")
+        case .duration(let duration): try container.encode(duration.raw)
+        }
+    }
+}
+
+/// Whether a ban executes immediately (`non-suspensive`, appeal can
+/// only reverse it) or only after the appeal window passes unused
+/// (`suspensive`). Spec §5.2 normative constraint 1.
+public enum AppealEffect: String, Codable, Sendable, Equatable {
+    case suspensive
+    case nonSuspensive = "non-suspensive"
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
@@ -1,0 +1,87 @@
+import Foundation
+import OnymFoundation
+
+/// One entry in the interface's published authority directory. The
+/// directory pins each authority's operator public key out-of-band
+/// from its manifest: a MITM that swaps the hosted manifest can't also
+/// swap the key it must verify against.
+public struct AuthorityListing: Codable, Sendable, Equatable {
+    /// `onym:component:<authority-id>`.
+    public let componentId: String
+    /// Human-readable name shown in the picker.
+    public let name: String
+    public let manifestURL: URL
+    /// The authority's Ed25519 operator public key, base64 raw bytes.
+    public let operatorPublicKeyBase64: String
+
+    public init(componentId: String, name: String, manifestURL: URL, operatorPublicKeyBase64: String) {
+        self.componentId = componentId
+        self.name = name
+        self.manifestURL = manifestURL
+        self.operatorPublicKeyBase64 = operatorPublicKeyBase64
+    }
+}
+
+struct KnownAuthoritiesDocument: Codable {
+    let authorities: [AuthorityListing]
+}
+
+/// Network seam that fetches the curated list of moderation
+/// authorities this interface designates. Same shape and trust story
+/// as `KnownRelayersFetcher` in OnymChain: a GitHub latest-release
+/// asset with an optional detached `.sig`, soft-verified until the
+/// release-signing pipeline is live.
+public protocol KnownAuthoritiesFetcher: Sendable {
+    /// Fetch and parse the latest `authorities.json`. Throws on
+    /// network failure, non-2xx, or malformed JSON; callers fall back
+    /// to the cached list.
+    func fetchLatest() async throws -> [AuthorityListing]
+}
+
+/// Production `KnownAuthoritiesFetcher`. Pure `URLSession`; tests
+/// inject a fake session via `URLProtocol`.
+public struct GitHubReleasesKnownAuthoritiesFetcher: KnownAuthoritiesFetcher {
+    /// GitHub redirect that always resolves to the latest release's
+    /// `authorities.json` asset.
+    public static let defaultURL = URL(string: "https://github.com/onymchat/onym-authorities/releases/latest/download/authorities.json")!
+
+    let url: URL
+    let session: URLSession
+    let decoder: JSONDecoder
+
+    public init(
+        url: URL = defaultURL,
+        session: URLSession = .shared,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.url = url
+        self.session = session
+        self.decoder = decoder
+    }
+
+    public func fetchLatest() async throws -> [AuthorityListing] {
+        let (data, response) = try await session.data(from: url)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(statusCode) else {
+            throw KnownAuthoritiesFetchError.badStatus(statusCode)
+        }
+        try await SignedAsset.verify(
+            assetData: data,
+            assetURL: url,
+            session: session,
+            label: "authorities.json"
+        )
+        let document: KnownAuthoritiesDocument
+        do {
+            document = try decoder.decode(KnownAuthoritiesDocument.self, from: data)
+        } catch {
+            throw KnownAuthoritiesFetchError.malformedDocument(error)
+        }
+        return document.authorities
+    }
+}
+
+public enum KnownAuthoritiesFetchError: Error, Sendable {
+    case badStatus(Int)
+    case malformedDocument(Error)
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// A signed mandate plus everything needed to honor it offline: the
+/// consented manifest snapshot (exact bytes — re-verifiable, still
+/// renderable if the authority disappears) and the countersignature
+/// state.
+public struct MandateRecord: Codable, Sendable, Equatable {
+    public let mandate: ModerationMandate
+    /// The exact manifest bytes `mandate.manifestHash` was computed
+    /// over. Never re-fetched, never re-encoded.
+    public let manifestBytes: Data
+    /// Display name from the directory listing at consent time.
+    public let authorityName: String
+    /// False while the interface signature is the stub sentinel — a
+    /// record that can never be mistaken for a spec-valid mandate.
+    public let countersigned: Bool
+    /// Exactly one record is active per identity–device pair.
+    /// Switching authorities deactivates the old record without
+    /// touching anything else (mandates are immutable, spec §12).
+    public var isActive: Bool
+    public let createdAt: Date
+
+    public init(
+        mandate: ModerationMandate,
+        manifestBytes: Data,
+        authorityName: String,
+        countersigned: Bool,
+        isActive: Bool,
+        createdAt: Date
+    ) {
+        self.mandate = mandate
+        self.manifestBytes = manifestBytes
+        self.authorityName = authorityName
+        self.countersigned = countersigned
+        self.isActive = isActive
+        self.createdAt = createdAt
+    }
+
+    /// The consented manifest, decoded from the stored snapshot.
+    public func consentedManifest() -> SignedManifest? {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let manifest = try? decoder.decode(AuthorityManifest.self, from: manifestBytes) else {
+            return nil
+        }
+        return SignedManifest(manifest: manifest, rawBytes: manifestBytes)
+    }
+}
+
+/// Persistence seam for mandate records. UserDefaults-backed — a
+/// mandate is a signed public consent object, not a secret (the
+/// signature is worthless without the private key, which stays in
+/// the Keychain behind `ModerationSigner`).
+public protocol MandateStore: Sendable {
+    func load() -> [MandateRecord]
+    func save(_ records: [MandateRecord])
+}
+
+/// Production `MandateStore`. Keys scoped under
+/// `app.onym.ios.moderation.*`; suite injectable for test isolation.
+///
+/// `@unchecked Sendable` because `UserDefaults` is documented as
+/// thread-safe but isn't formally `Sendable`.
+public struct UserDefaultsMandateStore: MandateStore, @unchecked Sendable {
+    private static let recordsKey = "app.onym.ios.moderation.mandates"
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> [MandateRecord] {
+        guard let data = defaults.data(forKey: Self.recordsKey),
+              let records = try? Self.decoder().decode([MandateRecord].self, from: data)
+        else { return [] }
+        return records
+    }
+
+    public func save(_ records: [MandateRecord]) {
+        guard let data = try? Self.encoder().encode(records) else { return }
+        defaults.set(data, forKey: Self.recordsKey)
+    }
+
+    /// ISO 8601 dates so persisted mandates stay byte-comparable with
+    /// their signing form.
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Receipt for a filed report. Intake weighting (reporter track
+/// record) is the authority's business; the client only learns the
+/// report was received.
+public struct ReportReceipt: Codable, Sendable, Equatable {
+    public let reportId: String
+    public let receivedAt: Date
+
+    public init(reportId: String, receivedAt: Date) {
+        self.reportId = reportId
+        self.receivedAt = receivedAt
+    }
+}
+
+/// The accused's signed response to a case notice: statements and
+/// counter-evidence (Moderation.md §5.5 — "the response mirrors the
+/// report's shape"). Additional evidence within the window travels
+/// through the same object, so `submit-evidence` needs no separate
+/// operation client-side.
+public struct CaseResponse: Codable, Sendable, Equatable {
+    public let statement: String
+    public let evidence: [EvidenceItem]
+    public var signature: String
+
+    public init(statement: String, evidence: [EvidenceItem] = [], signature: String = "") {
+        self.statement = statement
+        self.evidence = evidence
+        self.signature = signature
+    }
+}
+
+/// An appeal filed within the declared window — or a new-holder claim,
+/// which the spec treats as a mandatory appeal class with expedited
+/// review (§5.7, error `new_holder_claim`).
+public struct AppealSubmission: Codable, Sendable, Equatable {
+    public enum Kind: String, Codable, Sendable {
+        case appeal
+        case newHolderClaim = "new-holder-claim"
+    }
+
+    public let kind: Kind
+    public let statement: String
+    public var signature: String
+
+    public init(kind: Kind, statement: String, signature: String = "") {
+        self.kind = kind
+        self.statement = statement
+        self.signature = signature
+    }
+}
+
+/// Stage-and-deadlines answer to a status query, per the authority's
+/// confidentiality rules.
+public struct CaseStatus: Codable, Sendable, Equatable {
+    public let caseId: String
+    public let stage: String
+    public let responseDeadline: Date?
+    public let decisionDeadline: Date?
+
+    public init(caseId: String, stage: String, responseDeadline: Date? = nil, decisionDeadline: Date? = nil) {
+        self.caseId = caseId
+        self.stage = stage
+        self.responseDeadline = responseDeadline
+        self.decisionDeadline = decisionDeadline
+    }
+}
+
+/// The client-visible operations of a moderation authority
+/// (Moderation.md §6). Notices and verdicts travel the other way —
+/// they arrive via the enforcement backend's gate check — so this
+/// surface is only what a user initiates.
+///
+/// Deliberately smaller than the spec's operation table:
+/// `submit-evidence` is folded into `respond` (same signed shape, same
+/// window), and `accept-mandate` is authority-side. One implementation
+/// per authority; the repository picks the client for the mandated
+/// authority, which is what makes authorities swappable.
+public protocol ModerationAuthorityClient: Sendable {
+    func fileReport(_ report: Report) async throws -> ReportReceipt
+    func respond(caseId: String, _ response: CaseResponse) async throws
+    func appeal(caseId: String, _ submission: AppealSubmission) async throws
+    func queryStatus(caseId: String) async throws -> CaseStatus
+}
+
+/// Stub client — no authority service is deployed yet. Every
+/// operation throws `.notImplemented` so UI entry points exist and
+/// fail honestly rather than pretending a case moved.
+public struct StubModerationAuthorityClient: ModerationAuthorityClient {
+    public init() {}
+
+    public func fileReport(_ report: Report) async throws -> ReportReceipt {
+        throw ModerationError.notImplemented("file-report")
+    }
+
+    public func respond(caseId: String, _ response: CaseResponse) async throws {
+        throw ModerationError.notImplemented("respond")
+    }
+
+    public func appeal(caseId: String, _ submission: AppealSubmission) async throws {
+        throw ModerationError.notImplemented("appeal")
+    }
+
+    public func queryStatus(caseId: String) async throws -> CaseStatus {
+        throw ModerationError.notImplemented("query-status")
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -25,6 +25,10 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// base64 operator key) could not be parsed as an Ed25519 public
     /// key. See `AuthorityKey`.
     case keyInvalid(String)
+    /// A component reference (`onym:component:<identifier>`) could not
+    /// be parsed — absent prefix, or an empty/blank identifier naming
+    /// no component. See `ComponentReference`.
+    case componentReferenceInvalid(String)
     /// DeviceCheck is unsupported here (simulator, enterprise-signed
     /// build). Callers degrade toward gate-check-required, never toward
     /// unmoderated operation (profile §8.5).

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Client-relevant subset of the moderation spec's error table
+/// (Moderation.md §10), plus the client-only conditions the DeviceCheck
+/// profile introduces (attestation availability, unimplemented stub
+/// operations).
+public enum ModerationError: Error, Sendable, Equatable {
+    /// The authority's manifest declares a profile this client doesn't
+    /// implement, or a duration/term outside the supported grammar.
+    case unsupportedProfile(String)
+    /// A manifest window/term used a duration string outside the
+    /// `P<n>D` subset this client parses.
+    case invalidDuration(String)
+    /// A verdict referenced no mandate this user signed.
+    case noMandate
+    /// A verdict named a violation class outside the consented mandate.
+    case classOutsideMandate(String)
+    /// A verdict failed mechanical shape validation (Moderation.md
+    /// §5.6). The reason is developer-facing diagnostic detail.
+    case verdictInvalid(String)
+    /// The manifest failed decode or signature validation at consent.
+    case manifestInvalid(String)
+    /// DeviceCheck is unsupported here (simulator, enterprise-signed
+    /// build). Callers degrade toward gate-check-required, never toward
+    /// unmoderated operation (profile §8.5).
+    case attestationUnavailable
+    /// The operation exists in the protocol surface but the concrete
+    /// implementation is a stub (no enforcement backend / authority
+    /// service is deployed yet).
+    case notImplemented(String)
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -18,8 +18,13 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// A verdict failed mechanical shape validation (Moderation.md
     /// §5.6). The reason is developer-facing diagnostic detail.
     case verdictInvalid(String)
-    /// The manifest failed decode or signature validation at consent.
+    /// The manifest failed decode, signature, or consent-time validity
+    /// validation (`AuthorityManifestValidator`).
     case manifestInvalid(String)
+    /// A key reference (`onym:key:<hex>`, or a directory listing's
+    /// base64 operator key) could not be parsed as an Ed25519 public
+    /// key. See `AuthorityKey`.
+    case keyInvalid(String)
     /// DeviceCheck is unsupported here (simulator, enterprise-signed
     /// build). Callers degrade toward gate-check-required, never toward
     /// unmoderated operation (profile §8.5).

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationMandate.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationMandate.swift
@@ -1,0 +1,89 @@
+import Foundation
+import CryptoKit
+
+/// The consent artifact (Moderation.md §5.3): signed by the user at
+/// onboarding, countersigned by the interface, binding exactly one
+/// identity–device pair to one authority under one manifest hash.
+/// Immutable once signed — switching authorities means signing a
+/// fresh mandate, never editing this one.
+public struct ModerationMandate: Codable, Sendable, Equatable {
+    public let mandateVersion: Int
+    /// `onym:key:<user-identity>`.
+    public let user: String
+    /// `onym:component:<interface-id>` — this app.
+    public let interface: String
+    /// `onym:component:<authority-id>`.
+    public let authority: String
+    /// SHA-256 (lowercase hex) of the exact manifest bytes consented to.
+    public let manifestHash: String
+    public let classes: [String]
+    /// Vendor-local opaque enrollment identifier issued by the
+    /// enforcement backend — NOT a DeviceCheck token (tokens are
+    /// ephemeral and unlinkable by design; profile §5).
+    public let deviceBinding: String
+    public let acceptedAt: Date
+    /// `[userSignature, interfaceSignature]`, base64. The interface
+    /// countersignature comes from the enforcement backend; a stub
+    /// backend appends a sentinel that can never verify (see
+    /// `StubEnforcementBackendClient`).
+    public var signatures: [String]
+
+    public init(
+        mandateVersion: Int = 1,
+        user: String,
+        interface: String,
+        authority: String,
+        manifestHash: String,
+        classes: [String],
+        deviceBinding: String,
+        acceptedAt: Date,
+        signatures: [String] = []
+    ) {
+        self.mandateVersion = mandateVersion
+        self.user = user
+        self.interface = interface
+        self.authority = authority
+        self.manifestHash = manifestHash
+        self.classes = classes
+        self.deviceBinding = deviceBinding
+        self.acceptedAt = acceptedAt
+        self.signatures = signatures
+    }
+
+    /// The bytes the user (and later the interface) sign: every field
+    /// except `signatures`, JSON-encoded with sorted keys and ISO 8601
+    /// dates.
+    ///
+    /// PROVISIONAL: the draft spec defines no canonical JSON form.
+    /// `.sortedKeys` + ISO 8601 is deterministic for this encoder but
+    /// is not a cross-implementation canonical encoding — when the
+    /// spec fixes one, only this helper changes, and mandates signed
+    /// before then will need re-consent.
+    public func signingBytes() throws -> Data {
+        var unsigned = self
+        unsigned.signatures = []
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        var data = try encoder.encode(unsigned)
+        // Excise the empty `signatures` array so countersigning later
+        // doesn't change the signed content: the signed form has no
+        // signatures field at all.
+        if let text = String(data: data, encoding: .utf8) {
+            let stripped = text
+                .replacingOccurrences(of: ",\"signatures\":[]", with: "")
+                .replacingOccurrences(of: "\"signatures\":[],", with: "")
+            data = Data(stripped.utf8)
+        }
+        return data
+    }
+
+    /// `mandateRef` as verdicts and notices carry it: SHA-256
+    /// (lowercase hex) over `signingBytes()`. Signature-independent so
+    /// the reference is stable across countersigning. Same PROVISIONAL
+    /// caveat as `signingBytes()`.
+    public func mandateHash() throws -> String {
+        let bytes = try signingBytes()
+        return SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationMandate.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationMandate.swift
@@ -52,7 +52,10 @@ public struct ModerationMandate: Codable, Sendable, Equatable {
 
     /// The bytes the user (and later the interface) sign: every field
     /// except `signatures`, JSON-encoded with sorted keys and ISO 8601
-    /// dates.
+    /// dates. Built from an explicit payload type — no `signatures`
+    /// field at all, so countersigning can't change the signed content,
+    /// and no string surgery on already-encoded JSON. `ModerationSigningPayloadTests`
+    /// guards the mirror against field drift.
     ///
     /// PROVISIONAL: the draft spec defines no canonical JSON form.
     /// `.sortedKeys` + ISO 8601 is deterministic for this encoder but
@@ -60,22 +63,27 @@ public struct ModerationMandate: Codable, Sendable, Equatable {
     /// spec fixes one, only this helper changes, and mandates signed
     /// before then will need re-consent.
     public func signingBytes() throws -> Data {
-        var unsigned = self
-        unsigned.signatures = []
+        struct Unsigned: Encodable {
+            let mandateVersion: Int
+            let user, interface, authority, manifestHash: String
+            let classes: [String]
+            let deviceBinding: String
+            let acceptedAt: Date
+        }
+        let unsigned = Unsigned(
+            mandateVersion: mandateVersion,
+            user: user,
+            interface: interface,
+            authority: authority,
+            manifestHash: manifestHash,
+            classes: classes,
+            deviceBinding: deviceBinding,
+            acceptedAt: acceptedAt
+        )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
-        var data = try encoder.encode(unsigned)
-        // Excise the empty `signatures` array so countersigning later
-        // doesn't change the signed content: the signed form has no
-        // signatures field at all.
-        if let text = String(data: data, encoding: .utf8) {
-            let stripped = text
-                .replacingOccurrences(of: ",\"signatures\":[]", with: "")
-                .replacingOccurrences(of: "\"signatures\":[],", with: "")
-            data = Data(stripped.utf8)
-        }
-        return data
+        return try encoder.encode(unsigned)
     }
 
     /// `mandateRef` as verdicts and notices carry it: SHA-256

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -41,6 +41,27 @@ public struct ModerationState: Sendable, Equatable {
     }
 }
 
+/// A manifest this repository fetched, authenticated, and validated —
+/// the unit of consent, mintable only by `manifestForReview(_:)`.
+///
+/// `SignedManifest` is a plain value with a public initializer, so taking
+/// one at signing time would move authenticity (directory-pinned operator
+/// key, detached signature over the exact bytes) out of the repository and
+/// onto whoever calls it — and a hand-built value can pair `rawBytes` of
+/// one manifest with the decoded fields of another, pinning a hash whose
+/// contents differ from the classes the mandate enumerates. Wrapping it in
+/// a type with no public initializer keeps the check where the invariant
+/// lives: the only bytes that can reach a signed mandate are bytes the
+/// fetcher verified.
+public struct ReviewedManifest: Sendable, Equatable {
+    /// The reviewed manifest, for the consent surface to display.
+    public let signedManifest: SignedManifest
+
+    init(_ signedManifest: SignedManifest) {
+        self.signedManifest = signedManifest
+    }
+}
+
 /// Owns authority designation + mandate lifecycle: fetches the
 /// directory, verifies and pins manifests, signs mandates, and keeps
 /// exactly one record active per device. `manifestForReview(_:)` and
@@ -120,10 +141,10 @@ public actor ModerationRepository {
     /// consent surface. The returned value is the unit of consent: callers
     /// must retain it and pass that same value to
     /// `consent(to:reviewedManifest:)` after the user agrees.
-    public func manifestForReview(_ listing: AuthorityListing) async throws -> SignedManifest {
+    public func manifestForReview(_ listing: AuthorityListing) async throws -> ReviewedManifest {
         let signedManifest = try await manifestFetcher.fetch(listing)
         try manifestValidator.validateForConsent(signedManifest, now: clock())
-        return signedManifest
+        return ReviewedManifest(signedManifest)
     }
 
     /// Consent to the exact manifest the user reviewed: validate it again
@@ -138,8 +159,9 @@ public actor ModerationRepository {
     @discardableResult
     public func consent(
         to listing: AuthorityListing,
-        reviewedManifest signedManifest: SignedManifest
+        reviewedManifest: ReviewedManifest
     ) async throws -> MandateRecord {
+        let signedManifest = reviewedManifest.signedManifest
         guard signedManifest.manifest.componentId == listing.componentId else {
             throw ModerationError.manifestInvalid(
                 "reviewed manifest componentId does not match the selected authority"

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -52,6 +52,7 @@ public actor ModerationRepository {
 
     private let authoritiesFetcher: any KnownAuthoritiesFetcher
     private let manifestFetcher: any AuthorityManifestFetcher
+    private let manifestValidator: AuthorityManifestValidator
     private let mandateStore: any MandateStore
     private let backend: any EnforcementBackendClient
     private let attestation: any DeviceAttestationProvider
@@ -71,10 +72,12 @@ public actor ModerationRepository {
         backend: any EnforcementBackendClient,
         attestation: any DeviceAttestationProvider,
         signer: any ModerationSigner,
+        manifestValidator: AuthorityManifestValidator = AuthorityManifestValidator(),
         clock: @escaping @Sendable () -> Date = Date.init
     ) {
         self.authoritiesFetcher = authoritiesFetcher
         self.manifestFetcher = manifestFetcher
+        self.manifestValidator = manifestValidator
         self.mandateStore = mandateStore
         self.backend = backend
         self.attestation = attestation
@@ -112,14 +115,20 @@ public actor ModerationRepository {
 
     // MARK: - Consent
 
-    /// Consent to `listing`: fetch + verify + pin its manifest, enroll
-    /// this device, sign the mandate, obtain the interface
-    /// countersignature, persist. Any previously active record is
+    /// Consent to `listing`: fetch + verify + validate + pin its
+    /// manifest, enroll this device, sign the mandate, obtain the
+    /// interface countersignature, persist. Any previously active record is
     /// deactivated untouched — its mandate stays bound to the manifest
     /// hash it consented to, forever.
     @discardableResult
     public func consent(to listing: AuthorityListing) async throws -> MandateRecord {
         let signedManifest = try await manifestFetcher.fetch(listing)
+
+        // Validity conditions (validUntil, supported profile, external
+        // appellate for permanent classes) gate enrollment and signing —
+        // not just the consent UI. An invalid manifest must never end up
+        // pinned by a signed mandate.
+        try manifestValidator.validateForConsent(signedManifest, now: clock())
 
         // Enrollment: (identity signature, device token) presented
         // together is the only token↔enrollment linkage. A nil token

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -43,9 +43,10 @@ public struct ModerationState: Sendable, Equatable {
 
 /// Owns authority designation + mandate lifecycle: fetches the
 /// directory, verifies and pins manifests, signs mandates, and keeps
-/// exactly one record active per device. `consent(to:)` is one path
-/// for both onboarding and switching — swapping authorities *is*
-/// signing a fresh mandate (Moderation.md §5.3).
+/// exactly one record active per device. `manifestForReview(_:)` and
+/// `consent(to:reviewedManifest:)` form one two-step path for both
+/// onboarding and switching — swapping authorities *is* signing a
+/// fresh mandate (Moderation.md §5.3).
 public actor ModerationRepository {
     /// This interface's component id, carried in every mandate.
     public static let interfaceComponentId = "onym:component:onym-ios"
@@ -115,14 +116,35 @@ public actor ModerationRepository {
 
     // MARK: - Consent
 
-    /// Consent to `listing`: fetch + verify + validate + pin its
-    /// manifest, enroll this device, sign the mandate, obtain the
-    /// interface countersignature, persist. Any previously active record is
-    /// deactivated untouched — its mandate stays bound to the manifest
-    /// hash it consented to, forever.
-    @discardableResult
-    public func consent(to listing: AuthorityListing) async throws -> MandateRecord {
+    /// Fetch, verify, and validate the exact manifest bytes to put on the
+    /// consent surface. The returned value is the unit of consent: callers
+    /// must retain it and pass that same value to
+    /// `consent(to:reviewedManifest:)` after the user agrees.
+    public func manifestForReview(_ listing: AuthorityListing) async throws -> SignedManifest {
         let signedManifest = try await manifestFetcher.fetch(listing)
+        try manifestValidator.validateForConsent(signedManifest, now: clock())
+        return signedManifest
+    }
+
+    /// Consent to the exact manifest the user reviewed: validate it again
+    /// at signing time, pin its already-computed hash and raw bytes, enroll
+    /// this device, sign the mandate, obtain the interface countersignature,
+    /// and persist. This method deliberately never refetches the manifest;
+    /// an authority changing its hosted terms between review and agreement
+    /// therefore cannot replace the artifact that gets signed.
+    ///
+    /// Any previously active record is deactivated untouched — its mandate
+    /// stays bound to the manifest hash it consented to, forever.
+    @discardableResult
+    public func consent(
+        to listing: AuthorityListing,
+        reviewedManifest signedManifest: SignedManifest
+    ) async throws -> MandateRecord {
+        guard signedManifest.manifest.componentId == listing.componentId else {
+            throw ModerationError.manifestInvalid(
+                "reviewed manifest componentId does not match the selected authority"
+            )
+        }
 
         // Validity conditions (validUntil, supported profile, external
         // appellate for permanent classes) gate enrollment and signing —

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -141,13 +141,24 @@ public actor ModerationRepository {
             token = nil
         }
         let userKey = try await signer.userKeyID()
+        // The signed bytes are built from exactly the fields the
+        // request transmits, so the backend can recompute and verify
+        // them — the timestamp travels with the signature it covers.
+        let enrollmentTimestamp = clock()
         let enrollmentSignature = try await signer.sign(
-            GateCheckRequest.signedPayload(deviceToken: token, timestamp: clock())
+            EnrollmentRequest.signedPayload(
+                deviceToken: token,
+                userKey: userKey,
+                timestamp: enrollmentTimestamp
+            )
         )
         let enrollment = try await backend.enrollDevice(
-            token: token,
-            userKey: userKey,
-            signature: enrollmentSignature
+            EnrollmentRequest(
+                deviceToken: token,
+                userKey: userKey,
+                timestamp: enrollmentTimestamp,
+                signature: enrollmentSignature
+            )
         )
 
         var mandate = ModerationMandate(
@@ -162,12 +173,19 @@ public actor ModerationRepository {
         let userSignature = try await signer.sign(mandate.signingBytes())
         mandate.signatures = [userSignature.base64EncodedString()]
 
-        let countersigned = try await backend.countersignMandate(mandate)
-        let isCountersigned = countersigned.signatures.count > 1
-            && countersigned.signatures.last != StubEnforcementBackendClient.countersignSentinel
+        // The countersignature is appended to the client's own copy.
+        // The backend never hands back a mandate, so no consented
+        // field can change behind the user's signature.
+        let countersignature = try await backend.countersignMandate(mandate)
+        let isCountersigned = countersignature.signature
+            != StubEnforcementBackendClient.countersignSentinel
+        mandate.signatures = [
+            userSignature.base64EncodedString(),
+            countersignature.signature,
+        ]
 
         let record = MandateRecord(
-            mandate: countersigned,
+            mandate: mandate,
             manifestBytes: signedManifest.rawBytes,
             authorityName: listing.name,
             countersigned: isCountersigned,

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+/// Outcome of the most recent authorities-directory fetch. Same
+/// shape as `RelayerFetchStatus` so the picker copy stays consistent.
+public enum AuthorityFetchStatus: Equatable, Sendable {
+    case idle
+    case fetching
+    case success
+    case failed(message: String)
+}
+
+/// Combined snapshot for consent and settings UI: the designated
+/// authorities, the fetch state of that list, and the mandate
+/// history for this device.
+public struct ModerationState: Sendable, Equatable {
+    public let authorities: [AuthorityListing]
+    public let fetchStatus: AuthorityFetchStatus
+    /// The active record, if the user has consented.
+    public let activeMandate: MandateRecord?
+    /// Every record ever signed on this device, newest first —
+    /// old mandates stay pinned to their consented manifest hashes.
+    public let history: [MandateRecord]
+
+    public static let empty = ModerationState(
+        authorities: [],
+        fetchStatus: .idle,
+        activeMandate: nil,
+        history: []
+    )
+
+    public init(
+        authorities: [AuthorityListing],
+        fetchStatus: AuthorityFetchStatus,
+        activeMandate: MandateRecord?,
+        history: [MandateRecord]
+    ) {
+        self.authorities = authorities
+        self.fetchStatus = fetchStatus
+        self.activeMandate = activeMandate
+        self.history = history
+    }
+}
+
+/// Owns authority designation + mandate lifecycle: fetches the
+/// directory, verifies and pins manifests, signs mandates, and keeps
+/// exactly one record active per device. `consent(to:)` is one path
+/// for both onboarding and switching — swapping authorities *is*
+/// signing a fresh mandate (Moderation.md §5.3).
+public actor ModerationRepository {
+    /// This interface's component id, carried in every mandate.
+    public static let interfaceComponentId = "onym:component:onym-ios"
+
+    private let authoritiesFetcher: any KnownAuthoritiesFetcher
+    private let manifestFetcher: any AuthorityManifestFetcher
+    private let mandateStore: any MandateStore
+    private let backend: any EnforcementBackendClient
+    private let attestation: any DeviceAttestationProvider
+    private let signer: any ModerationSigner
+    private let clock: @Sendable () -> Date
+
+    private var authorities: [AuthorityListing] = []
+    private var fetchStatus: AuthorityFetchStatus = .idle
+    private var records: [MandateRecord]
+    private var continuations: [UUID: AsyncStream<ModerationState>.Continuation] = [:]
+    private var startTask: Task<Void, Never>?
+
+    public init(
+        authoritiesFetcher: any KnownAuthoritiesFetcher,
+        manifestFetcher: any AuthorityManifestFetcher,
+        mandateStore: any MandateStore,
+        backend: any EnforcementBackendClient,
+        attestation: any DeviceAttestationProvider,
+        signer: any ModerationSigner,
+        clock: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.authoritiesFetcher = authoritiesFetcher
+        self.manifestFetcher = manifestFetcher
+        self.mandateStore = mandateStore
+        self.backend = backend
+        self.attestation = attestation
+        self.signer = signer
+        self.clock = clock
+        self.records = mandateStore.load()
+    }
+
+    // MARK: - Directory refresh
+
+    /// Background refresh of the designated-authorities list.
+    /// Idempotent; failures leave the (empty or previous) list alone.
+    public func start() {
+        guard startTask == nil else { return }
+        startTask = Task { [weak self] in
+            try? await self?.refresh()
+        }
+    }
+
+    /// Fetch the latest directory. Throws so consent UI can surface
+    /// failure with a retry affordance.
+    public func refresh() async throws {
+        fetchStatus = .fetching
+        publish()
+        do {
+            authorities = try await authoritiesFetcher.fetchLatest()
+            fetchStatus = .success
+        } catch {
+            fetchStatus = .failed(message: String(localized: "Couldn't load the authority list."))
+            publish()
+            throw error
+        }
+        publish()
+    }
+
+    // MARK: - Consent
+
+    /// Consent to `listing`: fetch + verify + pin its manifest, enroll
+    /// this device, sign the mandate, obtain the interface
+    /// countersignature, persist. Any previously active record is
+    /// deactivated untouched — its mandate stays bound to the manifest
+    /// hash it consented to, forever.
+    @discardableResult
+    public func consent(to listing: AuthorityListing) async throws -> MandateRecord {
+        let signedManifest = try await manifestFetcher.fetch(listing)
+
+        // Enrollment: (identity signature, device token) presented
+        // together is the only token↔enrollment linkage. A nil token
+        // (simulator) still enrolls — the backend decides what that
+        // means; the client never fabricates one.
+        let token: Data?
+        if attestation.isSupported {
+            token = try? await attestation.generateToken()
+        } else {
+            token = nil
+        }
+        let userKey = try await signer.userKeyID()
+        let enrollmentSignature = try await signer.sign(
+            GateCheckRequest.signedPayload(deviceToken: token, timestamp: clock())
+        )
+        let enrollment = try await backend.enrollDevice(
+            token: token,
+            userKey: userKey,
+            signature: enrollmentSignature
+        )
+
+        var mandate = ModerationMandate(
+            user: userKey,
+            interface: Self.interfaceComponentId,
+            authority: listing.componentId,
+            manifestHash: signedManifest.manifestHash,
+            classes: signedManifest.manifest.violationClasses.map(\.classId),
+            deviceBinding: enrollment.deviceBinding,
+            acceptedAt: clock()
+        )
+        let userSignature = try await signer.sign(mandate.signingBytes())
+        mandate.signatures = [userSignature.base64EncodedString()]
+
+        let countersigned = try await backend.countersignMandate(mandate)
+        let isCountersigned = countersigned.signatures.count > 1
+            && countersigned.signatures.last != StubEnforcementBackendClient.countersignSentinel
+
+        let record = MandateRecord(
+            mandate: countersigned,
+            manifestBytes: signedManifest.rawBytes,
+            authorityName: listing.name,
+            countersigned: isCountersigned,
+            isActive: true,
+            createdAt: clock()
+        )
+
+        // Deactivate the previous active record without touching
+        // anything else in it (mandates are immutable, spec §12).
+        records = records.map { existing in
+            var existing = existing
+            existing.isActive = false
+            return existing
+        }
+        records.insert(record, at: 0)
+        mandateStore.save(records)
+        publish()
+        return record
+    }
+
+    // MARK: - Read
+
+    public func activeMandateRecord() -> MandateRecord? {
+        records.first { $0.isActive }
+    }
+
+    public func currentState() -> ModerationState {
+        ModerationState(
+            authorities: authorities,
+            fetchStatus: fetchStatus,
+            activeMandate: activeMandateRecord(),
+            history: records
+        )
+    }
+
+    // MARK: - AsyncStream
+
+    public nonisolated var snapshots: AsyncStream<ModerationState> {
+        AsyncStream { continuation in
+            let id = UUID()
+            Task { await self.subscribe(id: id, continuation: continuation) }
+            continuation.onTermination = { _ in
+                Task { await self.unsubscribe(id: id) }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func subscribe(id: UUID, continuation: AsyncStream<ModerationState>.Continuation) {
+        continuations[id] = continuation
+        continuation.yield(currentState())
+    }
+
+    private func unsubscribe(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func publish() {
+        let state = currentState()
+        for continuation in continuations.values {
+            continuation.yield(state)
+        }
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationSigner.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationSigner.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Identity seam: how moderation objects get user signatures without
+/// this package depending on OnymIdentity. The app target adapts
+/// `IdentityRepository` behind this — the private key never crosses
+/// the boundary, only detached signatures do.
+public protocol ModerationSigner: Sendable {
+    /// The user's identity key reference as mandates carry it:
+    /// `onym:key:<hex>`.
+    func userKeyID() async throws -> String
+    /// Ed25519 detached signature over `message`.
+    func sign(_ message: Data) async throws -> Data
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationTrust.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationTrust.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Soft/enforce switches for moderation signature checks, mirroring
+/// `ContractsTrust` in OnymFoundation: **no real authority publishes
+/// signed manifests or verdicts yet**, so enforcement defaults off and
+/// a missing/invalid signature is logged and accepted. Flipping either
+/// switch on requires real authorities with published operator keys —
+/// under enforcement an unverifiable object is rejected outright.
+public enum ModerationTrust {
+    /// Reject authority manifests whose `signature` doesn't verify
+    /// against the directory-pinned operator key. **Leave `false`**
+    /// until real authorities publish signed manifests.
+    public static let enforceManifestSignatures = false
+
+    /// Reject verdicts whose `signature` doesn't verify against the
+    /// consented manifest's operator key. **Leave `false`** until real
+    /// authorities issue signed verdicts (the stub backend's fixture
+    /// verdicts carry sentinel signatures).
+    public static let enforceVerdictSignatures = false
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/Report.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/Report.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// One disclosed item of evidence (Moderation.md §5.4): a message or
+/// media the reporter legitimately received, with proof the accused
+/// authored it. Content without an authenticity proof is a complaint,
+/// not evidence.
+public struct EvidenceItem: Codable, Sendable, Equatable {
+    /// The specific message or media, from the reporter's own device.
+    public let disclosedContent: String
+    /// Sender signature or envelope commitment binding the content to
+    /// the accused's key.
+    public let authenticityProof: String
+    /// Optional conversation context the reporter chooses to add.
+    public let context: String?
+
+    public init(disclosedContent: String, authenticityProof: String, context: String? = nil) {
+        self.disclosedContent = disclosedContent
+        self.authenticityProof = authenticityProof
+        self.context = context
+    }
+}
+
+/// A signed report of prohibited content (Moderation.md §5.4), filed
+/// voluntarily by a recipient of the content. Reporting UI is not
+/// built yet; the type exists so the `ModerationAuthorityClient` seam
+/// is complete.
+public struct Report: Codable, Sendable, Equatable {
+    public let reportVersion: Int
+    public let reportId: String
+    public let reporter: String
+    /// Hash of the reporter's own mandate — standing follows the
+    /// reporter's consent (spec §5.4 constraint 5).
+    public let reporterMandate: String
+    public let accused: String
+    public let classId: String
+    public let evidence: [EvidenceItem]
+    public let filedAt: Date
+    public var signature: String
+
+    public init(
+        reportVersion: Int = 1,
+        reportId: String,
+        reporter: String,
+        reporterMandate: String,
+        accused: String,
+        classId: String,
+        evidence: [EvidenceItem],
+        filedAt: Date,
+        signature: String = ""
+    ) {
+        self.reportVersion = reportVersion
+        self.reportId = reportId
+        self.reporter = reporter
+        self.reporterMandate = reporterMandate
+        self.accused = accused
+        self.classId = classId
+        self.evidence = evidence
+        self.filedAt = filedAt
+        self.signature = signature
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/StubEnforcementBackendClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/StubEnforcementBackendClient.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Stub enforcement backend — no real backend is deployed (the Apple
+/// DeviceCheck key doesn't exist yet), so this keeps the whole client
+/// rail exercisable: enrollment issues a stable local identifier,
+/// countersigning appends a sentinel that can never verify, and the
+/// gate check answers a canned scenario.
+///
+/// HONESTY RULE: this stub is the only implementation allowed to
+/// answer `.clear` to a nil-token gate check. There is no live
+/// moderation to evade yet, and blocking every simulator run would
+/// make the app undevelopable. A real `EnforcementBackendClient` must
+/// answer `.checkRequired(.attestationUnavailable)` instead —
+/// nil token never means unmoderated operation (profile §8.5).
+public struct StubEnforcementBackendClient: EnforcementBackendClient, @unchecked Sendable {
+    /// Which canned world the stub simulates. Driven by the
+    /// `--moderation-scenario` launch argument in DEBUG builds.
+    public enum Scenario: String, Sendable {
+        case clear
+        case caseOpen = "case-open"
+        case banned
+        case checkRequired = "check-required"
+    }
+
+    /// Sentinel appended by `countersignMandate`. Deliberately not a
+    /// signature: any record carrying it stays `countersigned: false`
+    /// so a stub mandate can never pass as spec-valid.
+    public static let countersignSentinel = "stub:interface-unsigned"
+
+    private static let bindingKey = "app.onym.ios.moderation.stub.deviceBinding"
+
+    private let scenario: Scenario
+    private let defaults: UserDefaults
+    private let now: @Sendable () -> Date
+
+    public init(
+        scenario: Scenario = .clear,
+        defaults: UserDefaults = .standard,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.scenario = scenario
+        self.defaults = defaults
+        self.now = now
+    }
+
+    /// Stable across calls — an enrollment identifier that churns
+    /// would sever every mandate's `deviceBinding` on next launch.
+    public func enrollDevice(token: Data?, userKey: String, signature: Data) async throws -> DeviceEnrollment {
+        if let existing = defaults.string(forKey: Self.bindingKey) {
+            return DeviceEnrollment(deviceBinding: existing)
+        }
+        let binding = "stub-enrollment:\(UUID().uuidString)"
+        defaults.set(binding, forKey: Self.bindingKey)
+        return DeviceEnrollment(deviceBinding: binding)
+    }
+
+    public func countersignMandate(_ mandate: ModerationMandate) async throws -> ModerationMandate {
+        var countersigned = mandate
+        countersigned.signatures.append(Self.countersignSentinel)
+        return countersigned
+    }
+
+    public func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult {
+        switch scenario {
+        case .clear:
+            return .clear
+        case .caseOpen:
+            return .caseOpen([Self.fixtureNotice(for: request, now: now())])
+        case .banned:
+            return .banned(Self.fixtureBanState(for: request, now: now()))
+        case .checkRequired:
+            return .checkRequired(.attestationUnavailable)
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// Canned case notice shaped like a real one so the banner and
+    /// detail UI render meaningfully in every scenario run.
+    static func fixtureNotice(for request: GateCheckRequest, now: Date) -> CaseNotice {
+        CaseNotice(
+            caseId: "stub-case-1",
+            authority: "onym:component:stub-authority",
+            accused: request.userKey,
+            mandateRef: request.mandateRef ?? "stub-mandate",
+            classId: "unsolicited-pornography",
+            evidenceSummary: "stub-evidence-hash",
+            responseDeadline: now.addingTimeInterval(7 * 86_400),
+            decisionDeadline: now.addingTimeInterval(14 * 86_400),
+            signature: "stub:authority-unsigned"
+        )
+    }
+
+    /// Canned ban with the full display surface: verdict reference,
+    /// authority contact, expiry, appeal and new-holder paths.
+    static func fixtureBanState(for request: GateCheckRequest, now: Date) -> BanState {
+        let decidedAt = now.addingTimeInterval(-86_400)
+        let verdict = Verdict(
+            caseId: "stub-case-1",
+            authority: "onym:component:stub-authority",
+            mandateRef: request.mandateRef ?? "stub-mandate",
+            accusedKeys: [request.userKey],
+            deviceBinding: "stub-enrollment",
+            classId: "unsolicited-pornography",
+            disposition: .ban,
+            marks: Marks(caseOpen: false, banned: true),
+            banExpires: now.addingTimeInterval(90 * 86_400),
+            executeAfter: decidedAt,
+            reasoning: "stub-reasoning-hash",
+            appealDeadline: now.addingTimeInterval(30 * 86_400),
+            decidedAt: decidedAt,
+            signature: "stub:authority-unsigned",
+            isFinal: false
+        )
+        return BanState(
+            verdictRef: "stub-verdict-hash",
+            verdict: verdict,
+            authorityContact: "appeals@stub-authority.example",
+            banExpires: verdict.banExpires,
+            appealURL: URL(string: "https://stub-authority.example/appeal"),
+            newHolderURL: URL(string: "https://stub-authority.example/new-holder")
+        )
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/StubEnforcementBackendClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/StubEnforcementBackendClient.swift
@@ -13,8 +13,11 @@ import Foundation
 /// answer `.checkRequired(.attestationUnavailable)` instead —
 /// nil token never means unmoderated operation (profile §8.5).
 public struct StubEnforcementBackendClient: EnforcementBackendClient, @unchecked Sendable {
-    /// Which canned world the stub simulates. Driven by the
-    /// `--moderation-scenario` launch argument in DEBUG builds.
+    /// Which canned world the stub simulates. Chosen by whoever
+    /// constructs the client; nothing reads a launch argument yet — PR-3
+    /// wires the app and will supply the scenario from
+    /// `--moderation-scenario` in DEBUG builds (the raw values here are
+    /// that argument's vocabulary).
     public enum Scenario: String, Sendable {
         case clear
         case caseOpen = "case-open"
@@ -28,6 +31,12 @@ public struct StubEnforcementBackendClient: EnforcementBackendClient, @unchecked
     public static let countersignSentinel = "stub:interface-unsigned"
 
     private static let bindingKey = "app.onym.ios.moderation.stub.deviceBinding"
+
+    /// Serializes the read-then-write in `enrollDevice`. Without it two
+    /// concurrent enrollments can both miss the stored value and mint
+    /// different bindings, and the caller that loses the write walks away
+    /// with a mandate bound to a `deviceBinding` nothing persisted.
+    private static let bindingLock = NSLock()
 
     private let scenario: Scenario
     private let defaults: UserDefaults
@@ -44,8 +53,12 @@ public struct StubEnforcementBackendClient: EnforcementBackendClient, @unchecked
     }
 
     /// Stable across calls — an enrollment identifier that churns
-    /// would sever every mandate's `deviceBinding` on next launch.
+    /// would sever every mandate's `deviceBinding` on next launch. The
+    /// check-then-store is taken under `bindingLock` so concurrent
+    /// enrollments all observe the same binding.
     public func enrollDevice(token: Data?, userKey: String, signature: Data) async throws -> DeviceEnrollment {
+        Self.bindingLock.lock()
+        defer { Self.bindingLock.unlock() }
         if let existing = defaults.string(forKey: Self.bindingKey) {
             return DeviceEnrollment(deviceBinding: existing)
         }

--- a/Packages/OnymModeration/Sources/OnymModeration/StubEnforcementBackendClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/StubEnforcementBackendClient.swift
@@ -56,7 +56,7 @@ public struct StubEnforcementBackendClient: EnforcementBackendClient, @unchecked
     /// would sever every mandate's `deviceBinding` on next launch. The
     /// check-then-store is taken under `bindingLock` so concurrent
     /// enrollments all observe the same binding.
-    public func enrollDevice(token: Data?, userKey: String, signature: Data) async throws -> DeviceEnrollment {
+    public func enrollDevice(_ request: EnrollmentRequest) async throws -> DeviceEnrollment {
         Self.bindingLock.lock()
         defer { Self.bindingLock.unlock() }
         if let existing = defaults.string(forKey: Self.bindingKey) {
@@ -67,10 +67,8 @@ public struct StubEnforcementBackendClient: EnforcementBackendClient, @unchecked
         return DeviceEnrollment(deviceBinding: binding)
     }
 
-    public func countersignMandate(_ mandate: ModerationMandate) async throws -> ModerationMandate {
-        var countersigned = mandate
-        countersigned.signatures.append(Self.countersignSentinel)
-        return countersigned
+    public func countersignMandate(_ mandate: ModerationMandate) async throws -> InterfaceCountersignature {
+        InterfaceCountersignature(signature: Self.countersignSentinel)
     }
 
     public func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult {
@@ -106,8 +104,15 @@ public struct StubEnforcementBackendClient: EnforcementBackendClient, @unchecked
 
     /// Canned ban with the full display surface: verdict reference,
     /// authority contact, expiry, appeal and new-holder paths.
+    ///
+    /// The dates model an executed **suspensive** P90D ban with a P30D
+    /// appeal window, so the fixture satisfies `VerdictValidator`'s
+    /// derived-deadline rules rather than merely rendering: decided 40
+    /// days ago, appeal window lapsed 10 days ago, execution began
+    /// there, expiry is execution + the consented term.
     static func fixtureBanState(for request: GateCheckRequest, now: Date) -> BanState {
-        let decidedAt = now.addingTimeInterval(-86_400)
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let appealDeadline = decidedAt.addingTimeInterval(30 * 86_400)
         let verdict = Verdict(
             caseId: "stub-case-1",
             authority: "onym:component:stub-authority",
@@ -117,10 +122,10 @@ public struct StubEnforcementBackendClient: EnforcementBackendClient, @unchecked
             classId: "unsolicited-pornography",
             disposition: .ban,
             marks: Marks(caseOpen: false, banned: true),
-            banExpires: now.addingTimeInterval(90 * 86_400),
-            executeAfter: decidedAt,
+            banExpires: appealDeadline.addingTimeInterval(90 * 86_400),
+            executeAfter: appealDeadline,
             reasoning: "stub-reasoning-hash",
-            appealDeadline: now.addingTimeInterval(30 * 86_400),
+            appealDeadline: appealDeadline,
             decidedAt: decidedAt,
             signature: "stub:authority-unsigned",
             isFinal: false

--- a/Packages/OnymModeration/Sources/OnymModeration/Verdict.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/Verdict.swift
@@ -99,7 +99,8 @@ public struct Verdict: Codable, Sendable, Equatable {
     /// The bytes the authority signs: every field except `signature`,
     /// JSON with sorted keys + ISO 8601 dates. Same PROVISIONAL caveat
     /// as `ModerationMandate.signingBytes()` — no canonical JSON exists
-    /// in the draft spec yet.
+    /// in the draft spec yet. The explicit mirror below is guarded
+    /// against field drift by `ModerationSigningPayloadTests`.
     public func signingBytes() throws -> Data {
         struct Unsigned: Encodable {
             let verdictVersion: Int

--- a/Packages/OnymModeration/Sources/OnymModeration/Verdict.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/Verdict.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// The two device-mark states the abstract rail defines (Moderation.md
+/// §5.7). Spec JSON keys are `"case-open"` / `"banned"`.
+public struct Marks: Codable, Sendable, Equatable {
+    public let caseOpen: Bool
+    public let banned: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case caseOpen = "case-open"
+        case banned
+    }
+
+    public init(caseOpen: Bool, banned: Bool) {
+        self.caseOpen = caseOpen
+        self.banned = banned
+    }
+}
+
+/// A signed verdict (Moderation.md §5.6) — the only object that moves
+/// device marks. The client validates shape mechanically for display;
+/// mark execution is the enforcement backend's job.
+public struct Verdict: Codable, Sendable, Equatable {
+    public enum Disposition: String, Codable, Sendable, Equatable {
+        case openCase = "open-case"
+        case dismiss
+        case ban
+    }
+
+    public let verdictVersion: Int
+    public let caseId: String
+    public let authority: String
+    /// Hash of the accused's mandate — must resolve to a mandate this
+    /// user actually signed.
+    public let mandateRef: String
+    public let accusedKeys: [String]
+    public let deviceBinding: String
+    public let classId: String
+    public let disposition: Disposition
+    public let marks: Marks
+    /// Required on bans unless the consented class term is `permanent`.
+    public let banExpires: Date?
+    /// When writing the banned mark becomes conforming: `decidedAt`
+    /// for non-suspensive classes, `appealDeadline` for suspensive
+    /// ones (§5.6 constraint 4). Required on every ban.
+    public let executeAfter: Date?
+    /// Content address of the findings. Mandatory — an unexplained
+    /// sanction is nonconforming.
+    public let reasoning: String
+    public let appealDeadline: Date?
+    public let decidedAt: Date
+    public let signature: String
+    /// False until the appeal deadline passes or the appeal concludes.
+    public let isFinal: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case verdictVersion, caseId, authority, mandateRef, accusedKeys
+        case deviceBinding, classId, disposition, marks, banExpires
+        case executeAfter, reasoning, appealDeadline, decidedAt, signature
+        case isFinal = "final"
+    }
+
+    public init(
+        verdictVersion: Int = 1,
+        caseId: String,
+        authority: String,
+        mandateRef: String,
+        accusedKeys: [String],
+        deviceBinding: String,
+        classId: String,
+        disposition: Disposition,
+        marks: Marks,
+        banExpires: Date? = nil,
+        executeAfter: Date? = nil,
+        reasoning: String,
+        appealDeadline: Date? = nil,
+        decidedAt: Date,
+        signature: String,
+        isFinal: Bool
+    ) {
+        self.verdictVersion = verdictVersion
+        self.caseId = caseId
+        self.authority = authority
+        self.mandateRef = mandateRef
+        self.accusedKeys = accusedKeys
+        self.deviceBinding = deviceBinding
+        self.classId = classId
+        self.disposition = disposition
+        self.marks = marks
+        self.banExpires = banExpires
+        self.executeAfter = executeAfter
+        self.reasoning = reasoning
+        self.appealDeadline = appealDeadline
+        self.decidedAt = decidedAt
+        self.signature = signature
+        self.isFinal = isFinal
+    }
+
+    /// The bytes the authority signs: every field except `signature`,
+    /// JSON with sorted keys + ISO 8601 dates. Same PROVISIONAL caveat
+    /// as `ModerationMandate.signingBytes()` — no canonical JSON exists
+    /// in the draft spec yet.
+    public func signingBytes() throws -> Data {
+        struct Unsigned: Encodable {
+            let verdictVersion: Int
+            let caseId, authority, mandateRef: String
+            let accusedKeys: [String]
+            let deviceBinding, classId: String
+            let disposition: Disposition
+            let marks: Marks
+            let banExpires, executeAfter: Date?
+            let reasoning: String
+            let appealDeadline: Date?
+            let decidedAt: Date
+            let `final`: Bool
+        }
+        let unsigned = Unsigned(
+            verdictVersion: verdictVersion,
+            caseId: caseId,
+            authority: authority,
+            mandateRef: mandateRef,
+            accusedKeys: accusedKeys,
+            deviceBinding: deviceBinding,
+            classId: classId,
+            disposition: disposition,
+            marks: marks,
+            banExpires: banExpires,
+            executeAfter: executeAfter,
+            reasoning: reasoning,
+            appealDeadline: appealDeadline,
+            decidedAt: decidedAt,
+            final: isFinal
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(unsigned)
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/VerdictValidator.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/VerdictValidator.swift
@@ -27,10 +27,12 @@ public struct VerdictValidator: Sendable {
     /// manifest that mandate consented to.
     ///
     /// - Parameters:
-    ///   - verifier: Ed25519 verifier keyed on the consented manifest's
-    ///     operator key. Signature failures throw only under
-    ///     `enforceSignature` (soft mode logs and continues — no real
-    ///     authority signs verdicts yet; see `ModerationTrust`).
+    ///   - consented: must be the very manifest `mandate.manifestHash`
+    ///     pins — validating against any other manifest would validate
+    ///     against terms the user never consented to.
+    ///   - enforceSignature: signature failures throw only under
+    ///     enforcement (soft mode logs and continues — no real authority
+    ///     signs verdicts yet; see `ModerationTrust`).
     /// - Returns: whether the verdict is executable now or stored until
     ///   its `executeAfter`.
     /// - Throws: `ModerationError` on any shape violation.
@@ -39,11 +41,20 @@ public struct VerdictValidator: Sendable {
         mandate: ModerationMandate,
         consented: SignedManifest,
         now: Date,
-        verifier: Ed25519DetachedSignatureVerifier,
         enforceSignature: Bool = ModerationTrust.enforceVerdictSignatures
     ) throws -> Outcome {
+        // The manifest handed in must be the mandate's pinned manifest,
+        // not merely *a* manifest from this authority.
+        guard consented.manifestHash == mandate.manifestHash else {
+            throw ModerationError.verdictInvalid("consented manifest is not the mandate's pinned manifest")
+        }
+
         // Authority signature (spec §5.7: "authority signature" is the
-        // first mechanical check).
+        // first mechanical check), keyed on the consented manifest's
+        // operator key through the one `AuthorityKey` parser. An
+        // unparseable key yields a nil-key verifier, which never
+        // validates — the soft/enforce policy then applies.
+        let verifier = Ed25519DetachedSignatureVerifier(publicKey: try? consented.manifest.operatorPublicKey())
         try validateSignature(verdict, verifier: verifier, enforce: enforceSignature)
 
         // Mandate reference: the verdict must name a mandate this user
@@ -53,6 +64,9 @@ public struct VerdictValidator: Sendable {
         }
         guard let mandateHash = try? mandate.mandateHash(), verdict.mandateRef == mandateHash else {
             throw ModerationError.noMandate
+        }
+        guard verdict.accusedKeys.contains(mandate.user) else {
+            throw ModerationError.verdictInvalid("the mandate's user is not among accusedKeys")
         }
         guard verdict.deviceBinding == mandate.deviceBinding else {
             throw ModerationError.verdictInvalid("deviceBinding outside the mandate")

--- a/Packages/OnymModeration/Sources/OnymModeration/VerdictValidator.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/VerdictValidator.swift
@@ -1,0 +1,163 @@
+import Foundation
+import os.log
+import OnymFoundation
+
+/// Pure, stateless verdict shape validation — the client's half of the
+/// spec's "the interface executes verdicts mechanically" (Moderation.md
+/// §5.7). Mark *writes* happen only in the enforcement backend; the
+/// client validates every verdict it displays so a malformed sanction
+/// is never rendered as legitimate.
+///
+/// Checks are exactly the §5.6 normative constraints; the validator
+/// never weighs the verdict's wisdom.
+public struct VerdictValidator: Sendable {
+    public enum Outcome: Sendable, Equatable {
+        /// The verdict's marks state is executable now.
+        case execute
+        /// A valid ban whose `executeAfter` hasn't arrived: stored,
+        /// not executed — writing its mark early is nonconforming.
+        case storeUntilExecuteAfter(Date)
+    }
+
+    private static let log = Logger(subsystem: "app.onym.ios", category: "ModerationVerdict")
+
+    public init() {}
+
+    /// Validate `verdict` against the mandate it references and the
+    /// manifest that mandate consented to.
+    ///
+    /// - Parameters:
+    ///   - verifier: Ed25519 verifier keyed on the consented manifest's
+    ///     operator key. Signature failures throw only under
+    ///     `enforceSignature` (soft mode logs and continues — no real
+    ///     authority signs verdicts yet; see `ModerationTrust`).
+    /// - Returns: whether the verdict is executable now or stored until
+    ///   its `executeAfter`.
+    /// - Throws: `ModerationError` on any shape violation.
+    public func validate(
+        _ verdict: Verdict,
+        mandate: ModerationMandate,
+        consented: SignedManifest,
+        now: Date,
+        verifier: Ed25519DetachedSignatureVerifier,
+        enforceSignature: Bool = ModerationTrust.enforceVerdictSignatures
+    ) throws -> Outcome {
+        // Authority signature (spec §5.7: "authority signature" is the
+        // first mechanical check).
+        try validateSignature(verdict, verifier: verifier, enforce: enforceSignature)
+
+        // Mandate reference: the verdict must name a mandate this user
+        // actually signed, for this authority, on this device.
+        guard verdict.authority == mandate.authority else {
+            throw ModerationError.verdictInvalid("authority \(verdict.authority) is not the mandated authority")
+        }
+        guard let mandateHash = try? mandate.mandateHash(), verdict.mandateRef == mandateHash else {
+            throw ModerationError.noMandate
+        }
+        guard verdict.deviceBinding == mandate.deviceBinding else {
+            throw ModerationError.verdictInvalid("deviceBinding outside the mandate")
+        }
+
+        // Class within mandate, and within the consented manifest.
+        guard mandate.classes.contains(verdict.classId) else {
+            throw ModerationError.classOutsideMandate(verdict.classId)
+        }
+        guard let violationClass = consented.manifest.violationClass(id: verdict.classId) else {
+            throw ModerationError.verdictInvalid("class \(verdict.classId) missing from consented manifest")
+        }
+
+        // Reasoning is mandatory on every disposition — an unexplained
+        // sanction (or case opening) is nonconforming.
+        guard !verdict.reasoning.isEmpty else {
+            throw ModerationError.verdictInvalid("missing reasoning")
+        }
+
+        switch verdict.disposition {
+        case .openCase:
+            return try validateOpenCase(verdict)
+        case .dismiss:
+            return try validateDismissal(verdict)
+        case .ban:
+            return try validateBan(verdict, violationClass: violationClass, now: now)
+        }
+    }
+
+    // MARK: - Per-disposition shape
+
+    /// §5.6 constraint 7: the interim object's only permitted effect is
+    /// the case-open mark; it carries no sanction fields and is never
+    /// final.
+    private func validateOpenCase(_ verdict: Verdict) throws -> Outcome {
+        guard verdict.marks == Marks(caseOpen: true, banned: false) else {
+            throw ModerationError.verdictInvalid("open-case marks inconsistent with disposition")
+        }
+        guard verdict.banExpires == nil, verdict.executeAfter == nil,
+              verdict.appealDeadline == nil, !verdict.isFinal
+        else {
+            throw ModerationError.verdictInvalid("open-case verdict carries sanction fields")
+        }
+        return .execute
+    }
+
+    /// Dismissals clear both marks (§5.6 constraint 6).
+    private func validateDismissal(_ verdict: Verdict) throws -> Outcome {
+        guard verdict.marks == Marks(caseOpen: false, banned: false) else {
+            throw ModerationError.verdictInvalid("dismissal marks inconsistent with disposition")
+        }
+        return .execute
+    }
+
+    /// §5.6 constraints 3–4: expiry present unless the consented term
+    /// is permanent; `executeAfter` present and consistent with the
+    /// class's appeal effect; early execution refused.
+    private func validateBan(
+        _ verdict: Verdict,
+        violationClass: ViolationClass,
+        now: Date
+    ) throws -> Outcome {
+        guard verdict.marks == Marks(caseOpen: false, banned: true) else {
+            throw ModerationError.verdictInvalid("ban marks inconsistent with disposition")
+        }
+        if violationClass.banTerm != .permanent, verdict.banExpires == nil {
+            throw ModerationError.verdictInvalid("ban missing banExpires on non-permanent class")
+        }
+        guard let executeAfter = verdict.executeAfter else {
+            throw ModerationError.verdictInvalid("ban missing executeAfter")
+        }
+        switch violationClass.appealEffect {
+        case .nonSuspensive:
+            guard executeAfter == verdict.decidedAt else {
+                throw ModerationError.verdictInvalid("non-suspensive executeAfter must equal decidedAt")
+            }
+        case .suspensive:
+            guard let appealDeadline = verdict.appealDeadline, executeAfter == appealDeadline else {
+                throw ModerationError.verdictInvalid("suspensive executeAfter must equal appealDeadline")
+            }
+        }
+        if executeAfter > now {
+            return .storeUntilExecuteAfter(executeAfter)
+        }
+        return .execute
+    }
+
+    // MARK: - Signature
+
+    private func validateSignature(
+        _ verdict: Verdict,
+        verifier: Ed25519DetachedSignatureVerifier,
+        enforce: Bool
+    ) throws {
+        guard
+            let signature = Data(base64Encoded: verdict.signature),
+            let bytes = try? verdict.signingBytes(),
+            verifier.isValid(signature: signature, for: bytes)
+        else {
+            if enforce {
+                Self.log.error("verdict \(verdict.caseId, privacy: .public): signature did NOT verify; rejecting (enforcement ON)")
+                throw ModerationError.verdictInvalid("authority signature did not verify")
+            }
+            Self.log.warning("verdict \(verdict.caseId, privacy: .public): signature did NOT verify; accepting anyway (enforcement OFF)")
+            return
+        }
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/VerdictValidator.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/VerdictValidator.swift
@@ -132,26 +132,70 @@ public struct VerdictValidator: Sendable {
         guard verdict.marks == Marks(caseOpen: false, banned: true) else {
             throw ModerationError.verdictInvalid("ban marks inconsistent with disposition")
         }
-        if violationClass.banTerm != .permanent, verdict.banExpires == nil {
-            throw ModerationError.verdictInvalid("ban missing banExpires on non-permanent class")
+
+        // The appeal window is a consented term, so the deadline is
+        // derived, not declared: without this an authority could set
+        // `appealDeadline == decidedAt` and offer zero appeal on a
+        // class the user consented to with P30D.
+        guard let appealDeadline = verdict.appealDeadline else {
+            throw ModerationError.verdictInvalid("ban missing appealDeadline")
         }
+        let consentedAppealDeadline = verdict.decidedAt.addingTimeInterval(
+            violationClass.appealWindow.timeInterval
+        )
+        guard Self.sameInstant(appealDeadline, consentedAppealDeadline) else {
+            throw ModerationError.verdictInvalid(
+                "appealDeadline must equal decidedAt + the consented appealWindow (\(violationClass.appealWindow.raw))"
+            )
+        }
+
         guard let executeAfter = verdict.executeAfter else {
             throw ModerationError.verdictInvalid("ban missing executeAfter")
         }
         switch violationClass.appealEffect {
         case .nonSuspensive:
-            guard executeAfter == verdict.decidedAt else {
+            guard Self.sameInstant(executeAfter, verdict.decidedAt) else {
                 throw ModerationError.verdictInvalid("non-suspensive executeAfter must equal decidedAt")
             }
         case .suspensive:
-            guard let appealDeadline = verdict.appealDeadline, executeAfter == appealDeadline else {
+            guard Self.sameInstant(executeAfter, appealDeadline) else {
                 throw ModerationError.verdictInvalid("suspensive executeAfter must equal appealDeadline")
             }
         }
+
+        // The served term is the consented `banTerm` measured from
+        // execution (§5.6 constraint 3) — otherwise a P90D class could
+        // carry a ten-year expiry and still validate.
+        switch violationClass.banTerm {
+        case .permanent:
+            guard verdict.banExpires == nil else {
+                throw ModerationError.verdictInvalid("permanent class carries banExpires")
+            }
+        case .duration(let term):
+            guard let banExpires = verdict.banExpires else {
+                throw ModerationError.verdictInvalid("ban missing banExpires on non-permanent class")
+            }
+            let consentedExpiry = executeAfter.addingTimeInterval(term.timeInterval)
+            guard Self.sameInstant(banExpires, consentedExpiry) else {
+                throw ModerationError.verdictInvalid(
+                    "banExpires must equal executeAfter + the consented banTerm (\(term.raw))"
+                )
+            }
+        }
+
         if executeAfter > now {
             return .storeUntilExecuteAfter(executeAfter)
         }
         return .execute
+    }
+
+    /// Derived deadlines are compared with a one-second tolerance.
+    /// Manifest windows are whole days, but an authority computing them
+    /// in a different language/timezone can land a second off; demanding
+    /// exact `Date` equality would reject conforming verdicts over
+    /// rounding, while a second of slack changes no consented bound.
+    static func sameInstant(_ lhs: Date, _ rhs: Date) -> Bool {
+        abs(lhs.timeIntervalSince(rhs)) <= 1
     }
 
     // MARK: - Signature

--- a/Tests/OnymIOSTests/ModerationSigningPayloadTests.swift
+++ b/Tests/OnymIOSTests/ModerationSigningPayloadTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import OnymModeration
+
+/// Drift guard for the two PROVISIONAL signed payloads. Both
+/// `signingBytes()` helpers are built from an explicit mirror type, so a
+/// field added to the object without being added to the mirror would
+/// silently fall outside the signature. These tests pin the key sets:
+/// signed form == encoded form minus the signature field(s).
+final class ModerationSigningPayloadTests: XCTestCase {
+    private func keys(of data: Data) throws -> Set<String> {
+        let object = try JSONSerialization.jsonObject(with: data)
+        let dictionary = try XCTUnwrap(object as? [String: Any])
+        return Set(dictionary.keys)
+    }
+
+    private func encodedKeys(of value: some Encodable) throws -> Set<String> {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try keys(of: encoder.encode(value))
+    }
+
+    private func makeMandate() -> ModerationMandate {
+        ModerationMandate(
+            user: "onym:key:\(String(repeating: "ab", count: 32))",
+            interface: ModerationRepository.interfaceComponentId,
+            authority: "onym:component:test-authority",
+            manifestHash: String(repeating: "0", count: 64),
+            classes: ["unsolicited-pornography"],
+            deviceBinding: "enrollment-1",
+            acceptedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            signatures: ["dXNlci1zaWc="]
+        )
+    }
+
+    private func makeVerdict() -> Verdict {
+        Verdict(
+            caseId: "case-1",
+            authority: "onym:component:test-authority",
+            mandateRef: String(repeating: "1", count: 64),
+            accusedKeys: ["onym:key:\(String(repeating: "ab", count: 32))"],
+            deviceBinding: "enrollment-1",
+            classId: "unsolicited-pornography",
+            disposition: .ban,
+            marks: Marks(caseOpen: false, banned: true),
+            banExpires: Date(timeIntervalSince1970: 1_800_000_000),
+            executeAfter: Date(timeIntervalSince1970: 1_700_000_000),
+            reasoning: "reasoning-hash",
+            appealDeadline: Date(timeIntervalSince1970: 1_700_000_000),
+            decidedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            signature: "YXV0aG9yaXR5LXNpZw==",
+            isFinal: false
+        )
+    }
+
+    // MARK: - Mandate
+
+    func test_mandateSigningBytes_coverEveryFieldExceptSignatures() throws {
+        let mandate = makeMandate()
+        let signed = try keys(of: mandate.signingBytes())
+        XCTAssertEqual(signed, try encodedKeys(of: mandate).subtracting(["signatures"]))
+        XCTAssertFalse(signed.contains("signatures"))
+    }
+
+    /// The signed form carries no `signatures` field at all, so the
+    /// interface countersignature can't change what the user signed —
+    /// which is what makes `mandateHash()` a stable `mandateRef`.
+    func test_mandateHash_isStableAcrossCountersigning() throws {
+        var mandate = makeMandate()
+        let before = try mandate.mandateHash()
+        mandate.signatures.append(StubEnforcementBackendClient.countersignSentinel)
+        XCTAssertEqual(before, try mandate.mandateHash())
+    }
+
+    // MARK: - Verdict
+
+    func test_verdictSigningBytes_coverEveryFieldExceptSignature() throws {
+        let verdict = makeVerdict()
+        let signed = try keys(of: verdict.signingBytes())
+        XCTAssertEqual(signed, try encodedKeys(of: verdict).subtracting(["signature"]))
+        XCTAssertFalse(signed.contains("signature"))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -32,6 +32,7 @@ packages:
   OnymIdentityUI: {path: Packages/OnymIdentityUI}
   OnymChatsUI: {path: Packages/OnymChatsUI}
   OnymSettings: {path: Packages/OnymSettings}
+  OnymModeration: {path: Packages/OnymModeration}
 
 targets:
   OnymIOS:
@@ -58,6 +59,7 @@ targets:
       - package: OnymIdentityUI
       - package: OnymChatsUI
       - package: OnymSettings
+      - package: OnymModeration
     # Hand-written Info.plist via xcodegen's `info:` block. We tried
     # the GENERATE_INFOPLIST_FILE + INFOPLIST_KEY_* approach first but
     # `INFOPLIST_KEY_UILaunchScreen_BackgroundColor` / `_ImageName` are
@@ -218,6 +220,7 @@ targets:
       - package: OnymIdentityUI
       - package: OnymChatsUI
       - package: OnymSettings
+      - package: OnymModeration
 
   OnymIOSUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## What

First slice of the client-side moderation seat from the onym-system spec ([Moderation.md](https://github.com/onymchat/onym-system/blob/main/moderation/Moderation.md), [Moderation-DeviceCheck.md](https://github.com/onymchat/onym-system/blob/main/moderation/Moderation-DeviceCheck.md)): a new `Packages/OnymModeration` SPM package with the domain model, the swappable-authority abstraction, and the Apple DeviceCheck profile's client half. No UI, no app wiring — the package compiles standalone and is linked into the app target (unused) via `project.yml`.

## Design

**Authorities are data, not code.** A signed directory (`KnownAuthoritiesFetcher`, same shape/trust story as `KnownRelayersFetcher`) pins each authority's operator key; `AuthorityManifestFetcher` fetches the manifest as exact bytes, hashes them (SHA-256 of fetched bytes = the `manifestHash` the mandate pins), and verifies the manifest signature against the directory-pinned key (soft mode via `ModerationTrust`, mirroring `ContractsTrust`). Switching authorities = signing a fresh `ModerationMandate`; `ModerationRepository.consent(to:)` is one path for onboarding and switching, and deactivated records keep their consented manifest snapshot byte-identical forever.

**The client never computes ban state.** `EnforcementBackendClient` is the seam for the vendor backend that holds the Apple `.p8` key (the only party that can read/write the DeviceCheck bits). The client's whole authority is: generate a `DCDevice` token, present it with an identity signature in one session, render the backend's `GateCheckResult`, and degrade toward blocking — `GateCheckRepository` owns the launch + P1D cadence with a P3D offline grace window on the persisted last-known state, then `gate-check-required`. Never toward unmoderated operation.

**Verdicts are validated mechanically.** `VerdictValidator` is a pure function over the §5.6 constraints (mandate ref, class-in-mandate, marks/disposition consistency, `banExpires` unless permanent, `executeAfter` = `decidedAt`/`appealDeadline` per appeal effect, early-write refusal via `.storeUntilExecuteAfter`) so a malformed sanction is never rendered as legitimate.

**Stubs are honest.** `StubEnforcementBackendClient` countersigns with a sentinel that keeps records `countersigned: false` (a stub mandate can never pass as spec-valid), issues a stable local `deviceBinding`, and is documented as the only implementation allowed to answer `.clear` to a nil-token check (simulators must stay developable; a real backend must answer `.checkRequired`).

## Provisional (flagged in code)

- No canonical JSON exists in the draft spec — `signingBytes()` uses sorted-keys JSON and is documented as provisional; mandates signed now will need re-consent when the spec fixes canonical form.
- Interface countersignature and real bit reads are impossible client-only by design; the seams (`countersignMandate`, `gateCheck`) are shaped for the real backend to slot in.

## Stack

- **PR-1 (this): domain + seams + stubs**
- PR-2: `OnymModerationUI` (consent flow, settings, ban/gate screens)
- PR-3: app wiring (identity signing adapter, composition root, RootView gate, UITest fakes)
- PR-4: tests

## Verification

- `xcodebuild -scheme OnymModeration -destination 'generic/platform=iOS Simulator' build` — succeeds
- Full app build with the package linked — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)