### PR TITLE
feat(moderation): wire the moderation gate into the app

### DIFF
--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
@@ -252,6 +252,25 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
         return snapshot.blsSecretKey
     }
 
+    /// Ed25519 detached signature over `message` with the
+    /// currently-selected identity's derived Stellar signing key. Used
+    /// by the moderation layer to sign mandates and gate-check
+    /// sessions. Same posture as `blsSecretKey()`: the private key is
+    /// derived per call from the Keychain snapshot and never leaves
+    /// this repository — only the signature does.
+    public func signWithStellarKey(_ message: Data) throws -> Data {
+        guard let currentID else {
+            throw IdentityError.identityNotLoaded
+        }
+        guard let snapshot = try keychain.read(currentID) else {
+            throw IdentityError.identityNotLoaded
+        }
+        let privateKey = try Self.stellarSigningPrivateKey(
+            fromNostrSecret: snapshot.nostrSecretKey
+        )
+        return try privateKey.signature(for: message)
+    }
+
     // MARK: - Streams
 
     public nonisolated var snapshots: AsyncStream<Identity?> {

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -6,6 +6,7 @@ import OnymInbox
 import OnymRecovery
 import OnymChatsUI
 import OnymSettings
+import OnymModerationUI
 
 /// App-wide composition root. Constructed exactly once by `OnymIOSApp`
 /// and threaded down to views via `RootView`. Each member is a factory
@@ -68,4 +69,10 @@ struct AppDependencies {
     /// `GroupNamePayload` out to members. Backs the admin-only rename
     /// affordance in `ChatMembersView`.
     let setGroupName: @MainActor (_ groupIDHex: String, _ name: String) async -> Void
+    /// Single shared instance — the app root switches on its gate
+    /// (consent / banned / check-required / operational) and Settings
+    /// observes the same state, so a factory would split them.
+    let moderationGateFlow: ModerationGateFlow
+    let makeModerationConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
+    let makeModerationSettingsFlow: @MainActor () -> ModerationSettingsFlow
 }

--- a/Sources/OnymIOS/IdentityModerationSigner.swift
+++ b/Sources/OnymIOS/IdentityModerationSigner.swift
@@ -1,0 +1,23 @@
+import Foundation
+import OnymIdentity
+import OnymModeration
+
+/// Adapts `IdentityRepository` to the moderation package's signer
+/// seam. The mandate's `user` key is the identity's derived Stellar
+/// Ed25519 public key (`onym:key:<hex>`); signatures come from the
+/// matching private key, which never leaves the repository.
+struct IdentityModerationSigner: ModerationSigner {
+    let repository: IdentityRepository
+
+    func userKeyID() async throws -> String {
+        guard let identity = await repository.currentIdentity() else {
+            throw ModerationError.notImplemented("no identity bootstrapped yet")
+        }
+        let hex = identity.stellarPublicKey.map { String(format: "%02x", $0) }.joined()
+        return "onym:key:\(hex)"
+    }
+
+    func sign(_ message: Data) async throws -> Data {
+        try await repository.signWithStellarKey(message)
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -11,6 +11,8 @@ import OnymInbox
 import OnymRecovery
 import OnymChatsUI
 import OnymSettings
+import OnymModeration
+import OnymModerationUI
 
 @main
 struct OnymIOSApp: App {
@@ -32,6 +34,11 @@ struct OnymIOSApp: App {
     private let groupStateVerifier: GroupStateVerifier
     private let introKeyStore: any IntroKeyStore
     private let introRequestStore: any IntroRequestStore
+    /// Moderation seat: authority designation + mandate lifecycle,
+    /// and the DeviceCheck gate-check cadence. The enforcement
+    /// backend is a stub until one is deployed.
+    private let moderationRepository: ModerationRepository
+    private let gateCheckRepository: GateCheckRepository
     /// Factory for the per-request SEP contract transport. Normally
     /// `URLSessionSEPContractTransport`; swapped for an in-memory
     /// ledger-backed fake under `--ui-loopback` so a Tyranny group
@@ -102,6 +109,79 @@ struct OnymIOSApp: App {
         self.identityRepository = repository
         self.relayerRepository = relayerRepository
         self.contractsRepository = contractsRepository
+
+        // Moderation seat. Authorities are swappable data (a signed
+        // directory + per-authority manifests); the enforcement
+        // backend seam is stubbed — `StubEnforcementBackendClient`
+        // answers the gate per `--moderation-scenario` in UI tests
+        // and `.clear` in production until a real backend exists.
+        let moderationSigner = IdentityModerationSigner(repository: repository)
+        let moderationRepository: ModerationRepository
+        let gateCheckRepository: GateCheckRepository
+        let moderationManifestFetcher: any AuthorityManifestFetcher
+        #if DEBUG
+        if args.contains("--ui-testing") {
+            let backend = StubEnforcementBackendClient(
+                scenario: Self.resolveModerationScenario(args: args)
+            )
+            moderationManifestFetcher = UITestAuthorityManifestFetcher()
+            moderationRepository = ModerationRepository(
+                authoritiesFetcher: UITestKnownAuthoritiesFetcher(),
+                manifestFetcher: moderationManifestFetcher,
+                mandateStore: UITestMandateStore(
+                    seeded: !args.contains("--moderation-needs-consent")
+                ),
+                backend: backend,
+                attestation: UITestDeviceAttestationProvider(),
+                signer: moderationSigner
+            )
+            gateCheckRepository = GateCheckRepository(
+                attestation: UITestDeviceAttestationProvider(),
+                backend: backend,
+                moderation: moderationRepository,
+                signer: moderationSigner,
+                store: UITestGateStateStore()
+            )
+        } else {
+            let backend = StubEnforcementBackendClient()
+            moderationManifestFetcher = URLSessionAuthorityManifestFetcher()
+            moderationRepository = ModerationRepository(
+                authoritiesFetcher: GitHubReleasesKnownAuthoritiesFetcher(),
+                manifestFetcher: moderationManifestFetcher,
+                mandateStore: UserDefaultsMandateStore(),
+                backend: backend,
+                attestation: DCDeviceAttestationProvider(),
+                signer: moderationSigner
+            )
+            gateCheckRepository = GateCheckRepository(
+                attestation: DCDeviceAttestationProvider(),
+                backend: backend,
+                moderation: moderationRepository,
+                signer: moderationSigner,
+                store: UserDefaultsGateStateStore()
+            )
+        }
+        #else
+        let moderationBackend = StubEnforcementBackendClient()
+        moderationManifestFetcher = URLSessionAuthorityManifestFetcher()
+        moderationRepository = ModerationRepository(
+            authoritiesFetcher: GitHubReleasesKnownAuthoritiesFetcher(),
+            manifestFetcher: moderationManifestFetcher,
+            mandateStore: UserDefaultsMandateStore(),
+            backend: moderationBackend,
+            attestation: DCDeviceAttestationProvider(),
+            signer: moderationSigner
+        )
+        gateCheckRepository = GateCheckRepository(
+            attestation: DCDeviceAttestationProvider(),
+            backend: moderationBackend,
+            moderation: moderationRepository,
+            signer: moderationSigner,
+            store: UserDefaultsGateStateStore()
+        )
+        #endif
+        self.moderationRepository = moderationRepository
+        self.gateCheckRepository = gateCheckRepository
 
         // Group repository — falls back to in-memory if the on-disk
         // store can't open (rare; FileProtection / sandbox issues).
@@ -364,6 +444,11 @@ struct OnymIOSApp: App {
             }
         )
 
+        let moderationGateFlow = ModerationGateFlow(
+            moderation: moderationRepository,
+            gateCheck: gateCheckRepository
+        )
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -458,11 +543,39 @@ struct OnymIOSApp: App {
             },
             setGroupName: { groupIDHex, name in
                 await groupAvatarBroadcaster.setName(groupIDHex: groupIDHex, name: name)
+            },
+            moderationGateFlow: moderationGateFlow,
+            makeModerationConsentFlow: { @MainActor mode in
+                ModerationConsentFlow(
+                    mode: mode,
+                    repository: moderationRepository,
+                    onConsented: { moderationGateFlow.consentCompleted() }
+                )
+            },
+            makeModerationSettingsFlow: { @MainActor in
+                ModerationSettingsFlow(
+                    repository: moderationRepository,
+                    gateCheck: gateCheckRepository
+                )
             }
         )
     }
 
     #if DEBUG
+    /// `--moderation-scenario clear|case-open|banned|check-required`
+    /// (with `--ui-testing`): which canned world the stub enforcement
+    /// backend answers, so UI tests can drive the ban screen, the
+    /// open-case banner, and the gate-required screen deterministically.
+    private static func resolveModerationScenario(
+        args: [String]
+    ) -> StubEnforcementBackendClient.Scenario {
+        guard let flagIndex = args.firstIndex(of: "--moderation-scenario"),
+              flagIndex + 1 < args.count,
+              let scenario = StubEnforcementBackendClient.Scenario(rawValue: args[flagIndex + 1])
+        else { return .clear }
+        return scenario
+    }
+
     /// Canned `ChatVideoEncoder.Encoded` for the UI-test video-send path:
     /// a real poster (from the shared test JPEG) plus small placeholder
     /// MP4 bytes. The test only asserts the poster renders + round-trips;
@@ -538,6 +651,13 @@ struct OnymIOSApp: App {
                     // UI harness — the hardcoded seed stays the default).
                     await nostrRelaysRepository.start()
                     await blossomServersRepository.start()
+                    // Moderation: refresh the designated-authorities
+                    // directory and begin the gate-check cadence
+                    // (launch check + P1D interval). Runs after
+                    // identity bootstrap above so gate sessions can
+                    // carry an identity signature.
+                    await moderationRepository.start()
+                    await gateCheckRepository.start()
                     // Replay groups + invitations for the in-memory snapshot streams.
                     await groupRepository.reload()
                     await incomingInvitations.reload()

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import OnymSearch
 import OnymChatsUI
 import OnymSettings
+import OnymModerationUI
 
 /// App shell — `TabView` with the iOS 18+ `Tab(_, systemImage:, value:)`
 /// syntax. The `.search` role places its tab in the system's bottom-right
@@ -24,8 +25,52 @@ struct RootView: View {
     let dependencies: AppDependencies
 
     @State private var selectedTab: RootTab = .chats
+    @Environment(\.scenePhase) private var scenePhase
+
+    /// Whether the blocking consent sheet is up. Driven by the gate;
+    /// a `Bool` binding because `fullScreenCover(isPresented:)` wants
+    /// one, with the gate as the single source of truth.
+    @State private var showConsent = false
 
     var body: some View {
+        // The moderation gate is the enforcement surface (DeviceCheck
+        // profile §5): banned and gate-check-required replace the app
+        // wholesale; consent covers it; an open case only banners it.
+        Group {
+            switch dependencies.moderationGateFlow.gate {
+            case .banned(let banState):
+                BannedView(state: banState)
+            case .gateCheckRequired(let reason):
+                GateCheckRequiredView(reason: reason) {
+                    dependencies.moderationGateFlow.tappedRetry()
+                }
+            case .checking, .needsConsent, .operational:
+                tabs
+                    .overlay(alignment: .top) {
+                        if case .operational(let openCases) = dependencies.moderationGateFlow.gate,
+                           !openCases.isEmpty {
+                            OpenCaseBanner(notices: openCases)
+                        }
+                    }
+            }
+        }
+        .task { dependencies.moderationGateFlow.start() }
+        .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
+            showConsent = gate == .needsConsent
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                dependencies.moderationGateFlow.appForegrounded()
+            }
+        }
+        .fullScreenCover(isPresented: $showConsent) {
+            ModerationConsentView(
+                flow: dependencies.makeModerationConsentFlow(.onboarding)
+            )
+        }
+    }
+
+    private var tabs: some View {
         TabView(selection: $selectedTab) {
             Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: .chats) {
                 NavigationStack {
@@ -58,7 +103,9 @@ struct RootView: View {
                         makeBlossomRelaySettingsFlow: dependencies.makeBlossomRelaySettingsFlow,
                         makeAnchorsPickerFlow: dependencies.makeAnchorsPickerFlow,
                         identitiesFlow: dependencies.identitiesFlow,
-                        onClearAllMessages: { await dependencies.messageRepository.removeAll() }
+                        onClearAllMessages: { await dependencies.messageRepository.removeAll() },
+                        makeModerationSettingsFlow: dependencies.makeModerationSettingsFlow,
+                        makeModerationConsentFlow: dependencies.makeModerationConsentFlow
                     )
                 }
             }

--- a/Sources/OnymIOS/UITestFakes.swift
+++ b/Sources/OnymIOS/UITestFakes.swift
@@ -4,6 +4,7 @@ import OnymTransport
 import OnymChain
 import OnymTransportBlossom
 import OnymChatsCore
+import OnymModeration
 
 /// App-side fakes used by `OnymIOSApp` when launched with the
 /// `--ui-testing` argument. They live in production sources (not the
@@ -303,6 +304,138 @@ final class UITestBlossomClient: BlossomClient, @unchecked Sendable {
             throw BlossomError.badStatus(404)
         }
         return data
+    }
+}
+
+// MARK: - Moderation
+
+/// One canned authority so consent-flow UI tests have a deterministic
+/// row to pick.
+struct UITestKnownAuthoritiesFetcher: KnownAuthoritiesFetcher {
+    static let authority = AuthorityListing(
+        componentId: "onym:component:uitest-authority",
+        name: "UITest Authority",
+        manifestURL: URL(string: "https://uitest-authority.example/manifest.json")!,
+        operatorPublicKeyBase64: ""
+    )
+
+    func fetchLatest() async throws -> [AuthorityListing] {
+        [Self.authority]
+    }
+}
+
+/// Serves a fixture manifest as exact bytes so the consent flow's
+/// hash pinning behaves exactly like production (the hash is of these
+/// bytes, deterministically).
+struct UITestAuthorityManifestFetcher: AuthorityManifestFetcher {
+    static let manifestJSON = Data("""
+    {
+      "version": 1,
+      "componentId": "onym:component:uitest-authority",
+      "seat": "moderation",
+      "operator": "onym:key:uitest-operator",
+      "moderationProfileId": "onym:moderation-profile:consent-bound-v1",
+      "violationClasses": [
+        {
+          "classId": "csam",
+          "definition": "https://uitest-authority.example/defs/csam",
+          "responseWindow": "P3D",
+          "decisionDeadline": "P7D",
+          "banTerm": "permanent",
+          "appealWindow": "P30D",
+          "appealEffect": "non-suspensive"
+        },
+        {
+          "classId": "unsolicited-pornography",
+          "definition": "https://uitest-authority.example/defs/unsolicited-pornography",
+          "responseWindow": "P7D",
+          "decisionDeadline": "P14D",
+          "banTerm": "P90D",
+          "appealWindow": "P30D",
+          "appealEffect": "suspensive"
+        }
+      ],
+      "appellate": "onym:component:uitest-appellate",
+      "newHolderAppeal": "https://uitest-authority.example/new-holder",
+      "validUntil": "2030-01-01T00:00:00Z",
+      "signature": "uitest-unsigned"
+    }
+    """.utf8)
+
+    func fetch(_ listing: AuthorityListing) async throws -> SignedManifest {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let manifest = try decoder.decode(AuthorityManifest.self, from: Self.manifestJSON)
+        return SignedManifest(manifest: manifest, rawBytes: Self.manifestJSON)
+    }
+}
+
+/// In-memory mandate store. Seeded with a pre-signed fixture mandate
+/// by default so the consent gate doesn't block every unrelated UI
+/// test; `--moderation-needs-consent` starts it empty to exercise the
+/// consent flow itself.
+final class UITestMandateStore: MandateStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var records: [MandateRecord]
+
+    init(seeded: Bool) {
+        if seeded {
+            let manifest = UITestAuthorityManifestFetcher.manifestJSON
+            let mandate = ModerationMandate(
+                user: "onym:key:uitest-user",
+                interface: ModerationRepository.interfaceComponentId,
+                authority: "onym:component:uitest-authority",
+                manifestHash: SignedManifest.hash(of: manifest),
+                classes: ["csam", "unsolicited-pornography"],
+                deviceBinding: "uitest-enrollment",
+                acceptedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                signatures: ["uitest-user-signature"]
+            )
+            records = [MandateRecord(
+                mandate: mandate,
+                manifestBytes: manifest,
+                authorityName: "UITest Authority",
+                countersigned: false,
+                isActive: true,
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+            )]
+        } else {
+            records = []
+        }
+    }
+
+    func load() -> [MandateRecord] {
+        lock.withLock { records }
+    }
+
+    func save(_ records: [MandateRecord]) {
+        lock.withLock { self.records = records }
+    }
+}
+
+/// In-memory gate state so every launch starts with no persisted
+/// grace window.
+final class UITestGateStateStore: GateStateStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var state: PersistedGateState?
+
+    func load() -> PersistedGateState? {
+        lock.withLock { state }
+    }
+
+    func save(_ state: PersistedGateState?) {
+        lock.withLock { self.state = state }
+    }
+}
+
+/// Simulator has no DeviceCheck; UI tests use a provider that
+/// pretends support and returns fixed token bytes so the stub
+/// backend's request shape stays realistic.
+struct UITestDeviceAttestationProvider: DeviceAttestationProvider {
+    var isSupported: Bool { true }
+
+    func generateToken() async throws -> Data {
+        Data("uitest-device-token".utf8)
     }
 }
 


