### PR TITLE
feat(moderation): add Authority transport and mandate registration

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
@@ -32,11 +32,35 @@ public struct AuthorityListing: Codable, Sendable, Equatable {
         self.apiBaseURL = apiBaseURL
         self.operatorPublicKeyBase64 = operatorPublicKeyBase64
     }
-
 }
 
-struct KnownAuthoritiesDocument: Codable {
+private struct LossyAuthorityListing: Decodable {
+    let value: AuthorityListing?
+
+    init(from decoder: Decoder) throws {
+        value = try? AuthorityListing(from: decoder)
+    }
+}
+
+struct KnownAuthoritiesDocument: Decodable {
     let authorities: [AuthorityListing]
+
+    private enum CodingKeys: String, CodingKey {
+        case authorities
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decoded = try container.decode([LossyAuthorityListing].self, forKey: .authorities)
+        authorities = decoded.compactMap(\.value)
+        guard !authorities.isEmpty else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .authorities,
+                in: container,
+                debugDescription: "directory contains no valid Authority entries"
+            )
+        }
+    }
 }
 
 /// Network seam that fetches the curated list of moderation

--- a/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
@@ -33,11 +33,6 @@ public struct AuthorityListing: Codable, Sendable, Equatable {
         self.operatorPublicKeyBase64 = operatorPublicKeyBase64
     }
 
