### PR TITLE
test(moderation): validator fixture table, gate cadence, hash pinning, mandate immutability

### DIFF
--- a/Tests/OnymIOSTests/ConsentedTermsEnforcementTests.swift
+++ b/Tests/OnymIOSTests/ConsentedTermsEnforcementTests.swift
@@ -285,12 +285,73 @@ final class ConsentedTermsEnforcementTests: XCTestCase {
     }
 
     func testNonComponentAppellateRefused() throws {
-        for appellate in ["self", "", "the appeals board", "https://authority.example/appeals"] {
+        for appellate in [
+            "self",
+            "",
+            "the appeals board",
+            "https://authority.example/appeals",
+            // The bare prefix carries the right shape while naming
+            // nobody — an appellate that resolves to no component can
+            // hear no appeal.
+            "onym:component:",
+            "onym:component:   ",
+            "onym:component:has whitespace",
+        ] {
             XCTAssertThrowsError(
                 try validateManifest(manifestJSON(appellate: appellate)),
                 appellate
             )
         }
+    }
+
+    /// A manifest whose own `componentId` doesn't resolve can't
+    /// establish that its appellate is anyone else.
+    func testUnparseableIssuerComponentIdRefusedForPermanentClass() throws {
+        XCTAssertThrowsError(
+            try validateManifest(manifestJSON(componentId: "onym:component:"))
+        )
+        XCTAssertThrowsError(
+            try validateManifest(manifestJSON(componentId: "authority"))
+        )
+    }
+
+    // MARK: - ComponentReference
+
+    func testComponentReferenceParsesAndRejects() throws {
+        XCTAssertEqual(
+            try ComponentReference.identifier(from: "onym:component:appellate"),
+            "appellate"
+        )
+        XCTAssertEqual(
+            ComponentReference.reference(for: "appellate"),
+            "onym:component:appellate"
+        )
+        for bad in [
+            "",
+            "onym:component:",
+            "onym:component: ",
+            "onym:component:\t",
+            "onym:component:a b",
+            "appellate",
+            "onym:key:00",
+            "ONYM:COMPONENT:appellate",
+        ] {
+            XCTAssertThrowsError(try ComponentReference.identifier(from: bad), bad)
+        }
+    }
+
+    func testNamesSameComponentIsFalseForUnparseableReferences() {
+        XCTAssertTrue(
+            ComponentReference.namesSameComponent("onym:component:a", "onym:component:a")
+        )
+        XCTAssertFalse(
+            ComponentReference.namesSameComponent("onym:component:a", "onym:component:b")
+        )
+        // Two identically-malformed references must not read as "the
+        // same component" — neither names one.
+        XCTAssertFalse(
+            ComponentReference.namesSameComponent("onym:component:", "onym:component:")
+        )
     }
 
     func testMissingAppellateRefusedOnlyForPermanentClasses() throws {

--- a/Tests/OnymIOSTests/ConsentedTermsEnforcementTests.swift
+++ b/Tests/OnymIOSTests/ConsentedTermsEnforcementTests.swift
@@ -1,0 +1,338 @@
+import XCTest
+@testable import OnymModeration
+
+/// The consented-terms bounds (Moderation.md §5.6 constraint 3) and the
+/// consent-time validity conditions. These are the checks that make the
+/// seat's central promise real: the sanction a user can receive is the
+/// one they read before signing.
+final class ConsentedTermsEnforcementTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let validator = VerdictValidator()
+
+    // MARK: - Fixtures
+
+    /// `csam` permanent / non-suspensive; `unsolicited-pornography`
+    /// P90D / suspensive with a P30D appeal window.
+    private static let manifestBytes = Data("""
+    {
+      "version": 1,
+      "componentId": "onym:component:authority",
+      "seat": "moderation",
+      "operator": "onym:key:1111111111111111111111111111111111111111111111111111111111111111",
+      "moderationProfileId": "onym:moderation-profile:consent-bound-v1",
+      "violationClasses": [
+        {
+          "classId": "csam",
+          "definition": "hash:csam",
+          "responseWindow": "P3D",
+          "decisionDeadline": "P7D",
+          "banTerm": "permanent",
+          "appealWindow": "P30D",
+          "appealEffect": "non-suspensive"
+        },
+        {
+          "classId": "unsolicited-pornography",
+          "definition": "hash:up",
+          "responseWindow": "P7D",
+          "decisionDeadline": "P14D",
+          "banTerm": "P90D",
+          "appealWindow": "P30D",
+          "appealEffect": "suspensive"
+        }
+      ],
+      "appellate": "onym:component:appellate",
+      "newHolderAppeal": "hash:new-holder",
+      "validUntil": "2030-01-01T00:00:00Z"
+    }
+    """.utf8)
+
+    private func consented() throws -> SignedManifest {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return SignedManifest(
+            manifest: try decoder.decode(AuthorityManifest.self, from: Self.manifestBytes),
+            rawBytes: Self.manifestBytes
+        )
+    }
+
+    private func mandate() throws -> ModerationMandate {
+        ModerationMandate(
+            user: "onym:key:user",
+            interface: "onym:component:onym-ios",
+            authority: "onym:component:authority",
+            manifestHash: try consented().manifestHash,
+            classes: ["csam", "unsolicited-pornography"],
+            deviceBinding: "enrollment-1",
+            acceptedAt: now.addingTimeInterval(-100 * 86_400),
+            signatures: ["user-sig"]
+        )
+    }
+
+    /// A conforming executed suspensive ban: decided 40 days ago,
+    /// appeal window (P30D) lapsed 10 days ago, execution began there,
+    /// expiry is execution + the consented P90D.
+    private func suspensiveBan(
+        appealDeadline overrideAppeal: Date? = nil,
+        executeAfter overrideExecute: Date? = nil,
+        banExpires overrideExpiry: Date? = nil
+    ) throws -> Verdict {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let appealDeadline = overrideAppeal ?? decidedAt.addingTimeInterval(30 * 86_400)
+        let executeAfter = overrideExecute ?? appealDeadline
+        return Verdict(
+            caseId: "case-1",
+            authority: "onym:component:authority",
+            mandateRef: try mandate().mandateHash(),
+            accusedKeys: ["onym:key:user"],
+            deviceBinding: "enrollment-1",
+            classId: "unsolicited-pornography",
+            disposition: .ban,
+            marks: Marks(caseOpen: false, banned: true),
+            banExpires: overrideExpiry ?? executeAfter.addingTimeInterval(90 * 86_400),
+            executeAfter: executeAfter,
+            reasoning: "hash:findings",
+            appealDeadline: appealDeadline,
+            decidedAt: decidedAt,
+            signature: "unsigned-fixture",
+            isFinal: false
+        )
+    }
+
+    private func validate(_ verdict: Verdict) throws -> VerdictValidator.Outcome {
+        try validator.validate(
+            verdict,
+            mandate: try mandate(),
+            consented: try consented(),
+            now: now,
+            enforceSignature: false
+        )
+    }
+
+    // MARK: - Baseline
+
+    func testConformingSuspensiveBanExecutes() throws {
+        XCTAssertEqual(try validate(try suspensiveBan()), .execute)
+    }
+
+    // MARK: - Ban term
+
+    /// The headline case from the review: a P90D class carrying a
+    /// ten-year expiry must not validate.
+    func testBanExpiryBeyondConsentedTermRefused() throws {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let executeAfter = decidedAt.addingTimeInterval(30 * 86_400)
+        let verdict = try suspensiveBan(
+            banExpires: executeAfter.addingTimeInterval(3650 * 86_400)
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testBanExpiryShorterThanConsentedTermRefused() throws {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let executeAfter = decidedAt.addingTimeInterval(30 * 86_400)
+        let verdict = try suspensiveBan(
+            banExpires: executeAfter.addingTimeInterval(10 * 86_400)
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    /// Expiry runs from execution, not decision (§5.6 constraint 3) —
+    /// for a suspensive class those differ by the appeal window.
+    func testBanExpiryMeasuredFromExecutionNotDecision() throws {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let verdict = try suspensiveBan(
+            banExpires: decidedAt.addingTimeInterval(90 * 86_400)
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testPermanentClassCarryingExpiryRefused() throws {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let verdict = Verdict(
+            caseId: "case-1",
+            authority: "onym:component:authority",
+            mandateRef: try mandate().mandateHash(),
+            accusedKeys: ["onym:key:user"],
+            deviceBinding: "enrollment-1",
+            classId: "csam",
+            disposition: .ban,
+            marks: Marks(caseOpen: false, banned: true),
+            banExpires: now.addingTimeInterval(365 * 86_400),
+            executeAfter: decidedAt,
+            reasoning: "hash:findings",
+            appealDeadline: decidedAt.addingTimeInterval(30 * 86_400),
+            decidedAt: decidedAt,
+            signature: "unsigned-fixture",
+            isFinal: false
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    // MARK: - Appeal window
+
+    /// The other headline case: an authority must not be able to
+    /// collapse the consented appeal window to nothing.
+    func testZeroAppealWindowRefused() throws {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let verdict = try suspensiveBan(
+            appealDeadline: decidedAt,
+            executeAfter: decidedAt
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testAppealDeadlineBeyondConsentedWindowRefused() throws {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let stretched = decidedAt.addingTimeInterval(60 * 86_400)
+        let verdict = try suspensiveBan(appealDeadline: stretched, executeAfter: stretched)
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    /// Non-suspensive bans previously escaped the appeal-deadline check
+    /// entirely by omitting the field.
+    func testNonSuspensiveBanMissingAppealDeadlineRefused() throws {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let verdict = Verdict(
+            caseId: "case-1",
+            authority: "onym:component:authority",
+            mandateRef: try mandate().mandateHash(),
+            accusedKeys: ["onym:key:user"],
+            deviceBinding: "enrollment-1",
+            classId: "csam",
+            disposition: .ban,
+            marks: Marks(caseOpen: false, banned: true),
+            banExpires: nil,
+            executeAfter: decidedAt,
+            reasoning: "hash:findings",
+            appealDeadline: nil,
+            decidedAt: decidedAt,
+            signature: "unsigned-fixture",
+            isFinal: false
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    /// Whole-day windows computed elsewhere can land a second off;
+    /// that must not reject an otherwise conforming verdict.
+    func testSubSecondRoundingTolerated() throws {
+        let decidedAt = now.addingTimeInterval(-40 * 86_400)
+        let appealDeadline = decidedAt.addingTimeInterval(30 * 86_400 + 0.4)
+        let verdict = try suspensiveBan(
+            appealDeadline: appealDeadline,
+            executeAfter: appealDeadline,
+            banExpires: appealDeadline.addingTimeInterval(90 * 86_400 - 0.4)
+        )
+        XCTAssertEqual(try validate(verdict), .execute)
+    }
+
+    // MARK: - Consent-time manifest validity
+
+    private func validateManifest(_ json: String) throws {
+        let bytes = Data(json.utf8)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let signed = SignedManifest(
+            manifest: try decoder.decode(AuthorityManifest.self, from: bytes),
+            rawBytes: bytes
+        )
+        try AuthorityManifestValidator().validateForConsent(signed, now: now)
+    }
+
+    private func manifestJSON(
+        componentId: String = "onym:component:authority",
+        appellate: String? = "onym:component:appellate",
+        newHolderAppeal: String? = "hash:new-holder",
+        banTerm: String = "permanent"
+    ) -> String {
+        let appellateLine = appellate.map { "\"appellate\": \"\($0)\"," } ?? ""
+        let newHolderLine = newHolderAppeal.map { "\"newHolderAppeal\": \"\($0)\"," } ?? ""
+        return """
+        {
+          "version": 1,
+          "componentId": "\(componentId)",
+          "seat": "moderation",
+          "operator": "onym:key:1111111111111111111111111111111111111111111111111111111111111111",
+          "moderationProfileId": "onym:moderation-profile:consent-bound-v1",
+          "violationClasses": [
+            {
+              "classId": "csam",
+              "definition": "hash:csam",
+              "responseWindow": "P3D",
+              "decisionDeadline": "P7D",
+              "banTerm": "\(banTerm)",
+              "appealWindow": "P30D",
+              "appealEffect": "non-suspensive"
+            }
+          ],
+          \(appellateLine)
+          \(newHolderLine)
+          "validUntil": "2030-01-01T00:00:00Z"
+        }
+        """
+    }
+
+    func testAcceptsConformingManifest() throws {
+        XCTAssertNoThrow(try validateManifest(manifestJSON()))
+    }
+
+    /// §5.2 constraint 2 exists so no permanent sanction depends on its
+    /// issuer staying alive — an issuer naming itself defeats it.
+    func testIssuerAsOwnAppellateRefused() throws {
+        XCTAssertThrowsError(
+            try validateManifest(manifestJSON(appellate: "onym:component:authority"))
+        )
+    }
+
+    func testNonComponentAppellateRefused() throws {
+        for appellate in ["self", "", "the appeals board", "https://authority.example/appeals"] {
+            XCTAssertThrowsError(
+                try validateManifest(manifestJSON(appellate: appellate)),
+                appellate
+            )
+        }
+    }
+
+    func testMissingAppellateRefusedOnlyForPermanentClasses() throws {
+        XCTAssertThrowsError(try validateManifest(manifestJSON(appellate: nil)))
+        // A duration class needs no external appellate.
+        XCTAssertNoThrow(try validateManifest(manifestJSON(appellate: nil, banTerm: "P90D")))
+    }
+
+    /// Device marks survive resale, so the new-holder remedy is
+    /// mandatory (§5.7) — a manifest without one can't deliver it.
+    func testMissingNewHolderAppealRefused() throws {
+        XCTAssertThrowsError(try validateManifest(manifestJSON(newHolderAppeal: nil)))
+        XCTAssertThrowsError(try validateManifest(manifestJSON(newHolderAppeal: "")))
+    }
+
+    func testExpiredManifestRefused() throws {
+        let expired = manifestJSON().replacingOccurrences(
+            of: "\"validUntil\": \"2030-01-01T00:00:00Z\"",
+            with: "\"validUntil\": \"2020-01-01T00:00:00Z\""
+        )
+        XCTAssertThrowsError(try validateManifest(expired))
+    }
+
+    func testUnsupportedProfileRefused() throws {
+        let other = manifestJSON().replacingOccurrences(
+            of: "onym:moderation-profile:consent-bound-v1",
+            with: "onym:profile:something-else"
+        )
+        XCTAssertThrowsError(try validateManifest(other)) { error in
+            XCTAssertEqual(
+                error as? ModerationError,
+                .unsupportedProfile("onym:profile:something-else")
+            )
+        }
+    }
+
+    /// The spec fixes this string (§5.1 profile, §5.2 manifest); a
+    /// conforming manifest must be accepted by default.
+    func testSpecProfileIdIsSupportedByDefault() {
+        XCTAssertTrue(
+            AuthorityManifestValidator.defaultSupportedProfileIds
+                .contains("onym:moderation-profile:consent-bound-v1")
+        )
+    }
+}

--- a/Tests/OnymIOSTests/GateCheckDeriveTests.swift
+++ b/Tests/OnymIOSTests/GateCheckDeriveTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import OnymModeration
+
+/// The gate-check cadence arithmetic (DeviceCheck profile §5) as a
+/// pure-function table: success serves the result, unreachable serves
+/// the last known state inside the grace window, and every degraded
+/// path lands on blocking — never on unmoderated operation.
+final class GateCheckDeriveTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let policy = GateCheckPolicy.default
+
+    private func banState() -> BanState {
+        BanState(verdictRef: "verdict-1", authorityContact: "appeals@authority.example")
+    }
+
+    // MARK: - Success
+
+    func testSuccessClearIsOperationalAndPersists() {
+        let (status, persisted) = GateCheckRepository.derive(
+            persisted: nil,
+            attempt: .success(.clear),
+            now: now,
+            policy: policy
+        )
+        XCTAssertEqual(status, .operational(openCases: []))
+        XCTAssertEqual(persisted, PersistedGateState(lastResult: .clear, lastSuccessAt: now))
+    }
+
+    func testSuccessBannedBlocks() {
+        let (status, _) = GateCheckRepository.derive(
+            persisted: nil,
+            attempt: .success(.banned(banState())),
+            now: now,
+            policy: policy
+        )
+        XCTAssertEqual(status, .banned(banState()))
+    }
+
+    func testSuccessCheckRequiredBlocks() {
+        let (status, _) = GateCheckRepository.derive(
+            persisted: nil,
+            attempt: .success(.checkRequired(.reidentificationRequired)),
+            now: now,
+            policy: policy
+        )
+        XCTAssertEqual(status, .gateCheckRequired(.reidentificationRequired))
+    }
+
+    // MARK: - Unreachable
+
+    func testUnreachableWithNoHistoryBlocks() {
+        let (status, persisted) = GateCheckRepository.derive(
+            persisted: nil,
+            attempt: .unreachable,
+            now: now,
+            policy: policy
+        )
+        XCTAssertEqual(status, .gateCheckRequired(.neverChecked))
+        XCTAssertNil(persisted)
+    }
+
+    func testUnreachableInsideGraceServesLastKnownState() {
+        let lastSuccess = now.addingTimeInterval(-policy.offlineGrace)  // boundary: exactly P3D ago
+        let persisted = PersistedGateState(lastResult: .clear, lastSuccessAt: lastSuccess)
+        let (status, kept) = GateCheckRepository.derive(
+            persisted: persisted,
+            attempt: .unreachable,
+            now: now,
+            policy: policy
+        )
+        XCTAssertEqual(status, .operational(openCases: []))
+        XCTAssertEqual(kept, persisted)
+    }
+
+    func testUnreachablePastGraceBlocks() {
+        let lastSuccess = now.addingTimeInterval(-policy.offlineGrace - 1)
+        let persisted = PersistedGateState(lastResult: .clear, lastSuccessAt: lastSuccess)
+        let (status, kept) = GateCheckRepository.derive(
+            persisted: persisted,
+            attempt: .unreachable,
+            now: now,
+            policy: policy
+        )
+        XCTAssertEqual(status, .gateCheckRequired(.offlineGraceExpired))
+        // Persisted state kept: a later success overwrites, and the
+        // stale record is inert (no conforming path serves it past
+        // grace).
+        XCTAssertEqual(kept, persisted)
+    }
+
+    func testUnreachableInsideGraceServesLastKnownBan() {
+        // Grace never launders a ban: the last known state is what's
+        // served, whatever it was.
+        let persisted = PersistedGateState(
+            lastResult: .banned(banState()),
+            lastSuccessAt: now.addingTimeInterval(-86_400)
+        )
+        let (status, _) = GateCheckRepository.derive(
+            persisted: persisted,
+            attempt: .unreachable,
+            now: now,
+            policy: policy
+        )
+        XCTAssertEqual(status, .banned(banState()))
+    }
+
+    // MARK: - Persistence round-trip
+
+    func testGateStateStoreRoundTripsResultKinds() throws {
+        let suite = "gate-derive-tests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = UserDefaultsGateStateStore(defaults: defaults)
+
+        let notice = CaseNotice(
+            caseId: "case-1",
+            authority: "onym:component:authority",
+            accused: "onym:key:user",
+            mandateRef: "aa",
+            classId: "csam",
+            evidenceSummary: "hash:evidence",
+            responseDeadline: now.addingTimeInterval(3 * 86_400),
+            decisionDeadline: now.addingTimeInterval(7 * 86_400),
+            signature: "sig"
+        )
+        for result in [
+            GateCheckResult.clear,
+            .caseOpen([notice]),
+            .banned(banState()),
+            .checkRequired(.tokenInvalid),
+        ] {
+            let state = PersistedGateState(lastResult: result, lastSuccessAt: now)
+            store.save(state)
+            XCTAssertEqual(store.load(), state)
+        }
+
+        store.save(nil)
+        XCTAssertNil(store.load())
+    }
+}

--- a/Tests/OnymIOSTests/GateHardeningTests.swift
+++ b/Tests/OnymIOSTests/GateHardeningTests.swift
@@ -1,0 +1,275 @@
+import XCTest
+@testable import OnymModeration
+
+/// The enforcement-path hardening: signed session payloads a backend
+/// can actually verify, a countersignature round-trip that can't alter
+/// consent, stale gate completions that can't reopen the app, and a
+/// grace window that can't be extended by winding the clock back.
+final class GateHardeningTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Signed session payloads
+
+    /// The backend receives token, userKey and timestamp, so it must be
+    /// able to recompute exactly what was signed from those fields.
+    func testEnrollmentPayloadIsReconstructibleFromTransmittedFields() {
+        let token = Data("device-token".utf8)
+        let request = EnrollmentRequest(
+            deviceToken: token,
+            userKey: "onym:key:user",
+            timestamp: now,
+            signature: Data()
+        )
+        let recomputed = EnrollmentRequest.signedPayload(
+            deviceToken: request.deviceToken,
+            userKey: request.userKey,
+            timestamp: request.timestamp
+        )
+        XCTAssertEqual(
+            recomputed,
+            EnrollmentRequest.signedPayload(deviceToken: token, userKey: "onym:key:user", timestamp: now)
+        )
+    }
+
+    func testEnrollmentAndGatePayloadsAreDomainSeparated() {
+        let token = Data("t".utf8)
+        let enrollment = EnrollmentRequest.signedPayload(
+            deviceToken: token, userKey: "u", timestamp: now
+        )
+        let gate = GateCheckRequest.signedPayload(
+            deviceToken: token, userKey: "u", mandateRef: nil, timestamp: now
+        )
+        // Otherwise an enrollment signature could be replayed as a
+        // gate-check signature for the same session.
+        XCTAssertNotEqual(enrollment, gate)
+    }
+
+    /// Length-prefixing makes concatenation injective: no two distinct
+    /// field splits can produce identical bytes.
+    func testFieldBoundariesAreUnambiguous() {
+        let a = EnrollmentRequest.signedPayload(
+            deviceToken: Data("ab".utf8), userKey: "c", timestamp: now
+        )
+        let b = EnrollmentRequest.signedPayload(
+            deviceToken: Data("a".utf8), userKey: "bc", timestamp: now
+        )
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testGatePayloadCoversMandateRef() {
+        let one = GateCheckRequest.signedPayload(
+            deviceToken: nil, userKey: "u", mandateRef: "mandate-a", timestamp: now
+        )
+        let two = GateCheckRequest.signedPayload(
+            deviceToken: nil, userKey: "u", mandateRef: "mandate-b", timestamp: now
+        )
+        XCTAssertNotEqual(one, two)
+    }
+
+    func testPayloadChangesWithTimestamp() {
+        let one = EnrollmentRequest.signedPayload(deviceToken: nil, userKey: "u", timestamp: now)
+        let two = EnrollmentRequest.signedPayload(
+            deviceToken: nil, userKey: "u", timestamp: now.addingTimeInterval(60)
+        )
+        XCTAssertNotEqual(one, two)
+    }
+
+    // MARK: - Countersignature can't alter consent
+
+    /// `countersignMandate` returns only a signature, so there is no
+    /// channel through which a backend could change a consented field.
+    /// This is a type-level guarantee; the test pins it against drift.
+    func testCountersignatureCarriesOnlyASignature() async throws {
+        let suite = "countersign-tests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let mandate = ModerationMandate(
+            user: "onym:key:user",
+            interface: "onym:component:onym-ios",
+            authority: "onym:component:authority",
+            manifestHash: "aa",
+            classes: ["csam"],
+            deviceBinding: "enrollment-1",
+            acceptedAt: now,
+            signatures: ["user-sig"]
+        )
+        let countersignature = try await StubEnforcementBackendClient(defaults: defaults)
+            .countersignMandate(mandate)
+
+        XCTAssertEqual(countersignature.signature, StubEnforcementBackendClient.countersignSentinel)
+        // The mandate the client holds is untouched by the round-trip.
+        XCTAssertEqual(mandate.signatures, ["user-sig"])
+    }
+
+    // MARK: - Clock rollback
+
+    func testClockBehindLastSuccessBlocks() {
+        let persisted = PersistedGateState(
+            lastResult: .clear,
+            lastSuccessAt: now.addingTimeInterval(60)  // "future" relative to now
+        )
+        let (status, kept) = GateCheckRepository.derive(
+            persisted: persisted,
+            attempt: .unreachable,
+            now: now,
+            policy: .default
+        )
+        XCTAssertEqual(status, .gateCheckRequired(.clockRollback))
+        XCTAssertEqual(kept, persisted)
+    }
+
+    /// The rollback that used to buy unlimited grace: set the clock far
+    /// back, block the backend, keep serving a cached `.clear`.
+    func testLargeRollbackDoesNotExtendGrace() {
+        let persisted = PersistedGateState(
+            lastResult: .clear,
+            lastSuccessAt: now.addingTimeInterval(365 * 86_400)
+        )
+        let (status, _) = GateCheckRepository.derive(
+            persisted: persisted,
+            attempt: .unreachable,
+            now: now,
+            policy: .default
+        )
+        XCTAssertEqual(status, .gateCheckRequired(.clockRollback))
+    }
+
+    func testZeroAgeStillInsideGrace() {
+        let persisted = PersistedGateState(lastResult: .clear, lastSuccessAt: now)
+        let (status, _) = GateCheckRepository.derive(
+            persisted: persisted,
+            attempt: .unreachable,
+            now: now,
+            policy: .default
+        )
+        XCTAssertEqual(status, .operational(openCases: []))
+    }
+
+    // MARK: - Stale completions can't reopen the app
+
+    /// A backend whose responses complete out of order: the first call
+    /// is slow and answers `.clear`, the second is fast and answers
+    /// `.banned`. The slow completion must not overwrite the ban.
+    private final class ReorderingBackend: EnforcementBackendClient, @unchecked Sendable {
+        private let lock = NSLock()
+        private var callCount = 0
+        /// Signalled once the fast (second) call has finished.
+        let fastCallFinished = XCTestExpectation(description: "fast call finished")
+
+        func enrollDevice(_ request: EnrollmentRequest) async throws -> DeviceEnrollment {
+            DeviceEnrollment(deviceBinding: "enrollment-1")
+        }
+
+        func countersignMandate(_ mandate: ModerationMandate) async throws -> InterfaceCountersignature {
+            InterfaceCountersignature(signature: "sig")
+        }
+
+        func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult {
+            let index = lock.withLock { () -> Int in
+                callCount += 1
+                return callCount
+            }
+            if index == 1 {
+                // Slow: finishes after the ban has landed.
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                return .clear
+            }
+            let banned = GateCheckResult.banned(
+                BanState(verdictRef: "verdict-1", authorityContact: "appeals@authority.example")
+            )
+            fastCallFinished.fulfill()
+            return banned
+        }
+    }
+
+    private struct FixedAttestation: DeviceAttestationProvider {
+        var isSupported: Bool { true }
+        func generateToken() async throws -> Data { Data("token".utf8) }
+    }
+
+    private struct FixedSigner: ModerationSigner {
+        func userKeyID() async throws -> String { "onym:key:user" }
+        func sign(_ message: Data) async throws -> Data { Data("sig".utf8) }
+    }
+
+    private final class InMemoryGateStateStore: GateStateStore, @unchecked Sendable {
+        private let lock = NSLock()
+        private var state: PersistedGateState?
+        func load() -> PersistedGateState? { lock.withLock { state } }
+        func save(_ state: PersistedGateState?) { lock.withLock { self.state = state } }
+    }
+
+    private final class SeededMandateStore: MandateStore, @unchecked Sendable {
+        private let records: [MandateRecord]
+        init(records: [MandateRecord]) { self.records = records }
+        func load() -> [MandateRecord] { records }
+        func save(_ records: [MandateRecord]) {}
+    }
+
+    private struct EmptyAuthoritiesFetcher: KnownAuthoritiesFetcher {
+        func fetchLatest() async throws -> [AuthorityListing] { [] }
+    }
+
+    private struct UnusedManifestFetcher: AuthorityManifestFetcher {
+        func fetch(_ listing: AuthorityListing) async throws -> SignedManifest {
+            throw ModerationError.notImplemented("unused")
+        }
+    }
+
+    func testStaleGateCompletionDoesNotOverwriteNewerBan() async throws {
+        let mandate = ModerationMandate(
+            user: "onym:key:user",
+            interface: "onym:component:onym-ios",
+            authority: "onym:component:authority",
+            manifestHash: "aa",
+            classes: ["csam"],
+            deviceBinding: "enrollment-1",
+            acceptedAt: now,
+            signatures: ["user-sig"]
+        )
+        let record = MandateRecord(
+            mandate: mandate,
+            manifestBytes: Data("{}".utf8),
+            authorityName: "A",
+            countersigned: false,
+            isActive: true,
+            createdAt: now
+        )
+        let backend = ReorderingBackend()
+        let moderation = ModerationRepository(
+            authoritiesFetcher: EmptyAuthoritiesFetcher(),
+            manifestFetcher: UnusedManifestFetcher(),
+            mandateStore: SeededMandateStore(records: [record]),
+            backend: backend,
+            attestation: FixedAttestation(),
+            signer: FixedSigner(),
+            clock: { [now] in now }
+        )
+        let gate = GateCheckRepository(
+            attestation: FixedAttestation(),
+            backend: backend,
+            moderation: moderation,
+            signer: FixedSigner(),
+            store: InMemoryGateStateStore(),
+            clock: { [now] in now }
+        )
+
+        // Start the slow check, then the fast one; await both.
+        async let slow: Void = gate.checkNow()
+        try await Task.sleep(nanoseconds: 20_000_000)
+        async let fast: Void = gate.checkNow()
+        _ = await (slow, fast)
+
+        await fulfillment(of: [backend.fastCallFinished], timeout: 5)
+
+        // The slow `.clear` resumed last; without the generation guard
+        // it would have replaced the ban and reopened the app.
+        let status = await gate.currentStatus()
+        XCTAssertEqual(
+            status,
+            .banned(BanState(verdictRef: "verdict-1", authorityContact: "appeals@authority.example"))
+        )
+    }
+}

--- a/Tests/OnymIOSTests/ModerationDomainTests.swift
+++ b/Tests/OnymIOSTests/ModerationDomainTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import OnymModeration
+
+/// Domain primitives: the duration grammar, ban terms, manifest hash
+/// pinning, and mandate signing-bytes determinism — the properties
+/// consent immutability rests on.
+final class ModerationDomainTests: XCTestCase {
+
+    // MARK: - ISO8601Duration
+
+    func testParsesDayGranularDurations() throws {
+        XCTAssertEqual(try ISO8601Duration(parsing: "P1D").days, 1)
+        XCTAssertEqual(try ISO8601Duration(parsing: "P3D").days, 3)
+        XCTAssertEqual(try ISO8601Duration(parsing: "P30D").days, 30)
+        XCTAssertEqual(try ISO8601Duration(parsing: "P365D").days, 365)
+        XCTAssertEqual(try ISO8601Duration(parsing: "P3D").timeInterval, 3 * 86_400)
+        XCTAssertEqual(try ISO8601Duration(parsing: "P7D").raw, "P7D")
+    }
+
+    func testRejectsUnsupportedDurations() {
+        for raw in ["", "P", "PD", "P0D", "P-1D", "PT1H", "P3W", "3D", "P3", "p3d"] {
+            XCTAssertThrowsError(try ISO8601Duration(parsing: raw), raw)
+        }
+    }
+
+    // MARK: - BanTerm
+
+    func testBanTermDecodesPermanentAndDuration() throws {
+        let decoder = JSONDecoder()
+        XCTAssertEqual(
+            try decoder.decode(BanTerm.self, from: Data("\"permanent\"".utf8)),
+            .permanent
+        )
+        XCTAssertEqual(
+            try decoder.decode(BanTerm.self, from: Data("\"P90D\"".utf8)),
+            .duration(try ISO8601Duration(parsing: "P90D"))
+        )
+        XCTAssertThrowsError(
+            try decoder.decode(BanTerm.self, from: Data("\"forever\"".utf8))
+        )
+    }
+
+    // MARK: - Manifest hash pinning
+
+    func testManifestHashIsOverExactBytes() {
+        // SHA-256("abc") — the FIPS 180-2 test vector.
+        XCTAssertEqual(
+            SignedManifest.hash(of: Data("abc".utf8)),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        )
+    }
+
+    func testOneByteDifferenceChangesManifestHash() {
+        let original = Data("{\"version\":1}".utf8)
+        let tweaked = Data("{\"version\":2}".utf8)
+        XCTAssertNotEqual(SignedManifest.hash(of: original), SignedManifest.hash(of: tweaked))
+    }
+
+    // MARK: - Mandate signing bytes
+
+    private func fixtureMandate(signatures: [String] = []) -> ModerationMandate {
+        ModerationMandate(
+            user: "onym:key:user",
+            interface: "onym:component:onym-ios",
+            authority: "onym:component:authority",
+            manifestHash: "aa",
+            classes: ["csam"],
+            deviceBinding: "enrollment-1",
+            acceptedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            signatures: signatures
+        )
+    }
+
+    func testSigningBytesAreDeterministic() throws {
+        let mandate = fixtureMandate()
+        XCTAssertEqual(try mandate.signingBytes(), try mandate.signingBytes())
+    }
+
+    func testSigningBytesExcludeSignatures() throws {
+        // The signed form must not change when signatures are added —
+        // otherwise the interface countersignature would invalidate
+        // the user's own signature.
+        let unsigned = fixtureMandate()
+        let signed = fixtureMandate(signatures: ["user-sig", "interface-sig"])
+        XCTAssertEqual(try unsigned.signingBytes(), try signed.signingBytes())
+        let bytes = try signed.signingBytes()
+        XCTAssertFalse(String(data: bytes, encoding: .utf8)!.contains("signatures"))
+    }
+
+    func testMandateHashStableAcrossCountersigning() throws {
+        // `mandateRef` in notices/verdicts must resolve the same
+        // mandate before and after the interface countersigns.
+        XCTAssertEqual(
+            try fixtureMandate(signatures: ["user-sig"]).mandateHash(),
+            try fixtureMandate(signatures: ["user-sig", "interface-sig"]).mandateHash()
+        )
+    }
+}

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -1,0 +1,297 @@
+import XCTest
+@testable import OnymModeration
+
+/// Consent lifecycle: manifest hash pinning to fetched bytes, mandate
+/// immutability across authority switches, the stub's honesty
+/// guarantees, and the never-fabricate-a-token rule.
+final class ModerationRepositoryTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    private struct FakeAuthoritiesFetcher: KnownAuthoritiesFetcher {
+        let listings: [AuthorityListing]
+        func fetchLatest() async throws -> [AuthorityListing] { listings }
+    }
+
+    private struct FakeManifestFetcher: AuthorityManifestFetcher {
+        /// Raw manifest bytes per componentId — returned verbatim so
+        /// tests control the exact bytes the hash pins.
+        let bytesByComponent: [String: Data]
+
+        func fetch(_ listing: AuthorityListing) async throws -> SignedManifest {
+            guard let bytes = bytesByComponent[listing.componentId] else {
+                throw ModerationError.manifestInvalid("no fixture")
+            }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let manifest = try decoder.decode(AuthorityManifest.self, from: bytes)
+            return SignedManifest(manifest: manifest, rawBytes: bytes)
+        }
+    }
+
+    private final class InMemoryMandateStore: MandateStore, @unchecked Sendable {
+        private let lock = NSLock()
+        private var records: [MandateRecord] = []
+        func load() -> [MandateRecord] { lock.withLock { records } }
+        func save(_ records: [MandateRecord]) { lock.withLock { self.records = records } }
+    }
+
+    /// Records every request so tests can assert what the client
+    /// actually presented (tokens, signatures).
+    private final class RecordingBackend: EnforcementBackendClient, @unchecked Sendable {
+        private let lock = NSLock()
+        var enrollTokens: [Data?] { lock.withLock { _enrollTokens } }
+        var gateRequests: [GateCheckRequest] { lock.withLock { _gateRequests } }
+        private var _enrollTokens: [Data?] = []
+        private var _gateRequests: [GateCheckRequest] = []
+        var gateResult: GateCheckResult = .clear
+
+        func enrollDevice(token: Data?, userKey: String, signature: Data) async throws -> DeviceEnrollment {
+            lock.withLock { _enrollTokens.append(token) }
+            return DeviceEnrollment(deviceBinding: "recorded-enrollment")
+        }
+
+        func countersignMandate(_ mandate: ModerationMandate) async throws -> ModerationMandate {
+            var countersigned = mandate
+            countersigned.signatures.append(StubEnforcementBackendClient.countersignSentinel)
+            return countersigned
+        }
+
+        func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult {
+            lock.withLock { _gateRequests.append(request) }
+            return gateResult
+        }
+    }
+
+    private struct FakeAttestation: DeviceAttestationProvider {
+        let supported: Bool
+        var isSupported: Bool { supported }
+        func generateToken() async throws -> Data {
+            guard supported else { throw ModerationError.attestationUnavailable }
+            return Data("fake-token".utf8)
+        }
+    }
+
+    private struct FakeSigner: ModerationSigner {
+        func userKeyID() async throws -> String { "onym:key:test-user" }
+        func sign(_ message: Data) async throws -> Data { Data("fake-signature".utf8) }
+    }
+
+    // MARK: - Fixtures
+
+    private func manifestBytes(componentId: String, tweak: String = "") -> Data {
+        Data("""
+        {
+          "version": 1,
+          "componentId": "\(componentId)",
+          "seat": "moderation",
+          "operator": "onym:key:operator",
+          "moderationProfileId": "onym:moderation-profile:consent-bound-v1",
+          "violationClasses": [
+            {
+              "classId": "csam",
+              "definition": "hash:csam-def\(tweak)",
+              "responseWindow": "P3D",
+              "decisionDeadline": "P7D",
+              "banTerm": "permanent",
+              "appealWindow": "P30D",
+              "appealEffect": "non-suspensive"
+            }
+          ],
+          "appellate": "onym:component:appellate",
+          "validUntil": "2030-01-01T00:00:00Z",
+          "signature": "unsigned-fixture"
+        }
+        """.utf8)
+    }
+
+    private func listing(_ componentId: String, name: String) -> AuthorityListing {
+        AuthorityListing(
+            componentId: componentId,
+            name: name,
+            manifestURL: URL(string: "https://example.com/\(name).json")!,
+            operatorPublicKeyBase64: ""
+        )
+    }
+
+    private func makeRepository(
+        listings: [AuthorityListing],
+        bytesByComponent: [String: Data],
+        backend: any EnforcementBackendClient,
+        attestation: any DeviceAttestationProvider = FakeAttestation(supported: true),
+        store: MandateStore? = nil
+    ) -> ModerationRepository {
+        ModerationRepository(
+            authoritiesFetcher: FakeAuthoritiesFetcher(listings: listings),
+            manifestFetcher: FakeManifestFetcher(bytesByComponent: bytesByComponent),
+            mandateStore: store ?? InMemoryMandateStore(),
+            backend: backend,
+            attestation: attestation,
+            signer: FakeSigner(),
+            clock: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+    }
+
+    // MARK: - Consent pins fetched bytes
+
+    func testConsentPinsHashOfExactFetchedBytes() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend()
+        )
+
+        let record = try await repository.consent(to: listing(componentId, name: "A"))
+
+        XCTAssertEqual(record.manifestBytes, bytes)
+        XCTAssertEqual(record.mandate.manifestHash, SignedManifest.hash(of: bytes))
+        XCTAssertEqual(record.mandate.user, "onym:key:test-user")
+        XCTAssertEqual(record.mandate.deviceBinding, "recorded-enrollment")
+        XCTAssertEqual(record.mandate.classes, ["csam"])
+        XCTAssertTrue(record.isActive)
+        // The consented snapshot must decode standalone (renders
+        // offline, survives the authority disappearing).
+        XCTAssertNotNil(record.consentedManifest())
+    }
+
+    // MARK: - Switching immutability
+
+    func testSwitchingDeactivatesOldRecordUntouched() async throws {
+        let aID = "onym:component:a"
+        let bID = "onym:component:b"
+        let aBytes = manifestBytes(componentId: aID)
+        let bBytes = manifestBytes(componentId: bID, tweak: "-b")
+        let store = InMemoryMandateStore()
+        let repository = makeRepository(
+            listings: [listing(aID, name: "A"), listing(bID, name: "B")],
+            bytesByComponent: [aID: aBytes, bID: bBytes],
+            backend: RecordingBackend(),
+            store: store
+        )
+
+        let first = try await repository.consent(to: listing(aID, name: "A"))
+        let second = try await repository.consent(to: listing(bID, name: "B"))
+
+        let records = store.load()
+        XCTAssertEqual(records.count, 2)
+        XCTAssertEqual(records.first?.mandate.authority, bID)
+        XCTAssertTrue(second.isActive)
+
+        // The deactivated record is byte-identical apart from the
+        // active flag — mandates are immutable (spec §12).
+        let deactivated = try XCTUnwrap(records.first { $0.mandate.authority == aID })
+        XCTAssertFalse(deactivated.isActive)
+        XCTAssertEqual(deactivated.mandate, first.mandate)
+        XCTAssertEqual(deactivated.manifestBytes, aBytes)
+        XCTAssertEqual(deactivated.mandate.manifestHash, SignedManifest.hash(of: aBytes))
+
+        let active = await repository.activeMandateRecord()
+        XCTAssertEqual(active?.mandate.authority, bID)
+    }
+
+    // MARK: - Stub honesty
+
+    func testStubCountersignSentinelNeverReadsAsCountersigned() async throws {
+        let componentId = "onym:component:a"
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: RecordingBackend()  // appends the stub sentinel
+        )
+
+        let record = try await repository.consent(to: listing(componentId, name: "A"))
+
+        XCTAssertFalse(record.countersigned)
+        XCTAssertEqual(record.mandate.signatures.count, 2)
+        XCTAssertEqual(record.mandate.signatures.last, StubEnforcementBackendClient.countersignSentinel)
+    }
+
+    func testStubEnrollmentBindingIsStableAcrossCalls() async throws {
+        let suite = "stub-backend-tests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let stub = StubEnforcementBackendClient(defaults: defaults)
+
+        let first = try await stub.enrollDevice(token: nil, userKey: "u", signature: Data())
+        let second = try await stub.enrollDevice(token: Data("t".utf8), userKey: "u", signature: Data())
+        XCTAssertEqual(first.deviceBinding, second.deviceBinding)
+    }
+
+    // MARK: - Never fabricate a token
+
+    func testUnsupportedAttestationEnrollsWithNilToken() async throws {
+        let componentId = "onym:component:a"
+        let backend = RecordingBackend()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: backend,
+            attestation: FakeAttestation(supported: false)
+        )
+
+        _ = try await repository.consent(to: listing(componentId, name: "A"))
+
+        XCTAssertEqual(backend.enrollTokens, [nil])
+    }
+
+    func testGateCheckPassesNilTokenThroughAndBlocksOnCheckRequired() async throws {
+        let componentId = "onym:component:a"
+        let backend = RecordingBackend()
+        backend.gateResult = .checkRequired(.attestationUnavailable)
+        let moderation = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: backend,
+            attestation: FakeAttestation(supported: false)
+        )
+        _ = try await moderation.consent(to: listing(componentId, name: "A"))
+
+        let gate = GateCheckRepository(
+            attestation: FakeAttestation(supported: false),
+            backend: backend,
+            moderation: moderation,
+            signer: FakeSigner(),
+            store: InMemoryGateStateStore(),
+            clock: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+        await gate.checkNow()
+
+        XCTAssertEqual(backend.gateRequests.count, 1)
+        XCTAssertNil(backend.gateRequests.first?.deviceToken)
+        let status = await gate.currentStatus()
+        XCTAssertEqual(status, .gateCheckRequired(.attestationUnavailable))
+    }
+
+    func testGateCheckIsNotMandatedWithoutActiveMandate() async throws {
+        let backend = RecordingBackend()
+        let moderation = makeRepository(
+            listings: [],
+            bytesByComponent: [:],
+            backend: backend
+        )
+        let gate = GateCheckRepository(
+            attestation: FakeAttestation(supported: true),
+            backend: backend,
+            moderation: moderation,
+            signer: FakeSigner(),
+            store: InMemoryGateStateStore(),
+            clock: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+        await gate.checkNow()
+
+        // No mandate → no backend calls at all (the protocol stays
+        // usable pre-consent; only this interface requires a mandate).
+        XCTAssertTrue(backend.gateRequests.isEmpty)
+        let status = await gate.currentStatus()
+        XCTAssertEqual(status, .notMandated)
+    }
+
+    private final class InMemoryGateStateStore: GateStateStore, @unchecked Sendable {
+        private let lock = NSLock()
+        private var state: PersistedGateState?
+        func load() -> PersistedGateState? { lock.withLock { state } }
+        func save(_ state: PersistedGateState?) { lock.withLock { self.state = state } }
+    }
+}

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -139,6 +139,97 @@ final class ModerationRepositoryTests: XCTestCase {
         )
     }
 
+    /// Serves one set of bytes on the first fetch and different bytes
+    /// afterwards — an authority editing its hosted terms between the
+    /// user's review and their agreement.
+    private final class SwitchingManifestFetcher: AuthorityManifestFetcher, @unchecked Sendable {
+        private let lock = NSLock()
+        private var fetchCount = 0
+        let first: Data
+        let second: Data
+
+        init(first: Data, second: Data) {
+            self.first = first
+            self.second = second
+        }
+
+        var fetches: Int { lock.withLock { fetchCount } }
+
+        func fetch(_ listing: AuthorityListing) async throws -> SignedManifest {
+            let bytes = lock.withLock { () -> Data in
+                fetchCount += 1
+                return fetchCount == 1 ? first : second
+            }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return SignedManifest(
+                manifest: try decoder.decode(AuthorityManifest.self, from: bytes),
+                rawBytes: bytes
+            )
+        }
+    }
+
+    // MARK: - The reviewed manifest is the signed one
+
+    /// The consent surface promises the mandate binds the exact terms
+    /// shown. If `consent` refetched, an authority could swap them in
+    /// the window between review and agreement.
+    func testConsentPinsTheReviewedManifestNotARefetchedOne() async throws {
+        let componentId = "onym:component:a"
+        let reviewedBytes = manifestBytes(componentId: componentId)
+        let swappedBytes = manifestBytes(componentId: componentId, tweak: "-swapped")
+        XCTAssertNotEqual(reviewedBytes, swappedBytes)
+
+        let fetcher = SwitchingManifestFetcher(first: reviewedBytes, second: swappedBytes)
+        let repository = ModerationRepository(
+            authoritiesFetcher: FakeAuthoritiesFetcher(listings: [listing(componentId, name: "A")]),
+            manifestFetcher: fetcher,
+            mandateStore: InMemoryMandateStore(),
+            backend: RecordingBackend(),
+            attestation: FakeAttestation(supported: true),
+            signer: FakeSigner(),
+            clock: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        let reviewed = try await repository.manifestForReview(listing(componentId, name: "A"))
+        let record = try await repository.consent(
+            to: listing(componentId, name: "A"),
+            reviewedManifest: reviewed
+        )
+
+        XCTAssertEqual(record.mandate.manifestHash, SignedManifest.hash(of: reviewedBytes))
+        XCTAssertEqual(record.manifestBytes, reviewedBytes)
+        XCTAssertNotEqual(record.mandate.manifestHash, SignedManifest.hash(of: swappedBytes))
+        // Exactly one fetch: signing must not go back to the network.
+        XCTAssertEqual(fetcher.fetches, 1)
+    }
+
+    /// A reviewed manifest from a different authority can't be signed
+    /// against this listing.
+    func testConsentRejectsManifestForADifferentAuthority() async throws {
+        let aID = "onym:component:a"
+        let bID = "onym:component:b"
+        let repository = makeRepository(
+            listings: [listing(aID, name: "A"), listing(bID, name: "B")],
+            bytesByComponent: [
+                aID: manifestBytes(componentId: aID),
+                bID: manifestBytes(componentId: bID),
+            ],
+            backend: RecordingBackend()
+        )
+
+        let otherManifest = try await repository.manifestForReview(listing(bID, name: "B"))
+        do {
+            _ = try await repository.consent(
+                to: listing(aID, name: "A"),
+                reviewedManifest: otherManifest
+            )
+            XCTFail("expected a mismatched-authority manifest to be refused")
+        } catch {
+            // expected
+        }
+    }
+
     // MARK: - Consent pins fetched bytes
 
     func testConsentPinsHashOfExactFetchedBytes() async throws {
@@ -150,7 +241,7 @@ final class ModerationRepositoryTests: XCTestCase {
             backend: RecordingBackend()
         )
 
-        let record = try await repository.consent(to: listing(componentId, name: "A"))
+        let record = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
 
         XCTAssertEqual(record.manifestBytes, bytes)
         XCTAssertEqual(record.mandate.manifestHash, SignedManifest.hash(of: bytes))
@@ -178,8 +269,8 @@ final class ModerationRepositoryTests: XCTestCase {
             store: store
         )
 
-        let first = try await repository.consent(to: listing(aID, name: "A"))
-        let second = try await repository.consent(to: listing(bID, name: "B"))
+        let first = try await repository.reviewAndConsent(to: listing(aID, name: "A"))
+        let second = try await repository.reviewAndConsent(to: listing(bID, name: "B"))
 
         let records = store.load()
         XCTAssertEqual(records.count, 2)
@@ -208,7 +299,7 @@ final class ModerationRepositoryTests: XCTestCase {
             backend: RecordingBackend()  // appends the stub sentinel
         )
 
-        let record = try await repository.consent(to: listing(componentId, name: "A"))
+        let record = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
 
         XCTAssertFalse(record.countersigned)
         XCTAssertEqual(record.mandate.signatures.count, 2)
@@ -247,7 +338,7 @@ final class ModerationRepositoryTests: XCTestCase {
             attestation: FakeAttestation(supported: false)
         )
 
-        _ = try await repository.consent(to: listing(componentId, name: "A"))
+        _ = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
 
         XCTAssertEqual(backend.enrollTokens, [nil])
     }
@@ -262,7 +353,7 @@ final class ModerationRepositoryTests: XCTestCase {
             backend: backend,
             attestation: FakeAttestation(supported: false)
         )
-        _ = try await moderation.consent(to: listing(componentId, name: "A"))
+        _ = try await moderation.reviewAndConsent(to: listing(componentId, name: "A"))
 
         let gate = GateCheckRepository(
             attestation: FakeAttestation(supported: false),
@@ -309,5 +400,17 @@ final class ModerationRepositoryTests: XCTestCase {
         private var state: PersistedGateState?
         func load() -> PersistedGateState? { lock.withLock { state } }
         func save(_ state: PersistedGateState?) { lock.withLock { self.state = state } }
+    }
+}
+
+extension ModerationRepository {
+    /// Test convenience for the two-step consent path: review the
+    /// manifest, then consent to that exact value — what the UI does.
+    /// Tests that care about the review/sign split call the two methods
+    /// directly instead.
+    @discardableResult
+    func reviewAndConsent(to listing: AuthorityListing) async throws -> MandateRecord {
+        let reviewed = try await manifestForReview(listing)
+        return try await consent(to: listing, reviewedManifest: reviewed)
     }
 }

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -6,6 +6,9 @@ import XCTest
 /// guarantees, and the never-fabricate-a-token rule.
 final class ModerationRepositoryTests: XCTestCase {
 
+    /// The instant the fixture repositories' injected clock returns.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
     // MARK: - Fakes
 
     private struct FakeAuthoritiesFetcher: KnownAuthoritiesFetcher {
@@ -40,21 +43,24 @@ final class ModerationRepositoryTests: XCTestCase {
     /// actually presented (tokens, signatures).
     private final class RecordingBackend: EnforcementBackendClient, @unchecked Sendable {
         private let lock = NSLock()
-        var enrollTokens: [Data?] { lock.withLock { _enrollTokens } }
+        var enrollRequests: [EnrollmentRequest] { lock.withLock { _enrollRequests } }
+        var enrollTokens: [Data?] { enrollRequests.map(\.deviceToken) }
         var gateRequests: [GateCheckRequest] { lock.withLock { _gateRequests } }
-        private var _enrollTokens: [Data?] = []
+        private var _enrollRequests: [EnrollmentRequest] = []
         private var _gateRequests: [GateCheckRequest] = []
         var gateResult: GateCheckResult = .clear
+        /// When set, `countersignMandate` returns this instead of the
+        /// stub sentinel — lets a test assert what the client does with
+        /// a backend-supplied signature.
+        var countersignature: String = StubEnforcementBackendClient.countersignSentinel
 
-        func enrollDevice(token: Data?, userKey: String, signature: Data) async throws -> DeviceEnrollment {
-            lock.withLock { _enrollTokens.append(token) }
+        func enrollDevice(_ request: EnrollmentRequest) async throws -> DeviceEnrollment {
+            lock.withLock { _enrollRequests.append(request) }
             return DeviceEnrollment(deviceBinding: "recorded-enrollment")
         }
 
-        func countersignMandate(_ mandate: ModerationMandate) async throws -> ModerationMandate {
-            var countersigned = mandate
-            countersigned.signatures.append(StubEnforcementBackendClient.countersignSentinel)
-            return countersigned
+        func countersignMandate(_ mandate: ModerationMandate) async throws -> InterfaceCountersignature {
+            InterfaceCountersignature(signature: lock.withLock { countersignature })
         }
 
         func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult {
@@ -99,6 +105,7 @@ final class ModerationRepositoryTests: XCTestCase {
             }
           ],
           "appellate": "onym:component:appellate",
+          "newHolderAppeal": "hash:new-holder",
           "validUntil": "2030-01-01T00:00:00Z",
           "signature": "unsigned-fixture"
         }
@@ -214,8 +221,17 @@ final class ModerationRepositoryTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suite) }
         let stub = StubEnforcementBackendClient(defaults: defaults)
 
-        let first = try await stub.enrollDevice(token: nil, userKey: "u", signature: Data())
-        let second = try await stub.enrollDevice(token: Data("t".utf8), userKey: "u", signature: Data())
+        let first = try await stub.enrollDevice(
+            EnrollmentRequest(deviceToken: nil, userKey: "u", timestamp: now, signature: Data())
+        )
+        let second = try await stub.enrollDevice(
+            EnrollmentRequest(
+                deviceToken: Data("t".utf8),
+                userKey: "u",
+                timestamp: now.addingTimeInterval(60),
+                signature: Data()
+            )
+        )
         XCTAssertEqual(first.deviceBinding, second.deviceBinding)
     }
 

--- a/Tests/OnymIOSTests/VerdictValidatorTests.swift
+++ b/Tests/OnymIOSTests/VerdictValidatorTests.swift
@@ -1,0 +1,372 @@
+import XCTest
+import CryptoKit
+@testable import OnymModeration
+@testable import OnymFoundation
+
+/// The §5.6 fixture table: mechanical verdict shape validation. Every
+/// case here is a constraint the spec names; a validator change that
+/// breaks one of these is a conformance regression, not a refactor.
+final class VerdictValidatorTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let validator = VerdictValidator()
+
+    /// The key the fixture manifest names as its `operator`. Verdict
+    /// signatures verify against it, so enforce-on tests sign with the
+    /// matching private key.
+    private static let operatorKey = Curve25519.Signing.PrivateKey()
+
+    /// Literal manifest bytes, exactly as production sees them (a
+    /// fetched document), so the pinned hash is stable by construction
+    /// rather than by encoder configuration.
+    private static func manifestBytes(operatorReference: String) -> Data {
+        Data("""
+        {
+          "version": 1,
+          "componentId": "onym:component:authority",
+          "seat": "moderation",
+          "operator": "\(operatorReference)",
+          "moderationProfileId": "onym:moderation-profile:consent-bound-v1",
+          "violationClasses": [
+            {
+              "classId": "csam",
+              "definition": "hash:csam-def",
+              "responseWindow": "P3D",
+              "decisionDeadline": "P7D",
+              "banTerm": "permanent",
+              "appealWindow": "P30D",
+              "appealEffect": "non-suspensive"
+            },
+            {
+              "classId": "unsolicited-pornography",
+              "definition": "hash:up-def",
+              "responseWindow": "P7D",
+              "decisionDeadline": "P14D",
+              "banTerm": "P90D",
+              "appealWindow": "P30D",
+              "appealEffect": "suspensive"
+            }
+          ],
+          "newHolderAppeal": "hash:new-holder",
+          "appellate": "onym:component:appellate",
+          "validUntil": "2030-01-01T00:00:00Z"
+        }
+        """.utf8)
+    }
+
+    private func signedManifest(bytes: Data) throws -> SignedManifest {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return SignedManifest(
+            manifest: try decoder.decode(AuthorityManifest.self, from: bytes),
+            rawBytes: bytes
+        )
+    }
+
+    /// `onym:key:<hex>` for raw key bytes — the form
+    /// `AuthorityKey.rawBytes(fromReference:)` parses.
+    private static func reference(for publicKey: Curve25519.Signing.PublicKey) -> String {
+        AuthorityKey.referencePrefix
+            + publicKey.rawRepresentation.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func fixtureManifest() throws -> SignedManifest {
+        try signedManifest(
+            bytes: Self.manifestBytes(operatorReference: Self.reference(for: Self.operatorKey.publicKey))
+        )
+    }
+
+    /// Pinned to the fixture manifest's real hash — the validator
+    /// requires the supplied manifest to be the consented one.
+    private func fixtureMandate() -> ModerationMandate {
+        ModerationMandate(
+            user: "onym:key:user",
+            interface: "onym:component:onym-ios",
+            authority: "onym:component:authority",
+            manifestHash: (try? fixtureManifest().manifestHash) ?? "",
+            classes: ["csam", "unsolicited-pornography"],
+            deviceBinding: "enrollment-1",
+            acceptedAt: now.addingTimeInterval(-30 * 86_400),
+            signatures: ["user-sig"]
+        )
+    }
+
+    /// A shape-valid, executed (`executeAfter == decidedAt`, both in
+    /// the past) non-suspensive ban against the permanent class.
+    private func validBan(mandate: ModerationMandate) throws -> Verdict {
+        let decidedAt = now.addingTimeInterval(-86_400)
+        return Verdict(
+            caseId: "case-1",
+            authority: "onym:component:authority",
+            mandateRef: try mandate.mandateHash(),
+            accusedKeys: ["onym:key:user"],
+            deviceBinding: "enrollment-1",
+            classId: "csam",
+            disposition: .ban,
+            marks: Marks(caseOpen: false, banned: true),
+            banExpires: nil,  // permanent class
+            executeAfter: decidedAt,
+            reasoning: "hash:findings",
+            appealDeadline: now.addingTimeInterval(29 * 86_400),
+            decidedAt: decidedAt,
+            signature: "unsigned-fixture",
+            isFinal: false
+        )
+    }
+
+    private func copy(
+        _ verdict: Verdict,
+        classId: String? = nil,
+        disposition: Verdict.Disposition? = nil,
+        marks: Marks? = nil,
+        banExpires: Date?? = nil,
+        executeAfter: Date?? = nil,
+        reasoning: String? = nil,
+        appealDeadline: Date?? = nil,
+        mandateRef: String? = nil,
+        deviceBinding: String? = nil,
+        isFinal: Bool? = nil
+    ) -> Verdict {
+        Verdict(
+            caseId: verdict.caseId,
+            authority: verdict.authority,
+            mandateRef: mandateRef ?? verdict.mandateRef,
+            accusedKeys: verdict.accusedKeys,
+            deviceBinding: deviceBinding ?? verdict.deviceBinding,
+            classId: classId ?? verdict.classId,
+            disposition: disposition ?? verdict.disposition,
+            marks: marks ?? verdict.marks,
+            banExpires: banExpires ?? verdict.banExpires,
+            executeAfter: executeAfter ?? verdict.executeAfter,
+            reasoning: reasoning ?? verdict.reasoning,
+            appealDeadline: appealDeadline ?? verdict.appealDeadline,
+            decidedAt: verdict.decidedAt,
+            signature: verdict.signature,
+            isFinal: isFinal ?? verdict.isFinal
+        )
+    }
+
+    private func validate(_ verdict: Verdict) throws -> VerdictValidator.Outcome {
+        try validator.validate(
+            verdict,
+            mandate: fixtureMandate(),
+            consented: try fixtureManifest(),
+            now: now,
+            enforceSignature: false
+        )
+    }
+
+    // MARK: - Executable shapes
+
+    func testValidNonSuspensiveBanExecutes() throws {
+        XCTAssertEqual(try validate(try validBan(mandate: fixtureMandate())), .execute)
+    }
+
+    func testSuspensiveBanStoredUntilExecuteAfter() throws {
+        // Suspensive class: executeAfter == appealDeadline, which is
+        // still in the future → stored, not executed (early mark
+        // writes are nonconforming).
+        let appealDeadline = now.addingTimeInterval(29 * 86_400)
+        let verdict = copy(
+            try validBan(mandate: fixtureMandate()),
+            classId: "unsolicited-pornography",
+            banExpires: .some(now.addingTimeInterval(119 * 86_400)),
+            executeAfter: .some(appealDeadline),
+            appealDeadline: .some(appealDeadline)
+        )
+        XCTAssertEqual(try validate(verdict), .storeUntilExecuteAfter(appealDeadline))
+    }
+
+    func testValidOpenCaseAndDismissalExecute() throws {
+        let base = try validBan(mandate: fixtureMandate())
+        let openCase = copy(
+            base,
+            disposition: .openCase,
+            marks: Marks(caseOpen: true, banned: false),
+            banExpires: .some(nil),
+            executeAfter: .some(nil),
+            reasoning: "hash:intake",
+            appealDeadline: .some(nil)
+        )
+        XCTAssertEqual(try validate(openCase), .execute)
+
+        let dismissal = copy(
+            base,
+            disposition: .dismiss,
+            marks: Marks(caseOpen: false, banned: false),
+            executeAfter: .some(nil)
+        )
+        XCTAssertEqual(try validate(dismissal), .execute)
+    }
+
+    // MARK: - Mandate binding
+
+    func testMandateRefMismatchIsNoMandate() throws {
+        let verdict = copy(try validBan(mandate: fixtureMandate()), mandateRef: "deadbeef")
+        XCTAssertThrowsError(try validate(verdict)) { error in
+            XCTAssertEqual(error as? ModerationError, .noMandate)
+        }
+    }
+
+    func testClassOutsideMandateRefused() throws {
+        let verdict = copy(try validBan(mandate: fixtureMandate()), classId: "spam")
+        XCTAssertThrowsError(try validate(verdict)) { error in
+            XCTAssertEqual(error as? ModerationError, .classOutsideMandate("spam"))
+        }
+    }
+
+    func testDeviceBindingOutsideMandateRefused() throws {
+        let verdict = copy(try validBan(mandate: fixtureMandate()), deviceBinding: "other-device")
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    // MARK: - Ban shape
+
+    func testBanWithInconsistentMarksRefused() throws {
+        let verdict = copy(
+            try validBan(mandate: fixtureMandate()),
+            marks: Marks(caseOpen: true, banned: true)
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testBanMissingExpiryOnNonPermanentClassRefused() throws {
+        let appealDeadline = now.addingTimeInterval(29 * 86_400)
+        let verdict = copy(
+            try validBan(mandate: fixtureMandate()),
+            classId: "unsolicited-pornography",
+            banExpires: .some(nil),
+            executeAfter: .some(appealDeadline),
+            appealDeadline: .some(appealDeadline)
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testBanMissingExecuteAfterRefused() throws {
+        let verdict = copy(try validBan(mandate: fixtureMandate()), executeAfter: .some(nil))
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testNonSuspensiveExecuteAfterMustEqualDecidedAt() throws {
+        let base = try validBan(mandate: fixtureMandate())
+        let verdict = copy(base, executeAfter: .some(base.decidedAt.addingTimeInterval(60)))
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testSuspensiveExecuteAfterMustEqualAppealDeadline() throws {
+        let base = try validBan(mandate: fixtureMandate())
+        let verdict = copy(
+            base,
+            classId: "unsolicited-pornography",
+            banExpires: .some(now.addingTimeInterval(119 * 86_400)),
+            executeAfter: .some(base.decidedAt)  // ≠ appealDeadline
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    // MARK: - Open-case / dismissal shape
+
+    func testOpenCaseCarryingSanctionFieldsRefused() throws {
+        let base = try validBan(mandate: fixtureMandate())
+        let verdict = copy(
+            base,
+            disposition: .openCase,
+            marks: Marks(caseOpen: true, banned: false),
+            banExpires: .some(now.addingTimeInterval(90 * 86_400)),
+            executeAfter: .some(nil),
+            appealDeadline: .some(nil)
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testEmptyReasoningRefused() throws {
+        let verdict = copy(try validBan(mandate: fixtureMandate()), reasoning: "")
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    func testDismissalWithResidualMarksRefused() throws {
+        let verdict = copy(
+            try validBan(mandate: fixtureMandate()),
+            disposition: .dismiss,
+            marks: Marks(caseOpen: true, banned: false),
+            executeAfter: .some(nil)
+        )
+        XCTAssertThrowsError(try validate(verdict))
+    }
+
+    // MARK: - Signature enforcement
+
+    func testEnforcedSignatureAcceptsProperlySignedVerdict() throws {
+        // Signed by the key the consented manifest names as its
+        // `operator` — the validator derives the verifier from there.
+        let mandate = fixtureMandate()
+        let unsigned = try validBan(mandate: mandate)
+        let signature = try Self.operatorKey.signature(for: try unsigned.signingBytes())
+        let signed = Verdict(
+            caseId: unsigned.caseId,
+            authority: unsigned.authority,
+            mandateRef: unsigned.mandateRef,
+            accusedKeys: unsigned.accusedKeys,
+            deviceBinding: unsigned.deviceBinding,
+            classId: unsigned.classId,
+            disposition: unsigned.disposition,
+            marks: unsigned.marks,
+            banExpires: unsigned.banExpires,
+            executeAfter: unsigned.executeAfter,
+            reasoning: unsigned.reasoning,
+            appealDeadline: unsigned.appealDeadline,
+            decidedAt: unsigned.decidedAt,
+            signature: signature.base64EncodedString(),
+            isFinal: unsigned.isFinal
+        )
+        let outcome = try validator.validate(
+            signed,
+            mandate: mandate,
+            consented: try fixtureManifest(),
+            now: now,
+            enforceSignature: true
+        )
+        XCTAssertEqual(outcome, .execute)
+    }
+
+    /// A verdict signed by anyone other than the consented manifest's
+    /// operator must not execute under enforcement.
+    func testEnforcedSignatureRejectsWrongKey() throws {
+        let signingKey = Curve25519.Signing.PrivateKey()
+        let mandate = fixtureMandate()
+        let unsigned = try validBan(mandate: mandate)
+        let signature = try signingKey.signature(for: try unsigned.signingBytes())
+        let verdict = Verdict(
+            caseId: unsigned.caseId,
+            authority: unsigned.authority,
+            mandateRef: unsigned.mandateRef,
+            accusedKeys: unsigned.accusedKeys,
+            deviceBinding: unsigned.deviceBinding,
+            classId: unsigned.classId,
+            disposition: unsigned.disposition,
+            marks: unsigned.marks,
+            banExpires: unsigned.banExpires,
+            executeAfter: unsigned.executeAfter,
+            reasoning: unsigned.reasoning,
+            appealDeadline: unsigned.appealDeadline,
+            decidedAt: unsigned.decidedAt,
+            signature: signature.base64EncodedString(),
+            isFinal: unsigned.isFinal
+        )
+        XCTAssertThrowsError(try validator.validate(
+            verdict,
+            mandate: mandate,
+            consented: try fixtureManifest(),
+            now: now,
+            enforceSignature: true
+        ))
+    }
+
+    func testSoftModeAcceptsUnverifiableSignature() throws {
+        // Default posture until real authorities sign verdicts: log
+        // and accept, exactly like `ContractsTrust` soft mode.
+        XCTAssertEqual(try validate(try validBan(mandate: fixtureMandate())), .execute)
+    }
+}


### PR DESCRIPTION
## What

Stacked on the wiring PR; final PR of the stack — all 40 moderation tests, green on the iPhone 17 simulator.

- **`VerdictValidatorTests` (17)** — the Moderation.md §5.6 fixture table: mandateRef mismatch (`no_mandate`), class/device outside mandate, marks-vs-disposition consistency, `banExpires` required on non-permanent classes, `executeAfter` = `decidedAt` (non-suspensive) / `appealDeadline` (suspensive), early-write refusal (`.storeUntilExecuteAfter`), open-case verdicts carrying sanction fields, empty reasoning, dismissal with residual marks — plus real Ed25519 enforce-on signature accept/reject and the soft-mode default.
- **`GateCheckDeriveTests` (8)** — pure cadence arithmetic: success per result kind, unreachable inside/at/past the P3D grace boundary, no-history → blocked, grace never launders a ban, `GateCheckResult` Codable round-trip through the UserDefaults store.
- **`ModerationDomainTests` (8)** — `P<n>D` duration grammar (accept/reject table), `BanTerm` decode, SHA-256 exact-bytes hash (FIPS vector), one-byte tamper changes the hash, `signingBytes()` deterministic + signature-independent, mandate hash stable across countersigning.
- **`ModerationRepositoryTests` (7)** — consent pins the hash of the exact fetched bytes and stores the snapshot; switching deactivates the old record byte-identically; stub countersign sentinel never reads as countersigned; stub enrollment binding stable; unsupported attestation sends `token: nil` (never fabricates) and check-required blocks; no mandate → no backend calls.

## Stack

- PR-1: #216 — domain + seams + stubs
- PR-2: #217 — UI package
- PR-3: wiring
- **PR-4 (this): tests**

🤖 Generated with [Claude Code](https://claude.com/claude-code)