### PR TITLE
feat(moderation): OnymModerationUI package — consent, settings, ban and gate screens

### DIFF
--- a/Packages/OnymDesign/Sources/OnymDesign/SettingsDesign.swift
+++ b/Packages/OnymDesign/Sources/OnymDesign/SettingsDesign.swift
@@ -80,6 +80,8 @@ public struct SettingsContentTile<Content: View>: View {
 /// Section label above a card. All-caps, mid-grey, small letterspacing.
 public struct SettingsSectionLabel<Trailing: View>: View {
     let text: LocalizedStringKey
+    /// Runtime data rather than UI copy — see `SettingsRow.verbatimTitle`.
+    var verbatimText: String? = nil
     @ViewBuilder var trailing: () -> Trailing
 
     // The trailing-content variant has no external consumer today, so
@@ -89,9 +91,15 @@ public struct SettingsSectionLabel<Trailing: View>: View {
         self.trailing = trailing
     }
 
+    init(verbatimText: String, @ViewBuilder trailing: @escaping () -> Trailing = { EmptyView() }) {
+        self.text = ""
+        self.verbatimText = verbatimText
+        self.trailing = trailing
+    }
+
     public var body: some View {
         HStack(alignment: .bottom) {
-            Text(text)
+            (verbatimText.map { Text(verbatim: $0) } ?? Text(text))
                 .font(.system(size: 12.5, weight: .medium))
                 .foregroundStyle(OnymTokens.text2)
             Spacer()
@@ -107,15 +115,28 @@ extension SettingsSectionLabel where Trailing == EmptyView {
     public init(_ text: LocalizedStringKey) {
         self.init(text, trailing: { EmptyView() })
     }
+
+    /// Label from runtime data (e.g. an authority-supplied class id).
+    public init(verbatim text: String) {
+        self.init(verbatimText: text, trailing: { EmptyView() })
+    }
 }
 
 /// Footnote text beneath a card — italic-equivalent grey copy used as
 /// section explanations.
 public struct SettingsFootnote: View {
     let text: LocalizedStringKey
+    /// Runtime data rather than UI copy — see `SettingsRow.verbatimTitle`.
+    var verbatimText: String? = nil
     public init(_ text: LocalizedStringKey) { self.text = text }
+    /// Footnote from runtime data (e.g. an already-localized error
+    /// message, which must not be re-looked-up as a key).
+    public init(verbatim text: String) {
+        self.text = ""
+        self.verbatimText = text
+    }
     public var body: some View {
-        Text(text)
+        (verbatimText.map { Text(verbatim: $0) } ?? Text(text))
             .font(.system(size: 12.5))
             .foregroundStyle(OnymTokens.text2)
             .lineSpacing(2)
@@ -129,9 +150,16 @@ public struct SettingsFootnote: View {
 /// shows beneath the nav bar on each top-level screen.
 public struct SettingsLargeTitle: View {
     let text: LocalizedStringKey
+    /// Runtime data rather than UI copy — see `SettingsRow.verbatimTitle`.
+    var verbatimText: String? = nil
     public init(_ text: LocalizedStringKey) { self.text = text }
+    /// Title from runtime data (e.g. an authority's published name).
+    public init(verbatim text: String) {
+        self.text = ""
+        self.verbatimText = text
+    }
     public var body: some View {
-        Text(text)
+        (verbatimText.map { Text(verbatim: $0) } ?? Text(text))
             .font(.system(size: 34, weight: .bold))
             .foregroundStyle(OnymTokens.text)
             .tracking(-0.75)
@@ -257,6 +285,12 @@ public struct SettingsRowDivider: View {
 /// itself owns the tap.
 public struct SettingsRow<Tile: View, Right: View>: View {
     let title: LocalizedStringKey
+    /// Set instead of `title` when the text is runtime data (a name
+    /// fetched from the network, an identifier) rather than UI copy.
+    /// Such a string must not be looked up as a localization key — a
+    /// remote value that happens to match one would render the
+    /// translation instead of itself.
+    var verbatimTitle: String? = nil
     var titleColor: Color = OnymTokens.text
     var titleMono: Bool = false
     var subtitle: String? = nil
@@ -299,6 +333,39 @@ public struct SettingsRow<Tile: View, Right: View>: View {
         self.right = right
     }
 
+    /// Row whose title is runtime data rather than UI copy — rendered
+    /// verbatim, never looked up as a localization key. Distinct
+    /// argument label (not an overload on `title:`) so a string literal
+    /// can't silently resolve to the wrong initializer.
+    public init(
+        titleText: String,
+        titleColor: Color = OnymTokens.text,
+        titleMono: Bool = false,
+        subtitle: String? = nil,
+        subtitleMono: Bool = false,
+        subtitleLineLimit: Int? = 1,
+        hasChevron: Bool = true,
+        inset: CGFloat = 60,
+        last: Bool = false,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder tile: @escaping () -> Tile,
+        @ViewBuilder right: @escaping () -> Right
+    ) {
+        self.title = ""
+        self.verbatimTitle = titleText
+        self.titleColor = titleColor
+        self.titleMono = titleMono
+        self.subtitle = subtitle
+        self.subtitleMono = subtitleMono
+        self.subtitleLineLimit = subtitleLineLimit
+        self.hasChevron = hasChevron
+        self.inset = inset
+        self.last = last
+        self.onTap = onTap
+        self.tile = tile
+        self.right = right
+    }
+
     public var body: some View {
         if let onTap {
             // Tappable variant — used for in-place actions (Copy
@@ -316,7 +383,7 @@ public struct SettingsRow<Tile: View, Right: View>: View {
             HStack(spacing: 12) {
                 tile()
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(title)
+                    (verbatimTitle.map { Text(verbatim: $0) } ?? Text(title))
                         .font(titleMono
                               ? .system(size: 16.5, design: .monospaced)
                               : .system(size: 16.5))
@@ -366,6 +433,36 @@ extension SettingsRow where Right == EmptyView {
         @ViewBuilder tile: @escaping () -> Tile
     ) {
         self.title = title
+        self.titleColor = titleColor
+        self.titleMono = titleMono
+        self.subtitle = subtitle
+        self.subtitleMono = subtitleMono
+        self.subtitleLineLimit = subtitleLineLimit
+        self.hasChevron = hasChevron
+        self.inset = inset
+        self.last = last
+        self.onTap = onTap
+        self.tile = tile
+        self.right = { EmptyView() }
+    }
+
+    /// Tile-only row whose title is runtime data — see the
+    /// `titleText:` initializer on `SettingsRow`.
+    public init(
+        titleText: String,
+        titleColor: Color = OnymTokens.text,
+        titleMono: Bool = false,
+        subtitle: String? = nil,
+        subtitleMono: Bool = false,
+        subtitleLineLimit: Int? = 1,
+        hasChevron: Bool = true,
+        inset: CGFloat = 60,
+        last: Bool = false,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder tile: @escaping () -> Tile
+    ) {
+        self.title = ""
+        self.verbatimTitle = titleText
         self.titleColor = titleColor
         self.titleMono = titleMono
         self.subtitle = subtitle

--- a/Packages/OnymModerationUI/Package.swift
+++ b/Packages/OnymModerationUI/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OnymModerationUI",
+    platforms: [.iOS("18.0")],
+    products: [
+        .library(name: "OnymModerationUI", targets: ["OnymModerationUI"]),
+    ],
+    dependencies: [
+        .package(path: "../OnymModeration"),
+        .package(path: "../OnymDesign"),
+    ],
+    targets: [
+        .target(
+            name: "OnymModerationUI",
+            dependencies: [
+                "OnymModeration",
+                "OnymDesign",
+            ]
+        ),
+    ]
+)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+import OnymDesign
+import OnymModeration
+
+/// The enforcement UX for a banned device (DeviceCheck profile §5):
+/// full-screen, non-dismissable, and complete — verdict reference,
+/// violation class, reasoning address, authority contact, expiry, and
+/// both appeal paths including the new-holder claim. A silent brick
+/// is nonconforming; this screen is the conforming alternative.
+public struct BannedView: View {
+    let state: BanState
+    /// Entry point into the authority's appeal path. Stubbed today
+    /// (`ModerationAuthorityClient.appeal` throws `.notImplemented`);
+    /// the URLs below remain the declared out-of-band procedure.
+    let onNewHolderClaim: () -> Void
+
+    @Environment(\.openURL) private var openURL
+
+    public init(state: BanState, onNewHolderClaim: @escaping () -> Void = {}) {
+        self.state = state
+        self.onNewHolderClaim = onNewHolderClaim
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 10) {
+                    Image(systemName: "hand.raised.fill")
+                        .font(.system(size: 40))
+                        .foregroundStyle(OnymTokens.red)
+                    Text("This device is banned from Onym")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text)
+                        .multilineTextAlignment(.center)
+                    Text(expiryLine)
+                        .font(.system(size: 14))
+                        .foregroundStyle(OnymTokens.text2)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 60)
+                .padding(.horizontal, 24)
+                .padding(.bottom, 20)
+
+                SettingsSectionLabel("VERDICT")
+                SettingsCard {
+                    VStack(alignment: .leading, spacing: 8) {
+                        detailRow("Reference", state.verdictRef, monospaced: true)
+                        if let verdict = state.verdict {
+                            detailRow("Violation class", verdict.classId)
+                            detailRow("Decided", verdict.decidedAt.formatted(date: .abbreviated, time: .shortened))
+                            detailRow("Reasoning", verdict.reasoning, monospaced: true)
+                            if let appealDeadline = verdict.appealDeadline {
+                                detailRow("Appeal deadline", appealDeadline.formatted(date: .abbreviated, time: .shortened))
+                            }
+                        }
+                        detailRow("Authority contact", state.authorityContact)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+                }
+                SettingsFootnote("The ban covers this device on this app only. The Onym protocol itself remains open.")
+
+                VStack(spacing: 10) {
+                    if let appealURL = state.appealURL {
+                        SettingsPrimaryButton(action: { openURL(appealURL) }) {
+                            Text("Appeal this ban")
+                        }
+                        .accessibilityIdentifier("moderation.banned.appeal")
+                    }
+                    // The new-holder path is its own affordance, not a
+                    // footnote: DeviceCheck bits survive resale, and the
+                    // device's next owner is the person this screen is
+                    // most likely wronging.
+                    Button {
+                        if let url = state.newHolderURL {
+                            openURL(url)
+                        } else {
+                            onNewHolderClaim()
+                        }
+                    } label: {
+                        Text("I'm this device's new owner")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(OnymTokens.text)
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                            .background(OnymTokens.surface2,
+                                        in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("moderation.banned.new_holder")
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .accessibilityIdentifier("moderation.banned")
+    }
+
+    private var expiryLine: String {
+        if let expiry = state.banExpires {
+            return String(localized: "Until \(expiry.formatted(date: .long, time: .omitted)). You can appeal below.")
+        }
+        return String(localized: "Permanent. It remains appealable at the authority's external appellate for as long as it is in force.")
+    }
+
+    private func detailRow(_ label: LocalizedStringKey, _ value: String, monospaced: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(value)
+                .font(monospaced ? .system(size: 12, design: .monospaced) : .system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
@@ -9,16 +9,25 @@ import OnymModeration
 /// is nonconforming; this screen is the conforming alternative.
 public struct BannedView: View {
     let state: BanState
-    /// Entry point into the authority's appeal path. Stubbed today
-    /// (`ModerationAuthorityClient.appeal` throws `.notImplemented`);
-    /// the URLs below remain the declared out-of-band procedure.
-    let onNewHolderClaim: () -> Void
+    /// Entry point into the authority's new-holder procedure when the
+    /// verdict carries no `newHolderURL`. No default: this is the most
+    /// safety-critical affordance on the screen, and an empty closure
+    /// would make tapping it do nothing — a dead button on a blocking
+    /// screen is the silent brick the profile forbids. Callers with no
+    /// in-app path pass `nil`, and the screen falls back to the
+    /// authority's contact instead of offering a button that lies.
+    let onNewHolderClaim: (() -> Void)?
 
     @Environment(\.openURL) private var openURL
 
-    public init(state: BanState, onNewHolderClaim: @escaping () -> Void = {}) {
+    public init(state: BanState, onNewHolderClaim: (() -> Void)? = nil) {
         self.state = state
         self.onNewHolderClaim = onNewHolderClaim
+    }
+
+    /// Whether the new-holder path can actually be reached from here.
+    private var hasNewHolderPath: Bool {
+        state.newHolderURL != nil || onNewHolderClaim != nil
     }
 
     public var body: some View {
@@ -71,26 +80,34 @@ public struct BannedView: View {
                     // The new-holder path is its own affordance, not a
                     // footnote: DeviceCheck bits survive resale, and the
                     // device's next owner is the person this screen is
-                    // most likely wronging.
-                    Button {
-                        if let url = state.newHolderURL {
-                            openURL(url)
-                        } else {
-                            onNewHolderClaim()
+                    // most likely wronging. Shown only when it actually
+                    // leads somewhere; otherwise the footnote below
+                    // routes them to the authority directly.
+                    if hasNewHolderPath {
+                        Button {
+                            if let url = state.newHolderURL {
+                                openURL(url)
+                            } else {
+                                onNewHolderClaim?()
+                            }
+                        } label: {
+                            Text("I'm this device's new owner")
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundStyle(OnymTokens.text)
+                                .frame(maxWidth: .infinity, minHeight: 44)
+                                .background(OnymTokens.surface2,
+                                            in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                         }
-                    } label: {
-                        Text("I'm this device's new owner")
-                            .font(.system(size: 15, weight: .medium))
-                            .foregroundStyle(OnymTokens.text)
-                            .frame(maxWidth: .infinity, minHeight: 44)
-                            .background(OnymTokens.surface2,
-                                        in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("moderation.banned.new_holder")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("moderation.banned.new_holder")
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 16)
+
+                if !hasNewHolderPath {
+                    SettingsFootnote("If you're this device's new owner, contact the authority above — device bans survive a change of hands, and the authority runs an expedited procedure for it.")
+                }
             }
             .padding(.bottom, 32)
         }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
@@ -56,6 +56,8 @@ public struct GateCheckRequiredView: View {
             return String(localized: "Device verification isn't available in this environment.")
         case .reidentificationRequired:
             return String(localized: "This device needs to be re-identified. Sign in with your identity to continue.")
+        case .clockRollback:
+            return String(localized: "This device's clock is set earlier than its last verification. Check the date and time, then connect to continue.")
         }
     }
 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import OnymDesign
+import OnymModeration
+
+/// Blocking screen for `gateCheckRequired`: the app has no
+/// trustworthy gate answer (offline past the grace window, token
+/// repeatedly invalid, no attestation path) and the profile fails
+/// toward requiring one — never toward unmoderated operation.
+public struct GateCheckRequiredView: View {
+    let reason: CheckRequiredReason
+    let onRetry: () -> Void
+
+    public init(reason: CheckRequiredReason, onRetry: @escaping () -> Void) {
+        self.reason = reason
+        self.onRetry = onRetry
+    }
+
+    public var body: some View {
+        VStack(spacing: 14) {
+            Spacer()
+            Image(systemName: "checkmark.shield")
+                .font(.system(size: 40))
+                .foregroundStyle(OnymTokens.text2)
+            Text("Verification required")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(message)
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text2)
+                .multilineTextAlignment(.center)
+                .lineSpacing(3)
+                .padding(.horizontal, 32)
+            SettingsPrimaryButton(action: onRetry) {
+                Text("Try again")
+            }
+            .padding(.horizontal, 48)
+            .padding(.top, 8)
+            .accessibilityIdentifier("moderation.gate_required.retry")
+            Spacer()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .accessibilityIdentifier("moderation.gate_required")
+    }
+
+    private var message: String {
+        switch reason {
+        case .offlineGraceExpired:
+            return String(localized: "Onym couldn't verify this device for several days. Connect to the internet to continue.")
+        case .neverChecked:
+            return String(localized: "Onym needs to verify this device once before it can start. Connect to the internet to continue.")
+        case .tokenInvalid:
+            return String(localized: "This device's verification token was rejected. Try again.")
+        case .attestationUnavailable:
+            return String(localized: "Device verification isn't available in this environment.")
+        case .reidentificationRequired:
+            return String(localized: "This device needs to be re-identified. Sign in with your identity to continue.")
+        }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentFlow.swift
@@ -27,22 +27,19 @@ public final class ModerationConsentFlow {
         public var authorities: [AuthorityListing] = []
         public var fetchStatus: AuthorityFetchStatus = .idle
         public var selectedListing: AuthorityListing?
+        /// The exact manifest on the consent surface. This same value is
+        /// handed back to `consent(to:reviewedManifest:)`, so what the
+        /// user read is what the mandate pins — and being a
+        /// `ReviewedManifest`, it can only have come from the
+        /// repository's verified fetch.
         public var reviewingManifest: ReviewedManifest?
         public var errorMessage: String?
-    }
-
-    /// The manifest under review plus the hash the mandate will pin —
-    /// displayed on the consent surface so what's signed is inspectable.
-    public struct ReviewedManifest: Equatable {
-        public let manifest: AuthorityManifest
-        public let manifestHash: String
     }
 
     public let mode: Mode
     public private(set) var state = State()
 
     private let repository: ModerationRepository
-    private let manifestFetcher: any AuthorityManifestFetcher
     private var snapshotTask: Task<Void, Never>?
     /// Called after a successful consent so the presenter can dismiss
     /// and trigger an immediate gate check.
@@ -51,12 +48,10 @@ public final class ModerationConsentFlow {
     public init(
         mode: Mode,
         repository: ModerationRepository,
-        manifestFetcher: any AuthorityManifestFetcher,
         onConsented: @escaping @MainActor () -> Void = {}
     ) {
         self.mode = mode
         self.repository = repository
-        self.manifestFetcher = manifestFetcher
         self.onConsented = onConsented
     }
 
@@ -87,18 +82,15 @@ public final class ModerationConsentFlow {
 
     // MARK: - Intents
 
-    /// Row tap in the authority picker: fetch + pin the manifest and
-    /// move to the review (consent) surface.
+    /// Row tap in the authority picker: fetch, verify, and validate the
+    /// manifest, then move to the review (consent) surface. The value
+    /// retained here is the one that gets signed — see `tappedAgree`.
     public func selectedAuthority(_ listing: AuthorityListing) {
         state.selectedListing = listing
         state.errorMessage = nil
         Task {
             do {
-                let signed = try await manifestFetcher.fetch(listing)
-                state.reviewingManifest = ReviewedManifest(
-                    manifest: signed.manifest,
-                    manifestHash: signed.manifestHash
-                )
+                state.reviewingManifest = try await repository.manifestForReview(listing)
                 state.step = .reviewingManifest
             } catch {
                 state.errorMessage = String(localized: "Couldn't load this authority's terms. Try again.")
@@ -107,13 +99,21 @@ public final class ModerationConsentFlow {
     }
 
     /// "I agree and sign" on the consent surface.
+    ///
+    /// Hands back the exact `SignedManifest` that was displayed, so the
+    /// mandate pins the bytes the user read. The repository never
+    /// refetches, which is what closes the window where an authority
+    /// could serve different terms between review and agreement — the
+    /// footnote on the consent surface promises precisely this.
     public func tappedAgree() {
-        guard let listing = state.selectedListing else { return }
+        guard let listing = state.selectedListing,
+              let reviewed = state.reviewingManifest
+        else { return }
         state.step = .signing
         state.errorMessage = nil
         Task {
             do {
-                try await repository.consent(to: listing)
+                try await repository.consent(to: listing, reviewedManifest: reviewed)
                 state.step = .done
                 onConsented()
             } catch {

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentFlow.swift
@@ -1,0 +1,139 @@
+import Foundation
+import OnymModeration
+
+/// Drives the authority pick → manifest review → sign sequence, used
+/// both at onboarding (`.onboarding`, blocking gate) and from Settings
+/// (`.switching`, signs a fresh mandate; the old record stays pinned).
+@MainActor
+@Observable
+public final class ModerationConsentFlow {
+    public enum Mode: Equatable {
+        case onboarding
+        case switching
+    }
+
+    public enum Step: Equatable {
+        case loadingDirectory
+        case pickingAuthority
+        /// Reviewing the fetched, hash-pinned manifest — the consent
+        /// surface itself.
+        case reviewingManifest
+        case signing
+        case done
+    }
+
+    public struct State: Equatable {
+        public var step: Step = .loadingDirectory
+        public var authorities: [AuthorityListing] = []
+        public var fetchStatus: AuthorityFetchStatus = .idle
+        public var selectedListing: AuthorityListing?
+        public var reviewingManifest: ReviewedManifest?
+        public var errorMessage: String?
+    }
+
+    /// The manifest under review plus the hash the mandate will pin —
+    /// displayed on the consent surface so what's signed is inspectable.
+    public struct ReviewedManifest: Equatable {
+        public let manifest: AuthorityManifest
+        public let manifestHash: String
+    }
+
+    public let mode: Mode
+    public private(set) var state = State()
+
+    private let repository: ModerationRepository
+    private let manifestFetcher: any AuthorityManifestFetcher
+    private var snapshotTask: Task<Void, Never>?
+    /// Called after a successful consent so the presenter can dismiss
+    /// and trigger an immediate gate check.
+    private let onConsented: @MainActor () -> Void
+
+    public init(
+        mode: Mode,
+        repository: ModerationRepository,
+        manifestFetcher: any AuthorityManifestFetcher,
+        onConsented: @escaping @MainActor () -> Void = {}
+    ) {
+        self.mode = mode
+        self.repository = repository
+        self.manifestFetcher = manifestFetcher
+        self.onConsented = onConsented
+    }
+
+    public func start() {
+        guard snapshotTask == nil else { return }
+        snapshotTask = Task { [weak self] in
+            guard let self else { return }
+            for await snapshot in self.repository.snapshots {
+                self.state.authorities = snapshot.authorities
+                self.state.fetchStatus = snapshot.fetchStatus
+                if self.state.step == .loadingDirectory {
+                    switch snapshot.fetchStatus {
+                    case .success, .failed:
+                        self.state.step = .pickingAuthority
+                    case .idle, .fetching:
+                        break
+                    }
+                }
+            }
+        }
+        Task { try? await repository.refresh() }
+    }
+
+    public func stop() {
+        snapshotTask?.cancel()
+        snapshotTask = nil
+    }
+
+    // MARK: - Intents
+
+    /// Row tap in the authority picker: fetch + pin the manifest and
+    /// move to the review (consent) surface.
+    public func selectedAuthority(_ listing: AuthorityListing) {
+        state.selectedListing = listing
+        state.errorMessage = nil
+        Task {
+            do {
+                let signed = try await manifestFetcher.fetch(listing)
+                state.reviewingManifest = ReviewedManifest(
+                    manifest: signed.manifest,
+                    manifestHash: signed.manifestHash
+                )
+                state.step = .reviewingManifest
+            } catch {
+                state.errorMessage = String(localized: "Couldn't load this authority's terms. Try again.")
+            }
+        }
+    }
+
+    /// "I agree and sign" on the consent surface.
+    public func tappedAgree() {
+        guard let listing = state.selectedListing else { return }
+        state.step = .signing
+        state.errorMessage = nil
+        Task {
+            do {
+                try await repository.consent(to: listing)
+                state.step = .done
+                onConsented()
+            } catch {
+                state.step = .reviewingManifest
+                state.errorMessage = String(localized: "Signing failed. Try again.")
+            }
+        }
+    }
+
+    /// Back from the review surface to the picker.
+    public func tappedBack() {
+        state.step = .pickingAuthority
+        state.reviewingManifest = nil
+        state.selectedListing = nil
+        state.errorMessage = nil
+    }
+
+    /// Retry button on a failed directory fetch.
+    public func tappedRetry() {
+        state.errorMessage = nil
+        Task { try? await repository.refresh() }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
@@ -1,0 +1,284 @@
+import SwiftUI
+import OnymDesign
+import OnymModeration
+
+/// The consent surface (Moderation.md §8 interface obligation 1):
+/// full-screen, every violation class with all five terms, the
+/// appellate and new-holder paths, the manifest hash being pinned,
+/// and one explicit agree button. Nothing collapsed by default,
+/// nothing buried in unrelated terms.
+public struct ModerationConsentView: View {
+    @State private var flow: ModerationConsentFlow
+
+    public init(flow: ModerationConsentFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    switch flow.state.step {
+                    case .loadingDirectory:
+                        loading
+                    case .pickingAuthority:
+                        picker
+                    case .reviewingManifest, .signing:
+                        review
+                    case .done:
+                        done
+                    }
+                }
+                .padding(.bottom, 32)
+            }
+            .background(OnymTokens.surface.ignoresSafeArea())
+            .navigationTitle(flow.mode == .onboarding ? "Moderation" : "Switch Authority")
+            .navigationBarTitleDisplayMode(.inline)
+            .task { flow.start() }
+        }
+        .interactiveDismissDisabled(flow.mode == .onboarding)
+    }
+
+    // MARK: - Steps
+
+    private var loading: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Loading moderation authorities…")
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text2)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 120)
+    }
+
+    @ViewBuilder
+    private var picker: some View {
+        SettingsLargeTitle("Choose a moderation authority")
+        Text("Onym requires a moderation authority to handle reports of prohibited content. You choose who that is. Its entire power over you is written in the terms you'll review next — nothing can be added to them later without your fresh consent.")
+            .font(.system(size: 14))
+            .foregroundStyle(OnymTokens.text2)
+            .lineSpacing(3)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+
+        switch flow.state.fetchStatus {
+        case .failed(let message):
+            SettingsCard {
+                VStack(spacing: 10) {
+                    Text(message)
+                        .font(.system(size: 14))
+                        .foregroundStyle(OnymTokens.text2)
+                    Button("Retry") { flow.tappedRetry() }
+                        .accessibilityIdentifier("moderation.consent.retry")
+                }
+                .frame(maxWidth: .infinity)
+                .padding(16)
+            }
+        case .fetching, .idle:
+            SettingsCard {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(16)
+            }
+        case .success where flow.state.authorities.isEmpty:
+            SettingsCard {
+                Text("No authorities are published yet.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text3)
+                    .frame(maxWidth: .infinity)
+                    .padding(16)
+            }
+        case .success:
+            SettingsCard {
+                ForEach(Array(flow.state.authorities.enumerated()), id: \.element.componentId) { idx, listing in
+                    Button { flow.selectedAuthority(listing) } label: {
+                        SettingsRow(
+                            title: LocalizedStringKey(listing.name),
+                            subtitle: listing.componentId,
+                            last: idx == flow.state.authorities.count - 1
+                        ) {
+                            SettingsIconTile(symbol: "checkmark.shield", bg: SettingsTile.indigo)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("moderation.consent.authority.\(listing.componentId)")
+                }
+            }
+        }
+
+        if let error = flow.state.errorMessage {
+            SettingsFootnote(LocalizedStringKey(error))
+        }
+    }
+
+    @ViewBuilder
+    private var review: some View {
+        if let reviewing = flow.state.reviewingManifest {
+            SettingsLargeTitle(LocalizedStringKey(flow.state.selectedListing?.name ?? "Terms"))
+
+            Text("These are the exact terms you're consenting to. A case can only ever reach you under a violation class listed here, with these windows and this appeal path.")
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text2)
+                .lineSpacing(3)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 12)
+
+            ForEach(reviewing.manifest.violationClasses, id: \.classId) { violationClass in
+                classCard(violationClass)
+            }
+
+            proceduralCard(reviewing)
+
+            SettingsSectionLabel("WHAT YOU'RE SIGNING")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Manifest hash")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text)
+                    Text(reviewing.manifestHash)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text2)
+                        .textSelection(.enabled)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+            SettingsFootnote("Your consent binds to this hash of these exact terms. The authority cannot edit them under your mandate — changed terms bind only new consents.")
+
+            if let error = flow.state.errorMessage {
+                SettingsFootnote(LocalizedStringKey(error))
+            }
+
+            VStack(spacing: 10) {
+                SettingsPrimaryButton(action: { flow.tappedAgree() }) {
+                    if flow.state.step == .signing {
+                        ProgressView().tint(OnymTokens.onAccent)
+                    } else {
+                        Text("I agree and sign")
+                    }
+                }
+                .disabled(flow.state.step == .signing)
+                .accessibilityIdentifier("moderation.consent.agree")
+
+                Button("Back") { flow.tappedBack() }
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text2)
+                    .disabled(flow.state.step == .signing)
+                    .accessibilityIdentifier("moderation.consent.back")
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+        }
+    }
+
+    private var done: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(OnymTokens.green)
+            Text("Mandate signed")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 120)
+        .accessibilityIdentifier("moderation.consent.done")
+    }
+
+    // MARK: - Cards
+
+    /// One violation class with all five mandatory terms visible.
+    private func classCard(_ violationClass: ViolationClass) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SettingsSectionLabel(LocalizedStringKey(violationClass.classId.replacingOccurrences(of: "-", with: " ").uppercased()))
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    termRow("Response window", violationClass.responseWindow.display)
+                    termRow("Decision deadline", violationClass.decisionDeadline.display)
+                    termRow("Ban term", banTermDisplay(violationClass.banTerm))
+                    termRow("Appeal window", violationClass.appealWindow.display)
+                    termRow("Appeal effect", violationClass.appealEffect == .suspensive
+                            ? String(localized: "Suspensive — no ban until the appeal window passes unused")
+                            : String(localized: "Non-suspensive — the ban executes at once; appeal can reverse it"))
+                    if let lawful = violationClass.lawfulReporting {
+                        termRow("Lawful reporting", lawful)
+                    }
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Definition")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text)
+                        definitionLink(violationClass.definition)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+        }
+    }
+
+    /// Appellate, new-holder path, and validity — the manifest-level
+    /// terms shared by all classes.
+    private func proceduralCard(_ reviewing: ModerationConsentFlow.ReviewedManifest) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SettingsSectionLabel("PROCEDURE")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let appellate = reviewing.manifest.appellate {
+                        termRow("Appeals heard by", appellate)
+                    }
+                    if let newHolder = reviewing.manifest.newHolderAppeal {
+                        termRow("New device owner", newHolder)
+                    }
+                    termRow("Terms valid until", reviewing.manifest.validUntil.formatted(date: .abbreviated, time: .omitted))
+                    termRow("Operated by", reviewing.manifest.operatorKey)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+        }
+    }
+
+    private func termRow(_ label: LocalizedStringKey, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(value)
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+        }
+    }
+
+    /// Definitions are content-addressed; when the address is a URL,
+    /// make it tappable so the exact wording is one tap away.
+    @ViewBuilder
+    private func definitionLink(_ address: String) -> some View {
+        if let url = URL(string: address), url.scheme == "https" {
+            Link(address, destination: url)
+                .font(.system(size: 12, design: .monospaced))
+        } else {
+            Text(address)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(OnymTokens.text2)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func banTermDisplay(_ term: BanTerm) -> String {
+        switch term {
+        case .permanent:
+            return String(localized: "Permanent (appealable at the external appellate for as long as it is in force)")
+        case .duration(let duration):
+            return duration.display
+        }
+    }
+}
+
+extension ISO8601Duration {
+    /// "3 days", "1 day" — the consent surface shows human terms, with
+    /// the raw ISO string preserved in the manifest hash it pins.
+    var display: String {
+        days == 1 ? String(localized: "1 day") : String(localized: "\(days) days")
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
@@ -9,6 +9,7 @@ import OnymModeration
 /// nothing buried in unrelated terms.
 public struct ModerationConsentView: View {
     @State private var flow: ModerationConsentFlow
+    @Environment(\.dismiss) private var dismiss
 
     public init(flow: ModerationConsentFlow) {
         _flow = State(initialValue: flow)
@@ -34,9 +35,32 @@ public struct ModerationConsentView: View {
             .background(OnymTokens.surface.ignoresSafeArea())
             .navigationTitle(flow.mode == .onboarding ? "Moderation" : "Switch Authority")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                // Switching is a normal, abandonable settings task, and
+                // the `.done` step has no other way out — `onConsented`
+                // belongs to the app factory and can't dismiss us.
+                // Onboarding deliberately has no escape: consent is the
+                // gate.
+                if flow.mode == .switching {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(dismissLabel) { dismiss() }
+                            .accessibilityIdentifier("moderation.consent.dismiss")
+                    }
+                }
+            }
             .task { flow.start() }
+            .onDisappear { flow.stop() }
         }
         .interactiveDismissDisabled(flow.mode == .onboarding)
+    }
+
+    /// "Cancel" while the task can still be abandoned; "Done" once the
+    /// mandate exists, whichever terms it ended up binding.
+    private var dismissLabel: LocalizedStringKey {
+        switch flow.state.step {
+        case .done: return "Done"
+        default: return "Cancel"
+        }
     }
 
     // MARK: - Steps
@@ -94,7 +118,7 @@ public struct ModerationConsentView: View {
                 ForEach(Array(flow.state.authorities.enumerated()), id: \.element.componentId) { idx, listing in
                     Button { flow.selectedAuthority(listing) } label: {
                         SettingsRow(
-                            title: LocalizedStringKey(listing.name),
+                            titleText: listing.name,
                             subtitle: listing.componentId,
                             last: idx == flow.state.authorities.count - 1
                         ) {
@@ -108,14 +132,14 @@ public struct ModerationConsentView: View {
         }
 
         if let error = flow.state.errorMessage {
-            SettingsFootnote(LocalizedStringKey(error))
+            SettingsFootnote(verbatim: error)
         }
     }
 
     @ViewBuilder
     private var review: some View {
-        if let reviewing = flow.state.reviewingManifest {
-            SettingsLargeTitle(LocalizedStringKey(flow.state.selectedListing?.name ?? "Terms"))
+        if let reviewing = flow.state.reviewingManifest?.signedManifest {
+            SettingsLargeTitle(verbatim: flow.state.selectedListing?.name ?? String(localized: "Terms"))
 
             Text("These are the exact terms you're consenting to. A case can only ever reach you under a violation class listed here, with these windows and this appeal path.")
                 .font(.system(size: 14))
@@ -147,7 +171,7 @@ public struct ModerationConsentView: View {
             SettingsFootnote("Your consent binds to this hash of these exact terms. The authority cannot edit them under your mandate — changed terms bind only new consents.")
 
             if let error = flow.state.errorMessage {
-                SettingsFootnote(LocalizedStringKey(error))
+                SettingsFootnote(verbatim: error)
             }
 
             VStack(spacing: 10) {
@@ -191,7 +215,7 @@ public struct ModerationConsentView: View {
     /// One violation class with all five mandatory terms visible.
     private func classCard(_ violationClass: ViolationClass) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            SettingsSectionLabel(LocalizedStringKey(violationClass.classId.replacingOccurrences(of: "-", with: " ").uppercased()))
+            SettingsSectionLabel(verbatim: violationClass.classId.replacingOccurrences(of: "-", with: " ").uppercased())
             SettingsCard {
                 VStack(alignment: .leading, spacing: 8) {
                     termRow("Response window", violationClass.responseWindow.display)
@@ -219,7 +243,7 @@ public struct ModerationConsentView: View {
 
     /// Appellate, new-holder path, and validity — the manifest-level
     /// terms shared by all classes.
-    private func proceduralCard(_ reviewing: ModerationConsentFlow.ReviewedManifest) -> some View {
+    private func proceduralCard(_ reviewing: SignedManifest) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             SettingsSectionLabel("PROCEDURE")
             SettingsCard {

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
@@ -9,7 +9,9 @@ import OnymModeration
 @Observable
 public final class ModerationGateFlow {
     public enum RootGate: Equatable {
-        /// Repositories haven't reported yet — keep the launch screen.
+        /// Repositories haven't reported yet. The app renders normally
+        /// in this state — see `recompute`, which explains why blocking
+        /// launch on the first gate answer waits on a real backend.
         case checking
         /// No active mandate: present the consent flow (blocking).
         case needsConsent

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
@@ -1,0 +1,123 @@
+import Foundation
+import OnymModeration
+
+/// Merges `ModerationRepository` and `GateCheckRepository` snapshots
+/// into the single state the app root switches on. The root gate is
+/// the enforcement surface: consent before use, ban screen on bit1,
+/// blocking check-required when no trustworthy gate answer exists.
+@MainActor
+@Observable
+public final class ModerationGateFlow {
+    public enum RootGate: Equatable {
+        /// Repositories haven't reported yet — keep the launch screen.
+        case checking
+        /// No active mandate: present the consent flow (blocking).
+        case needsConsent
+        /// bit1 — the app refuses to operate (blocking).
+        case banned(BanState)
+        /// No trustworthy gate answer and grace exhausted (blocking).
+        case gateCheckRequired(CheckRequiredReason)
+        /// Operating; non-empty `openCases` shows the case banner.
+        case operational(openCases: [CaseNotice])
+    }
+
+    public private(set) var gate: RootGate = .checking
+
+    private let moderation: ModerationRepository
+    private let gateCheck: GateCheckRepository
+    private var moderationTask: Task<Void, Never>?
+    private var gateTask: Task<Void, Never>?
+
+    private var hasMandate: Bool?
+    private var authoritiesAvailable = false
+    private var gateStatus: GateStatus?
+
+    public init(moderation: ModerationRepository, gateCheck: GateCheckRepository) {
+        self.moderation = moderation
+        self.gateCheck = gateCheck
+    }
+
+    /// Begin draining both repositories. Idempotent.
+    public func start() {
+        guard moderationTask == nil else { return }
+        moderationTask = Task { [weak self] in
+            guard let self else { return }
+            for await state in self.moderation.snapshots {
+                self.hasMandate = state.activeMandate != nil
+                self.authoritiesAvailable = !state.authorities.isEmpty
+                self.recompute()
+            }
+        }
+        gateTask = Task { [weak self] in
+            guard let self else { return }
+            for await status in self.gateCheck.snapshots {
+                self.gateStatus = status
+                self.recompute()
+            }
+        }
+    }
+
+    public func stop() {
+        moderationTask?.cancel()
+        moderationTask = nil
+        gateTask?.cancel()
+        gateTask = nil
+    }
+
+    // MARK: - Intents
+
+    /// Retry button on the check-required screen.
+    public func tappedRetry() {
+        Task { await gateCheck.checkNow() }
+    }
+
+    /// The consent flow finished — run the first gate check for the
+    /// fresh mandate immediately instead of waiting for the interval.
+    public func consentCompleted() {
+        Task { await gateCheck.checkNow() }
+    }
+
+    /// App returned to foreground: refresh the gate (covers the P1D
+    /// cadence across relaunches and long backgrounding).
+    public func appForegrounded() {
+        Task { await gateCheck.checkNow() }
+    }
+
+    // MARK: - Private
+
+    /// Consent outranks the gate: with no mandate the only lawful
+    /// screen is the consent surface (the gate repository reports
+    /// `.notMandated` and makes no backend calls). With a mandate,
+    /// the gate status governs.
+    ///
+    /// Two deliberate softenings while no real moderation stack is
+    /// deployed:
+    /// - **No authorities, no gate.** The consent screen only blocks
+    ///   when the designated-authorities directory actually yields
+    ///   entries. An interface without a designated authority answers
+    ///   to its distribution channel, not this contract (Moderation.md
+    ///   §11.12) — and bricking every install on an unpublished
+    ///   directory would be a self-inflicted outage.
+    /// - **`.checking` renders the app.** Blocking launch on the first
+    ///   gate answer only makes sense against a real backend; until
+    ///   then enforcement applies the moment a definitive status
+    ///   arrives.
+    private func recompute() {
+        guard let hasMandate else { return }
+        if !hasMandate {
+            gate = authoritiesAvailable ? .needsConsent : .operational(openCases: [])
+            return
+        }
+        switch gateStatus {
+        case nil, .notMandated:
+            // Mandate exists but the gate hasn't answered yet.
+            gate = .checking
+        case .operational(let openCases):
+            gate = .operational(openCases: openCases)
+        case .banned(let state):
+            gate = .banned(state)
+        case .gateCheckRequired(let reason):
+            gate = .gateCheckRequired(reason)
+        }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
@@ -1,0 +1,64 @@
+import Foundation
+import OnymModeration
+
+/// Backs Settings → Moderation: the active mandate, the read-only
+/// mandate history, and the entry point into the switching consent
+/// flow. Pure snapshot drain — all mutations go through
+/// `ModerationConsentFlow.consent`.
+@MainActor
+@Observable
+public final class ModerationSettingsFlow {
+    public struct State: Equatable {
+        public var snapshot: ModerationState = .empty
+        public var openCases: [CaseNotice] = []
+    }
+
+    public private(set) var state = State()
+
+    private let repository: ModerationRepository
+    private let gateCheck: GateCheckRepository
+    private var snapshotTask: Task<Void, Never>?
+    private var gateTask: Task<Void, Never>?
+
+    public init(repository: ModerationRepository, gateCheck: GateCheckRepository) {
+        self.repository = repository
+        self.gateCheck = gateCheck
+    }
+
+    public func start() {
+        guard snapshotTask == nil else { return }
+        snapshotTask = Task { [weak self] in
+            guard let self else { return }
+            for await snapshot in self.repository.snapshots {
+                self.state.snapshot = snapshot
+            }
+        }
+        gateTask = Task { [weak self] in
+            guard let self else { return }
+            for await status in self.gateCheck.snapshots {
+                if case .operational(let openCases) = status {
+                    self.state.openCases = openCases
+                }
+            }
+        }
+    }
+
+    public func stop() {
+        snapshotTask?.cancel()
+        snapshotTask = nil
+        gateTask?.cancel()
+        gateTask = nil
+    }
+
+    // MARK: - Read helpers
+
+    public var activeMandate: MandateRecord? {
+        state.snapshot.activeMandate
+    }
+
+    /// Deactivated records, newest first — each still pinned to the
+    /// manifest hash it consented to.
+    public var previousMandates: [MandateRecord] {
+        state.snapshot.history.filter { !$0.isActive }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
@@ -36,8 +36,14 @@ public final class ModerationSettingsFlow {
         gateTask = Task { [weak self] in
             guard let self else { return }
             for await status in self.gateCheck.snapshots {
-                if case .operational(let openCases) = status {
+                // Assign on every status, not just `.operational`:
+                // keeping the last-seen notices when the gate moves
+                // elsewhere would leave a closed case on screen.
+                switch status {
+                case .operational(let openCases):
                     self.state.openCases = openCases
+                case .notMandated, .banned, .gateCheckRequired:
+                    self.state.openCases = []
                 }
             }
         }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+import OnymDesign
+import OnymModeration
+
+/// Settings → Moderation. Shows the consented authority and its
+/// pinned terms, any open cases, the mandate history, and the
+/// "Switch authority" path (a fresh consent — the old mandate stays
+/// exactly as signed).
+public struct ModerationSettingsView: View {
+    @State private var flow: ModerationSettingsFlow
+    private let makeConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
+
+    @State private var showSwitchConsent = false
+
+    public init(
+        flow: ModerationSettingsFlow,
+        makeConsentFlow: @escaping @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
+    ) {
+        _flow = State(initialValue: flow)
+        self.makeConsentFlow = makeConsentFlow
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SettingsLargeTitle("Moderation")
+
+                if !flow.state.openCases.isEmpty {
+                    OpenCaseBanner(notices: flow.state.openCases)
+                        .padding(.bottom, 8)
+                }
+
+                if let record = flow.activeMandate {
+                    activeCard(record)
+                } else {
+                    noMandateCard
+                }
+
+                if !flow.previousMandates.isEmpty {
+                    SettingsSectionLabel("PREVIOUS MANDATES")
+                    SettingsCard {
+                        ForEach(Array(flow.previousMandates.enumerated()), id: \.element.mandate.acceptedAt) { idx, record in
+                            SettingsRow(
+                                title: LocalizedStringKey(record.authorityName),
+                                subtitle: "Consented \(record.mandate.acceptedAt.formatted(date: .abbreviated, time: .omitted)) · \(String(record.mandate.manifestHash.prefix(16)))…",
+                                hasChevron: false,
+                                last: idx == flow.previousMandates.count - 1
+                            ) {
+                                SettingsIconTile(symbol: "doc.text", bg: SettingsTile.gray)
+                            }
+                        }
+                    }
+                    SettingsFootnote("Old mandates stay bound to the exact terms they consented to. Switching authorities never rewrites them.")
+                }
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .navigationTitle("Moderation")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { flow.start() }
+        .sheet(isPresented: $showSwitchConsent) {
+            ModerationConsentView(flow: makeConsentFlow(.switching))
+        }
+    }
+
+    // MARK: - Cards
+
+    private func activeCard(_ record: MandateRecord) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SettingsSectionLabel("CURRENT AUTHORITY")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    row("Authority", record.authorityName)
+                    row("Component", record.mandate.authority, monospaced: true)
+                    row("Consented", record.mandate.acceptedAt.formatted(date: .abbreviated, time: .shortened))
+                    row("Manifest hash", record.mandate.manifestHash, monospaced: true)
+                    if let manifest = record.consentedManifest() {
+                        row("Terms valid until", manifest.manifest.validUntil.formatted(date: .abbreviated, time: .omitted))
+                        row("Violation classes", manifest.manifest.violationClasses.map(\.classId).joined(separator: ", "))
+                    }
+                    if !record.countersigned {
+                        row("Countersignature", String(localized: "Pending — no enforcement backend is deployed yet"))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+
+                SettingsRowDivider()
+
+                Button { showSwitchConsent = true } label: {
+                    SettingsRow(
+                        title: "Switch authority",
+                        subtitle: "Signs a fresh mandate under the new authority's terms",
+                        last: true
+                    ) {
+                        SettingsIconTile(symbol: "arrow.triangle.2.circlepath", bg: SettingsTile.indigo)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("moderation.settings.switch")
+            }
+            SettingsFootnote("Your consent is the authority's entire jurisdiction: it can only decide cases against you under the classes and terms you signed, and its verdicts must be reasoned, expiring, and appealable.")
+        }
+    }
+
+    private var noMandateCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SettingsSectionLabel("CURRENT AUTHORITY")
+            SettingsCard {
+                Button { showSwitchConsent = true } label: {
+                    SettingsRow(
+                        title: "Choose a moderation authority",
+                        subtitle: "No mandate signed on this device yet",
+                        last: true
+                    ) {
+                        SettingsIconTile(symbol: "checkmark.shield", bg: SettingsTile.indigo)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("moderation.settings.choose")
+            }
+        }
+    }
+
+    private func row(_ label: LocalizedStringKey, _ value: String, monospaced: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(value)
+                .font(monospaced ? .system(size: 11, design: .monospaced) : .system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
@@ -39,9 +39,9 @@ public struct ModerationSettingsView: View {
                 if !flow.previousMandates.isEmpty {
                     SettingsSectionLabel("PREVIOUS MANDATES")
                     SettingsCard {
-                        ForEach(Array(flow.previousMandates.enumerated()), id: \.element.mandate.acceptedAt) { idx, record in
+                        ForEach(Array(flow.previousMandates.enumerated()), id: \.element.historyRowID) { idx, record in
                             SettingsRow(
-                                title: LocalizedStringKey(record.authorityName),
+                                titleText: record.authorityName,
                                 subtitle: "Consented \(record.mandate.acceptedAt.formatted(date: .abbreviated, time: .omitted)) · \(String(record.mandate.manifestHash.prefix(16)))…",
                                 hasChevron: false,
                                 last: idx == flow.previousMandates.count - 1
@@ -59,6 +59,7 @@ public struct ModerationSettingsView: View {
         .navigationTitle("Moderation")
         .navigationBarTitleDisplayMode(.inline)
         .task { flow.start() }
+        .onDisappear { flow.stop() }
         .sheet(isPresented: $showSwitchConsent) {
             ModerationConsentView(flow: makeConsentFlow(.switching))
         }
@@ -133,5 +134,15 @@ public struct ModerationSettingsView: View {
                 .foregroundStyle(OnymTokens.text2)
                 .textSelection(.enabled)
         }
+    }
+}
+
+private extension MandateRecord {
+    /// Stable list identity for the read-only history. `acceptedAt`
+    /// alone isn't enough: the repository stamps it from an injectable
+    /// clock, so two records can share an instant (trivially so under
+    /// a fixed test clock) and collide as `ForEach` ids.
+    var historyRowID: String {
+        "\(mandate.authority)|\(mandate.manifestHash)|\(mandate.acceptedAt.timeIntervalSince1970)"
     }
 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import OnymDesign
+import OnymModeration
+
+/// Non-blocking banner shown while a case is open against this
+/// device. The case-open mark is procedural state: the spec forbids
+/// degrading service on it beyond displaying the case's existence
+/// (Moderation.md §5.5), so this overlays the normal UI and taps
+/// through to the notice detail.
+public struct OpenCaseBanner: View {
+    let notices: [CaseNotice]
+    @State private var presented: CaseNotice?
+
+    public init(notices: [CaseNotice]) {
+        self.notices = notices
+    }
+
+    public var body: some View {
+        if let first = notices.first {
+            Button { presented = first } label: {
+                HStack(spacing: 10) {
+                    Circle().fill(SettingsTile.amber).frame(width: 22, height: 22)
+                        .overlay(Image(systemName: "exclamationmark")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(.white))
+                    Text(notices.count == 1
+                         ? "A moderation case is open against this device."
+                         : "\(notices.count) moderation cases are open against this device.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.text)
+                    Spacer(minLength: 4)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text2)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(OnymTokens.surface2,
+                            in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(OnymTokens.hairlineStrong, lineWidth: 0.5))
+                .padding(.horizontal, 16)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("moderation.case_banner")
+            .sheet(item: $presented) { notice in
+                NavigationStack {
+                    CaseNoticeDetailView(notice: notice)
+                }
+            }
+        }
+    }
+}
+
+extension CaseNotice: @retroactive Identifiable {
+    public var id: String { caseId }
+}
+
+/// The served notice, presented faithfully: class, deadlines,
+/// evidence reference, and the response path (stubbed — the client
+/// operation throws `.notImplemented` until an authority service
+/// exists; the screen says so instead of pretending).
+public struct CaseNoticeDetailView: View {
+    let notice: CaseNotice
+
+    public init(notice: CaseNotice) {
+        self.notice = notice
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SettingsLargeTitle("Moderation case")
+
+                SettingsSectionLabel("NOTICE")
+                SettingsCard {
+                    VStack(alignment: .leading, spacing: 8) {
+                        row("Case", notice.caseId, monospaced: true)
+                        row("Authority", notice.authority)
+                        row("Violation class", notice.classId)
+                        row("Evidence", notice.evidenceSummary, monospaced: true)
+                        row("Respond by", notice.responseDeadline.formatted(date: .abbreviated, time: .shortened))
+                        row("Decision due", notice.decisionDeadline.formatted(date: .abbreviated, time: .shortened))
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+                }
+                SettingsFootnote("If the authority doesn't decide by the deadline, the case is dismissed automatically — silence never bans anyone. Not responding doesn't concede the case; it proceeds on the record.")
+
+                SettingsSectionLabel("RESPONSE")
+                SettingsCard {
+                    Text("Responding from the app isn't available yet. Use the authority's contact channel to respond before the deadline.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(OnymTokens.text2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(16)
+                }
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .navigationTitle("Case")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("moderation.case_detail")
+    }
+
+    private func row(_ label: LocalizedStringKey, _ value: String, monospaced: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(value)
+                .font(monospaced ? .system(size: 12, design: .monospaced) : .system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/Packages/OnymSettings/Package.swift
+++ b/Packages/OnymSettings/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         .package(path: "../OnymTransportBlossom"),
         .package(path: "../OnymChatsCore"),
         .package(path: "../OnymDesign"),
+        .package(path: "../OnymModerationUI"),
     ],
     targets: [
         .target(
@@ -29,6 +30,7 @@ let package = Package(
                 "OnymTransportBlossom",
                 "OnymChatsCore",
                 "OnymDesign",
+                "OnymModerationUI",
             ]
         ),
     ]

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -5,6 +5,7 @@ import OnymIdentity
 import OnymIdentityUI
 import OnymRecovery
 import OnymChatsCore
+import OnymModerationUI
 
 /// Settings tab — Onym design home. Identity hero (active identity
 /// avatar + truncated BLS fingerprint) and a per-identity invite QR
@@ -25,6 +26,11 @@ public struct SettingsView: View {
     /// Wipes every local message (keeps chats). Wired to
     /// `MessageRepository.removeAll`. Runs behind a two-step confirm.
     let onClearAllMessages: () async -> Void
+    /// Moderation drill-down factories. Optional so the Settings
+    /// screen renders without the moderation stack (the row is hidden
+    /// until the app wires these in).
+    let makeModerationSettingsFlow: (@MainActor () -> ModerationSettingsFlow)?
+    let makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)?
 
     public init(
         makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow,
@@ -33,7 +39,9 @@ public struct SettingsView: View {
         makeBlossomRelaySettingsFlow: @escaping @MainActor () -> BlossomRelaySettingsFlow,
         makeAnchorsPickerFlow: @escaping @MainActor () -> AnchorsPickerFlow,
         identitiesFlow: IdentitiesFlow,
-        onClearAllMessages: @escaping () async -> Void
+        onClearAllMessages: @escaping () async -> Void,
+        makeModerationSettingsFlow: (@MainActor () -> ModerationSettingsFlow)? = nil,
+        makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)? = nil
     ) {
         self.makeBackupFlow = makeBackupFlow
         self.makeRelayerSettingsFlow = makeRelayerSettingsFlow
@@ -42,6 +50,8 @@ public struct SettingsView: View {
         self.makeAnchorsPickerFlow = makeAnchorsPickerFlow
         self.identitiesFlow = identitiesFlow
         self.onClearAllMessages = onClearAllMessages
+        self.makeModerationSettingsFlow = makeModerationSettingsFlow
+        self.makeModerationConsentFlow = makeModerationConsentFlow
     }
 
     @State private var showRecoveryPhrase = false
@@ -153,6 +163,29 @@ public struct SettingsView: View {
                     .accessibilityIdentifier("settings.blossom_relays_row")
                 }
                 SettingsFootnote("Nostr relays and Blossom servers carry your messages and media. Replace them with your own instances for maximum privacy.")
+
+                if let makeModerationSettingsFlow, let makeModerationConsentFlow {
+                    SettingsSectionLabel("MODERATION")
+                    SettingsCard {
+                        NavigationLink {
+                            ModerationSettingsView(
+                                flow: makeModerationSettingsFlow(),
+                                makeConsentFlow: makeModerationConsentFlow
+                            )
+                        } label: {
+                            SettingsRow(
+                                title: "Moderation",
+                                subtitle: "Your consented authority and its terms",
+                                last: true
+                            ) {
+                                SettingsIconTile(symbol: "checkmark.shield", bg: SettingsTile.green)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("settings.moderation_row")
+                    }
+                    SettingsFootnote("The moderation authority handles reports of prohibited content under terms you consented to. You can switch to a different authority at any time.")
+                }
 
                 SettingsSectionLabel("DATA")
                 SettingsCard {

--- a/project.yml
+++ b/project.yml
@@ -33,6 +33,7 @@ packages:
   OnymChatsUI: {path: Packages/OnymChatsUI}
   OnymSettings: {path: Packages/OnymSettings}
   OnymModeration: {path: Packages/OnymModeration}
+  OnymModerationUI: {path: Packages/OnymModerationUI}
 
 targets:
   OnymIOS:
@@ -60,6 +61,7 @@ targets:
       - package: OnymChatsUI
       - package: OnymSettings
       - package: OnymModeration
+      - package: OnymModerationUI
     # Hand-written Info.plist via xcodegen's `info:` block. We tried
     # the GENERATE_INFOPLIST_FILE + INFOPLIST_KEY_* approach first but
     # `INFOPLIST_KEY_UILaunchScreen_BackgroundColor` / `_ImageName` are
@@ -221,6 +223,7 @@ targets:
       - package: OnymChatsUI
       - package: OnymSettings
       - package: OnymModeration
+      - package: OnymModerationUI
 
   OnymIOSUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## What

Stacked on #216. New `Packages/OnymModerationUI` SPM package: every screen of the moderation seat's client UX, plus the (hidden until wired) Settings row.

- **`ModerationConsentView` + `ModerationConsentFlow`** — the consent surface (Moderation.md §8 obligation 1): full-screen, every violation class with all five terms (response window, decision deadline, ban term, appeal window, appeal effect), appellate + new-holder path, the manifest hash being pinned, one explicit "I agree and sign". Serves both onboarding (`.onboarding`, non-dismissable) and later switching (`.switching`).
- **`ModerationSettingsView`/`Flow`** — current authority with its pinned terms and countersignature state, open cases, read-only mandate history (old mandates keep their consented hashes), "Switch authority" → fresh consent.
- **`BannedView`** — the conforming enforcement UX: verdict reference, class, reasoning address, authority contact, expiry (or permanent + appellate note), Appeal button and a distinct "I'm this device's new owner" button. A silent brick is nonconforming; this screen is the alternative.
- **`GateCheckRequiredView`** — blocking "verification required" screen with retry, for every degraded path (offline past grace, token invalid, no attestation).
- **`OpenCaseBanner` + `CaseNoticeDetailView`** — non-blocking (the case-open mark must not degrade service, §5.5).
- **`ModerationGateFlow`** — merges repository snapshots into the single `RootGate` the app root switches on. Two documented softenings while nothing real is deployed: consent only blocks when the authority directory actually yields entries (an interface without a designated authority answers to its distribution channel, §11.12), and `.checking` renders the app rather than blocking launch on the first gate answer.

`SettingsView` gains optional moderation factories (row hidden until the app passes them — next PR), so this PR leaves app behavior unchanged.

## Stack

- PR-1: #216 — domain + seams + stubs
- **PR-2 (this): UI package**
- PR-3: app wiring
- PR-4: tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)