-    /// Named at call sites to make the directory's trust designation
-    /// visible where a client is constructed.
-    public var resolvedAPIBaseURL: URL {
-        apiBaseURL
-    }
 }
 
 struct KnownAuthoritiesDocument: Codable {

--- a/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OnymFoundation
+import os.log
 
 /// One entry in the interface's published authority directory. The
 /// directory pins each authority's operator public key out-of-band
@@ -35,10 +36,40 @@ public struct AuthorityListing: Codable, Sendable, Equatable {
 }
 
 private struct LossyAuthorityListing: Decodable {
+    private static let log = Logger(
+        subsystem: "app.onym.ios",
+        category: "ModerationDirectory"
+    )
+
     let value: AuthorityListing?
 
     init(from decoder: Decoder) throws {
-        value = try? AuthorityListing(from: decoder)
+        do {
+            let listing = try AuthorityListing(from: decoder)
+            guard listing.apiBaseURL.scheme?.lowercased() == "https",
+                  listing.apiBaseURL.host != nil
+            else {
+                throw DecodingError.dataCorrupted(
+                    .init(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Authority apiBaseURL must use HTTPS"
+                    )
+                )
+            }
+            value = listing
+        } catch {
+            let componentId = (try? decoder.container(keyedBy: DiagnosticKeys.self))
+                .flatMap { try? $0.decodeIfPresent(String.self, forKey: .componentId) }
+                ?? "<unknown>"
+            Self.log.error(
+                "Skipping malformed Authority \(componentId, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+            value = nil
+        }
+    }
+
+    private enum DiagnosticKeys: String, CodingKey {
+        case componentId
     }
 }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
@@ -11,14 +11,32 @@ public struct AuthorityListing: Codable, Sendable, Equatable {
     /// Human-readable name shown in the picker.
     public let name: String
     public let manifestURL: URL
+    /// Base URL of the Authority HTTP API. Optional for compatibility
+    /// with directories published before the operation surface existed;
+    /// those entries resolve the API beside `manifestURL`.
+    public let apiBaseURL: URL?
     /// The authority's Ed25519 operator public key, base64 raw bytes.
     public let operatorPublicKeyBase64: String
 
-    public init(componentId: String, name: String, manifestURL: URL, operatorPublicKeyBase64: String) {
+    public init(
+        componentId: String,
+        name: String,
+        manifestURL: URL,
+        apiBaseURL: URL? = nil,
+        operatorPublicKeyBase64: String
+    ) {
         self.componentId = componentId
         self.name = name
         self.manifestURL = manifestURL
+        self.apiBaseURL = apiBaseURL
         self.operatorPublicKeyBase64 = operatorPublicKeyBase64
+    }
+
+    /// The reference implementation serves `/manifest.json` and `/v1/*`
+    /// from one base. New directory entries should publish `apiBaseURL`
+    /// explicitly; the fallback keeps already-published entries usable.
+    public var resolvedAPIBaseURL: URL {
+        apiBaseURL ?? manifestURL.deletingLastPathComponent()
     }
 }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/KnownAuthoritiesFetcher.swift
@@ -11,10 +11,11 @@ public struct AuthorityListing: Codable, Sendable, Equatable {
     /// Human-readable name shown in the picker.
     public let name: String
     public let manifestURL: URL
-    /// Base URL of the Authority HTTP API. Optional for compatibility
-    /// with directories published before the operation surface existed;
-    /// those entries resolve the API beside `manifestURL`.
-    public let apiBaseURL: URL?
+    /// Base URL of the Authority HTTP API, explicitly designated by the
+    /// Interface's directory. It is never inferred from `manifestURL`:
+    /// manifests may be safely mirrored because their bytes are signed,
+    /// while this endpoint receives the user's signed mandate.
+    public let apiBaseURL: URL
     /// The authority's Ed25519 operator public key, base64 raw bytes.
     public let operatorPublicKeyBase64: String
 
@@ -22,7 +23,7 @@ public struct AuthorityListing: Codable, Sendable, Equatable {
         componentId: String,
         name: String,
         manifestURL: URL,
-        apiBaseURL: URL? = nil,
+        apiBaseURL: URL,
         operatorPublicKeyBase64: String
     ) {
         self.componentId = componentId
@@ -32,11 +33,10 @@ public struct AuthorityListing: Codable, Sendable, Equatable {
         self.operatorPublicKeyBase64 = operatorPublicKeyBase64
     }
 
-    /// The reference implementation serves `/manifest.json` and `/v1/*`
-    /// from one base. New directory entries should publish `apiBaseURL`
-    /// explicitly; the fallback keeps already-published entries usable.
+    /// Named at call sites to make the directory's trust designation
+    /// visible where a client is constructed.
     public var resolvedAPIBaseURL: URL {
-        apiBaseURL ?? manifestURL.deletingLastPathComponent()
+        apiBaseURL
     }
 }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
@@ -19,6 +19,12 @@ public struct MandateRecord: Codable, Sendable, Equatable {
     /// record remains persisted with this false so a retry can resend
     /// identical bytes instead of minting a second consent artifact.
     public var authorityRegistered: Bool
+    /// A real countersigned mandate awaiting acknowledgement from its
+    /// Authority. It is neither current consent nor historical consent
+    /// and must not be presented as either one.
+    public var registrationPending: Bool {
+        countersigned && !authorityRegistered
+    }
     /// Exactly one record is active per identity–device pair.
     /// Switching authorities deactivates the old record without
     /// touching anything else (mandates are immutable, spec §12).

--- a/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
@@ -14,6 +14,11 @@ public struct MandateRecord: Codable, Sendable, Equatable {
     /// False while the interface signature is the stub sentinel — a
     /// record that can never be mistaken for a spec-valid mandate.
     public let countersigned: Bool
+    /// True only after the Authority accepted this exact countersigned
+    /// mandate and returned its matching content reference. A pending
+    /// record remains persisted with this false so a retry can resend
+    /// identical bytes instead of minting a second consent artifact.
+    public var authorityRegistered: Bool
     /// Exactly one record is active per identity–device pair.
     /// Switching authorities deactivates the old record without
     /// touching anything else (mandates are immutable, spec §12).
@@ -25,6 +30,7 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         manifestBytes: Data,
         authorityName: String,
         countersigned: Bool,
+        authorityRegistered: Bool = false,
         isActive: Bool,
         createdAt: Date
     ) {
@@ -32,8 +38,37 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         self.manifestBytes = manifestBytes
         self.authorityName = authorityName
         self.countersigned = countersigned
+        self.authorityRegistered = authorityRegistered
         self.isActive = isActive
         self.createdAt = createdAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case mandate
+        case manifestBytes
+        case authorityName
+        case countersigned
+        case authorityRegistered
+        case isActive
+        case createdAt
+    }
+
+    /// Records written before Authority registration existed decode as
+    /// unregistered instead of making the entire mandate history fail
+    /// to load. Stub-era records were never accepted by an Authority,
+    /// so `false` is also the truthful migration value.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        mandate = try container.decode(ModerationMandate.self, forKey: .mandate)
+        manifestBytes = try container.decode(Data.self, forKey: .manifestBytes)
+        authorityName = try container.decode(String.self, forKey: .authorityName)
+        countersigned = try container.decode(Bool.self, forKey: .countersigned)
+        authorityRegistered = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .authorityRegistered
+        ) ?? false
+        isActive = try container.decode(Bool.self, forKey: .isActive)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
     }
 
     /// The consented manifest, decoded from the stored snapshot.

--- a/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
@@ -19,19 +19,10 @@ public struct MandateRecord: Codable, Sendable, Equatable {
     /// record remains persisted with this false so a retry can resend
     /// identical bytes instead of minting a second consent artifact.
     public var authorityRegistered: Bool
-    /// True after a definitive Authority refusal. The signed attempt is
-    /// retained for an honest local audit trail, but exact replay is no
-    /// longer forced because it cannot change that outcome.
-    public var registrationRejected: Bool
     /// A real countersigned mandate awaiting acknowledgement from its
     /// Authority. It is neither current consent nor historical consent
     /// and must not be presented as either one.
     public var registrationPending: Bool {
-        countersigned && !authorityRegistered && !registrationRejected
-    }
-    /// Registration attempts are internal state until acknowledged;
-    /// neither pending nor rejected attempts belong in mandate history UI.
-    public var registrationIncomplete: Bool {
         countersigned && !authorityRegistered
     }
     /// Exactly one record is active per identity–device pair.
@@ -46,7 +37,6 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         authorityName: String,
         countersigned: Bool,
         authorityRegistered: Bool = false,
-        registrationRejected: Bool = false,
         isActive: Bool,
         createdAt: Date
     ) {
@@ -55,7 +45,6 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         self.authorityName = authorityName
         self.countersigned = countersigned
         self.authorityRegistered = authorityRegistered
-        self.registrationRejected = registrationRejected
         self.isActive = isActive
         self.createdAt = createdAt
     }
@@ -66,7 +55,6 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         case authorityName
         case countersigned
         case authorityRegistered
-        case registrationRejected
         case isActive
         case createdAt
     }
@@ -84,10 +72,6 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         authorityRegistered = try container.decodeIfPresent(
             Bool.self,
             forKey: .authorityRegistered
-        ) ?? false
-        registrationRejected = try container.decodeIfPresent(
-            Bool.self,
-            forKey: .registrationRejected
         ) ?? false
         isActive = try container.decode(Bool.self, forKey: .isActive)
         createdAt = try container.decode(Date.self, forKey: .createdAt)

--- a/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/MandateStore.swift
@@ -19,10 +19,19 @@ public struct MandateRecord: Codable, Sendable, Equatable {
     /// record remains persisted with this false so a retry can resend
     /// identical bytes instead of minting a second consent artifact.
     public var authorityRegistered: Bool
+    /// True after a definitive Authority refusal. The signed attempt is
+    /// retained for an honest local audit trail, but exact replay is no
+    /// longer forced because it cannot change that outcome.
+    public var registrationRejected: Bool
     /// A real countersigned mandate awaiting acknowledgement from its
     /// Authority. It is neither current consent nor historical consent
     /// and must not be presented as either one.
     public var registrationPending: Bool {
+        countersigned && !authorityRegistered && !registrationRejected
+    }
+    /// Registration attempts are internal state until acknowledged;
+    /// neither pending nor rejected attempts belong in mandate history UI.
+    public var registrationIncomplete: Bool {
         countersigned && !authorityRegistered
     }
     /// Exactly one record is active per identity–device pair.
@@ -37,6 +46,7 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         authorityName: String,
         countersigned: Bool,
         authorityRegistered: Bool = false,
+        registrationRejected: Bool = false,
         isActive: Bool,
         createdAt: Date
     ) {
@@ -45,6 +55,7 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         self.authorityName = authorityName
         self.countersigned = countersigned
         self.authorityRegistered = authorityRegistered
+        self.registrationRejected = registrationRejected
         self.isActive = isActive
         self.createdAt = createdAt
     }
@@ -55,6 +66,7 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         case authorityName
         case countersigned
         case authorityRegistered
+        case registrationRejected
         case isActive
         case createdAt
     }
@@ -72,6 +84,10 @@ public struct MandateRecord: Codable, Sendable, Equatable {
         authorityRegistered = try container.decodeIfPresent(
             Bool.self,
             forKey: .authorityRegistered
+        ) ?? false
+        registrationRejected = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .registrationRejected
         ) ?? false
         isActive = try container.decode(Bool.self, forKey: .isActive)
         createdAt = try container.decode(Date.self, forKey: .createdAt)

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -85,6 +85,7 @@ public enum AuthorityClientError: Error, Sendable, Equatable {
     case mandateNotAccepted(mandateRef: String)
     case mandateReferenceMismatch(expected: String, received: String)
     case invalidPathComponent(String)
+    case insecureBaseURL(String)
 }
 
 /// The accused's signed response to a case notice: statements and
@@ -361,6 +362,9 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         body: Data? = nil,
         headers: [String: String] = [:]
     ) async throws -> Data {
+        guard baseURL.scheme?.lowercased() == "https", baseURL.host != nil else {
+            throw AuthorityClientError.insecureBaseURL(baseURL.absoluteString)
+        }
         let allowed = CharacterSet(
             charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
         )

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -261,7 +261,7 @@ public struct URLSessionModerationAuthorityClientFactory: ModerationAuthorityCli
 
     public func client(for listing: AuthorityListing) -> any ModerationAuthorityClient {
         URLSessionModerationAuthorityClient(
-            baseURL: listing.resolvedAPIBaseURL,
+            baseURL: listing.apiBaseURL,
             session: session,
             signer: signer,
             clock: clock

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -84,7 +84,7 @@ public enum AuthorityClientError: Error, Sendable, Equatable {
     case rejected(AuthorityRejection)
     case mandateNotAccepted(mandateRef: String)
     case mandateReferenceMismatch(expected: String, received: String)
-    case localMandateRecordMissing(mandateRef: String)
+    case invalidPathComponent(String)
 }
 
 /// The accused's signed response to a case notice: statements and
@@ -297,14 +297,14 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         let data = try await send(method: "POST", path: ["v1", "mandates"], body: body)
         let receipt: MandateRegistrationReceipt = try decode(data)
         let expected = try mandate.mandateHash()
-        guard receipt.accepted else {
-            throw AuthorityClientError.mandateNotAccepted(mandateRef: receipt.mandateRef)
-        }
         guard receipt.mandateRef == expected else {
             throw AuthorityClientError.mandateReferenceMismatch(
                 expected: expected,
                 received: receipt.mandateRef
             )
+        }
+        guard receipt.accepted else {
+            throw AuthorityClientError.mandateNotAccepted(mandateRef: receipt.mandateRef)
         }
         return receipt
     }
@@ -360,6 +360,28 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         path: [String],
         body: Data? = nil,
         headers: [String: String] = [:]
+    ) async throws -> Data {
+        let allowed = CharacterSet(
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        )
+        guard let invalid = path.first(where: {
+            $0 == "." || $0 == ".." || $0.rangeOfCharacter(from: allowed.inverted) != nil
+        }) else {
+            return try await sendValidated(
+                method: method,
+                path: path,
+                body: body,
+                headers: headers
+            )
+        }
+        throw AuthorityClientError.invalidPathComponent(invalid)
+    }
+
+    private func sendValidated(
+        method: String,
+        path: [String],
+        body: Data?,
+        headers: [String: String]
     ) async throws -> Data {
         let url = path.reduce(baseURL) { partial, component in
             partial.appending(path: component)

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -82,15 +82,22 @@ public enum AuthorityClientError: Error, Sendable, Equatable {
     case invalidResponse
     case malformedResponse(String)
     case rejected(AuthorityRejection)
+    case mandateNotAccepted(mandateRef: String)
     case mandateReferenceMismatch(expected: String, received: String)
 }
 
 /// The accused's signed response to a case notice: statements and
-/// counter-evidence. Additional evidence within the window travels
-/// through the same object.
+/// counter-evidence (Moderation.md §5.5 — "the response mirrors the
+/// report's shape"). Additional evidence within the window travels
+/// through the same object, so `submit-evidence` needs no separate
+/// operation client-side.
 public struct CaseResponse: Codable, Sendable, Equatable {
-    /// The case being answered. It is carried in the signed body as well
-    /// as the request path to prevent cross-case replay.
+    /// The case being answered. Carried in the object — and therefore
+    /// inside the signed bytes — rather than alongside it: a signed
+    /// statement that names no case can be lifted from the case it was
+    /// written for and replayed onto another, so an innocuous "that
+    /// wasn't me" would register as an answer to an accusation its
+    /// signer never saw.
     public let caseId: String
     public let statement: String
     public let evidence: [EvidenceItem]
@@ -109,6 +116,7 @@ public struct CaseResponse: Codable, Sendable, Equatable {
     }
 
     /// The bytes the accused signs: every field except `signature`.
+    /// See `ModerationCanonicalEncoder` for why the ordering matters.
     public func signingBytes() throws -> Data {
         struct Unsigned: Encodable {
             let caseId: String
@@ -121,14 +129,17 @@ public struct CaseResponse: Codable, Sendable, Equatable {
     }
 }
 
-/// An appeal filed within the declared window, or an unauthenticated
-/// new-holder claim handled by the Authority's dedicated remedy.
+/// An appeal filed within the declared window — or a new-holder claim,
+/// which the spec treats as a mandatory appeal class with expedited
+/// review (§5.7, error `new_holder_claim`).
 public struct AppealSubmission: Codable, Sendable, Equatable {
     public enum Kind: String, Codable, Sendable {
         case appeal
         case newHolderClaim = "new-holder-claim"
     }
 
+    /// The case appealed. Signed, for the same replay reason as
+    /// `CaseResponse.caseId`.
     public let caseId: String
     public let kind: Kind
     public let statement: String
@@ -142,6 +153,11 @@ public struct AppealSubmission: Codable, Sendable, Equatable {
     }
 
     /// The bytes the accused signs: every field except `signature`.
+    ///
+    /// A `newHolderClaim` is signed too where the holder still has the
+    /// mandated identity, but an authority cannot require it — the
+    /// whole premise of that path is a device whose new owner is *not*
+    /// the mandated user (§5.7).
     public func signingBytes() throws -> Data {
         struct Unsigned: Encodable {
             let caseId: String
@@ -203,7 +219,15 @@ public struct CaseStatus: Codable, Sendable, Equatable {
     }
 }
 
-/// User-initiated operations exposed by one moderation Authority.
+/// The client-visible operations of a moderation Authority. Notices
+/// and verdicts travel the other way via the Interface's gate check.
+/// `submit-evidence` is folded into `respond` because it has the same
+/// signed shape and window.
+///
+/// HTTP implementations put `CaseResponse.caseId` and
+/// `AppealSubmission.caseId` in both the path and signed body. A
+/// conforming Authority must reject a path/body mismatch; trusting
+/// either value alone would reopen cross-case replay.
 public protocol ModerationAuthorityClient: Sendable {
     func registerMandate(_ mandate: ModerationMandate) async throws -> MandateRegistrationReceipt
     func fileReport(_ report: Report) async throws -> ReportReceipt
@@ -272,7 +296,10 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         let data = try await send(method: "POST", path: ["v1", "mandates"], body: body)
         let receipt: MandateRegistrationReceipt = try decode(data)
         let expected = try mandate.mandateHash()
-        guard receipt.accepted, receipt.mandateRef == expected else {
+        guard receipt.accepted else {
+            throw AuthorityClientError.mandateNotAccepted(mandateRef: receipt.mandateRef)
+        }
+        guard receipt.mandateRef == expected else {
             throw AuthorityClientError.mandateReferenceMismatch(
                 expected: expected,
                 received: receipt.mandateRef
@@ -307,6 +334,10 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
 
     public func queryStatus(caseId: String) async throws -> CaseStatus {
         let timestamp = Self.timestamp(clock())
+        // This is deliberately the exact credential message verified by
+        // the merged reference Authority (`authority/src/api.rs`,
+        // `authorize_case_party`). Changing it client-side to include a
+        // request line or host would make status queries incompatible.
         let signedBytes = Data("query-status:\(caseId):\(timestamp)".utf8)
         let key = try await signer.userKeyID()
         let signature = try await signer.sign(signedBytes).base64EncodedString()

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -1,30 +1,96 @@
 import Foundation
 
-/// Receipt for a filed report. Intake weighting (reporter track
-/// record) is the authority's business; the client only learns the
-/// report was received.
-public struct ReportReceipt: Codable, Sendable, Equatable {
-    public let reportId: String
-    public let receivedAt: Date
+/// Receipt returned after the Interface registers a countersigned
+/// mandate with the Authority. The reference is the SHA-256 of the
+/// mandate's canonical unsigned bytes and must agree with the value the
+/// client computed before registration.
+public struct MandateRegistrationReceipt: Codable, Sendable, Equatable {
+    public let mandateRef: String
+    public let accepted: Bool
 
-    public init(reportId: String, receivedAt: Date) {
-        self.reportId = reportId
-        self.receivedAt = receivedAt
+    public init(mandateRef: String, accepted: Bool) {
+        self.mandateRef = mandateRef
+        self.accepted = accepted
     }
 }
 
+/// Receipt for a filed report, matching the merged Authority response.
+/// `intakeWeight` and `duplicate` are optional because an exact replay
+/// returns the original case and deadlines without recalculating weight.
+public struct ReportReceipt: Codable, Sendable, Equatable {
+    public let reportId: String
+    public let receivedAt: Date
+    public let caseId: String
+    public let intakeWeight: Double?
+    public let responseDeadline: Date?
+    public let decisionDeadline: Date?
+    public let duplicate: Bool?
+
+    public init(
+        reportId: String,
+        receivedAt: Date,
+        caseId: String,
+        intakeWeight: Double? = nil,
+        responseDeadline: Date? = nil,
+        decisionDeadline: Date? = nil,
+        duplicate: Bool? = nil
+    ) {
+        self.reportId = reportId
+        self.receivedAt = receivedAt
+        self.caseId = caseId
+        self.intakeWeight = intakeWeight
+        self.responseDeadline = responseDeadline
+        self.decisionDeadline = decisionDeadline
+        self.duplicate = duplicate
+    }
+}
+
+/// Stable error vocabulary emitted by the reference Authority.
+public enum AuthorityErrorCode: String, Codable, Sendable, Equatable {
+    case badRequest = "bad_request"
+    case signatureInvalid = "signature_invalid"
+    case reporterUnconsented = "reporter_unconsented"
+    case noJurisdiction = "no_jurisdiction"
+    case authenticityUnverified = "authenticity_unverified"
+    case classOutsideMandate = "class_outside_mandate"
+    case windowClosed = "window_closed"
+    case caseState = "case_state"
+    case notFound = "not_found"
+    case internalError = "internal_error"
+}
+
+/// A non-2xx response from an Authority. `rawCode` is retained even
+/// when a newer Authority introduces a code this app does not know yet.
+public struct AuthorityRejection: Error, Sendable, Equatable {
+    public let statusCode: Int
+    public let rawCode: String
+    public let message: String
+
+    public var code: AuthorityErrorCode? { AuthorityErrorCode(rawValue: rawCode) }
+
+    public init(statusCode: Int, rawCode: String, message: String) {
+        self.statusCode = statusCode
+        self.rawCode = rawCode
+        self.message = message
+    }
+}
+
+/// Client-side failures before a conforming Authority response can be
+/// handed to the caller. Network failures remain their original
+/// `URLError`, so retry policy can distinguish them directly.
+public enum AuthorityClientError: Error, Sendable, Equatable {
+    case invalidResponse
+    case malformedResponse(String)
+    case rejected(AuthorityRejection)
+    case mandateReferenceMismatch(expected: String, received: String)
+}
+
 /// The accused's signed response to a case notice: statements and
-/// counter-evidence (Moderation.md §5.5 — "the response mirrors the
-/// report's shape"). Additional evidence within the window travels
-/// through the same object, so `submit-evidence` needs no separate
-/// operation client-side.
+/// counter-evidence. Additional evidence within the window travels
+/// through the same object.
 public struct CaseResponse: Codable, Sendable, Equatable {
-    /// The case being answered. Carried in the object — and therefore
-    /// inside the signed bytes — rather than alongside it: a signed
-    /// statement that names no case can be lifted from the case it was
-    /// written for and replayed onto another, so an innocuous "that
-    /// wasn't me" would register as an answer to an accusation its
-    /// signer never saw.
+    /// The case being answered. It is carried in the signed body as well
+    /// as the request path to prevent cross-case replay.
     public let caseId: String
     public let statement: String
     public let evidence: [EvidenceItem]
@@ -43,7 +109,6 @@ public struct CaseResponse: Codable, Sendable, Equatable {
     }
 
     /// The bytes the accused signs: every field except `signature`.
-    /// See `ModerationCanonicalEncoder` for why the ordering matters.
     public func signingBytes() throws -> Data {
         struct Unsigned: Encodable {
             let caseId: String
@@ -56,17 +121,14 @@ public struct CaseResponse: Codable, Sendable, Equatable {
     }
 }
 
-/// An appeal filed within the declared window — or a new-holder claim,
-/// which the spec treats as a mandatory appeal class with expedited
-/// review (§5.7, error `new_holder_claim`).
+/// An appeal filed within the declared window, or an unauthenticated
+/// new-holder claim handled by the Authority's dedicated remedy.
 public struct AppealSubmission: Codable, Sendable, Equatable {
     public enum Kind: String, Codable, Sendable {
         case appeal
         case newHolderClaim = "new-holder-claim"
     }
 
-    /// The case appealed. Signed, for the same replay reason as
-    /// `CaseResponse.caseId`.
     public let caseId: String
     public let kind: Kind
     public let statement: String
@@ -80,11 +142,6 @@ public struct AppealSubmission: Codable, Sendable, Equatable {
     }
 
     /// The bytes the accused signs: every field except `signature`.
-    ///
-    /// A `newHolderClaim` is signed too where the holder still has the
-    /// mandated identity, but an authority cannot require it — the
-    /// whole premise of that path is a device whose new owner is *not*
-    /// the mandated user (§5.7).
     public func signingBytes() throws -> Data {
         struct Unsigned: Encodable {
             let caseId: String
@@ -97,49 +154,248 @@ public struct AppealSubmission: Codable, Sendable, Equatable {
     }
 }
 
-/// Stage-and-deadlines answer to a status query, per the authority's
-/// confidentiality rules.
+/// Party-visible subset of the Authority's case status document.
+/// Additional assessment and event fields are deliberately ignored by
+/// this first client surface and can be modeled when their UI lands.
 public struct CaseStatus: Codable, Sendable, Equatable {
     public let caseId: String
     public let stage: String
+    public let classId: String?
+    public let openedAt: Date?
     public let responseDeadline: Date?
     public let decisionDeadline: Date?
+    public let responded: Bool?
+    public let responsesOnFile: Int?
+    public let disposition: String?
+    public let appealDeadline: Date?
+    public let appealState: String?
+    public let newHolderState: String?
+    public let claimRevision: Int?
 
-    public init(caseId: String, stage: String, responseDeadline: Date? = nil, decisionDeadline: Date? = nil) {
+    public init(
+        caseId: String,
+        stage: String,
+        classId: String? = nil,
+        openedAt: Date? = nil,
+        responseDeadline: Date? = nil,
+        decisionDeadline: Date? = nil,
+        responded: Bool? = nil,
+        responsesOnFile: Int? = nil,
+        disposition: String? = nil,
+        appealDeadline: Date? = nil,
+        appealState: String? = nil,
+        newHolderState: String? = nil,
+        claimRevision: Int? = nil
+    ) {
         self.caseId = caseId
         self.stage = stage
+        self.classId = classId
+        self.openedAt = openedAt
         self.responseDeadline = responseDeadline
         self.decisionDeadline = decisionDeadline
+        self.responded = responded
+        self.responsesOnFile = responsesOnFile
+        self.disposition = disposition
+        self.appealDeadline = appealDeadline
+        self.appealState = appealState
+        self.newHolderState = newHolderState
+        self.claimRevision = claimRevision
     }
 }
 
-/// The client-visible operations of a moderation authority
-/// (Moderation.md §6). Notices and verdicts travel the other way —
-/// they arrive via the enforcement backend's gate check — so this
-/// surface is only what a user initiates.
-///
-/// Deliberately smaller than the spec's operation table:
-/// `submit-evidence` is folded into `respond` (same signed shape, same
-/// window), and `accept-mandate` is authority-side. One implementation
-/// per authority; the repository picks the client for the mandated
-/// authority, which is what makes authorities swappable.
-///
-/// An HTTP implementation must put `CaseResponse.caseId` and
-/// `AppealSubmission.caseId` in both the request path and the signed body.
-/// The authority must reject a path/body mismatch; trusting either one alone
-/// would reopen the cross-case replay that signing `caseId` prevents.
+/// User-initiated operations exposed by one moderation Authority.
 public protocol ModerationAuthorityClient: Sendable {
+    func registerMandate(_ mandate: ModerationMandate) async throws -> MandateRegistrationReceipt
     func fileReport(_ report: Report) async throws -> ReportReceipt
     func respond(_ response: CaseResponse) async throws
     func appeal(_ submission: AppealSubmission) async throws
     func queryStatus(caseId: String) async throws -> CaseStatus
 }
 
-/// Stub client — no authority service is deployed yet. Every
-/// operation throws `.notImplemented` so UI entry points exist and
-/// fail honestly rather than pretending a case moved.
+/// Resolves the client for a directory-selected Authority. Keeping this
+/// as a seam lets tests and UI fixtures avoid network access while the
+/// production factory derives a concrete client from the listing.
+public protocol ModerationAuthorityClientFactory: Sendable {
+    func client(for listing: AuthorityListing) -> any ModerationAuthorityClient
+}
+
+public struct URLSessionModerationAuthorityClientFactory: ModerationAuthorityClientFactory {
+    private let session: URLSession
+    private let signer: any ModerationSigner
+    private let clock: @Sendable () -> Date
+
+    public init(
+        session: URLSession = .shared,
+        signer: any ModerationSigner,
+        clock: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.session = session
+        self.signer = signer
+        self.clock = clock
+    }
+
+    public func client(for listing: AuthorityListing) -> any ModerationAuthorityClient {
+        URLSessionModerationAuthorityClient(
+            baseURL: listing.resolvedAPIBaseURL,
+            session: session,
+            signer: signer,
+            clock: clock
+        )
+    }
+}
+
+/// HTTP implementation of the operation surface in `onym-moderation`.
+/// Request objects are encoded once per call with the same canonical
+/// encoder used for their signatures.
+public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
+    private let baseURL: URL
+    private let session: URLSession
+    private let signer: any ModerationSigner
+    private let clock: @Sendable () -> Date
+
+    public init(
+        baseURL: URL,
+        session: URLSession = .shared,
+        signer: any ModerationSigner,
+        clock: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.signer = signer
+        self.clock = clock
+    }
+
+    public func registerMandate(
+        _ mandate: ModerationMandate
+    ) async throws -> MandateRegistrationReceipt {
+        let body = try ModerationCanonicalEncoder.encode(mandate)
+        let data = try await send(method: "POST", path: ["v1", "mandates"], body: body)
+        let receipt: MandateRegistrationReceipt = try decode(data)
+        let expected = try mandate.mandateHash()
+        guard receipt.accepted, receipt.mandateRef == expected else {
+            throw AuthorityClientError.mandateReferenceMismatch(
+                expected: expected,
+                received: receipt.mandateRef
+            )
+        }
+        return receipt
+    }
+
+    public func fileReport(_ report: Report) async throws -> ReportReceipt {
+        let body = try ModerationCanonicalEncoder.encode(report)
+        let data = try await send(method: "POST", path: ["v1", "reports"], body: body)
+        return try decode(data)
+    }
+
+    public func respond(_ response: CaseResponse) async throws {
+        let body = try ModerationCanonicalEncoder.encode(response)
+        _ = try await send(
+            method: "POST",
+            path: ["v1", "cases", response.caseId, "respond"],
+            body: body
+        )
+    }
+
+    public func appeal(_ submission: AppealSubmission) async throws {
+        let body = try ModerationCanonicalEncoder.encode(submission)
+        _ = try await send(
+            method: "POST",
+            path: ["v1", "cases", submission.caseId, "appeal"],
+            body: body
+        )
+    }
+
+    public func queryStatus(caseId: String) async throws -> CaseStatus {
+        let timestamp = Self.timestamp(clock())
+        let signedBytes = Data("query-status:\(caseId):\(timestamp)".utf8)
+        let key = try await signer.userKeyID()
+        let signature = try await signer.sign(signedBytes).base64EncodedString()
+        let headers = [
+            "X-Onym-Key": key,
+            "X-Onym-Timestamp": timestamp,
+            "X-Onym-Signature": signature,
+        ]
+        let data = try await send(
+            method: "GET",
+            path: ["v1", "cases", caseId, "status"],
+            headers: headers
+        )
+        return try decode(data)
+    }
+
+    private func send(
+        method: String,
+        path: [String],
+        body: Data? = nil,
+        headers: [String: String] = [:]
+    ) async throws -> Data {
+        let url = path.reduce(baseURL) { partial, component in
+            partial.appending(path: component)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.httpBody = body
+        if body != nil {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        for (name, value) in headers {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AuthorityClientError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            struct ErrorBody: Decodable {
+                let error: String
+                let message: String
+            }
+            let decoded = try? Self.decoder().decode(ErrorBody.self, from: data)
+            throw AuthorityClientError.rejected(
+                AuthorityRejection(
+                    statusCode: http.statusCode,
+                    rawCode: decoded?.error ?? "http_\(http.statusCode)",
+                    message: decoded?.message ?? "Authority returned HTTP \(http.statusCode)"
+                )
+            )
+        }
+        return data
+    }
+
+    private func decode<Value: Decodable>(_ data: Data) throws -> Value {
+        do {
+            return try Self.decoder().decode(Value.self, from: data)
+        } catch {
+            throw AuthorityClientError.malformedResponse(String(describing: error))
+        }
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    private static func timestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
+    }
+}
+
+/// Explicitly non-operational client for previews and scenarios that do
+/// not configure an Authority service.
 public struct StubModerationAuthorityClient: ModerationAuthorityClient {
     public init() {}
+
+    public func registerMandate(
+        _ mandate: ModerationMandate
+    ) async throws -> MandateRegistrationReceipt {
+        throw ModerationError.notImplemented("accept-mandate")
+    }
 
     public func fileReport(_ report: Report) async throws -> ReportReceipt {
         throw ModerationError.notImplemented("file-report")
@@ -155,5 +411,13 @@ public struct StubModerationAuthorityClient: ModerationAuthorityClient {
 
     public func queryStatus(caseId: String) async throws -> CaseStatus {
         throw ModerationError.notImplemented("query-status")
+    }
+}
+
+public struct StubModerationAuthorityClientFactory: ModerationAuthorityClientFactory {
+    public init() {}
+
+    public func client(for listing: AuthorityListing) -> any ModerationAuthorityClient {
+        StubModerationAuthorityClient()
     }
 }

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -84,6 +84,7 @@ public enum AuthorityClientError: Error, Sendable, Equatable {
     case rejected(AuthorityRejection)
     case mandateNotAccepted(mandateRef: String)
     case mandateReferenceMismatch(expected: String, received: String)
+    case localMandateRecordMissing(mandateRef: String)
 }
 
 /// The accused's signed response to a case notice: statements and
@@ -365,6 +366,7 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         }
         var request = URLRequest(url: url)
         request.httpMethod = method
+        request.timeoutInterval = 15
         request.httpBody = body
         if body != nil {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -405,7 +407,30 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
 
     private static func decoder() -> JSONDecoder {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        // RFC 3339 permits fractional seconds. Foundation's built-in
+        // `.iso8601` strategy accepts only the whole-second form, so
+        // try both shapes used by conforming Authority implementations.
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+
+            let fractional = ISO8601DateFormatter()
+            fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = fractional.date(from: value) {
+                return date
+            }
+
+            let wholeSeconds = ISO8601DateFormatter()
+            wholeSeconds.formatOptions = [.withInternetDateTime]
+            if let date = wholeSeconds.date(from: value) {
+                return date
+            }
+
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "expected an RFC 3339 timestamp"
+            )
+        }
         return decoder
     }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -29,6 +29,12 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// be parsed — absent prefix, or an empty/blank identifier naming
     /// no component. See `ComponentReference`.
     case componentReferenceInvalid(String)
+    /// A persisted registration cannot be retried because its Authority
+    /// is not present in the Interface's current designated directory.
+    case authorityUnavailable(String)
+    /// The requested artifact has already resolved (or was never a
+    /// persisted registration attempt).
+    case registrationNotPending
     /// DeviceCheck is unsupported here (simulator, enterprise-signed
     /// build). Callers degrade toward gate-check-required, never toward
     /// unmoderated operation (profile §8.5).

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -17,8 +17,9 @@ public struct ModerationState: Sendable, Equatable {
     public let fetchStatus: AuthorityFetchStatus
     /// The active record, if the user has consented.
     public let activeMandate: MandateRecord?
-    /// Every record ever signed on this device, newest first —
-    /// old mandates stay pinned to their consented manifest hashes.
+    /// Accepted mandates and registration attempts whose outcome is
+    /// still ambiguous, newest first. Definitively refused attempts are
+    /// not mandates and are removed from this retained state.
     public let history: [MandateRecord]
 
     public static let empty = ModerationState(
@@ -173,12 +174,6 @@ public actor ModerationRepository {
         reviewedManifest: ReviewedManifest
     ) async throws -> MandateRecord {
         let signedManifest = reviewedManifest.signedManifest
-        guard signedManifest.manifest.componentId == listing.componentId else {
-            throw ModerationError.manifestInvalid(
-                "reviewed manifest componentId does not match the selected authority"
-            )
-        }
-        try manifestValidator.validateForConsent(signedManifest, now: clock())
         let userKey = try await signer.userKeyID()
         let key = ConsentKey(
             authority: listing.componentId,
@@ -387,7 +382,7 @@ public actor ModerationRepository {
             // become valid through exact replay and must not deadlock
             // every future consent attempt.
             if isDeterministicRegistrationRejection(error) {
-                markRegistrationRejected(pending)
+                discardRegistrationAttempt(pending)
             }
             throw error
         }
@@ -395,11 +390,11 @@ public actor ModerationRepository {
         // checks here preserves the invariant for every factory-injected
         // implementation of the protocol.
         guard receipt.accepted else {
-            markRegistrationRejected(pending)
+            discardRegistrationAttempt(pending)
             throw AuthorityClientError.mandateNotAccepted(mandateRef: receipt.mandateRef)
         }
         guard receipt.mandateRef == expectedRef else {
-            markRegistrationRejected(pending)
+            discardRegistrationAttempt(pending)
             throw AuthorityClientError.mandateReferenceMismatch(
                 expected: expectedRef,
                 received: receipt.mandateRef
@@ -433,9 +428,9 @@ public actor ModerationRepository {
         })
     }
 
-    private func markRegistrationRejected(_ record: MandateRecord) {
+    private func discardRegistrationAttempt(_ record: MandateRecord) {
         guard let index = recordIndex(of: record) else { return }
-        records[index].registrationRejected = true
+        records.remove(at: index)
         mandateStore.save(records)
         publish()
     }
@@ -446,7 +441,9 @@ public actor ModerationRepository {
         case .mandateNotAccepted, .mandateReferenceMismatch:
             return true
         case .rejected(let rejection):
-            return rejection.code == .badRequest || rejection.code == .signatureInvalid
+            return (400..<500).contains(rejection.statusCode)
+                && rejection.statusCode != 408
+                && rejection.statusCode != 429
         case .invalidResponse, .malformedResponse, .localMandateRecordMissing:
             return false
         }

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -223,17 +223,28 @@ public actor ModerationRepository {
         // pinned by a signed mandate.
         try manifestValidator.validateForConsent(signedManifest, now: clock())
 
-        // If registration previously failed after countersigning, retry
-        // that immutable mandate byte-for-byte. Minting a replacement
-        // would leave two consent artifacts at an Authority that may
-        // have accepted the first request before its response was lost.
-        if let pending = records.first(where: {
+        // Resolve every older ambiguous registration for this Authority
+        // before minting under newly reviewed terms. A manifest rotation
+        // must not orphan hidden pending bytes or create a replacement
+        // while the old request may already have committed.
+        while let pending = records.first(where: {
             $0.mandate.authority == listing.componentId
                 && $0.mandate.user == userKey
-                && $0.mandate.manifestHash == signedManifest.manifestHash
                 && $0.registrationPending
         }) {
-            return try await registerAndActivate(pending, with: listing)
+            if pending.mandate.manifestHash == signedManifest.manifestHash {
+                return try await registerPending(pending, with: listing, activate: true)
+            }
+            do {
+                _ = try await registerPending(pending, with: listing, activate: false)
+            } catch {
+                // A definitive refusal removes the old attempt, so the
+                // consent the user just gave to the new manifest may
+                // proceed. Ambiguous outcomes still block replacement.
+                guard isDeterministicRegistrationRejection(error) else {
+                    throw error
+                }
+            }
         }
 
         // Enrollment: (identity signature, device token) presented
@@ -309,7 +320,7 @@ public actor ModerationRepository {
             records.insert(record, at: 0)
             mandateStore.save(records)
             publish()
-            return try await registerAndActivate(record, with: listing)
+            return try await registerPending(record, with: listing, activate: true)
         }
 
         // Deactivate the previous active record without touching
@@ -363,12 +374,14 @@ public actor ModerationRepository {
         continuations.removeValue(forKey: id)
     }
 
-    /// Register a pending countersigned mandate, verify that the
-    /// Authority derived the same content reference, then atomically
-    /// make it the locally active record.
-    private func registerAndActivate(
+    /// Register a pending countersigned mandate and verify that the
+    /// Authority derived the same content reference. Current reviewed
+    /// terms become active; older terms resolved ahead of a rotation are
+    /// retained as history without transiently becoming current.
+    private func registerPending(
         _ pending: MandateRecord,
-        with listing: AuthorityListing
+        with listing: AuthorityListing,
+        activate: Bool
     ) async throws -> MandateRecord {
         let expectedRef = try pending.mandate.mandateHash()
         let client = authorityClients.client(for: listing)
@@ -389,10 +402,6 @@ public actor ModerationRepository {
         // The concrete HTTP client validates these too. Repeating the
         // checks here preserves the invariant for every factory-injected
         // implementation of the protocol.
-        guard receipt.accepted else {
-            discardRegistrationAttempt(pending)
-            throw AuthorityClientError.mandateNotAccepted(mandateRef: receipt.mandateRef)
-        }
         guard receipt.mandateRef == expectedRef else {
             discardRegistrationAttempt(pending)
             throw AuthorityClientError.mandateReferenceMismatch(
@@ -400,16 +409,38 @@ public actor ModerationRepository {
                 received: receipt.mandateRef
             )
         }
+        guard receipt.accepted else {
+            discardRegistrationAttempt(pending)
+            throw AuthorityClientError.mandateNotAccepted(mandateRef: receipt.mandateRef)
+        }
 
         // The content reference excludes signatures. Locate the exact
         // persisted record instead, then activate only that array entry;
         // two records with the same unsigned fields must never both become
         // active merely because they share a content hash.
         guard let pendingIndex = recordIndex(of: pending) else {
-            throw AuthorityClientError.localMandateRecordMissing(mandateRef: expectedRef)
+            // Defensive recovery for a future mutation path: the
+            // Authority has accepted these exact bytes, so reconstruct
+            // the local registered record rather than minting again.
+            var recovered = pending
+            recovered.authorityRegistered = true
+            recovered.isActive = activate
+            if activate {
+                for index in records.indices {
+                    records[index].isActive = false
+                }
+            }
+            records.insert(recovered, at: 0)
+            mandateStore.save(records)
+            publish()
+            return recovered
         }
-        for index in records.indices {
-            records[index].isActive = index == pendingIndex
+        if activate {
+            for index in records.indices {
+                records[index].isActive = index == pendingIndex
+            }
+        } else {
+            records[pendingIndex].isActive = false
         }
         records[pendingIndex].authorityRegistered = true
         let activated = records[pendingIndex]
@@ -444,7 +475,7 @@ public actor ModerationRepository {
             return (400..<500).contains(rejection.statusCode)
                 && rejection.statusCode != 408
                 && rejection.statusCode != 429
-        case .invalidResponse, .malformedResponse, .localMandateRecordMissing:
+        case .invalidResponse, .malformedResponse, .invalidPathComponent:
             return false
         }
     }

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -89,12 +89,26 @@ public actor ModerationRepository {
         let manifestHash: String
     }
 
+    /// Exact persisted registration artifact. `mandateBytes` includes
+    /// both signatures; `createdAt` distinguishes two locally retained
+    /// records whose signed bytes happen to be identical.
+    private struct RegistrationKey: Hashable {
+        let mandateBytes: Data
+        let createdAt: Date
+    }
+
+    private struct RegistrationFlight {
+        let task: Task<MandateRegistrationReceipt, Error>
+        var waiters: Int
+    }
+
     private var authorities: [AuthorityListing] = []
     private var fetchStatus: AuthorityFetchStatus = .idle
     private var records: [MandateRecord]
     private var continuations: [UUID: AsyncStream<ModerationState>.Continuation] = [:]
     private var startTask: Task<Void, Never>?
     private var consentTasks: [ConsentKey: Task<MandateRecord, Error>] = [:]
+    private var registrationFlights: [RegistrationKey: RegistrationFlight] = [:]
 
     public init(
         authoritiesFetcher: any KnownAuthoritiesFetcher,
@@ -359,6 +373,30 @@ public actor ModerationRepository {
         )
     }
 
+    /// Retry one persisted registration attempt without minting or
+    /// signing anything new. A later consent always wins: resolving an
+    /// older artifact records it as history rather than silently making
+    /// its Authority current again.
+    @discardableResult
+    public func retryRegistration(_ pending: MandateRecord) async throws -> MandateRecord {
+        guard let storedIndex = recordIndex(of: pending) else {
+            throw ModerationError.registrationNotPending
+        }
+        guard records[storedIndex].registrationPending else {
+            return records[storedIndex]
+        }
+        guard let listing = authorities.first(where: {
+            $0.componentId == pending.mandate.authority
+        }) else {
+            throw ModerationError.authorityUnavailable(pending.mandate.authority)
+        }
+        return try await registerPending(
+            pending,
+            with: listing,
+            activate: shouldActivateResolvedPending(pending)
+        )
+    }
+
     // MARK: - AsyncStream
 
     public nonisolated var snapshots: AsyncStream<ModerationState> {
@@ -390,11 +428,9 @@ public actor ModerationRepository {
         let userKey = try await signer.userKeyID()
         guard let pending = records.first(where: {
             $0.mandate.user == userKey && $0.registrationPending
-        }), let listing = authorities.first(where: {
-            $0.componentId == pending.mandate.authority
         }) else { return }
 
-        _ = try await registerPending(pending, with: listing, activate: true)
+        _ = try await retryRegistration(pending)
     }
 
     /// Register a pending countersigned mandate and verify that the
@@ -407,11 +443,30 @@ public actor ModerationRepository {
         activate: Bool
     ) async throws -> MandateRecord {
         let expectedRef = try pending.mandate.mandateHash()
-        let client = authorityClients.client(for: listing)
+        let registrationKey = RegistrationKey(
+            mandateBytes: try ModerationCanonicalEncoder.encode(pending.mandate),
+            createdAt: pending.createdAt
+        )
+        let registrationTask: Task<MandateRegistrationReceipt, Error>
+        if var flight = registrationFlights[registrationKey] {
+            flight.waiters += 1
+            registrationFlights[registrationKey] = flight
+            registrationTask = flight.task
+        } else {
+            let client = authorityClients.client(for: listing)
+            let task = Task {
+                try await client.registerMandate(pending.mandate)
+            }
+            registrationFlights[registrationKey] = RegistrationFlight(task: task, waiters: 1)
+            registrationTask = task
+        }
+
         let receipt: MandateRegistrationReceipt
         do {
-            receipt = try await client.registerMandate(pending.mandate)
+            receipt = try await registrationTask.value
+            releaseRegistrationFlight(registrationKey)
         } catch {
+            releaseRegistrationFlight(registrationKey)
             // A transport failure, malformed reply, or 5xx may happen
             // after the Authority committed, so those retain the exact
             // artifact for retry. A definitive artifact failure cannot
@@ -458,11 +513,15 @@ public actor ModerationRepository {
             publish()
             return recovered
         }
+        let wasPending = records[pendingIndex].registrationPending
         if activate {
             for index in records.indices {
                 records[index].isActive = index == pendingIndex
             }
-        } else {
+        } else if wasPending {
+            // Do not let a second waiter with `activate == false`
+            // deactivate a record an explicit-consent waiter has just
+            // activated from the same shared registration response.
             records[pendingIndex].isActive = false
         }
         records[pendingIndex].authorityRegistered = true
@@ -470,6 +529,31 @@ public actor ModerationRepository {
         mandateStore.save(records)
         publish()
         return activated
+    }
+
+    private func releaseRegistrationFlight(_ key: RegistrationKey) {
+        guard var flight = registrationFlights[key] else { return }
+        flight.waiters -= 1
+        if flight.waiters == 0 {
+            registrationFlights.removeValue(forKey: key)
+        } else {
+            registrationFlights[key] = flight
+        }
+    }
+
+    /// Records are newest-first. Dates make the ordering explicit; the
+    /// array position breaks ties for stores written under a fixed or
+    /// low-resolution clock. Any later completed consent prevents this
+    /// background retry from rolling the user's selection backward.
+    private func shouldActivateResolvedPending(_ pending: MandateRecord) -> Bool {
+        guard let pendingIndex = recordIndex(of: pending) else { return false }
+        return !records.enumerated().contains { index, record in
+            guard record.mandate.user == pending.mandate.user,
+                  !record.registrationPending
+            else { return false }
+            return record.createdAt > pending.createdAt
+                || (record.createdAt == pending.createdAt && index < pendingIndex)
+        }
     }
 
     private func recordIndex(of record: MandateRecord) -> Int? {
@@ -498,7 +582,7 @@ public actor ModerationRepository {
             return (400..<500).contains(rejection.statusCode)
                 && rejection.statusCode != 408
                 && rejection.statusCode != 429
-        case .invalidResponse, .malformedResponse, .invalidPathComponent:
+        case .invalidResponse, .malformedResponse, .invalidPathComponent, .insecureBaseURL:
             return false
         }
     }

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -82,11 +82,18 @@ public actor ModerationRepository {
     private let signer: any ModerationSigner
     private let clock: @Sendable () -> Date
 
+    private struct ConsentKey: Hashable {
+        let authority: String
+        let user: String
+        let manifestHash: String
+    }
+
     private var authorities: [AuthorityListing] = []
     private var fetchStatus: AuthorityFetchStatus = .idle
     private var records: [MandateRecord]
     private var continuations: [UUID: AsyncStream<ModerationState>.Continuation] = [:]
     private var startTask: Task<Void, Never>?
+    private var consentTasks: [ConsentKey: Task<MandateRecord, Error>] = [:]
 
     public init(
         authoritiesFetcher: any KnownAuthoritiesFetcher,
@@ -171,13 +178,55 @@ public actor ModerationRepository {
                 "reviewed manifest componentId does not match the selected authority"
             )
         }
+        try manifestValidator.validateForConsent(signedManifest, now: clock())
+        let userKey = try await signer.userKeyID()
+        let key = ConsentKey(
+            authority: listing.componentId,
+            user: userKey,
+            manifestHash: signedManifest.manifestHash
+        )
+
+        // Actor methods are reentrant at every network await. Share one
+        // consent task per user/authority/manifest so overlapping taps
+        // cannot both pass the pending lookup and mint two artifacts.
+        if let task = consentTasks[key] {
+            return try await task.value
+        }
+        let task = Task {
+            try await self.performConsent(
+                to: listing,
+                reviewedManifest: reviewedManifest,
+                userKey: userKey
+            )
+        }
+        consentTasks[key] = task
+        do {
+            let record = try await task.value
+            consentTasks.removeValue(forKey: key)
+            return record
+        } catch {
+            consentTasks.removeValue(forKey: key)
+            throw error
+        }
+    }
+
+    private func performConsent(
+        to listing: AuthorityListing,
+        reviewedManifest: ReviewedManifest,
+        userKey: String
+    ) async throws -> MandateRecord {
+        let signedManifest = reviewedManifest.signedManifest
+        guard signedManifest.manifest.componentId == listing.componentId else {
+            throw ModerationError.manifestInvalid(
+                "reviewed manifest componentId does not match the selected authority"
+            )
+        }
 
         // Validity conditions (validUntil, supported profile, external
         // appellate for permanent classes) gate enrollment and signing —
         // not just the consent UI. An invalid manifest must never end up
         // pinned by a signed mandate.
         try manifestValidator.validateForConsent(signedManifest, now: clock())
-        let userKey = try await signer.userKeyID()
 
         // If registration previously failed after countersigning, retry
         // that immutable mandate byte-for-byte. Minting a replacement
@@ -187,8 +236,7 @@ public actor ModerationRepository {
             $0.mandate.authority == listing.componentId
                 && $0.mandate.user == userKey
                 && $0.mandate.manifestHash == signedManifest.manifestHash
-                && $0.countersigned
-                && !$0.authorityRegistered
+                && $0.registrationPending
         }) {
             return try await registerAndActivate(pending, with: listing)
         }
@@ -329,11 +377,29 @@ public actor ModerationRepository {
     ) async throws -> MandateRecord {
         let expectedRef = try pending.mandate.mandateHash()
         let client = authorityClients.client(for: listing)
-        let receipt = try await client.registerMandate(pending.mandate)
+        let receipt: MandateRegistrationReceipt
+        do {
+            receipt = try await client.registerMandate(pending.mandate)
+        } catch {
+            // A transport failure, malformed reply, or 5xx may happen
+            // after the Authority committed, so those retain the exact
+            // artifact for retry. A definitive artifact failure cannot
+            // become valid through exact replay and must not deadlock
+            // every future consent attempt.
+            if isDeterministicRegistrationRejection(error) {
+                markRegistrationRejected(pending)
+            }
+            throw error
+        }
+        // The concrete HTTP client validates these too. Repeating the
+        // checks here preserves the invariant for every factory-injected
+        // implementation of the protocol.
         guard receipt.accepted else {
+            markRegistrationRejected(pending)
             throw AuthorityClientError.mandateNotAccepted(mandateRef: receipt.mandateRef)
         }
         guard receipt.mandateRef == expectedRef else {
+            markRegistrationRejected(pending)
             throw AuthorityClientError.mandateReferenceMismatch(
                 expected: expectedRef,
                 received: receipt.mandateRef
@@ -344,16 +410,8 @@ public actor ModerationRepository {
         // persisted record instead, then activate only that array entry;
         // two records with the same unsigned fields must never both become
         // active merely because they share a content hash.
-        guard let pendingIndex = records.firstIndex(where: {
-            $0.mandate == pending.mandate
-                && $0.manifestBytes == pending.manifestBytes
-                && $0.authorityName == pending.authorityName
-                && $0.countersigned == pending.countersigned
-                && $0.createdAt == pending.createdAt
-        }) else {
-            throw AuthorityClientError.malformedResponse(
-                "registered mandate disappeared from the local store"
-            )
+        guard let pendingIndex = recordIndex(of: pending) else {
+            throw AuthorityClientError.localMandateRecordMissing(mandateRef: expectedRef)
         }
         for index in records.indices {
             records[index].isActive = index == pendingIndex
@@ -363,6 +421,35 @@ public actor ModerationRepository {
         mandateStore.save(records)
         publish()
         return activated
+    }
+
+    private func recordIndex(of record: MandateRecord) -> Int? {
+        records.firstIndex(where: {
+            $0.mandate == record.mandate
+                && $0.manifestBytes == record.manifestBytes
+                && $0.authorityName == record.authorityName
+                && $0.countersigned == record.countersigned
+                && $0.createdAt == record.createdAt
+        })
+    }
+
+    private func markRegistrationRejected(_ record: MandateRecord) {
+        guard let index = recordIndex(of: record) else { return }
+        records[index].registrationRejected = true
+        mandateStore.save(records)
+        publish()
+    }
+
+    private func isDeterministicRegistrationRejection(_ error: Error) -> Bool {
+        guard let error = error as? AuthorityClientError else { return false }
+        switch error {
+        case .mandateNotAccepted, .mandateReferenceMismatch:
+            return true
+        case .rejected(let rejection):
+            return rejection.code == .badRequest || rejection.code == .signatureInvalid
+        case .invalidResponse, .malformedResponse, .localMandateRecordMissing:
+            return false
+        }
     }
 
     private func publish() {

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -126,7 +126,15 @@ public actor ModerationRepository {
     public func start() {
         guard startTask == nil else { return }
         startTask = Task { [weak self] in
-            try? await self?.refresh()
+            guard let self else { return }
+            do {
+                try await self.refresh()
+                try await self.retryNewestPendingRegistration()
+            } catch {
+                // Directory and registration retry state are already
+                // published/persisted by their individual operations.
+                // A later consent attempt resumes safely.
+            }
         }
     }
 
@@ -372,6 +380,21 @@ public actor ModerationRepository {
 
     private func unsubscribe(id: UUID) {
         continuations.removeValue(forKey: id)
+    }
+
+    /// Resume the newest interrupted consent after the directory is
+    /// available. The user already signed these exact bytes; this does
+    /// not create consent in the background, it only completes delivery
+    /// of the persisted artifact.
+    private func retryNewestPendingRegistration() async throws {
+        let userKey = try await signer.userKeyID()
+        guard let pending = records.first(where: {
+            $0.mandate.user == userKey && $0.registrationPending
+        }), let listing = authorities.first(where: {
+            $0.componentId == pending.mandate.authority
+        }) else { return }
+
+        _ = try await registerPending(pending, with: listing, activate: true)
     }
 
     /// Register a pending countersigned mandate and verify that the

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -77,6 +77,7 @@ public actor ModerationRepository {
     private let manifestValidator: AuthorityManifestValidator
     private let mandateStore: any MandateStore
     private let backend: any EnforcementBackendClient
+    private let authorityClients: any ModerationAuthorityClientFactory
     private let attestation: any DeviceAttestationProvider
     private let signer: any ModerationSigner
     private let clock: @Sendable () -> Date
@@ -92,6 +93,7 @@ public actor ModerationRepository {
         manifestFetcher: any AuthorityManifestFetcher,
         mandateStore: any MandateStore,
         backend: any EnforcementBackendClient,
+        authorityClients: any ModerationAuthorityClientFactory = StubModerationAuthorityClientFactory(),
         attestation: any DeviceAttestationProvider,
         signer: any ModerationSigner,
         manifestValidator: AuthorityManifestValidator = AuthorityManifestValidator(),
@@ -102,6 +104,7 @@ public actor ModerationRepository {
         self.manifestValidator = manifestValidator
         self.mandateStore = mandateStore
         self.backend = backend
+        self.authorityClients = authorityClients
         self.attestation = attestation
         self.signer = signer
         self.clock = clock
@@ -150,7 +153,8 @@ public actor ModerationRepository {
     /// Consent to the exact manifest the user reviewed: validate it again
     /// at signing time, pin its already-computed hash and raw bytes, enroll
     /// this device, sign the mandate, obtain the interface countersignature,
-    /// and persist. This method deliberately never refetches the manifest;
+    /// register those exact bytes with the Authority, and only then activate
+    /// the local record. This method deliberately never refetches the manifest;
     /// an authority changing its hosted terms between review and agreement
     /// therefore cannot replace the artifact that gets signed.
     ///
@@ -173,6 +177,21 @@ public actor ModerationRepository {
         // not just the consent UI. An invalid manifest must never end up
         // pinned by a signed mandate.
         try manifestValidator.validateForConsent(signedManifest, now: clock())
+        let userKey = try await signer.userKeyID()
+
+        // If registration previously failed after countersigning, retry
+        // that immutable mandate byte-for-byte. Minting a replacement
+        // would leave two consent artifacts at an Authority that may
+        // have accepted the first request before its response was lost.
+        if let pending = records.first(where: {
+            $0.mandate.authority == listing.componentId
+                && $0.mandate.user == userKey
+                && $0.mandate.manifestHash == signedManifest.manifestHash
+                && $0.countersigned
+                && !$0.authorityRegistered
+        }) {
+            return try await registerAndActivate(pending, with: listing)
+        }
 
         // Enrollment: (identity signature, device token) presented
         // together is the only token↔enrollment linkage. A nil token
@@ -184,7 +203,6 @@ public actor ModerationRepository {
         } else {
             token = nil
         }
-        let userKey = try await signer.userKeyID()
         // The signed bytes are built from exactly the fields the
         // request transmits, so the backend can recompute and verify
         // them — the timestamp travels with the signature it covers.
@@ -233,9 +251,23 @@ public actor ModerationRepository {
             manifestBytes: signedManifest.rawBytes,
             authorityName: listing.name,
             countersigned: isCountersigned,
-            isActive: true,
+            authorityRegistered: false,
+            // The sentinel exists only for UI/dev scenarios with no
+            // deployed Interface or Authority. Preserve that explicit
+            // nonconforming scaffold, but never send it to an Authority.
+            isActive: !isCountersigned,
             createdAt: clock()
         )
+
+        if isCountersigned {
+            // Persist before the network hop. If the Authority commits
+            // and its response is lost, the next attempt resends this
+            // exact mandate rather than signing another one.
+            records.insert(record, at: 0)
+            mandateStore.save(records)
+            publish()
+            return try await registerAndActivate(record, with: listing)
+        }
 
         // Deactivate the previous active record without touching
         // anything else in it (mandates are immutable, spec §12).
@@ -286,6 +318,45 @@ public actor ModerationRepository {
 
     private func unsubscribe(id: UUID) {
         continuations.removeValue(forKey: id)
+    }
+
+    /// Register a pending countersigned mandate, verify that the
+    /// Authority derived the same content reference, then atomically
+    /// make it the locally active record.
+    private func registerAndActivate(
+        _ pending: MandateRecord,
+        with listing: AuthorityListing
+    ) async throws -> MandateRecord {
+        let expectedRef = try pending.mandate.mandateHash()
+        let client = authorityClients.client(for: listing)
+        let receipt = try await client.registerMandate(pending.mandate)
+        guard receipt.accepted, receipt.mandateRef == expectedRef else {
+            throw AuthorityClientError.mandateReferenceMismatch(
+                expected: expectedRef,
+                received: receipt.mandateRef
+            )
+        }
+
+        var activated: MandateRecord?
+        records = records.map { existing in
+            var existing = existing
+            if (try? existing.mandate.mandateHash()) == expectedRef {
+                existing.authorityRegistered = true
+                existing.isActive = true
+                activated = existing
+            } else {
+                existing.isActive = false
+            }
+            return existing
+        }
+        guard let activated else {
+            throw AuthorityClientError.malformedResponse(
+                "registered mandate disappeared from the local store"
+            )
+        }
+        mandateStore.save(records)
+        publish()
+        return activated
     }
 
     private func publish() {

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -93,7 +93,7 @@ public actor ModerationRepository {
         manifestFetcher: any AuthorityManifestFetcher,
         mandateStore: any MandateStore,
         backend: any EnforcementBackendClient,
-        authorityClients: any ModerationAuthorityClientFactory = StubModerationAuthorityClientFactory(),
+        authorityClients: any ModerationAuthorityClientFactory,
         attestation: any DeviceAttestationProvider,
         signer: any ModerationSigner,
         manifestValidator: AuthorityManifestValidator = AuthorityManifestValidator(),
@@ -330,30 +330,36 @@ public actor ModerationRepository {
         let expectedRef = try pending.mandate.mandateHash()
         let client = authorityClients.client(for: listing)
         let receipt = try await client.registerMandate(pending.mandate)
-        guard receipt.accepted, receipt.mandateRef == expectedRef else {
+        guard receipt.accepted else {
+            throw AuthorityClientError.mandateNotAccepted(mandateRef: receipt.mandateRef)
+        }
+        guard receipt.mandateRef == expectedRef else {
             throw AuthorityClientError.mandateReferenceMismatch(
                 expected: expectedRef,
                 received: receipt.mandateRef
             )
         }
 
-        var activated: MandateRecord?
-        records = records.map { existing in
-            var existing = existing
-            if (try? existing.mandate.mandateHash()) == expectedRef {
-                existing.authorityRegistered = true
-                existing.isActive = true
-                activated = existing
-            } else {
-                existing.isActive = false
-            }
-            return existing
-        }
-        guard let activated else {
+        // The content reference excludes signatures. Locate the exact
+        // persisted record instead, then activate only that array entry;
+        // two records with the same unsigned fields must never both become
+        // active merely because they share a content hash.
+        guard let pendingIndex = records.firstIndex(where: {
+            $0.mandate == pending.mandate
+                && $0.manifestBytes == pending.manifestBytes
+                && $0.authorityName == pending.authorityName
+                && $0.countersigned == pending.countersigned
+                && $0.createdAt == pending.createdAt
+        }) else {
             throw AuthorityClientError.malformedResponse(
                 "registered mandate disappeared from the local store"
             )
         }
+        for index in records.indices {
+            records[index].isActive = index == pendingIndex
+        }
+        records[pendingIndex].authorityRegistered = true
+        let activated = records[pendingIndex]
         mandateStore.save(records)
         publish()
         return activated

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
@@ -63,8 +63,9 @@ public final class ModerationSettingsFlow {
     }
 
     /// Deactivated records, newest first — each still pinned to the
-    /// manifest hash it consented to.
+    /// manifest hash it consented to. A persisted registration attempt
+    /// is retry state, not a mandate the user previously held.
     public var previousMandates: [MandateRecord] {
-        state.snapshot.history.filter { !$0.isActive }
+        state.snapshot.history.filter { !$0.isActive && !$0.registrationPending }
     }
 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
@@ -66,6 +66,6 @@ public final class ModerationSettingsFlow {
     /// manifest hash it consented to. A persisted registration attempt
     /// is retry state, not a mandate the user previously held.
     public var previousMandates: [MandateRecord] {
-        state.snapshot.history.filter { !$0.isActive && !$0.registrationIncomplete }
+        state.snapshot.history.filter { !$0.isActive && !$0.registrationPending }
     }
 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
@@ -11,6 +11,8 @@ public final class ModerationSettingsFlow {
     public struct State: Equatable {
         public var snapshot: ModerationState = .empty
         public var openCases: [CaseNotice] = []
+        public var retryingRegistration: String?
+        public var registrationErrorMessage: String?
     }
 
     public private(set) var state = State()
@@ -67,5 +69,33 @@ public final class ModerationSettingsFlow {
     /// is retry state, not a mandate the user previously held.
     public var previousMandates: [MandateRecord] {
         state.snapshot.history.filter { !$0.isActive && !$0.registrationPending }
+    }
+
+    /// Signed, countersigned artifacts whose Authority acknowledgement
+    /// is still ambiguous. They are deliberately shown separately from
+    /// both current consent and immutable history.
+    public var pendingRegistrations: [MandateRecord] {
+        state.snapshot.history.filter(\.registrationPending)
+    }
+
+    public func retryRegistration(_ record: MandateRecord) async {
+        let id = record.registrationRowID
+        guard state.retryingRegistration == nil else { return }
+        state.retryingRegistration = id
+        state.registrationErrorMessage = nil
+        defer { state.retryingRegistration = nil }
+        do {
+            try await repository.retryRegistration(record)
+        } catch {
+            state.registrationErrorMessage = String(
+                localized: "Couldn't confirm this mandate with its authority. Try again."
+            )
+        }
+    }
+}
+
+private extension MandateRecord {
+    var registrationRowID: String {
+        "\(mandate.authority)|\(mandate.manifestHash)|\(mandate.acceptedAt.timeIntervalSince1970)"
     }
 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsFlow.swift
@@ -66,6 +66,6 @@ public final class ModerationSettingsFlow {
     /// manifest hash it consented to. A persisted registration attempt
     /// is retry state, not a mandate the user previously held.
     public var previousMandates: [MandateRecord] {
-        state.snapshot.history.filter { !$0.isActive && !$0.registrationPending }
+        state.snapshot.history.filter { !$0.isActive && !$0.registrationIncomplete }
     }
 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
@@ -36,6 +36,41 @@ public struct ModerationSettingsView: View {
                     noMandateCard
                 }
 
+                if !flow.pendingRegistrations.isEmpty {
+                    SettingsSectionLabel("PENDING REGISTRATION")
+                    SettingsCard {
+                        ForEach(
+                            Array(flow.pendingRegistrations.enumerated()),
+                            id: \.element.historyRowID
+                        ) { idx, record in
+                            Button {
+                                Task { await flow.retryRegistration(record) }
+                            } label: {
+                                SettingsRow(
+                                    titleText: record.authorityName,
+                                    subtitle: pendingRegistrationSubtitle(record),
+                                    last: idx == flow.pendingRegistrations.count - 1
+                                ) {
+                                    SettingsIconTile(
+                                        symbol: "clock.arrow.circlepath",
+                                        bg: SettingsTile.indigo
+                                    )
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(flow.state.retryingRegistration != nil)
+                            .accessibilityIdentifier("moderation.settings.retry-registration")
+                        }
+                    }
+                    if let message = flow.state.registrationErrorMessage {
+                        SettingsFootnote(verbatim: message)
+                    } else {
+                        SettingsFootnote(
+                            "These signed mandates are not active. Tap one to retry delivery of the exact persisted artifact; no new consent is created."
+                        )
+                    }
+                }
+
                 if !flow.previousMandates.isEmpty {
                     SettingsSectionLabel("PREVIOUS MANDATES")
                     SettingsCard {
@@ -122,6 +157,13 @@ public struct ModerationSettingsView: View {
                 .accessibilityIdentifier("moderation.settings.choose")
             }
         }
+    }
+
+    private func pendingRegistrationSubtitle(_ record: MandateRecord) -> String {
+        if flow.state.retryingRegistration == record.historyRowID {
+            return String(localized: "Confirming with authority…")
+        }
+        return String(localized: "Not active · Tap to retry")
     }
 
     private func row(_ label: LocalizedStringKey, _ value: String, monospaced: Bool = false) -> some View {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -150,6 +150,9 @@ struct OnymIOSApp: App {
                 manifestFetcher: moderationManifestFetcher,
                 mandateStore: UserDefaultsMandateStore(),
                 backend: backend,
+                authorityClients: URLSessionModerationAuthorityClientFactory(
+                    signer: moderationSigner
+                ),
                 attestation: DCDeviceAttestationProvider(),
                 signer: moderationSigner
             )
@@ -169,6 +172,9 @@ struct OnymIOSApp: App {
             manifestFetcher: moderationManifestFetcher,
             mandateStore: UserDefaultsMandateStore(),
             backend: moderationBackend,
+            authorityClients: URLSessionModerationAuthorityClientFactory(
+                signer: moderationSigner
+            ),
             attestation: DCDeviceAttestationProvider(),
             signer: moderationSigner
         )

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -132,6 +132,7 @@ struct OnymIOSApp: App {
                     seeded: !args.contains("--moderation-needs-consent")
                 ),
                 backend: backend,
+                authorityClients: StubModerationAuthorityClientFactory(),
                 attestation: UITestDeviceAttestationProvider(),
                 signer: moderationSigner
             )

--- a/Sources/OnymIOS/UITestFakes.swift
+++ b/Sources/OnymIOS/UITestFakes.swift
@@ -316,6 +316,7 @@ struct UITestKnownAuthoritiesFetcher: KnownAuthoritiesFetcher {
         componentId: "onym:component:uitest-authority",
         name: "UITest Authority",
         manifestURL: URL(string: "https://uitest-authority.example/manifest.json")!,
+        apiBaseURL: URL(string: "https://uitest-authority.example")!,
         operatorPublicKeyBase64: ""
     )
 

--- a/Tests/OnymIOSTests/GateHardeningTests.swift
+++ b/Tests/OnymIOSTests/GateHardeningTests.swift
@@ -243,6 +243,7 @@ final class GateHardeningTests: XCTestCase {
             manifestFetcher: UnusedManifestFetcher(),
             mandateStore: SeededMandateStore(records: [record]),
             backend: backend,
+            authorityClients: StubModerationAuthorityClientFactory(),
             attestation: FixedAttestation(),
             signer: FixedSigner(),
             clock: { [now] in now }

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -1,0 +1,280 @@
+import XCTest
+@testable import OnymModeration
+
+final class ModerationAuthorityClientTests: XCTestCase {
+    private let baseURL = URL(string: "https://authority.example/service")!
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private var session: URLSession!
+
+    private struct FakeSigner: ModerationSigner {
+        func userKeyID() async throws -> String { "onym:key:0102" }
+        func sign(_ message: Data) async throws -> Data {
+            XCTAssertEqual(
+                String(decoding: message, as: UTF8.self),
+                "query-status:case-1:2023-11-14T22:13:20Z"
+            )
+            return Data("status-signature".utf8)
+        }
+    }
+
+    private final class RecordedBodies: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [String: Data] = [:]
+
+        func set(_ data: Data?, for key: String) {
+            lock.withLock { values[key] = data }
+        }
+
+        func snapshot() -> [String: Data] {
+            lock.withLock { values }
+        }
+    }
+
+    override func setUp() {
+        super.setUp()
+        session = StubURLProtocol.makeSession()
+    }
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        session = nil
+        super.tearDown()
+    }
+
+    private func makeClient() -> URLSessionModerationAuthorityClient {
+        URLSessionModerationAuthorityClient(
+            baseURL: baseURL,
+            session: session,
+            signer: FakeSigner(),
+            clock: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+    }
+
+    private func mandate() -> ModerationMandate {
+        ModerationMandate(
+            user: "onym:key:0102",
+            interface: "onym:component:onym-ios",
+            authority: "onym:component:authority",
+            manifestHash: String(repeating: "a", count: 64),
+            classes: ["csam"],
+            deviceBinding: "device-1",
+            acceptedAt: now,
+            signatures: ["user-signature", "interface-signature"]
+        )
+    }
+
+    func testAuthorityListingUsesExplicitAPIBaseURL() throws {
+        let data = Data(#"""
+        {
+          "componentId":"onym:component:authority",
+          "name":"Authority",
+          "manifestURL":"https://cdn.example/authority/manifest.json",
+          "apiBaseURL":"https://api.example/moderation",
+          "operatorPublicKeyBase64":"key"
+        }
+        """#.utf8)
+        let listing = try JSONDecoder().decode(AuthorityListing.self, from: data)
+
+        XCTAssertEqual(listing.resolvedAPIBaseURL.absoluteString, "https://api.example/moderation")
+    }
+
+    func testLegacyAuthorityListingResolvesAPIBesideManifest() throws {
+        let data = Data(#"""
+        {
+          "componentId":"onym:component:authority",
+          "name":"Authority",
+          "manifestURL":"https://authority.example/service/manifest.json",
+          "operatorPublicKeyBase64":"key"
+        }
+        """#.utf8)
+        let listing = try JSONDecoder().decode(AuthorityListing.self, from: data)
+
+        XCTAssertNil(listing.apiBaseURL)
+        XCTAssertEqual(listing.resolvedAPIBaseURL.absoluteString, "https://authority.example/service/")
+    }
+
+    func testRegisterMandatePostsCanonicalBodyAndChecksReference() async throws {
+        let mandate = mandate()
+        let expectedRef = try mandate.mandateHash()
+        StubURLProtocol.set { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://authority.example/service/v1/mandates")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+            let body = try XCTUnwrap(Self.body(of: request))
+            XCTAssertEqual(body, try JSONEncoder.moderationFixture().encode(mandate))
+            let response = Data(#"{"accepted":true,"mandateRef":"\#(expectedRef)"}"#.utf8)
+            return (response, Self.httpResponse(for: request, status: 200))
+        }
+
+        let receipt = try await makeClient().registerMandate(mandate)
+        XCTAssertEqual(receipt, MandateRegistrationReceipt(mandateRef: expectedRef, accepted: true))
+    }
+
+    func testFileReportDecodesFullReferenceReceipt() async throws {
+        let report = Report(
+            reportId: "report-1",
+            reporter: "onym:key:0102",
+            reporterMandate: "mandate-1",
+            accused: "onym:key:0304",
+            classId: "csam",
+            evidence: [EvidenceItem(disclosedContent: "content", authenticityProof: "proof")],
+            filedAt: now,
+            signature: "report-signature"
+        )
+        StubURLProtocol.set { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://authority.example/service/v1/reports")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(Self.body(of: request), try JSONEncoder.moderationFixture().encode(report))
+            let response = Data(#"""
+            {
+              "reportId":"report-1",
+              "receivedAt":"2023-11-14T22:13:20Z",
+              "caseId":"case-1",
+              "intakeWeight":1.5,
+              "responseDeadline":"2023-11-17T22:13:20Z",
+              "decisionDeadline":"2023-11-21T22:13:20Z"
+            }
+            """#.utf8)
+            return (response, Self.httpResponse(for: request, status: 200))
+        }
+
+        let receipt = try await makeClient().fileReport(report)
+        XCTAssertEqual(receipt.reportId, "report-1")
+        XCTAssertEqual(receipt.caseId, "case-1")
+        XCTAssertEqual(receipt.intakeWeight, 1.5)
+        XCTAssertNil(receipt.duplicate)
+        XCTAssertNotNil(receipt.responseDeadline)
+        XCTAssertNotNil(receipt.decisionDeadline)
+    }
+
+    func testAuthorityErrorVocabularyIsPreserved() async throws {
+        StubURLProtocol.set { request in
+            let body = Data(#"{"error":"no_jurisdiction","message":"no_jurisdiction"}"#.utf8)
+            return (body, Self.httpResponse(for: request, status: 403))
+        }
+
+        do {
+            _ = try await makeClient().fileReport(
+                Report(
+                    reportId: "report-1",
+                    reporter: "onym:key:0102",
+                    reporterMandate: "mandate-1",
+                    accused: "onym:key:0304",
+                    classId: "csam",
+                    evidence: [],
+                    filedAt: now,
+                    signature: "signature"
+                )
+            )
+            XCTFail("expected Authority refusal")
+        } catch let AuthorityClientError.rejected(rejection) {
+            XCTAssertEqual(rejection.statusCode, 403)
+            XCTAssertEqual(rejection.code, .noJurisdiction)
+            XCTAssertEqual(rejection.rawCode, "no_jurisdiction")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testStatusQueryUsesSignedHeaders() async throws {
+        StubURLProtocol.set { request in
+            XCTAssertEqual(
+                request.url?.absoluteString,
+                "https://authority.example/service/v1/cases/case-1/status"
+            )
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Onym-Key"), "onym:key:0102")
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "X-Onym-Timestamp"),
+                "2023-11-14T22:13:20Z"
+            )
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "X-Onym-Signature"),
+                Data("status-signature".utf8).base64EncodedString()
+            )
+            let response = Data(#"""
+            {
+              "caseId":"case-1",
+              "stage":"open",
+              "classId":"csam",
+              "openedAt":"2023-11-14T22:13:20Z",
+              "responseDeadline":"2023-11-17T22:13:20Z",
+              "decisionDeadline":"2023-11-21T22:13:20Z",
+              "responded":false,
+              "responsesOnFile":0,
+              "appealState":"none",
+              "newHolderState":"none",
+              "claimRevision":0,
+              "assessment":null,
+              "events":[]
+            }
+            """#.utf8)
+            return (response, Self.httpResponse(for: request, status: 200))
+        }
+
+        let status = try await makeClient().queryStatus(caseId: "case-1")
+        XCTAssertEqual(status.caseId, "case-1")
+        XCTAssertEqual(status.stage, "open")
+        XCTAssertEqual(status.classId, "csam")
+        XCTAssertEqual(status.responded, false)
+    }
+
+    func testResponseAndAppealPutCaseIDInPathAndSignedBody() async throws {
+        let recorded = RecordedBodies()
+        StubURLProtocol.set { request in
+            recorded.set(Self.body(of: request), for: request.url!.lastPathComponent)
+            return (
+                Data(#"{"recorded":true}"#.utf8),
+                Self.httpResponse(for: request, status: 200)
+            )
+        }
+        let client = makeClient()
+        let response = CaseResponse(caseId: "case-1", statement: "answer", signature: "sig")
+        let appeal = AppealSubmission(
+            caseId: "case-1",
+            kind: .appeal,
+            statement: "review",
+            signature: "sig"
+        )
+
+        try await client.respond(response)
+        try await client.appeal(appeal)
+
+        let bodies = recorded.snapshot()
+        XCTAssertEqual(bodies["respond"], try JSONEncoder.moderationFixture().encode(response))
+        XCTAssertEqual(bodies["appeal"], try JSONEncoder.moderationFixture().encode(appeal))
+    }
+
+    private static func httpResponse(for request: URLRequest, status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+
+    /// URLSession presents an `httpBody` as a stream to custom
+    /// URLProtocols even when the caller assigned `Data` directly.
+    private static func body(of request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+
+        var body = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            if count == 0 { break }
+            body.append(contentsOf: buffer.prefix(count))
+        }
+        return body
+    }
+}
+
+private extension JSONEncoder {
+    static func moderationFixture() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -91,6 +91,32 @@ final class ModerationAuthorityClientTests: XCTestCase {
         XCTAssertThrowsError(try JSONDecoder().decode(AuthorityListing.self, from: data))
     }
 
+    func testDirectorySkipsInvalidEntryWithoutDroppingValidAuthorities() throws {
+        let data = Data(#"""
+        {
+          "authorities": [
+            {
+              "componentId":"onym:component:valid",
+              "name":"Valid",
+              "manifestURL":"https://cdn.example/valid/manifest.json",
+              "apiBaseURL":"https://api.example/valid",
+              "operatorPublicKeyBase64":"key"
+            },
+            {
+              "componentId":"onym:component:invalid",
+              "name":"Missing API endpoint",
+              "manifestURL":"https://cdn.example/invalid/manifest.json",
+              "operatorPublicKeyBase64":"key"
+            }
+          ]
+        }
+        """#.utf8)
+
+        let document = try JSONDecoder().decode(KnownAuthoritiesDocument.self, from: data)
+
+        XCTAssertEqual(document.authorities.map(\.componentId), ["onym:component:valid"])
+    }
+
     func testRegisterMandatePostsCanonicalBodyAndChecksReference() async throws {
         let mandate = mandate()
         let expectedRef = try mandate.mandateHash()
@@ -101,7 +127,7 @@ final class ModerationAuthorityClientTests: XCTestCase {
             XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
 
             let body = try XCTUnwrap(Self.body(of: request))
-            XCTAssertEqual(body, try JSONEncoder.moderationFixture().encode(mandate))
+            XCTAssertEqual(body, try ModerationCanonicalEncoder.encode(mandate))
             let response = Data(#"{"accepted":true,"mandateRef":"\#(expectedRef)"}"#.utf8)
             return (response, Self.httpResponse(for: request, status: 200))
         }
@@ -128,6 +154,24 @@ final class ModerationAuthorityClientTests: XCTestCase {
         }
     }
 
+    func testRegisterMandateChecksReferenceBeforeAcceptedFlag() async throws {
+        StubURLProtocol.set { request in
+            let response = Data(#"{"accepted":false,"mandateRef":"unrelated"}"#.utf8)
+            return (response, Self.httpResponse(for: request, status: 200))
+        }
+        let expected = try mandate().mandateHash()
+
+        do {
+            _ = try await makeClient().registerMandate(mandate())
+            XCTFail("expected unrelated receipt reference to be rejected")
+        } catch let AuthorityClientError.mandateReferenceMismatch(actual, received) {
+            XCTAssertEqual(actual, expected)
+            XCTAssertEqual(received, "unrelated")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
     func testFileReportDecodesFullReferenceReceipt() async throws {
         let report = Report(
             reportId: "report-1",
@@ -142,7 +186,7 @@ final class ModerationAuthorityClientTests: XCTestCase {
         StubURLProtocol.set { request in
             XCTAssertEqual(request.url?.absoluteString, "https://authority.example/service/v1/reports")
             XCTAssertEqual(request.httpMethod, "POST")
-            XCTAssertEqual(Self.body(of: request), try JSONEncoder.moderationFixture().encode(report))
+            XCTAssertEqual(Self.body(of: request), try ModerationCanonicalEncoder.encode(report))
             let response = Data(#"""
             {
               "reportId":"report-1",
@@ -357,8 +401,26 @@ final class ModerationAuthorityClientTests: XCTestCase {
         try await client.appeal(appeal)
 
         let bodies = recorded.snapshot()
-        XCTAssertEqual(bodies["respond"], try JSONEncoder.moderationFixture().encode(response))
-        XCTAssertEqual(bodies["appeal"], try JSONEncoder.moderationFixture().encode(appeal))
+        XCTAssertEqual(bodies["respond"], try ModerationCanonicalEncoder.encode(response))
+        XCTAssertEqual(bodies["appeal"], try ModerationCanonicalEncoder.encode(appeal))
+    }
+
+    func testCaseIDCannotEscapeItsPathSegment() async throws {
+        StubURLProtocol.set { _ in
+            XCTFail("invalid case id must be rejected before a request is sent")
+            throw URLError(.badURL)
+        }
+
+        do {
+            try await makeClient().respond(
+                CaseResponse(caseId: "case/../admin", statement: "answer", signature: "sig")
+            )
+            XCTFail("expected invalid path component")
+        } catch let AuthorityClientError.invalidPathComponent(component) {
+            XCTAssertEqual(component, "case/../admin")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
     }
 
     private static func httpResponse(for request: URLRequest, status: Int) -> HTTPURLResponse {
@@ -382,14 +444,5 @@ final class ModerationAuthorityClientTests: XCTestCase {
             body.append(contentsOf: buffer.prefix(count))
         }
         return body
-    }
-}
-
-private extension JSONEncoder {
-    static func moderationFixture() -> JSONEncoder {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        return encoder
     }
 }

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -78,7 +78,7 @@ final class ModerationAuthorityClientTests: XCTestCase {
         XCTAssertEqual(listing.resolvedAPIBaseURL.absoluteString, "https://api.example/moderation")
     }
 
-    func testLegacyAuthorityListingResolvesAPIBesideManifest() throws {
+    func testAuthorityListingWithoutExplicitAPIBaseURLFailsClosed() throws {
         let data = Data(#"""
         {
           "componentId":"onym:component:authority",
@@ -87,10 +87,8 @@ final class ModerationAuthorityClientTests: XCTestCase {
           "operatorPublicKeyBase64":"key"
         }
         """#.utf8)
-        let listing = try JSONDecoder().decode(AuthorityListing.self, from: data)
 
-        XCTAssertNil(listing.apiBaseURL)
-        XCTAssertEqual(listing.resolvedAPIBaseURL.absoluteString, "https://authority.example/service/")
+        XCTAssertThrowsError(try JSONDecoder().decode(AuthorityListing.self, from: data))
     }
 
     func testRegisterMandatePostsCanonicalBodyAndChecksReference() async throws {
@@ -99,6 +97,7 @@ final class ModerationAuthorityClientTests: XCTestCase {
         StubURLProtocol.set { request in
             XCTAssertEqual(request.url?.absoluteString, "https://authority.example/service/v1/mandates")
             XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.timeoutInterval, 15)
             XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
 
             let body = try XCTUnwrap(Self.body(of: request))
@@ -147,11 +146,11 @@ final class ModerationAuthorityClientTests: XCTestCase {
             let response = Data(#"""
             {
               "reportId":"report-1",
-              "receivedAt":"2023-11-14T22:13:20Z",
+              "receivedAt":"2023-11-14T22:13:20.123456Z",
               "caseId":"case-1",
               "intakeWeight":1.5,
-              "responseDeadline":"2023-11-17T22:13:20Z",
-              "decisionDeadline":"2023-11-21T22:13:20Z"
+              "responseDeadline":"2023-11-17T22:13:20.123456Z",
+              "decisionDeadline":"2023-11-21T22:13:20.123456Z"
             }
             """#.utf8)
             return (response, Self.httpResponse(for: request, status: 200))
@@ -161,6 +160,7 @@ final class ModerationAuthorityClientTests: XCTestCase {
         XCTAssertEqual(receipt.reportId, "report-1")
         XCTAssertEqual(receipt.caseId, "case-1")
         XCTAssertEqual(receipt.intakeWeight, 1.5)
+        XCTAssertEqual(receipt.receivedAt.timeIntervalSince1970, 1_700_000_000.123456, accuracy: 0.001)
         XCTAssertNil(receipt.duplicate)
         XCTAssertNotNil(receipt.responseDeadline)
         XCTAssertNotNil(receipt.decisionDeadline)

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -111,6 +111,24 @@ final class ModerationAuthorityClientTests: XCTestCase {
         XCTAssertEqual(receipt, MandateRegistrationReceipt(mandateRef: expectedRef, accepted: true))
     }
 
+    func testRegisterMandateReportsExplicitRejectionSeparatelyFromReferenceMismatch() async throws {
+        let mandate = mandate()
+        let expectedRef = try mandate.mandateHash()
+        StubURLProtocol.set { request in
+            let response = Data(#"{"accepted":false,"mandateRef":"\#(expectedRef)"}"#.utf8)
+            return (response, Self.httpResponse(for: request, status: 200))
+        }
+
+        do {
+            _ = try await makeClient().registerMandate(mandate)
+            XCTFail("expected the Authority not to accept the mandate")
+        } catch let AuthorityClientError.mandateNotAccepted(mandateRef) {
+            XCTAssertEqual(mandateRef, expectedRef)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
     func testFileReportDecodesFullReferenceReceipt() async throws {
         let report = Report(
             reportId: "report-1",
@@ -175,6 +193,103 @@ final class ModerationAuthorityClientTests: XCTestCase {
         } catch {
             XCTFail("unexpected error: \(error)")
         }
+    }
+
+    func testNonJSONProxyErrorUsesHTTPStatusFallback() async throws {
+        StubURLProtocol.set { request in
+            (Data("bad gateway".utf8), Self.httpResponse(for: request, status: 502))
+        }
+
+        do {
+            _ = try await makeClient().fileReport(
+                Report(
+                    reportId: "report-1",
+                    reporter: "onym:key:0102",
+                    reporterMandate: "mandate-1",
+                    accused: "onym:key:0304",
+                    classId: "csam",
+                    evidence: [],
+                    filedAt: now,
+                    signature: "signature"
+                )
+            )
+            XCTFail("expected proxy rejection")
+        } catch let AuthorityClientError.rejected(rejection) {
+            XCTAssertEqual(rejection.statusCode, 502)
+            XCTAssertEqual(rejection.rawCode, "http_502")
+            XCTAssertEqual(rejection.message, "Authority returned HTTP 502")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testNonHTTPResponseIsRejected() async throws {
+        StubURLProtocol.set { request in
+            let response = URLResponse(
+                url: request.url!,
+                mimeType: "application/json",
+                expectedContentLength: 2,
+                textEncodingName: nil
+            )
+            return (Data("{}".utf8), response)
+        }
+
+        do {
+            _ = try await makeClient().registerMandate(mandate())
+            XCTFail("expected a non-HTTP response to be rejected")
+        } catch AuthorityClientError.invalidResponse {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testMalformedSuccessBodyIsRejected() async throws {
+        StubURLProtocol.set { request in
+            (Data("{}".utf8), Self.httpResponse(for: request, status: 200))
+        }
+
+        do {
+            _ = try await makeClient().registerMandate(mandate())
+            XCTFail("expected malformed success response")
+        } catch AuthorityClientError.malformedResponse {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testDuplicateReportReceiptDecodesReplayFields() async throws {
+        StubURLProtocol.set { request in
+            let response = Data(#"""
+            {
+              "reportId":"report-1",
+              "receivedAt":"2023-11-14T22:13:20Z",
+              "caseId":"case-1",
+              "duplicate":true,
+              "responseDeadline":"2023-11-17T22:13:20Z",
+              "decisionDeadline":"2023-11-21T22:13:20Z"
+            }
+            """#.utf8)
+            return (response, Self.httpResponse(for: request, status: 200))
+        }
+
+        let receipt = try await makeClient().fileReport(
+            Report(
+                reportId: "report-1",
+                reporter: "onym:key:0102",
+                reporterMandate: "mandate-1",
+                accused: "onym:key:0304",
+                classId: "csam",
+                evidence: [],
+                filedAt: now,
+                signature: "signature"
+            )
+        )
+
+        XCTAssertEqual(receipt.duplicate, true)
+        XCTAssertNil(receipt.intakeWeight)
+        XCTAssertEqual(receipt.caseId, "case-1")
     }
 
     func testStatusQueryUsesSignedHeaders() async throws {

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -107,6 +107,13 @@ final class ModerationAuthorityClientTests: XCTestCase {
               "name":"Missing API endpoint",
               "manifestURL":"https://cdn.example/invalid/manifest.json",
               "operatorPublicKeyBase64":"key"
+            },
+            {
+              "componentId":"onym:component:insecure",
+              "name":"Insecure API endpoint",
+              "manifestURL":"https://cdn.example/insecure/manifest.json",
+              "apiBaseURL":"http://api.example/insecure",
+              "operatorPublicKeyBase64":"key"
             }
           ]
         }
@@ -115,6 +122,29 @@ final class ModerationAuthorityClientTests: XCTestCase {
         let document = try JSONDecoder().decode(KnownAuthoritiesDocument.self, from: data)
 
         XCTAssertEqual(document.authorities.map(\.componentId), ["onym:component:valid"])
+    }
+
+    func testAuthorityClientRejectsInsecureBaseURLBeforeSendingSignedBytes() async throws {
+        StubURLProtocol.set { _ in
+            XCTFail("an insecure Authority endpoint must be rejected before sending a request")
+            throw URLError(.badURL)
+        }
+        let insecureURL = URL(string: "http://authority.example/service")!
+        let client = URLSessionModerationAuthorityClient(
+            baseURL: insecureURL,
+            session: session,
+            signer: FakeSigner(),
+            clock: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        do {
+            _ = try await client.registerMandate(mandate())
+            XCTFail("expected insecure transport rejection")
+        } catch let AuthorityClientError.insecureBaseURL(url) {
+            XCTAssertEqual(url, insecureURL.absoluteString)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
     }
 
     func testRegisterMandatePostsCanonicalBodyAndChecksReference() async throws {

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -75,7 +75,7 @@ final class ModerationAuthorityClientTests: XCTestCase {
         """#.utf8)
         let listing = try JSONDecoder().decode(AuthorityListing.self, from: data)
 
-        XCTAssertEqual(listing.resolvedAPIBaseURL.absoluteString, "https://api.example/moderation")
+        XCTAssertEqual(listing.apiBaseURL.absoluteString, "https://api.example/moderation")
     }
 
     func testAuthorityListingWithoutExplicitAPIBaseURLFailsClosed() throws {

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -55,11 +55,16 @@ final class ModerationRepositoryTests: XCTestCase {
         private var _enrollRequests: [EnrollmentRequest] = []
         private var _gateRequests: [GateCheckRequest] = []
         private var _countersignCount = 0
+        private var _countersignDelayNanoseconds: UInt64 = 0
         var gateResult: GateCheckResult = .clear
         /// When set, `countersignMandate` returns this instead of the
         /// stub sentinel — lets a test assert what the client does with
         /// a backend-supplied signature.
         var countersignature: String = StubEnforcementBackendClient.countersignSentinel
+        var countersignDelayNanoseconds: UInt64 {
+            get { lock.withLock { _countersignDelayNanoseconds } }
+            set { lock.withLock { _countersignDelayNanoseconds = newValue } }
+        }
 
         func enrollDevice(_ request: EnrollmentRequest) async throws -> DeviceEnrollment {
             lock.withLock { _enrollRequests.append(request) }
@@ -67,7 +72,13 @@ final class ModerationRepositoryTests: XCTestCase {
         }
 
         func countersignMandate(_ mandate: ModerationMandate) async throws -> InterfaceCountersignature {
-            lock.withLock { _countersignCount += 1 }
+            let delay = lock.withLock { () -> UInt64 in
+                _countersignCount += 1
+                return _countersignDelayNanoseconds
+            }
+            if delay > 0 {
+                try await Task.sleep(nanoseconds: delay)
+            }
             return InterfaceCountersignature(signature: lock.withLock { countersignature })
         }
 
@@ -192,6 +203,7 @@ final class ModerationRepositoryTests: XCTestCase {
             componentId: componentId,
             name: name,
             manifestURL: URL(string: "https://example.com/\(name).json")!,
+            apiBaseURL: URL(string: "https://api.example.com/\(name)")!,
             operatorPublicKeyBase64: ""
         )
     }
@@ -429,7 +441,10 @@ final class ModerationRepositoryTests: XCTestCase {
             XCTFail("unexpected error: \(error)")
         }
 
-        XCTAssertFalse(try XCTUnwrap(store.load().first).isActive)
+        let rejected = try XCTUnwrap(store.load().first)
+        XCTAssertTrue(rejected.registrationRejected)
+        XCTAssertFalse(rejected.registrationPending)
+        XCTAssertFalse(rejected.isActive)
         let activeAfterMismatch = await repository.activeMandateRecord()
         XCTAssertNil(activeAfterMismatch)
     }
@@ -453,14 +468,51 @@ final class ModerationRepositoryTests: XCTestCase {
             _ = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
             XCTFail("expected Authority rejection")
         } catch let AuthorityClientError.mandateNotAccepted(mandateRef) {
-            XCTAssertEqual(mandateRef, try XCTUnwrap(store.load().first).mandate.mandateHash())
+            XCTAssertEqual(mandateRef, try XCTUnwrap(authority.mandates.first).mandateHash())
         } catch {
             XCTFail("unexpected error: \(error)")
         }
 
-        let pending = try XCTUnwrap(store.load().first)
-        XCTAssertTrue(pending.registrationPending)
-        XCTAssertFalse(pending.isActive)
+        let rejected = try XCTUnwrap(store.load().first)
+        XCTAssertTrue(rejected.registrationRejected)
+        XCTAssertFalse(rejected.registrationPending)
+        XCTAssertFalse(rejected.isActive)
+
+        authority.accepted = true
+        let retried = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
+        XCTAssertTrue(retried.isActive)
+        XCTAssertTrue(retried.authorityRegistered)
+        XCTAssertEqual(store.load().count, 2, "the rejected signed attempt remains auditable")
+        XCTAssertTrue(try XCTUnwrap(store.load().last).registrationRejected)
+        XCTAssertEqual(backend.countersignCount, 2, "a terminal refusal mints a fresh artifact")
+    }
+
+    func testOverlappingConsentCallsShareOneArtifact() async throws {
+        let componentId = "onym:component:a"
+        let selected = listing(componentId, name: "A")
+        let backend = RecordingBackend()
+        backend.countersignature = "interface-signature"
+        backend.countersignDelayNanoseconds = 50_000_000
+        let authority = RecordingAuthorityClient()
+        let store = InMemoryMandateStore()
+        let repository = makeRepository(
+            listings: [selected],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: backend,
+            authorityClient: authority,
+            store: store
+        )
+        let reviewed = try await repository.manifestForReview(selected)
+
+        async let first = repository.consent(to: selected, reviewedManifest: reviewed)
+        async let second = repository.consent(to: selected, reviewedManifest: reviewed)
+        let (firstRecord, secondRecord) = try await (first, second)
+
+        XCTAssertEqual(firstRecord, secondRecord)
+        XCTAssertEqual(store.load().count, 1)
+        XCTAssertEqual(backend.enrollRequests.count, 1)
+        XCTAssertEqual(backend.countersignCount, 1)
+        XCTAssertEqual(authority.mandates.count, 1)
     }
 
     func testRegistrationActivatesOnlyOneOfTwoRecordsSharingAContentHash() async throws {
@@ -579,6 +631,7 @@ final class ModerationRepositoryTests: XCTestCase {
             JSONSerialization.jsonObject(with: encoder.encode(record)) as? [String: Any]
         )
         json.removeValue(forKey: "authorityRegistered")
+        json.removeValue(forKey: "registrationRejected")
         let legacyBytes = try JSONSerialization.data(withJSONObject: json)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -586,6 +639,7 @@ final class ModerationRepositoryTests: XCTestCase {
         let decoded = try decoder.decode(MandateRecord.self, from: legacyBytes)
 
         XCTAssertFalse(decoded.authorityRegistered)
+        XCTAssertFalse(decoded.registrationRejected)
         XCTAssertEqual(decoded.mandate, record.mandate)
         XCTAssertTrue(decoded.isActive)
     }

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -114,6 +114,7 @@ final class ModerationRepositoryTests: XCTestCase {
         private var _accepted = true
         private var _registrationError: AuthorityClientError?
         private var _rejectedManifestHash: String?
+        private var _registrationDelayNanoseconds: UInt64 = 0
 
         var mandates: [ModerationMandate] { lock.withLock { _mandates } }
         var shouldFail: Bool {
@@ -136,20 +137,28 @@ final class ModerationRepositoryTests: XCTestCase {
             get { lock.withLock { _rejectedManifestHash } }
             set { lock.withLock { _rejectedManifestHash = newValue } }
         }
+        var registrationDelayNanoseconds: UInt64 {
+            get { lock.withLock { _registrationDelayNanoseconds } }
+            set { lock.withLock { _registrationDelayNanoseconds = newValue } }
+        }
 
         func registerMandate(
             _ mandate: ModerationMandate
         ) async throws -> MandateRegistrationReceipt {
             let state = lock.withLock {
-                () -> (Bool, String?, Bool, AuthorityClientError?, String?) in
+                () -> (Bool, String?, Bool, AuthorityClientError?, String?, UInt64) in
                 _mandates.append(mandate)
                 return (
                     _shouldFail,
                     _returnedReference,
                     _accepted,
                     _registrationError,
-                    _rejectedManifestHash
+                    _rejectedManifestHash,
+                    _registrationDelayNanoseconds
                 )
+            }
+            if state.5 > 0 {
+                try await Task.sleep(nanoseconds: state.5)
             }
             if state.0 { throw RegistrationFailure.unavailable }
             if let error = state.3 { throw error }
@@ -485,6 +494,120 @@ final class ModerationRepositoryTests: XCTestCase {
         XCTAssertTrue(active.authorityRegistered)
         XCTAssertEqual(active.mandate, pending.mandate)
         XCTAssertEqual(authority.mandates, [pending.mandate])
+    }
+
+    func testStartRetryDoesNotReplaceANewerActiveAuthority() async throws {
+        let oldID = "onym:component:old"
+        let currentID = "onym:component:current"
+        let oldBytes = manifestBytes(componentId: oldID)
+        let currentBytes = manifestBytes(componentId: currentID)
+        let pending = MandateRecord(
+            mandate: ModerationMandate(
+                user: "onym:key:test-user",
+                interface: ModerationRepository.interfaceComponentId,
+                authority: oldID,
+                manifestHash: SignedManifest.hash(of: oldBytes),
+                classes: ["csam"],
+                deviceBinding: "device-1",
+                acceptedAt: now,
+                signatures: ["user-signature", "interface-signature"]
+            ),
+            manifestBytes: oldBytes,
+            authorityName: "Old",
+            countersigned: true,
+            isActive: false,
+            createdAt: now
+        )
+        let current = MandateRecord(
+            mandate: ModerationMandate(
+                user: "onym:key:test-user",
+                interface: ModerationRepository.interfaceComponentId,
+                authority: currentID,
+                manifestHash: SignedManifest.hash(of: currentBytes),
+                classes: ["csam"],
+                deviceBinding: "device-1",
+                acceptedAt: now.addingTimeInterval(1),
+                signatures: ["user-signature", "interface-signature"]
+            ),
+            manifestBytes: currentBytes,
+            authorityName: "Current",
+            countersigned: true,
+            authorityRegistered: true,
+            isActive: true,
+            createdAt: now.addingTimeInterval(1)
+        )
+        let store = InMemoryMandateStore(records: [current, pending])
+        let authority = RecordingAuthorityClient()
+        let repository = makeRepository(
+            listings: [listing(oldID, name: "Old"), listing(currentID, name: "Current")],
+            bytesByComponent: [oldID: oldBytes, currentID: currentBytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: store
+        )
+
+        await repository.start()
+        for _ in 0..<100 {
+            if store.load().first(where: { $0.mandate.authority == oldID })?.authorityRegistered
+                == true { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        let records = store.load()
+        let resolvedOld = try XCTUnwrap(records.first(where: { $0.mandate.authority == oldID }))
+        XCTAssertTrue(resolvedOld.authorityRegistered)
+        XCTAssertFalse(resolvedOld.isActive)
+        XCTAssertEqual(records.first(where: \.isActive)?.mandate.authority, currentID)
+        XCTAssertEqual(authority.mandates, [pending.mandate])
+    }
+
+    func testStartRetryAndExplicitConsentShareOneRegistrationFlight() async throws {
+        let componentId = "onym:component:a"
+        let selected = listing(componentId, name: "A")
+        let bytes = manifestBytes(componentId: componentId)
+        let pending = MandateRecord(
+            mandate: ModerationMandate(
+                user: "onym:key:test-user",
+                interface: ModerationRepository.interfaceComponentId,
+                authority: componentId,
+                manifestHash: SignedManifest.hash(of: bytes),
+                classes: ["csam"],
+                deviceBinding: "device-1",
+                acceptedAt: now,
+                signatures: ["user-signature", "interface-signature"]
+            ),
+            manifestBytes: bytes,
+            authorityName: "A",
+            countersigned: true,
+            isActive: false,
+            createdAt: now
+        )
+        let store = InMemoryMandateStore(records: [pending])
+        let authority = RecordingAuthorityClient()
+        authority.registrationDelayNanoseconds = 100_000_000
+        let repository = makeRepository(
+            listings: [selected],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: store
+        )
+
+        await repository.start()
+        for _ in 0..<100 {
+            if authority.mandates.count == 1 { break }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        let reviewed = try await repository.manifestForReview(selected)
+        let activated = try await repository.consent(
+            to: selected,
+            reviewedManifest: reviewed
+        )
+
+        XCTAssertTrue(activated.authorityRegistered)
+        XCTAssertTrue(activated.isActive)
+        XCTAssertEqual(authority.mandates, [pending.mandate])
+        XCTAssertEqual(store.load().count, 1)
     }
 
     func testMismatchedAuthorityReferenceDoesNotActivateMandate() async throws {

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -113,6 +113,7 @@ final class ModerationRepositoryTests: XCTestCase {
         private var _returnedReference: String?
         private var _accepted = true
         private var _registrationError: AuthorityClientError?
+        private var _rejectedManifestHash: String?
 
         var mandates: [ModerationMandate] { lock.withLock { _mandates } }
         var shouldFail: Bool {
@@ -131,16 +132,36 @@ final class ModerationRepositoryTests: XCTestCase {
             get { lock.withLock { _registrationError } }
             set { lock.withLock { _registrationError = newValue } }
         }
+        var rejectedManifestHash: String? {
+            get { lock.withLock { _rejectedManifestHash } }
+            set { lock.withLock { _rejectedManifestHash = newValue } }
+        }
 
         func registerMandate(
             _ mandate: ModerationMandate
         ) async throws -> MandateRegistrationReceipt {
-            let state = lock.withLock { () -> (Bool, String?, Bool, AuthorityClientError?) in
+            let state = lock.withLock {
+                () -> (Bool, String?, Bool, AuthorityClientError?, String?) in
                 _mandates.append(mandate)
-                return (_shouldFail, _returnedReference, _accepted, _registrationError)
+                return (
+                    _shouldFail,
+                    _returnedReference,
+                    _accepted,
+                    _registrationError,
+                    _rejectedManifestHash
+                )
             }
             if state.0 { throw RegistrationFailure.unavailable }
             if let error = state.3 { throw error }
+            if state.4 == mandate.manifestHash {
+                throw AuthorityClientError.rejected(
+                    AuthorityRejection(
+                        statusCode: 400,
+                        rawCode: "bad_request",
+                        message: "manifest rotated"
+                    )
+                )
+            }
             let mandateRef: String
             if let returnedReference = state.1 {
                 mandateRef = returnedReference
@@ -428,6 +449,7 @@ final class ModerationRepositoryTests: XCTestCase {
         backend.countersignature = "interface-signature"
         let authority = RecordingAuthorityClient()
         authority.returnedReference = "wrong-reference"
+        authority.accepted = false
         let store = InMemoryMandateStore()
         let repository = makeRepository(
             listings: [listing(componentId, name: "A")],
@@ -529,6 +551,55 @@ final class ModerationRepositoryTests: XCTestCase {
         let activated = try await repository.consent(to: selected, reviewedManifest: reviewed)
         XCTAssertTrue(activated.isActive)
         XCTAssertEqual(Array(authority.mandates.suffix(2)), [pending.mandate, pending.mandate])
+    }
+
+    func testManifestRotationResolvesOldPendingBeforeRegisteringNewConsent() async throws {
+        let componentId = "onym:component:a"
+        let selected = listing(componentId, name: "A")
+        let oldBytes = manifestBytes(componentId: componentId)
+        let newBytes = manifestBytes(componentId: componentId, tweak: "-rotated")
+        let fetcher = SwitchingManifestFetcher(first: oldBytes, second: newBytes)
+        let backend = RecordingBackend()
+        backend.countersignature = "interface-signature"
+        let authority = RecordingAuthorityClient()
+        authority.shouldFail = true
+        let store = InMemoryMandateStore()
+        let repository = ModerationRepository(
+            authoritiesFetcher: FakeAuthoritiesFetcher(listings: [selected]),
+            manifestFetcher: fetcher,
+            mandateStore: store,
+            backend: backend,
+            authorityClients: RecordingAuthorityClientFactory(authority: authority),
+            attestation: FakeAttestation(supported: true),
+            signer: FakeSigner(),
+            clock: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        let oldReview = try await repository.manifestForReview(selected)
+        do {
+            _ = try await repository.consent(to: selected, reviewedManifest: oldReview)
+            XCTFail("expected ambiguous first registration")
+        } catch RegistrationFailure.unavailable {
+            // expected
+        }
+        let oldPending = try XCTUnwrap(store.load().first)
+        XCTAssertTrue(oldPending.registrationPending)
+
+        authority.shouldFail = false
+        authority.rejectedManifestHash = oldPending.mandate.manifestHash
+        let newReview = try await repository.manifestForReview(selected)
+        let current = try await repository.consent(to: selected, reviewedManifest: newReview)
+
+        XCTAssertEqual(current.mandate.manifestHash, SignedManifest.hash(of: newBytes))
+        XCTAssertTrue(current.authorityRegistered)
+        XCTAssertTrue(current.isActive)
+        XCTAssertEqual(store.load(), [current], "rotated pending attempt must not remain orphaned")
+        XCTAssertEqual(backend.countersignCount, 2)
+        XCTAssertEqual(authority.mandates.map(\.manifestHash), [
+            oldPending.mandate.manifestHash,
+            oldPending.mandate.manifestHash,
+            current.mandate.manifestHash,
+        ])
     }
 
     func testOverlappingConsentCallsShareOneArtifact() async throws {

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -443,6 +443,50 @@ final class ModerationRepositoryTests: XCTestCase {
         XCTAssertEqual(store.load().count, 1)
     }
 
+    func testStartRetriesNewestPersistedRegistration() async throws {
+        let componentId = "onym:component:a"
+        let selected = listing(componentId, name: "A")
+        let bytes = manifestBytes(componentId: componentId)
+        let pending = MandateRecord(
+            mandate: ModerationMandate(
+                user: "onym:key:test-user",
+                interface: ModerationRepository.interfaceComponentId,
+                authority: componentId,
+                manifestHash: SignedManifest.hash(of: bytes),
+                classes: ["csam"],
+                deviceBinding: "device-1",
+                acceptedAt: now,
+                signatures: ["user-signature", "interface-signature"]
+            ),
+            manifestBytes: bytes,
+            authorityName: "A",
+            countersigned: true,
+            isActive: false,
+            createdAt: now
+        )
+        let store = InMemoryMandateStore(records: [pending])
+        let authority = RecordingAuthorityClient()
+        let repository = makeRepository(
+            listings: [selected],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: store
+        )
+
+        await repository.start()
+        for _ in 0..<100 {
+            if await repository.activeMandateRecord() != nil { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        let activeRecord = await repository.activeMandateRecord()
+        let active = try XCTUnwrap(activeRecord)
+        XCTAssertTrue(active.authorityRegistered)
+        XCTAssertEqual(active.mandate, pending.mandate)
+        XCTAssertEqual(authority.mandates, [pending.mandate])
+    }
+
     func testMismatchedAuthorityReferenceDoesNotActivateMandate() async throws {
         let componentId = "onym:component:a"
         let backend = RecordingBackend()

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -112,6 +112,7 @@ final class ModerationRepositoryTests: XCTestCase {
         private var _shouldFail = false
         private var _returnedReference: String?
         private var _accepted = true
+        private var _registrationError: AuthorityClientError?
 
         var mandates: [ModerationMandate] { lock.withLock { _mandates } }
         var shouldFail: Bool {
@@ -126,15 +127,20 @@ final class ModerationRepositoryTests: XCTestCase {
             get { lock.withLock { _accepted } }
             set { lock.withLock { _accepted = newValue } }
         }
+        var registrationError: AuthorityClientError? {
+            get { lock.withLock { _registrationError } }
+            set { lock.withLock { _registrationError = newValue } }
+        }
 
         func registerMandate(
             _ mandate: ModerationMandate
         ) async throws -> MandateRegistrationReceipt {
-            let state = lock.withLock { () -> (Bool, String?, Bool) in
+            let state = lock.withLock { () -> (Bool, String?, Bool, AuthorityClientError?) in
                 _mandates.append(mandate)
-                return (_shouldFail, _returnedReference, _accepted)
+                return (_shouldFail, _returnedReference, _accepted, _registrationError)
             }
             if state.0 { throw RegistrationFailure.unavailable }
+            if let error = state.3 { throw error }
             let mandateRef: String
             if let returnedReference = state.1 {
                 mandateRef = returnedReference
@@ -441,10 +447,7 @@ final class ModerationRepositoryTests: XCTestCase {
             XCTFail("unexpected error: \(error)")
         }
 
-        let rejected = try XCTUnwrap(store.load().first)
-        XCTAssertTrue(rejected.registrationRejected)
-        XCTAssertFalse(rejected.registrationPending)
-        XCTAssertFalse(rejected.isActive)
+        XCTAssertTrue(store.load().isEmpty)
         let activeAfterMismatch = await repository.activeMandateRecord()
         XCTAssertNil(activeAfterMismatch)
     }
@@ -473,18 +476,59 @@ final class ModerationRepositoryTests: XCTestCase {
             XCTFail("unexpected error: \(error)")
         }
 
-        let rejected = try XCTUnwrap(store.load().first)
-        XCTAssertTrue(rejected.registrationRejected)
-        XCTAssertFalse(rejected.registrationPending)
-        XCTAssertFalse(rejected.isActive)
+        XCTAssertTrue(store.load().isEmpty)
 
         authority.accepted = true
         let retried = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
         XCTAssertTrue(retried.isActive)
         XCTAssertTrue(retried.authorityRegistered)
-        XCTAssertEqual(store.load().count, 2, "the rejected signed attempt remains auditable")
-        XCTAssertTrue(try XCTUnwrap(store.load().last).registrationRejected)
+        XCTAssertEqual(store.load().count, 1)
         XCTAssertEqual(backend.countersignCount, 2, "a terminal refusal mints a fresh artifact")
+    }
+
+    func testOrdinary4xxIsTerminalButRateLimitRetainsExactRetry() async throws {
+        let componentId = "onym:component:a"
+        let selected = listing(componentId, name: "A")
+        let backend = RecordingBackend()
+        backend.countersignature = "interface-signature"
+        let authority = RecordingAuthorityClient()
+        let store = InMemoryMandateStore()
+        let repository = makeRepository(
+            listings: [selected],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: backend,
+            authorityClient: authority,
+            store: store
+        )
+        let reviewed = try await repository.manifestForReview(selected)
+
+        authority.registrationError = .rejected(
+            AuthorityRejection(statusCode: 404, rawCode: "not_found", message: "not found")
+        )
+        do {
+            _ = try await repository.consent(to: selected, reviewedManifest: reviewed)
+            XCTFail("expected terminal 404")
+        } catch AuthorityClientError.rejected {
+            // expected
+        }
+        XCTAssertTrue(store.load().isEmpty)
+
+        authority.registrationError = .rejected(
+            AuthorityRejection(statusCode: 429, rawCode: "rate_limited", message: "slow down")
+        )
+        do {
+            _ = try await repository.consent(to: selected, reviewedManifest: reviewed)
+            XCTFail("expected retryable 429")
+        } catch AuthorityClientError.rejected {
+            // expected
+        }
+        let pending = try XCTUnwrap(store.load().first)
+        XCTAssertTrue(pending.registrationPending)
+
+        authority.registrationError = nil
+        let activated = try await repository.consent(to: selected, reviewedManifest: reviewed)
+        XCTAssertTrue(activated.isActive)
+        XCTAssertEqual(Array(authority.mandates.suffix(2)), [pending.mandate, pending.mandate])
     }
 
     func testOverlappingConsentCallsShareOneArtifact() async throws {
@@ -631,7 +675,6 @@ final class ModerationRepositoryTests: XCTestCase {
             JSONSerialization.jsonObject(with: encoder.encode(record)) as? [String: Any]
         )
         json.removeValue(forKey: "authorityRegistered")
-        json.removeValue(forKey: "registrationRejected")
         let legacyBytes = try JSONSerialization.data(withJSONObject: json)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -639,7 +682,6 @@ final class ModerationRepositoryTests: XCTestCase {
         let decoded = try decoder.decode(MandateRecord.self, from: legacyBytes)
 
         XCTAssertFalse(decoded.authorityRegistered)
-        XCTAssertFalse(decoded.registrationRejected)
         XCTAssertEqual(decoded.mandate, record.mandate)
         XCTAssertTrue(decoded.isActive)
     }

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -46,8 +46,10 @@ final class ModerationRepositoryTests: XCTestCase {
         var enrollRequests: [EnrollmentRequest] { lock.withLock { _enrollRequests } }
         var enrollTokens: [Data?] { enrollRequests.map(\.deviceToken) }
         var gateRequests: [GateCheckRequest] { lock.withLock { _gateRequests } }
+        var countersignCount: Int { lock.withLock { _countersignCount } }
         private var _enrollRequests: [EnrollmentRequest] = []
         private var _gateRequests: [GateCheckRequest] = []
+        private var _countersignCount = 0
         var gateResult: GateCheckResult = .clear
         /// When set, `countersignMandate` returns this instead of the
         /// stub sentinel — lets a test assert what the client does with
@@ -60,7 +62,8 @@ final class ModerationRepositoryTests: XCTestCase {
         }
 
         func countersignMandate(_ mandate: ModerationMandate) async throws -> InterfaceCountersignature {
-            InterfaceCountersignature(signature: lock.withLock { countersignature })
+            lock.withLock { _countersignCount += 1 }
+            return InterfaceCountersignature(signature: lock.withLock { countersignature })
         }
 
         func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult {
@@ -81,6 +84,68 @@ final class ModerationRepositoryTests: XCTestCase {
     private struct FakeSigner: ModerationSigner {
         func userKeyID() async throws -> String { "onym:key:test-user" }
         func sign(_ message: Data) async throws -> Data { Data("fake-signature".utf8) }
+    }
+
+    private enum RegistrationFailure: Error {
+        case unavailable
+    }
+
+    private final class RecordingAuthorityClient: ModerationAuthorityClient, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _mandates: [ModerationMandate] = []
+        private var _shouldFail = false
+        private var _returnedReference: String?
+
+        var mandates: [ModerationMandate] { lock.withLock { _mandates } }
+        var shouldFail: Bool {
+            get { lock.withLock { _shouldFail } }
+            set { lock.withLock { _shouldFail = newValue } }
+        }
+        var returnedReference: String? {
+            get { lock.withLock { _returnedReference } }
+            set { lock.withLock { _returnedReference = newValue } }
+        }
+
+        func registerMandate(
+            _ mandate: ModerationMandate
+        ) async throws -> MandateRegistrationReceipt {
+            let state = lock.withLock { () -> (Bool, String?) in
+                _mandates.append(mandate)
+                return (_shouldFail, _returnedReference)
+            }
+            if state.0 { throw RegistrationFailure.unavailable }
+            let mandateRef: String
+            if let returnedReference = state.1 {
+                mandateRef = returnedReference
+            } else {
+                mandateRef = try mandate.mandateHash()
+            }
+            return MandateRegistrationReceipt(
+                mandateRef: mandateRef,
+                accepted: true
+            )
+        }
+
+        func fileReport(_ report: Report) async throws -> ReportReceipt {
+            throw ModerationError.notImplemented("unused")
+        }
+        func respond(_ response: CaseResponse) async throws {
+            throw ModerationError.notImplemented("unused")
+        }
+        func appeal(_ submission: AppealSubmission) async throws {
+            throw ModerationError.notImplemented("unused")
+        }
+        func queryStatus(caseId: String) async throws -> CaseStatus {
+            throw ModerationError.notImplemented("unused")
+        }
+    }
+
+    private struct RecordingAuthorityClientFactory: ModerationAuthorityClientFactory {
+        let authority: RecordingAuthorityClient
+
+        func client(for listing: AuthorityListing) -> any ModerationAuthorityClient {
+            authority
+        }
     }
 
     // MARK: - Fixtures
@@ -125,14 +190,22 @@ final class ModerationRepositoryTests: XCTestCase {
         listings: [AuthorityListing],
         bytesByComponent: [String: Data],
         backend: any EnforcementBackendClient,
+        authorityClient: RecordingAuthorityClient? = nil,
         attestation: any DeviceAttestationProvider = FakeAttestation(supported: true),
         store: MandateStore? = nil
     ) -> ModerationRepository {
-        ModerationRepository(
+        let authorityClients: any ModerationAuthorityClientFactory
+        if let authorityClient {
+            authorityClients = RecordingAuthorityClientFactory(authority: authorityClient)
+        } else {
+            authorityClients = StubModerationAuthorityClientFactory()
+        }
+        return ModerationRepository(
             authoritiesFetcher: FakeAuthoritiesFetcher(listings: listings),
             manifestFetcher: FakeManifestFetcher(bytesByComponent: bytesByComponent),
             mandateStore: store ?? InMemoryMandateStore(),
             backend: backend,
+            authorityClients: authorityClients,
             attestation: attestation,
             signer: FakeSigner(),
             clock: { Date(timeIntervalSince1970: 1_700_000_000) }
@@ -254,6 +327,101 @@ final class ModerationRepositoryTests: XCTestCase {
         XCTAssertNotNil(record.consentedManifest())
     }
 
+    // MARK: - Authority registration
+
+    func testCountersignedMandateActivatesOnlyAfterAuthorityRegistration() async throws {
+        let componentId = "onym:component:a"
+        let backend = RecordingBackend()
+        backend.countersignature = "interface-signature"
+        let authority = RecordingAuthorityClient()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: backend,
+            authorityClient: authority
+        )
+
+        let record = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
+
+        XCTAssertTrue(record.countersigned)
+        XCTAssertTrue(record.authorityRegistered)
+        XCTAssertTrue(record.isActive)
+        XCTAssertEqual(authority.mandates, [record.mandate])
+        XCTAssertEqual(backend.countersignCount, 1)
+    }
+
+    func testFailedRegistrationPersistsAndRetriesTheExactMandate() async throws {
+        let componentId = "onym:component:a"
+        let selected = listing(componentId, name: "A")
+        let backend = RecordingBackend()
+        backend.countersignature = "interface-signature"
+        let authority = RecordingAuthorityClient()
+        authority.shouldFail = true
+        let store = InMemoryMandateStore()
+        let repository = makeRepository(
+            listings: [selected],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: backend,
+            authorityClient: authority,
+            store: store
+        )
+        let reviewed = try await repository.manifestForReview(selected)
+
+        do {
+            _ = try await repository.consent(to: selected, reviewedManifest: reviewed)
+            XCTFail("expected registration failure")
+        } catch RegistrationFailure.unavailable {
+            // expected
+        }
+
+        let pending = try XCTUnwrap(store.load().first)
+        XCTAssertTrue(pending.countersigned)
+        XCTAssertFalse(pending.authorityRegistered)
+        XCTAssertFalse(pending.isActive)
+        let activeAfterFailure = await repository.activeMandateRecord()
+        XCTAssertNil(activeAfterFailure)
+
+        authority.shouldFail = false
+        let activated = try await repository.consent(to: selected, reviewedManifest: reviewed)
+
+        XCTAssertTrue(activated.authorityRegistered)
+        XCTAssertTrue(activated.isActive)
+        XCTAssertEqual(authority.mandates, [pending.mandate, pending.mandate])
+        XCTAssertEqual(backend.enrollRequests.count, 1, "retry must not mint a new mandate")
+        XCTAssertEqual(backend.countersignCount, 1, "retry must reuse the countersignature")
+        XCTAssertEqual(store.load().count, 1)
+    }
+
+    func testMismatchedAuthorityReferenceDoesNotActivateMandate() async throws {
+        let componentId = "onym:component:a"
+        let backend = RecordingBackend()
+        backend.countersignature = "interface-signature"
+        let authority = RecordingAuthorityClient()
+        authority.returnedReference = "wrong-reference"
+        let store = InMemoryMandateStore()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: backend,
+            authorityClient: authority,
+            store: store
+        )
+
+        do {
+            _ = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
+            XCTFail("expected reference mismatch")
+        } catch let AuthorityClientError.mandateReferenceMismatch(expected, received) {
+            XCTAssertFalse(expected.isEmpty)
+            XCTAssertEqual(received, "wrong-reference")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        XCTAssertFalse(try XCTUnwrap(store.load().first).isActive)
+        let activeAfterMismatch = await repository.activeMandateRecord()
+        XCTAssertNil(activeAfterMismatch)
+    }
+
     // MARK: - Switching immutability
 
     func testSwitchingDeactivatesOldRecordUntouched() async throws {
@@ -290,6 +458,41 @@ final class ModerationRepositoryTests: XCTestCase {
     }
 
     // MARK: - Stub honesty
+
+    func testLegacyMandateRecordDecodesAsUnregistered() throws {
+        let record = MandateRecord(
+            mandate: ModerationMandate(
+                user: "onym:key:test-user",
+                interface: ModerationRepository.interfaceComponentId,
+                authority: "onym:component:a",
+                manifestHash: String(repeating: "a", count: 64),
+                classes: ["csam"],
+                deviceBinding: "device-1",
+                acceptedAt: now,
+                signatures: ["user", StubEnforcementBackendClient.countersignSentinel]
+            ),
+            manifestBytes: Data("manifest".utf8),
+            authorityName: "A",
+            countersigned: false,
+            isActive: true,
+            createdAt: now
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoder.encode(record)) as? [String: Any]
+        )
+        json.removeValue(forKey: "authorityRegistered")
+        let legacyBytes = try JSONSerialization.data(withJSONObject: json)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let decoded = try decoder.decode(MandateRecord.self, from: legacyBytes)
+
+        XCTAssertFalse(decoded.authorityRegistered)
+        XCTAssertEqual(decoded.mandate, record.mandate)
+        XCTAssertTrue(decoded.isActive)
+    }
 
     func testStubCountersignSentinelNeverReadsAsCountersigned() async throws {
         let componentId = "onym:component:a"

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -34,7 +34,12 @@ final class ModerationRepositoryTests: XCTestCase {
 
     private final class InMemoryMandateStore: MandateStore, @unchecked Sendable {
         private let lock = NSLock()
-        private var records: [MandateRecord] = []
+        private var records: [MandateRecord]
+
+        init(records: [MandateRecord] = []) {
+            self.records = records
+        }
+
         func load() -> [MandateRecord] { lock.withLock { records } }
         func save(_ records: [MandateRecord]) { lock.withLock { self.records = records } }
     }
@@ -95,6 +100,7 @@ final class ModerationRepositoryTests: XCTestCase {
         private var _mandates: [ModerationMandate] = []
         private var _shouldFail = false
         private var _returnedReference: String?
+        private var _accepted = true
 
         var mandates: [ModerationMandate] { lock.withLock { _mandates } }
         var shouldFail: Bool {
@@ -105,13 +111,17 @@ final class ModerationRepositoryTests: XCTestCase {
             get { lock.withLock { _returnedReference } }
             set { lock.withLock { _returnedReference = newValue } }
         }
+        var accepted: Bool {
+            get { lock.withLock { _accepted } }
+            set { lock.withLock { _accepted = newValue } }
+        }
 
         func registerMandate(
             _ mandate: ModerationMandate
         ) async throws -> MandateRegistrationReceipt {
-            let state = lock.withLock { () -> (Bool, String?) in
+            let state = lock.withLock { () -> (Bool, String?, Bool) in
                 _mandates.append(mandate)
-                return (_shouldFail, _returnedReference)
+                return (_shouldFail, _returnedReference, _accepted)
             }
             if state.0 { throw RegistrationFailure.unavailable }
             let mandateRef: String
@@ -122,7 +132,7 @@ final class ModerationRepositoryTests: XCTestCase {
             }
             return MandateRegistrationReceipt(
                 mandateRef: mandateRef,
-                accepted: true
+                accepted: state.2
             )
         }
 
@@ -259,6 +269,7 @@ final class ModerationRepositoryTests: XCTestCase {
             manifestFetcher: fetcher,
             mandateStore: InMemoryMandateStore(),
             backend: RecordingBackend(),
+            authorityClients: StubModerationAuthorityClientFactory(),
             attestation: FakeAttestation(supported: true),
             signer: FakeSigner(),
             clock: { Date(timeIntervalSince1970: 1_700_000_000) }
@@ -377,6 +388,7 @@ final class ModerationRepositoryTests: XCTestCase {
         let pending = try XCTUnwrap(store.load().first)
         XCTAssertTrue(pending.countersigned)
         XCTAssertFalse(pending.authorityRegistered)
+        XCTAssertTrue(pending.registrationPending)
         XCTAssertFalse(pending.isActive)
         let activeAfterFailure = await repository.activeMandateRecord()
         XCTAssertNil(activeAfterFailure)
@@ -420,6 +432,90 @@ final class ModerationRepositoryTests: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(store.load().first).isActive)
         let activeAfterMismatch = await repository.activeMandateRecord()
         XCTAssertNil(activeAfterMismatch)
+    }
+
+    func testAuthorityRejectionDoesNotMasqueradeAsReferenceMismatch() async throws {
+        let componentId = "onym:component:a"
+        let backend = RecordingBackend()
+        backend.countersignature = "interface-signature"
+        let authority = RecordingAuthorityClient()
+        authority.accepted = false
+        let store = InMemoryMandateStore()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: manifestBytes(componentId: componentId)],
+            backend: backend,
+            authorityClient: authority,
+            store: store
+        )
+
+        do {
+            _ = try await repository.reviewAndConsent(to: listing(componentId, name: "A"))
+            XCTFail("expected Authority rejection")
+        } catch let AuthorityClientError.mandateNotAccepted(mandateRef) {
+            XCTAssertEqual(mandateRef, try XCTUnwrap(store.load().first).mandate.mandateHash())
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        let pending = try XCTUnwrap(store.load().first)
+        XCTAssertTrue(pending.registrationPending)
+        XCTAssertFalse(pending.isActive)
+    }
+
+    func testRegistrationActivatesOnlyOneOfTwoRecordsSharingAContentHash() async throws {
+        let componentId = "onym:component:a"
+        let selected = listing(componentId, name: "A")
+        let bytes = manifestBytes(componentId: componentId)
+        let mandate = ModerationMandate(
+            user: "onym:key:test-user",
+            interface: ModerationRepository.interfaceComponentId,
+            authority: componentId,
+            manifestHash: SignedManifest.hash(of: bytes),
+            classes: ["csam"],
+            deviceBinding: "same-binding",
+            acceptedAt: now,
+            signatures: ["user-signature", "interface-signature-a"]
+        )
+        var otherMandate = mandate
+        otherMandate.signatures = ["user-signature", "interface-signature-b"]
+        XCTAssertEqual(try mandate.mandateHash(), try otherMandate.mandateHash())
+
+        let first = MandateRecord(
+            mandate: mandate,
+            manifestBytes: bytes,
+            authorityName: "A",
+            countersigned: true,
+            isActive: false,
+            createdAt: now
+        )
+        let second = MandateRecord(
+            mandate: otherMandate,
+            manifestBytes: bytes,
+            authorityName: "A",
+            countersigned: true,
+            isActive: false,
+            createdAt: now
+        )
+        let store = InMemoryMandateStore(records: [first, second])
+        let authority = RecordingAuthorityClient()
+        let repository = makeRepository(
+            listings: [selected],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: store
+        )
+        let reviewed = try await repository.manifestForReview(selected)
+
+        _ = try await repository.consent(to: selected, reviewedManifest: reviewed)
+
+        let records = store.load()
+        XCTAssertEqual(records.filter(\.isActive).count, 1)
+        XCTAssertEqual(records.filter(\.authorityRegistered).count, 1)
+        XCTAssertEqual(records.first?.mandate.signatures.last, "interface-signature-a")
+        XCTAssertTrue(try XCTUnwrap(records.first).isActive)
+        XCTAssertFalse(try XCTUnwrap(records.last).isActive)
     }
 
     // MARK: - Switching immutability

--- a/Tests/OnymIOSTests/Support/StubURLProtocol.swift
+++ b/Tests/OnymIOSTests/Support/StubURLProtocol.swift
@@ -16,7 +16,7 @@ import Foundation
 /// // ... use session
 /// ```
 final class StubURLProtocol: URLProtocol, @unchecked Sendable {
-    typealias Handler = @Sendable (URLRequest) throws -> (Data, HTTPURLResponse)
+    typealias Handler = @Sendable (URLRequest) throws -> (Data, URLResponse)
 
     nonisolated(unsafe) private static var handler: Handler?
     private static let lock = NSLock()


### PR DESCRIPTION
## Summary

- implement the merged onym-moderation Authority HTTP operation surface and structured error mapping
- register the exact countersigned mandate before local activation, persisting it for byte-identical retry after ambiguous failures
- require an explicit HTTPS Authority API base URL designated by the published authority directory; never derive a mandate endpoint from a mirrorable manifest URL
- single-flight overlapping consent and exact-artifact registration, including launch retry racing explicit consent
- resume persisted registration at launch without allowing an older pending Authority to replace newer completed consent
- resolve pending artifacts across manifest rotations and let deterministic refusals recover without replaying doomed bytes
- surface pending registration separately from current and historical mandates with an exact-artifact retry action
- log malformed directory entries while failing closed per entry
- wire the production client factory and cover canonical requests, status credentials, receipts, registration state, proxy failures, path safety, and RFC 3339 timestamps

## Directory rollout

onym-authorities v1 was published ahead of this schema-enforcement commit and contains apiBaseURL on every entry. Missing or insecure endpoints fail closed per entry without removing other valid Authorities.

## Source of truth

This mirrors the Authority reference implementation currently merged on onymchat/onym-moderation main. Project membership remains XcodeGen-managed; no pbxproj edits are included.

## Testing

- [x] OnymModeration iOS-simulator build
- [x] Focused ModerationAuthorityClientTests and ModerationRepositoryTests: 37 tests, 0 failures
- [ ] Full OnymIOSTests was attempted, but unrelated existing simulator Keychain entitlement failures (keychainRead(-34018)) block identity/keychain tests; existing chat-dispatcher failures also remain outside this change