### PR TITLE
feat(moderation): case UI — actionable open-case and ban surfaces

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -579,8 +579,18 @@ public actor ModerationRepository {
 
     /// The last fetched snapshot for a case, if any — for rendering
     /// offline or before the first fetch of a session completes.
-    public func storedCaseStatus(caseId: String) -> CaseStatusRecord? {
-        caseRecords.first { $0.caseId == caseId }
+    /// Owner-checked: a snapshot persisted for another local
+    /// identity's case never leaves the repository, so no caller can
+    /// render foreign case content while a network fetch is in flight.
+    public func storedCaseStatus(caseId: String) async -> CaseStatusRecord? {
+        guard let record = caseRecords.first(where: { $0.caseId == caseId }) else {
+            return nil
+        }
+        guard let userKey = try? await signer.userKeyID(),
+              record.user == userKey else {
+            return nil
+        }
+        return record
     }
 
     /// Drop every case snapshot not owned by one of `users`

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
@@ -23,8 +23,13 @@ public struct BannedView: View {
     /// the contact fallback remain for verdicts without a case path.
     let makeCaseFlow: (@MainActor (_ caseId: String, _ mandateRef: String) -> ModerationCaseFlow)?
 
+    private enum CaseSheet: String, Identifiable {
+        case appeal, newHolder
+        var id: String { rawValue }
+    }
+
     @Environment(\.openURL) private var openURL
-    @State private var showsCase = false
+    @State private var caseSheet: CaseSheet?
 
     public init(
         state: BanState,
@@ -91,13 +96,16 @@ public struct BannedView: View {
                     // In-app appeal outranks a link-out: the flow
                     // retains the exact signed filing and its receipt.
                     if let builder = caseFlowBuilder {
-                        SettingsPrimaryButton(action: { showsCase = true }) {
+                        SettingsPrimaryButton(action: { caseSheet = .appeal }) {
                             Text("Review case and appeal")
                         }
                         .accessibilityIdentifier("moderation.banned.appeal")
-                        .sheet(isPresented: $showsCase) {
+                        .sheet(item: $caseSheet) { sheet in
                             NavigationStack {
-                                ModerationCaseView(flow: builder())
+                                ModerationCaseView(
+                                    flow: builder(),
+                                    focusNewHolder: sheet == .newHolder
+                                )
                             }
                         }
                     } else if let appealURL = state.appealURL {
@@ -118,8 +126,9 @@ public struct BannedView: View {
                                 openURL(url)
                             } else if caseFlowBuilder != nil {
                                 // The case sheet carries the
-                                // new-holder section (banContext).
-                                showsCase = true
+                                // new-holder section (banContext);
+                                // open it scrolled to that section.
+                                caseSheet = .newHolder
                             } else {
                                 onNewHolderClaim?()
                             }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
@@ -17,17 +17,34 @@ public struct BannedView: View {
     /// in-app path pass `nil`, and the screen falls back to the
     /// authority's contact instead of offering a button that lies.
     let onNewHolderClaim: (() -> Void)?
+    /// Builds the in-app case flow for the banning verdict's case.
+    /// When present and the verdict is attached, appeal and new-holder
+    /// filings happen in-app; URLs (if the authority serves them) and
+    /// the contact fallback remain for verdicts without a case path.
+    let makeCaseFlow: (@MainActor (_ caseId: String, _ mandateRef: String) -> ModerationCaseFlow)?
 
     @Environment(\.openURL) private var openURL
+    @State private var showsCase = false
 
-    public init(state: BanState, onNewHolderClaim: (() -> Void)? = nil) {
+    public init(
+        state: BanState,
+        onNewHolderClaim: (() -> Void)? = nil,
+        makeCaseFlow: (@MainActor (_ caseId: String, _ mandateRef: String) -> ModerationCaseFlow)? = nil
+    ) {
         self.state = state
         self.onNewHolderClaim = onNewHolderClaim
+        self.makeCaseFlow = makeCaseFlow
+    }
+
+    /// In-app path into the banning case, when the verdict is attached.
+    private var caseFlowBuilder: (@MainActor () -> ModerationCaseFlow)? {
+        guard let makeCaseFlow, let verdict = state.verdict else { return nil }
+        return { makeCaseFlow(verdict.caseId, verdict.mandateRef) }
     }
 
     /// Whether the new-holder path can actually be reached from here.
     private var hasNewHolderPath: Bool {
-        state.newHolderURL != nil || onNewHolderClaim != nil
+        state.newHolderURL != nil || onNewHolderClaim != nil || caseFlowBuilder != nil
     }
 
     public var body: some View {
@@ -71,7 +88,19 @@ public struct BannedView: View {
                 SettingsFootnote("The ban covers this device on this app only. The Onym protocol itself remains open.")
 
                 VStack(spacing: 10) {
-                    if let appealURL = state.appealURL {
+                    // In-app appeal outranks a link-out: the flow
+                    // retains the exact signed filing and its receipt.
+                    if let builder = caseFlowBuilder {
+                        SettingsPrimaryButton(action: { showsCase = true }) {
+                            Text("Review case and appeal")
+                        }
+                        .accessibilityIdentifier("moderation.banned.appeal")
+                        .sheet(isPresented: $showsCase) {
+                            NavigationStack {
+                                ModerationCaseView(flow: builder())
+                            }
+                        }
+                    } else if let appealURL = state.appealURL {
                         SettingsPrimaryButton(action: { openURL(appealURL) }) {
                             Text("Appeal this ban")
                         }
@@ -87,6 +116,10 @@ public struct BannedView: View {
                         Button {
                             if let url = state.newHolderURL {
                                 openURL(url)
+                            } else if caseFlowBuilder != nil {
+                                // The case sheet carries the
+                                // new-holder section (banContext).
+                                showsCase = true
                             } else {
                                 onNewHolderClaim?()
                             }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
@@ -93,8 +93,14 @@ public struct BannedView: View {
                 SettingsFootnote("The ban covers this device on this app only. The Onym protocol itself remains open.")
 
                 VStack(spacing: 10) {
-                    // In-app appeal outranks a link-out: the flow
-                    // retains the exact signed filing and its receipt.
+                    // In-app appeal is primary — the flow retains the
+                    // exact signed filing and its receipt. The external
+                    // appellate link SUPPLEMENTS it rather than being
+                    // replaced: the case screen can be unable to help
+                    // (mandate no longer retained, authority missing
+                    // from the directory, anti-oracle 404), and a
+                    // permanent ban's header explicitly promises the
+                    // external appellate remains available.
                     if let builder = caseFlowBuilder {
                         SettingsPrimaryButton(action: { caseSheet = .appeal }) {
                             Text("Review case and appeal")
@@ -107,6 +113,20 @@ public struct BannedView: View {
                                     focusNewHolder: sheet == .newHolder
                                 )
                             }
+                        }
+                        if let appealURL = state.appealURL {
+                            Button {
+                                openURL(appealURL)
+                            } label: {
+                                Text("Appeal at the authority's appellate")
+                                    .font(.system(size: 15, weight: .medium))
+                                    .foregroundStyle(OnymTokens.text)
+                                    .frame(maxWidth: .infinity, minHeight: 44)
+                                    .background(OnymTokens.surface2,
+                                                in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("moderation.banned.appeal_external")
                         }
                     } else if let appealURL = state.appealURL {
                         SettingsPrimaryButton(action: { openURL(appealURL) }) {

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
@@ -122,13 +122,16 @@ public struct BannedView: View {
                     // routes them to the authority directly.
                     if hasNewHolderPath {
                         Button {
-                            if let url = state.newHolderURL {
-                                openURL(url)
-                            } else if caseFlowBuilder != nil {
+                            // In-app first, matching the appeal button:
+                            // the flow retains the exact signed filing
+                            // and its receipt, which a link-out cannot.
+                            if caseFlowBuilder != nil {
                                 // The case sheet carries the
                                 // new-holder section (banContext);
                                 // open it scrolled to that section.
                                 caseSheet = .newHolder
+                            } else if let url = state.newHolderURL {
+                                openURL(url)
                             } else {
                                 onNewHolderClaim?()
                             }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
@@ -165,6 +165,26 @@ public struct BannedView: View {
                         }
                         .buttonStyle(.plain)
                         .accessibilityIdentifier("moderation.banned.new_holder")
+                        // The authority's own procedure SUPPLEMENTS the
+                        // in-app claim, exactly like the appeal path:
+                        // the canonical new holder has a fresh install,
+                        // so the in-app filing (which signs with a
+                        // retained mandate context) can dead-end with
+                        // "mandate no longer on this device" — a
+                        // working authority URL must never be hidden
+                        // behind a form that cannot succeed for them.
+                        if caseFlowBuilder != nil, let url = state.newHolderURL {
+                            Button {
+                                openURL(url)
+                            } label: {
+                                Text("File the claim at the authority instead")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(OnymTokens.text2)
+                                    .frame(maxWidth: .infinity, minHeight: 36)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("moderation.banned.new_holder_external")
+                        }
                     }
                 }
                 .padding(.horizontal, 16)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
@@ -1,0 +1,207 @@
+import Foundation
+import OnymModeration
+
+/// Accused-side case screen state: authenticated status (with the
+/// persisted snapshot as the offline fallback), response filing, and
+/// appeal / new-holder filing. All gating here is ADVISORY — the
+/// Authority is the arbiter (the reference accepts late responses and
+/// answers 410 itself for a closed appeal window); this flow only
+/// shapes affordances and never hard-blocks a submission the server
+/// might still accept.
+@MainActor
+@Observable
+public final class ModerationCaseFlow {
+    public struct State: Equatable {
+        public var status: CaseStatus?
+        /// Non-nil while `status` is the persisted snapshot rather than
+        /// a fresh fetch — the UI labels it as of this instant.
+        public var snapshotFetchedAt: Date?
+        public var isLoading = false
+        public var isSubmittingResponse = false
+        public var isSubmittingAppeal = false
+        public var responseReceipt: CaseResponseReceipt?
+        public var appealReceipt: AppealReceipt?
+        public var statusErrorMessage: String?
+        public var responseErrorMessage: String?
+        public var appealErrorMessage: String?
+    }
+
+    public private(set) var state = State()
+    public let caseId: String
+    public let mandateRef: String
+    /// True when opened from the ban surface: the appeal and
+    /// new-holder affordances show even before (or without) a status
+    /// fetch, because the caller already holds a ban verdict.
+    public let banContext: Bool
+
+    private let repository: ModerationRepository
+    private let now: () -> Date
+
+    public init(
+        caseId: String,
+        mandateRef: String,
+        repository: ModerationRepository,
+        banContext: Bool = false,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.caseId = caseId
+        self.mandateRef = mandateRef
+        self.repository = repository
+        self.banContext = banContext
+        self.now = now
+    }
+
+    public func start() async {
+        if let stored = await repository.storedCaseStatus(caseId: caseId) {
+            state.status = stored.status
+            state.snapshotFetchedAt = stored.fetchedAt
+        }
+        await refresh()
+    }
+
+    public func refresh() async {
+        guard !state.isLoading else { return }
+        state.isLoading = true
+        state.statusErrorMessage = nil
+        defer { state.isLoading = false }
+        // The status query needs the authorities directory; a cold
+        // launch straight into the case screen may not have fetched it
+        // yet. Best-effort — a failure surfaces below as status copy.
+        try? await repository.refresh()
+        do {
+            let status = try await repository.caseStatus(
+                caseId: caseId,
+                mandateRef: mandateRef
+            )
+            state.status = status
+            state.snapshotFetchedAt = nil
+        } catch {
+            // A stale snapshot (if any) stays rendered; the error only
+            // annotates it.
+            state.statusErrorMessage = Self.statusMessage(for: error)
+        }
+    }
+
+    public func submitResponse(_ statement: String) async {
+        guard !state.isSubmittingResponse else { return }
+        state.isSubmittingResponse = true
+        state.responseErrorMessage = nil
+        defer { state.isSubmittingResponse = false }
+        do {
+            state.responseReceipt = try await repository.respond(
+                caseId: caseId,
+                mandateRef: mandateRef,
+                statement: statement
+            )
+            // Best-effort: pick up responded/responsesOnFile.
+            await refresh()
+        } catch {
+            state.responseErrorMessage = Self.submissionMessage(for: error)
+        }
+    }
+
+    public func submitAppeal(kind: AppealSubmission.Kind, statement: String) async {
+        guard !state.isSubmittingAppeal else { return }
+        state.isSubmittingAppeal = true
+        state.appealErrorMessage = nil
+        defer { state.isSubmittingAppeal = false }
+        do {
+            state.appealReceipt = try await repository.appeal(
+                caseId: caseId,
+                mandateRef: mandateRef,
+                kind: kind,
+                statement: statement
+            )
+            await refresh()
+        } catch {
+            state.appealErrorMessage = Self.submissionMessage(for: error)
+        }
+    }
+
+    // MARK: - Advisory gating
+
+    /// The reference accepts responses on any open case — even late,
+    /// flagged `late` — so the composer shows exactly while the case
+    /// is open.
+    public var canRespond: Bool {
+        state.status?.stage == "open"
+    }
+
+    /// Appeal affordance: a ban whose review isn't already decided.
+    /// From the ban surface it also shows before a status fetch —
+    /// the caller holds the verdict, and the Authority is the final
+    /// arbiter of the window either way.
+    public var showsAppealSection: Bool {
+        if let status = state.status {
+            guard status.disposition == "ban" else { return false }
+            switch status.appealState {
+            case nil, "none", "pending": return true
+            default: return false
+            }
+        }
+        return banContext
+    }
+
+    /// Non-nil when this device's clock says the appeal window has
+    /// closed — an annotation, never a hard block: clocks skew, and a
+    /// deterministic 410 from the Authority is the honest refusal.
+    public var appealDeadlinePassed: Date? {
+        guard let deadline = state.status?.appealDeadline,
+              now() > deadline else { return nil }
+        return deadline
+    }
+
+    /// Whether the response deadline has passed per this device's
+    /// clock. Advisory: the reference still accepts the filing and
+    /// marks it late.
+    public var responseDeadlinePassed: Date? {
+        guard let deadline = state.status?.responseDeadline,
+              now() > deadline else { return nil }
+        return deadline
+    }
+
+    // MARK: - Error copy
+
+    private static func statusMessage(for error: Error) -> String {
+        switch error {
+        case ModerationError.caseAccessUnavailable:
+            return String(localized: "This case belongs to a different identity on this device. Switch to the identity the case was opened against.")
+        case ModerationError.noMandate:
+            return String(localized: "The mandate this case was opened under is no longer on this device.")
+        case ModerationError.authorityUnavailable:
+            return String(localized: "Your authority isn't in the directory right now. Check your connection and try again.")
+        case let AuthorityClientError.rejected(rejection) where rejection.statusCode == 404:
+            // The reference deliberately answers 404 for unknown case,
+            // bad signature, and non-party alike — never present it as
+            // proof of anything.
+            return String(localized: "The authority didn't serve this case. That can mean a connection or identity problem — it neither confirms nor denies the case.")
+        case let AuthorityClientError.rejected(rejection):
+            return String(rejection.message.prefix(280))
+        default:
+            return String(localized: "Couldn't reach your authority for the current status.")
+        }
+    }
+
+    private static func submissionMessage(for error: Error) -> String {
+        switch error {
+        case ModerationError.statementInvalid:
+            return String(localized: "The statement is empty or exceeds your authority's 16 KB limit.")
+        case ModerationError.caseAccessUnavailable:
+            return String(localized: "This case belongs to a different identity on this device.")
+        case ModerationError.noMandate:
+            return String(localized: "The mandate this case was opened under is no longer on this device.")
+        case ModerationError.authorityUnavailable:
+            return String(localized: "Your authority isn't in the directory right now. Check your connection and try again.")
+        case let AuthorityClientError.rejected(rejection) where rejection.statusCode == 410:
+            return String(localized: "The appeal window has closed.")
+        case let AuthorityClientError.rejected(rejection) where rejection.statusCode == 404:
+            return String(localized: "The authority didn't accept this filing. That can mean a connection or identity problem — it neither confirms nor denies the case.")
+        case let AuthorityClientError.rejected(rejection):
+            // Authority-controlled text (409 case-state and friends);
+            // bounded before display.
+            return String(rejection.message.prefix(280))
+        default:
+            return String(localized: "Couldn't deliver the filing. Your signed statement is retained — try again to resend exactly the same content.")
+        }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
@@ -18,7 +18,10 @@ public final class ModerationCaseFlow {
         public var snapshotFetchedAt: Date?
         public var isLoading = false
         public var isSubmittingResponse = false
+        /// Per-kind, like the receipts/errors: an in-flight new-holder
+        /// claim must not disable (or relabel) the appeal button.
         public var isSubmittingAppeal = false
+        public var isSubmittingNewHolder = false
         public var responseReceipt: CaseResponseReceipt?
         /// Per-kind receipts and errors: an ordinary appeal and a
         /// new-holder claim are independent filings, and one must never
@@ -58,10 +61,11 @@ public final class ModerationCaseFlow {
 
     public func start() async {
         // Load the offline snapshot once (re-appearance must not
-        // relabel an already-fresh status as a snapshot), and only if
-        // it belongs to this flow's mandate — a snapshot persisted for
-        // another identity's case must never render just because the
-        // caseId matches.
+        // relabel an already-fresh status as a snapshot). Ownership is
+        // the repository's check — `storedCaseStatus` returns nothing
+        // for a snapshot another local identity owns — and the
+        // mandateRef comparison here only keeps a caller that resolved
+        // a different mandate for the same case from mixing terms.
         if state.status == nil,
            let stored = await repository.storedCaseStatus(caseId: caseId),
            stored.mandateRef == mandateRef {
@@ -129,18 +133,27 @@ public final class ModerationCaseFlow {
             // Best-effort: pick up responded/responsesOnFile.
             await refresh()
         } catch {
-            state.responseErrorMessage = Self.submissionMessage(for: error)
+            state.responseErrorMessage = Self.submissionMessage(for: error, kind: nil)
         }
     }
 
     public func submitAppeal(kind: AppealSubmission.Kind, statement: String) async {
-        guard !state.isSubmittingAppeal else { return }
-        state.isSubmittingAppeal = true
         switch kind {
-        case .appeal: state.appealErrorMessage = nil
-        case .newHolderClaim: state.newHolderErrorMessage = nil
+        case .appeal:
+            guard !state.isSubmittingAppeal else { return }
+            state.isSubmittingAppeal = true
+            state.appealErrorMessage = nil
+        case .newHolderClaim:
+            guard !state.isSubmittingNewHolder else { return }
+            state.isSubmittingNewHolder = true
+            state.newHolderErrorMessage = nil
         }
-        defer { state.isSubmittingAppeal = false }
+        defer {
+            switch kind {
+            case .appeal: state.isSubmittingAppeal = false
+            case .newHolderClaim: state.isSubmittingNewHolder = false
+            }
+        }
         do {
             let receipt = try await repository.appeal(
                 caseId: caseId,
@@ -156,9 +169,9 @@ public final class ModerationCaseFlow {
         } catch {
             switch kind {
             case .appeal:
-                state.appealErrorMessage = Self.submissionMessage(for: error)
+                state.appealErrorMessage = Self.submissionMessage(for: error, kind: .appeal)
             case .newHolderClaim:
-                state.newHolderErrorMessage = Self.submissionMessage(for: error)
+                state.newHolderErrorMessage = Self.submissionMessage(for: error, kind: .newHolderClaim)
             }
         }
     }
@@ -240,7 +253,14 @@ public final class ModerationCaseFlow {
         }
     }
 
-    private static func submissionMessage(for error: Error) -> String {
+    /// `kind` is nil for a response filing. The 410 copy is
+    /// appeal-specific: the reference never 410s a response (late
+    /// filings are accepted and flagged), so a response 410 from a
+    /// nonconforming authority falls through to its bounded message.
+    private static func submissionMessage(
+        for error: Error,
+        kind: AppealSubmission.Kind?
+    ) -> String {
         switch error {
         case ModerationError.statementInvalid:
             return String(localized: "The statement is empty or exceeds your authority's 16 KB limit.")
@@ -250,7 +270,8 @@ public final class ModerationCaseFlow {
             return String(localized: "The mandate this case was opened under is no longer on this device.")
         case ModerationError.authorityUnavailable:
             return String(localized: "Your authority isn't in the directory right now. Check your connection and try again.")
-        case let AuthorityClientError.rejected(rejection) where rejection.statusCode == 410:
+        case let AuthorityClientError.rejected(rejection)
+            where rejection.statusCode == 410 && kind == .appeal:
             return String(localized: "The appeal window has closed.")
         case let AuthorityClientError.rejected(rejection) where rejection.statusCode == 404:
             return String(localized: "The authority didn't accept this filing. That can mean a connection or identity problem — it neither confirms nor denies the case.")

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
@@ -75,11 +75,27 @@ public final class ModerationCaseFlow {
         await refresh()
     }
 
+    /// A refresh requested while one is in flight is QUEUED, not
+    /// dropped: the post-submission refresh must not silently no-op
+    /// against a concurrent pull-to-refresh, or the status card keeps
+    /// claiming "Response on file: No" after a successful filing.
+    private var followUpRequested = false
+
     public func refresh() async {
-        guard !state.isLoading else { return }
-        state.isLoading = true
+        guard !state.isLoading else {
+            followUpRequested = true
+            return
+        }
+        repeat {
+            followUpRequested = false
+            state.isLoading = true
+            await performRefresh()
+            state.isLoading = false
+        } while followUpRequested
+    }
+
+    private func performRefresh() async {
         state.statusErrorMessage = nil
-        defer { state.isLoading = false }
         do {
             let status = try await fetchStatusRecoveringDirectory()
             state.status = status
@@ -110,8 +126,16 @@ public final class ModerationCaseFlow {
                 caseId: caseId,
                 mandateRef: mandateRef
             )
-        } catch ModerationError.authorityUnavailable {
-            try await repository.refresh()
+        } catch let ModerationError.authorityUnavailable(authority) {
+            do {
+                try await repository.refresh()
+            } catch {
+                // The recovery fetch failing IS the directory being
+                // unavailable — keep the actionable connectivity copy
+                // instead of letting a transport error fall through to
+                // the generic message.
+                throw ModerationError.authorityUnavailable(authority)
+            }
             return try await repository.caseStatus(
                 caseId: caseId,
                 mandateRef: mandateRef

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
@@ -20,10 +20,15 @@ public final class ModerationCaseFlow {
         public var isSubmittingResponse = false
         public var isSubmittingAppeal = false
         public var responseReceipt: CaseResponseReceipt?
+        /// Per-kind receipts and errors: an ordinary appeal and a
+        /// new-holder claim are independent filings, and one must never
+        /// erase or mask the other's outcome.
         public var appealReceipt: AppealReceipt?
+        public var newHolderReceipt: AppealReceipt?
         public var statusErrorMessage: String?
         public var responseErrorMessage: String?
         public var appealErrorMessage: String?
+        public var newHolderErrorMessage: String?
     }
 
     public private(set) var state = State()
@@ -52,7 +57,14 @@ public final class ModerationCaseFlow {
     }
 
     public func start() async {
-        if let stored = await repository.storedCaseStatus(caseId: caseId) {
+        // Load the offline snapshot once (re-appearance must not
+        // relabel an already-fresh status as a snapshot), and only if
+        // it belongs to this flow's mandate — a snapshot persisted for
+        // another identity's case must never render just because the
+        // caseId matches.
+        if state.status == nil,
+           let stored = await repository.storedCaseStatus(caseId: caseId),
+           stored.mandateRef == mandateRef {
             state.status = stored.status
             state.snapshotFetchedAt = stored.fetchedAt
         }
@@ -77,7 +89,13 @@ public final class ModerationCaseFlow {
             state.snapshotFetchedAt = nil
         } catch {
             // A stale snapshot (if any) stays rendered; the error only
-            // annotates it.
+            // annotates it — EXCEPT when the repository refused
+            // standing: the active identity doesn't own this case's
+            // mandate, so nothing about the case may stay on screen.
+            if case ModerationError.caseAccessUnavailable = error {
+                state.status = nil
+                state.snapshotFetchedAt = nil
+            }
             state.statusErrorMessage = Self.statusMessage(for: error)
         }
     }
@@ -103,35 +121,60 @@ public final class ModerationCaseFlow {
     public func submitAppeal(kind: AppealSubmission.Kind, statement: String) async {
         guard !state.isSubmittingAppeal else { return }
         state.isSubmittingAppeal = true
-        state.appealErrorMessage = nil
+        switch kind {
+        case .appeal: state.appealErrorMessage = nil
+        case .newHolderClaim: state.newHolderErrorMessage = nil
+        }
         defer { state.isSubmittingAppeal = false }
         do {
-            state.appealReceipt = try await repository.appeal(
+            let receipt = try await repository.appeal(
                 caseId: caseId,
                 mandateRef: mandateRef,
                 kind: kind,
                 statement: statement
             )
+            switch kind {
+            case .appeal: state.appealReceipt = receipt
+            case .newHolderClaim: state.newHolderReceipt = receipt
+            }
             await refresh()
         } catch {
-            state.appealErrorMessage = Self.submissionMessage(for: error)
+            switch kind {
+            case .appeal:
+                state.appealErrorMessage = Self.submissionMessage(for: error)
+            case .newHolderClaim:
+                state.newHolderErrorMessage = Self.submissionMessage(for: error)
+            }
         }
     }
 
     // MARK: - Advisory gating
 
     /// The reference accepts responses on any open case — even late,
-    /// flagged `late` — so the composer shows exactly while the case
-    /// is open.
+    /// flagged `late` — so the composer shows while the case is open,
+    /// AND while no status is available at all: the notice that led
+    /// here already asserts the case is open, and hiding the composer
+    /// offline would hard-block the response path this flow promises
+    /// never to. The Authority arbitrates either way.
     public var canRespond: Bool {
-        state.status?.stage == "open"
+        // No status at all: default open from the notice path (which
+        // asserts an open case), closed from the ban surface (whose
+        // caller holds a decided verdict).
+        guard let status = state.status else { return !banContext }
+        return status.stage == "open"
     }
 
     /// Appeal affordance: a ban whose review isn't already decided.
-    /// From the ban surface it also shows before a status fetch —
-    /// the caller holds the verdict, and the Authority is the final
-    /// arbiter of the window either way.
+    /// From the ban surface it also shows before a status fetch — the
+    /// caller holds the verdict — and whenever the rendered status is
+    /// only a stale snapshot: a snapshot predating the ban (stage
+    /// "open", no disposition) must not hide the appeal exactly in the
+    /// offline case the snapshot exists for. Only a FRESH status may
+    /// conclude the appeal isn't available.
     public var showsAppealSection: Bool {
+        if banContext, state.status == nil || state.snapshotFetchedAt != nil {
+            return true
+        }
         if let status = state.status {
             guard status.disposition == "ban" else { return false }
             switch status.appealState {

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseFlow.swift
@@ -76,15 +76,8 @@ public final class ModerationCaseFlow {
         state.isLoading = true
         state.statusErrorMessage = nil
         defer { state.isLoading = false }
-        // The status query needs the authorities directory; a cold
-        // launch straight into the case screen may not have fetched it
-        // yet. Best-effort — a failure surfaces below as status copy.
-        try? await repository.refresh()
         do {
-            let status = try await repository.caseStatus(
-                caseId: caseId,
-                mandateRef: mandateRef
-            )
+            let status = try await fetchStatusRecoveringDirectory()
             state.status = status
             state.snapshotFetchedAt = nil
         } catch {
@@ -97,6 +90,28 @@ public final class ModerationCaseFlow {
                 state.snapshotFetchedAt = nil
             }
             state.statusErrorMessage = Self.statusMessage(for: error)
+        }
+    }
+
+    /// One status fetch, with a single directory-recovery retry: a
+    /// cold launch straight into the case screen may not have fetched
+    /// the authorities directory yet. The refresh happens ONLY when
+    /// the fetch failed for that exact reason — refreshing the
+    /// directory unconditionally on every pull would flip the
+    /// repository-wide fetch status (which the consent surface
+    /// observes) for no benefit.
+    private func fetchStatusRecoveringDirectory() async throws -> CaseStatus {
+        do {
+            return try await repository.caseStatus(
+                caseId: caseId,
+                mandateRef: mandateRef
+            )
+        } catch ModerationError.authorityUnavailable {
+            try await repository.refresh()
+            return try await repository.caseStatus(
+                caseId: caseId,
+                mandateRef: mandateRef
+            )
         }
     }
 

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
@@ -57,7 +57,16 @@ public struct ModerationCaseView: View {
                 .padding(.bottom, 32)
             }
             .onAppear {
-                if focusNewHolder { proxy.scrollTo("newHolder", anchor: .top) }
+                // Deferred one hop: scrolling in `onAppear` runs before
+                // the scroll content is laid out and is commonly a
+                // no-op — the tap that opened this sheet must actually
+                // land on the section it named.
+                guard focusNewHolder else { return }
+                Task { @MainActor in
+                    withAnimation {
+                        proxy.scrollTo("newHolder", anchor: .center)
+                    }
+                }
             }
         }
         .background(OnymTokens.surface.ignoresSafeArea())
@@ -79,7 +88,7 @@ public struct ModerationCaseView: View {
                         row("Case", status.caseId, monospaced: true)
                         row("Stage", stageLine(status))
                         if let classId = status.classId {
-                            row("Violation class", classId)
+                            row("Violation class", bounded(classId))
                         }
                         if let opened = status.openedAt {
                             row("Opened", opened.formatted(date: .abbreviated, time: .shortened))
@@ -92,13 +101,13 @@ public struct ModerationCaseView: View {
                         }
                         row("Response on file", responsesLine(status))
                         if let appealState = status.appealState, appealState != "none" {
-                            row("Appeal", appealState)
+                            row("Appeal", bounded(appealState))
                         }
                         if let deadline = status.appealDeadline {
                             row("Appeal deadline", deadline.formatted(date: .abbreviated, time: .shortened))
                         }
                         if let newHolderState = status.newHolderState, newHolderState != "none" {
-                            row("New-holder claim", newHolderState)
+                            row("New-holder claim", bounded(newHolderState))
                         }
                     } else if flow.state.isLoading {
                         HStack(spacing: 8) {
@@ -369,7 +378,7 @@ public struct ModerationCaseView: View {
         case ("decided", "reversed"):
             return String(localized: "Decided — reversed on appeal")
         default:
-            return status.stage
+            return bounded(status.stage)
         }
     }
 
@@ -395,8 +404,15 @@ public struct ModerationCaseView: View {
         case "decided": return String(localized: "Decided")
         case "decision_overdue": return String(localized: "Decision overdue")
         case "appeal_reversed": return String(localized: "Reversed on appeal")
-        default: return kind
+        default: return bounded(kind)
         }
+    }
+
+    /// Authority-controlled identifiers rendered verbatim get the same
+    /// bound as rejection messages — a hostile or buggy authority must
+    /// not be able to flood a row.
+    private func bounded(_ value: String) -> String {
+        String(value.prefix(120))
     }
 
     private func trimmed(_ text: String) -> String {

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
@@ -1,0 +1,384 @@
+import SwiftUI
+import OnymDesign
+import OnymModeration
+
+/// The accused-side case screen: authenticated status (or the labeled
+/// offline snapshot), the event log, the response composer while the
+/// case is open, and the appeal / new-holder filings for a ban. Every
+/// filing surfaces the Authority's actual answer — copy never promises
+/// reversal or suspension the returned terms don't state.
+public struct ModerationCaseView: View {
+    @State private var flow: ModerationCaseFlow
+    @State private var responseText = ""
+    @State private var appealText = ""
+    @State private var newHolderText = ""
+
+    public init(flow: ModerationCaseFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SettingsLargeTitle("Moderation case")
+
+                statusSection
+                if let events = flow.state.status?.events, !events.isEmpty {
+                    eventsSection(events)
+                }
+                if flow.canRespond {
+                    responseSection
+                }
+                if flow.showsAppealSection {
+                    appealSection
+                }
+                if flow.banContext {
+                    newHolderSection
+                }
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .navigationTitle("Case")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("moderation.case")
+        .task { await flow.start() }
+        .refreshable { await flow.refresh() }
+    }
+
+    // MARK: - Status
+
+    private var statusSection: some View {
+        Group {
+            SettingsSectionLabel("STATUS")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let status = flow.state.status {
+                        row("Case", status.caseId, monospaced: true)
+                        row("Stage", stageLine(status))
+                        if let classId = status.classId {
+                            row("Violation class", classId)
+                        }
+                        if let opened = status.openedAt {
+                            row("Opened", opened.formatted(date: .abbreviated, time: .shortened))
+                        }
+                        if let deadline = status.responseDeadline {
+                            row("Respond by", deadline.formatted(date: .abbreviated, time: .shortened))
+                        }
+                        if let deadline = status.decisionDeadline {
+                            row("Decision due", deadline.formatted(date: .abbreviated, time: .shortened))
+                        }
+                        row("Response on file", responsesLine(status))
+                        if let appealState = status.appealState, appealState != "none" {
+                            row("Appeal", appealState)
+                        }
+                        if let deadline = status.appealDeadline {
+                            row("Appeal deadline", deadline.formatted(date: .abbreviated, time: .shortened))
+                        }
+                        if let newHolderState = status.newHolderState, newHolderState != "none" {
+                            row("New-holder claim", newHolderState)
+                        }
+                    } else if flow.state.isLoading {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                            Text("Fetching the case from your authority…")
+                                .font(.system(size: 13))
+                                .foregroundStyle(OnymTokens.text2)
+                        }
+                    } else {
+                        Text("No case status is available yet.")
+                            .font(.system(size: 13))
+                            .foregroundStyle(OnymTokens.text2)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+            if let fetchedAt = flow.state.snapshotFetchedAt {
+                SettingsFootnote("Shown as of \(fetchedAt.formatted(date: .abbreviated, time: .shortened)) — the authority couldn't be reached for a newer status.")
+            }
+            if let message = flow.state.statusErrorMessage {
+                errorText(message, id: "moderation.case.status_error")
+            }
+            if flow.state.status == nil, !flow.state.isLoading {
+                retryButton
+            }
+        }
+    }
+
+    private var retryButton: some View {
+        Button {
+            Task { await flow.refresh() }
+        } label: {
+            Text("Try again")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(OnymTokens.text)
+                .frame(maxWidth: .infinity, minHeight: 44)
+                .background(OnymTokens.surface2,
+                            in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .accessibilityIdentifier("moderation.case.retry")
+    }
+
+    // MARK: - Events
+
+    private func eventsSection(_ events: [CaseEvent]) -> some View {
+        Group {
+            SettingsSectionLabel("HISTORY")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(Array(events.enumerated()), id: \.offset) { _, event in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text(event.at.formatted(date: .abbreviated, time: .shortened))
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundStyle(OnymTokens.text3)
+                            Text(eventLabel(event.kind))
+                                .font(.system(size: 13))
+                                .foregroundStyle(OnymTokens.text2)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+        }
+    }
+
+    // MARK: - Response
+
+    private var responseSection: some View {
+        Group {
+            SettingsSectionLabel("YOUR RESPONSE")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    if let receipt = flow.state.responseReceipt {
+                        Label(
+                            receipt.late
+                                ? "Your response is on file. It arrived after the response deadline and is marked late."
+                                : "Your response is on file.",
+                            systemImage: "checkmark.circle.fill"
+                        )
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.text)
+                        .accessibilityIdentifier("moderation.case.response_receipt")
+                        Text("You can file additional statements while the case is open; they attach to the same case.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    TextEditor(text: $responseText)
+                        .frame(minHeight: 100)
+                        .font(.system(size: 14))
+                        .scrollContentBackground(.hidden)
+                        .padding(8)
+                        .background(OnymTokens.surface,
+                                    in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        .accessibilityIdentifier("moderation.case.response_editor")
+                    if let passed = flow.responseDeadlinePassed {
+                        Text("The response deadline (\(passed.formatted(date: .abbreviated, time: .shortened))) has passed by this device's clock. A filing is still accepted — it will be marked late.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    if let message = flow.state.responseErrorMessage {
+                        inlineError(message, id: "moderation.case.response_error")
+                    }
+                    SettingsPrimaryButton(action: {
+                        let statement = responseText
+                        Task {
+                            await flow.submitResponse(statement)
+                            if flow.state.responseErrorMessage == nil { responseText = "" }
+                        }
+                    }) {
+                        HStack {
+                            if flow.state.isSubmittingResponse { ProgressView().tint(.white) }
+                            Text(flow.state.isSubmittingResponse ? "Filing…" : "File response")
+                        }
+                    }
+                    .disabled(trimmed(responseText).isEmpty || flow.state.isSubmittingResponse)
+                    .accessibilityIdentifier("moderation.case.submit_response")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+            SettingsFootnote("Your statement is signed with your identity key and disclosed to your authority in full. Not responding doesn't concede the case; it proceeds on the record.")
+        }
+    }
+
+    // MARK: - Appeal
+
+    private var appealSection: some View {
+        Group {
+            SettingsSectionLabel("APPEAL")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    if let receipt = flow.state.appealReceipt,
+                       receipt.kind == AppealSubmission.Kind.appeal.rawValue {
+                        Label("Your appeal is filed. The authority reviews it; a successful appeal issues a reversal.", systemImage: "checkmark.circle.fill")
+                            .font(.system(size: 13))
+                            .foregroundStyle(OnymTokens.text)
+                            .accessibilityIdentifier("moderation.case.appeal_receipt")
+                    }
+                    TextEditor(text: $appealText)
+                        .frame(minHeight: 80)
+                        .font(.system(size: 14))
+                        .scrollContentBackground(.hidden)
+                        .padding(8)
+                        .background(OnymTokens.surface,
+                                    in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        .accessibilityIdentifier("moderation.case.appeal_editor")
+                    if let passed = flow.appealDeadlinePassed {
+                        Text("The appeal window closed \(passed.formatted(date: .abbreviated, time: .shortened)) by this device's clock. The authority decides whether a filing is still accepted.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    if let message = flow.state.appealErrorMessage {
+                        inlineError(message, id: "moderation.case.appeal_error")
+                    }
+                    SettingsPrimaryButton(action: {
+                        let statement = appealText
+                        Task {
+                            await flow.submitAppeal(kind: .appeal, statement: statement)
+                            if flow.state.appealErrorMessage == nil { appealText = "" }
+                        }
+                    }) {
+                        HStack {
+                            if flow.state.isSubmittingAppeal { ProgressView().tint(.white) }
+                            Text(flow.state.isSubmittingAppeal ? "Filing…" : "File appeal")
+                        }
+                    }
+                    .disabled(trimmed(appealText).isEmpty || flow.state.isSubmittingAppeal)
+                    .accessibilityIdentifier("moderation.case.submit_appeal")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+            SettingsFootnote("Filing an appeal does not suspend the ban unless the consented terms say so.")
+        }
+    }
+
+    // MARK: - New holder
+
+    private var newHolderSection: some View {
+        Group {
+            SettingsSectionLabel("DEVICE CHANGED HANDS?")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("If you acquired this device after the ban, you can file a new-holder claim. A human reviews it on an expedited basis — a device is not a person.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.text2)
+                    if let receipt = flow.state.appealReceipt,
+                       receipt.kind == AppealSubmission.Kind.newHolderClaim.rawValue {
+                        Label("Your claim is submitted for expedited human review.", systemImage: "checkmark.circle.fill")
+                            .font(.system(size: 13))
+                            .foregroundStyle(OnymTokens.text)
+                            .accessibilityIdentifier("moderation.case.new_holder_receipt")
+                    } else {
+                        TextEditor(text: $newHolderText)
+                            .frame(minHeight: 60)
+                            .font(.system(size: 14))
+                            .scrollContentBackground(.hidden)
+                            .padding(8)
+                            .background(OnymTokens.surface,
+                                        in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                            .accessibilityIdentifier("moderation.case.new_holder_editor")
+                        Button {
+                            let statement = newHolderText
+                            Task {
+                                await flow.submitAppeal(kind: .newHolderClaim, statement: statement)
+                            }
+                        } label: {
+                            Text("File new-holder claim")
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundStyle(OnymTokens.text)
+                                .frame(maxWidth: .infinity, minHeight: 44)
+                                .background(OnymTokens.surface2,
+                                            in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(trimmed(newHolderText).isEmpty || flow.state.isSubmittingAppeal)
+                        .accessibilityIdentifier("moderation.case.submit_new_holder")
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func stageLine(_ status: CaseStatus) -> String {
+        switch (status.stage, status.disposition) {
+        case ("open", _):
+            return String(localized: "Open — awaiting decision")
+        case ("decided", "dismiss"):
+            return String(localized: "Decided — dismissed")
+        case ("decided", "ban"):
+            return String(localized: "Decided — ban")
+        case ("decided", "reversed"):
+            return String(localized: "Decided — reversed on appeal")
+        default:
+            return status.stage
+        }
+    }
+
+    private func responsesLine(_ status: CaseStatus) -> String {
+        if let count = status.responsesOnFile, count > 0 {
+            return String(localized: "Yes (\(count) filed)")
+        }
+        return status.responded == true ? String(localized: "Yes") : String(localized: "No")
+    }
+
+    /// Event kinds are the reference's identifiers; translate the
+    /// known vocabulary and show unknown kinds verbatim rather than
+    /// inventing meaning for them.
+    private func eventLabel(_ kind: String) -> String {
+        switch kind {
+        case "case_opened": return String(localized: "Case opened")
+        case "notice_evidence": return String(localized: "Evidence noticed")
+        case "report_joined": return String(localized: "Another report joined")
+        case "response": return String(localized: "Response filed")
+        case "response_late": return String(localized: "Response filed (late)")
+        case "appeal_filed": return String(localized: "Appeal filed")
+        case "new_holder_claim": return String(localized: "New-holder claim filed")
+        case "decided": return String(localized: "Decided")
+        case "decision_overdue": return String(localized: "Decision overdue")
+        case "appeal_reversed": return String(localized: "Reversed on appeal")
+        default: return kind
+        }
+    }
+
+    private func trimmed(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func inlineError(_ message: String, id: String) -> some View {
+        Text(message)
+            .font(.system(size: 12))
+            .foregroundStyle(OnymTokens.red)
+            .accessibilityIdentifier(id)
+    }
+
+    private func errorText(_ message: String, id: String) -> some View {
+        Text(message)
+            .font(.system(size: 12))
+            .foregroundStyle(OnymTokens.red)
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .accessibilityIdentifier(id)
+    }
+
+    private func row(_ label: LocalizedStringKey, _ value: String, monospaced: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(value)
+                .font(monospaced ? .system(size: 12, design: .monospaced) : .system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
@@ -12,31 +12,42 @@ public struct ModerationCaseView: View {
     @State private var responseText = ""
     @State private var appealText = ""
     @State private var newHolderText = ""
+    /// Scrolls to the new-holder section on first appearance — the ban
+    /// screen's "I'm this device's new owner" must land the user on
+    /// the affordance they tapped, not on the status card.
+    private let focusNewHolder: Bool
 
-    public init(flow: ModerationCaseFlow) {
+    public init(flow: ModerationCaseFlow, focusNewHolder: Bool = false) {
         _flow = State(initialValue: flow)
+        self.focusNewHolder = focusNewHolder
     }
 
     public var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Moderation case")
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    SettingsLargeTitle("Moderation case")
 
-                statusSection
-                if let events = flow.state.status?.events, !events.isEmpty {
-                    eventsSection(events)
+                    statusSection
+                    if let events = flow.state.status?.events, !events.isEmpty {
+                        eventsSection(events)
+                    }
+                    if flow.canRespond {
+                        responseSection
+                    }
+                    if flow.showsAppealSection {
+                        appealSection
+                    }
+                    if flow.banContext {
+                        newHolderSection
+                            .id("newHolder")
+                    }
                 }
-                if flow.canRespond {
-                    responseSection
-                }
-                if flow.showsAppealSection {
-                    appealSection
-                }
-                if flow.banContext {
-                    newHolderSection
-                }
+                .padding(.bottom, 32)
             }
-            .padding(.bottom, 32)
+            .onAppear {
+                if focusNewHolder { proxy.scrollTo("newHolder", anchor: .top) }
+            }
         }
         .background(OnymTokens.surface.ignoresSafeArea())
         .navigationTitle("Case")
@@ -213,8 +224,7 @@ public struct ModerationCaseView: View {
             SettingsSectionLabel("APPEAL")
             SettingsCard {
                 VStack(alignment: .leading, spacing: 10) {
-                    if let receipt = flow.state.appealReceipt,
-                       receipt.kind == AppealSubmission.Kind.appeal.rawValue {
+                    if flow.state.appealReceipt != nil {
                         Label("Your appeal is filed. The authority reviews it; a successful appeal issues a reversal.", systemImage: "checkmark.circle.fill")
                             .font(.system(size: 13))
                             .foregroundStyle(OnymTokens.text)
@@ -268,8 +278,7 @@ public struct ModerationCaseView: View {
                     Text("If you acquired this device after the ban, you can file a new-holder claim. A human reviews it on an expedited basis — a device is not a person.")
                         .font(.system(size: 13))
                         .foregroundStyle(OnymTokens.text2)
-                    if let receipt = flow.state.appealReceipt,
-                       receipt.kind == AppealSubmission.Kind.newHolderClaim.rawValue {
+                    if flow.state.newHolderReceipt != nil {
                         Label("Your claim is submitted for expedited human review.", systemImage: "checkmark.circle.fill")
                             .font(.system(size: 13))
                             .foregroundStyle(OnymTokens.text)
@@ -283,10 +292,14 @@ public struct ModerationCaseView: View {
                             .background(OnymTokens.surface,
                                         in: RoundedRectangle(cornerRadius: 10, style: .continuous))
                             .accessibilityIdentifier("moderation.case.new_holder_editor")
+                        if let message = flow.state.newHolderErrorMessage {
+                            inlineError(message, id: "moderation.case.new_holder_error")
+                        }
                         Button {
                             let statement = newHolderText
                             Task {
                                 await flow.submitAppeal(kind: .newHolderClaim, statement: statement)
+                                if flow.state.newHolderErrorMessage == nil { newHolderText = "" }
                             }
                         } label: {
                             Text("File new-holder claim")

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
@@ -29,6 +29,17 @@ public struct ModerationCaseView: View {
                     SettingsLargeTitle("Moderation case")
 
                     statusSection
+                    // Receipts render OUTSIDE the composer gates: a
+                    // fresh status can close a section at exactly the
+                    // moment a filing succeeds (case decided on first
+                    // response; appeal reviewed), and the confirmation
+                    // must survive that — this screen's contract is
+                    // that every filing surfaces the Authority's
+                    // actual answer.
+                    if flow.state.responseReceipt != nil
+                        || flow.state.appealReceipt != nil {
+                        receiptsSection
+                    }
                     if let events = flow.state.status?.events, !events.isEmpty {
                         eventsSection(events)
                     }
@@ -134,6 +145,37 @@ public struct ModerationCaseView: View {
         .accessibilityIdentifier("moderation.case.retry")
     }
 
+    // MARK: - Receipts
+
+    private var receiptsSection: some View {
+        Group {
+            SettingsSectionLabel("FILED")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    if let receipt = flow.state.responseReceipt {
+                        Label(
+                            receipt.late
+                                ? "Your response is on file. It arrived after the response deadline and is marked late."
+                                : "Your response is on file.",
+                            systemImage: "checkmark.circle.fill"
+                        )
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.text)
+                        .accessibilityIdentifier("moderation.case.response_receipt")
+                    }
+                    if flow.state.appealReceipt != nil {
+                        Label("Your appeal is filed. The authority reviews it; a successful appeal issues a reversal.", systemImage: "checkmark.circle.fill")
+                            .font(.system(size: 13))
+                            .foregroundStyle(OnymTokens.text)
+                            .accessibilityIdentifier("moderation.case.appeal_receipt")
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+        }
+    }
+
     // MARK: - Events
 
     private func eventsSection(_ events: [CaseEvent]) -> some View {
@@ -165,16 +207,7 @@ public struct ModerationCaseView: View {
             SettingsSectionLabel("YOUR RESPONSE")
             SettingsCard {
                 VStack(alignment: .leading, spacing: 10) {
-                    if let receipt = flow.state.responseReceipt {
-                        Label(
-                            receipt.late
-                                ? "Your response is on file. It arrived after the response deadline and is marked late."
-                                : "Your response is on file.",
-                            systemImage: "checkmark.circle.fill"
-                        )
-                        .font(.system(size: 13))
-                        .foregroundStyle(OnymTokens.text)
-                        .accessibilityIdentifier("moderation.case.response_receipt")
+                    if flow.state.responseReceipt != nil {
                         Text("You can file additional statements while the case is open; they attach to the same case.")
                             .font(.system(size: 12))
                             .foregroundStyle(OnymTokens.text3)
@@ -224,12 +257,6 @@ public struct ModerationCaseView: View {
             SettingsSectionLabel("APPEAL")
             SettingsCard {
                 VStack(alignment: .leading, spacing: 10) {
-                    if flow.state.appealReceipt != nil {
-                        Label("Your appeal is filed. The authority reviews it; a successful appeal issues a reversal.", systemImage: "checkmark.circle.fill")
-                            .font(.system(size: 13))
-                            .foregroundStyle(OnymTokens.text)
-                            .accessibilityIdentifier("moderation.case.appeal_receipt")
-                    }
                     TextEditor(text: $appealText)
                         .frame(minHeight: 80)
                         .font(.system(size: 14))
@@ -283,7 +310,16 @@ public struct ModerationCaseView: View {
                             .font(.system(size: 13))
                             .foregroundStyle(OnymTokens.text)
                             .accessibilityIdentifier("moderation.case.new_holder_receipt")
-                    } else {
+                        Text("You can file a corrected claim; it attaches to the same case.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    // The editor stays after a receipt: `filed` is
+                    // deliberately non-probative (the endpoint answers
+                    // 200 unconditionally), and a corrected claim is a
+                    // legitimate new filing the repository dedupes by
+                    // statement.
+                    Group {
                         TextEditor(text: $newHolderText)
                             .frame(minHeight: 60)
                             .font(.system(size: 14))

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
@@ -338,7 +338,7 @@ public struct ModerationCaseView: View {
                                 if flow.state.newHolderErrorMessage == nil { newHolderText = "" }
                             }
                         } label: {
-                            Text("File new-holder claim")
+                            Text(flow.state.isSubmittingNewHolder ? "Filing…" : "File new-holder claim")
                                 .font(.system(size: 15, weight: .medium))
                                 .foregroundStyle(OnymTokens.text)
                                 .frame(maxWidth: .infinity, minHeight: 44)
@@ -346,7 +346,7 @@ public struct ModerationCaseView: View {
                                             in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                         }
                         .buttonStyle(.plain)
-                        .disabled(trimmed(newHolderText).isEmpty || flow.state.isSubmittingAppeal)
+                        .disabled(trimmed(newHolderText).isEmpty || flow.state.isSubmittingNewHolder)
                         .accessibilityIdentifier("moderation.case.submit_new_holder")
                     }
                 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
@@ -9,14 +9,14 @@ import OnymModeration
 public struct ModerationSettingsView: View {
     @State private var flow: ModerationSettingsFlow
     private let makeConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
-    private let makeCaseFlow: @MainActor (CaseNotice) -> ModerationCaseFlow
+    private let makeCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)?
 
     @State private var showSwitchConsent = false
 
     public init(
         flow: ModerationSettingsFlow,
         makeConsentFlow: @escaping @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow,
-        makeCaseFlow: @escaping @MainActor (CaseNotice) -> ModerationCaseFlow
+        makeCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil
     ) {
         _flow = State(initialValue: flow)
         self.makeConsentFlow = makeConsentFlow

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
@@ -9,15 +9,18 @@ import OnymModeration
 public struct ModerationSettingsView: View {
     @State private var flow: ModerationSettingsFlow
     private let makeConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
+    private let makeCaseFlow: @MainActor (CaseNotice) -> ModerationCaseFlow
 
     @State private var showSwitchConsent = false
 
     public init(
         flow: ModerationSettingsFlow,
-        makeConsentFlow: @escaping @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
+        makeConsentFlow: @escaping @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow,
+        makeCaseFlow: @escaping @MainActor (CaseNotice) -> ModerationCaseFlow
     ) {
         _flow = State(initialValue: flow)
         self.makeConsentFlow = makeConsentFlow
+        self.makeCaseFlow = makeCaseFlow
     }
 
     public var body: some View {
@@ -26,7 +29,7 @@ public struct ModerationSettingsView: View {
                 SettingsLargeTitle("Moderation")
 
                 if !flow.state.openCases.isEmpty {
-                    OpenCaseBanner(notices: flow.state.openCases)
+                    OpenCaseBanner(notices: flow.state.openCases, makeCaseFlow: makeCaseFlow)
                         .padding(.bottom, 8)
                 }
 

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
@@ -103,31 +103,31 @@ public struct CaseNoticeDetailView: View {
 
                 SettingsSectionLabel("RESPONSE")
                 if let makeCaseFlow {
-                SettingsCard {
-                    NavigationLink {
-                        ModerationCaseView(flow: makeCaseFlow(notice))
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 3) {
-                                Text("Review and respond")
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .foregroundStyle(OnymTokens.text)
-                                Text("Fetch the case's current status, file your signed response, and follow the decision.")
-                                    .font(.system(size: 13))
+                    SettingsCard {
+                        NavigationLink {
+                            ModerationCaseView(flow: makeCaseFlow(notice))
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text("Review and respond")
+                                        .font(.system(size: 14, weight: .semibold))
+                                        .foregroundStyle(OnymTokens.text)
+                                    Text("Fetch the case's current status, file your signed response, and follow the decision.")
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(OnymTokens.text2)
+                                }
+                                Spacer(minLength: 4)
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 12, weight: .semibold))
                                     .foregroundStyle(OnymTokens.text2)
                             }
-                            Spacer(minLength: 4)
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 12, weight: .semibold))
-                                .foregroundStyle(OnymTokens.text2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(16)
+                            .contentShape(Rectangle())
                         }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(16)
-                        .contentShape(Rectangle())
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("moderation.case_detail.open_case")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("moderation.case_detail.open_case")
-                }
                 } else {
                     SettingsCard {
                         Text("Responding from this surface isn't wired up. Use the authority's contact channel to respond before the deadline.")

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
@@ -11,13 +11,15 @@ public struct OpenCaseBanner: View {
     let notices: [CaseNotice]
     /// Builds the case flow for a tapped notice. `CaseNotice` carries
     /// both `caseId` and `mandateRef`, which is exactly the standing
-    /// the repository resolves by.
-    let makeCaseFlow: @MainActor (CaseNotice) -> ModerationCaseFlow
+    /// the repository resolves by. Optional so surfaces without the
+    /// factory degrade to the informational notice (with the
+    /// authority-contact fallback) instead of vanishing.
+    let makeCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)?
     @State private var presented: CaseNotice?
 
     public init(
         notices: [CaseNotice],
-        makeCaseFlow: @escaping @MainActor (CaseNotice) -> ModerationCaseFlow
+        makeCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil
     ) {
         self.notices = notices
         self.makeCaseFlow = makeCaseFlow
@@ -69,11 +71,11 @@ extension CaseNotice: @retroactive Identifiable {
 /// response, and (after a decision) appeal.
 public struct CaseNoticeDetailView: View {
     let notice: CaseNotice
-    let makeCaseFlow: @MainActor (CaseNotice) -> ModerationCaseFlow
+    let makeCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)?
 
     public init(
         notice: CaseNotice,
-        makeCaseFlow: @escaping @MainActor (CaseNotice) -> ModerationCaseFlow
+        makeCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil
     ) {
         self.notice = notice
         self.makeCaseFlow = makeCaseFlow
@@ -100,6 +102,7 @@ public struct CaseNoticeDetailView: View {
                 SettingsFootnote("If the authority doesn't decide by the deadline, the case is dismissed automatically — silence never bans anyone. Not responding doesn't concede the case; it proceeds on the record.")
 
                 SettingsSectionLabel("RESPONSE")
+                if let makeCaseFlow {
                 SettingsCard {
                     NavigationLink {
                         ModerationCaseView(flow: makeCaseFlow(notice))
@@ -124,6 +127,15 @@ public struct CaseNoticeDetailView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("moderation.case_detail.open_case")
+                }
+                } else {
+                    SettingsCard {
+                        Text("Responding from this surface isn't wired up. Use the authority's contact channel to respond before the deadline.")
+                            .font(.system(size: 14))
+                            .foregroundStyle(OnymTokens.text2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(16)
+                    }
                 }
             }
             .padding(.bottom, 32)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
@@ -9,10 +9,18 @@ import OnymModeration
 /// through to the notice detail.
 public struct OpenCaseBanner: View {
     let notices: [CaseNotice]
+    /// Builds the case flow for a tapped notice. `CaseNotice` carries
+    /// both `caseId` and `mandateRef`, which is exactly the standing
+    /// the repository resolves by.
+    let makeCaseFlow: @MainActor (CaseNotice) -> ModerationCaseFlow
     @State private var presented: CaseNotice?
 
-    public init(notices: [CaseNotice]) {
+    public init(
+        notices: [CaseNotice],
+        makeCaseFlow: @escaping @MainActor (CaseNotice) -> ModerationCaseFlow
+    ) {
         self.notices = notices
+        self.makeCaseFlow = makeCaseFlow
     }
 
     public var body: some View {
@@ -45,7 +53,7 @@ public struct OpenCaseBanner: View {
             .accessibilityIdentifier("moderation.case_banner")
             .sheet(item: $presented) { notice in
                 NavigationStack {
-                    CaseNoticeDetailView(notice: notice)
+                    CaseNoticeDetailView(notice: notice, makeCaseFlow: makeCaseFlow)
                 }
             }
         }
@@ -57,14 +65,18 @@ extension CaseNotice: @retroactive Identifiable {
 }
 
 /// The served notice, presented faithfully: class, deadlines,
-/// evidence reference, and the response path (stubbed — the client
-/// operation throws `.notImplemented` until an authority service
-/// exists; the screen says so instead of pretending).
+/// evidence reference, and the path into the case itself — status,
+/// response, and (after a decision) appeal.
 public struct CaseNoticeDetailView: View {
     let notice: CaseNotice
+    let makeCaseFlow: @MainActor (CaseNotice) -> ModerationCaseFlow
 
-    public init(notice: CaseNotice) {
+    public init(
+        notice: CaseNotice,
+        makeCaseFlow: @escaping @MainActor (CaseNotice) -> ModerationCaseFlow
+    ) {
         self.notice = notice
+        self.makeCaseFlow = makeCaseFlow
     }
 
     public var body: some View {
@@ -89,11 +101,29 @@ public struct CaseNoticeDetailView: View {
 
                 SettingsSectionLabel("RESPONSE")
                 SettingsCard {
-                    Text("Responding from the app isn't available yet. Use the authority's contact channel to respond before the deadline.")
-                        .font(.system(size: 14))
-                        .foregroundStyle(OnymTokens.text2)
+                    NavigationLink {
+                        ModerationCaseView(flow: makeCaseFlow(notice))
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text("Review and respond")
+                                    .font(.system(size: 14, weight: .semibold))
+                                    .foregroundStyle(OnymTokens.text)
+                                Text("Fetch the case's current status, file your signed response, and follow the decision.")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(OnymTokens.text2)
+                            }
+                            Spacer(minLength: 4)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(OnymTokens.text2)
+                        }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(16)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("moderation.case_detail.open_case")
                 }
             }
             .padding(.bottom, 32)

--- a/Packages/OnymSettings/Package.swift
+++ b/Packages/OnymSettings/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         .package(path: "../OnymTransportBlossom"),
         .package(path: "../OnymChatsCore"),
         .package(path: "../OnymDesign"),
+        .package(path: "../OnymModeration"),
         .package(path: "../OnymModerationUI"),
     ],
     targets: [
@@ -30,6 +31,7 @@ let package = Package(
                 "OnymTransportBlossom",
                 "OnymChatsCore",
                 "OnymDesign",
+                "OnymModeration",
                 "OnymModerationUI",
             ]
         ),

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -5,6 +5,7 @@ import OnymIdentity
 import OnymIdentityUI
 import OnymRecovery
 import OnymChatsCore
+import OnymModeration
 import OnymModerationUI
 
 /// Settings tab — Onym design home. Identity hero (active identity
@@ -31,6 +32,7 @@ public struct SettingsView: View {
     /// until the app wires these in).
     let makeModerationSettingsFlow: (@MainActor () -> ModerationSettingsFlow)?
     let makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)?
+    let makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)?
 
     public init(
         makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow,
@@ -41,7 +43,8 @@ public struct SettingsView: View {
         identitiesFlow: IdentitiesFlow,
         onClearAllMessages: @escaping () async -> Void,
         makeModerationSettingsFlow: (@MainActor () -> ModerationSettingsFlow)? = nil,
-        makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)? = nil
+        makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)? = nil,
+        makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil
     ) {
         self.makeBackupFlow = makeBackupFlow
         self.makeRelayerSettingsFlow = makeRelayerSettingsFlow
@@ -52,6 +55,7 @@ public struct SettingsView: View {
         self.onClearAllMessages = onClearAllMessages
         self.makeModerationSettingsFlow = makeModerationSettingsFlow
         self.makeModerationConsentFlow = makeModerationConsentFlow
+        self.makeModerationCaseFlow = makeModerationCaseFlow
     }
 
     @State private var showRecoveryPhrase = false
@@ -164,13 +168,15 @@ public struct SettingsView: View {
                 }
                 SettingsFootnote("Nostr relays and Blossom servers carry your messages and media. Replace them with your own instances for maximum privacy.")
 
-                if let makeModerationSettingsFlow, let makeModerationConsentFlow {
+                if let makeModerationSettingsFlow, let makeModerationConsentFlow,
+                   let makeModerationCaseFlow {
                     SettingsSectionLabel("MODERATION")
                     SettingsCard {
                         NavigationLink {
                             ModerationSettingsView(
                                 flow: makeModerationSettingsFlow(),
-                                makeConsentFlow: makeModerationConsentFlow
+                                makeConsentFlow: makeModerationConsentFlow,
+                                makeCaseFlow: makeModerationCaseFlow
                             )
                         } label: {
                             SettingsRow(

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -168,8 +168,11 @@ public struct SettingsView: View {
                 }
                 SettingsFootnote("Nostr relays and Blossom servers carry your messages and media. Replace them with your own instances for maximum privacy.")
 
-                if let makeModerationSettingsFlow, let makeModerationConsentFlow,
-                   let makeModerationCaseFlow {
+                // The section gates on the two original factories; the
+                // case factory only enriches the open-case banner and
+                // must not make the whole MODERATION entry vanish for
+                // callers that don't supply it.
+                if let makeModerationSettingsFlow, let makeModerationConsentFlow {
                     SettingsSectionLabel("MODERATION")
                     SettingsCard {
                         NavigationLink {

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -81,4 +81,9 @@ struct AppDependencies {
     /// view this returns, keeping OnymChatsUI free of any
     /// OnymModerationUI dependency.
     let makeModerationReportView: @MainActor (ReportableMessage) -> AnyView
+    /// Case screen for a served notice — carries both the caseId and
+    /// the mandateRef the repository resolves standing by.
+    let makeModerationCaseFlow: @MainActor (CaseNotice) -> ModerationCaseFlow
+    /// Case screen from the ban surface: appeal + new-holder filings.
+    let makeModerationBanCaseFlow: @MainActor (_ caseId: String, _ mandateRef: String) -> ModerationCaseFlow
 }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -570,6 +570,21 @@ struct OnymIOSApp: App {
                     message: message,
                     repository: moderationRepository
                 )))
+            },
+            makeModerationCaseFlow: { @MainActor notice in
+                ModerationCaseFlow(
+                    caseId: notice.caseId,
+                    mandateRef: notice.mandateRef,
+                    repository: moderationRepository
+                )
+            },
+            makeModerationBanCaseFlow: { @MainActor caseId, mandateRef in
+                ModerationCaseFlow(
+                    caseId: caseId,
+                    mandateRef: mandateRef,
+                    repository: moderationRepository,
+                    banContext: true
+                )
             }
         )
     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -39,7 +39,10 @@ struct RootView: View {
         Group {
             switch dependencies.moderationGateFlow.gate {
             case .banned(let banState):
-                BannedView(state: banState)
+                BannedView(
+                    state: banState,
+                    makeCaseFlow: dependencies.makeModerationBanCaseFlow
+                )
             case .gateCheckRequired(let reason):
                 GateCheckRequiredView(reason: reason) {
                     dependencies.moderationGateFlow.tappedRetry()
@@ -49,7 +52,10 @@ struct RootView: View {
                     .overlay(alignment: .top) {
                         if case .operational(let openCases) = dependencies.moderationGateFlow.gate,
                            !openCases.isEmpty {
-                            OpenCaseBanner(notices: openCases)
+                            OpenCaseBanner(
+                                notices: openCases,
+                                makeCaseFlow: dependencies.makeModerationCaseFlow
+                            )
                         }
                     }
             }
@@ -106,7 +112,8 @@ struct RootView: View {
                         identitiesFlow: dependencies.identitiesFlow,
                         onClearAllMessages: { await dependencies.messageRepository.removeAll() },
                         makeModerationSettingsFlow: dependencies.makeModerationSettingsFlow,
-                        makeModerationConsentFlow: dependencies.makeModerationConsentFlow
+                        makeModerationConsentFlow: dependencies.makeModerationConsentFlow,
+                        makeModerationCaseFlow: dependencies.makeModerationCaseFlow
                     )
                 }
             }


### PR DESCRIPTION
## Summary

Third of four sequential PRs for the accused-side case lifecycle (status ✅ #224 → submissions ✅ #225 → **UI** → tests). The open-case notice and the ban screen become actionable.

- **`ModerationCaseFlow` + `ModerationCaseView`** — authenticated case status with the persisted snapshot as a labeled offline fallback ("shown as of …"), the reference's event log (known kinds translated, unknown kinds shown verbatim rather than invented), a response composer while the case is open, and appeal / new-holder sections for a ban. Full state coverage: loading, offline snapshot, retry, submitted (late-flagged when the Authority says so), rejected with bounded authority-controlled text, deadline-closed annotations.
- **Advisory gating, as planned** — the composer availability follows returned state, but nothing hard-blocks near a boundary: the reference accepts late responses (flagging them) and answers its own 410 for a closed appeal window; local clocks only annotate.
- **Anti-oracle 404 honored in copy** — the Authority deliberately conflates unknown case / bad signature / non-party into one 404; the screen presents that as "neither confirms nor denies", never as proof.
- **Entry points**: `CaseNoticeDetailView`'s "responding isn't available yet" stub → "Review and respond" into the case screen; `BannedView` → in-app "Review case and appeal" (in-app outranks link-out; URL fallback retained) with the new-holder affordance routed to the same sheet's dedicated section (`banContext` shows appeal/new-holder before any status fetch, since the caller holds the verdict); Settings' open-case banner wired identically.
- **Copy stays factual**: filing an appeal "does not suspend the ban unless the consented terms say so"; a new-holder claim is "submitted for expedited human review" — `filed: true` is never presented as recorded, matching the reference's non-oracular contract.

## Enforcement invariants

Case-screen network activity never touches gate state: a failed status fetch annotates the screen and keeps the stale snapshot; it neither relaxes nor tightens enforcement. `BannedView` remains full-screen and non-dismissable; the case sheet rides on top of it.

Known pre-existing gap, unchanged and re-flagged: `BannedView` renders `BanState.verdict` without running `VerdictValidator` (no production call sites). Wiring validation into gate handling is enforcement-side work, deliberately not smuggled into a UI PR.

## Scope

UI + composition wiring only — no domain changes. `OnymSettings` gains an `OnymModeration` dependency (it now names `CaseNotice` in a factory signature). No moderator/admin features, no media evidence, no push infrastructure. Per the agreed phasing, flow/UI tests land in the final `test/case-lifecycle` PR.

## Verification

Full OnymIOSTests suite green locally on a signed simulator test host (all new SettingsView/ModerationSettingsView parameters are additive; existing call sites compile unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)