### PR TITLE
feat(moderation): accused-side case status — standing, query, snapshot

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/CaseStatusStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/CaseStatusStore.swift
@@ -1,0 +1,95 @@
+import Foundation
+import OnymFoundation
+
+/// The last authenticated case-status document fetched for one case,
+/// retained so the case surface can render offline and across
+/// relaunches. A snapshot is a cache of the Authority's answer — the
+/// Authority remains the source of truth, and a stale snapshot is
+/// replaced wholesale by the next successful fetch.
+public struct CaseStatusRecord: Codable, Sendable, Equatable {
+    public let caseId: String
+    /// Content reference of the mandate this case proceeds under.
+    /// Standing follows this mandate — not the currently active one —
+    /// so the record keeps the linkage the next fetch must re-resolve.
+    public let mandateRef: String
+    /// `onym:key:` reference of the mandated user, retained so
+    /// identity removal can purge the snapshots that identity owned.
+    public let user: String
+    public var status: CaseStatus
+    public var fetchedAt: Date
+
+    public init(
+        caseId: String,
+        mandateRef: String,
+        user: String,
+        status: CaseStatus,
+        fetchedAt: Date
+    ) {
+        self.caseId = caseId
+        self.mandateRef = mandateRef
+        self.user = user
+        self.status = status
+        self.fetchedAt = fetchedAt
+    }
+}
+
+public protocol CaseStatusStore: Sendable {
+    func load() -> [CaseStatusRecord]
+    func save(_ records: [CaseStatusRecord]) throws
+}
+
+/// Encrypted-at-rest store, same posture as the report ledger: the
+/// status document names the violation class and deadlines of an
+/// accusation against this device's user, so it never lands in
+/// UserDefaults as plaintext.
+public struct UserDefaultsCaseStatusStore: CaseStatusStore, @unchecked Sendable {
+    private static let recordsKey = "app.onym.ios.moderation.caseStatus"
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> [CaseStatusRecord] {
+        guard let encrypted = defaults.data(forKey: Self.recordsKey),
+              let data = try? StorageEncryption.decrypt(encrypted),
+              let records = try? Self.decoder().decode([CaseStatusRecord].self, from: data)
+        else { return [] }
+        return records
+    }
+
+    public func save(_ records: [CaseStatusRecord]) throws {
+        let data = try Self.encoder().encode(records)
+        let encrypted = try StorageEncryption.encrypt(data)
+        defaults.set(encrypted, forKey: Self.recordsKey)
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+public final class InMemoryCaseStatusStore: CaseStatusStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var records: [CaseStatusRecord]
+
+    public init(records: [CaseStatusRecord] = []) {
+        self.records = records
+    }
+
+    public func load() -> [CaseStatusRecord] {
+        lock.withLock { records }
+    }
+
+    public func save(_ records: [CaseStatusRecord]) {
+        lock.withLock { self.records = records }
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -85,6 +85,7 @@ public enum AuthorityClientError: Error, Sendable, Equatable {
     case mandateNotAccepted(mandateRef: String)
     case mandateReferenceMismatch(expected: String, received: String)
     case reportIdentifierMismatch(expected: String, received: String)
+    case caseIdentifierMismatch(expected: String, received: String)
     case invalidPathComponent(String)
     case insecureBaseURL(String)
 }
@@ -173,9 +174,22 @@ public struct AppealSubmission: Codable, Sendable, Equatable {
     }
 }
 
+/// One entry of the Authority's case event log. The reference exposes
+/// timestamps and kinds only ("case_opened", "response", "decided",
+/// "appeal_filed", ...) — details are never served to a party.
+public struct CaseEvent: Codable, Sendable, Equatable {
+    public let at: Date
+    public let kind: String
+
+    public init(at: Date, kind: String) {
+        self.at = at
+        self.kind = kind
+    }
+}
+
 /// Party-visible subset of the Authority's case status document.
-/// Additional assessment and event fields are deliberately ignored by
-/// this first client surface and can be modeled when their UI lands.
+/// The `assessment` field is deliberately ignored by this client
+/// surface and can be modeled when its UI lands.
 public struct CaseStatus: Codable, Sendable, Equatable {
     public let caseId: String
     public let stage: String
@@ -190,6 +204,9 @@ public struct CaseStatus: Codable, Sendable, Equatable {
     public let appealState: String?
     public let newHolderState: String?
     public let claimRevision: Int?
+    /// Oldest-first event log. Optional for compatibility with an
+    /// authority that omits it; the reference always serves it.
+    public let events: [CaseEvent]?
 
     public init(
         caseId: String,
@@ -204,7 +221,8 @@ public struct CaseStatus: Codable, Sendable, Equatable {
         appealDeadline: Date? = nil,
         appealState: String? = nil,
         newHolderState: String? = nil,
-        claimRevision: Int? = nil
+        claimRevision: Int? = nil,
+        events: [CaseEvent]? = nil
     ) {
         self.caseId = caseId
         self.stage = stage
@@ -219,6 +237,7 @@ public struct CaseStatus: Codable, Sendable, Equatable {
         self.appealState = appealState
         self.newHolderState = newHolderState
         self.claimRevision = claimRevision
+        self.events = events
     }
 }
 
@@ -361,7 +380,16 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
             path: ["v1", "cases", caseId, "status"],
             headers: headers
         )
-        return try decode(data)
+        let status: CaseStatus = try decode(data)
+        // A status document for a different case must never be
+        // attributed to the one the caller asked about.
+        guard status.caseId == caseId else {
+            throw AuthorityClientError.caseIdentifierMismatch(
+                expected: caseId,
+                received: status.caseId
+            )
+        }
+        return status
     }
 
     private func send(

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -41,6 +41,12 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// The supplied evidence proof does not verify against the accused
     /// key over the exact content the user is about to disclose.
     case authenticityUnverified
+    /// An accused-side case operation was attempted without standing:
+    /// the case's mandate is retained but the active identity does not
+    /// own it. Standing follows the mandate a case was opened under,
+    /// so switching the selected identity — not switching authorities —
+    /// is what resolves this.
+    case caseAccessUnavailable(String)
     /// The Authority answered 409: it already holds this exact report.
     /// A terminal, benign outcome — the allegation is on file — but the
     /// original receipt (caseId) cannot be recovered without a lookup

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -86,11 +86,18 @@ public actor ModerationRepository {
     /// accumulate indefinitely.
     public static let maxResolvedReportRecords = 128
 
+    /// Retention bound on cached case-status snapshots. Snapshots
+    /// upsert by caseId, so the set grows only with distinct cases
+    /// against this device's identities; the bound is a backstop, and
+    /// the oldest fetch falls off first.
+    public static let maxCaseStatusRecords = 64
+
     private let authoritiesFetcher: any KnownAuthoritiesFetcher
     private let manifestFetcher: any AuthorityManifestFetcher
     private let manifestValidator: AuthorityManifestValidator
     private let mandateStore: any MandateStore
     private let reportStore: any ReportFilingStore
+    private let caseStore: any CaseStatusStore
     private let backend: any EnforcementBackendClient
     private let authorityClients: any ModerationAuthorityClientFactory
     private let attestation: any DeviceAttestationProvider
@@ -124,21 +131,30 @@ public actor ModerationRepository {
         let messageId: String
     }
 
+    private struct CaseStatusKey: Hashable {
+        let authority: String
+        let user: String
+        let caseId: String
+    }
+
     private var authorities: [AuthorityListing] = []
     private var fetchStatus: AuthorityFetchStatus = .idle
     private var records: [MandateRecord]
     private var reportRecords: [ReportFilingRecord]
+    private var caseRecords: [CaseStatusRecord]
     private var continuations: [UUID: AsyncStream<ModerationState>.Continuation] = [:]
     private var startTask: Task<Void, Never>?
     private var consentTasks: [ConsentKey: Task<MandateRecord, Error>] = [:]
     private var registrationFlights: [RegistrationKey: RegistrationFlight] = [:]
     private var reportTasks: [ReportKey: Task<ReportReceipt, Error>] = [:]
+    private var caseStatusTasks: [CaseStatusKey: Task<CaseStatus, Error>] = [:]
 
     public init(
         authoritiesFetcher: any KnownAuthoritiesFetcher,
         manifestFetcher: any AuthorityManifestFetcher,
         mandateStore: any MandateStore,
         reportStore: any ReportFilingStore = UserDefaultsReportFilingStore(),
+        caseStore: any CaseStatusStore = UserDefaultsCaseStatusStore(),
         backend: any EnforcementBackendClient,
         authorityClients: any ModerationAuthorityClientFactory,
         attestation: any DeviceAttestationProvider,
@@ -151,6 +167,7 @@ public actor ModerationRepository {
         self.manifestValidator = manifestValidator
         self.mandateStore = mandateStore
         self.reportStore = reportStore
+        self.caseStore = caseStore
         self.backend = backend
         self.authorityClients = authorityClients
         self.attestation = attestation
@@ -158,6 +175,7 @@ public actor ModerationRepository {
         self.clock = clock
         self.records = mandateStore.load()
         self.reportRecords = reportStore.load()
+        self.caseRecords = caseStore.load()
     }
 
     // MARK: - Directory refresh
@@ -474,6 +492,139 @@ public actor ModerationRepository {
             reportTasks.removeValue(forKey: key)
             throw error
         }
+    }
+
+    // MARK: - Case status (accused side)
+
+    /// The retained mandate a case references, resolved from history by
+    /// content hash. Standing in a case follows the mandate it was
+    /// opened under — NOT the currently active record: switching
+    /// authorities deactivates the old mandate but must not strand the
+    /// user out of a case that mandate still governs (mandates are
+    /// immutable, spec §12).
+    public func mandateRecord(forRef ref: String) -> MandateRecord? {
+        records.first { (try? $0.mandate.mandateHash()) == ref }
+    }
+
+    /// Fetch the authenticated status document for one case, persist it
+    /// as the offline snapshot, and return it. Fails closed when the
+    /// referenced mandate is not retained, the active identity does not
+    /// own it, or its Authority is absent from the directory.
+    ///
+    /// The reference Authority deliberately answers 404 for unknown
+    /// case, bad signature, and non-party alike (a case id must not be
+    /// an existence oracle), so callers cannot distinguish those —
+    /// surface 404 as "case unavailable", never as proof of anything.
+    public func caseStatus(caseId: String, mandateRef: String) async throws -> CaseStatus {
+        let (record, listing) = try await caseStanding(mandateRef: mandateRef)
+        let key = CaseStatusKey(
+            authority: listing.componentId,
+            user: record.mandate.user,
+            caseId: caseId
+        )
+        if let task = caseStatusTasks[key] {
+            return try await task.value
+        }
+        let task = Task {
+            try await self.performCaseStatus(
+                caseId: caseId,
+                mandateRef: mandateRef,
+                record: record,
+                listing: listing
+            )
+        }
+        caseStatusTasks[key] = task
+        do {
+            let status = try await task.value
+            caseStatusTasks.removeValue(forKey: key)
+            return status
+        } catch {
+            caseStatusTasks.removeValue(forKey: key)
+            throw error
+        }
+    }
+
+    /// The last fetched snapshot for a case, if any — for rendering
+    /// offline or before the first fetch of a session completes.
+    public func storedCaseStatus(caseId: String) -> CaseStatusRecord? {
+        caseRecords.first { $0.caseId == caseId }
+    }
+
+    /// Drop every case snapshot not owned by one of `users`
+    /// (`onym:key:<hex>` references). Called on identity removal, same
+    /// contract as `purgeReportRecords(keepingReporters:)`.
+    public func purgeCaseStatusRecords(keepingUsers users: Set<String>) {
+        let before = caseRecords.count
+        caseRecords.removeAll { !users.contains($0.user) }
+        guard caseRecords.count != before else { return }
+        try? caseStore.save(caseRecords)
+    }
+
+    /// Standing for any accused-side case operation: the case's mandate
+    /// must be retained, owned by the active identity, and its
+    /// Authority resolvable in the current directory.
+    private func caseStanding(
+        mandateRef: String
+    ) async throws -> (MandateRecord, AuthorityListing) {
+        guard let record = mandateRecord(forRef: mandateRef) else {
+            throw ModerationError.noMandate
+        }
+        let userKey = try await signer.userKeyID()
+        guard userKey == record.mandate.user else {
+            throw ModerationError.caseAccessUnavailable(
+                "active identity does not own the case's mandate"
+            )
+        }
+        guard let listing = authorities.first(where: {
+            $0.componentId == record.mandate.authority
+        }) else {
+            throw ModerationError.authorityUnavailable(record.mandate.authority)
+        }
+        return (record, listing)
+    }
+
+    private func performCaseStatus(
+        caseId: String,
+        mandateRef: String,
+        record: MandateRecord,
+        listing: AuthorityListing
+    ) async throws -> CaseStatus {
+        let client = authorityClients.client(for: listing)
+        let status = try await client.queryStatus(caseId: caseId)
+        // The concrete HTTP client correlates this too; repeating the
+        // check here preserves the invariant for every factory-injected
+        // implementation of the protocol.
+        guard status.caseId == caseId else {
+            throw AuthorityClientError.caseIdentifierMismatch(
+                expected: caseId,
+                received: status.caseId
+            )
+        }
+        let snapshot = CaseStatusRecord(
+            caseId: caseId,
+            mandateRef: mandateRef,
+            user: record.mandate.user,
+            status: status,
+            fetchedAt: clock()
+        )
+        if let index = caseRecords.firstIndex(where: { $0.caseId == caseId }) {
+            caseRecords[index] = snapshot
+        } else {
+            caseRecords.insert(snapshot, at: 0)
+        }
+        if caseRecords.count > Self.maxCaseStatusRecords {
+            caseRecords.sort { $0.fetchedAt > $1.fetchedAt }
+            caseRecords.removeLast(caseRecords.count - Self.maxCaseStatusRecords)
+        }
+        do {
+            try caseStore.save(caseRecords)
+        } catch {
+            // The snapshot is a cache; the Authority's answer is
+            // authoritative and must reach the caller. Error only —
+            // no case content — per no-activity-logging.
+            Self.logger.error("case snapshot persistence failed: \(error)")
+        }
+        return status
     }
 
     // MARK: - AsyncStream
@@ -885,7 +1036,7 @@ public actor ModerationRepository {
         case .rejected(let rejection):
             return Self.isDeterministicStatusCode(rejection.statusCode)
         case .invalidResponse, .malformedResponse, .invalidPathComponent, .insecureBaseURL,
-             .reportIdentifierMismatch:
+             .reportIdentifierMismatch, .caseIdentifierMismatch:
             return false
         }
     }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -719,11 +719,15 @@ struct OnymIOSApp: App {
                         // every identity's ledger, not just the
                         // removed one's.
                         if let remaining = try? await identityRepository.currentIdentities() {
+                            let keys = Set(remaining.map { summary in
+                                "onym:key:" + summary.sendingPublicKey
+                                    .map { String(format: "%02x", $0) }.joined()
+                            })
                             await moderationRepository.purgeReportRecords(
-                                keepingReporters: Set(remaining.map { summary in
-                                    "onym:key:" + summary.sendingPublicKey
-                                        .map { String(format: "%02x", $0) }.joined()
-                                })
+                                keepingReporters: keys
+                            )
+                            await moderationRepository.purgeCaseStatusRecords(
+                                keepingUsers: keys
                             )
                         }
                     }


### PR DESCRIPTION
## Summary

First of four sequential PRs delivering the accused-side case lifecycle (status → response/appeal submissions → UI → tests). This one is the domain layer: everything a later surface needs to *discover and follow* a case, with standing resolved correctly.

- **Mandate-by-reference standing** — `mandateRecord(forRef:)` resolves the mandate a case names from mandate history by content hash. Standing in a case follows the mandate it was opened under, **not** the currently active record: switching authorities deactivates the old mandate but must not strand the user out of a case that mandate still governs (mandates are immutable, spec §12). This is the API the response/appeal PR builds on.
- **`caseStatus(caseId:mandateRef:)`** — fails closed when the referenced mandate isn't retained (`noMandate`), the active identity doesn't own it (new `caseAccessUnavailable`), or its Authority isn't in the directory (`authorityUnavailable`); single-flights per (authority, user, caseId); queries the reference Authority's signed status endpoint (`GET /v1/cases/{id}/status`, header credential `query-status:{caseId}:{timestamp}` — unchanged, already matched `authorize_case_party`); and correlates the returned `caseId` at both the client and repository layers (new `caseIdentifierMismatch`).
- **Offline snapshot** — `CaseStatusRecord` persists the last fetched status document encrypted at rest (same posture as the report ledger), upserted by `caseId`, bounded at 64 (oldest fetch pruned first), purged on identity removal alongside report records, and readable via `storedCaseStatus(caseId:)` for rendering before/without network.
- **Event log modeled** — `CaseStatus.events: [{at, kind}]?` matches what the reference actually serves (kinds like `case_opened`, `response`, `decided`, `appeal_filed`; details are never exposed to a party). The `assessment` document remains deliberately unmodeled until its UI lands.

## Reference-implementation alignment (recon findings)

Verified against onym-moderation `main` before writing code:

- The gate check already delivers `caseId` to the client: `caseOpen` carries it per notice, `banned` carries it inside `verdict.caseId` — no plumbing was needed.
- Status responses always emit every field (nullables as JSON `null`); `stage` is only `open|decided`, terminal detail lives in `disposition` (including case-level `reversed`). The existing Swift DTO's optionals decode this correctly.
- The status endpoint deliberately answers **404 for unknown case, bad signature, and non-party alike** (a case id must not be an existence oracle). The repository doc calls this out so the UI layer never presents 404 as proof of anything.
- Known pre-existing gap, out of scope here and flagged for the UI PR: `BannedView` renders `BanState.verdict` without running `VerdictValidator` (which currently has no production call sites).

## Scope

Domain only — no UI change, no respond/appeal (next PR), no gate-behavior change (a failed status fetch neither relaxes nor tightens the gate; it isn't wired into gate state at all). Per the agreed phasing, tests for this layer land in the final `test/case-lifecycle` PR.

## Verification

Full OnymIOSTests suite green locally on a signed simulator test host (no behavior of existing paths changed; the one exhaustive-switch update routes the new correlation error to the non-deterministic branch, matching `reportIdentifierMismatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)