### PR TITLE
Fix chat list cold-start hydration

### DIFF
--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -710,17 +710,22 @@ struct OnymIOSApp: App {
                     // carry an identity signature.
                     await moderationRepository.start()
                     await gateCheckRepository.start()
-                    // Replay groups + invitations for the in-memory snapshot streams.
-                    await groupRepository.reload()
-                    await incomingInvitations.reload()
-                    // Wire identity selection → group + invitations filter
-                    // so both lists flip when the user switches identity.
+                    // Install the selected-identity filters before replaying
+                    // persisted snapshots. Reloading first publishes through
+                    // a nil filter, so a ChatsFlow that subscribes during
+                    // cold start can permanently receive an empty initial
+                    // list until the view is recreated (Settings → back).
                     if let initialID = await identityRepository.currentSelectedID() {
                         await groupRepository.setCurrentIdentity(initialID)
                         await incomingInvitations.setCurrentIdentity(initialID)
                         await pendingInvitesStore.setCurrentIdentity(initialID)
                         await pendingVerificationStore.setCurrentIdentity(initialID)
                     }
+                    // Replay groups + invitations only after their identity
+                    // filters are ready, so every startup subscriber sees
+                    // the persisted rows for the active identity.
+                    await groupRepository.reload()
+                    await incomingInvitations.reload()
                 }
                 .task {
                     // Long-lived listener: forward every selection change


### PR DESCRIPTION
## Summary
- install the selected identity on identity-scoped repositories before replaying persisted snapshots
- prevent the initial ChatsFlow from receiving an empty nil-filter snapshot during cold start
- fix the same startup ordering for incoming invitations

## Root cause
`OnymIOSApp` called `reload()` before `setCurrentIdentity(...)`. A chat-list flow subscribing during that window could retain the empty filtered snapshot; recreating the view through Settings caused a later subscription after identity selection and made chats appear.

## Validation
- `xcodebuild test -project OnymIOS.xcodeproj -scheme OnymIOS -destination 'platform=iOS Simulator,id=C7B91C00-48FB-497F-91EA-BC713959DE54'`
- 1,038 tests passed, 3 skipped, 0 failures
