### PR TITLE
feat(moderation): report authenticated chat messages

### DIFF
--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatMessage.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatMessage.swift
@@ -91,6 +91,12 @@ public struct ChatMessage: Equatable, Sendable, Identifiable {
     /// the image/video/album fields.
     public let voiceAttachment: ChatVoiceAttachment?
 
+    /// Sender's detached Ed25519 signature over `body`, retained solely
+    /// so an incoming text message can be disclosed as independently
+    /// verifiable moderation evidence. Nil for legacy and media-only
+    /// messages that this first reporting surface cannot file.
+    public let moderationAuthenticityProof: String?
+
     /// Canonical media list for rendering: the album when present, else
     /// the single image/video wrapped in a one-element list, else empty.
     public var media: [ChatMediaAttachment] {
@@ -131,6 +137,7 @@ public struct ChatMessage: Equatable, Sendable, Identifiable {
         replyToMessageID: UUID?,
         groupType: SEPGroupType,
         failureReason: SendFailureReason? = nil,
+        moderationAuthenticityProof: String? = nil,
         imageAttachment: ChatImageAttachment? = nil,
         videoAttachment: ChatVideoAttachment? = nil,
         albumAttachments: [ChatMediaAttachment]? = nil,
@@ -147,6 +154,7 @@ public struct ChatMessage: Equatable, Sendable, Identifiable {
         self.replyToMessageID = replyToMessageID
         self.groupType = groupType
         self.failureReason = failureReason
+        self.moderationAuthenticityProof = moderationAuthenticityProof
         self.imageAttachment = imageAttachment
         self.videoAttachment = videoAttachment
         self.albumAttachments = albumAttachments

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatMessagePayload.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatMessagePayload.swift
@@ -90,6 +90,14 @@ public struct ChatMessagePayload: Codable, Equatable, Sendable {
     /// `ChatVoiceAttachment`.
     public let voiceAttachment: ChatVoiceAttachment?
 
+    /// Detached Ed25519 signature by the sender over the exact UTF-8
+    /// bytes of `variant.body`. A recipient retains this so a voluntary
+    /// disclosure can satisfy the Authority contract's authenticity
+    /// rule without exposing an envelope or any recipient secrets.
+    /// Optional for wire compatibility with messages sent before
+    /// reporting existed.
+    public let moderationAuthenticityProof: String?
+
     public init(
         version: Int,
         messageID: UUID,
@@ -101,7 +109,8 @@ public struct ChatMessagePayload: Codable, Equatable, Sendable {
         attachment: ChatImageAttachment? = nil,
         videoAttachment: ChatVideoAttachment? = nil,
         attachments: [ChatMediaAttachment]? = nil,
-        voiceAttachment: ChatVoiceAttachment? = nil
+        voiceAttachment: ChatVoiceAttachment? = nil,
+        moderationAuthenticityProof: String? = nil
     ) {
         self.version = version
         self.messageID = messageID
@@ -114,6 +123,7 @@ public struct ChatMessagePayload: Codable, Equatable, Sendable {
         self.videoAttachment = videoAttachment
         self.attachments = attachments
         self.voiceAttachment = voiceAttachment
+        self.moderationAuthenticityProof = moderationAuthenticityProof
     }
 
     enum CodingKeys: String, CodingKey {
@@ -128,6 +138,7 @@ public struct ChatMessagePayload: Codable, Equatable, Sendable {
         case videoAttachment = "video_attachment"
         case attachments
         case voiceAttachment = "voice_attachment"
+        case moderationAuthenticityProof = "moderation_authenticity_proof"
     }
 }
 

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatMessagePayload.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatMessagePayload.swift
@@ -90,12 +90,15 @@ public struct ChatMessagePayload: Codable, Equatable, Sendable {
     /// `ChatVoiceAttachment`.
     public let voiceAttachment: ChatVoiceAttachment?
 
-    /// Detached Ed25519 signature by the sender over the exact UTF-8
-    /// bytes of `variant.body`. A recipient retains this so a voluntary
-    /// disclosure can satisfy the Authority contract's authenticity
-    /// rule without exposing an envelope or any recipient secrets.
-    /// Optional for wire compatibility with messages sent before
-    /// reporting existed.
+    /// Detached Ed25519 signature by the sender over the canonical
+    /// preimage `ChatModerationProof.signedContent` — `variant.body`
+    /// bound to this payload's `messageID`, `groupID`, and
+    /// `sentAtMillis`, so the proof attests one concrete send rather
+    /// than a transferable (body, signature) pair. A recipient retains
+    /// this so a voluntary disclosure can satisfy the Authority
+    /// contract's authenticity rule without exposing an envelope or
+    /// any recipient secrets. Optional for wire compatibility with
+    /// messages sent before reporting existed.
     public let moderationAuthenticityProof: String?
 
     public init(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatModerationProof.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatModerationProof.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Canonical preimage of the moderation authenticity proof — the exact
+/// string the sender signs and a reporter later discloses to an
+/// Authority as `EvidenceItem.disclosedContent`.
+///
+/// The proof must bind the body to its message identity. A signature
+/// over the bare body would be transferable: anyone holding a
+/// (body, signature) pair — including a third party who was never a
+/// recipient — could file it as evidence for any message, in any group,
+/// at any time, and the Authority couldn't tell. Folding `messageID`,
+/// `groupID`, and `sentAtMillis` into the signed bytes pins the proof
+/// to one concrete send.
+///
+/// The preimage is a JSON object with **UTF-8 byte-ordered keys**
+/// (`JSONEncoder.OutputFormatting.sortedKeys`), matching the canonical
+/// form every other moderation signing payload uses. The Authority
+/// never reconstructs these bytes — it verifies the signature over
+/// `disclosedContent` verbatim and parses the context fields out of it —
+/// so the only implementations that must agree byte-for-byte are the
+/// signing sender and the verifying recipient, both of which are this
+/// function.
+public enum ChatModerationProof {
+    /// Version discriminator inside the preimage so a future shape
+    /// change can't be confused with this one.
+    public static let version = 1
+
+    public static func signedContent(
+        messageID: UUID,
+        groupID: String,
+        sentAtMillis: Int64,
+        body: String
+    ) throws -> String {
+        struct Preimage: Encodable {
+            let body: String
+            let groupID: String
+            let messageID: String
+            let proofVersion: Int
+            let sentAtMillis: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case body
+                case groupID = "group_id"
+                case messageID = "message_id"
+                case proofVersion = "proof_version"
+                case sentAtMillis = "sent_at_millis"
+            }
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(Preimage(
+            body: body,
+            groupID: groupID,
+            messageID: messageID.uuidString.lowercased(),
+            proofVersion: version,
+            sentAtMillis: sentAtMillis
+        ))
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// Millisecond timestamp recovered from a stored `sentAt` date.
+    /// The receiver derives `sentAt` as `Date(millis / 1000)`; rounding
+    /// the reverse conversion recovers the wire value exactly (Double
+    /// carries sub-microsecond precision at epoch-seconds magnitude).
+    public static func sentAtMillis(from sentAt: Date) -> Int64 {
+        Int64((sentAt.timeIntervalSince1970 * 1000).rounded())
+    }
+}

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatModerationProof.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatModerationProof.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Canonical preimage of the moderation authenticity proof — the exact
@@ -20,6 +21,15 @@ import Foundation
 /// so the only implementations that must agree byte-for-byte are the
 /// signing sender and the verifying recipient, both of which are this
 /// function.
+///
+/// The group is bound through `group_binding` —
+/// `SHA-256("onym-moderation-proof-v1|" + groupID + "|" + messageID)` —
+/// rather than the raw group id. The recipient recomputes it from the
+/// same locals, so the binding is just as tight, but the disclosed
+/// content carries no cross-report-linkable identifier: two reports
+/// from the same group hash to unrelated values (the message id salts
+/// them), so an Authority cannot correlate independent reports to one
+/// group or join them against on-chain data.
 public enum ChatModerationProof {
     /// Version discriminator inside the preimage so a future shape
     /// change can't be confused with this one.
@@ -33,25 +43,29 @@ public enum ChatModerationProof {
     ) throws -> String {
         struct Preimage: Encodable {
             let body: String
-            let groupID: String
+            let groupBinding: String
             let messageID: String
             let proofVersion: Int
             let sentAtMillis: Int64
 
             enum CodingKeys: String, CodingKey {
                 case body
-                case groupID = "group_id"
+                case groupBinding = "group_binding"
                 case messageID = "message_id"
                 case proofVersion = "proof_version"
                 case sentAtMillis = "sent_at_millis"
             }
         }
+        let messageIDString = messageID.uuidString.lowercased()
+        let binding = SHA256.hash(data: Data(
+            "onym-moderation-proof-v1|\(groupID)|\(messageIDString)".utf8
+        )).map { String(format: "%02x", $0) }.joined()
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(Preimage(
             body: body,
-            groupID: groupID,
-            messageID: messageID.uuidString.lowercased(),
+            groupBinding: binding,
+            messageID: messageIDString,
             proofVersion: version,
             sentAtMillis: sentAtMillis
         ))

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatModerationProof.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatModerationProof.swift
@@ -22,14 +22,18 @@ import Foundation
 /// signing sender and the verifying recipient, both of which are this
 /// function.
 ///
-/// The group is bound through `group_binding` —
-/// `SHA-256("onym-moderation-proof-v1|" + groupID + "|" + messageID)` —
-/// rather than the raw group id. The recipient recomputes it from the
-/// same locals, so the binding is just as tight, but the disclosed
-/// content carries no cross-report-linkable identifier: two reports
-/// from the same group hash to unrelated values (the message id salts
-/// them), so an Authority cannot correlate independent reports to one
-/// group or join them against on-chain data.
+/// The group is bound through `group_binding` — a SHA-256 over the
+/// group's 32-byte shared secret (`ChatGroup.groupSecret`, sealed into
+/// invitations and never on-chain), the group id, and the message id —
+/// rather than the raw group id. Members recompute it from their
+/// stored group, so the binding is just as tight, but the disclosed
+/// content carries no identifier an outsider can resolve: group ids
+/// are public on-chain lookup keys, so a keyless hash could be broken
+/// by trial-hashing one candidate per group. The secret input closes
+/// that — an Authority cannot correlate independent reports to one
+/// group or join them against chain data — and the message id in the
+/// preimage keeps two reports from the same group unlinkable to each
+/// other as well.
 public enum ChatModerationProof {
     /// Version discriminator inside the preimage so a future shape
     /// change can't be confused with this one.
@@ -38,6 +42,7 @@ public enum ChatModerationProof {
     public static func signedContent(
         messageID: UUID,
         groupID: String,
+        groupSecret: Data,
         sentAtMillis: Int64,
         body: String
     ) throws -> String {
@@ -57,9 +62,12 @@ public enum ChatModerationProof {
             }
         }
         let messageIDString = messageID.uuidString.lowercased()
-        let binding = SHA256.hash(data: Data(
-            "onym-moderation-proof-v1|\(groupID)|\(messageIDString)".utf8
-        )).map { String(format: "%02x", $0) }.joined()
+        var hasher = SHA256()
+        hasher.update(data: Data("onym-moderation-proof-v1|".utf8))
+        hasher.update(data: groupSecret)
+        hasher.update(data: Data("|\(groupID)|\(messageIDString)".utf8))
+        let binding = hasher.finalize()
+            .map { String(format: "%02x", $0) }.joined()
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(Preimage(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/PersistedMessage.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/PersistedMessage.swift
@@ -68,6 +68,10 @@ final class PersistedMessage {
 
     var encryptedSenderBlsPubkeyHex: Data
     var encryptedBody: Data
+    /// Optional encrypted detached signature over `body`, retained for
+    /// Authority reporting. Nil is the lightweight-migration value for
+    /// messages persisted before reporting existed.
+    var encryptedModerationAuthenticityProof: Data?
     /// AES-GCM-encrypted JSON of the `ChatImageAttachment` (or `nil`
     /// for a text-only message). Encrypted at rest like `body` — it
     /// carries the per-image key. Optional so SwiftData's lightweight
@@ -102,6 +106,7 @@ final class PersistedMessage {
         deliveredAckSent: Bool? = nil,
         encryptedSenderBlsPubkeyHex: Data,
         encryptedBody: Data,
+        encryptedModerationAuthenticityProof: Data? = nil,
         encryptedAttachmentJSON: Data? = nil,
         encryptedVideoAttachmentJSON: Data? = nil,
         encryptedAlbumJSON: Data? = nil,
@@ -119,6 +124,7 @@ final class PersistedMessage {
         self.deliveredAckSent = deliveredAckSent
         self.encryptedSenderBlsPubkeyHex = encryptedSenderBlsPubkeyHex
         self.encryptedBody = encryptedBody
+        self.encryptedModerationAuthenticityProof = encryptedModerationAuthenticityProof
         self.encryptedAttachmentJSON = encryptedAttachmentJSON
         self.encryptedVideoAttachmentJSON = encryptedVideoAttachmentJSON
         self.encryptedAlbumJSON = encryptedAlbumJSON

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -146,9 +146,20 @@ public actor SendMessageInteractor {
 
         let messageID = UUID()
         let sentAtMillis = Int64(now.timeIntervalSince1970 * 1000)
-        let moderationAuthenticityProof = try await identity
-            .signWithStellarKey(Data(body.utf8))
-            .base64EncodedString()
+        // The proof signs the canonical preimage — body bound to this
+        // exact (messageID, groupID, sentAtMillis) — so a disclosed
+        // (content, signature) pair can't be replayed against another
+        // message. Best-effort by design: a signing failure ships the
+        // message without a proof (recipients just can't report it)
+        // rather than adding a crypto dependency to every text send.
+        let moderationAuthenticityProof = (try? await identity.signWithStellarKey(
+            Data(ChatModerationProof.signedContent(
+                messageID: messageID,
+                groupID: groupID,
+                sentAtMillis: sentAtMillis,
+                body: body
+            ).utf8)
+        ))?.base64EncodedString()
         let payload = ChatMessagePayload(
             version: 1,
             messageID: messageID,

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -189,13 +189,19 @@ public actor SendMessageInteractor {
         // Status flips later after the fan-out completes; the bubble
         // never disappears (re-tries flip pending → sent again, not
         // back to a different id).
+        //
+        // Persist `sentAt` from the wire millis (not the raw `now`):
+        // the proof signs the truncated millisecond value, so the
+        // stored date must reconstruct exactly that value — the same
+        // derivation every recipient makes — or the sender's own row
+        // could never re-derive the preimage it signed.
         let pending = ChatMessage(
             id: messageID,
             groupID: groupID,
             ownerIdentityID: group.ownerIdentityID,
             senderBlsPubkeyHex: myBlsHex,
             body: body,
-            sentAt: now,
+            sentAt: Date(timeIntervalSince1970: TimeInterval(sentAtMillis) / 1000.0),
             direction: .outgoing,
             status: .pending,
             replyToMessageID: replyToMessageID,

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -146,6 +146,9 @@ public actor SendMessageInteractor {
 
         let messageID = UUID()
         let sentAtMillis = Int64(now.timeIntervalSince1970 * 1000)
+        let moderationAuthenticityProof = try await identity
+            .signWithStellarKey(Data(body.utf8))
+            .base64EncodedString()
         let payload = ChatMessagePayload(
             version: 1,
             messageID: messageID,
@@ -153,7 +156,8 @@ public actor SendMessageInteractor {
             senderBlsPubkeyHex: myBlsHex,
             sentAtMillis: sentAtMillis,
             replyToMessageID: replyToMessageID,
-            variant: variant
+            variant: variant,
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
 
         // Optimistic insert — chat UI sees the bubble immediately.
@@ -170,7 +174,8 @@ public actor SendMessageInteractor {
             direction: .outgoing,
             status: .pending,
             replyToMessageID: replyToMessageID,
-            groupType: group.groupType
+            groupType: group.groupType,
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
         await messageRepository.insert(pending)
 
@@ -204,7 +209,8 @@ public actor SendMessageInteractor {
             status: finalStatus,
             replyToMessageID: pending.replyToMessageID,
             groupType: pending.groupType,
-            failureReason: failureReason
+            failureReason: failureReason,
+            moderationAuthenticityProof: pending.moderationAuthenticityProof
         )
     }
 
@@ -757,7 +763,8 @@ public actor SendMessageInteractor {
             attachment: message.imageAttachment,
             videoAttachment: message.videoAttachment,
             attachments: message.albumAttachments,
-            voiceAttachment: message.voiceAttachment
+            voiceAttachment: message.voiceAttachment,
+            moderationAuthenticityProof: message.moderationAuthenticityProof
         )
 
         // Re-upload the persisted ciphertext for any attachment so the
@@ -1006,6 +1013,7 @@ private extension ChatMessage {
             replyToMessageID: replyToMessageID,
             groupType: groupType,
             failureReason: status == .failed ? failureReason : nil,
+            moderationAuthenticityProof: moderationAuthenticityProof,
             imageAttachment: imageAttachment,
             videoAttachment: videoAttachment,
             albumAttachments: albumAttachments,

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -163,6 +163,7 @@ public actor SendMessageInteractor {
                 Data(ChatModerationProof.signedContent(
                     messageID: messageID,
                     groupID: groupID,
+                    groupSecret: group.groupSecret,
                     sentAtMillis: sentAtMillis,
                     body: body
                 ).utf8)

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CryptoKit
+import OSLog
 import OnymTransport
 import OnymIdentity
 import OnymTransportBlossom
@@ -39,6 +40,10 @@ public actor SendMessageInteractor {
     /// sender sees the media immediately — the optimistic bubble is now
     /// inserted *before* the upload, so the blob isn't on Blossom yet.
     private let imageLoader: ChatImageLoader?
+
+    private static let logger = Logger(
+        subsystem: "app.onym.ios", category: "moderation"
+    )
 
     /// Hard ceiling on an encrypted blob we'll attempt to upload. Sits
     /// under Blossom's ~100MB cap so a long clip fails fast client-side
@@ -152,14 +157,23 @@ public actor SendMessageInteractor {
         // message. Best-effort by design: a signing failure ships the
         // message without a proof (recipients just can't report it)
         // rather than adding a crypto dependency to every text send.
-        let moderationAuthenticityProof = (try? await identity.signWithStellarKey(
-            Data(ChatModerationProof.signedContent(
-                messageID: messageID,
-                groupID: groupID,
-                sentAtMillis: sentAtMillis,
-                body: body
-            ).utf8)
-        ))?.base64EncodedString()
+        let moderationAuthenticityProof: String?
+        do {
+            moderationAuthenticityProof = try await identity.signWithStellarKey(
+                Data(ChatModerationProof.signedContent(
+                    messageID: messageID,
+                    groupID: groupID,
+                    sentAtMillis: sentAtMillis,
+                    body: body
+                ).utf8)
+            ).base64EncodedString()
+        } catch {
+            // A systematic failure (e.g. keychain) must be visible in
+            // diagnostics. Error only — no message/group identifiers,
+            // per the no-activity-logging policy.
+            Self.logger.error("moderation proof signing failed: \(error, privacy: .private)")
+            moderationAuthenticityProof = nil
+        }
         let payload = ChatMessagePayload(
             version: 1,
             messageID: messageID,

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
@@ -164,16 +164,21 @@ public actor SwiftDataMessageStore: MessageStore {
                 existing.encryptedBody = encoded.encryptedBody
                 existing.encryptedModerationAuthenticityProof =
                     encoded.encryptedModerationAuthenticityProof
+                // Attachments and the reply pointer gate report
+                // eligibility (media/voice messages aren't reportable),
+                // so they are preserved with the tuple — a proof-less
+                // replay that bolts on an attachment would otherwise
+                // keep the pair but still remove Report from the menu.
+                existing.replyToMessageIDString = encoded.replyToMessageIDString
+                existing.encryptedAttachmentJSON = encoded.encryptedAttachmentJSON
+                existing.encryptedVideoAttachmentJSON = encoded.encryptedVideoAttachmentJSON
+                existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON
+                existing.encryptedVoiceAttachmentJSON = encoded.encryptedVoiceAttachmentJSON
             }
             existing.directionRaw = encoded.directionRaw
             existing.statusRaw = encoded.statusRaw
             existing.groupTypeRaw = encoded.groupTypeRaw
-            existing.replyToMessageIDString = encoded.replyToMessageIDString
             existing.failureReasonRaw = encoded.failureReasonRaw
-            existing.encryptedAttachmentJSON = encoded.encryptedAttachmentJSON
-            existing.encryptedVideoAttachmentJSON = encoded.encryptedVideoAttachmentJSON
-            existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON
-            existing.encryptedVoiceAttachmentJSON = encoded.encryptedVoiceAttachmentJSON
             do {
                 try context.save()
             } catch {

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
@@ -144,41 +144,35 @@ public actor SwiftDataMessageStore: MessageStore {
             predicate: #Predicate { $0.id == id && $0.ownerIdentityIDString == owner }
         )
         if let existing = try? context.fetch(descriptor).first {
-            // Receive-side replays land here as no-op overwrites; the
-            // outgoing pending → sent / failed flip uses the same path.
-            //
-            // A replay of a known id without a proof must not erase
-            // retained evidence. The proof signs the canonical preimage
-            // over (body, groupID, messageID, sentAt), so the entire
-            // signed tuple is kept together with it — overwriting any
-            // element (a shifted `sentAt` is the cheap one for a sender
-            // to forge) would leave a stored proof whose recomputed
-            // preimage no longer verifies, silently removing Report
-            // from the menu.
-            let preservesEvidence = existing.encryptedModerationAuthenticityProof != nil
-                && encoded.encryptedModerationAuthenticityProof == nil
-            if !preservesEvidence {
-                existing.groupID = encoded.groupID
-                existing.sentAt = encoded.sentAt
-                existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
-                existing.encryptedBody = encoded.encryptedBody
-                existing.encryptedModerationAuthenticityProof =
-                    encoded.encryptedModerationAuthenticityProof
-                // Attachments and the reply pointer gate report
-                // eligibility (media/voice messages aren't reportable),
-                // so they are preserved with the tuple — a proof-less
-                // replay that bolts on an attachment would otherwise
-                // keep the pair but still remove Report from the menu.
-                existing.replyToMessageIDString = encoded.replyToMessageIDString
-                existing.encryptedAttachmentJSON = encoded.encryptedAttachmentJSON
-                existing.encryptedVideoAttachmentJSON = encoded.encryptedVideoAttachmentJSON
-                existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON
-                existing.encryptedVoiceAttachmentJSON = encoded.encryptedVoiceAttachmentJSON
+            // An incoming row is immutable once received: a legitimate
+            // inbox replay is byte-identical, so there is nothing to
+            // update, and divergent content — laundered body, shifted
+            // timestamp, a *fresh* proof over the replacement, bolted-on
+            // attachments — is a sender trying to rewrite what the
+            // recipient already holds (and can report). Cross-direction
+            // overwrites are refused for the same reason: an echoed
+            // outgoing id must not rewrite the sender's own row.
+            let incoming = MessageDirection.incoming.rawValue
+            if existing.directionRaw == incoming
+                || existing.directionRaw != encoded.directionRaw {
+                return .updated
             }
-            existing.directionRaw = encoded.directionRaw
+            // Outgoing → outgoing: full overwrite (the pending → sent /
+            // failed flip and retry re-inserts use this path).
+            existing.groupID = encoded.groupID
+            existing.sentAt = encoded.sentAt
             existing.statusRaw = encoded.statusRaw
             existing.groupTypeRaw = encoded.groupTypeRaw
+            existing.replyToMessageIDString = encoded.replyToMessageIDString
             existing.failureReasonRaw = encoded.failureReasonRaw
+            existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
+            existing.encryptedBody = encoded.encryptedBody
+            existing.encryptedModerationAuthenticityProof =
+                encoded.encryptedModerationAuthenticityProof
+            existing.encryptedAttachmentJSON = encoded.encryptedAttachmentJSON
+            existing.encryptedVideoAttachmentJSON = encoded.encryptedVideoAttachmentJSON
+            existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON
+            existing.encryptedVoiceAttachmentJSON = encoded.encryptedVoiceAttachmentJSON
             do {
                 try context.save()
             } catch {

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
@@ -154,9 +154,17 @@ public actor SwiftDataMessageStore: MessageStore {
             existing.replyToMessageIDString = encoded.replyToMessageIDString
             existing.failureReasonRaw = encoded.failureReasonRaw
             existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
-            existing.encryptedBody = encoded.encryptedBody
-            existing.encryptedModerationAuthenticityProof =
-                encoded.encryptedModerationAuthenticityProof
+            if existing.encryptedModerationAuthenticityProof == nil
+                || encoded.encryptedModerationAuthenticityProof != nil {
+                existing.encryptedBody = encoded.encryptedBody
+                existing.encryptedModerationAuthenticityProof =
+                    encoded.encryptedModerationAuthenticityProof
+            }
+            // else: a replay of a known id without a proof must not
+            // erase retained evidence. The body and its proof travel as
+            // a signed pair, so both are kept — otherwise a re-sent
+            // proof-less body would orphan the signature it no longer
+            // matches (and silently remove Report from the menu).
             existing.encryptedAttachmentJSON = encoded.encryptedAttachmentJSON
             existing.encryptedVideoAttachmentJSON = encoded.encryptedVideoAttachmentJSON
             existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
@@ -155,6 +155,8 @@ public actor SwiftDataMessageStore: MessageStore {
             existing.failureReasonRaw = encoded.failureReasonRaw
             existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
             existing.encryptedBody = encoded.encryptedBody
+            existing.encryptedModerationAuthenticityProof =
+                encoded.encryptedModerationAuthenticityProof
             existing.encryptedAttachmentJSON = encoded.encryptedAttachmentJSON
             existing.encryptedVideoAttachmentJSON = encoded.encryptedVideoAttachmentJSON
             existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON
@@ -286,6 +288,9 @@ public actor SwiftDataMessageStore: MessageStore {
             failureReasonRaw: message.failureReason?.rawValue,
             encryptedSenderBlsPubkeyHex: try StorageEncryption.encrypt(message.senderBlsPubkeyHex),
             encryptedBody: try StorageEncryption.encrypt(message.body),
+            encryptedModerationAuthenticityProof: try message.moderationAuthenticityProof.map {
+                try StorageEncryption.encrypt($0)
+            },
             encryptedAttachmentJSON: encryptedAttachment,
             encryptedVideoAttachmentJSON: encryptedVideoAttachment,
             encryptedAlbumJSON: encryptedAlbum,
@@ -319,6 +324,8 @@ public actor SwiftDataMessageStore: MessageStore {
         let voiceAttachment: ChatVoiceAttachment? = row.encryptedVoiceAttachmentJSON
             .flatMap { try? StorageEncryption.decrypt($0) }
             .flatMap { try? JSONDecoder().decode(ChatVoiceAttachment.self, from: $0) }
+        let moderationAuthenticityProof = row.encryptedModerationAuthenticityProof
+            .flatMap { try? StorageEncryption.decryptString($0) }
         return ChatMessage(
             id: id,
             groupID: row.groupID,
@@ -331,6 +338,7 @@ public actor SwiftDataMessageStore: MessageStore {
             replyToMessageID: row.replyToMessageIDString.flatMap(UUID.init(uuidString:)),
             groupType: groupType,
             failureReason: row.failureReasonRaw.flatMap(SendFailureReason.init(rawValue:)),
+            moderationAuthenticityProof: moderationAuthenticityProof,
             imageAttachment: imageAttachment,
             videoAttachment: videoAttachment,
             albumAttachments: albumAttachments,

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
@@ -146,25 +146,30 @@ public actor SwiftDataMessageStore: MessageStore {
         if let existing = try? context.fetch(descriptor).first {
             // Receive-side replays land here as no-op overwrites; the
             // outgoing pending → sent / failed flip uses the same path.
-            existing.groupID = encoded.groupID
-            existing.sentAt = encoded.sentAt
+            //
+            // A replay of a known id without a proof must not erase
+            // retained evidence. The proof signs the canonical preimage
+            // over (body, groupID, messageID, sentAt), so the entire
+            // signed tuple is kept together with it — overwriting any
+            // element (a shifted `sentAt` is the cheap one for a sender
+            // to forge) would leave a stored proof whose recomputed
+            // preimage no longer verifies, silently removing Report
+            // from the menu.
+            let preservesEvidence = existing.encryptedModerationAuthenticityProof != nil
+                && encoded.encryptedModerationAuthenticityProof == nil
+            if !preservesEvidence {
+                existing.groupID = encoded.groupID
+                existing.sentAt = encoded.sentAt
+                existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
+                existing.encryptedBody = encoded.encryptedBody
+                existing.encryptedModerationAuthenticityProof =
+                    encoded.encryptedModerationAuthenticityProof
+            }
             existing.directionRaw = encoded.directionRaw
             existing.statusRaw = encoded.statusRaw
             existing.groupTypeRaw = encoded.groupTypeRaw
             existing.replyToMessageIDString = encoded.replyToMessageIDString
             existing.failureReasonRaw = encoded.failureReasonRaw
-            existing.encryptedSenderBlsPubkeyHex = encoded.encryptedSenderBlsPubkeyHex
-            if existing.encryptedModerationAuthenticityProof == nil
-                || encoded.encryptedModerationAuthenticityProof != nil {
-                existing.encryptedBody = encoded.encryptedBody
-                existing.encryptedModerationAuthenticityProof =
-                    encoded.encryptedModerationAuthenticityProof
-            }
-            // else: a replay of a known id without a proof must not
-            // erase retained evidence. The body and its proof travel as
-            // a signed pair, so both are kept — otherwise a re-sent
-            // proof-less body would orphan the signature it no longer
-            // matches (and silently remove Report from the menu).
             existing.encryptedAttachmentJSON = encoded.encryptedAttachmentJSON
             existing.encryptedVideoAttachmentJSON = encoded.encryptedVideoAttachmentJSON
             existing.encryptedAlbumJSON = encoded.encryptedAlbumJSON

--- a/Packages/OnymChatsUI/Package.swift
+++ b/Packages/OnymChatsUI/Package.swift
@@ -14,7 +14,9 @@ let package = Package(
         .package(path: "../OnymIdentity"),
         .package(path: "../OnymIdentityUI"),
         .package(path: "../OnymDesign"),
-        .package(path: "../OnymChain")
+        .package(path: "../OnymChain"),
+        .package(path: "../OnymModeration"),
+        .package(path: "../OnymModerationUI")
     ],
     targets: [
         .target(
@@ -26,7 +28,9 @@ let package = Package(
                 "OnymIdentity",
                 "OnymIdentityUI",
                 "OnymDesign",
-                "OnymChain"
+                "OnymChain",
+                "OnymModeration",
+                "OnymModerationUI"
             ]
         )
     ]

--- a/Packages/OnymChatsUI/Package.swift
+++ b/Packages/OnymChatsUI/Package.swift
@@ -15,8 +15,7 @@ let package = Package(
         .package(path: "../OnymIdentityUI"),
         .package(path: "../OnymDesign"),
         .package(path: "../OnymChain"),
-        .package(path: "../OnymModeration"),
-        .package(path: "../OnymModerationUI")
+        .package(path: "../OnymModeration")
     ],
     targets: [
         .target(
@@ -29,8 +28,7 @@ let package = Package(
                 "OnymIdentityUI",
                 "OnymDesign",
                 "OnymChain",
-                "OnymModeration",
-                "OnymModerationUI"
+                "OnymModeration"
             ]
         )
     ]

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
@@ -8,7 +8,6 @@ import OnymIdentity
 import OnymGroup
 import OnymChatsCore
 import OnymModeration
-import OnymModerationUI
 
 /// SwiftUI host for `ChatThreadViewController`. The chat screen is
 /// UIKit (per the design call on #150) but the surrounding app is
@@ -41,7 +40,10 @@ public struct ChatThreadView: View {
     let videoLoader: ChatVideoLoader
     /// Fetches + decrypts voice blobs for inline playback.
     let voiceLoader: ChatVoiceLoader
-    let makeModerationReportFlow: @MainActor (ReportableMessage) -> ModerationReportFlow
+    /// Builds the report sheet for a disclosable message. Injected as
+    /// an opaque view factory so the chats layer stays moderation-UI-
+    /// agnostic (OnymChatsUI does not depend on OnymModerationUI).
+    let makeModerationReportView: @MainActor (ReportableMessage) -> AnyView
     /// When non-nil (opened from Search), the thread cold-opens scrolled
     /// to this message and flashes it, instead of opening at the bottom.
     var scrollToMessageID: UUID? = nil
@@ -59,7 +61,7 @@ public struct ChatThreadView: View {
         imageLoader: ChatImageLoader,
         videoLoader: ChatVideoLoader,
         voiceLoader: ChatVoiceLoader,
-        makeModerationReportFlow: @escaping @MainActor (ReportableMessage) -> ModerationReportFlow,
+        makeModerationReportView: @escaping @MainActor (ReportableMessage) -> AnyView,
         scrollToMessageID: UUID? = nil
     ) {
         self.groupID = groupID
@@ -74,7 +76,7 @@ public struct ChatThreadView: View {
         self.imageLoader = imageLoader
         self.videoLoader = videoLoader
         self.voiceLoader = voiceLoader
-        self.makeModerationReportFlow = makeModerationReportFlow
+        self.makeModerationReportView = makeModerationReportView
         self.scrollToMessageID = scrollToMessageID
     }
 
@@ -246,7 +248,7 @@ public struct ChatThreadView: View {
             Button("Cancel", role: .cancel) {}
         }
         .sheet(item: $reportableMessage) { message in
-            ModerationReportView(flow: makeModerationReportFlow(message))
+            makeModerationReportView(message)
         }
         // The chat screen uses the standard SwiftUI navigation bar (its
         // system back button is the only "back" affordance — the UIKit
@@ -432,22 +434,7 @@ public struct ChatThreadView: View {
     }
 
     private func makeReportableMessage(from message: ChatMessage) -> ReportableMessage? {
-        guard message.direction == .incoming,
-              message.media.isEmpty,
-              message.voiceAttachment == nil,
-              !message.body.isEmpty,
-              let proof = message.moderationAuthenticityProof,
-              let profile = currentMemberProfiles[message.senderBlsPubkeyHex]
-        else { return nil }
-        let accused = "onym:key:" + profile.sendingPubkey
-            .map { String(format: "%02x", $0) }
-            .joined()
-        return ReportableMessage(
-            id: message.id.uuidString.lowercased(),
-            accused: accused,
-            disclosedContent: message.body,
-            authenticityProof: proof
-        )
+        ReportableMessageFactory.make(from: message, memberProfiles: currentMemberProfiles)
     }
 }
 

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
@@ -7,6 +7,8 @@ import OnymDesign
 import OnymIdentity
 import OnymGroup
 import OnymChatsCore
+import OnymModeration
+import OnymModerationUI
 
 /// SwiftUI host for `ChatThreadViewController`. The chat screen is
 /// UIKit (per the design call on #150) but the surrounding app is
@@ -39,6 +41,7 @@ public struct ChatThreadView: View {
     let videoLoader: ChatVideoLoader
     /// Fetches + decrypts voice blobs for inline playback.
     let voiceLoader: ChatVoiceLoader
+    let makeModerationReportFlow: @MainActor (ReportableMessage) -> ModerationReportFlow
     /// When non-nil (opened from Search), the thread cold-opens scrolled
     /// to this message and flashes it, instead of opening at the bottom.
     var scrollToMessageID: UUID? = nil
@@ -56,6 +59,7 @@ public struct ChatThreadView: View {
         imageLoader: ChatImageLoader,
         videoLoader: ChatVideoLoader,
         voiceLoader: ChatVoiceLoader,
+        makeModerationReportFlow: @escaping @MainActor (ReportableMessage) -> ModerationReportFlow,
         scrollToMessageID: UUID? = nil
     ) {
         self.groupID = groupID
@@ -70,6 +74,7 @@ public struct ChatThreadView: View {
         self.imageLoader = imageLoader
         self.videoLoader = videoLoader
         self.voiceLoader = voiceLoader
+        self.makeModerationReportFlow = makeModerationReportFlow
         self.scrollToMessageID = scrollToMessageID
     }
 
@@ -98,6 +103,7 @@ public struct ChatThreadView: View {
     /// `sentAt`. SwiftUI re-renders on every push so the bridge
     /// hands the controller fresh data via `updateUIViewController`.
     @State private var messages: [ChatMessage] = []
+    @State private var reportableMessage: ReportableMessage?
 
     public var body: some View {
         ChatThreadControllerBridge(
@@ -138,6 +144,10 @@ public struct ChatThreadView: View {
                 Task {
                     await interactor.retry(groupID: groupID, messageID: messageID)
                 }
+            },
+            canReportMessage: { makeReportableMessage(from: $0) != nil },
+            onReportRequested: { message in
+                reportableMessage = makeReportableMessage(from: message)
             },
             imageLoader: imageLoader,
             scrollToMessageID: scrollToMessageID,
@@ -234,6 +244,9 @@ public struct ChatThreadView: View {
                 Task { await interactor.delete(groupID: groupID, messageID: id) }
             }
             Button("Cancel", role: .cancel) {}
+        }
+        .sheet(item: $reportableMessage) { message in
+            ModerationReportView(flow: makeModerationReportFlow(message))
         }
         // The chat screen uses the standard SwiftUI navigation bar (its
         // system back button is the only "back" affordance — the UIKit
@@ -417,6 +430,25 @@ public struct ChatThreadView: View {
     private var currentInvitationMessage: String? {
         chatsFlow.groups.first { $0.id == groupID }?.invitationMessage
     }
+
+    private func makeReportableMessage(from message: ChatMessage) -> ReportableMessage? {
+        guard message.direction == .incoming,
+              message.media.isEmpty,
+              message.voiceAttachment == nil,
+              !message.body.isEmpty,
+              let proof = message.moderationAuthenticityProof,
+              let profile = currentMemberProfiles[message.senderBlsPubkeyHex]
+        else { return nil }
+        let accused = "onym:key:" + profile.sendingPubkey
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return ReportableMessage(
+            id: message.id.uuidString.lowercased(),
+            accused: accused,
+            disclosedContent: message.body,
+            authenticityProof: proof
+        )
+    }
 }
 
 private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
@@ -425,6 +457,8 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
     let messages: [ChatMessage]
     let onSendTapped: (String, UUID?) -> Void
     let onRetryRequested: (UUID) -> Void
+    let canReportMessage: (ChatMessage) -> Bool
+    let onReportRequested: (ChatMessage) -> Void
     let imageLoader: ChatImageLoader
     let scrollToMessageID: UUID?
     let onImageTapped: (ChatMessage) -> Void
@@ -447,6 +481,8 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         vc.openAtMessageID = scrollToMessageID
         vc.onSendTapped = onSendTapped
         vc.onRetryRequested = onRetryRequested
+        vc.canReportMessage = canReportMessage
+        vc.onReportRequested = onReportRequested
         vc.imageLoader = imageLoader
         vc.onImageTapped = onImageTapped
         vc.onVideoTapped = onVideoTapped
@@ -474,6 +510,8 @@ private struct ChatThreadControllerBridge: UIViewControllerRepresentable {
         // group-info now live in the SwiftUI nav bar, not the controller.)
         vc.onSendTapped = onSendTapped
         vc.onRetryRequested = onRetryRequested
+        vc.canReportMessage = canReportMessage
+        vc.onReportRequested = onReportRequested
         vc.imageLoader = imageLoader
         vc.onImageTapped = onImageTapped
         vc.onVideoTapped = onVideoTapped

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
@@ -434,7 +434,14 @@ public struct ChatThreadView: View {
     }
 
     private func makeReportableMessage(from message: ChatMessage) -> ReportableMessage? {
-        ReportableMessageFactory.make(from: message, memberProfiles: currentMemberProfiles)
+        guard let group = chatsFlow.groups.first(where: { $0.id == groupID }) else {
+            return nil
+        }
+        return ReportableMessageFactory.make(
+            from: message,
+            memberProfiles: currentMemberProfiles,
+            groupSecret: group.groupSecret
+        )
     }
 }
 

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
@@ -765,9 +765,14 @@ extension ChatThreadViewController: UITableViewDelegate {
         contextMenuConfigurationForRowAt indexPath: IndexPath,
         point: CGPoint
     ) -> UIContextMenuConfiguration? {
-        guard indexPath.row < orderedMessages.count else { return nil }
-        let message = orderedMessages[indexPath.row]
-        guard canReportMessage?(message) == true else { return nil }
+        // Resolve through the diffable data source, not `orderedMessages`:
+        // `update(messages:)` swaps the model array before the animated
+        // `apply` commits, so during an in-flight insert the committed
+        // rows and the array can disagree and a positional index would
+        // attach Report to the wrong message.
+        guard let id = dataSource.itemIdentifier(for: indexPath),
+              let message = messagesByID[id],
+              canReportMessage?(message) == true else { return nil }
         return UIContextMenuConfiguration(
             identifier: message.id as NSUUID,
             previewProvider: nil

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
@@ -30,6 +30,11 @@ final class ChatThreadViewController: UIViewController {
     /// rows have the tap target installed by `ChatBubbleCell`, so
     /// this never fires for other statuses.
     var onRetryRequested: ((UUID) -> Void)?
+    /// Whether an incoming row carries the content-level proof required
+    /// by the Authority contract. Only those rows receive a Report menu.
+    var canReportMessage: ((ChatMessage) -> Bool)?
+    /// Fired from the system long-press context menu.
+    var onReportRequested: ((ChatMessage) -> Void)?
 
     /// Loader used by bubbles to fetch + decrypt image attachments.
     var imageLoader: ChatImageLoader?
@@ -504,6 +509,7 @@ final class ChatThreadViewController: UIViewController {
         tableView.register(ChatBubbleCell.self, forCellReuseIdentifier: ChatBubbleCell.textReuseID)
         tableView.register(ChatBubbleCell.self, forCellReuseIdentifier: ChatBubbleCell.mediaReuseID)
         tableView.keyboardDismissMode = .interactive
+        tableView.delegate = self
         view.addSubview(tableView)
 
         // Empty state — a hosted SwiftUI view filling the message-list
@@ -750,5 +756,30 @@ extension ChatThreadViewController: UIGestureRecognizerDelegate {
             return velocity.x > 0 && abs(velocity.x) > abs(velocity.y)
         }
         return true
+    }
+}
+
+extension ChatThreadViewController: UITableViewDelegate {
+    func tableView(
+        _ tableView: UITableView,
+        contextMenuConfigurationForRowAt indexPath: IndexPath,
+        point: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard indexPath.row < orderedMessages.count else { return nil }
+        let message = orderedMessages[indexPath.row]
+        guard canReportMessage?(message) == true else { return nil }
+        return UIContextMenuConfiguration(
+            identifier: message.id as NSUUID,
+            previewProvider: nil
+        ) { [weak self] _ in
+            let report = UIAction(
+                title: String(localized: "Report"),
+                image: UIImage(systemName: "exclamationmark.bubble"),
+                attributes: .destructive
+            ) { [weak self] _ in
+                self?.onReportRequested?(message)
+            }
+            return UIMenu(children: [report])
+        }
     }
 }

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
@@ -6,6 +6,8 @@ import OnymIdentityUI
 import OnymGroup
 import OnymChatsCore
 import OnymInbox
+import OnymModeration
+import OnymModerationUI
 
 /// Chats tab — root list of groups the user has created. PR-C only
 /// supports Tyranny groups; this list is whatever
@@ -28,6 +30,7 @@ public struct ChatsView: View {
     let makeJoinFlow: @MainActor (IntroCapability) -> JoinFlow
     let setGroupAvatar: @MainActor (String, Data?) async -> Void
     let setGroupName: @MainActor (String, String) async -> Void
+    let makeModerationReportFlow: @MainActor (ReportableMessage) -> ModerationReportFlow
 
     public init(
         flow: ChatsFlow,
@@ -44,7 +47,8 @@ public struct ChatsView: View {
         makeShareInviteFlow: @escaping @MainActor () -> ShareInviteFlow,
         makeJoinFlow: @escaping @MainActor (IntroCapability) -> JoinFlow,
         setGroupAvatar: @escaping @MainActor (String, Data?) async -> Void,
-        setGroupName: @escaping @MainActor (String, String) async -> Void
+        setGroupName: @escaping @MainActor (String, String) async -> Void,
+        makeModerationReportFlow: @escaping @MainActor (ReportableMessage) -> ModerationReportFlow
     ) {
         self.flow = flow
         self.identitiesFlow = identitiesFlow
@@ -61,6 +65,7 @@ public struct ChatsView: View {
         self.makeJoinFlow = makeJoinFlow
         self.setGroupAvatar = setGroupAvatar
         self.setGroupName = setGroupName
+        self.makeModerationReportFlow = makeModerationReportFlow
     }
 
     @State private var showCreateGroup = false
@@ -344,7 +349,8 @@ public struct ChatsView: View {
                 setGroupName: setGroupName,
                 imageLoader: imageLoader,
                 videoLoader: videoLoader,
-                voiceLoader: voiceLoader
+                voiceLoader: voiceLoader,
+                makeModerationReportFlow: makeModerationReportFlow
             )
         }
     }

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
@@ -7,7 +7,6 @@ import OnymGroup
 import OnymChatsCore
 import OnymInbox
 import OnymModeration
-import OnymModerationUI
 
 /// Chats tab — root list of groups the user has created. PR-C only
 /// supports Tyranny groups; this list is whatever
@@ -30,7 +29,7 @@ public struct ChatsView: View {
     let makeJoinFlow: @MainActor (IntroCapability) -> JoinFlow
     let setGroupAvatar: @MainActor (String, Data?) async -> Void
     let setGroupName: @MainActor (String, String) async -> Void
-    let makeModerationReportFlow: @MainActor (ReportableMessage) -> ModerationReportFlow
+    let makeModerationReportView: @MainActor (ReportableMessage) -> AnyView
 
     public init(
         flow: ChatsFlow,
@@ -48,7 +47,7 @@ public struct ChatsView: View {
         makeJoinFlow: @escaping @MainActor (IntroCapability) -> JoinFlow,
         setGroupAvatar: @escaping @MainActor (String, Data?) async -> Void,
         setGroupName: @escaping @MainActor (String, String) async -> Void,
-        makeModerationReportFlow: @escaping @MainActor (ReportableMessage) -> ModerationReportFlow
+        makeModerationReportView: @escaping @MainActor (ReportableMessage) -> AnyView
     ) {
         self.flow = flow
         self.identitiesFlow = identitiesFlow
@@ -65,7 +64,7 @@ public struct ChatsView: View {
         self.makeJoinFlow = makeJoinFlow
         self.setGroupAvatar = setGroupAvatar
         self.setGroupName = setGroupName
-        self.makeModerationReportFlow = makeModerationReportFlow
+        self.makeModerationReportView = makeModerationReportView
     }
 
     @State private var showCreateGroup = false
@@ -350,7 +349,7 @@ public struct ChatsView: View {
                 imageLoader: imageLoader,
                 videoLoader: videoLoader,
                 voiceLoader: voiceLoader,
-                makeModerationReportFlow: makeModerationReportFlow
+                makeModerationReportView: makeModerationReportView
             )
         }
     }

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ReportableMessageFactory.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ReportableMessageFactory.swift
@@ -1,0 +1,47 @@
+import CryptoKit
+import Foundation
+import OnymChatsCore
+import OnymGroup
+import OnymModeration
+
+/// Decides whether a chat message is reportable and, if so, packages
+/// it for disclosure. Eligibility: an incoming, text-only message with
+/// a sender proof that actually verifies against the sender's stored
+/// Ed25519 key. Verifying here (not just checking presence) keeps a
+/// sender who ships a garbage proof from getting a Report menu entry
+/// that can only dead-end at submit time.
+enum ReportableMessageFactory {
+    static func make(
+        from message: ChatMessage,
+        memberProfiles: [String: MemberProfile]
+    ) -> ReportableMessage? {
+        guard message.direction == .incoming,
+              message.media.isEmpty,
+              message.voiceAttachment == nil,
+              !message.body.isEmpty,
+              let proof = message.moderationAuthenticityProof,
+              let signature = Data(base64Encoded: proof),
+              let profile = memberProfiles[message.senderBlsPubkeyHex],
+              let senderKey = try? Curve25519.Signing.PublicKey(
+                rawRepresentation: profile.sendingPubkey
+              ),
+              let disclosedContent = try? ChatModerationProof.signedContent(
+                messageID: message.id,
+                groupID: message.groupID,
+                sentAtMillis: ChatModerationProof.sentAtMillis(from: message.sentAt),
+                body: message.body
+              ),
+              senderKey.isValidSignature(signature, for: Data(disclosedContent.utf8))
+        else { return nil }
+        let accused = "onym:key:" + profile.sendingPubkey
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return ReportableMessage(
+            id: message.id.uuidString.lowercased(),
+            accused: accused,
+            disclosedContent: disclosedContent,
+            authenticityProof: proof,
+            displayBody: message.body
+        )
+    }
+}

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ReportableMessageFactory.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ReportableMessageFactory.swift
@@ -13,7 +13,8 @@ import OnymModeration
 enum ReportableMessageFactory {
     static func make(
         from message: ChatMessage,
-        memberProfiles: [String: MemberProfile]
+        memberProfiles: [String: MemberProfile],
+        groupSecret: Data
     ) -> ReportableMessage? {
         guard message.direction == .incoming,
               message.media.isEmpty,
@@ -28,6 +29,7 @@ enum ReportableMessageFactory {
               let disclosedContent = try? ChatModerationProof.signedContent(
                 messageID: message.id,
                 groupID: message.groupID,
+                groupSecret: groupSecret,
                 sentAtMillis: ChatModerationProof.sentAtMillis(from: message.sentAt),
                 body: message.body
               ),

--- a/Packages/OnymInbox/Sources/OnymInbox/IncomingMessageDispatcher.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/IncomingMessageDispatcher.swift
@@ -825,6 +825,7 @@ public struct IncomingMessageDispatcher: Sendable {
             // looks up local rows.
             replyToMessageID: payload.replyToMessageID,
             groupType: group.groupType,
+            moderationAuthenticityProof: payload.moderationAuthenticityProof,
             // Encrypted image (if any). The blob is fetched + decrypted
             // lazily at render time (`ChatImageLoader`); nothing is
             // downloaded on receipt.

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -84,6 +84,7 @@ public enum AuthorityClientError: Error, Sendable, Equatable {
     case rejected(AuthorityRejection)
     case mandateNotAccepted(mandateRef: String)
     case mandateReferenceMismatch(expected: String, received: String)
+    case reportIdentifierMismatch(expected: String, received: String)
     case invalidPathComponent(String)
     case insecureBaseURL(String)
 }
@@ -313,7 +314,14 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
     public func fileReport(_ report: Report) async throws -> ReportReceipt {
         let body = try ModerationCanonicalEncoder.encode(report)
         let data = try await send(method: "POST", path: ["v1", "reports"], body: body)
-        return try decode(data)
+        let receipt: ReportReceipt = try decode(data)
+        guard receipt.reportId == report.reportId else {
+            throw AuthorityClientError.reportIdentifierMismatch(
+                expected: report.reportId,
+                received: receipt.reportId
+            )
+        }
+        return receipt
     }
 
     public func respond(_ response: CaseResponse) async throws {

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -35,6 +35,12 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// The requested artifact has already resolved (or was never a
     /// persisted registration attempt).
     case registrationNotPending
+    /// Reporting requires a currently registered Authority mandate and
+    /// a directory entry capable of receiving the signed report.
+    case reportingUnavailable(String)
+    /// The supplied evidence proof does not verify against the accused
+    /// key over the exact content the user is about to disclose.
+    case authenticityUnverified
     /// DeviceCheck is unsupported here (simulator, enterprise-signed
     /// build). Callers degrade toward gate-check-required, never toward
     /// unmoderated operation (profile §8.5).

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -41,6 +41,11 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// The supplied evidence proof does not verify against the accused
     /// key over the exact content the user is about to disclose.
     case authenticityUnverified
+    /// The Authority answered 409: it already holds this exact report.
+    /// A terminal, benign outcome — the allegation is on file — but the
+    /// original receipt (caseId) cannot be recovered without a lookup
+    /// endpoint the Authority protocol doesn't define yet.
+    case reportAlreadyFiled(reportId: String)
     /// DeviceCheck is unsupported here (simulator, enterprise-signed
     /// build). Callers degrade toward gate-check-required, never toward
     /// unmoderated operation (profile §8.5).

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -74,6 +74,13 @@ public actor ModerationRepository {
     /// This interface's component id, carried in every mandate.
     public static let interfaceComponentId = "onym:component:onym-ios"
 
+    /// Retention bound on the report ledger. Rows whose delivery is
+    /// still ambiguous (no receipt) are always kept — they are the
+    /// idempotency keys for exact retry — but resolved rows beyond this
+    /// count are pruned oldest-first so disclosed content doesn't
+    /// accumulate indefinitely.
+    public static let maxResolvedReportRecords = 128
+
     private let authoritiesFetcher: any KnownAuthoritiesFetcher
     private let manifestFetcher: any AuthorityManifestFetcher
     private let manifestValidator: AuthorityManifestValidator
@@ -535,6 +542,9 @@ public actor ModerationRepository {
         }
         let reporterMandateRef = try reporterMandate.mandate.mandateHash()
 
+        // The idempotency identity deliberately includes `classId`:
+        // re-reporting the same message under a different violation
+        // class is a distinct allegation and mints its own report.
         if let existing = reportRecords.first(where: {
             $0.sourceMessageId == message.id
                 && $0.report.reporter == reporter
@@ -573,7 +583,7 @@ public actor ModerationRepository {
         // durably retained. A transport timeout may happen after intake
         // committed; without this write, a retry would mint a second report.
         do {
-            try reportStore.save(reportRecords)
+            try saveReportRecords()
         } catch {
             // Do not leave an unpersisted artifact eligible for the
             // in-memory exact-retry path on the next tap.
@@ -594,6 +604,18 @@ public actor ModerationRepository {
         do {
             receipt = try await client.fileReport(record.report)
         } catch {
+            // 409: the Authority already holds these exact bytes — a
+            // terminal, benign state, not a rejection. Keep the ledger
+            // row (it is the idempotency key) and surface it as its own
+            // error so the UI can present "already on file" rather than
+            // retry advice. The original receipt is unrecoverable until
+            // the Authority protocol grows a report-lookup endpoint.
+            if case let AuthorityClientError.rejected(rejection) = error,
+               rejection.statusCode == 409 {
+                throw ModerationError.reportAlreadyFiled(
+                    reportId: record.report.reportId
+                )
+            }
             if isDeterministicReportRejection(error) {
                 discardReport(record)
             }
@@ -612,8 +634,35 @@ public actor ModerationRepository {
             recovered.receipt = receipt
             reportRecords.insert(recovered, at: 0)
         }
-        try reportStore.save(reportRecords)
+        try saveReportRecords()
         return receipt
+    }
+
+    /// Persist the ledger, pruning resolved rows past the retention
+    /// bound. Records are newest-first, so dropping from the back of
+    /// the receipted subset removes the oldest disclosures first.
+    private func saveReportRecords() throws {
+        let resolved = reportRecords.filter { $0.receipt != nil }
+        if resolved.count > Self.maxResolvedReportRecords {
+            let cutoff = Set(
+                resolved.prefix(Self.maxResolvedReportRecords).map(\.report.reportId)
+            )
+            reportRecords.removeAll {
+                $0.receipt != nil && !cutoff.contains($0.report.reportId)
+            }
+        }
+        try reportStore.save(reportRecords)
+    }
+
+    /// Drop every report record not filed by one of `reporters`
+    /// (`onym:key:<hex>` references). Called when an identity is
+    /// removed so retained disclosures don't outlive the identity that
+    /// filed them.
+    public func purgeReportRecords(keepingReporters reporters: Set<String>) {
+        let before = reportRecords.count
+        reportRecords.removeAll { !reporters.contains($0.report.reporter) }
+        guard reportRecords.count != before else { return }
+        try? reportStore.save(reportRecords)
     }
 
     private func reportIndex(of record: ReportFilingRecord) -> Int? {
@@ -623,18 +672,16 @@ public actor ModerationRepository {
     private func discardReport(_ record: ReportFilingRecord) {
         guard let index = reportIndex(of: record) else { return }
         reportRecords.remove(at: index)
-        try? reportStore.save(reportRecords)
+        try? saveReportRecords()
     }
 
     private func isDeterministicReportRejection(_ error: Error) -> Bool {
         guard case let AuthorityClientError.rejected(rejection) = error else {
             return false
         }
-        // 409 means the Authority already holds this report. Keep the
-        // ledger row so a retry replays the same reportId instead of
-        // discarding it and minting a fresh one.
-        return rejection.statusCode != 409
-            && Self.isDeterministicStatusCode(rejection.statusCode)
+        // 409 never reaches here — `submitReport` converts it to
+        // `.reportAlreadyFiled` (terminal; keeps the ledger row).
+        return Self.isDeterministicStatusCode(rejection.statusCode)
     }
 
     /// A 4xx that exact replay can never turn into an acceptance —

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -630,9 +630,19 @@ public actor ModerationRepository {
         guard case let AuthorityClientError.rejected(rejection) = error else {
             return false
         }
-        return (400..<500).contains(rejection.statusCode)
-            && rejection.statusCode != 408
-            && rejection.statusCode != 429
+        // 409 means the Authority already holds this report. Keep the
+        // ledger row so a retry replays the same reportId instead of
+        // discarding it and minting a fresh one.
+        return rejection.statusCode != 409
+            && Self.isDeterministicStatusCode(rejection.statusCode)
+    }
+
+    /// A 4xx that exact replay can never turn into an acceptance —
+    /// excluding the transient pair (408 timeout, 429 rate limit).
+    private static func isDeterministicStatusCode(_ statusCode: Int) -> Bool {
+        (400..<500).contains(statusCode)
+            && statusCode != 408
+            && statusCode != 429
     }
 
     /// Resume the newest interrupted consent after the directory is
@@ -794,9 +804,7 @@ public actor ModerationRepository {
         case .mandateNotAccepted, .mandateReferenceMismatch:
             return true
         case .rejected(let rejection):
-            return (400..<500).contains(rejection.statusCode)
-                && rejection.statusCode != 408
-                && rejection.statusCode != 429
+            return Self.isDeterministicStatusCode(rejection.statusCode)
         case .invalidResponse, .malformedResponse, .invalidPathComponent, .insecureBaseURL,
              .reportIdentifierMismatch:
             return false

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -557,6 +557,13 @@ public actor ModerationRepository {
                 )]
         }) {
             if let receipt = existing.receipt { return receipt }
+            if existing.resolvedWithoutReceipt == true {
+                // Confirmed on file (409). Re-delivery can only 409
+                // again; short-circuit to the same terminal outcome.
+                throw ModerationError.reportAlreadyFiled(
+                    reportId: existing.report.reportId
+                )
+            }
             return try await submitReport(existing, to: listing)
         }
 
@@ -612,6 +619,10 @@ public actor ModerationRepository {
             // the Authority protocol grows a report-lookup endpoint.
             if case let AuthorityClientError.rejected(rejection) = error,
                rejection.statusCode == 409 {
+                if let index = reportIndex(of: record) {
+                    reportRecords[index].resolvedWithoutReceipt = true
+                    try? saveReportRecords()
+                }
                 throw ModerationError.reportAlreadyFiled(
                     reportId: record.report.reportId
                 )
@@ -621,6 +632,9 @@ public actor ModerationRepository {
             }
             throw error
         }
+        // The concrete HTTP client correlates this too; repeating the
+        // check here preserves the invariant for every factory-injected
+        // implementation of the protocol.
         guard receipt.reportId == record.report.reportId else {
             throw AuthorityClientError.reportIdentifierMismatch(
                 expected: record.report.reportId,
@@ -642,13 +656,13 @@ public actor ModerationRepository {
     /// bound. Records are newest-first, so dropping from the back of
     /// the receipted subset removes the oldest disclosures first.
     private func saveReportRecords() throws {
-        let resolved = reportRecords.filter { $0.receipt != nil }
+        let resolved = reportRecords.filter(\.isResolved)
         if resolved.count > Self.maxResolvedReportRecords {
             let cutoff = Set(
                 resolved.prefix(Self.maxResolvedReportRecords).map(\.report.reportId)
             )
             reportRecords.removeAll {
-                $0.receipt != nil && !cutoff.contains($0.report.reportId)
+                $0.isResolved && !cutoff.contains($0.report.reportId)
             }
         }
         try reportStore.save(reportRecords)

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CryptoKit
+import OSLog
 
 /// Outcome of the most recent authorities-directory fetch. Same
 /// shape as `RelayerFetchStatus` so the picker copy stays consistent.
@@ -73,6 +74,10 @@ public struct ReviewedManifest: Sendable, Equatable {
 public actor ModerationRepository {
     /// This interface's component id, carried in every mandate.
     public static let interfaceComponentId = "onym:component:onym-ios"
+
+    private static let logger = Logger(
+        subsystem: "app.onym.ios", category: "moderation"
+    )
 
     /// Retention bound on the report ledger. Rows whose delivery is
     /// still ambiguous (no receipt) are always kept — they are the
@@ -542,9 +547,13 @@ public actor ModerationRepository {
         }
         let reporterMandateRef = try reporterMandate.mandate.mandateHash()
 
-        // The idempotency identity deliberately includes `classId`:
-        // re-reporting the same message under a different violation
-        // class is a distinct allegation and mints its own report.
+        // The idempotency identity deliberately includes `classId` and
+        // `reporterMandate`: re-reporting the same message under a
+        // different violation class is a distinct allegation, and a
+        // report's standing follows the mandate it was filed under
+        // (spec §5.4 constraint 5) — re-consenting mints new standing,
+        // with the Authority's own intake dedup as the backstop against
+        // duplicate allegations over identical evidence.
         if let existing = reportRecords.first(where: {
             $0.sourceMessageId == message.id
                 && $0.report.reporter == reporter
@@ -648,7 +657,16 @@ public actor ModerationRepository {
             recovered.receipt = receipt
             reportRecords.insert(recovered, at: 0)
         }
-        try saveReportRecords()
+        do {
+            try saveReportRecords()
+        } catch {
+            // The Authority has accepted — that outcome is authoritative
+            // and must reach the user. Losing the receipt's persistence
+            // is recoverable (a post-relaunch retry hits the terminal
+            // already-filed path); reporting success as failure is not.
+            // Error only — no report content — per no-activity-logging.
+            Self.logger.error("report receipt persistence failed: \(error)")
+        }
         return receipt
     }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 /// Outcome of the most recent authorities-directory fetch. Same
 /// shape as `RelayerFetchStatus` so the picker copy stays consistent.
@@ -77,6 +78,7 @@ public actor ModerationRepository {
     private let manifestFetcher: any AuthorityManifestFetcher
     private let manifestValidator: AuthorityManifestValidator
     private let mandateStore: any MandateStore
+    private let reportStore: any ReportFilingStore
     private let backend: any EnforcementBackendClient
     private let authorityClients: any ModerationAuthorityClientFactory
     private let attestation: any DeviceAttestationProvider
@@ -102,18 +104,29 @@ public actor ModerationRepository {
         var waiters: Int
     }
 
+    private struct ReportKey: Hashable {
+        let authority: String
+        let reporter: String
+        let accused: String
+        let classId: String
+        let messageId: String
+    }
+
     private var authorities: [AuthorityListing] = []
     private var fetchStatus: AuthorityFetchStatus = .idle
     private var records: [MandateRecord]
+    private var reportRecords: [ReportFilingRecord]
     private var continuations: [UUID: AsyncStream<ModerationState>.Continuation] = [:]
     private var startTask: Task<Void, Never>?
     private var consentTasks: [ConsentKey: Task<MandateRecord, Error>] = [:]
     private var registrationFlights: [RegistrationKey: RegistrationFlight] = [:]
+    private var reportTasks: [ReportKey: Task<ReportReceipt, Error>] = [:]
 
     public init(
         authoritiesFetcher: any KnownAuthoritiesFetcher,
         manifestFetcher: any AuthorityManifestFetcher,
         mandateStore: any MandateStore,
+        reportStore: any ReportFilingStore = UserDefaultsReportFilingStore(),
         backend: any EnforcementBackendClient,
         authorityClients: any ModerationAuthorityClientFactory,
         attestation: any DeviceAttestationProvider,
@@ -125,12 +138,14 @@ public actor ModerationRepository {
         self.manifestFetcher = manifestFetcher
         self.manifestValidator = manifestValidator
         self.mandateStore = mandateStore
+        self.reportStore = reportStore
         self.backend = backend
         self.authorityClients = authorityClients
         self.attestation = attestation
         self.signer = signer
         self.clock = clock
         self.records = mandateStore.load()
+        self.reportRecords = reportStore.load()
     }
 
     // MARK: - Directory refresh
@@ -397,6 +412,58 @@ public actor ModerationRepository {
         )
     }
 
+    // MARK: - Reporting
+
+    /// Violation classes the current Authority declared and the user
+    /// consented to. The report UI presents these exact class IDs; the
+    /// Authority still independently checks the accused mandate.
+    public func availableReportClasses() throws -> [ViolationClass] {
+        let record = try activeReportingMandate()
+        guard let manifest = record.consentedManifest()?.manifest else {
+            throw ModerationError.reportingUnavailable("consented manifest is unavailable")
+        }
+        return manifest.violationClasses.filter {
+            record.mandate.classes.contains($0.classId)
+        }
+    }
+
+    /// File one recipient-held text message with the currently selected
+    /// Authority. The report is signed and persisted before delivery;
+    /// ambiguous retries reuse byte-identical JSON and the same reportId.
+    @discardableResult
+    public func fileReport(
+        message: ReportableMessage,
+        classId: String
+    ) async throws -> ReportReceipt {
+        let mandate = try activeReportingMandate()
+        let key = ReportKey(
+            authority: mandate.mandate.authority,
+            reporter: mandate.mandate.user,
+            accused: message.accused,
+            classId: classId,
+            messageId: message.id
+        )
+        if let task = reportTasks[key] {
+            return try await task.value
+        }
+        let task = Task {
+            try await self.performFileReport(
+                message: message,
+                classId: classId,
+                reporterMandate: mandate
+            )
+        }
+        reportTasks[key] = task
+        do {
+            let receipt = try await task.value
+            reportTasks.removeValue(forKey: key)
+            return receipt
+        } catch {
+            reportTasks.removeValue(forKey: key)
+            throw error
+        }
+    }
+
     // MARK: - AsyncStream
 
     public nonisolated var snapshots: AsyncStream<ModerationState> {
@@ -418,6 +485,154 @@ public actor ModerationRepository {
 
     private func unsubscribe(id: UUID) {
         continuations.removeValue(forKey: id)
+    }
+
+    private func activeReportingMandate() throws -> MandateRecord {
+        guard let record = activeMandateRecord(),
+              record.countersigned,
+              record.authorityRegistered
+        else {
+            throw ModerationError.reportingUnavailable(
+                "no active Authority-registered mandate"
+            )
+        }
+        return record
+    }
+
+    private func performFileReport(
+        message: ReportableMessage,
+        classId: String,
+        reporterMandate: MandateRecord
+    ) async throws -> ReportReceipt {
+        let reporter = try await signer.userKeyID()
+        guard reporter == reporterMandate.mandate.user else {
+            throw ModerationError.reportingUnavailable(
+                "active identity does not own the reporting mandate"
+            )
+        }
+        guard let manifest = reporterMandate.consentedManifest()?.manifest,
+              reporterMandate.mandate.classes.contains(classId),
+              manifest.violationClasses.contains(where: { $0.classId == classId })
+        else {
+            throw ModerationError.classOutsideMandate(classId)
+        }
+        guard !message.disclosedContent.isEmpty,
+              let signature = Data(base64Encoded: message.authenticityProof),
+              let accusedKey = try? AuthorityKey.publicKey(fromReference: message.accused),
+              accusedKey.isValidSignature(
+                signature,
+                for: Data(message.disclosedContent.utf8)
+              )
+        else {
+            throw ModerationError.authenticityUnverified
+        }
+        guard let listing = authorities.first(where: {
+            $0.componentId == reporterMandate.mandate.authority
+        }) else {
+            throw ModerationError.authorityUnavailable(
+                reporterMandate.mandate.authority
+            )
+        }
+        let reporterMandateRef = try reporterMandate.mandate.mandateHash()
+
+        if let existing = reportRecords.first(where: {
+            $0.sourceMessageId == message.id
+                && $0.report.reporter == reporter
+                && $0.report.reporterMandate == reporterMandateRef
+                && $0.report.accused == message.accused
+                && $0.report.classId == classId
+                && $0.report.evidence == [EvidenceItem(
+                    disclosedContent: message.disclosedContent,
+                    authenticityProof: message.authenticityProof
+                )]
+        }) {
+            if let receipt = existing.receipt { return receipt }
+            return try await submitReport(existing, to: listing)
+        }
+
+        var report = Report(
+            reportId: "report-\(UUID().uuidString.lowercased())",
+            reporter: reporter,
+            reporterMandate: reporterMandateRef,
+            accused: message.accused,
+            classId: classId,
+            evidence: [EvidenceItem(
+                disclosedContent: message.disclosedContent,
+                authenticityProof: message.authenticityProof
+            )],
+            filedAt: clock()
+        )
+        report.signature = try await signer.sign(report.signingBytes()).base64EncodedString()
+        let record = ReportFilingRecord(
+            sourceMessageId: message.id,
+            report: report,
+            authorityName: listing.name
+        )
+        reportRecords.insert(record, at: 0)
+        // Delivery must not begin unless the exact signed artifact is
+        // durably retained. A transport timeout may happen after intake
+        // committed; without this write, a retry would mint a second report.
+        do {
+            try reportStore.save(reportRecords)
+        } catch {
+            // Do not leave an unpersisted artifact eligible for the
+            // in-memory exact-retry path on the next tap.
+            if let index = reportIndex(of: record) {
+                reportRecords.remove(at: index)
+            }
+            throw error
+        }
+        return try await submitReport(record, to: listing)
+    }
+
+    private func submitReport(
+        _ record: ReportFilingRecord,
+        to listing: AuthorityListing
+    ) async throws -> ReportReceipt {
+        let client = authorityClients.client(for: listing)
+        let receipt: ReportReceipt
+        do {
+            receipt = try await client.fileReport(record.report)
+        } catch {
+            if isDeterministicReportRejection(error) {
+                discardReport(record)
+            }
+            throw error
+        }
+        guard receipt.reportId == record.report.reportId else {
+            throw AuthorityClientError.reportIdentifierMismatch(
+                expected: record.report.reportId,
+                received: receipt.reportId
+            )
+        }
+        if let index = reportIndex(of: record) {
+            reportRecords[index].receipt = receipt
+        } else {
+            var recovered = record
+            recovered.receipt = receipt
+            reportRecords.insert(recovered, at: 0)
+        }
+        try reportStore.save(reportRecords)
+        return receipt
+    }
+
+    private func reportIndex(of record: ReportFilingRecord) -> Int? {
+        reportRecords.firstIndex { $0.report.reportId == record.report.reportId }
+    }
+
+    private func discardReport(_ record: ReportFilingRecord) {
+        guard let index = reportIndex(of: record) else { return }
+        reportRecords.remove(at: index)
+        try? reportStore.save(reportRecords)
+    }
+
+    private func isDeterministicReportRejection(_ error: Error) -> Bool {
+        guard case let AuthorityClientError.rejected(rejection) = error else {
+            return false
+        }
+        return (400..<500).contains(rejection.statusCode)
+            && rejection.statusCode != 408
+            && rejection.statusCode != 429
     }
 
     /// Resume the newest interrupted consent after the directory is
@@ -582,7 +797,8 @@ public actor ModerationRepository {
             return (400..<500).contains(rejection.statusCode)
                 && rejection.statusCode != 408
                 && rejection.statusCode != 429
-        case .invalidResponse, .malformedResponse, .invalidPathComponent, .insecureBaseURL:
+        case .invalidResponse, .malformedResponse, .invalidPathComponent, .insecureBaseURL,
+             .reportIdentifierMismatch:
             return false
         }
     }

--- a/Packages/OnymModeration/Sources/OnymModeration/Report.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/Report.swift
@@ -21,9 +21,7 @@ public struct EvidenceItem: Codable, Sendable, Equatable {
 }
 
 /// A signed report of prohibited content (Moderation.md §5.4), filed
-/// voluntarily by a recipient of the content. Reporting UI is not
-/// built yet; the type exists so the `ModerationAuthorityClient` seam
-/// is complete.
+/// voluntarily by a recipient of the content.
 public struct Report: Codable, Sendable, Equatable {
     public let reportVersion: Int
     public let reportId: String

--- a/Packages/OnymModeration/Sources/OnymModeration/ReportFilingStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ReportFilingStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+import OnymFoundation
+
+/// Exact signed report retained across ambiguous delivery outcomes.
+/// Successful records remain as a local idempotency ledger so tapping
+/// Report twice cannot mint a second allegation for the same evidence.
+public struct ReportFilingRecord: Codable, Sendable, Equatable {
+    public let sourceMessageId: String
+    public let report: Report
+    public let authorityName: String
+    public var receipt: ReportReceipt?
+
+    public init(
+        sourceMessageId: String,
+        report: Report,
+        authorityName: String,
+        receipt: ReportReceipt? = nil
+    ) {
+        self.sourceMessageId = sourceMessageId
+        self.report = report
+        self.authorityName = authorityName
+        self.receipt = receipt
+    }
+}
+
+public protocol ReportFilingStore: Sendable {
+    func load() -> [ReportFilingRecord]
+    func save(_ records: [ReportFilingRecord]) throws
+}
+
+public struct UserDefaultsReportFilingStore: ReportFilingStore, @unchecked Sendable {
+    private static let recordsKey = "app.onym.ios.moderation.reports"
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> [ReportFilingRecord] {
+        guard let encrypted = defaults.data(forKey: Self.recordsKey),
+              let data = try? StorageEncryption.decrypt(encrypted),
+              let records = try? Self.decoder().decode([ReportFilingRecord].self, from: data)
+        else { return [] }
+        return records
+    }
+
+    public func save(_ records: [ReportFilingRecord]) throws {
+        let data = try Self.encoder().encode(records)
+        let encrypted = try StorageEncryption.encrypt(data)
+        defaults.set(encrypted, forKey: Self.recordsKey)
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+public final class InMemoryReportFilingStore: ReportFilingStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var records: [ReportFilingRecord]
+
+    public init(records: [ReportFilingRecord] = []) {
+        self.records = records
+    }
+
+    public func load() -> [ReportFilingRecord] {
+        lock.withLock { records }
+    }
+
+    public func save(_ records: [ReportFilingRecord]) {
+        lock.withLock { self.records = records }
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ReportFilingStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ReportFilingStore.swift
@@ -9,17 +9,32 @@ public struct ReportFilingRecord: Codable, Sendable, Equatable {
     public let report: Report
     public let authorityName: String
     public var receipt: ReportReceipt?
+    /// The Authority answered 409 for these exact bytes: the report is
+    /// on file but the original receipt is unrecoverable. Terminal like
+    /// `receipt` — the row prunes under the resolved bound and a later
+    /// Submit short-circuits instead of re-delivering. Optional so
+    /// records persisted before this field decode as nil.
+    public var resolvedWithoutReceipt: Bool?
 
     public init(
         sourceMessageId: String,
         report: Report,
         authorityName: String,
-        receipt: ReportReceipt? = nil
+        receipt: ReportReceipt? = nil,
+        resolvedWithoutReceipt: Bool? = nil
     ) {
         self.sourceMessageId = sourceMessageId
         self.report = report
         self.authorityName = authorityName
         self.receipt = receipt
+        self.resolvedWithoutReceipt = resolvedWithoutReceipt
+    }
+
+    /// A row that reached a terminal outcome (accepted with a receipt,
+    /// or confirmed already-on-file) — retained only as history, so it
+    /// is eligible for retention pruning.
+    public var isResolved: Bool {
+        receipt != nil || resolvedWithoutReceipt == true
     }
 }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ReportableMessage.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ReportableMessage.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A recipient-held text message that can be disclosed to an Authority.
+/// The proof is the sender's Ed25519 signature over the exact UTF-8 bytes
+/// of `disclosedContent`; the Authority independently verifies it against
+/// `accused` before the content can support a case.
+public struct ReportableMessage: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let accused: String
+    public let disclosedContent: String
+    public let authenticityProof: String
+
+    public init(
+        id: String,
+        accused: String,
+        disclosedContent: String,
+        authenticityProof: String
+    ) {
+        self.id = id
+        self.accused = accused
+        self.disclosedContent = disclosedContent
+        self.authenticityProof = authenticityProof
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ReportableMessage.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ReportableMessage.swift
@@ -1,24 +1,30 @@
 import Foundation
 
 /// A recipient-held text message that can be disclosed to an Authority.
-/// The proof is the sender's Ed25519 signature over the exact UTF-8 bytes
-/// of `disclosedContent`; the Authority independently verifies it against
-/// `accused` before the content can support a case.
+/// `disclosedContent` is the canonical proof preimage — the message
+/// body bound to its message id, group id, and send timestamp — and
+/// `authenticityProof` is the sender's Ed25519 signature over its exact
+/// UTF-8 bytes; the Authority independently verifies it against
+/// `accused` before the content can support a case. `displayBody` is
+/// the bare body, for showing the user what they are disclosing.
 public struct ReportableMessage: Sendable, Equatable, Identifiable {
     public let id: String
     public let accused: String
     public let disclosedContent: String
     public let authenticityProof: String
+    public let displayBody: String
 
     public init(
         id: String,
         accused: String,
         disclosedContent: String,
-        authenticityProof: String
+        authenticityProof: String,
+        displayBody: String
     ) {
         self.id = id
         self.accused = accused
         self.disclosedContent = disclosedContent
         self.authenticityProof = authenticityProof
+        self.displayBody = displayBody
     }
 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
@@ -28,6 +28,11 @@ public final class ModerationReportFlow {
         state.isLoading = true
         state.errorMessage = nil
         defer { state.isLoading = false }
+        // Delivery needs the authorities directory; on a cold launch
+        // straight into Report it may not have been fetched yet, and
+        // `fileReport` would throw `authorityUnavailable`. Best-effort —
+        // a failure here surfaces at submit with directory copy.
+        try? await repository.refresh()
         do {
             let classes = try await repository.availableReportClasses()
             state.classes = classes
@@ -62,6 +67,23 @@ public final class ModerationReportFlow {
         } catch ModerationError.authenticityUnverified {
             state.errorMessage = String(
                 localized: "This message has no valid sender proof and cannot be filed as evidence."
+            )
+        } catch ModerationError.reportAlreadyFiled {
+            // Terminal and benign: the Authority already holds this
+            // exact report. Retry advice would be wrong — nothing is
+            // left to deliver.
+            state.errorMessage = String(
+                localized: "Your authority already has this report on file."
+            )
+        } catch ModerationError.reportingUnavailable,
+                ModerationError.classOutsideMandate {
+            // Permanent for this message/mandate; "try again" is wrong.
+            state.errorMessage = String(
+                localized: "Reporting requires an active mandate registered with this authority."
+            )
+        } catch ModerationError.authorityUnavailable {
+            state.errorMessage = String(
+                localized: "Your authority isn't in the directory right now. Check your connection and try again."
             )
         } catch let AuthorityClientError.rejected(rejection) {
             // Authority-controlled text; bound it so a hostile or buggy

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
@@ -10,6 +10,9 @@ public final class ModerationReportFlow {
         public var isLoading = false
         public var isSubmitting = false
         public var receipt: ReportReceipt?
+        /// Terminal like `receipt`: the Authority confirmed it already
+        /// holds this exact report (409), but no receipt exists to show.
+        public var alreadyFiled = false
         public var errorMessage: String?
     }
 
@@ -70,11 +73,9 @@ public final class ModerationReportFlow {
             )
         } catch ModerationError.reportAlreadyFiled {
             // Terminal and benign: the Authority already holds this
-            // exact report. Retry advice would be wrong — nothing is
-            // left to deliver.
-            state.errorMessage = String(
-                localized: "Your authority already has this report on file."
-            )
+            // exact report. Rendered like success, not as an error —
+            // a Submit retry could only 409 again.
+            state.alreadyFiled = true
         } catch ModerationError.reportingUnavailable,
                 ModerationError.classOutsideMandate {
             // Permanent for this message/mandate; "try again" is wrong.

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
@@ -1,0 +1,74 @@
+import Foundation
+import OnymModeration
+
+@MainActor
+@Observable
+public final class ModerationReportFlow {
+    public struct State: Equatable {
+        public var classes: [ViolationClass] = []
+        public var selectedClassId: String?
+        public var isLoading = false
+        public var isSubmitting = false
+        public var receipt: ReportReceipt?
+        public var errorMessage: String?
+    }
+
+    public private(set) var state = State()
+    public let message: ReportableMessage
+
+    private let repository: ModerationRepository
+
+    public init(message: ReportableMessage, repository: ModerationRepository) {
+        self.message = message
+        self.repository = repository
+    }
+
+    public func start() async {
+        guard state.classes.isEmpty, !state.isLoading else { return }
+        state.isLoading = true
+        state.errorMessage = nil
+        defer { state.isLoading = false }
+        do {
+            let classes = try await repository.availableReportClasses()
+            state.classes = classes
+            state.selectedClassId = classes.first?.classId
+            if classes.isEmpty {
+                state.errorMessage = String(
+                    localized: "Your current authority offers no reportable classes."
+                )
+            }
+        } catch {
+            state.errorMessage = String(
+                localized: "Reporting requires an active mandate registered with this authority."
+            )
+        }
+    }
+
+    public func selectClass(_ classId: String) {
+        guard state.classes.contains(where: { $0.classId == classId }) else { return }
+        state.selectedClassId = classId
+    }
+
+    public func submit() async {
+        guard let classId = state.selectedClassId, !state.isSubmitting else { return }
+        state.isSubmitting = true
+        state.errorMessage = nil
+        defer { state.isSubmitting = false }
+        do {
+            state.receipt = try await repository.fileReport(
+                message: message,
+                classId: classId
+            )
+        } catch ModerationError.authenticityUnverified {
+            state.errorMessage = String(
+                localized: "This message has no valid sender proof and cannot be filed as evidence."
+            )
+        } catch let AuthorityClientError.rejected(rejection) {
+            state.errorMessage = rejection.message
+        } catch {
+            state.errorMessage = String(
+                localized: "The report could not be delivered. Try again to resend the exact signed report."
+            )
+        }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
@@ -64,7 +64,9 @@ public final class ModerationReportFlow {
                 localized: "This message has no valid sender proof and cannot be filed as evidence."
             )
         } catch let AuthorityClientError.rejected(rejection) {
-            state.errorMessage = rejection.message
+            // Authority-controlled text; bound it so a hostile or buggy
+            // authority can't flood the sheet with an arbitrary payload.
+            state.errorMessage = String(rejection.message.prefix(280))
         } catch {
             state.errorMessage = String(
                 localized: "The report could not be delivered. Try again to resend the exact signed report."

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+import OnymDesign
+import OnymModeration
+
+public struct ModerationReportView: View {
+    @State private var flow: ModerationReportFlow
+    @Environment(\.dismiss) private var dismiss
+
+    public init(flow: ModerationReportFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    if let receipt = flow.state.receipt {
+                        success(receipt)
+                    } else {
+                        reportForm
+                    }
+                }
+                .padding(20)
+            }
+            .background(OnymTokens.surface.ignoresSafeArea())
+            .navigationTitle(flow.state.receipt == nil ? "Report message" : "Report filed")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(flow.state.receipt == nil ? "Cancel" : "Done") { dismiss() }
+                }
+            }
+        }
+        .task { await flow.start() }
+    }
+
+    private var reportForm: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("MESSAGE TO DISCLOSE")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(flow.message.disclosedContent)
+                    .font(.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+                    .background(.background, in: RoundedRectangle(cornerRadius: 14))
+                    .textSelection(.enabled)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("VIOLATION CLASS")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Picker(
+                    "Violation class",
+                    selection: Binding(
+                        get: { flow.state.selectedClassId ?? "" },
+                        set: { flow.selectClass($0) }
+                    )
+                ) {
+                    ForEach(flow.state.classes, id: \.classId) { item in
+                        Text(item.classId).tag(item.classId)
+                    }
+                }
+                .pickerStyle(.menu)
+                .disabled(flow.state.classes.isEmpty || flow.state.isSubmitting)
+                .accessibilityIdentifier("moderation.report.class")
+            }
+
+            Label(
+                "Submitting discloses this exact message and its sender proof to your moderation authority. No surrounding conversation is included.",
+                systemImage: "lock.shield"
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+
+            if let error = flow.state.errorMessage {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .accessibilityIdentifier("moderation.report.error")
+            }
+
+            Button {
+                Task { await flow.submit() }
+            } label: {
+                HStack {
+                    if flow.state.isSubmitting { ProgressView() }
+                    Text(flow.state.isSubmitting ? "Submitting…" : "Submit report")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(
+                flow.state.selectedClassId == nil
+                    || flow.state.isSubmitting
+                    || flow.state.isLoading
+            )
+            .accessibilityIdentifier("moderation.report.submit")
+        }
+    }
+
+    private func success(_ receipt: ReportReceipt) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: "checkmark.shield.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(.green)
+            Text("Your authority accepted the report.")
+                .font(.title3.weight(.semibold))
+            LabeledContent("Case", value: receipt.caseId)
+            LabeledContent("Report", value: receipt.reportId)
+            Text("The reported user will receive notice through their interface and can respond before a decision.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("moderation.report.success")
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -40,7 +40,7 @@ public struct ModerationReportView: View {
                 Text("MESSAGE TO DISCLOSE")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Text(flow.message.disclosedContent)
+                Text(flow.message.displayBody)
                     .font(.body)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(16)
@@ -66,10 +66,23 @@ public struct ModerationReportView: View {
                 .pickerStyle(.menu)
                 .disabled(flow.state.classes.isEmpty || flow.state.isSubmitting)
                 .accessibilityIdentifier("moderation.report.class")
+
+                // The consented definition of the selected class — the
+                // reporter must see what they are alleging, not just a
+                // raw class id.
+                if let selected = flow.state.classes.first(where: {
+                    $0.classId == flow.state.selectedClassId
+                }) {
+                    Text("Definition: \(selected.definition)")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .accessibilityIdentifier("moderation.report.definition")
+                }
             }
 
             Label(
-                "Submitting discloses this exact message and its sender proof to your moderation authority. No surrounding conversation is included.",
+                "Submitting discloses this exact message — its text, identifiers, and timestamp — and its sender proof to your moderation authority. No surrounding conversation is included.",
                 systemImage: "lock.shield"
             )
             .font(.footnote)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -67,17 +67,28 @@ public struct ModerationReportView: View {
                 .disabled(flow.state.classes.isEmpty || flow.state.isSubmitting)
                 .accessibilityIdentifier("moderation.report.class")
 
-                // The consented definition of the selected class — the
-                // reporter must see what they are alleging, not just a
-                // raw class id.
+                // The consented definition of the selected class.
+                // `definition` is a content address (hash-or-url,
+                // AuthorityManifest): a URL opens the consented
+                // prohibited-content definition; a bare hash can only
+                // be shown as the address the user consented to.
                 if let selected = flow.state.classes.first(where: {
                     $0.classId == flow.state.selectedClassId
                 }) {
-                    Text("Definition: \(selected.definition)")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
+                    if let url = URL(string: selected.definition),
+                       url.scheme == "https" || url.scheme == "http" {
+                        Link(destination: url) {
+                            Label("Read the consented definition of this class", systemImage: "arrow.up.right.square")
+                                .font(.footnote)
+                        }
                         .accessibilityIdentifier("moderation.report.definition")
+                    } else {
+                        Text("Consented definition (content address): \(selected.definition)")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .accessibilityIdentifier("moderation.report.definition")
+                    }
                 }
             }
 

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -16,6 +16,8 @@ public struct ModerationReportView: View {
                 VStack(alignment: .leading, spacing: 20) {
                     if let receipt = flow.state.receipt {
                         success(receipt)
+                    } else if flow.state.alreadyFiled {
+                        alreadyFiled
                     } else {
                         reportForm
                     }
@@ -23,15 +25,36 @@ public struct ModerationReportView: View {
                 .padding(20)
             }
             .background(OnymTokens.surface.ignoresSafeArea())
-            .navigationTitle(flow.state.receipt == nil ? "Report message" : "Report filed")
+            .navigationTitle(isTerminal ? "Report filed" : "Report message")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(flow.state.receipt == nil ? "Cancel" : "Done") { dismiss() }
+                    Button(isTerminal ? "Done" : "Cancel") { dismiss() }
                 }
             }
         }
         .task { await flow.start() }
+    }
+
+    /// Both terminal outcomes: accepted with a receipt, or confirmed
+    /// already on file (409, no receipt to show).
+    private var isTerminal: Bool {
+        flow.state.receipt != nil || flow.state.alreadyFiled
+    }
+
+    private var alreadyFiled: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: "checkmark.shield.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(.green)
+            Text("Your authority already has this report on file.")
+                .font(.title3.weight(.semibold))
+            Text("Nothing further is needed. The reported user receives notice through their interface and can respond before a decision.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("moderation.report.alreadyFiled")
     }
 
     private var reportForm: some View {

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import OnymIdentity
 import OnymGroup
 import OnymChatsCore
@@ -76,5 +77,8 @@ struct AppDependencies {
     let moderationGateFlow: ModerationGateFlow
     let makeModerationConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
     let makeModerationSettingsFlow: @MainActor () -> ModerationSettingsFlow
-    let makeModerationReportFlow: @MainActor (ReportableMessage) -> ModerationReportFlow
+    /// Opaque report-sheet factory: the chats layer presents whatever
+    /// view this returns, keeping OnymChatsUI free of any
+    /// OnymModerationUI dependency.
+    let makeModerationReportView: @MainActor (ReportableMessage) -> AnyView
 }

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -7,6 +7,7 @@ import OnymRecovery
 import OnymChatsUI
 import OnymSettings
 import OnymModerationUI
+import OnymModeration
 
 /// App-wide composition root. Constructed exactly once by `OnymIOSApp`
 /// and threaded down to views via `RootView`. Each member is a factory
@@ -75,4 +76,5 @@ struct AppDependencies {
     let moderationGateFlow: ModerationGateFlow
     let makeModerationConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
     let makeModerationSettingsFlow: @MainActor () -> ModerationSettingsFlow
+    let makeModerationReportFlow: @MainActor (ReportableMessage) -> ModerationReportFlow
 }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -714,13 +714,18 @@ struct OnymIOSApp: App {
                         // IdentityID (and the removed identity's keys
                         // are already gone) — so purge by keeping only
                         // the reporters that still exist locally.
-                        let remaining = (try? await identityRepository.currentIdentities()) ?? []
-                        await moderationRepository.purgeReportRecords(
-                            keepingReporters: Set(remaining.map { summary in
-                                "onym:key:" + summary.sendingPublicKey
-                                    .map { String(format: "%02x", $0) }.joined()
-                            })
-                        )
+                        // Skip the purge entirely if the identity list
+                        // can't be read: an empty keep-set would wipe
+                        // every identity's ledger, not just the
+                        // removed one's.
+                        if let remaining = try? await identityRepository.currentIdentities() {
+                            await moderationRepository.purgeReportRecords(
+                                keepingReporters: Set(remaining.map { summary in
+                                    "onym:key:" + summary.sendingPublicKey
+                                        .map { String(format: "%02x", $0) }.joined()
+                                })
+                            )
+                        }
                     }
                 }
                 .task {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -709,6 +709,18 @@ struct OnymIOSApp: App {
                         // backup post-removal can't decrypt
                         // outstanding intro requests.
                         await introKeyStore.deleteForOwner(removed)
+                        // Filed-report ledger rows are keyed by the
+                        // reporter's `onym:key:` reference, not by
+                        // IdentityID (and the removed identity's keys
+                        // are already gone) — so purge by keeping only
+                        // the reporters that still exist locally.
+                        let remaining = (try? await identityRepository.currentIdentities()) ?? []
+                        await moderationRepository.purgeReportRecords(
+                            keepingReporters: Set(remaining.map { summary in
+                                "onym:key:" + summary.sendingPublicKey
+                                    .map { String(format: "%02x", $0) }.joined()
+                            })
+                        )
                     }
                 }
                 .task {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -564,6 +564,12 @@ struct OnymIOSApp: App {
                     repository: moderationRepository,
                     gateCheck: gateCheckRepository
                 )
+            },
+            makeModerationReportFlow: { @MainActor message in
+                ModerationReportFlow(
+                    message: message,
+                    repository: moderationRepository
+                )
             }
         )
     }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -565,11 +565,11 @@ struct OnymIOSApp: App {
                     gateCheck: gateCheckRepository
                 )
             },
-            makeModerationReportFlow: { @MainActor message in
-                ModerationReportFlow(
+            makeModerationReportView: { @MainActor message in
+                AnyView(ModerationReportView(flow: ModerationReportFlow(
                     message: message,
                     repository: moderationRepository
-                )
+                )))
             }
         )
     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -90,7 +90,7 @@ struct RootView: View {
                         makeJoinFlow: dependencies.makeJoinFlow,
                         setGroupAvatar: dependencies.setGroupAvatar,
                         setGroupName: dependencies.setGroupName,
-                        makeModerationReportFlow: dependencies.makeModerationReportFlow
+                        makeModerationReportView: dependencies.makeModerationReportView
                     )
                 }
             }
@@ -136,7 +136,7 @@ struct RootView: View {
                             imageLoader: dependencies.imageLoader,
                             videoLoader: dependencies.videoLoader,
                             voiceLoader: dependencies.voiceLoader,
-                            makeModerationReportFlow: dependencies.makeModerationReportFlow,
+                            makeModerationReportView: dependencies.makeModerationReportView,
                             scrollToMessageID: result.messageID
                         )
                     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -89,7 +89,8 @@ struct RootView: View {
                         makeShareInviteFlow: dependencies.makeShareInviteFlow,
                         makeJoinFlow: dependencies.makeJoinFlow,
                         setGroupAvatar: dependencies.setGroupAvatar,
-                        setGroupName: dependencies.setGroupName
+                        setGroupName: dependencies.setGroupName,
+                        makeModerationReportFlow: dependencies.makeModerationReportFlow
                     )
                 }
             }
@@ -135,6 +136,7 @@ struct RootView: View {
                             imageLoader: dependencies.imageLoader,
                             videoLoader: dependencies.videoLoader,
                             voiceLoader: dependencies.voiceLoader,
+                            makeModerationReportFlow: dependencies.makeModerationReportFlow,
                             scrollToMessageID: result.messageID
                         )
                     }

--- a/Tests/OnymIOSTests/ChatMessagePayloadTests.swift
+++ b/Tests/OnymIOSTests/ChatMessagePayloadTests.swift
@@ -39,6 +39,32 @@ final class ChatMessagePayloadTests: XCTestCase {
         XCTAssertEqual(decoded.variant.body, "héllo 🌍 こんにちは")
     }
 
+    func test_roundtrip_moderationAuthenticityProof_preservesProof() throws {
+        let original = makePayload(body: "reportable", moderationAuthenticityProof: "c2lnbmF0dXJl")
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: encoded)
+
+        XCTAssertEqual(decoded.moderationAuthenticityProof, "c2lnbmF0dXJl")
+        let object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        XCTAssertEqual(object?["moderation_authenticity_proof"] as? String, "c2lnbmF0dXJl")
+    }
+
+    func test_decode_legacyPayloadWithoutModerationProof_isNil() throws {
+        let json = #"""
+        {
+          "version": 1,
+          "message_id": "11111111-1111-1111-1111-111111111111",
+          "group_id": "QkJC",
+          "sender_bls_pubkey_hex": "ab",
+          "sent_at_millis": 0,
+          "variant": { "kind": "tyranny", "body": "hi" }
+        }
+        """#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ChatMessagePayload.self, from: json)
+        XCTAssertNil(decoded.moderationAuthenticityProof)
+    }
+
     // MARK: - Reply reference
 
     func test_roundtrip_replyRef_preservesTargetID() throws {
@@ -177,7 +203,8 @@ final class ChatMessagePayloadTests: XCTestCase {
 
     private func makePayload(
         body: String,
-        replyToMessageID: UUID? = nil
+        replyToMessageID: UUID? = nil,
+        moderationAuthenticityProof: String? = nil
     ) -> ChatMessagePayload {
         ChatMessagePayload(
             version: 1,
@@ -186,7 +213,8 @@ final class ChatMessagePayloadTests: XCTestCase {
             senderBlsPubkeyHex: String(repeating: "ab", count: 48),
             sentAtMillis: 1_700_000_000_000,
             replyToMessageID: replyToMessageID,
-            variant: .tyranny(body: body)
+            variant: .tyranny(body: body),
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
     }
 }

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -135,6 +135,40 @@ final class ChatThreadViewControllerTests: XCTestCase {
         XCTAssertEqual(tableView(in: vc)?.numberOfRows(inSection: 0), 1)
     }
 
+    // MARK: - Moderation report menu
+
+    func test_longPress_reportableMessageOffersContextMenu() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.canReportMessage = { $0.direction == .incoming }
+        vc.update(messages: [makeMessage(body: "report me", direction: .incoming)])
+        let table = tableView(in: vc)!
+
+        let configuration = vc.tableView(
+            table,
+            contextMenuConfigurationForRowAt: IndexPath(row: 0, section: 0),
+            point: .zero
+        )
+
+        XCTAssertNotNil(configuration)
+    }
+
+    func test_longPress_unreportableMessageHasNoContextMenu() {
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.canReportMessage = { $0.direction == .incoming }
+        vc.update(messages: [makeMessage(body: "mine", direction: .outgoing)])
+        let table = tableView(in: vc)!
+
+        let configuration = vc.tableView(
+            table,
+            contextMenuConfigurationForRowAt: IndexPath(row: 0, section: 0),
+            point: .zero
+        )
+
+        XCTAssertNil(configuration)
+    }
+
     // MARK: - Input panel wiring (PR 7 / PR 8)
 
     func test_inputPanel_isHosted_andClearsTextOnSendTap() {

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -120,6 +120,27 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
                        "an inbound reply must carry its target id onto the persisted message")
     }
 
+    func test_chatMessage_persistsModerationAuthenticityProof() async throws {
+        let payload = makePayload(
+            body: "reportable",
+            moderationAuthenticityProof: "c2lnbmF0dXJl"
+        )
+        let dispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-proof",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let stored = await messages.currentMessages(groupID: groupIDHex, owner: owner)
+        XCTAssertEqual(stored.first?.moderationAuthenticityProof, "c2lnbmF0dXJl")
+    }
+
     // MARK: - Drop paths
 
     func test_chatMessage_unknownGroup_drops() async throws {
@@ -343,7 +364,8 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         groupIDBytes: Data? = nil,
         senderBlsHex: String? = nil,
         messageID: UUID = UUID(),
-        replyToMessageID: UUID? = nil
+        replyToMessageID: UUID? = nil,
+        moderationAuthenticityProof: String? = nil
     ) -> ChatMessagePayload {
         ChatMessagePayload(
             version: 1,
@@ -352,7 +374,8 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             senderBlsPubkeyHex: senderBlsHex ?? self.senderBlsHex,
             sentAtMillis: 1_700_000_000_000,
             replyToMessageID: replyToMessageID,
-            variant: .tyranny(body: body)
+            variant: .tyranny(body: body),
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
     }
 

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -240,6 +240,39 @@ final class ModerationAuthorityClientTests: XCTestCase {
         XCTAssertNotNil(receipt.decisionDeadline)
     }
 
+    func testFileReportRejectsReceiptForDifferentReport() async throws {
+        StubURLProtocol.set { request in
+            let response = Data(#"""
+            {
+              "reportId":"report-other",
+              "receivedAt":"2023-11-14T22:13:20Z",
+              "caseId":"case-1"
+            }
+            """#.utf8)
+            return (response, Self.httpResponse(for: request, status: 200))
+        }
+        let report = Report(
+            reportId: "report-1",
+            reporter: "onym:key:0102",
+            reporterMandate: "mandate-1",
+            accused: "onym:key:0304",
+            classId: "csam",
+            evidence: [],
+            filedAt: now,
+            signature: "signature"
+        )
+
+        do {
+            _ = try await makeClient().fileReport(report)
+            XCTFail("expected receipt correlation failure")
+        } catch let AuthorityClientError.reportIdentifierMismatch(expected, received) {
+            XCTAssertEqual(expected, "report-1")
+            XCTAssertEqual(received, "report-other")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
     func testAuthorityErrorVocabularyIsPreserved() async throws {
         StubURLProtocol.set { request in
             let body = Data(#"{"error":"no_jurisdiction","message":"no_jurisdiction"}"#.utf8)

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -1023,7 +1023,7 @@ final class ModerationRepositoryTests: XCTestCase {
         XCTAssertNotNil(reportStore.load().first?.receipt)
     }
 
-    func testAlreadyFiledConflictKeepsLedgerRowSoRetryReusesTheSameReportId() async throws {
+    func testAlreadyFiledConflictIsTerminalAndShortCircuitsRetries() async throws {
         let componentId = "onym:component:a"
         let bytes = manifestBytes(componentId: componentId)
         let authority = RecordingAuthorityClient()
@@ -1048,19 +1048,24 @@ final class ModerationRepositoryTests: XCTestCase {
             _ = try await repository.fileReport(message: message, classId: "csam")
             XCTFail("expected the conflict to surface as already-filed")
         } catch let ModerationError.reportAlreadyFiled(reportId) {
-            // Terminal, benign — the UI shows "already on file", not
-            // retry advice.
             XCTAssertEqual(reportId, reportStore.load().first?.report.reportId)
         }
-        // The signed artifact must survive the conflict: any replay has
-        // to reuse the same reportId, never mint a fresh allegation.
-        let retained = try XCTUnwrap(reportStore.load().first?.report)
+        // The row is retained but terminal: it prunes like a receipted
+        // row and never re-delivers.
+        let retained = try XCTUnwrap(reportStore.load().first)
+        XCTAssertEqual(retained.resolvedWithoutReceipt, true)
+        XCTAssertTrue(retained.isResolved)
+
+        // A later Submit short-circuits locally — no second POST, same
+        // reportId in the terminal error.
         authority.reportError = nil
-
-        let receipt = try await repository.fileReport(message: message, classId: "csam")
-
-        XCTAssertEqual(receipt.reportId, retained.reportId)
-        XCTAssertEqual(authority.reports, [retained, retained])
+        do {
+            _ = try await repository.fileReport(message: message, classId: "csam")
+            XCTFail("expected the terminal state to short-circuit")
+        } catch let ModerationError.reportAlreadyFiled(reportId) {
+            XCTAssertEqual(reportId, retained.report.reportId)
+        }
+        XCTAssertEqual(authority.reports.count, 1)
     }
 
     func testDeterministicReportRejectionDiscardsLedgerRow() async throws {

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -1046,12 +1046,14 @@ final class ModerationRepositoryTests: XCTestCase {
 
         do {
             _ = try await repository.fileReport(message: message, classId: "csam")
-            XCTFail("expected the 409 to surface")
-        } catch AuthorityClientError.rejected {
-            // expected
+            XCTFail("expected the conflict to surface as already-filed")
+        } catch let ModerationError.reportAlreadyFiled(reportId) {
+            // Terminal, benign — the UI shows "already on file", not
+            // retry advice.
+            XCTAssertEqual(reportId, reportStore.load().first?.report.reportId)
         }
-        // The signed artifact must survive the conflict: a retry has to
-        // replay the same reportId, not mint a fresh allegation.
+        // The signed artifact must survive the conflict: any replay has
+        // to reuse the same reportId, never mint a fresh allegation.
         let retained = try XCTUnwrap(reportStore.load().first?.report)
         authority.reportError = nil
 
@@ -1091,6 +1093,81 @@ final class ModerationRepositoryTests: XCTestCase {
         // Exact replay of a deterministically rejected artifact can never
         // succeed; retaining it would deadlock every future attempt.
         XCTAssertTrue(reportStore.load().isEmpty)
+    }
+
+    func testPurgeReportRecordsDropsReportersNoLongerPresent() async throws {
+        let mine = filedRecord(reportId: "report-mine", reporter: "onym:key:test-user")
+        let removed = filedRecord(reportId: "report-gone", reporter: "onym:key:removed-user")
+        let reportStore = InMemoryReportFilingStore(records: [mine, removed])
+        let repository = makeRepository(
+            listings: [],
+            bytesByComponent: [:],
+            backend: RecordingBackend(),
+            authorityClient: RecordingAuthorityClient(),
+            store: InMemoryMandateStore(records: []),
+            reportStore: reportStore
+        )
+
+        await repository.purgeReportRecords(keepingReporters: ["onym:key:test-user"])
+
+        XCTAssertEqual(reportStore.load().map(\.report.reportId), ["report-mine"])
+    }
+
+    func testResolvedReportLedgerIsBoundedOldestFirst() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        // Preload the ledger to the cap with resolved rows (newest
+        // first, as the repository maintains it).
+        let preloaded = (0..<ModerationRepository.maxResolvedReportRecords).map {
+            filedRecord(reportId: "report-\($0)", reporter: "onym:key:test-user")
+        }
+        let reportStore = InMemoryReportFilingStore(records: preloaded)
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: reportStore
+        )
+        try await repository.refresh()
+        let message = try reportableMessage()
+
+        _ = try await repository.fileReport(message: message, classId: "csam")
+
+        let stored = reportStore.load()
+        XCTAssertEqual(stored.count, ModerationRepository.maxResolvedReportRecords)
+        // The new row is retained; the oldest resolved disclosure fell off.
+        XCTAssertEqual(stored.first?.sourceMessageId, message.id)
+        XCTAssertFalse(stored.contains {
+            $0.report.reportId == "report-\(ModerationRepository.maxResolvedReportRecords - 1)"
+        })
+    }
+
+    private func filedRecord(reportId: String, reporter: String) -> ReportFilingRecord {
+        ReportFilingRecord(
+            sourceMessageId: "message-\(reportId)",
+            report: Report(
+                reportId: reportId,
+                reporter: reporter,
+                reporterMandate: "mandate-1",
+                accused: "onym:key:accused",
+                classId: "csam",
+                evidence: [EvidenceItem(
+                    disclosedContent: "disclosed",
+                    authenticityProof: "proof"
+                )],
+                filedAt: now,
+                signature: "signature"
+            ),
+            authorityName: "A",
+            receipt: ReportReceipt(
+                reportId: reportId,
+                receivedAt: now,
+                caseId: "case-\(reportId)"
+            )
+        )
     }
 
     func testUserDefaultsReportStoreEncryptsDisclosedEvidenceAtRest() throws {

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -125,6 +125,7 @@ final class ModerationRepositoryTests: XCTestCase {
         private var _registrationDelayNanoseconds: UInt64 = 0
         private var _reports: [Report] = []
         private var _reportShouldFail = false
+        private var _reportError: AuthorityClientError?
         private var _reportReceiptId: String?
 
         var mandates: [ModerationMandate] { lock.withLock { _mandates } }
@@ -132,6 +133,10 @@ final class ModerationRepositoryTests: XCTestCase {
         var reportShouldFail: Bool {
             get { lock.withLock { _reportShouldFail } }
             set { lock.withLock { _reportShouldFail = newValue } }
+        }
+        var reportError: AuthorityClientError? {
+            get { lock.withLock { _reportError } }
+            set { lock.withLock { _reportError = newValue } }
         }
         var reportReceiptId: String? {
             get { lock.withLock { _reportReceiptId } }
@@ -204,13 +209,15 @@ final class ModerationRepositoryTests: XCTestCase {
         }
 
         func fileReport(_ report: Report) async throws -> ReportReceipt {
-            let state = lock.withLock { () -> (Bool, String?) in
+            let state = lock.withLock { () -> (Bool, AuthorityClientError?, String?) in
                 _reports.append(report)
-                return (_reportShouldFail, _reportReceiptId)
+                return (_reportShouldFail, _reportError, _reportReceiptId)
             }
             if state.0 { throw RegistrationFailure.unavailable }
+            if let error = state.1 { throw error }
+            let receiptId = state.2
             return ReportReceipt(
-                reportId: state.1 ?? report.reportId,
+                reportId: receiptId ?? report.reportId,
                 receivedAt: Date(timeIntervalSince1970: 1_700_000_000),
                 caseId: "case-1"
             )
@@ -330,7 +337,8 @@ final class ModerationRepositoryTests: XCTestCase {
             id: "message-1",
             accused: "onym:key:\(keyHex)",
             disclosedContent: body,
-            authenticityProof: proof
+            authenticityProof: proof,
+            displayBody: body
         )
     }
 
@@ -970,7 +978,8 @@ final class ModerationRepositoryTests: XCTestCase {
             id: valid.id,
             accused: valid.accused,
             disclosedContent: "modified",
-            authenticityProof: valid.authenticityProof
+            authenticityProof: valid.authenticityProof,
+            displayBody: "modified"
         )
 
         do {
@@ -1012,6 +1021,76 @@ final class ModerationRepositoryTests: XCTestCase {
 
         XCTAssertEqual(authority.reports, [retained, retained])
         XCTAssertNotNil(reportStore.load().first?.receipt)
+    }
+
+    func testAlreadyFiledConflictKeepsLedgerRowSoRetryReusesTheSameReportId() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        authority.reportError = .rejected(AuthorityRejection(
+            statusCode: 409,
+            rawCode: "already_filed",
+            message: "report already on file"
+        ))
+        let reportStore = InMemoryReportFilingStore()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: reportStore
+        )
+        try await repository.refresh()
+        let message = try reportableMessage()
+
+        do {
+            _ = try await repository.fileReport(message: message, classId: "csam")
+            XCTFail("expected the 409 to surface")
+        } catch AuthorityClientError.rejected {
+            // expected
+        }
+        // The signed artifact must survive the conflict: a retry has to
+        // replay the same reportId, not mint a fresh allegation.
+        let retained = try XCTUnwrap(reportStore.load().first?.report)
+        authority.reportError = nil
+
+        let receipt = try await repository.fileReport(message: message, classId: "csam")
+
+        XCTAssertEqual(receipt.reportId, retained.reportId)
+        XCTAssertEqual(authority.reports, [retained, retained])
+    }
+
+    func testDeterministicReportRejectionDiscardsLedgerRow() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        authority.reportError = .rejected(AuthorityRejection(
+            statusCode: 422,
+            rawCode: "invalid_report",
+            message: "malformed"
+        ))
+        let reportStore = InMemoryReportFilingStore()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: reportStore
+        )
+        try await repository.refresh()
+        let message = try reportableMessage()
+
+        do {
+            _ = try await repository.fileReport(message: message, classId: "csam")
+            XCTFail("expected the 422 to surface")
+        } catch AuthorityClientError.rejected {
+            // expected
+        }
+        // Exact replay of a deterministically rejected artifact can never
+        // succeed; retaining it would deadlock every future attempt.
+        XCTAssertTrue(reportStore.load().isEmpty)
     }
 
     func testUserDefaultsReportStoreEncryptsDisclosedEvidenceAtRest() throws {

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -1,5 +1,7 @@
+import CryptoKit
 import XCTest
 @testable import OnymModeration
+import OnymFoundation
 
 /// Consent lifecycle: manifest hash pinning to fetched bytes, mandate
 /// immutability across authority switches, the stub's honesty
@@ -42,6 +44,12 @@ final class ModerationRepositoryTests: XCTestCase {
 
         func load() -> [MandateRecord] { lock.withLock { records } }
         func save(_ records: [MandateRecord]) { lock.withLock { self.records = records } }
+    }
+
+    private struct FailingReportStore: ReportFilingStore {
+        struct Failure: Error {}
+        func load() -> [ReportFilingRecord] { [] }
+        func save(_ records: [ReportFilingRecord]) throws { throw Failure() }
     }
 
     /// Records every request so tests can assert what the client
@@ -115,8 +123,20 @@ final class ModerationRepositoryTests: XCTestCase {
         private var _registrationError: AuthorityClientError?
         private var _rejectedManifestHash: String?
         private var _registrationDelayNanoseconds: UInt64 = 0
+        private var _reports: [Report] = []
+        private var _reportShouldFail = false
+        private var _reportReceiptId: String?
 
         var mandates: [ModerationMandate] { lock.withLock { _mandates } }
+        var reports: [Report] { lock.withLock { _reports } }
+        var reportShouldFail: Bool {
+            get { lock.withLock { _reportShouldFail } }
+            set { lock.withLock { _reportShouldFail = newValue } }
+        }
+        var reportReceiptId: String? {
+            get { lock.withLock { _reportReceiptId } }
+            set { lock.withLock { _reportReceiptId = newValue } }
+        }
         var shouldFail: Bool {
             get { lock.withLock { _shouldFail } }
             set { lock.withLock { _shouldFail = newValue } }
@@ -184,7 +204,16 @@ final class ModerationRepositoryTests: XCTestCase {
         }
 
         func fileReport(_ report: Report) async throws -> ReportReceipt {
-            throw ModerationError.notImplemented("unused")
+            let state = lock.withLock { () -> (Bool, String?) in
+                _reports.append(report)
+                return (_reportShouldFail, _reportReceiptId)
+            }
+            if state.0 { throw RegistrationFailure.unavailable }
+            return ReportReceipt(
+                reportId: state.1 ?? report.reportId,
+                receivedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                caseId: "case-1"
+            )
         }
         func respond(_ response: CaseResponse) async throws {
             throw ModerationError.notImplemented("unused")
@@ -250,7 +279,8 @@ final class ModerationRepositoryTests: XCTestCase {
         backend: any EnforcementBackendClient,
         authorityClient: RecordingAuthorityClient? = nil,
         attestation: any DeviceAttestationProvider = FakeAttestation(supported: true),
-        store: MandateStore? = nil
+        store: MandateStore? = nil,
+        reportStore: any ReportFilingStore = InMemoryReportFilingStore()
     ) -> ModerationRepository {
         let authorityClients: any ModerationAuthorityClientFactory
         if let authorityClient {
@@ -262,11 +292,45 @@ final class ModerationRepositoryTests: XCTestCase {
             authoritiesFetcher: FakeAuthoritiesFetcher(listings: listings),
             manifestFetcher: FakeManifestFetcher(bytesByComponent: bytesByComponent),
             mandateStore: store ?? InMemoryMandateStore(),
+            reportStore: reportStore,
             backend: backend,
             authorityClients: authorityClients,
             attestation: attestation,
             signer: FakeSigner(),
             clock: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+    }
+
+    private func activeRecord(componentId: String, bytes: Data) -> MandateRecord {
+        MandateRecord(
+            mandate: ModerationMandate(
+                user: "onym:key:test-user",
+                interface: ModerationRepository.interfaceComponentId,
+                authority: componentId,
+                manifestHash: SignedManifest.hash(of: bytes),
+                classes: ["csam"],
+                deviceBinding: "device-1",
+                acceptedAt: now,
+                signatures: ["user-signature", "interface-signature"]
+            ),
+            manifestBytes: bytes,
+            authorityName: "A",
+            countersigned: true,
+            authorityRegistered: true,
+            isActive: true,
+            createdAt: now
+        )
+    }
+
+    private func reportableMessage(body: String = "prohibited content") throws -> ReportableMessage {
+        let accused = Curve25519.Signing.PrivateKey()
+        let proof = try accused.signature(for: Data(body.utf8)).base64EncodedString()
+        let keyHex = accused.publicKey.rawRepresentation.map { String(format: "%02x", $0) }.joined()
+        return ReportableMessage(
+            id: "message-1",
+            accused: "onym:key:\(keyHex)",
+            disclosedContent: body,
+            authenticityProof: proof
         )
     }
 
@@ -850,6 +914,161 @@ final class ModerationRepositoryTests: XCTestCase {
         XCTAssertEqual(records.first?.mandate.signatures.last, "interface-signature-a")
         XCTAssertTrue(try XCTUnwrap(records.first).isActive)
         XCTAssertFalse(try XCTUnwrap(records.last).isActive)
+    }
+
+    // MARK: - Message reporting
+
+    func testFileReportSendsAccusedSignedMessageUnderActiveMandate() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        let reportStore = InMemoryReportFilingStore()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: reportStore
+        )
+        try await repository.refresh()
+        let message = try reportableMessage()
+
+        let receipt = try await repository.fileReport(message: message, classId: "csam")
+
+        XCTAssertEqual(receipt.caseId, "case-1")
+        let report = try XCTUnwrap(authority.reports.first)
+        XCTAssertEqual(report.reporter, "onym:key:test-user")
+        XCTAssertEqual(report.reporterMandate, try activeRecord(
+            componentId: componentId,
+            bytes: bytes
+        ).mandate.mandateHash())
+        XCTAssertEqual(report.accused, message.accused)
+        XCTAssertEqual(report.classId, "csam")
+        XCTAssertEqual(report.evidence, [EvidenceItem(
+            disclosedContent: message.disclosedContent,
+            authenticityProof: message.authenticityProof
+        )])
+        XCTAssertEqual(report.signature, Data("fake-signature".utf8).base64EncodedString())
+        XCTAssertEqual(reportStore.load().first?.receipt, receipt)
+    }
+
+    func testFileReportRejectsProofThatDoesNotSignTheDisclosedBytes() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)])
+        )
+        try await repository.refresh()
+        let valid = try reportableMessage(body: "original")
+        let tampered = ReportableMessage(
+            id: valid.id,
+            accused: valid.accused,
+            disclosedContent: "modified",
+            authenticityProof: valid.authenticityProof
+        )
+
+        do {
+            _ = try await repository.fileReport(message: tampered, classId: "csam")
+            XCTFail("expected the altered disclosure to fail locally")
+        } catch ModerationError.authenticityUnverified {
+            // expected
+        }
+        XCTAssertTrue(authority.reports.isEmpty)
+    }
+
+    func testAmbiguousReportFailureRetriesExactPersistedArtifact() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        authority.reportShouldFail = true
+        let reportStore = InMemoryReportFilingStore()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: reportStore
+        )
+        try await repository.refresh()
+        let message = try reportableMessage()
+
+        do {
+            _ = try await repository.fileReport(message: message, classId: "csam")
+            XCTFail("expected an ambiguous transport failure")
+        } catch RegistrationFailure.unavailable {
+            // expected
+        }
+        let retained = try XCTUnwrap(reportStore.load().first?.report)
+        authority.reportShouldFail = false
+
+        _ = try await repository.fileReport(message: message, classId: "csam")
+
+        XCTAssertEqual(authority.reports, [retained, retained])
+        XCTAssertNotNil(reportStore.load().first?.receipt)
+    }
+
+    func testUserDefaultsReportStoreEncryptsDisclosedEvidenceAtRest() throws {
+        let suite = "report-store-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = UserDefaultsReportFilingStore(defaults: defaults)
+        let record = ReportFilingRecord(
+            sourceMessageId: "message-1",
+            report: Report(
+                reportId: "report-1",
+                reporter: "onym:key:reporter",
+                reporterMandate: "mandate-1",
+                accused: "onym:key:accused",
+                classId: "csam",
+                evidence: [EvidenceItem(
+                    disclosedContent: "sensitive disclosed message",
+                    authenticityProof: "proof"
+                )],
+                filedAt: now,
+                signature: "signature"
+            ),
+            authorityName: "A"
+        )
+
+        try store.save([record])
+
+        XCTAssertEqual(store.load(), [record])
+        let raw = try XCTUnwrap(defaults.data(forKey: "app.onym.ios.moderation.reports"))
+        XCTAssertFalse(String(decoding: raw, as: UTF8.self).contains("sensitive disclosed message"))
+    }
+
+    func testReportIsNeverDeliveredWhenExactArtifactCannotBePersisted() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: FailingReportStore()
+        )
+        try await repository.refresh()
+        let message = try reportableMessage()
+
+        for _ in 0..<2 {
+            do {
+                _ = try await repository.fileReport(message: message, classId: "csam")
+                XCTFail("expected persistence to gate delivery")
+            } catch is FailingReportStore.Failure {
+                // expected
+            }
+        }
+
+        XCTAssertTrue(authority.reports.isEmpty)
     }
 
     // MARK: - Switching immutability

--- a/Tests/OnymIOSTests/ReportableMessageFactoryTests.swift
+++ b/Tests/OnymIOSTests/ReportableMessageFactoryTests.swift
@@ -1,0 +1,166 @@
+import CryptoKit
+import XCTest
+@testable import OnymChatsUI
+import OnymChatsCore
+import OnymGroup
+import OnymIdentity
+
+/// Eligibility rules for the Report context-menu entry —
+/// `ReportableMessageFactory.make` decides which messages can be
+/// disclosed. Only an incoming, text-only message whose sender proof
+/// actually verifies against the sender's stored Ed25519 key is
+/// reportable; everything else must return nil so the menu never
+/// offers a report that can only dead-end at submit.
+final class ReportableMessageFactoryTests: XCTestCase {
+
+    private let senderKey = Curve25519.Signing.PrivateKey()
+    private let senderHex = String(repeating: "11", count: 48)
+    private let groupID = String(repeating: "aa", count: 32)
+
+    func test_incomingSignedTextMessage_isReportable() throws {
+        let message = try signedMessage(body: "prohibited content")
+
+        let reportable = try XCTUnwrap(
+            ReportableMessageFactory.make(from: message, memberProfiles: profiles())
+        )
+
+        XCTAssertEqual(reportable.id, message.id.uuidString.lowercased())
+        XCTAssertEqual(
+            reportable.accused,
+            "onym:key:" + senderKey.publicKey.rawRepresentation
+                .map { String(format: "%02x", $0) }.joined()
+        )
+        XCTAssertEqual(reportable.displayBody, "prohibited content")
+        XCTAssertEqual(reportable.disclosedContent, try ChatModerationProof.signedContent(
+            messageID: message.id,
+            groupID: groupID,
+            sentAtMillis: ChatModerationProof.sentAtMillis(from: message.sentAt),
+            body: message.body
+        ))
+        // The exported pair must verify exactly the way the repository
+        // and the Authority will check it.
+        let signature = try XCTUnwrap(Data(base64Encoded: reportable.authenticityProof))
+        XCTAssertTrue(senderKey.publicKey.isValidSignature(
+            signature, for: Data(reportable.disclosedContent.utf8)
+        ))
+    }
+
+    func test_outgoingMessage_isNotReportable() throws {
+        let message = try signedMessage(direction: .outgoing)
+        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+    }
+
+    func test_messageWithoutProof_isNotReportable() throws {
+        let message = try signedMessage(proofOverride: .some(nil))
+        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+    }
+
+    func test_messageWithGarbageProof_isNotReportable() throws {
+        // Present but unverifiable — mere presence must not surface the
+        // menu entry (it could only fail later, at submit).
+        let message = try signedMessage(
+            proofOverride: .some(Data(repeating: 7, count: 64).base64EncodedString())
+        )
+        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+    }
+
+    func test_proofOverBareBody_isNotReportable() throws {
+        // Legacy / non-canonical proof: a signature over the bare body
+        // is transferable and must not be exportable as evidence.
+        let body = "prohibited content"
+        let bareProof = try senderKey.signature(for: Data(body.utf8)).base64EncodedString()
+        let message = try signedMessage(body: body, proofOverride: .some(bareProof))
+        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+    }
+
+    func test_emptyBody_isNotReportable() throws {
+        let message = try signedMessage(body: "")
+        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+    }
+
+    func test_unknownSender_isNotReportable() throws {
+        let message = try signedMessage()
+        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: [:]))
+    }
+
+    func test_mediaMessage_isNotReportable() throws {
+        let image = ChatImageAttachment(
+            sha256: String(repeating: "cd", count: 32),
+            mimeType: "image/jpeg",
+            byteSize: 1234,
+            width: 10,
+            height: 10,
+            encKey: Data(repeating: 7, count: 32),
+            blurhash: "LEHV6nWB2yk8",
+            server: "https://blossom.onym.app"
+        )
+        let message = try signedMessage(imageAttachment: image)
+        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+    }
+
+    func test_voiceMessage_isNotReportable() throws {
+        let voice = ChatVoiceAttachment(
+            sha256: String(repeating: "cd", count: 32),
+            mimeType: "audio/mp4",
+            byteSize: 1234,
+            durationSeconds: 2,
+            encKey: Data(repeating: 7, count: 32),
+            waveform: [10, 200],
+            server: "https://blossom.onym.app"
+        )
+        let message = try signedMessage(body: "caption", voiceAttachment: voice)
+        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+    }
+
+    // MARK: - Helpers
+
+    private func profiles() -> [String: MemberProfile] {
+        [senderHex: MemberProfile(
+            alias: "Sender",
+            inboxPublicKey: Data(repeating: 1, count: 32),
+            sendingPubkey: senderKey.publicKey.rawRepresentation
+        )]
+    }
+
+    /// An incoming message whose proof is a valid canonical-preimage
+    /// signature by `senderKey`, unless overridden. `proofOverride`
+    /// distinguishes "leave the valid proof" (nil) from "force this
+    /// value, including no proof at all" (.some).
+    private func signedMessage(
+        body: String = "prohibited content",
+        direction: MessageDirection = .incoming,
+        proofOverride: String?? = nil,
+        imageAttachment: ChatImageAttachment? = nil,
+        voiceAttachment: ChatVoiceAttachment? = nil
+    ) throws -> ChatMessage {
+        let id = UUID()
+        let sentAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let proof: String?
+        if let proofOverride {
+            proof = proofOverride
+        } else {
+            let preimage = try ChatModerationProof.signedContent(
+                messageID: id,
+                groupID: groupID,
+                sentAtMillis: ChatModerationProof.sentAtMillis(from: sentAt),
+                body: body
+            )
+            proof = try senderKey.signature(for: Data(preimage.utf8)).base64EncodedString()
+        }
+        return ChatMessage(
+            id: id,
+            groupID: groupID,
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: senderHex,
+            body: body,
+            sentAt: sentAt,
+            direction: direction,
+            status: direction == .incoming ? .received : .sent,
+            replyToMessageID: nil,
+            groupType: .tyranny,
+            moderationAuthenticityProof: proof,
+            imageAttachment: imageAttachment,
+            voiceAttachment: voiceAttachment
+        )
+    }
+}

--- a/Tests/OnymIOSTests/ReportableMessageFactoryTests.swift
+++ b/Tests/OnymIOSTests/ReportableMessageFactoryTests.swift
@@ -16,12 +16,15 @@ final class ReportableMessageFactoryTests: XCTestCase {
     private let senderKey = Curve25519.Signing.PrivateKey()
     private let senderHex = String(repeating: "11", count: 48)
     private let groupID = String(repeating: "aa", count: 32)
+    private let groupSecret = Data(repeating: 0x55, count: 32)
 
     func test_incomingSignedTextMessage_isReportable() throws {
         let message = try signedMessage(body: "prohibited content")
 
         let reportable = try XCTUnwrap(
-            ReportableMessageFactory.make(from: message, memberProfiles: profiles())
+            ReportableMessageFactory.make(
+            from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        )
         )
 
         XCTAssertEqual(reportable.id, message.id.uuidString.lowercased())
@@ -34,6 +37,7 @@ final class ReportableMessageFactoryTests: XCTestCase {
         XCTAssertEqual(reportable.disclosedContent, try ChatModerationProof.signedContent(
             messageID: message.id,
             groupID: groupID,
+            groupSecret: groupSecret,
             sentAtMillis: ChatModerationProof.sentAtMillis(from: message.sentAt),
             body: message.body
         ))
@@ -47,12 +51,16 @@ final class ReportableMessageFactoryTests: XCTestCase {
 
     func test_outgoingMessage_isNotReportable() throws {
         let message = try signedMessage(direction: .outgoing)
-        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        ))
     }
 
     func test_messageWithoutProof_isNotReportable() throws {
         let message = try signedMessage(proofOverride: .some(nil))
-        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        ))
     }
 
     func test_messageWithGarbageProof_isNotReportable() throws {
@@ -61,7 +69,9 @@ final class ReportableMessageFactoryTests: XCTestCase {
         let message = try signedMessage(
             proofOverride: .some(Data(repeating: 7, count: 64).base64EncodedString())
         )
-        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        ))
     }
 
     func test_proofOverBareBody_isNotReportable() throws {
@@ -70,17 +80,34 @@ final class ReportableMessageFactoryTests: XCTestCase {
         let body = "prohibited content"
         let bareProof = try senderKey.signature(for: Data(body.utf8)).base64EncodedString()
         let message = try signedMessage(body: body, proofOverride: .some(bareProof))
-        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        ))
+    }
+
+    func test_wrongGroupSecret_isNotReportable() throws {
+        // The group binding is keyed by the group's shared secret; a
+        // preimage rebuilt with a different secret must not verify.
+        let message = try signedMessage()
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message,
+            memberProfiles: profiles(),
+            groupSecret: Data(repeating: 0x66, count: 32)
+        ))
     }
 
     func test_emptyBody_isNotReportable() throws {
         let message = try signedMessage(body: "")
-        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        ))
     }
 
     func test_unknownSender_isNotReportable() throws {
         let message = try signedMessage()
-        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: [:]))
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message, memberProfiles: [:], groupSecret: groupSecret
+        ))
     }
 
     func test_mediaMessage_isNotReportable() throws {
@@ -95,7 +122,9 @@ final class ReportableMessageFactoryTests: XCTestCase {
             server: "https://blossom.onym.app"
         )
         let message = try signedMessage(imageAttachment: image)
-        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        ))
     }
 
     func test_voiceMessage_isNotReportable() throws {
@@ -109,7 +138,9 @@ final class ReportableMessageFactoryTests: XCTestCase {
             server: "https://blossom.onym.app"
         )
         let message = try signedMessage(body: "caption", voiceAttachment: voice)
-        XCTAssertNil(ReportableMessageFactory.make(from: message, memberProfiles: profiles()))
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        ))
     }
 
     // MARK: - Helpers
@@ -142,6 +173,7 @@ final class ReportableMessageFactoryTests: XCTestCase {
             let preimage = try ChatModerationProof.signedContent(
                 messageID: id,
                 groupID: groupID,
+                groupSecret: groupSecret,
                 sentAtMillis: ChatModerationProof.sentAtMillis(from: sentAt),
                 body: body
             )

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -498,6 +498,7 @@ final class SendMessageInteractorTests: XCTestCase {
         let preimage = try ChatModerationProof.signedContent(
             messageID: result.id,
             groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),  // seedGroup's secret
             sentAtMillis: ChatModerationProof.sentAtMillis(from: result.sentAt),
             body: body
         )

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -479,16 +479,31 @@ final class SendMessageInteractorTests: XCTestCase {
         XCTAssertEqual(stored[0].status, .sent)
     }
 
-    func test_send_signsExactBodyForModerationEvidence() async throws {
+    func test_send_signsCanonicalPreimageForModerationEvidence() async throws {
         let groupID = await seedGroupWithTwoPeers()
         let body = "exact UTF-8 evidence — こんにちは"
 
-        let result = try await interactor.send(groupID: groupID, body: body)
+        // Whole-second send time: the interactor truncates fractional
+        // millis into the wire value it signs, so a sub-millisecond
+        // `now` would make any local reconstruction ambiguous.
+        // (Receivers are unaffected — they recover the exact wire
+        // millis from the payload.)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let result = try await interactor.send(groupID: groupID, body: body, now: now)
 
         let encodedProof = try XCTUnwrap(result.moderationAuthenticityProof)
         let proof = try XCTUnwrap(Data(base64Encoded: encodedProof))
         let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: mySendingPubkey)
-        XCTAssertTrue(publicKey.isValidSignature(proof, for: Data(body.utf8)))
+        // The proof binds the body to this exact message, group, and
+        // send time — a signature over the bare body must NOT verify.
+        let preimage = try ChatModerationProof.signedContent(
+            messageID: result.id,
+            groupID: groupID,
+            sentAtMillis: ChatModerationProof.sentAtMillis(from: result.sentAt),
+            body: body
+        )
+        XCTAssertTrue(publicKey.isValidSignature(proof, for: Data(preimage.utf8)))
+        XCTAssertFalse(publicKey.isValidSignature(proof, for: Data(body.utf8)))
 
         let stored = await messages.currentMessages(groupID: groupID, owner: currentIdentityID)
         XCTAssertEqual(stored.first?.moderationAuthenticityProof, encodedProof)

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -479,6 +479,21 @@ final class SendMessageInteractorTests: XCTestCase {
         XCTAssertEqual(stored[0].status, .sent)
     }
 
+    func test_send_signsExactBodyForModerationEvidence() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        let body = "exact UTF-8 evidence — こんにちは"
+
+        let result = try await interactor.send(groupID: groupID, body: body)
+
+        let encodedProof = try XCTUnwrap(result.moderationAuthenticityProof)
+        let proof = try XCTUnwrap(Data(base64Encoded: encodedProof))
+        let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: mySendingPubkey)
+        XCTAssertTrue(publicKey.isValidSignature(proof, for: Data(body.utf8)))
+
+        let stored = await messages.currentMessages(groupID: groupID, owner: currentIdentityID)
+        XCTAssertEqual(stored.first?.moderationAuthenticityProof, encodedProof)
+    }
+
     func test_send_skipsSelfRecipient() async throws {
         // Even though our profile is in memberProfiles, we must not
         // send a copy to our own inbox.

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -483,12 +483,11 @@ final class SendMessageInteractorTests: XCTestCase {
         let groupID = await seedGroupWithTwoPeers()
         let body = "exact UTF-8 evidence — こんにちは"
 
-        // Whole-second send time: the interactor truncates fractional
-        // millis into the wire value it signs, so a sub-millisecond
-        // `now` would make any local reconstruction ambiguous.
-        // (Receivers are unaffected — they recover the exact wire
-        // millis from the payload.)
-        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        // Deliberately sub-millisecond: the interactor truncates the
+        // wire millis it signs, and persists `sentAt` re-derived from
+        // that truncated value — so the stored row reconstructs the
+        // signed preimage exactly, whatever `now` was.
+        let now = Date(timeIntervalSince1970: 1_700_000_000.7777)
         let result = try await interactor.send(groupID: groupID, body: body, now: now)
 
         let encodedProof = try XCTUnwrap(result.moderationAuthenticityProof)

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -36,7 +36,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             body: "hello",
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
             direction: .outgoing,
-            status: .pending
+            status: .pending,
+            moderationAuthenticityProof: "c2lnbmF0dXJl"
         )
 
         let outcome = await store.insertOrUpdate(msg)
@@ -54,6 +55,7 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         XCTAssertEqual(first.direction, .outgoing)
         XCTAssertEqual(first.status, .pending)
         XCTAssertEqual(first.groupType, .tyranny)
+        XCTAssertEqual(first.moderationAuthenticityProof, "c2lnbmF0dXJl")
         XCTAssertNil(first.replyToMessageID,
                      "a non-reply message round-trips with no reply target")
     }
@@ -456,7 +458,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         sentAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
         direction: MessageDirection = .outgoing,
         status: MessageStatus = .sent,
-        replyToMessageID: UUID? = nil
+        replyToMessageID: UUID? = nil,
+        moderationAuthenticityProof: String? = nil
     ) -> ChatMessage {
         ChatMessage(
             id: id,
@@ -468,7 +471,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             direction: direction,
             status: status,
             replyToMessageID: replyToMessageID,
-            groupType: .tyranny
+            groupType: .tyranny,
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
     }
 }

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -443,9 +443,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         // a laundered body, a shifted timestamp, AND a bolted-on
         // attachment (media messages aren't reportable, so a surviving
         // attachment would remove Report from the menu even with the
-        // pair intact). The proof signs the (body, group, id, sentAt)
-        // tuple; the whole tuple plus the eligibility-gating fields
-        // must survive.
+        // pair intact). Incoming rows are immutable once received, so
+        // nothing about the stored row may change.
         let replay = makeMessage(
             id: id,
             body: "innocent content",
@@ -475,26 +474,86 @@ final class SwiftDataMessageStoreTests: XCTestCase {
                      "a proof-less replay must not bolt on an attachment")
     }
 
-    func test_insertOrUpdate_replayWithProof_overwritesBodyAndProofTogether() async {
+    func test_insertOrUpdate_incomingReplayWithFreshProof_neverMutatesSignedTuple() async {
+        // The strongest laundering attempt: same messageID, laundered
+        // body, shifted timestamp, and a *fresh* proof over the new
+        // preimage (the sender holds the signing key, so it verifies).
+        // An incoming row is immutable once received — a legitimate
+        // replay is byte-identical, so divergence is hostile.
         let id = UUID()
-        _ = await store.insertOrUpdate(makeMessage(
+        let original = makeMessage(
             id: id,
-            body: "first",
-            moderationAuthenticityProof: nil
-        ))
+            body: "prohibited content",
+            direction: .incoming,
+            status: .received,
+            moderationAuthenticityProof: "c2lnbmF0dXJl"
+        )
+        _ = await store.insertOrUpdate(original)
 
         let replay = makeMessage(
             id: id,
-            body: "second",
-            moderationAuthenticityProof: "bmV3LXByb29m"
+            body: "innocent content",
+            sentAt: original.sentAt.addingTimeInterval(-3600),
+            direction: .incoming,
+            status: .received,
+            moderationAuthenticityProof: "ZnJlc2gtdmFsaWQtcHJvb2Y="
         )
-        _ = await store.insertOrUpdate(replay)
+        let outcome = await store.insertOrUpdate(replay)
+        XCTAssertEqual(outcome, .updated)
 
         let listed = await store.list(
-            groupID: replay.groupID, ownerIDString: kOwner.rawValue.uuidString
+            groupID: original.groupID, ownerIDString: kOwner.rawValue.uuidString
         )
-        XCTAssertEqual(listed[0].body, "second")
-        XCTAssertEqual(listed[0].moderationAuthenticityProof, "bmV3LXByb29m")
+        XCTAssertEqual(listed[0].body, "prohibited content")
+        XCTAssertEqual(listed[0].sentAt, original.sentAt)
+        XCTAssertEqual(listed[0].moderationAuthenticityProof, "c2lnbmF0dXJl")
+    }
+
+    func test_insertOrUpdate_incomingEcho_neverRewritesOutgoingRow() async {
+        // A group member replays the recipient's own messageID as an
+        // incoming payload. Cross-direction overwrites are refused —
+        // the sender's own row must survive untouched.
+        let id = UUID()
+        let mine = makeMessage(
+            id: id,
+            body: "my message",
+            direction: .outgoing,
+            status: .sent,
+            moderationAuthenticityProof: "bXktcHJvb2Y="
+        )
+        _ = await store.insertOrUpdate(mine)
+
+        let echo = makeMessage(
+            id: id,
+            body: "forged echo",
+            direction: .incoming,
+            status: .received
+        )
+        _ = await store.insertOrUpdate(echo)
+
+        let listed = await store.list(
+            groupID: mine.groupID, ownerIDString: kOwner.rawValue.uuidString
+        )
+        XCTAssertEqual(listed[0].body, "my message")
+        XCTAssertEqual(listed[0].direction, .outgoing)
+        XCTAssertEqual(listed[0].moderationAuthenticityProof, "bXktcHJvb2Y=")
+    }
+
+    func test_insertOrUpdate_outgoingRow_stillAcceptsOverwrites() async {
+        // Outgoing rows keep the full update path — the pending → sent
+        // flip and retry re-inserts depend on it.
+        let id = UUID()
+        _ = await store.insertOrUpdate(makeMessage(
+            id: id, body: "draft", status: .pending
+        ))
+        _ = await store.insertOrUpdate(makeMessage(
+            id: id, body: "draft", status: .sent
+        ))
+
+        let listed = await store.list(
+            groupID: "aa".repeated(32), ownerIDString: kOwner.rawValue.uuidString
+        )
+        XCTAssertEqual(listed[0].status, .sent)
     }
 
     func test_deleteOwner_removesAllMessagesForIdentity() async {

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -428,6 +428,60 @@ final class SwiftDataMessageStoreTests: XCTestCase {
                        "deleting one identity's thread leaves the other's copy of the group")
     }
 
+    func test_insertOrUpdate_replayWithoutProof_preservesStoredEvidence() async {
+        let id = UUID()
+        let original = makeMessage(
+            id: id,
+            body: "prohibited content",
+            direction: .incoming,
+            status: .received,
+            moderationAuthenticityProof: "c2lnbmF0dXJl"
+        )
+        _ = await store.insertOrUpdate(original)
+
+        // An abuser re-sends the same messageID with the proof omitted
+        // (and a laundered body). The stored body + proof pair must
+        // survive so Report doesn't silently vanish from the menu.
+        let replay = makeMessage(
+            id: id,
+            body: "innocent content",
+            direction: .incoming,
+            status: .received,
+            moderationAuthenticityProof: nil
+        )
+        let outcome = await store.insertOrUpdate(replay)
+        XCTAssertEqual(outcome, .updated)
+
+        let listed = await store.list(
+            groupID: original.groupID, ownerIDString: kOwner.rawValue.uuidString
+        )
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed[0].body, "prohibited content")
+        XCTAssertEqual(listed[0].moderationAuthenticityProof, "c2lnbmF0dXJl")
+    }
+
+    func test_insertOrUpdate_replayWithProof_overwritesBodyAndProofTogether() async {
+        let id = UUID()
+        _ = await store.insertOrUpdate(makeMessage(
+            id: id,
+            body: "first",
+            moderationAuthenticityProof: nil
+        ))
+
+        let replay = makeMessage(
+            id: id,
+            body: "second",
+            moderationAuthenticityProof: "bmV3LXByb29m"
+        )
+        _ = await store.insertOrUpdate(replay)
+
+        let listed = await store.list(
+            groupID: replay.groupID, ownerIDString: kOwner.rawValue.uuidString
+        )
+        XCTAssertEqual(listed[0].body, "second")
+        XCTAssertEqual(listed[0].moderationAuthenticityProof, "bmV3LXByb29m")
+    }
+
     func test_deleteOwner_removesAllMessagesForIdentity() async {
         let aliceID = IdentityID()
         let bobID = IdentityID()

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -440,17 +440,25 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         _ = await store.insertOrUpdate(original)
 
         // An abuser re-sends the same messageID with the proof omitted,
-        // a laundered body, AND a shifted timestamp. The proof signs the
-        // (body, group, id, sentAt) tuple, so the whole tuple must
-        // survive — a preserved proof over a replaced sentAt would no
-        // longer verify, and Report would silently vanish from the menu.
+        // a laundered body, a shifted timestamp, AND a bolted-on
+        // attachment (media messages aren't reportable, so a surviving
+        // attachment would remove Report from the menu even with the
+        // pair intact). The proof signs the (body, group, id, sentAt)
+        // tuple; the whole tuple plus the eligibility-gating fields
+        // must survive.
         let replay = makeMessage(
             id: id,
             body: "innocent content",
             sentAt: original.sentAt.addingTimeInterval(3600),
             direction: .incoming,
             status: .received,
-            moderationAuthenticityProof: nil
+            moderationAuthenticityProof: nil,
+            imageAttachment: ChatImageAttachment(
+                sha256: "cd".repeated(32), mimeType: "image/jpeg",
+                byteSize: 1, width: 1, height: 1,
+                encKey: Data(repeating: 7, count: 32),
+                blurhash: "LEHV6nWB2yk8", server: "https://blossom.test"
+            )
         )
         let outcome = await store.insertOrUpdate(replay)
         XCTAssertEqual(outcome, .updated)
@@ -463,6 +471,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         XCTAssertEqual(listed[0].sentAt, original.sentAt)
         XCTAssertEqual(listed[0].senderBlsPubkeyHex, original.senderBlsPubkeyHex)
         XCTAssertEqual(listed[0].moderationAuthenticityProof, "c2lnbmF0dXJl")
+        XCTAssertNil(listed[0].imageAttachment,
+                     "a proof-less replay must not bolt on an attachment")
     }
 
     func test_insertOrUpdate_replayWithProof_overwritesBodyAndProofTogether() async {
@@ -518,7 +528,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         direction: MessageDirection = .outgoing,
         status: MessageStatus = .sent,
         replyToMessageID: UUID? = nil,
-        moderationAuthenticityProof: String? = nil
+        moderationAuthenticityProof: String? = nil,
+        imageAttachment: ChatImageAttachment? = nil
     ) -> ChatMessage {
         ChatMessage(
             id: id,
@@ -531,7 +542,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
             status: status,
             replyToMessageID: replyToMessageID,
             groupType: .tyranny,
-            moderationAuthenticityProof: moderationAuthenticityProof
+            moderationAuthenticityProof: moderationAuthenticityProof,
+            imageAttachment: imageAttachment
         )
     }
 }

--- a/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataMessageStoreTests.swift
@@ -439,12 +439,15 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         )
         _ = await store.insertOrUpdate(original)
 
-        // An abuser re-sends the same messageID with the proof omitted
-        // (and a laundered body). The stored body + proof pair must
-        // survive so Report doesn't silently vanish from the menu.
+        // An abuser re-sends the same messageID with the proof omitted,
+        // a laundered body, AND a shifted timestamp. The proof signs the
+        // (body, group, id, sentAt) tuple, so the whole tuple must
+        // survive — a preserved proof over a replaced sentAt would no
+        // longer verify, and Report would silently vanish from the menu.
         let replay = makeMessage(
             id: id,
             body: "innocent content",
+            sentAt: original.sentAt.addingTimeInterval(3600),
             direction: .incoming,
             status: .received,
             moderationAuthenticityProof: nil
@@ -457,6 +460,8 @@ final class SwiftDataMessageStoreTests: XCTestCase {
         )
         XCTAssertEqual(listed.count, 1)
         XCTAssertEqual(listed[0].body, "prohibited content")
+        XCTAssertEqual(listed[0].sentAt, original.sentAt)
+        XCTAssertEqual(listed[0].senderBlsPubkeyHex, original.senderBlsPubkeyHex)
         XCTAssertEqual(listed[0].moderationAuthenticityProof, "c2lnbmF0dXJl")
     }
 


### PR DESCRIPTION
## Summary

- sign every newly sent text message over the canonical proof preimage — the body bound to its message id, a message-salted group binding, and the send timestamp — and retain that proof encrypted on recipients
- offer Report from the long-press menu only for incoming text messages whose sender proof verifies against the sender's stored key
- let the reporter review the exact disclosure and choose a class from their active consented Authority manifest
- construct and sign the reference Authority Report shape, bind it to the active registered reporter mandate, and verify the accused proof locally before filing
- encrypt and persist the exact signed report before network delivery, reuse it after ambiguous failures, single-flight overlapping taps, correlate the returned report ID, and treat the Authority's already-on-file answer as terminal
- bound the report ledger (resolved rows prune oldest-first; rows awaiting an outcome are kept as idempotency keys) and purge it when the filing identity is removed

## Scope

This PR intentionally reports text only. Legacy messages and media do not expose Report because they do not carry the content-level sender proof required by the finalized Authority contract.

No surrounding conversation context is disclosed; the proof's group binding is keyed by the group's shared secret (never on-chain) and salted per message, so an Authority cannot resolve it to a group — even holding the public on-chain group set — nor correlate independent reports to one group.

## Limitations (deliberate)

- **Reportability is sender-opt-in by wire design.** The proof field is optional (older clients ship none), so a modified client that omits or garbles it makes its messages unreportable. Closing that would require Authority-side verification of a different commitment (e.g. envelope-level), i.e. a protocol/contract change outside this client PR. Recipients can still see that a message carries no proof (no Report entry).
- **A 409 (already filed) cannot recover the original receipt** — the Authority protocol has no report-lookup endpoint; the client records the terminal state and stops re-delivering.

## Verification

- full OnymIOSTests suite passes
- focused coverage includes payload compatibility, canonical preimage signatures, encrypted persistence, inbound evidence retention across replays, local authenticity rejection, mandate/class binding, byte-identical retry, receipt correlation, already-filed terminality, ledger bounds/purge, and long-press eligibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)
