### PR TITLE
feat(moderation): enforce manifest signatures — the trust chain closes

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationTrust.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationTrust.swift
@@ -7,16 +7,20 @@ import Foundation
 /// through these checks.)
 public enum ModerationTrust {
     /// Reject authority manifests whose `signature` doesn't verify
-    /// against the directory-pinned operator key.
+    /// against the directory-pinned operator key. ON: every deploy
+    /// signs the exact materialized manifest bytes inside the
+    /// authority image and publishes the detached signature at
+    /// `<manifest-url>.sig` (onym-infra#5), moved into place so the
+    /// published signature either matches the published manifest or
+    /// is absent — and the deploy's verify step proves the served
+    /// pair before finishing. The wire contract (base64 of the
+    /// 64-byte raw signature + trailing LF; `SignedAsset` trims
+    /// before decoding) is pinned in onym-infra's README.
     ///
-    /// **Still `false` for one deployment reason only**: the client
-    /// verifies the detached signature served at `<manifest-url>.sig`,
-    /// and the deployed authority answers 404 there (verified
-    /// 2026-08-09 against authority.onym.app). Flipping this on before
-    /// that asset exists would hard-fail every consent. Publish the
-    /// `.sig` (operator signature over the exact manifest bytes), then
-    /// flip.
-    public static let enforceManifestSignatures = false
+    /// Under enforcement a missing or stale signature rejects the
+    /// manifest and blocks consent outright — this flip must ship
+    /// only after the signed deploy is live (curl the `.sig` first).
+    public static let enforceManifestSignatures = true
 
     /// Reject verdicts whose `signature` doesn't verify against the
     /// consented manifest's operator key. ON: the deployed authority


### PR DESCRIPTION
## Summary

One-line flip (plus its doc comment): `ModerationTrust.enforceManifestSignatures = true`. The client now **rejects** any authority manifest whose detached signature at `<manifest-url>.sig` fails to verify against the directory-pinned operator key — soft-verified acceptance ends.

This closes the chain the last three PRs built toward:

1. **Directory** pins the operator key out of band (`onym-authorities`).
2. **Manifest** — exact bytes signed by that key, verified before consent (**this PR**).
3. **Mandate** pins the manifest hash (consent artifact).
4. **Verdicts** — signed by the same key, run through `VerdictValidator` against the consented manifest before display (#227).

## ⚠️ Merge gate

**Do not merge until onymchat/onym-infra#5 is merged and deployed.** Under enforcement, a 404 on the `.sig` rejects the manifest and **blocks consent outright** for every user. Pre-merge check:

```
curl -fsS https://authority.onym.app/manifest.json.sig
```

Expected: 89 bytes, base64 + trailing LF (the wire contract pinned in onym-infra's README; `SignedAsset.decodeSignature` trims before decoding — that tolerance is what makes the LF safe). The infra deploy's own verify step also proves the served signature covers the served manifest bytes before the deploy reports success.

## Stacking

Based on `feat/live-enforcement-backend` (#227), which owns the surrounding `ModerationTrust` wording — merging #227 first, then this, keeps both diffs honest. If #227 merges before the infra deploy happens, this PR simply waits on the gate above.

## Scope

The flip and its comment. Nothing else: UI-test builds are unaffected (their fixture fetcher doesn't route through this check — made structural in #227), and unit tests pass signature-enforcement flags explicitly.

## Verification

Full OnymIOSTests suite green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)