### PR TITLE
feat(moderation): canonical signing bytes for reports, responses and appeals

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -123,6 +123,11 @@ public struct CaseStatus: Codable, Sendable, Equatable {
 /// window), and `accept-mandate` is authority-side. One implementation
 /// per authority; the repository picks the client for the mandated
 /// authority, which is what makes authorities swappable.
+///
+/// An HTTP implementation must put `CaseResponse.caseId` and
+/// `AppealSubmission.caseId` in both the request path and the signed body.
+/// The authority must reject a path/body mismatch; trusting either one alone
+/// would reopen the cross-case replay that signing `caseId` prevents.
 public protocol ModerationAuthorityClient: Sendable {
     func fileReport(_ report: Report) async throws -> ReportReceipt
     func respond(_ response: CaseResponse) async throws

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -19,11 +19,24 @@ public struct ReportReceipt: Codable, Sendable, Equatable {
 /// through the same object, so `submit-evidence` needs no separate
 /// operation client-side.
 public struct CaseResponse: Codable, Sendable, Equatable {
+    /// The case being answered. Carried in the object — and therefore
+    /// inside the signed bytes — rather than alongside it: a signed
+    /// statement that names no case can be lifted from the case it was
+    /// written for and replayed onto another, so an innocuous "that
+    /// wasn't me" would register as an answer to an accusation its
+    /// signer never saw.
+    public let caseId: String
     public let statement: String
     public let evidence: [EvidenceItem]
     public var signature: String
 
-    public init(statement: String, evidence: [EvidenceItem] = [], signature: String = "") {
+    public init(
+        caseId: String,
+        statement: String,
+        evidence: [EvidenceItem] = [],
+        signature: String = ""
+    ) {
+        self.caseId = caseId
         self.statement = statement
         self.evidence = evidence
         self.signature = signature
@@ -33,11 +46,12 @@ public struct CaseResponse: Codable, Sendable, Equatable {
     /// See `ModerationCanonicalEncoder` for why the ordering matters.
     public func signingBytes() throws -> Data {
         struct Unsigned: Encodable {
+            let caseId: String
             let statement: String
             let evidence: [EvidenceItem]
         }
         return try ModerationCanonicalEncoder.encode(
-            Unsigned(statement: statement, evidence: evidence)
+            Unsigned(caseId: caseId, statement: statement, evidence: evidence)
         )
     }
 }
@@ -51,11 +65,15 @@ public struct AppealSubmission: Codable, Sendable, Equatable {
         case newHolderClaim = "new-holder-claim"
     }
 
+    /// The case appealed. Signed, for the same replay reason as
+    /// `CaseResponse.caseId`.
+    public let caseId: String
     public let kind: Kind
     public let statement: String
     public var signature: String
 
-    public init(kind: Kind, statement: String, signature: String = "") {
+    public init(caseId: String, kind: Kind, statement: String, signature: String = "") {
+        self.caseId = caseId
         self.kind = kind
         self.statement = statement
         self.signature = signature
@@ -69,11 +87,12 @@ public struct AppealSubmission: Codable, Sendable, Equatable {
     /// the mandated user (§5.7).
     public func signingBytes() throws -> Data {
         struct Unsigned: Encodable {
+            let caseId: String
             let kind: Kind
             let statement: String
         }
         return try ModerationCanonicalEncoder.encode(
-            Unsigned(kind: kind, statement: statement)
+            Unsigned(caseId: caseId, kind: kind, statement: statement)
         )
     }
 }
@@ -106,8 +125,8 @@ public struct CaseStatus: Codable, Sendable, Equatable {
 /// authority, which is what makes authorities swappable.
 public protocol ModerationAuthorityClient: Sendable {
     func fileReport(_ report: Report) async throws -> ReportReceipt
-    func respond(caseId: String, _ response: CaseResponse) async throws
-    func appeal(caseId: String, _ submission: AppealSubmission) async throws
+    func respond(_ response: CaseResponse) async throws
+    func appeal(_ submission: AppealSubmission) async throws
     func queryStatus(caseId: String) async throws -> CaseStatus
 }
 
@@ -121,11 +140,11 @@ public struct StubModerationAuthorityClient: ModerationAuthorityClient {
         throw ModerationError.notImplemented("file-report")
     }
 
-    public func respond(caseId: String, _ response: CaseResponse) async throws {
+    public func respond(_ response: CaseResponse) async throws {
         throw ModerationError.notImplemented("respond")
     }
 
-    public func appeal(caseId: String, _ submission: AppealSubmission) async throws {
+    public func appeal(_ submission: AppealSubmission) async throws {
         throw ModerationError.notImplemented("appeal")
     }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -28,6 +28,18 @@ public struct CaseResponse: Codable, Sendable, Equatable {
         self.evidence = evidence
         self.signature = signature
     }
+
+    /// The bytes the accused signs: every field except `signature`.
+    /// See `ModerationCanonicalEncoder` for why the ordering matters.
+    public func signingBytes() throws -> Data {
+        struct Unsigned: Encodable {
+            let statement: String
+            let evidence: [EvidenceItem]
+        }
+        return try ModerationCanonicalEncoder.encode(
+            Unsigned(statement: statement, evidence: evidence)
+        )
+    }
 }
 
 /// An appeal filed within the declared window — or a new-holder claim,
@@ -47,6 +59,22 @@ public struct AppealSubmission: Codable, Sendable, Equatable {
         self.kind = kind
         self.statement = statement
         self.signature = signature
+    }
+
+    /// The bytes the accused signs: every field except `signature`.
+    ///
+    /// A `newHolderClaim` is signed too where the holder still has the
+    /// mandated identity, but an authority cannot require it — the
+    /// whole premise of that path is a device whose new owner is *not*
+    /// the mandated user (§5.7).
+    public func signingBytes() throws -> Data {
+        struct Unsigned: Encodable {
+            let kind: Kind
+            let statement: String
+        }
+        return try ModerationCanonicalEncoder.encode(
+            Unsigned(kind: kind, statement: statement)
+        )
     }
 }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationCanonicalEncoder.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationCanonicalEncoder.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// The one encoder configuration every moderation signing form uses.
+///
+/// Two settings, both load-bearing:
+///
+/// - **`.sortedKeys`** — `JSONEncoder` sorts keys by UTF-8 byte order.
+///   Beware that `JSONSerialization` has an option of the same name
+///   that sorts *case-insensitively*; the two disagree whenever keys
+///   differ by case at the deciding character. Among the moderation
+///   objects, `Report` is the one where that actually bites
+///   (`reportId`/`reportVersion` versus `reporter`), so signing bytes
+///   must never be produced through `JSONSerialization`.
+/// - **`.iso8601` dates** — seconds precision, UTC, matching the form
+///   every timestamp crosses the wire in.
+///
+/// Byte order is also what every non-Apple JSON library does by
+/// default (serde_json, Go's `encoding/json`, Python's `sort_keys`),
+/// which is what lets an authority written in another language
+/// reconstruct these bytes at all.
+///
+/// PROVISIONAL: the draft spec fixes no canonical JSON form. When it
+/// does, this is the single place that changes — and objects signed
+/// before then will need re-signing.
+enum ModerationCanonicalEncoder {
+    static func encode<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(value)
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationCanonicalEncoder.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationCanonicalEncoder.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The one encoder configuration every moderation signing form uses.
 ///
-/// Two settings, both load-bearing:
+/// Three rules, all load-bearing:
 ///
 /// - **`.sortedKeys`** — `JSONEncoder` sorts keys by UTF-8 byte order.
 ///   Beware that `JSONSerialization` has an option of the same name
@@ -13,6 +13,10 @@ import Foundation
 ///   must never be produced through `JSONSerialization`.
 /// - **`.iso8601` dates** — seconds precision, UTC, matching the form
 ///   every timestamp crosses the wire in.
+/// - **Nil optionals are omitted** — Swift's synthesized `Encodable`
+///   uses `encodeIfPresent`, so absent values are not emitted as JSON
+///   `null`. This applies to `EvidenceItem.context` and the optional
+///   verdict dates; another implementation must preserve that form.
 ///
 /// Byte order is also what every non-Apple JSON library does by
 /// default (serde_json, Go's `encoding/json`, Python's `sort_keys`),

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationMandate.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationMandate.swift
@@ -80,10 +80,7 @@ public struct ModerationMandate: Codable, Sendable, Equatable {
             deviceBinding: deviceBinding,
             acceptedAt: acceptedAt
         )
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        return try encoder.encode(unsigned)
+        return try ModerationCanonicalEncoder.encode(unsigned)
     }
 
     /// `mandateRef` as verdicts and notices carry it: SHA-256

--- a/Packages/OnymModeration/Sources/OnymModeration/Report.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/Report.swift
@@ -58,4 +58,43 @@ public struct Report: Codable, Sendable, Equatable {
         self.filedAt = filedAt
         self.signature = signature
     }
+
+    /// The bytes the reporter signs: every field except `signature`.
+    ///
+    /// Keys sort by **UTF-8 byte order**, which is what
+    /// `JSONEncoder.OutputFormatting.sortedKeys` does. That is not a
+    /// free choice here: `Foundation` also offers
+    /// `JSONSerialization`'s `.sortedKeys`, which sorts
+    /// *case-insensitively*, and `Report` is the one moderation object
+    /// whose keys actually disagree between the two —
+    /// `reportId` and `reportVersion` precede `reporter` by byte order
+    /// and follow it case-insensitively. An authority reconstructing
+    /// these bytes with a byte-ordered JSON library (serde_json, Go's
+    /// encoding/json, Python's `sort_keys`) would reject every
+    /// signature produced the other way, so this must stay on
+    /// `JSONEncoder`. `SigningBytesTests` pins exactly that.
+    ///
+    /// Same PROVISIONAL caveat as `ModerationMandate.signingBytes()`:
+    /// the draft spec fixes no canonical JSON form, so this agreement
+    /// holds by construction between implementations rather than by
+    /// specification.
+    public func signingBytes() throws -> Data {
+        struct Unsigned: Encodable {
+            let reportVersion: Int
+            let reportId, reporter, reporterMandate, accused, classId: String
+            let evidence: [EvidenceItem]
+            let filedAt: Date
+        }
+        let unsigned = Unsigned(
+            reportVersion: reportVersion,
+            reportId: reportId,
+            reporter: reporter,
+            reporterMandate: reporterMandate,
+            accused: accused,
+            classId: classId,
+            evidence: evidence,
+            filedAt: filedAt
+        )
+        return try ModerationCanonicalEncoder.encode(unsigned)
+    }
 }

--- a/Packages/OnymModeration/Sources/OnymModeration/Report.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/Report.swift
@@ -72,7 +72,7 @@ public struct Report: Codable, Sendable, Equatable {
     /// these bytes with a byte-ordered JSON library (serde_json, Go's
     /// encoding/json, Python's `sort_keys`) would reject every
     /// signature produced the other way, so this must stay on
-    /// `JSONEncoder`. `SigningBytesTests` pins exactly that.
+    /// `JSONEncoder`. `ModerationCanonicalOrderTests` pins exactly that.
     ///
     /// Same PROVISIONAL caveat as `ModerationMandate.signingBytes()`:
     /// the draft spec fixes no canonical JSON form, so this agreement

--- a/Packages/OnymModeration/Sources/OnymModeration/Verdict.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/Verdict.swift
@@ -132,9 +132,6 @@ public struct Verdict: Codable, Sendable, Equatable {
             decidedAt: decidedAt,
             final: isFinal
         )
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        return try encoder.encode(unsigned)
+        return try ModerationCanonicalEncoder.encode(unsigned)
     }
 }

--- a/Tests/OnymIOSTests/ModerationCanonicalOrderTests.swift
+++ b/Tests/OnymIOSTests/ModerationCanonicalOrderTests.swift
@@ -16,7 +16,7 @@ import OnymModeration
 /// These tests pin the byte-order rule so a future switch to
 /// `JSONSerialization` fails here instead.
 final class ModerationCanonicalOrderTests: XCTestCase {
-    private func keyOrder(of data: Data) throws -> [String] {
+    private func keyOrder(of data: Data, atDepth targetDepth: Int = 1) throws -> [String] {
         // Scan the raw JSON rather than parsing: parsing into a
         // dictionary discards the very thing under test.
         let text = try XCTUnwrap(String(data: data, encoding: .utf8))
@@ -25,23 +25,56 @@ final class ModerationCanonicalOrderTests: XCTestCase {
         var depth = 0
         while index < text.endIndex {
             let character = text[index]
-            if character == "{" || character == "[" { depth += 1 }
-            if character == "}" || character == "]" { depth -= 1 }
-            if character == "\"", depth == 1 {
-                let start = text.index(after: index)
-                if let end = text[start...].firstIndex(of: "\"") {
-                    let candidate = String(text[start..<end])
-                    let after = text.index(after: end)
-                    if after < text.endIndex, text[after] == ":" {
-                        keys.append(candidate)
+            if character == "{" || character == "[" {
+                depth += 1
+                index = text.index(after: index)
+                continue
+            }
+            if character == "}" || character == "]" {
+                depth -= 1
+                index = text.index(after: index)
+                continue
+            }
+            if character == "\"" {
+                var cursor = text.index(after: index)
+                var candidate = ""
+                var escaped = false
+                while cursor < text.endIndex {
+                    let current = text[cursor]
+                    if escaped {
+                        candidate.append(current)
+                        escaped = false
+                    } else if current == "\\" {
+                        escaped = true
+                    } else if current == "\"" {
+                        break
+                    } else {
+                        candidate.append(current)
                     }
-                    index = after
-                    continue
+                    cursor = text.index(after: cursor)
                 }
+                guard cursor < text.endIndex else {
+                    XCTFail("unterminated JSON string")
+                    return keys
+                }
+
+                var after = text.index(after: cursor)
+                while after < text.endIndex, text[after].isWhitespace {
+                    after = text.index(after: after)
+                }
+                if depth == targetDepth, after < text.endIndex, text[after] == ":" {
+                    keys.append(candidate)
+                }
+                index = after
+                continue
             }
             index = text.index(after: index)
         }
         return keys
+    }
+
+    private func byteOrdered(_ keys: [String]) -> [String] {
+        keys.sorted { Array($0.utf8).lexicographicallyPrecedes(Array($1.utf8)) }
     }
 
     private func makeReport() -> Report {
@@ -54,7 +87,8 @@ final class ModerationCanonicalOrderTests: XCTestCase {
             evidence: [
                 EvidenceItem(
                     disclosedContent: "the disclosed message",
-                    authenticityProof: "c2VuZGVyLXNpZ25hdHVyZQ=="
+                    authenticityProof: "c2VuZGVyLXNpZ25hdHVyZQ==",
+                    context: "the preceding exchange"
                 )
             ],
             filedAt: Date(timeIntervalSince1970: 1_700_000_000),
@@ -96,6 +130,13 @@ final class ModerationCanonicalOrderTests: XCTestCase {
         )
     }
 
+    func test_reportSigningBytes_haveTheExactNestedEvidenceKeyOrder() throws {
+        XCTAssertEqual(
+            try keyOrder(of: try makeReport().signingBytes(), atDepth: 3),
+            ["authenticityProof", "context", "disclosedContent"]
+        )
+    }
+
     /// Guard against anyone "simplifying" the encoder: this is what the
     /// bytes would look like if produced through `JSONSerialization`,
     /// and it must not be what we emit.
@@ -116,22 +157,14 @@ final class ModerationCanonicalOrderTests: XCTestCase {
         XCTAssertNotEqual(oursCollisionPart, theirs)
     }
 
-    /// The objects that already cross this boundary sort identically
-    /// under both rules — which is why the interface has interoperated
-    /// so far. Pinned so a renamed field can't quietly change that.
-    func test_mandateAndVerdictKeysAreUnaffectedByTheOrderingDifference() throws {
-        for keys in [
-            ["mandateVersion", "user", "interface", "authority", "manifestHash",
-             "classes", "deviceBinding", "acceptedAt"],
-            ["verdictVersion", "caseId", "authority", "mandateRef", "accusedKeys",
-             "deviceBinding", "classId", "disposition", "marks", "banExpires",
-             "executeAfter", "reasoning", "appealDeadline", "decidedAt", "final"],
-        ] {
-            let byteOrder = keys.sorted { Array($0.utf8).lexicographicallyPrecedes(Array($1.utf8)) }
-            let object = Dictionary(uniqueKeysWithValues: keys.map { ($0, 1) })
-            let serialized = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
-            XCTAssertEqual(try keyOrder(of: serialized), byteOrder)
-        }
+    /// Pin the ordering check to the actual signed forms rather than
+    /// parallel hardcoded key lists that can drift from the types.
+    func test_mandateAndVerdictSigningBytes_sortKeysByByteOrder() throws {
+        let mandateKeys = try keyOrder(of: try makeMandate().signingBytes())
+        XCTAssertEqual(mandateKeys, byteOrdered(mandateKeys))
+
+        let verdictKeys = try keyOrder(of: try makeVerdict().signingBytes())
+        XCTAssertEqual(verdictKeys, byteOrdered(verdictKeys))
     }
 
     // MARK: - Response and appeal
@@ -139,7 +172,7 @@ final class ModerationCanonicalOrderTests: XCTestCase {
     func test_responseAndAppealSigningBytesExcludeTheirSignature() throws {
         let response = CaseResponse(
             caseId: "case-1",
-            statement: "context changes its meaning",
+            statement: #"context { changes "its" [meaning] }"#,
             signature: "c2ln"
         )
         XCTAssertEqual(try keyOrder(of: try response.signingBytes()), ["caseId", "evidence", "statement"])
@@ -174,5 +207,38 @@ final class ModerationCanonicalOrderTests: XCTestCase {
         let before = try report.signingBytes()
         report.signature = "ZGlmZmVyZW50LXNpZ25hdHVyZQ=="
         XCTAssertEqual(try report.signingBytes(), before)
+    }
+
+    private func makeMandate() -> ModerationMandate {
+        ModerationMandate(
+            user: "onym:key:\(String(repeating: "ab", count: 32))",
+            interface: ModerationRepository.interfaceComponentId,
+            authority: "onym:component:test-authority",
+            manifestHash: String(repeating: "0", count: 64),
+            classes: ["unsolicited-pornography"],
+            deviceBinding: "enrollment-1",
+            acceptedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            signatures: ["dXNlci1zaWc="]
+        )
+    }
+
+    private func makeVerdict() -> Verdict {
+        Verdict(
+            caseId: "case-1",
+            authority: "onym:component:test-authority",
+            mandateRef: String(repeating: "1", count: 64),
+            accusedKeys: ["onym:key:\(String(repeating: "ab", count: 32))"],
+            deviceBinding: "enrollment-1",
+            classId: "unsolicited-pornography",
+            disposition: .ban,
+            marks: Marks(caseOpen: false, banned: true),
+            banExpires: Date(timeIntervalSince1970: 1_800_000_000),
+            executeAfter: Date(timeIntervalSince1970: 1_700_000_000),
+            reasoning: "reasoning-hash",
+            appealDeadline: Date(timeIntervalSince1970: 1_700_000_000),
+            decidedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            signature: "YXV0aG9yaXR5LXNpZw==",
+            isFinal: false
+        )
     }
 }

--- a/Tests/OnymIOSTests/ModerationCanonicalOrderTests.swift
+++ b/Tests/OnymIOSTests/ModerationCanonicalOrderTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+import OnymModeration
+
+/// Key ordering in the signed payloads.
+///
+/// Signing bytes only work if the *other* side can reproduce them, and
+/// the other side is a moderation authority that may be written in any
+/// language. Every mainstream JSON library sorts object keys by UTF-8
+/// byte order — with one exception that ships in this very process:
+/// `JSONSerialization`'s `.sortedKeys` sorts *case-insensitively*,
+/// unlike `JSONEncoder`'s option of the same name.
+///
+/// Among the moderation objects only `Report` has keys that disagree
+/// between those two rules, so it is the one that would break, and it
+/// would break silently — as "every report signature is invalid".
+/// These tests pin the byte-order rule so a future switch to
+/// `JSONSerialization` fails here instead.
+final class ModerationCanonicalOrderTests: XCTestCase {
+    private func keyOrder(of data: Data) throws -> [String] {
+        // Scan the raw JSON rather than parsing: parsing into a
+        // dictionary discards the very thing under test.
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        var keys: [String] = []
+        var index = text.startIndex
+        var depth = 0
+        while index < text.endIndex {
+            let character = text[index]
+            if character == "{" || character == "[" { depth += 1 }
+            if character == "}" || character == "]" { depth -= 1 }
+            if character == "\"", depth == 1 {
+                let start = text.index(after: index)
+                if let end = text[start...].firstIndex(of: "\"") {
+                    let candidate = String(text[start..<end])
+                    let after = text.index(after: end)
+                    if after < text.endIndex, text[after] == ":" {
+                        keys.append(candidate)
+                    }
+                    index = after
+                    continue
+                }
+            }
+            index = text.index(after: index)
+        }
+        return keys
+    }
+
+    private func makeReport() -> Report {
+        Report(
+            reportId: "report-1",
+            reporter: "onym:key:\(String(repeating: "ab", count: 32))",
+            reporterMandate: String(repeating: "1", count: 64),
+            accused: "onym:key:\(String(repeating: "cd", count: 32))",
+            classId: "unsolicited-pornography",
+            evidence: [
+                EvidenceItem(
+                    disclosedContent: "the disclosed message",
+                    authenticityProof: "c2VuZGVyLXNpZ25hdHVyZQ=="
+                )
+            ],
+            filedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            signature: "cmVwb3J0ZXItc2ln"
+        )
+    }
+
+    /// The case that actually differs between the two Foundation
+    /// rules. Byte order puts the capitalised `I`/`V` before lowercase
+    /// `e`; a case-insensitive sort puts `reporter*` first.
+    func test_reportSigningBytes_sortKeysByByteOrderNotCaseInsensitively() throws {
+        let order = try keyOrder(of: try makeReport().signingBytes())
+
+        let reportId = try XCTUnwrap(order.firstIndex(of: "reportId"))
+        let reportVersion = try XCTUnwrap(order.firstIndex(of: "reportVersion"))
+        let reporter = try XCTUnwrap(order.firstIndex(of: "reporter"))
+        let reporterMandate = try XCTUnwrap(order.firstIndex(of: "reporterMandate"))
+
+        XCTAssertLessThan(reportId, reporter, "byte order puts reportId before reporter")
+        XCTAssertLessThan(reportVersion, reporter, "byte order puts reportVersion before reporter")
+        XCTAssertLessThan(reporter, reporterMandate)
+    }
+
+    /// The whole key list, so any reordering — not just the collision
+    /// above — is caught.
+    func test_reportSigningBytes_haveTheExactByteOrderedKeyList() throws {
+        XCTAssertEqual(
+            try keyOrder(of: try makeReport().signingBytes()),
+            [
+                "accused",
+                "classId",
+                "evidence",
+                "filedAt",
+                "reportId",
+                "reportVersion",
+                "reporter",
+                "reporterMandate",
+            ]
+        )
+    }
+
+    /// Guard against anyone "simplifying" the encoder: this is what the
+    /// bytes would look like if produced through `JSONSerialization`,
+    /// and it must not be what we emit.
+    func test_jsonSerializationOrderingWouldDifferFromOurs() throws {
+        let ours = try keyOrder(of: try makeReport().signingBytes())
+
+        let viaSerialization = try JSONSerialization.data(
+            withJSONObject: ["reportId": 1, "reportVersion": 2, "reporter": 3],
+            options: [.sortedKeys]
+        )
+        let theirs = try keyOrder(of: viaSerialization)
+
+        // If Foundation ever makes the two agree this assertion fails,
+        // which is the right moment to revisit the comment in
+        // `ModerationCanonicalEncoder`.
+        XCTAssertEqual(theirs, ["reporter", "reportId", "reportVersion"])
+        let oursCollisionPart = ours.filter { theirs.contains($0) }
+        XCTAssertNotEqual(oursCollisionPart, theirs)
+    }
+
+    /// The objects that already cross this boundary sort identically
+    /// under both rules — which is why the interface has interoperated
+    /// so far. Pinned so a renamed field can't quietly change that.
+    func test_mandateAndVerdictKeysAreUnaffectedByTheOrderingDifference() throws {
+        for keys in [
+            ["mandateVersion", "user", "interface", "authority", "manifestHash",
+             "classes", "deviceBinding", "acceptedAt"],
+            ["verdictVersion", "caseId", "authority", "mandateRef", "accusedKeys",
+             "deviceBinding", "classId", "disposition", "marks", "banExpires",
+             "executeAfter", "reasoning", "appealDeadline", "decidedAt", "final"],
+        ] {
+            let byteOrder = keys.sorted { Array($0.utf8).lexicographicallyPrecedes(Array($1.utf8)) }
+            let object = Dictionary(uniqueKeysWithValues: keys.map { ($0, 1) })
+            let serialized = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+            XCTAssertEqual(try keyOrder(of: serialized), byteOrder)
+        }
+    }
+
+    // MARK: - Response and appeal
+
+    func test_responseAndAppealSigningBytesExcludeTheirSignature() throws {
+        let response = CaseResponse(statement: "context changes its meaning", signature: "c2ln")
+        XCTAssertEqual(try keyOrder(of: try response.signingBytes()), ["evidence", "statement"])
+
+        let appeal = AppealSubmission(kind: .newHolderClaim, statement: "I bought this phone", signature: "c2ln")
+        XCTAssertEqual(try keyOrder(of: try appeal.signingBytes()), ["kind", "statement"])
+    }
+
+    /// Signing bytes must not change when the signature is attached —
+    /// otherwise attaching it would invalidate it.
+    func test_signingBytesAreIndependentOfTheSignatureField() throws {
+        var report = makeReport()
+        let before = try report.signingBytes()
+        report.signature = "ZGlmZmVyZW50LXNpZ25hdHVyZQ=="
+        XCTAssertEqual(try report.signingBytes(), before)
+    }
+}

--- a/Tests/OnymIOSTests/ModerationCanonicalOrderTests.swift
+++ b/Tests/OnymIOSTests/ModerationCanonicalOrderTests.swift
@@ -137,11 +137,34 @@ final class ModerationCanonicalOrderTests: XCTestCase {
     // MARK: - Response and appeal
 
     func test_responseAndAppealSigningBytesExcludeTheirSignature() throws {
-        let response = CaseResponse(statement: "context changes its meaning", signature: "c2ln")
-        XCTAssertEqual(try keyOrder(of: try response.signingBytes()), ["evidence", "statement"])
+        let response = CaseResponse(
+            caseId: "case-1",
+            statement: "context changes its meaning",
+            signature: "c2ln"
+        )
+        XCTAssertEqual(try keyOrder(of: try response.signingBytes()), ["caseId", "evidence", "statement"])
 
-        let appeal = AppealSubmission(kind: .newHolderClaim, statement: "I bought this phone", signature: "c2ln")
-        XCTAssertEqual(try keyOrder(of: try appeal.signingBytes()), ["kind", "statement"])
+        let appeal = AppealSubmission(
+            caseId: "case-1",
+            kind: .newHolderClaim,
+            statement: "I bought this phone",
+            signature: "c2ln"
+        )
+        XCTAssertEqual(try keyOrder(of: try appeal.signingBytes()), ["caseId", "kind", "statement"])
+    }
+
+    /// The case a response answers is *inside* what gets signed. Left
+    /// outside, the same signed bytes would verify against any case,
+    /// and an answer to one accusation could be replayed as an answer
+    /// to another the signer never saw.
+    func test_responseAndAppealSigningBytesBindTheirCase() throws {
+        let first = CaseResponse(caseId: "case-1", statement: "not me")
+        let second = CaseResponse(caseId: "case-2", statement: "not me")
+        XCTAssertNotEqual(try first.signingBytes(), try second.signingBytes())
+
+        let appealed = AppealSubmission(caseId: "case-1", kind: .appeal, statement: "wrong")
+        let elsewhere = AppealSubmission(caseId: "case-2", kind: .appeal, statement: "wrong")
+        XCTAssertNotEqual(try appealed.signingBytes(), try elsewhere.signingBytes())
     }
 
     /// Signing bytes must not change when the signature is attached —

--- a/Tests/OnymIOSTests/ModerationSigningPayloadTests.swift
+++ b/Tests/OnymIOSTests/ModerationSigningPayloadTests.swift
@@ -52,6 +52,24 @@ final class ModerationSigningPayloadTests: XCTestCase {
         )
     }
 
+    private func makeReport() -> Report {
+        Report(
+            reportId: "report-1",
+            reporter: "onym:key:\(String(repeating: "ab", count: 32))",
+            reporterMandate: String(repeating: "1", count: 64),
+            accused: "onym:key:\(String(repeating: "cd", count: 32))",
+            classId: "unsolicited-pornography",
+            evidence: [
+                EvidenceItem(
+                    disclosedContent: "the disclosed message",
+                    authenticityProof: "c2VuZGVyLXNpZ25hdHVyZQ=="
+                )
+            ],
+            filedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            signature: "cmVwb3J0ZXItc2ln"
+        )
+    }
+
     // MARK: - Mandate
 
     func test_mandateSigningBytes_coverEveryFieldExceptSignatures() throws {
@@ -77,6 +95,39 @@ final class ModerationSigningPayloadTests: XCTestCase {
         let verdict = makeVerdict()
         let signed = try keys(of: verdict.signingBytes())
         XCTAssertEqual(signed, try encodedKeys(of: verdict).subtracting(["signature"]))
+        XCTAssertFalse(signed.contains("signature"))
+    }
+
+    // MARK: - Report, response and appeal
+
+    func test_reportSigningBytes_coverEveryFieldExceptSignature() throws {
+        let report = makeReport()
+        let signed = try keys(of: report.signingBytes())
+        XCTAssertEqual(signed, try encodedKeys(of: report).subtracting(["signature"]))
+        XCTAssertFalse(signed.contains("signature"))
+    }
+
+    func test_responseSigningBytes_coverEveryFieldExceptSignature() throws {
+        let response = CaseResponse(
+            caseId: "case-1",
+            statement: "context changes its meaning",
+            evidence: makeReport().evidence,
+            signature: "c2ln"
+        )
+        let signed = try keys(of: response.signingBytes())
+        XCTAssertEqual(signed, try encodedKeys(of: response).subtracting(["signature"]))
+        XCTAssertFalse(signed.contains("signature"))
+    }
+
+    func test_appealSigningBytes_coverEveryFieldExceptSignature() throws {
+        let appeal = AppealSubmission(
+            caseId: "case-1",
+            kind: .appeal,
+            statement: "the decision is wrong",
+            signature: "c2ln"
+        )
+        let signed = try keys(of: appeal.signingBytes())
+        XCTAssertEqual(signed, try encodedKeys(of: appeal).subtracting(["signature"]))
         XCTAssertFalse(signed.contains("signature"))
     }
 }


### PR DESCRIPTION
`Report`, `CaseResponse` and `AppealSubmission` each carry a `signature` field with no defined bytes to sign. The report path therefore can't be implemented without someone inventing a canonical form at the call site — and there is a specific wrong way to invent it that fails silently.

## The hazard

Foundation ships **two** `.sortedKeys` options that disagree:

| | sorts by |
|---|---|
| `JSONEncoder.OutputFormatting.sortedKeys` | UTF-8 byte order |
| `JSONSerialization.WritingOptions.sortedKeys` | case-insensitively |

Of the moderation boundary objects, `Report` is the only one whose keys collide under that difference: `reportId` and `reportVersion` precede `reporter` by byte order and follow it case-insensitively. `mandate`, `verdict` and `notice` sort identically under both rules — which is why the existing client and the enforcement backend have interoperated fine.

Byte order is the interoperable choice: serde_json, Go's `encoding/json` and Python's `sort_keys` all do it, so an authority written in any of them can reconstruct these bytes. A report signed the other way is rejected by all of them, and the failure surfaces as *"every report signature is invalid"* rather than as an encoding bug — which is a bad afternoon for whoever debugs it.

## What this PR does

- Adds `signingBytes()` to `Report`, `CaseResponse` and `AppealSubmission`, following the existing mirror-struct pattern from `ModerationMandate` and `Verdict`.
- Moves the encoder configuration into one `ModerationCanonicalEncoder`. There were three copies of "sortedKeys + iso8601" across the package; a canonical form with three definitions is one waiting to diverge. `ModerationMandate` and `Verdict` now route through it — no behaviour change, verified by the existing `ModerationSigningPayloadTests`.
- Adds `ModerationCanonicalOrderTests`, which pins the byte-order rule by reading key order out of the raw JSON (parsing into a dictionary would discard exactly the thing under test): the collision case, the full expected key list, a guard asserting `JSONSerialization` would order differently, and a check that mandate/verdict remain unaffected.

## Verified against the reference authority

Not just unit-tested — checked against the Rust authority in [onymchat/onym-moderation#2](https://github.com/onymchat/onym-moderation/pull/2), which reconstructs these bytes with serde_json:

| | |
|---|---|
| report signed with `Report.signingBytes()` | **accepted**, opened a case |
| same report signed over `JSONSerialization`-ordered bytes | `signature_invalid: reporter signature did not verify` |

Both directions, so the fix is load-bearing rather than cosmetic.

## Note on scope

I originally reported this as "the client's canonicalization ends in `JSONSerialization`, so report signatures will fail". That was wrong about `main` — there is no `JSONSerialization` anywhere in `OnymModeration`, and the existing signing forms were already byte-ordered and correct. The real gap was that reports had no defined signing bytes at all. This PR closes that gap and pins the rule so the wrong option can't be chosen later.

The `PROVISIONAL` caveat still stands: the draft spec fixes no canonical JSON form, so this agreement holds by construction between implementations. A spec decision naming one would let both sides drop the caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)