### PR TITLE
feat(moderation): accused-side case submissions — response and appeal

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/CaseSubmissionStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/CaseSubmissionStore.swift
@@ -18,8 +18,13 @@ public struct CaseSubmissionRecord: Codable, Sendable, Equatable {
 
     public let caseId: String
     public let mandateRef: String
-    /// `onym:key:` reference of the submitting user, for
-    /// identity-removal purge (same contract as the other ledgers).
+    /// `onym:key:` reference of the LOCAL identity that filed this
+    /// submission, for identity-removal purge (same contract as the
+    /// other ledgers). For a response or ordinary appeal this equals
+    /// the case mandate's user; for a new-holder claim it is the
+    /// device's current identity — the mandated user is by premise not
+    /// local, and keying the row to them would let the purge silently
+    /// drop a pending claim's retry artifact.
     public let user: String
     public let authorityName: String
     public let kind: Kind

--- a/Packages/OnymModeration/Sources/OnymModeration/CaseSubmissionStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/CaseSubmissionStore.swift
@@ -1,0 +1,125 @@
+import Foundation
+import OnymFoundation
+
+/// Exact signed case submission (response or appeal), retained across
+/// ambiguous delivery outcomes so a retry re-delivers byte-identical
+/// content — never differently signed content. Records with a receipt
+/// remain as a local idempotency ledger: the reference Authority does
+/// NOT deduplicate responses (each delivery files a new row, bounded
+/// at 32 per case), so client-side "same statement → same artifact →
+/// return the stored receipt" is the only thing keeping a double-tap
+/// or a re-entered identical statement from filing twice.
+public struct CaseSubmissionRecord: Codable, Sendable, Equatable {
+    public enum Kind: String, Codable, Sendable {
+        case response
+        case appeal
+        case newHolderClaim
+    }
+
+    public let caseId: String
+    public let mandateRef: String
+    /// `onym:key:` reference of the submitting user, for
+    /// identity-removal purge (same contract as the other ledgers).
+    public let user: String
+    public let authorityName: String
+    public let kind: Kind
+    /// Exactly one of these is set, matching `kind`. Stored whole —
+    /// including the signature — so retry re-encodes the identical
+    /// canonical bytes.
+    public let response: CaseResponse?
+    public let appeal: AppealSubmission?
+    public var responseReceipt: CaseResponseReceipt?
+    public var appealReceipt: AppealReceipt?
+    public let createdAt: Date
+
+    public init(
+        caseId: String,
+        mandateRef: String,
+        user: String,
+        authorityName: String,
+        kind: Kind,
+        response: CaseResponse? = nil,
+        appeal: AppealSubmission? = nil,
+        responseReceipt: CaseResponseReceipt? = nil,
+        appealReceipt: AppealReceipt? = nil,
+        createdAt: Date
+    ) {
+        self.caseId = caseId
+        self.mandateRef = mandateRef
+        self.user = user
+        self.authorityName = authorityName
+        self.kind = kind
+        self.response = response
+        self.appeal = appeal
+        self.responseReceipt = responseReceipt
+        self.appealReceipt = appealReceipt
+        self.createdAt = createdAt
+    }
+
+    /// Delivery reached a terminal acknowledged outcome; the row is
+    /// retained only as the idempotency ledger and prunes under the
+    /// resolved retention bound.
+    public var isResolved: Bool {
+        responseReceipt != nil || appealReceipt != nil
+    }
+}
+
+public protocol CaseSubmissionStore: Sendable {
+    func load() -> [CaseSubmissionRecord]
+    func save(_ records: [CaseSubmissionRecord]) throws
+}
+
+/// Encrypted-at-rest, same posture as the report ledger — a statement
+/// is the user's own words about an accusation and never lands in
+/// UserDefaults as plaintext.
+public struct UserDefaultsCaseSubmissionStore: CaseSubmissionStore, @unchecked Sendable {
+    private static let recordsKey = "app.onym.ios.moderation.caseSubmissions"
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> [CaseSubmissionRecord] {
+        guard let encrypted = defaults.data(forKey: Self.recordsKey),
+              let data = try? StorageEncryption.decrypt(encrypted),
+              let records = try? Self.decoder().decode([CaseSubmissionRecord].self, from: data)
+        else { return [] }
+        return records
+    }
+
+    public func save(_ records: [CaseSubmissionRecord]) throws {
+        let data = try Self.encoder().encode(records)
+        let encrypted = try StorageEncryption.encrypt(data)
+        defaults.set(encrypted, forKey: Self.recordsKey)
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+public final class InMemoryCaseSubmissionStore: CaseSubmissionStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var records: [CaseSubmissionRecord]
+
+    public init(records: [CaseSubmissionRecord] = []) {
+        self.records = records
+    }
+
+    public func load() -> [CaseSubmissionRecord] {
+        lock.withLock { records }
+    }
+
+    public func save(_ records: [CaseSubmissionRecord]) {
+        lock.withLock { self.records = records }
+    }
+}

--- a/Packages/OnymModeration/Sources/OnymModeration/CaseSubmissionStore.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/CaseSubmissionStore.swift
@@ -16,6 +16,9 @@ public struct CaseSubmissionRecord: Codable, Sendable, Equatable {
         case newHolderClaim
     }
 
+    /// Stable row identity, so ledger mutations can never alias two
+    /// rows that happen to share content and a (test-fixed) clock.
+    public let id: UUID
     public let caseId: String
     public let mandateRef: String
     /// `onym:key:` reference of the LOCAL identity that filed this
@@ -38,6 +41,7 @@ public struct CaseSubmissionRecord: Codable, Sendable, Equatable {
     public let createdAt: Date
 
     public init(
+        id: UUID = UUID(),
         caseId: String,
         mandateRef: String,
         user: String,
@@ -49,6 +53,7 @@ public struct CaseSubmissionRecord: Codable, Sendable, Equatable {
         appealReceipt: AppealReceipt? = nil,
         createdAt: Date
     ) {
+        self.id = id
         self.caseId = caseId
         self.mandateRef = mandateRef
         self.user = user

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -174,6 +174,41 @@ public struct AppealSubmission: Codable, Sendable, Equatable {
     }
 }
 
+/// The Authority's acknowledgment of a filed case response
+/// (`POST /v1/cases/{id}/respond`). The reference enforces no response
+/// deadline — a late filing is accepted and flagged, never refused —
+/// so `late` is information for the user, not an error.
+public struct CaseResponseReceipt: Codable, Sendable, Equatable {
+    public let caseId: String
+    public let recorded: Bool
+    public let late: Bool
+
+    public init(caseId: String, recorded: Bool, late: Bool) {
+        self.caseId = caseId
+        self.recorded = recorded
+        self.late = late
+    }
+}
+
+/// The Authority's acknowledgment of an appeal or new-holder filing.
+/// For a new-holder claim the reference answers 200 with `filed: true`
+/// unconditionally — deliberately non-oracular — so `filed` never
+/// proves the claim was recorded; only the authenticated status
+/// endpoint's `newHolderState` can show that.
+public struct AppealReceipt: Codable, Sendable, Equatable {
+    public let caseId: String
+    public let filed: Bool
+    public let kind: String
+    public let note: String?
+
+    public init(caseId: String, filed: Bool, kind: String, note: String? = nil) {
+        self.caseId = caseId
+        self.filed = filed
+        self.kind = kind
+        self.note = note
+    }
+}
+
 /// One entry of the Authority's case event log. The reference exposes
 /// timestamps and kinds only ("case_opened", "response", "decided",
 /// "appeal_filed", ...) — details are never served to a party.
@@ -253,8 +288,10 @@ public struct CaseStatus: Codable, Sendable, Equatable {
 public protocol ModerationAuthorityClient: Sendable {
     func registerMandate(_ mandate: ModerationMandate) async throws -> MandateRegistrationReceipt
     func fileReport(_ report: Report) async throws -> ReportReceipt
-    func respond(_ response: CaseResponse) async throws
-    func appeal(_ submission: AppealSubmission) async throws
+    @discardableResult
+    func respond(_ response: CaseResponse) async throws -> CaseResponseReceipt
+    @discardableResult
+    func appeal(_ submission: AppealSubmission) async throws -> AppealReceipt
     func queryStatus(caseId: String) async throws -> CaseStatus
 }
 
@@ -343,22 +380,40 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         return receipt
     }
 
-    public func respond(_ response: CaseResponse) async throws {
+    @discardableResult
+    public func respond(_ response: CaseResponse) async throws -> CaseResponseReceipt {
         let body = try ModerationCanonicalEncoder.encode(response)
-        _ = try await send(
+        let data = try await send(
             method: "POST",
             path: ["v1", "cases", response.caseId, "respond"],
             body: body
         )
+        let receipt: CaseResponseReceipt = try decode(data)
+        guard receipt.caseId == response.caseId else {
+            throw AuthorityClientError.caseIdentifierMismatch(
+                expected: response.caseId,
+                received: receipt.caseId
+            )
+        }
+        return receipt
     }
 
-    public func appeal(_ submission: AppealSubmission) async throws {
+    @discardableResult
+    public func appeal(_ submission: AppealSubmission) async throws -> AppealReceipt {
         let body = try ModerationCanonicalEncoder.encode(submission)
-        _ = try await send(
+        let data = try await send(
             method: "POST",
             path: ["v1", "cases", submission.caseId, "appeal"],
             body: body
         )
+        let receipt: AppealReceipt = try decode(data)
+        guard receipt.caseId == submission.caseId else {
+            throw AuthorityClientError.caseIdentifierMismatch(
+                expected: submission.caseId,
+                received: receipt.caseId
+            )
+        }
+        return receipt
     }
 
     public func queryStatus(caseId: String) async throws -> CaseStatus {
@@ -519,11 +574,11 @@ public struct StubModerationAuthorityClient: ModerationAuthorityClient {
         throw ModerationError.notImplemented("file-report")
     }
 
-    public func respond(_ response: CaseResponse) async throws {
+    public func respond(_ response: CaseResponse) async throws -> CaseResponseReceipt {
         throw ModerationError.notImplemented("respond")
     }
 
-    public func appeal(_ submission: AppealSubmission) async throws {
+    public func appeal(_ submission: AppealSubmission) async throws -> AppealReceipt {
         throw ModerationError.notImplemented("appeal")
     }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -135,7 +135,10 @@ public struct CaseResponse: Codable, Sendable, Equatable {
 
 /// An appeal filed within the declared window — or a new-holder claim,
 /// which the spec treats as a mandatory appeal class with expedited
-/// review (§5.7, error `new_holder_claim`).
+/// review (§5.7; the spec's error identifier is `new_holder_claim`,
+/// but the reference wire value for `kind` — request and echoed
+/// receipt alike — is the hyphenated `new-holder-claim`, and the
+/// reference echoes the submitted string verbatim).
 public struct AppealSubmission: Codable, Sendable, Equatable {
     public enum Kind: String, Codable, Sendable {
         case appeal

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -413,6 +413,13 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
                 received: receipt.caseId
             )
         }
+        // The reference echoes the filed kind; an acknowledgment for a
+        // different kind must not be attributed to this submission.
+        guard receipt.kind == submission.kind.rawValue else {
+            throw AuthorityClientError.malformedResponse(
+                "appeal receipt kind '\(receipt.kind)' does not match submitted '\(submission.kind.rawValue)'"
+            )
+        }
         return receipt
     }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -50,6 +50,11 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// A case statement failed local validation (empty, or beyond the
     /// reference Authority's byte cap) before any signing or delivery.
     case statementInvalid(String)
+    /// Internal ledger invariant violation (a record whose payload
+    /// doesn't match its kind). Unreachable by construction from any
+    /// user input; surfaced distinctly so it is never rendered as a
+    /// validation message.
+    case ledgerInconsistent(String)
     /// The Authority answered 409: it already holds this exact report.
     /// A terminal, benign outcome — the allegation is on file — but the
     /// original receipt (caseId) cannot be recovered without a lookup

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -47,6 +47,9 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// so switching the selected identity — not switching authorities —
     /// is what resolves this.
     case caseAccessUnavailable(String)
+    /// A case statement failed local validation (empty, or beyond the
+    /// reference Authority's byte cap) before any signing or delivery.
+    case statementInvalid(String)
     /// The Authority answered 409: it already holds this exact report.
     /// A terminal, benign outcome — the allegation is on file — but the
     /// original receipt (caseId) cannot be recovered without a lookup

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -93,9 +93,15 @@ public actor ModerationRepository {
 
     /// Retention bound on resolved case-submission ledger rows, same
     /// scheme as `maxResolvedReportRecords`: acknowledged rows prune
-    /// oldest-first; rows whose delivery is still ambiguous are always
-    /// kept — they are the byte-identical-retry artifacts.
+    /// oldest-first.
     public static let maxResolvedCaseSubmissions = 128
+
+    /// Bound on pending (unacknowledged) submission rows. Unlike report
+    /// rows, dropping one cannot mint a duplicate allegation — the
+    /// reference doesn't deduplicate submissions anyway — so a
+    /// generous cap beats unbounded statement text accumulating from
+    /// edited retries while the Authority is unreachable.
+    public static let maxPendingCaseSubmissions = 128
 
     /// Retention bound on cached case-status snapshots. Snapshots
     /// upsert by caseId, so the set grows only with distinct cases
@@ -153,6 +159,7 @@ public actor ModerationRepository {
         let authority: String
         let user: String
         let caseId: String
+        let mandateRef: String
         let kind: CaseSubmissionRecord.Kind
         let statementHash: String
     }
@@ -687,6 +694,7 @@ public actor ModerationRepository {
             authority: listing.componentId,
             user: record.mandate.user,
             caseId: caseId,
+            mandateRef: mandateRef,
             kind: .response,
             statementHash: Self.statementHash(statement)
         )
@@ -703,7 +711,17 @@ public actor ModerationRepository {
             )
         }
         caseResponseTasks[key] = task
-        defer { caseResponseTasks.removeValue(forKey: key) }
+        // The flight key is released by a janitor task AFTER delivery
+        // completes — not by a caller-side defer, which a cancelled
+        // awaiting caller would run while the unstructured delivery
+        // task keeps going, letting a second call start a concurrent
+        // duplicate delivery against a server with no idempotency
+        // token. (A completed task lingering briefly in the dictionary
+        // is harmless: new callers receive its settled result.)
+        Task {
+            _ = try? await task.value
+            self.caseResponseTasks.removeValue(forKey: key)
+        }
         return try await task.value
     }
 
@@ -750,6 +768,7 @@ public actor ModerationRepository {
             authority: listing.componentId,
             user: submittingUser,
             caseId: caseId,
+            mandateRef: mandateRef,
             kind: recordKind,
             statementHash: Self.statementHash(statement)
         )
@@ -768,7 +787,11 @@ public actor ModerationRepository {
             )
         }
         caseAppealTasks[key] = task
-        defer { caseAppealTasks.removeValue(forKey: key) }
+        // Same janitor-cleanup rationale as `respond`.
+        Task {
+            _ = try? await task.value
+            self.caseAppealTasks.removeValue(forKey: key)
+        }
         return try await task.value
     }
 
@@ -900,7 +923,11 @@ public actor ModerationRepository {
             // anti-oracle 404) cannot become an acceptance through
             // exact replay; retaining the artifact would deadlock the
             // key. Ambiguous outcomes keep it for byte-identical retry.
-            if isDeterministicReportRejection(error) {
+            // A post-200 correlation/decoding failure is terminal too:
+            // the server accepted and does not deduplicate, so a
+            // "retry" would file a second row, not resolve the first.
+            if isDeterministicReportRejection(error)
+                || Self.isPostAcceptanceFailure(error) {
                 discardSubmission(submission)
             }
             throw error
@@ -921,7 +948,8 @@ public actor ModerationRepository {
         do {
             receipt = try await client.appeal(appeal)
         } catch {
-            if isDeterministicReportRejection(error) {
+            if isDeterministicReportRejection(error)
+                || Self.isPostAcceptanceFailure(error) {
                 discardSubmission(submission)
             }
             throw error
@@ -933,17 +961,18 @@ public actor ModerationRepository {
     /// Record the acknowledgment. The Authority's answer is
     /// authoritative and must reach the caller; a persistence failure
     /// is logged (error only), not surfaced as a delivery failure.
+    ///
+    /// A row absent from the ledger stays absent: the only removal
+    /// paths are deterministic discard and the identity-removal purge,
+    /// and resurrecting a purged row would re-persist a removed
+    /// identity's statement, defeating the purge contract. The receipt
+    /// still returns to the caller.
     private func finishSubmission(
         _ submission: CaseSubmissionRecord,
         apply: (inout CaseSubmissionRecord) -> Void
     ) {
-        if let index = submissionIndex(of: submission) {
-            apply(&caseSubmissions[index])
-        } else {
-            var recovered = submission
-            apply(&recovered)
-            caseSubmissions.insert(recovered, at: 0)
-        }
+        guard let index = submissionIndex(of: submission) else { return }
+        apply(&caseSubmissions[index])
         do {
             try saveCaseSubmissions()
         } catch {
@@ -951,31 +980,43 @@ public actor ModerationRepository {
         }
     }
 
-    /// Persist the ledger, pruning acknowledged rows past the bound.
-    /// The array is newest-first, so counting down the list keeps the
-    /// newest resolved rows and drops the oldest. The prune commits to
-    /// memory only after the store write succeeds — a failed save must
-    /// not leave rows dropped in memory while still on disk.
+    /// Persist the ledger, pruning acknowledged rows past the bound —
+    /// and, unlike the report ledger, pending rows past their own
+    /// bound: the reference does not deduplicate submissions, so a
+    /// dropped pending row costs at worst a re-file the user performs
+    /// knowingly, whereas unbounded pending statements (each up to
+    /// 16 KB, one per edited retry while the Authority is unreachable)
+    /// would grow without limit. The array is newest-first; the prune
+    /// commits to memory only after the store write succeeds.
     private func saveCaseSubmissions() throws {
         var resolvedKept = 0
+        var pendingKept = 0
+        var droppedPending = 0
         let pruned = caseSubmissions.filter { record in
-            guard record.isResolved else { return true }
-            resolvedKept += 1
-            return resolvedKept <= Self.maxResolvedCaseSubmissions
+            if record.isResolved {
+                resolvedKept += 1
+                return resolvedKept <= Self.maxResolvedCaseSubmissions
+            }
+            pendingKept += 1
+            if pendingKept > Self.maxPendingCaseSubmissions {
+                droppedPending += 1
+                return false
+            }
+            return true
         }
         try caseSubmissionStore.save(pruned)
         caseSubmissions = pruned
+        if droppedPending > 0 {
+            // Never silent: a dropped pending row means that retry
+            // artifact is gone and re-filing is a fresh submission.
+            Self.logger.notice(
+                "case submission ledger dropped \(droppedPending) oldest pending rows past the bound"
+            )
+        }
     }
 
     private func submissionIndex(of submission: CaseSubmissionRecord) -> Int? {
-        caseSubmissions.firstIndex {
-            $0.caseId == submission.caseId
-                && $0.kind == submission.kind
-                && $0.user == submission.user
-                && $0.response?.statement == submission.response?.statement
-                && $0.appeal?.statement == submission.appeal?.statement
-                && $0.createdAt == submission.createdAt
-        }
+        caseSubmissions.firstIndex { $0.id == submission.id }
     }
 
     private func discardSubmission(_ submission: CaseSubmissionRecord) {
@@ -995,6 +1036,20 @@ public actor ModerationRepository {
             )
         }
         return trimmed
+    }
+
+    /// Failures that can only occur AFTER the Authority answered 200:
+    /// a receipt that fails caseId/kind correlation or cannot be
+    /// decoded. The submission was accepted server-side, so the
+    /// artifact must not be retained as retryable.
+    private static func isPostAcceptanceFailure(_ error: Error) -> Bool {
+        switch error {
+        case AuthorityClientError.caseIdentifierMismatch,
+             AuthorityClientError.malformedResponse:
+            return true
+        default:
+            return false
+        }
     }
 
     private static func statementHash(_ statement: String) -> String {
@@ -1176,12 +1231,14 @@ public actor ModerationRepository {
                 received: receipt.reportId
             )
         }
+        // A row absent from the ledger stays absent — the only removal
+        // paths are deterministic discard and the identity-removal
+        // purge, and resurrecting a purged row would re-persist a
+        // removed identity's disclosure. The receipt still returns.
         if let index = reportIndex(of: record) {
             reportRecords[index].receipt = receipt
         } else {
-            var recovered = record
-            recovered.receipt = receipt
-            reportRecords.insert(recovered, at: 0)
+            return receipt
         }
         do {
             try saveReportRecords()

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -86,6 +86,17 @@ public actor ModerationRepository {
     /// accumulate indefinitely.
     public static let maxResolvedReportRecords = 128
 
+    /// Reference Authority's cap on a statement body
+    /// (`MAX_STATEMENT_BYTES`). Checked client-side so an oversize
+    /// statement fails fast with a usable message instead of a 400.
+    public static let maxStatementBytes = 16_384
+
+    /// Retention bound on resolved case-submission ledger rows, same
+    /// scheme as `maxResolvedReportRecords`: acknowledged rows prune
+    /// oldest-first; rows whose delivery is still ambiguous are always
+    /// kept — they are the byte-identical-retry artifacts.
+    public static let maxResolvedCaseSubmissions = 128
+
     /// Retention bound on cached case-status snapshots. Snapshots
     /// upsert by caseId, so the set grows only with distinct cases
     /// against this device's identities; the bound is a backstop, and
@@ -98,6 +109,7 @@ public actor ModerationRepository {
     private let mandateStore: any MandateStore
     private let reportStore: any ReportFilingStore
     private let caseStore: any CaseStatusStore
+    private let caseSubmissionStore: any CaseSubmissionStore
     private let backend: any EnforcementBackendClient
     private let authorityClients: any ModerationAuthorityClientFactory
     private let attestation: any DeviceAttestationProvider
@@ -137,17 +149,28 @@ public actor ModerationRepository {
         let caseId: String
     }
 
+    private struct CaseSubmissionKey: Hashable {
+        let authority: String
+        let user: String
+        let caseId: String
+        let kind: CaseSubmissionRecord.Kind
+        let statementHash: String
+    }
+
     private var authorities: [AuthorityListing] = []
     private var fetchStatus: AuthorityFetchStatus = .idle
     private var records: [MandateRecord]
     private var reportRecords: [ReportFilingRecord]
     private var caseRecords: [CaseStatusRecord]
+    private var caseSubmissions: [CaseSubmissionRecord]
     private var continuations: [UUID: AsyncStream<ModerationState>.Continuation] = [:]
     private var startTask: Task<Void, Never>?
     private var consentTasks: [ConsentKey: Task<MandateRecord, Error>] = [:]
     private var registrationFlights: [RegistrationKey: RegistrationFlight] = [:]
     private var reportTasks: [ReportKey: Task<ReportReceipt, Error>] = [:]
     private var caseStatusTasks: [CaseStatusKey: Task<CaseStatus, Error>] = [:]
+    private var caseResponseTasks: [CaseSubmissionKey: Task<CaseResponseReceipt, Error>] = [:]
+    private var caseAppealTasks: [CaseSubmissionKey: Task<AppealReceipt, Error>] = [:]
 
     public init(
         authoritiesFetcher: any KnownAuthoritiesFetcher,
@@ -155,6 +178,7 @@ public actor ModerationRepository {
         mandateStore: any MandateStore,
         reportStore: any ReportFilingStore = UserDefaultsReportFilingStore(),
         caseStore: any CaseStatusStore = UserDefaultsCaseStatusStore(),
+        caseSubmissionStore: any CaseSubmissionStore = UserDefaultsCaseSubmissionStore(),
         backend: any EnforcementBackendClient,
         authorityClients: any ModerationAuthorityClientFactory,
         attestation: any DeviceAttestationProvider,
@@ -168,6 +192,7 @@ public actor ModerationRepository {
         self.mandateStore = mandateStore
         self.reportStore = reportStore
         self.caseStore = caseStore
+        self.caseSubmissionStore = caseSubmissionStore
         self.backend = backend
         self.authorityClients = authorityClients
         self.attestation = attestation
@@ -176,6 +201,7 @@ public actor ModerationRepository {
         self.records = mandateStore.load()
         self.reportRecords = reportStore.load()
         self.caseRecords = caseStore.load()
+        self.caseSubmissions = caseSubmissionStore.load()
     }
 
     // MARK: - Directory refresh
@@ -563,17 +589,24 @@ public actor ModerationRepository {
     /// Standing for any accused-side case operation: the case's mandate
     /// must be retained, owned by the active identity, and its
     /// Authority resolvable in the current directory.
+    /// `requireOwnership: false` exists for one caller: a new-holder
+    /// claim, whose premise is that the device's current holder is NOT
+    /// the mandated user (the reference accepts it unsigned for the
+    /// same reason). Everything else must own the mandate it acts under.
     private func caseStanding(
-        mandateRef: String
+        mandateRef: String,
+        requireOwnership: Bool = true
     ) async throws -> (MandateRecord, AuthorityListing) {
         guard let record = mandateRecord(forRef: mandateRef) else {
             throw ModerationError.noMandate
         }
-        let userKey = try await signer.userKeyID()
-        guard userKey == record.mandate.user else {
-            throw ModerationError.caseAccessUnavailable(
-                "active identity does not own the case's mandate"
-            )
+        if requireOwnership {
+            let userKey = try await signer.userKeyID()
+            guard userKey == record.mandate.user else {
+                throw ModerationError.caseAccessUnavailable(
+                    "active identity does not own the case's mandate"
+                )
+            }
         }
         guard let listing = authorities.first(where: {
             $0.componentId == record.mandate.authority
@@ -625,6 +658,328 @@ public actor ModerationRepository {
             Self.logger.error("case snapshot persistence failed: \(error)")
         }
         return status
+    }
+
+    // MARK: - Case submissions (accused side)
+
+    /// File the accused's signed statement on an open case. Standing
+    /// follows the case's mandate (resolved by reference, owned by the
+    /// active identity). The signed artifact is persisted before
+    /// delivery and ambiguous outcomes retry byte-identically; an
+    /// identical statement re-submitted after an acknowledgment returns
+    /// the stored receipt instead of re-delivering — the reference
+    /// Authority does NOT deduplicate responses (every delivery files
+    /// a new row, bounded at 32 per case), so this client-side ledger
+    /// is the only double-file protection.
+    ///
+    /// The reference enforces no response deadline: a late statement
+    /// is accepted and flagged (`receipt.late`), never refused. Client
+    /// deadline gating is therefore advisory UI, not enforcement.
+    @discardableResult
+    public func respond(
+        caseId: String,
+        mandateRef: String,
+        statement: String
+    ) async throws -> CaseResponseReceipt {
+        let statement = try Self.validatedStatement(statement)
+        let (record, listing) = try await caseStanding(mandateRef: mandateRef)
+        let key = CaseSubmissionKey(
+            authority: listing.componentId,
+            user: record.mandate.user,
+            caseId: caseId,
+            kind: .response,
+            statementHash: Self.statementHash(statement)
+        )
+        if let task = caseResponseTasks[key] {
+            return try await task.value
+        }
+        let task = Task {
+            try await self.performRespond(
+                caseId: caseId,
+                mandateRef: mandateRef,
+                statement: statement,
+                record: record,
+                listing: listing
+            )
+        }
+        caseResponseTasks[key] = task
+        defer { caseResponseTasks.removeValue(forKey: key) }
+        return try await task.value
+    }
+
+    /// File an appeal (`.appeal`, signed, gated server-side on a ban
+    /// with an open appeal window) or a new-holder claim
+    /// (`.newHolderClaim`, which the reference accepts unsigned and
+    /// answers 200 unconditionally — `receipt.filed` never proves the
+    /// claim was recorded). Same persist-before-deliver / exact-retry /
+    /// single-flight discipline as `respond`.
+    @discardableResult
+    public func appeal(
+        caseId: String,
+        mandateRef: String,
+        kind: AppealSubmission.Kind,
+        statement: String
+    ) async throws -> AppealReceipt {
+        let statement = try Self.validatedStatement(statement)
+        // A new-holder claim is definitionally filed by someone who is
+        // not the mandated user; ownership is not required for it.
+        let (record, listing) = try await caseStanding(
+            mandateRef: mandateRef,
+            requireOwnership: kind == .appeal
+        )
+        let recordKind: CaseSubmissionRecord.Kind =
+            kind == .appeal ? .appeal : .newHolderClaim
+        let key = CaseSubmissionKey(
+            authority: listing.componentId,
+            user: record.mandate.user,
+            caseId: caseId,
+            kind: recordKind,
+            statementHash: Self.statementHash(statement)
+        )
+        if let task = caseAppealTasks[key] {
+            return try await task.value
+        }
+        let task = Task {
+            try await self.performAppeal(
+                caseId: caseId,
+                mandateRef: mandateRef,
+                kind: kind,
+                recordKind: recordKind,
+                statement: statement,
+                record: record,
+                listing: listing
+            )
+        }
+        caseAppealTasks[key] = task
+        defer { caseAppealTasks.removeValue(forKey: key) }
+        return try await task.value
+    }
+
+    /// Ledger rows for one case, newest first — pending rows are the
+    /// retry artifacts, acknowledged rows the filing history.
+    public func caseSubmissions(caseId: String) -> [CaseSubmissionRecord] {
+        caseSubmissions.filter { $0.caseId == caseId }
+    }
+
+    /// Same contract as the other ledgers: drop every submission not
+    /// owned by one of `users` when an identity is removed.
+    public func purgeCaseSubmissionRecords(keepingUsers users: Set<String>) {
+        let before = caseSubmissions.count
+        caseSubmissions.removeAll { !users.contains($0.user) }
+        guard caseSubmissions.count != before else { return }
+        try? caseSubmissionStore.save(caseSubmissions)
+    }
+
+    private func performRespond(
+        caseId: String,
+        mandateRef: String,
+        statement: String,
+        record: MandateRecord,
+        listing: AuthorityListing
+    ) async throws -> CaseResponseReceipt {
+        if let existing = caseSubmissions.first(where: {
+            $0.kind == .response
+                && $0.caseId == caseId
+                && $0.user == record.mandate.user
+                && $0.mandateRef == mandateRef
+                && $0.response?.statement == statement
+        }) {
+            if let receipt = existing.responseReceipt { return receipt }
+            return try await deliverResponse(existing, to: listing)
+        }
+
+        var response = CaseResponse(
+            caseId: caseId,
+            statement: statement,
+            evidence: []
+        )
+        response.signature = try await signer.sign(response.signingBytes())
+            .base64EncodedString()
+        let submission = CaseSubmissionRecord(
+            caseId: caseId,
+            mandateRef: mandateRef,
+            user: record.mandate.user,
+            authorityName: listing.name,
+            kind: .response,
+            response: response,
+            createdAt: clock()
+        )
+        try persistNewSubmission(submission)
+        return try await deliverResponse(submission, to: listing)
+    }
+
+    private func performAppeal(
+        caseId: String,
+        mandateRef: String,
+        kind: AppealSubmission.Kind,
+        recordKind: CaseSubmissionRecord.Kind,
+        statement: String,
+        record: MandateRecord,
+        listing: AuthorityListing
+    ) async throws -> AppealReceipt {
+        if let existing = caseSubmissions.first(where: {
+            $0.kind == recordKind
+                && $0.caseId == caseId
+                && $0.user == record.mandate.user
+                && $0.mandateRef == mandateRef
+                && $0.appeal?.statement == statement
+        }) {
+            if let receipt = existing.appealReceipt { return receipt }
+            return try await deliverAppeal(existing, to: listing)
+        }
+
+        var appeal = AppealSubmission(
+            caseId: caseId,
+            kind: kind,
+            statement: statement
+        )
+        // A new-holder claim is signed too — the reference ignores the
+        // signature by design, but signing costs nothing and keeps the
+        // artifact self-describing if the endpoint ever authenticates.
+        appeal.signature = try await signer.sign(appeal.signingBytes())
+            .base64EncodedString()
+        let submission = CaseSubmissionRecord(
+            caseId: caseId,
+            mandateRef: mandateRef,
+            user: record.mandate.user,
+            authorityName: listing.name,
+            kind: recordKind,
+            appeal: appeal,
+            createdAt: clock()
+        )
+        try persistNewSubmission(submission)
+        return try await deliverAppeal(submission, to: listing)
+    }
+
+    /// Delivery must not begin unless the exact signed artifact is
+    /// durably retained — a transport timeout may happen after the
+    /// Authority committed, and only the persisted artifact lets the
+    /// retry re-deliver byte-identical content.
+    private func persistNewSubmission(_ submission: CaseSubmissionRecord) throws {
+        caseSubmissions.insert(submission, at: 0)
+        do {
+            try saveCaseSubmissions()
+        } catch {
+            if let index = submissionIndex(of: submission) {
+                caseSubmissions.remove(at: index)
+            }
+            throw error
+        }
+    }
+
+    private func deliverResponse(
+        _ submission: CaseSubmissionRecord,
+        to listing: AuthorityListing
+    ) async throws -> CaseResponseReceipt {
+        guard let response = submission.response else {
+            throw ModerationError.statementInvalid("submission holds no response")
+        }
+        let client = authorityClients.client(for: listing)
+        let receipt: CaseResponseReceipt
+        do {
+            receipt = try await client.respond(response)
+        } catch {
+            // Deterministic refusal (case already decided, filing cap,
+            // anti-oracle 404) cannot become an acceptance through
+            // exact replay; retaining the artifact would deadlock the
+            // key. Ambiguous outcomes keep it for byte-identical retry.
+            if isDeterministicReportRejection(error) {
+                discardSubmission(submission)
+            }
+            throw error
+        }
+        finishSubmission(submission) { $0.responseReceipt = receipt }
+        return receipt
+    }
+
+    private func deliverAppeal(
+        _ submission: CaseSubmissionRecord,
+        to listing: AuthorityListing
+    ) async throws -> AppealReceipt {
+        guard let appeal = submission.appeal else {
+            throw ModerationError.statementInvalid("submission holds no appeal")
+        }
+        let client = authorityClients.client(for: listing)
+        let receipt: AppealReceipt
+        do {
+            receipt = try await client.appeal(appeal)
+        } catch {
+            if isDeterministicReportRejection(error) {
+                discardSubmission(submission)
+            }
+            throw error
+        }
+        finishSubmission(submission) { $0.appealReceipt = receipt }
+        return receipt
+    }
+
+    /// Record the acknowledgment. The Authority's answer is
+    /// authoritative and must reach the caller; a persistence failure
+    /// is logged (error only), not surfaced as a delivery failure.
+    private func finishSubmission(
+        _ submission: CaseSubmissionRecord,
+        apply: (inout CaseSubmissionRecord) -> Void
+    ) {
+        if let index = submissionIndex(of: submission) {
+            apply(&caseSubmissions[index])
+        } else {
+            var recovered = submission
+            apply(&recovered)
+            caseSubmissions.insert(recovered, at: 0)
+        }
+        do {
+            try saveCaseSubmissions()
+        } catch {
+            Self.logger.error("case submission persistence failed: \(error)")
+        }
+    }
+
+    /// Persist the ledger, pruning acknowledged rows past the bound.
+    /// The array is newest-first, so counting down the list keeps the
+    /// newest resolved rows and drops the oldest.
+    private func saveCaseSubmissions() throws {
+        var resolvedKept = 0
+        caseSubmissions = caseSubmissions.filter { record in
+            guard record.isResolved else { return true }
+            resolvedKept += 1
+            return resolvedKept <= Self.maxResolvedCaseSubmissions
+        }
+        try caseSubmissionStore.save(caseSubmissions)
+    }
+
+    private func submissionIndex(of submission: CaseSubmissionRecord) -> Int? {
+        caseSubmissions.firstIndex {
+            $0.caseId == submission.caseId
+                && $0.kind == submission.kind
+                && $0.user == submission.user
+                && $0.response?.statement == submission.response?.statement
+                && $0.appeal?.statement == submission.appeal?.statement
+                && $0.createdAt == submission.createdAt
+        }
+    }
+
+    private func discardSubmission(_ submission: CaseSubmissionRecord) {
+        guard let index = submissionIndex(of: submission) else { return }
+        caseSubmissions.remove(at: index)
+        try? saveCaseSubmissions()
+    }
+
+    private static func validatedStatement(_ statement: String) throws -> String {
+        let trimmed = statement.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ModerationError.statementInvalid("statement is empty")
+        }
+        guard trimmed.utf8.count <= Self.maxStatementBytes else {
+            throw ModerationError.statementInvalid(
+                "statement exceeds \(Self.maxStatementBytes) bytes"
+            )
+        }
+        return trimmed
+    }
+
+    private static func statementHash(_ statement: String) -> String {
+        SHA256.hash(data: Data(statement.utf8))
+            .map { String(format: "%02x", $0) }.joined()
     }
 
     // MARK: - AsyncStream

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -723,15 +723,32 @@ public actor ModerationRepository {
         let statement = try Self.validatedStatement(statement)
         // A new-holder claim is definitionally filed by someone who is
         // not the mandated user; ownership is not required for it.
+        // Scope note: standing still resolves the former holder's
+        // mandate from local history, so this path serves the
+        // same-device case where that record is retained. A fresh
+        // holder with nothing retained files from the ban surface,
+        // which has the verdict (and its mandateRef/authority) in
+        // hand — that flow lands with the case UI.
         let (record, listing) = try await caseStanding(
             mandateRef: mandateRef,
             requireOwnership: kind == .appeal
         )
+        // The ledger row belongs to the identity that FILED it — for a
+        // new-holder claim that is the device's current identity, not
+        // the mandated (previous) holder, whose key is by premise not
+        // local and would make the identity-removal purge silently
+        // drop a pending claim's retry artifact.
+        let submittingUser: String
+        if kind == .appeal {
+            submittingUser = record.mandate.user
+        } else {
+            submittingUser = try await signer.userKeyID()
+        }
         let recordKind: CaseSubmissionRecord.Kind =
             kind == .appeal ? .appeal : .newHolderClaim
         let key = CaseSubmissionKey(
             authority: listing.componentId,
-            user: record.mandate.user,
+            user: submittingUser,
             caseId: caseId,
             kind: recordKind,
             statementHash: Self.statementHash(statement)
@@ -746,7 +763,7 @@ public actor ModerationRepository {
                 kind: kind,
                 recordKind: recordKind,
                 statement: statement,
-                record: record,
+                submittingUser: submittingUser,
                 listing: listing
             )
         }
@@ -814,13 +831,13 @@ public actor ModerationRepository {
         kind: AppealSubmission.Kind,
         recordKind: CaseSubmissionRecord.Kind,
         statement: String,
-        record: MandateRecord,
+        submittingUser: String,
         listing: AuthorityListing
     ) async throws -> AppealReceipt {
         if let existing = caseSubmissions.first(where: {
             $0.kind == recordKind
                 && $0.caseId == caseId
-                && $0.user == record.mandate.user
+                && $0.user == submittingUser
                 && $0.mandateRef == mandateRef
                 && $0.appeal?.statement == statement
         }) {
@@ -841,7 +858,7 @@ public actor ModerationRepository {
         let submission = CaseSubmissionRecord(
             caseId: caseId,
             mandateRef: mandateRef,
-            user: record.mandate.user,
+            user: submittingUser,
             authorityName: listing.name,
             kind: recordKind,
             appeal: appeal,
@@ -872,7 +889,7 @@ public actor ModerationRepository {
         to listing: AuthorityListing
     ) async throws -> CaseResponseReceipt {
         guard let response = submission.response else {
-            throw ModerationError.statementInvalid("submission holds no response")
+            throw ModerationError.ledgerInconsistent("submission holds no response")
         }
         let client = authorityClients.client(for: listing)
         let receipt: CaseResponseReceipt
@@ -897,7 +914,7 @@ public actor ModerationRepository {
         to listing: AuthorityListing
     ) async throws -> AppealReceipt {
         guard let appeal = submission.appeal else {
-            throw ModerationError.statementInvalid("submission holds no appeal")
+            throw ModerationError.ledgerInconsistent("submission holds no appeal")
         }
         let client = authorityClients.client(for: listing)
         let receipt: AppealReceipt
@@ -936,15 +953,18 @@ public actor ModerationRepository {
 
     /// Persist the ledger, pruning acknowledged rows past the bound.
     /// The array is newest-first, so counting down the list keeps the
-    /// newest resolved rows and drops the oldest.
+    /// newest resolved rows and drops the oldest. The prune commits to
+    /// memory only after the store write succeeds — a failed save must
+    /// not leave rows dropped in memory while still on disk.
     private func saveCaseSubmissions() throws {
         var resolvedKept = 0
-        caseSubmissions = caseSubmissions.filter { record in
+        let pruned = caseSubmissions.filter { record in
             guard record.isResolved else { return true }
             resolvedKept += 1
             return resolvedKept <= Self.maxResolvedCaseSubmissions
         }
-        try caseSubmissionStore.save(caseSubmissions)
+        try caseSubmissionStore.save(pruned)
+        caseSubmissions = pruned
     }
 
     private func submissionIndex(of submission: CaseSubmissionRecord) -> Int? {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -729,6 +729,9 @@ struct OnymIOSApp: App {
                             await moderationRepository.purgeCaseStatusRecords(
                                 keepingUsers: keys
                             )
+                            await moderationRepository.purgeCaseSubmissionRecords(
+                                keepingUsers: keys
+                            )
                         }
                     }
                 }

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -446,8 +446,12 @@ final class ModerationAuthorityClientTests: XCTestCase {
         let recorded = RecordedBodies()
         StubURLProtocol.set { request in
             recorded.set(Self.body(of: request), for: request.url!.lastPathComponent)
+            // The reference success shapes (`authority/src/api.rs`).
+            let payload = request.url!.lastPathComponent == "respond"
+                ? #"{"caseId":"case-1","recorded":true,"late":false}"#
+                : #"{"caseId":"case-1","filed":true,"kind":"appeal","note":"reviewed by the authority"}"#
             return (
-                Data(#"{"recorded":true}"#.utf8),
+                Data(payload.utf8),
                 Self.httpResponse(for: request, status: 200)
             )
         }
@@ -460,12 +464,19 @@ final class ModerationAuthorityClientTests: XCTestCase {
             signature: "sig"
         )
 
-        try await client.respond(response)
-        try await client.appeal(appeal)
+        let responseReceipt = try await client.respond(response)
+        let appealReceipt = try await client.appeal(appeal)
 
         let bodies = recorded.snapshot()
         XCTAssertEqual(bodies["respond"], try ModerationCanonicalEncoder.encode(response))
         XCTAssertEqual(bodies["appeal"], try ModerationCanonicalEncoder.encode(appeal))
+        XCTAssertEqual(
+            responseReceipt,
+            CaseResponseReceipt(caseId: "case-1", recorded: true, late: false)
+        )
+        XCTAssertEqual(appealReceipt.caseId, "case-1")
+        XCTAssertEqual(appealReceipt.kind, "appeal")
+        XCTAssertTrue(appealReceipt.filed)
     }
 
     func testCaseIDCannotEscapeItsPathSegment() async throws {

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -479,6 +479,46 @@ final class ModerationAuthorityClientTests: XCTestCase {
         XCTAssertTrue(appealReceipt.filed)
     }
 
+    func testNewHolderClaimKindCorrelatesAgainstTheHyphenatedWireValue() async throws {
+        // The reference echoes the submitted `kind` verbatim
+        // (`authority/src/api.rs`, the new-holder branch), and the wire
+        // value is the hyphenated "new-holder-claim" — the spec's error
+        // identifier `new_holder_claim` never appears in a receipt.
+        StubURLProtocol.set { request in
+            (
+                Data(#"{"caseId":"case-1","filed":true,"kind":"new-holder-claim","note":"expedited"}"#.utf8),
+                Self.httpResponse(for: request, status: 200)
+            )
+        }
+        let receipt = try await makeClient().appeal(AppealSubmission(
+            caseId: "case-1",
+            kind: .newHolderClaim,
+            statement: "the device changed hands",
+            signature: "sig"
+        ))
+        XCTAssertEqual(receipt.kind, AppealSubmission.Kind.newHolderClaim.rawValue)
+    }
+
+    func testAppealReceiptWithMismatchedKindIsRejected() async throws {
+        StubURLProtocol.set { request in
+            (
+                Data(#"{"caseId":"case-1","filed":true,"kind":"new-holder-claim","note":"n"}"#.utf8),
+                Self.httpResponse(for: request, status: 200)
+            )
+        }
+        do {
+            _ = try await makeClient().appeal(AppealSubmission(
+                caseId: "case-1",
+                kind: .appeal,
+                statement: "review",
+                signature: "sig"
+            ))
+            XCTFail("expected the mismatched kind to be rejected")
+        } catch AuthorityClientError.malformedResponse {
+            // expected
+        }
+    }
+
     func testCaseIDCannotEscapeItsPathSegment() async throws {
         StubURLProtocol.set { _ in
             XCTFail("invalid case id must be rejected before a request is sent")

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -222,10 +222,10 @@ final class ModerationRepositoryTests: XCTestCase {
                 caseId: "case-1"
             )
         }
-        func respond(_ response: CaseResponse) async throws {
+        func respond(_ response: CaseResponse) async throws -> CaseResponseReceipt {
             throw ModerationError.notImplemented("unused")
         }
-        func appeal(_ submission: AppealSubmission) async throws {
+        func appeal(_ submission: AppealSubmission) async throws -> AppealReceipt {
             throw ModerationError.notImplemented("unused")
         }
         func queryStatus(caseId: String) async throws -> CaseStatus {


### PR DESCRIPTION
## Summary

Second of four sequential PRs for the accused-side case lifecycle (status ✅ #224 → **submissions** → UI → tests). This adds the write half of the domain: filing a signed statement on a case, and filing an appeal or new-holder claim.

- **`respond(caseId:mandateRef:statement:)`** — standing resolved by the case's mandate reference (#224), statement validated client-side against the reference's 16384-byte cap, signed over the existing canonical bytes (`caseId` inside the signature — cross-case replay stays closed), persisted before delivery, single-flighted per (authority, user, caseId, kind, statementHash).
- **`appeal(caseId:mandateRef:kind:statement:)`** — `.appeal` requires mandate ownership; `.newHolderClaim` deliberately does not (its premise is that the device's holder is *not* the mandated user — the reference accepts it unsigned for the same reason; we sign anyway since it costs nothing).
- **Exact-retry ledger** (`CaseSubmissionStore`, encrypted at rest): delivery never starts unless the signed artifact is durably persisted; ambiguous outcomes retain it so retry re-delivers byte-identical content; deterministic refusals discard it; an identical statement after acknowledgment returns the stored receipt. Resolved rows cap at 128, purged on identity removal alongside the other ledgers.
- **Receipts** — client `respond`/`appeal` now decode and correlate the reference's success bodies (`{caseId, recorded, late}` / `{caseId, filed, kind, note}`) instead of discarding them. `late` matters: the reference enforces **no response deadline** (late filings accepted and flagged), so client-side deadline gating stays advisory, per the plan.

## Reference-implementation alignment

- **The reference does not deduplicate responses** — every delivery files a new row (bounded at 32 per case, then 409 `case_state`). The client-side ledger is therefore the *only* double-file protection; that's why identical-statement resubmission short-circuits to the stored receipt. A duplicate caused by an ambiguous outcome where the server actually committed remains possible and is byte-identical by construction — the API offers no idempotency token to do better.
- Appeal gating (`disposition == ban`, 410 `window_closed`, supplements while `pending`, decided-review 409) is enforced server-side; the repository surfaces those as-is. UI-level advisory gating comes in the next PR.
- New-holder claims answer 200 unconditionally by design (non-oracular): `filed: true` never proves recording — only the authenticated status endpoint's `newHolderState` can. The receipt doc-comment says exactly this so the UI PR can't oversell it.
- Anti-oracle 404 (unknown case / bad signature / non-party are indistinguishable) is treated as a deterministic refusal: exact replay cannot change it, so the artifact is discarded rather than deadlocking the retry key.

## Scope

Domain only — no UI (next PR), no gate-behavior change, no media evidence on responses (statement + empty evidence array; disclosure UX for counter-evidence is its own decision). Per the agreed phasing, tests for this layer land in the final `test/case-lifecycle` PR.

## Verification

Full OnymIOSTests suite green locally on a signed simulator test host. One existing client test updated: its canned respond/appeal success body was `{"recorded":true}`, which the client used to discard; it now returns the reference's actual success shapes, which the client decodes and correlates — the test additionally asserts both receipts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)