### PR DESCRIPTION
## What

Stacked on #217. Turns the packages on:

- **`OnymIdentity`**: new `IdentityRepository.signWithStellarKey(_:)` — Ed25519 detached signature with the derived Stellar key, same posture as `blsSecretKey()`: derived per call from the Keychain snapshot, the private key never leaves the repository. Adapted into the moderation seam by `IdentityModerationSigner` (`user` = `onym:key:<stellar-pubkey-hex>`).
- **`OnymIOSApp`**: composes the moderation stack — production uses `GitHubReleasesKnownAuthoritiesFetcher` + `URLSessionAuthorityManifestFetcher` + UserDefaults stores + `DCDeviceAttestationProvider` + `StubEnforcementBackendClient` (no enforcement backend exists yet); repositories start after identity bootstrap so gate sessions carry an identity signature.
- **`RootView`**: switches on the gate — banned and gate-check-required replace the app wholesale, consent covers it (fullScreenCover, non-dismissable), an open case only banners it. Foregrounding triggers a fresh gate check (covers the P1D cadence across backgrounding).
- **UITest harness**: canned authority + fixture manifest, seeded in-memory mandate store (so existing UI tests aren't blocked by the consent gate), `--moderation-scenario clear|case-open|banned|check-required` drives the stub, `--moderation-needs-consent` starts unconsented to exercise the consent flow.

## Behavior in production today

No authorities directory is published, so the consent gate never blocks and the stub gate answers `.clear`: user-visible behavior is unchanged except the (factory-gated) Moderation row in Settings. The enforcement rail is live end-to-end the moment a real directory + backend exist.

## Verified

Simulator smoke runs: `banned` scenario shows the full ban screen (verdict ref, expiry, appeal + new-holder), `--moderation-needs-consent` shows the authority picker, default seeded run boots to the normal app.

## Stack

- PR-1: #216 — domain + seams + stubs
- PR-2: #217 — UI package
- **PR-3 (this): app wiring**
- PR-4: tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)