### PR TITLE
Device recovery behind reidentificationRequired — moderator-decided

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/DeviceRecovery.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/DeviceRecovery.swift
@@ -1,0 +1,236 @@
+import CryptoKit
+import Foundation
+
+// Device recovery (REFERENCE-AUTHORITY-POLICY §6): the way back for a
+// marked device whose enrolled identity did not survive a reinstall or
+// a change of hands. There is deliberately no self-serve path — the
+// holder files a claim carrying a real contact and their own account
+// of how they hold the device, a human moderator at the authority
+// decides it, and only the grant that decision signs can move the
+// case's record at the enforcement backend.
+
+// MARK: - The grant
+
+/// A moderator-issued recovery grant, held as the **exact bytes** the
+/// authority signed. They travel verbatim: the operator signature is
+/// over the canonical form of these bytes, so re-encoding them would
+/// orphan it.
+public struct RecoveryGrant: Sendable, Equatable {
+    public let raw: Data
+    public let caseId: String
+    /// The identity key the grant was issued to. The enforcement
+    /// backend refuses a session by any other key, so a stolen grant
+    /// is inert.
+    public let grantee: String
+    public let authority: String
+    public let issuedAt: String
+
+    public init(raw: Data) throws {
+        struct Wire: Decodable {
+            let caseId, grantee, authority, issuedAt, signature: String
+        }
+        let wire: Wire
+        do {
+            wire = try JSONDecoder().decode(Wire.self, from: raw)
+        } catch {
+            throw ModerationError.grantInvalid("recovery grant: \(error)")
+        }
+        self.raw = raw
+        self.caseId = wire.caseId
+        self.grantee = wire.grantee
+        self.authority = wire.authority
+        self.issuedAt = wire.issuedAt
+    }
+
+    /// The grant's reference: SHA-256 over the canonical signing bytes
+    /// (every field except `signature`, sorted keys). The enforcement
+    /// backend derives the same value from the raw bytes to make the
+    /// grant single-use, and the session signature binds it — so the
+    /// two derivations must agree. Reconstructed through a typed
+    /// mirror, like `Verdict.signingBytes()`: JSONEncoder's
+    /// `.sortedKeys` is UTF-8 byte order, matching serde's map order.
+    /// A grant carrying fields this mirror doesn't know would derive a
+    /// different reference and fail the session — acceptable, since
+    /// grants are consumed by the interface whose vocabulary this is.
+    public func reference() throws -> String {
+        struct Unsigned: Encodable {
+            let grantVersion: Int
+            let caseId, grantee, authority, issuedAt: String
+        }
+        let bytes = try ModerationCanonicalEncoder.encode(
+            Unsigned(
+                grantVersion: 1,
+                caseId: caseId,
+                grantee: grantee,
+                authority: authority,
+                issuedAt: issuedAt
+            )
+        )
+        return SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - Redemption at the enforcement backend
+
+/// `POST /v1/recover` as the client presents it: the grant's exact
+/// bytes plus the same session envelope as a gate check, signed by the
+/// grantee identity with the grant's reference bound into the payload.
+public struct RecoveryRequest: Codable, Sendable, Equatable {
+    public let deviceToken: Data?
+    public let userKey: String
+    /// The grant's exact signed bytes; travels as base64.
+    public let grant: Data
+    public let timestamp: Date
+    public let signature: Data
+
+    public init(deviceToken: Data?, userKey: String, grant: Data, timestamp: Date, signature: Data) {
+        self.deviceToken = deviceToken
+        self.userKey = userKey
+        self.grant = grant
+        self.timestamp = timestamp
+        self.signature = signature
+    }
+
+    /// Same five-field layout as the other session payloads, with the
+    /// grant reference in the trailing slot — one signature presents
+    /// one grant, and can be replayed against no other endpoint.
+    public static func signedPayload(
+        deviceToken: Data?,
+        userKey: String,
+        grantRef: String,
+        timestamp: Date
+    ) -> Data {
+        SignedSessionPayload.bytes(
+            context: "onym-moderation-recover-v1",
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            mandateRef: grantRef
+        )
+    }
+}
+
+/// What redemption answered. `recovered` carries the gate result the
+/// backend's reconciliation produced — no second round trip decides
+/// whether the device is usable. `markInForce` means a record still
+/// bans the device (the case's, or the claimant's own); nothing moved,
+/// the grant was not consumed, and the routes point back at the
+/// authority.
+public enum RecoveryResult: Sendable, Equatable {
+    case recovered(GateCheckResult)
+    case markInForce(authorityContact: String, newHolderURL: URL?, appealURL: URL?)
+}
+
+extension RecoveryResult: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case status, gate, authorityContact, newHolderUrl, appealUrl
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(String.self, forKey: .status) {
+        case "recovered":
+            self = .recovered(try container.decode(GateCheckResult.self, forKey: .gate))
+        case "markInForce":
+            self = .markInForce(
+                authorityContact: try container.decode(String.self, forKey: .authorityContact),
+                newHolderURL: try container.decodeIfPresent(URL.self, forKey: .newHolderUrl),
+                appealURL: try container.decodeIfPresent(URL.self, forKey: .appealUrl)
+            )
+        case let other:
+            throw ModerationError.grantInvalid("recovery status \(other)")
+        }
+    }
+}
+
+extension EnforcementBackendClient {
+    /// Redeem a moderator-issued recovery grant. Default refuses so
+    /// existing conformers (fakes, the UI-test stub's scenarios that
+    /// never reach recovery) stay source-compatible; real backends
+    /// override.
+    public func recover(_ request: RecoveryRequest) async throws -> RecoveryResult {
+        throw ModerationError.notImplemented("recover")
+    }
+}
+
+// MARK: - The claim, at the authority
+
+/// Where a filed claim stands. The authority answers this only to the
+/// key the claim names.
+public struct RecoveryClaimStatus: Sendable, Equatable {
+    /// `open` | `granted` | `refused`.
+    public let state: String
+    /// The moderator's reasons, once decided.
+    public let reasoning: String?
+    /// The signed grant, present exactly when `state == "granted"`.
+    public let grant: RecoveryGrant?
+
+    public init(state: String, reasoning: String?, grant: RecoveryGrant?) {
+        self.state = state
+        self.reasoning = reasoning
+        self.grant = grant
+    }
+}
+
+extension ModerationAuthorityClient {
+    /// File a device-recovery claim: a real contact for the moderator
+    /// to verify the holder through, and the holder's own account of
+    /// how they came to hold the marked device. Returns the claim id
+    /// to poll. Default refuses so existing conformers stay
+    /// source-compatible.
+    public func fileRecoveryClaim(contact: String, statement: String) async throws -> String {
+        throw ModerationError.notImplemented("file-recovery-claim")
+    }
+
+    public func recoveryClaimStatus(claimId: String) async throws -> RecoveryClaimStatus {
+        throw ModerationError.notImplemented("recovery-claim-status")
+    }
+}
+
+// MARK: - Claim persistence
+
+/// The one pending claim id, kept across launches so the gate screen
+/// resumes polling instead of asking the holder to file again.
+public protocol RecoveryClaimStore: Sendable {
+    func load() -> String?
+    func save(_ claimId: String?)
+}
+
+/// `@unchecked Sendable` for the same reason as
+/// `UserDefaultsGateStateStore`: `UserDefaults` is documented
+/// thread-safe but not formally `Sendable`.
+public struct UserDefaultsRecoveryClaimStore: RecoveryClaimStore, @unchecked Sendable {
+    private static let claimKey = "app.onym.ios.moderation.recoveryClaim"
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> String? {
+        defaults.string(forKey: Self.claimKey)
+    }
+
+    public func save(_ claimId: String?) {
+        guard let claimId else {
+            defaults.removeObject(forKey: Self.claimKey)
+            return
+        }
+        defaults.set(claimId, forKey: Self.claimKey)
+    }
+}
+
+// MARK: - Redemption through the gate repository
+
+/// What redeeming a grant did to the gate, in terms the UI acts on.
+public enum RecoveryRedemption: Sendable, Equatable {
+    /// The record moved and reconciliation ran; the gate now shows
+    /// this. `.operational` means the device is usable again.
+    case recovered(GateStatus)
+    /// A record still bans the device; the grant survives for after
+    /// the authority resolves it.
+    case markInForce(authorityContact: String, newHolderURL: URL?, appealURL: URL?)
+    case failed(String)
+}
+

--- a/Packages/OnymModeration/Sources/OnymModeration/DeviceRecovery.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/DeviceRecovery.swift
@@ -17,6 +17,10 @@ import Foundation
 /// orphan it.
 public struct RecoveryGrant: Sendable, Equatable {
     public let raw: Data
+    /// The wire's `grantVersion`; the authority defaults an absent one
+    /// to 1, and so does this decode (`RecoveryGrant` in
+    /// `apple/src/types.rs`, `#[serde(default = "one")]`).
+    public let version: Int
     public let caseId: String
     /// The identity key the grant was issued to. The enforcement
     /// backend refuses a session by any other key, so a stolen grant
@@ -27,6 +31,7 @@ public struct RecoveryGrant: Sendable, Equatable {
 
     public init(raw: Data) throws {
         struct Wire: Decodable {
+            let grantVersion: Int?
             let caseId, grantee, authority, issuedAt, signature: String
         }
         let wire: Wire
@@ -35,7 +40,19 @@ public struct RecoveryGrant: Sendable, Equatable {
         } catch {
             throw ModerationError.grantInvalid("recovery grant: \(error)")
         }
+        // Refuse a version this client does not implement, by name —
+        // the version is inside the signed bytes, so presenting a v2
+        // grant through v1 assumptions could only fail at the backend
+        // with an opaque session rejection. The interface refuses the
+        // same way (`enforcement.rs`, "unsupported grantVersion").
+        let version = wire.grantVersion ?? 1
+        guard version == 1 else {
+            throw ModerationError.grantInvalid(
+                "unsupported recovery grant version \(version); this client implements 1"
+            )
+        }
         self.raw = raw
+        self.version = version
         self.caseId = wire.caseId
         self.grantee = wire.grantee
         self.authority = wire.authority
@@ -59,7 +76,7 @@ public struct RecoveryGrant: Sendable, Equatable {
         }
         let bytes = try ModerationCanonicalEncoder.encode(
             Unsigned(
-                grantVersion: 1,
+                grantVersion: version,
                 caseId: caseId,
                 grantee: grantee,
                 authority: authority,
@@ -122,6 +139,10 @@ public enum RecoveryResult: Sendable, Equatable {
 }
 
 extension RecoveryResult: Decodable {
+    // This is deliberately the exact `{status, …}` tagged shape the
+    // merged reference interface serializes (`RecoveryResult` in
+    // `apple/src/types.rs`, onym-moderation#27): `recovered` carries
+    // `gate`, `markInForce` carries the contact and optional routes.
     private enum CodingKeys: String, CodingKey {
         case status, gate, authorityContact, newHolderUrl, appealUrl
     }
@@ -138,7 +159,16 @@ extension RecoveryResult: Decodable {
                 appealURL: try container.decodeIfPresent(URL.self, forKey: .appealUrl)
             )
         case let other:
-            throw ModerationError.grantInvalid("recovery status \(other)")
+            // A DecodingError, not a ModerationError: the real client
+            // wraps every decode failure into
+            // `AuthorityClientError.malformedResponse`, and an unknown
+            // status is exactly that — a response this decode does not
+            // speak — not a defect in the grant.
+            throw DecodingError.dataCorruptedError(
+                forKey: .status,
+                in: container,
+                debugDescription: "unknown recovery status '\(other)'"
+            )
         }
     }
 }
@@ -190,10 +220,13 @@ extension ModerationAuthorityClient {
 // MARK: - Claim persistence
 
 /// The one pending claim id, kept across launches so the gate screen
-/// resumes polling instead of asking the holder to file again.
+/// resumes polling instead of asking the holder to file again. Scoped
+/// to the grantee key the claim was signed by: the authority answers
+/// a claim only to that key, so a claim resumed under a different
+/// identity could never be polled — it must read as "no claim".
 public protocol RecoveryClaimStore: Sendable {
-    func load() -> String?
-    func save(_ claimId: String?)
+    func load(grantee: String) -> String?
+    func save(_ claimId: String?, grantee: String)
 }
 
 /// `@unchecked Sendable` for the same reason as
@@ -201,6 +234,7 @@ public protocol RecoveryClaimStore: Sendable {
 /// thread-safe but not formally `Sendable`.
 public struct UserDefaultsRecoveryClaimStore: RecoveryClaimStore, @unchecked Sendable {
     private static let claimKey = "app.onym.ios.moderation.recoveryClaim"
+    private static let granteeKey = "app.onym.ios.moderation.recoveryClaimGrantee"
 
     private let defaults: UserDefaults
 
@@ -208,16 +242,21 @@ public struct UserDefaultsRecoveryClaimStore: RecoveryClaimStore, @unchecked Sen
         self.defaults = defaults
     }
 
-    public func load() -> String? {
-        defaults.string(forKey: Self.claimKey)
+    public func load(grantee: String) -> String? {
+        guard defaults.string(forKey: Self.granteeKey) == grantee else {
+            return nil
+        }
+        return defaults.string(forKey: Self.claimKey)
     }
 
-    public func save(_ claimId: String?) {
+    public func save(_ claimId: String?, grantee: String) {
         guard let claimId else {
             defaults.removeObject(forKey: Self.claimKey)
+            defaults.removeObject(forKey: Self.granteeKey)
             return
         }
         defaults.set(claimId, forKey: Self.claimKey)
+        defaults.set(grantee, forKey: Self.granteeKey)
     }
 }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/EnforcementBackendClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/EnforcementBackendClient.swift
@@ -271,4 +271,12 @@ public protocol EnforcementBackendClient: Sendable {
 
     /// The launch/interval gate check (profile §5).
     func gateCheck(_ request: GateCheckRequest) async throws -> GateCheckResult
+
+    /// Redeem a moderator-issued recovery grant (§6) — the way back
+    /// for a marked device whose enrolled identity did not survive a
+    /// reinstall or a change of hands. Declared as a requirement so
+    /// calls through `any EnforcementBackendClient` dispatch to the
+    /// real client; a refusing default in the extension keeps
+    /// conformers that never reach recovery source-compatible.
+    func recover(_ request: RecoveryRequest) async throws -> RecoveryResult
 }

--- a/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
@@ -317,6 +317,15 @@ public actor GateCheckRepository {
             let timestamp = max(clock(), lastSessionTimestamp.addingTimeInterval(1))
             lastSessionTimestamp = timestamp
             let userKey = try await signer.userKeyID()
+            // The backend refuses a session by any key but the grantee;
+            // saying so here turns that opaque rejection into something
+            // the holder can act on (the grant belongs to a different
+            // identity — likely a re-consent since the claim was filed).
+            guard grant.grantee == userKey else {
+                return .failed(
+                    "This grant was issued to a different identity on this device. File a new claim under the current identity."
+                )
+            }
             let signature = try await signer.sign(
                 RecoveryRequest.signedPayload(
                     deviceToken: token,
@@ -338,9 +347,17 @@ public actor GateCheckRepository {
                 // its answer as the newest check so the gate opens (or
                 // honestly reports what still stands) without a second
                 // round trip. Bump the generation so a slow in-flight
-                // check can't overwrite this with a stale answer.
+                // check can't overwrite this with a stale answer — and,
+                // as in `checkNow`, re-check it after the await below:
+                // a `checkNow` starting inside `sanitize` takes a newer
+                // generation, and this completion must not overwrite
+                // its answer either.
                 generation &+= 1
+                let generation = generation
                 let sanitized = await sanitize(gate)
+                guard generation == self.generation else {
+                    return .recovered(cached)
+                }
                 let (status, persisted) = Self.derive(
                     persisted: store.load(),
                     attempt: .success(sanitized),

--- a/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
@@ -301,6 +301,71 @@ public actor GateCheckRepository {
         }
     }
 
+    // MARK: - Device recovery
+
+    /// Present a moderator-issued grant to the enforcement backend and
+    /// fold the answer into the gate state. Its own session, not a
+    /// gate check: recovery is exactly the state in which no
+    /// mandate-bound gate check can succeed, and the backend requires
+    /// a real device token — a nil token is refused, never guessed
+    /// about.
+    public func redeemRecoveryGrant(_ grant: RecoveryGrant) async -> RecoveryRedemption {
+        guard attestation.isSupported, let token = try? await attestation.generateToken() else {
+            return .failed("Device attestation is unavailable; recovery needs the marked device.")
+        }
+        do {
+            let timestamp = max(clock(), lastSessionTimestamp.addingTimeInterval(1))
+            lastSessionTimestamp = timestamp
+            let userKey = try await signer.userKeyID()
+            let signature = try await signer.sign(
+                RecoveryRequest.signedPayload(
+                    deviceToken: token,
+                    userKey: userKey,
+                    grantRef: try grant.reference(),
+                    timestamp: timestamp
+                )
+            )
+            let request = RecoveryRequest(
+                deviceToken: token,
+                userKey: userKey,
+                grant: grant.raw,
+                timestamp: timestamp,
+                signature: signature
+            )
+            switch try await backend.recover(request) {
+            case .recovered(let gate):
+                // The backend reconciled on this very session; adopt
+                // its answer as the newest check so the gate opens (or
+                // honestly reports what still stands) without a second
+                // round trip. Bump the generation so a slow in-flight
+                // check can't overwrite this with a stale answer.
+                generation &+= 1
+                let sanitized = await sanitize(gate)
+                let (status, persisted) = Self.derive(
+                    persisted: store.load(),
+                    attempt: .success(sanitized),
+                    now: clock(),
+                    policy: policy
+                )
+                store.save(persisted)
+                cached = status
+                publish()
+                return .recovered(status)
+            case .markInForce(let contact, let newHolderURL, let appealURL):
+                return .markInForce(
+                    authorityContact: contact,
+                    newHolderURL: newHolderURL,
+                    appealURL: appealURL
+                )
+            }
+        } catch {
+            if case let AuthorityClientError.rejected(rejection) = error {
+                return .failed(rejection.message)
+            }
+            return .failed("The enforcement backend could not be reached.")
+        }
+    }
+
     /// `no_mandate` is its own state because its recovery is different
     /// in kind: no amount of retrying fixes a backend that has lost the
     /// enrollment — only re-consent does, and the gate flow routes

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -297,6 +297,15 @@ public protocol ModerationAuthorityClient: Sendable {
     func appeal(_ submission: AppealSubmission) async throws -> AppealReceipt
     func queryStatus(caseId: String) async throws -> CaseStatus
     func queryRecoverableCases() async throws -> [String]
+
+    /// File a device-recovery claim (§6): a real contact for the
+    /// moderator to verify the holder through, and the holder's own
+    /// account of how they hold the marked device. Requirements (not
+    /// extension-only) so `any ModerationAuthorityClient` dispatches
+    /// to the real client; refusing defaults keep other conformers
+    /// source-compatible.
+    func fileRecoveryClaim(contact: String, statement: String) async throws -> String
+    func recoveryClaimStatus(claimId: String) async throws -> RecoveryClaimStatus
 }
 
 /// Resolves the client for a directory-selected Authority. Keeping this
@@ -469,6 +478,75 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         ]
         return try await decode(
             try await send(method: "GET", path: ["v1", "cases", "mine"], headers: headers)
+        )
+    }
+
+    /// File a device-recovery claim (§6). Signed by the *new* identity
+    /// key — the grantee a moderator's grant would name; the old key
+    /// is exactly what was lost. Filing moves nothing anywhere: a
+    /// human decides the claim.
+    public func fileRecoveryClaim(contact: String, statement: String) async throws -> String {
+        struct Unsigned: Encodable {
+            let contact, grantee, statement, timestamp: String
+        }
+        struct Signed: Encodable {
+            let contact, grantee, signature, statement, timestamp: String
+        }
+        struct Receipt: Decodable {
+            let claimId: String
+        }
+        let timestamp = Self.timestamp(clock())
+        let grantee = try await signer.userKeyID()
+        // The authority verifies over the canonical bytes with the
+        // signature field removed — the same form `Unsigned` encodes,
+        // as long as `Signed` adds nothing but the signature.
+        let signingBytes = try ModerationCanonicalEncoder.encode(
+            Unsigned(contact: contact, grantee: grantee, statement: statement, timestamp: timestamp)
+        )
+        let signature = try await signer.sign(signingBytes).base64EncodedString()
+        let body = try ModerationCanonicalEncoder.encode(
+            Signed(
+                contact: contact,
+                grantee: grantee,
+                signature: signature,
+                statement: statement,
+                timestamp: timestamp
+            )
+        )
+        let receipt: Receipt = try await decode(
+            try await send(method: "POST", path: ["v1", "recovery-claims"], body: body)
+        )
+        return receipt.claimId
+    }
+
+    /// Where a filed claim stands. Answered only to the key the claim
+    /// names; when granted, the response carries the grant's exact
+    /// signed bytes.
+    public func recoveryClaimStatus(claimId: String) async throws -> RecoveryClaimStatus {
+        struct Wire: Decodable {
+            let state: String
+            let reasoning: String?
+            let grant: Data?
+        }
+        let timestamp = Self.timestamp(clock())
+        let key = try await signer.userKeyID()
+        let message = Data("recovery-claim-status:\(claimId):\(timestamp)".utf8)
+        let signature = try await signer.sign(message).base64EncodedString()
+        let wire: Wire = try await decode(
+            try await send(
+                method: "GET",
+                path: ["v1", "recovery-claims", claimId],
+                headers: [
+                    "X-Onym-Key": key,
+                    "X-Onym-Timestamp": timestamp,
+                    "X-Onym-Signature": signature,
+                ]
+            )
+        )
+        return RecoveryClaimStatus(
+            state: wire.state,
+            reasoning: wire.reasoning,
+            grant: try wire.grant.map { try RecoveryGrant(raw: $0) }
         )
     }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -499,7 +499,15 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         let grantee = try await signer.userKeyID()
         // The authority verifies over the canonical bytes with the
         // signature field removed — the same form `Unsigned` encodes,
-        // as long as `Signed` adds nothing but the signature.
+        // as long as `Signed` adds nothing but the signature. This is
+        // deliberately the exact field set the reference Authority's
+        // `file_recovery_claim` (`authority/src/api.rs`,
+        // onym-moderation#28) recomputes via
+        // `canonical::grant_signing_bytes(&body)`: the request body
+        // minus `signature`, keys sorted. Adding a field client-side
+        // without the authority knowing it would not break the
+        // signature (it verifies the body it received) — but renaming
+        // or dropping one of these four would.
         let signingBytes = try ModerationCanonicalEncoder.encode(
             Unsigned(contact: contact, grantee: grantee, statement: statement, timestamp: timestamp)
         )
@@ -530,6 +538,12 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         }
         let timestamp = Self.timestamp(clock())
         let key = try await signer.userKeyID()
+        // This is deliberately the exact credential message verified by
+        // the reference Authority (`authority/src/api.rs`,
+        // `recovery_claim_status`, onym-moderation#28) — as with
+        // `query-status:` above, changing it client-side would make
+        // every status poll answer 404. The response's `{state,
+        // reasoning, grant}` (grant base64) is that handler's shape too.
         let message = Data("recovery-claim-status:\(claimId):\(timestamp)".utf8)
         let signature = try await signer.sign(message).base64EncodedString()
         let wire: Wire = try await decode(

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationError.swift
@@ -68,6 +68,9 @@ public enum ModerationError: Error, Sendable, Equatable {
     /// build). Callers degrade toward gate-check-required, never toward
     /// unmoderated operation (profile §8.5).
     case attestationUnavailable
+    /// A recovery grant that does not parse, or a recovery answer in
+    /// a shape this client does not speak.
+    case grantInvalid(String)
     /// The operation exists in the protocol surface but the concrete
     /// implementation is a stub (no enforcement backend / authority
     /// service is deployed yet).

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -484,6 +484,33 @@ public actor ModerationRepository {
         return try await client.queryRecoverableCases()
     }
 
+    /// File a device-recovery claim (§6) with the active mandate's
+    /// authority: the contact a moderator can verify the holder
+    /// through, and the holder's account of how they hold the marked
+    /// device. Signed by the current (new) identity — the grantee a
+    /// grant would name. Returns the claim id to poll.
+    public func fileDeviceRecoveryClaim(contact: String, statement: String) async throws -> String {
+        try await recoveryAuthorityClient().fileRecoveryClaim(contact: contact, statement: statement)
+    }
+
+    /// Where a filed device-recovery claim stands; carries the signed
+    /// grant once a moderator issues one.
+    public func deviceRecoveryClaimStatus(claimId: String) async throws -> RecoveryClaimStatus {
+        try await recoveryAuthorityClient().recoveryClaimStatus(claimId: claimId)
+    }
+
+    private func recoveryAuthorityClient() throws -> any ModerationAuthorityClient {
+        guard let record = activeMandateRecord() else {
+            throw ModerationError.noMandate
+        }
+        guard let listing = authorities.first(where: {
+            $0.componentId == record.mandate.authority
+        }) else {
+            throw ModerationError.authorityUnavailable(record.mandate.authority)
+        }
+        return authorityClients.client(for: listing)
+    }
+
     /// Retry one persisted registration attempt without minting or
     /// signing anything new. A later consent always wins: resolving an
     /// older artifact records it as history rather than silently making

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -472,16 +472,7 @@ public actor ModerationRepository {
     /// identity. The Authority authenticates the lookup with that identity
     /// and returns IDs only; details still require the case-status request.
     public func recoverableCaseIDs() async throws -> [String] {
-        guard let record = activeMandateRecord() else {
-            throw ModerationError.noMandate
-        }
-        guard let listing = authorities.first(where: {
-            $0.componentId == record.mandate.authority
-        }) else {
-            throw ModerationError.authorityUnavailable(record.mandate.authority)
-        }
-        let client = authorityClients.client(for: listing)
-        return try await client.queryRecoverableCases()
+        try await recoveryAuthorityClient().queryRecoverableCases()
     }
 
     /// File a device-recovery claim (§6) with the active mandate's

--- a/Packages/OnymModeration/Sources/OnymModeration/URLSessionEnforcementBackendClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/URLSessionEnforcementBackendClient.swift
@@ -71,6 +71,16 @@ public struct URLSessionEnforcementBackendClient: EnforcementBackendClient {
         return try decode(data)
     }
 
+    /// Redeem a moderator-issued recovery grant. The grant travels as
+    /// its exact signed bytes (base64 via `Data`'s default coding);
+    /// the session envelope binds the grant's reference, so this
+    /// signature presents this grant and nothing else.
+    public func recover(_ request: RecoveryRequest) async throws -> RecoveryResult {
+        let body = try Self.encoder().encode(request)
+        let data = try await send(path: ["v1", "recover"], body: body)
+        return try decode(data)
+    }
+
     // MARK: - Transport
 
     private func send(path: [String], body: Data) async throws -> Data {

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryFlow.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Observation
+import OnymModeration
+
+/// The device-recovery conversation, as the blocked holder sees it:
+/// file a claim (a real contact, and their account of how they hold
+/// the marked device), wait for a human at the authority to decide,
+/// then redeem the signed grant at the enforcement backend. There is
+/// no self-serve step anywhere in this flow — every transition that
+/// could unblock the device passes through the moderator's decision.
+@MainActor
+@Observable
+public final class DeviceRecoveryFlow: Identifiable {
+    public enum Phase: Equatable {
+        /// No claim on file: show the form.
+        case form
+        case filing
+        /// Filed; a human decides. Poll with the check button / on
+        /// appearance.
+        case awaitingReview(claimId: String)
+        case checking(claimId: String)
+        /// The moderator refused, with reasons. `startOver()` files a
+        /// fresh claim (e.g. with a reachable contact this time).
+        case refused(reasons: String)
+        case redeeming
+        /// The grant was issued but a record still bans the device —
+        /// the case's, or this identity's own. The grant is kept; the
+        /// routes point back at the authority.
+        case markInForce(authorityContact: String, newHolderURL: URL?, appealURL: URL?)
+        /// Redeemed and reconciled. The gate publishes the new status
+        /// itself, so this phase is normally visible only for the
+        /// moment before the blocking screen goes away.
+        case recovered
+    }
+
+    public private(set) var phase: Phase
+    /// A transient problem (network, refusal) that leaves the phase
+    /// actionable; rendered under the current phase's controls.
+    public private(set) var errorMessage: String?
+
+    private let claimStore: any RecoveryClaimStore
+    private let fileClaim: @MainActor (_ contact: String, _ statement: String) async throws -> String
+    private let claimStatus: @MainActor (_ claimId: String) async throws -> RecoveryClaimStatus
+    private let redeem: @MainActor (RecoveryGrant) async -> RecoveryRedemption
+
+    public init(
+        claimStore: any RecoveryClaimStore,
+        fileClaim: @escaping @MainActor (_ contact: String, _ statement: String) async throws -> String,
+        claimStatus: @escaping @MainActor (_ claimId: String) async throws -> RecoveryClaimStatus,
+        redeem: @escaping @MainActor (RecoveryGrant) async -> RecoveryRedemption
+    ) {
+        self.claimStore = claimStore
+        self.fileClaim = fileClaim
+        self.claimStatus = claimStatus
+        self.redeem = redeem
+        if let claimId = claimStore.load() {
+            phase = .awaitingReview(claimId: claimId)
+        } else {
+            phase = .form
+        }
+    }
+
+    // MARK: - Intents
+
+    public func submitClaim(contact: String, statement: String) async {
+        guard case .form = phase else { return }
+        let contact = contact.trimmingCharacters(in: .whitespacesAndNewlines)
+        let statement = statement.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !contact.isEmpty, !statement.isEmpty else {
+            errorMessage = String(localized: "Both a contact and your account of the device are required — a person reads this claim and needs a way to reach you.")
+            return
+        }
+        phase = .filing
+        errorMessage = nil
+        do {
+            let claimId = try await fileClaim(contact, statement)
+            claimStore.save(claimId)
+            phase = .awaitingReview(claimId: claimId)
+        } catch {
+            phase = .form
+            errorMessage = Self.describe(error)
+        }
+    }
+
+    /// Poll the claim; when a grant is on it, redeem immediately —
+    /// the person already asked by filing, and the moderator already
+    /// decided by granting.
+    public func checkClaim() async {
+        guard let claimId = pollableClaimId else { return }
+        phase = .checking(claimId: claimId)
+        errorMessage = nil
+        do {
+            let status = try await claimStatus(claimId)
+            switch status.state {
+            case "granted":
+                guard let grant = status.grant else {
+                    phase = .awaitingReview(claimId: claimId)
+                    errorMessage = String(localized: "The claim is granted but the grant hasn't arrived yet. Try again in a moment.")
+                    return
+                }
+                await redeemGrant(grant, claimId: claimId)
+            case "refused":
+                claimStore.save(nil)
+                phase = .refused(
+                    reasons: status.reasoning
+                        ?? String(localized: "The moderator did not include reasons.")
+                )
+            default:
+                phase = .awaitingReview(claimId: claimId)
+            }
+        } catch {
+            phase = .awaitingReview(claimId: claimId)
+            errorMessage = Self.describe(error)
+        }
+    }
+
+    /// After a refusal (or to correct a bad contact): drop the old
+    /// claim and show the form again.
+    public func startOver() {
+        claimStore.save(nil)
+        errorMessage = nil
+        phase = .form
+    }
+
+    // MARK: - Private
+
+    private var pollableClaimId: String? {
+        switch phase {
+        case .awaitingReview(let claimId), .checking(let claimId):
+            return claimId
+        default:
+            return nil
+        }
+    }
+
+    private func redeemGrant(_ grant: RecoveryGrant, claimId: String) async {
+        phase = .redeeming
+        switch await redeem(grant) {
+        case .recovered:
+            // The claim served its purpose; the gate repository has
+            // already published the new status.
+            claimStore.save(nil)
+            phase = .recovered
+        case .markInForce(let contact, let newHolderURL, let appealURL):
+            // Keep the claim: the grant on it stays valid for after
+            // the authority resolves whatever still stands.
+            phase = .markInForce(
+                authorityContact: contact,
+                newHolderURL: newHolderURL,
+                appealURL: appealURL
+            )
+        case .failed(let message):
+            phase = .awaitingReview(claimId: claimId)
+            errorMessage = message
+        }
+    }
+
+    private static func describe(_ error: Error) -> String {
+        if case let AuthorityClientError.rejected(rejection) = error {
+            return rejection.message
+        }
+        if let error = error as? ModerationError, case .noMandate = error {
+            return String(localized: "No moderation authority is configured for this identity yet. Complete the consent step, then file the claim.")
+        }
+        return String(localized: "The authority could not be reached. Check the connection and try again.")
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryFlow.swift
@@ -39,21 +39,28 @@ public final class DeviceRecoveryFlow: Identifiable {
     public private(set) var errorMessage: String?
 
     private let claimStore: any RecoveryClaimStore
+    /// The identity key claims are filed and polled under. A persisted
+    /// claim belongs to the key that signed it — the authority answers
+    /// it to no other — so a claim from a previous identity must not
+    /// resume here.
+    private let grantee: String
     private let fileClaim: @MainActor (_ contact: String, _ statement: String) async throws -> String
     private let claimStatus: @MainActor (_ claimId: String) async throws -> RecoveryClaimStatus
     private let redeem: @MainActor (RecoveryGrant) async -> RecoveryRedemption
 
     public init(
         claimStore: any RecoveryClaimStore,
+        grantee: String,
         fileClaim: @escaping @MainActor (_ contact: String, _ statement: String) async throws -> String,
         claimStatus: @escaping @MainActor (_ claimId: String) async throws -> RecoveryClaimStatus,
         redeem: @escaping @MainActor (RecoveryGrant) async -> RecoveryRedemption
     ) {
         self.claimStore = claimStore
+        self.grantee = grantee
         self.fileClaim = fileClaim
         self.claimStatus = claimStatus
         self.redeem = redeem
-        if let claimId = claimStore.load() {
+        if let claimId = claimStore.load(grantee: grantee) {
             phase = .awaitingReview(claimId: claimId)
         } else {
             phase = .form
@@ -74,7 +81,7 @@ public final class DeviceRecoveryFlow: Identifiable {
         errorMessage = nil
         do {
             let claimId = try await fileClaim(contact, statement)
-            claimStore.save(claimId)
+            claimStore.save(claimId, grantee: grantee)
             phase = .awaitingReview(claimId: claimId)
         } catch {
             phase = .form
@@ -100,7 +107,7 @@ public final class DeviceRecoveryFlow: Identifiable {
                 }
                 await redeemGrant(grant, claimId: claimId)
             case "refused":
-                claimStore.save(nil)
+                claimStore.save(nil, grantee: grantee)
                 phase = .refused(
                     reasons: status.reasoning
                         ?? String(localized: "The moderator did not include reasons.")
@@ -114,20 +121,29 @@ public final class DeviceRecoveryFlow: Identifiable {
         }
     }
 
-    /// After a refusal (or to correct a bad contact): drop the old
-    /// claim and show the form again.
+    /// After a refusal, a claim the authority no longer knows, or to
+    /// correct a bad contact: drop the old claim and show the form
+    /// again.
     public func startOver() {
-        claimStore.save(nil)
+        claimStore.save(nil, grantee: grantee)
         errorMessage = nil
         phase = .form
     }
 
     // MARK: - Private
 
+    /// `.checking` is deliberately NOT pollable: it means a check is
+    /// already in flight, and a second one racing it could redeem the
+    /// same single-use grant twice — the loser's failure would then
+    /// overwrite the winner's success. `.markInForce` IS pollable (the
+    /// claim and its grant were kept): "check again" after resolving
+    /// things with the authority re-polls and re-redeems.
     private var pollableClaimId: String? {
         switch phase {
-        case .awaitingReview(let claimId), .checking(let claimId):
+        case .awaitingReview(let claimId):
             return claimId
+        case .markInForce:
+            return claimStore.load(grantee: grantee)
         default:
             return nil
         }
@@ -139,7 +155,7 @@ public final class DeviceRecoveryFlow: Identifiable {
         case .recovered:
             // The claim served its purpose; the gate repository has
             // already published the new status.
-            claimStore.save(nil)
+            claimStore.save(nil, grantee: grantee)
             phase = .recovered
         case .markInForce(let contact, let newHolderURL, let appealURL):
             // Keep the claim: the grant on it stays valid for after

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryView.swift
@@ -1,0 +1,218 @@
+import SwiftUI
+import OnymDesign
+import OnymModeration
+
+/// The recovery sheet behind `reidentificationRequired`: file a claim
+/// for a human moderator, watch its status, and let the flow redeem
+/// the grant when one is issued.
+public struct DeviceRecoveryView: View {
+    @State private var flow: DeviceRecoveryFlow
+    @State private var contact = ""
+    @State private var statement = ""
+
+    @Environment(\.dismiss) private var dismiss
+
+    public init(flow: DeviceRecoveryFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    content
+                }
+                .padding(20)
+            }
+            .background(OnymTokens.surface.ignoresSafeArea())
+            .navigationTitle(Text("Recover this device", comment: "Device recovery sheet title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .task {
+                // Resume politely: if a claim is already on file,
+                // check it once on appearance.
+                await flow.checkClaim()
+            }
+        }
+        .accessibilityIdentifier("moderation.device_recovery")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch flow.phase {
+        case .form, .filing:
+            claimForm
+        case .awaitingReview(let claimId), .checking(let claimId):
+            awaitingReview(claimId: claimId)
+        case .refused(let reasons):
+            refused(reasons: reasons)
+        case .redeeming:
+            statusBlock(
+                icon: "arrow.triangle.2.circlepath",
+                title: String(localized: "Applying the moderator's decision…"),
+                detail: String(localized: "The device is presenting the signed grant to the enforcement service.")
+            )
+            ProgressView()
+        case .markInForce(let contact, let newHolderURL, let appealURL):
+            markInForce(contact: contact, newHolderURL: newHolderURL, appealURL: appealURL)
+        case .recovered:
+            statusBlock(
+                icon: "checkmark.seal",
+                title: String(localized: "Device recovered"),
+                detail: String(localized: "The record was cleared. Onym will continue in a moment.")
+            )
+        }
+        if let errorMessage = flow.errorMessage {
+            Text(errorMessage)
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.red)
+                .accessibilityIdentifier("moderation.device_recovery.error")
+        }
+    }
+
+    private var claimForm: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("A person at the moderation authority reviews device-recovery claims. Say how this device came to you and leave a real way to reach you — the moderator may need to verify your account before deciding.", comment: "Device recovery claim form intro")
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text2)
+                .lineSpacing(3)
+
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 12) {
+                    TextField(String(localized: "Contact — email or phone", comment: "Recovery claim contact field"), text: $contact)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .accessibilityIdentifier("moderation.device_recovery.contact")
+                    Divider()
+                    TextField(
+                        String(localized: "How do you hold this device? (bought used, reset, …)", comment: "Recovery claim statement field"),
+                        text: $statement,
+                        axis: .vertical
+                    )
+                    .lineLimit(4...8)
+                    .accessibilityIdentifier("moderation.device_recovery.statement")
+                }
+                .padding(16)
+            }
+
+            SettingsPrimaryButton(action: submit) {
+                if case .filing = flow.phase {
+                    ProgressView().tint(OnymTokens.onAccent)
+                } else {
+                    Text("Send to the moderator", comment: "Recovery claim submit button")
+                }
+            }
+            .disabled(isFiling)
+            .accessibilityIdentifier("moderation.device_recovery.submit")
+        }
+    }
+
+    private func awaitingReview(claimId: String) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            statusBlock(
+                icon: "person.badge.clock",
+                title: String(localized: "A person is reviewing your claim"),
+                detail: String(localized: "The moderator may contact you before deciding. This can take a while — you can close this screen and check back later.")
+            )
+            Text(claimId)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(OnymTokens.text3)
+            SettingsPrimaryButton(action: check) {
+                if isChecking {
+                    ProgressView().tint(OnymTokens.onAccent)
+                } else {
+                    Text("Check the decision", comment: "Recovery claim poll button")
+                }
+            }
+            .disabled(isChecking)
+            .accessibilityIdentifier("moderation.device_recovery.check")
+        }
+    }
+
+    private func refused(reasons: String) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            statusBlock(
+                icon: "hand.raised",
+                title: String(localized: "The moderator refused this claim"),
+                detail: reasons
+            )
+            Button {
+                flow.startOver()
+            } label: {
+                Text("File a new claim", comment: "Recovery claim start over button")
+                    .font(.system(size: 14, weight: .medium))
+            }
+            .accessibilityIdentifier("moderation.device_recovery.start_over")
+        }
+    }
+
+    private func markInForce(contact: String, newHolderURL: URL?, appealURL: URL?) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            statusBlock(
+                icon: "exclamationmark.shield",
+                title: String(localized: "A moderation record still bans this device"),
+                detail: String(localized: "The grant stays valid, but nothing moves while a ban stands. Resolve the case with the authority, then check again.")
+            )
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(contact)
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.text)
+                    if let appealURL {
+                        Link(destination: appealURL) {
+                            Text("Appeal the case", comment: "Recovery mark-in-force appeal link")
+                        }
+                        .accessibilityIdentifier("moderation.device_recovery.appeal")
+                    }
+                    if let newHolderURL {
+                        Link(destination: newHolderURL) {
+                            Text("New-holder claim", comment: "Recovery mark-in-force new holder link")
+                        }
+                        .accessibilityIdentifier("moderation.device_recovery.new_holder")
+                    }
+                }
+                .padding(16)
+            }
+            SettingsPrimaryButton(action: check) {
+                Text("Check again", comment: "Recovery mark-in-force re-check button")
+            }
+        }
+    }
+
+    private func statusBlock(icon: String, title: String, detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 28))
+                .foregroundStyle(OnymTokens.text2)
+            Text(title)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(detail)
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text2)
+                .lineSpacing(3)
+        }
+    }
+
+    private var isFiling: Bool {
+        if case .filing = flow.phase { return true }
+        return false
+    }
+
+    private var isChecking: Bool {
+        if case .checking = flow.phase { return true }
+        return false
+    }
+
+    private func submit() {
+        Task { await flow.submitClaim(contact: contact, statement: statement) }
+    }
+
+    private func check() {
+        Task { await flow.checkClaim() }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryView.swift
@@ -130,6 +130,18 @@ public struct DeviceRecoveryView: View {
             }
             .disabled(isChecking)
             .accessibilityIdentifier("moderation.device_recovery.check")
+            if flow.errorMessage != nil {
+                // The recurring-error exit: a persisted claim the
+                // authority no longer knows (re-consent, a pruned
+                // claim) would otherwise pin the holder here forever.
+                Button {
+                    flow.startOver()
+                } label: {
+                    Text("File a new claim", comment: "Recovery claim start over button")
+                        .font(.system(size: 14, weight: .medium))
+                }
+                .accessibilityIdentifier("moderation.device_recovery.start_over")
+            }
         }
     }
 

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
@@ -11,10 +11,27 @@ public struct GateCheckRequiredView: View {
     let onRetry: @MainActor () async -> Void
     let lookupRecoveryCaseIDs: (@MainActor () async -> [String])?
     let makeRecoveryCaseFlow: (@MainActor (String) async -> ModerationCaseFlow?)?
-    let makeDeviceRecoveryFlow: (@MainActor () -> DeviceRecoveryFlow)?
+    let makeDeviceRecoveryFlow: (@MainActor () async -> DeviceRecoveryFlow)?
 
-    @State private var showRecovery = false
-    @State private var deviceRecoveryFlow: DeviceRecoveryFlow?
+    /// Both recovery paths present from this screen. One `sheet(item:)`
+    /// over one enum, deliberately: two `.sheet` modifiers live on the
+    /// same view here, and SwiftUI has a long history of only honoring
+    /// one of them.
+    private enum ActiveSheet: Identifiable {
+        case caseAppeal
+        case deviceRecovery(DeviceRecoveryFlow)
+
+        var id: String {
+            switch self {
+            case .caseAppeal:
+                return "caseAppeal"
+            case .deviceRecovery(let flow):
+                return "deviceRecovery-\(ObjectIdentifier(flow))"
+            }
+        }
+    }
+
+    @State private var activeSheet: ActiveSheet?
     @State private var isRetrying = false
     @State private var retryMessage: String?
 
@@ -23,7 +40,7 @@ public struct GateCheckRequiredView: View {
         onRetry: @escaping @MainActor () async -> Void,
         lookupRecoveryCaseIDs: (@MainActor () async -> [String])? = nil,
         makeRecoveryCaseFlow: (@MainActor (String) async -> ModerationCaseFlow?)? = nil,
-        makeDeviceRecoveryFlow: (@MainActor () -> DeviceRecoveryFlow)? = nil
+        makeDeviceRecoveryFlow: (@MainActor () async -> DeviceRecoveryFlow)? = nil
     ) {
         self.reason = reason
         self.onRetry = onRetry
@@ -70,7 +87,9 @@ public struct GateCheckRequiredView: View {
             }
             if reason == .reidentificationRequired, let makeDeviceRecoveryFlow {
                 SettingsPrimaryButton(action: {
-                    deviceRecoveryFlow = makeDeviceRecoveryFlow()
+                    Task { @MainActor in
+                        activeSheet = .deviceRecovery(await makeDeviceRecoveryFlow())
+                    }
                 }) {
                     Text("Ask a moderator to recover this device")
                 }
@@ -81,7 +100,7 @@ public struct GateCheckRequiredView: View {
             if reason == .reidentificationRequired,
                lookupRecoveryCaseIDs != nil,
                makeRecoveryCaseFlow != nil {
-                Button("Appeal by case ID") { showRecovery = true }
+                Button("Appeal by case ID") { activeSheet = .caseAppeal }
                     .font(.system(size: 14, weight: .medium))
                     .foregroundStyle(OnymTokens.text)
                     .accessibilityIdentifier("moderation.gate_required.appeal")
@@ -92,16 +111,18 @@ public struct GateCheckRequiredView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(OnymTokens.surface.ignoresSafeArea())
         .accessibilityIdentifier("moderation.gate_required")
-        .sheet(isPresented: $showRecovery) {
-            if let lookupRecoveryCaseIDs, let makeRecoveryCaseFlow {
-                RecoveryAppealView(
-                    lookupCaseIDs: lookupRecoveryCaseIDs,
-                    makeCaseFlow: makeRecoveryCaseFlow
-                )
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .caseAppeal:
+                if let lookupRecoveryCaseIDs, let makeRecoveryCaseFlow {
+                    RecoveryAppealView(
+                        lookupCaseIDs: lookupRecoveryCaseIDs,
+                        makeCaseFlow: makeRecoveryCaseFlow
+                    )
+                }
+            case .deviceRecovery(let flow):
+                DeviceRecoveryView(flow: flow)
             }
-        }
-        .sheet(item: $deviceRecoveryFlow) { flow in
-            DeviceRecoveryView(flow: flow)
         }
     }
 

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
@@ -11,8 +11,10 @@ public struct GateCheckRequiredView: View {
     let onRetry: @MainActor () async -> Void
     let lookupRecoveryCaseIDs: (@MainActor () async -> [String])?
     let makeRecoveryCaseFlow: (@MainActor (String) async -> ModerationCaseFlow?)?
+    let makeDeviceRecoveryFlow: (@MainActor () -> DeviceRecoveryFlow)?
 
     @State private var showRecovery = false
+    @State private var deviceRecoveryFlow: DeviceRecoveryFlow?
     @State private var isRetrying = false
     @State private var retryMessage: String?
 
@@ -20,12 +22,14 @@ public struct GateCheckRequiredView: View {
         reason: CheckRequiredReason,
         onRetry: @escaping @MainActor () async -> Void,
         lookupRecoveryCaseIDs: (@MainActor () async -> [String])? = nil,
-        makeRecoveryCaseFlow: (@MainActor (String) async -> ModerationCaseFlow?)? = nil
+        makeRecoveryCaseFlow: (@MainActor (String) async -> ModerationCaseFlow?)? = nil,
+        makeDeviceRecoveryFlow: (@MainActor () -> DeviceRecoveryFlow)? = nil
     ) {
         self.reason = reason
         self.onRetry = onRetry
         self.lookupRecoveryCaseIDs = lookupRecoveryCaseIDs
         self.makeRecoveryCaseFlow = makeRecoveryCaseFlow
+        self.makeDeviceRecoveryFlow = makeDeviceRecoveryFlow
     }
 
     public var body: some View {
@@ -64,6 +68,16 @@ public struct GateCheckRequiredView: View {
                     .padding(.horizontal, 32)
                     .accessibilityIdentifier("moderation.gate_required.retry_result")
             }
+            if reason == .reidentificationRequired, let makeDeviceRecoveryFlow {
+                SettingsPrimaryButton(action: {
+                    deviceRecoveryFlow = makeDeviceRecoveryFlow()
+                }) {
+                    Text("Ask a moderator to recover this device")
+                }
+                .padding(.horizontal, 48)
+                .padding(.top, 8)
+                .accessibilityIdentifier("moderation.gate_required.recover")
+            }
             if reason == .reidentificationRequired,
                lookupRecoveryCaseIDs != nil,
                makeRecoveryCaseFlow != nil {
@@ -86,6 +100,9 @@ public struct GateCheckRequiredView: View {
                 )
             }
         }
+        .sheet(item: $deviceRecoveryFlow) { flow in
+            DeviceRecoveryView(flow: flow)
+        }
     }
 
     private var message: String {
@@ -99,7 +116,7 @@ public struct GateCheckRequiredView: View {
         case .attestationUnavailable:
             return String(localized: "Device verification isn't available in this environment. This is expected on Simulator; use UI-testing mode or a physical device.")
         case .reidentificationRequired:
-            return String(localized: "This device was previously flagged by the moderation authority, but this install cannot verify its original identity. Reinstalling or retrying will not fix this. Recover your case below to appeal the decision.")
+            return String(localized: "This device carries a moderation mark, but this install cannot verify its original identity. Reinstalling or retrying will not fix this. Ask a moderator to recover the device below — a person reviews your claim and decides.")
         case .clockRollback:
             return String(localized: "This device's clock is set earlier than its last verification. Check the date and time, then connect to continue.")
         case .backendRefused:

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -96,4 +96,8 @@ struct AppDependencies {
     let makeModerationRecoveryCaseFlow: @MainActor (_ caseId: String) async -> ModerationCaseFlow?
     /// Authenticated recovery lookup; the Authority returns case IDs only.
     let lookupModerationRecoveryCaseIDs: @MainActor () async -> [String]
+    /// Device recovery behind `reidentificationRequired`: file a claim
+    /// with the authority's human moderator, poll it, and redeem the
+    /// signed grant at the enforcement backend. Nothing self-serve.
+    let makeDeviceRecoveryFlow: @MainActor () -> DeviceRecoveryFlow
 }

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -99,5 +99,5 @@ struct AppDependencies {
     /// Device recovery behind `reidentificationRequired`: file a claim
     /// with the authority's human moderator, poll it, and redeem the
     /// signed grant at the enforcement backend. Nothing self-serve.
-    let makeDeviceRecoveryFlow: @MainActor () -> DeviceRecoveryFlow
+    let makeDeviceRecoveryFlow: @MainActor () async -> DeviceRecoveryFlow
 }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -610,6 +610,23 @@ struct OnymIOSApp: App {
             },
             lookupModerationRecoveryCaseIDs: { @MainActor in
                 (try? await moderationRepository.recoverableCaseIDs()) ?? []
+            },
+            makeDeviceRecoveryFlow: { @MainActor in
+                DeviceRecoveryFlow(
+                    claimStore: UserDefaultsRecoveryClaimStore(),
+                    fileClaim: { contact, statement in
+                        try await moderationRepository.fileDeviceRecoveryClaim(
+                            contact: contact,
+                            statement: statement
+                        )
+                    },
+                    claimStatus: { claimId in
+                        try await moderationRepository.deviceRecoveryClaimStatus(claimId: claimId)
+                    },
+                    redeem: { grant in
+                        await gateCheckRepository.redeemRecoveryGrant(grant)
+                    }
+                )
             }
         )
     }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -612,8 +612,14 @@ struct OnymIOSApp: App {
                 (try? await moderationRepository.recoverableCaseIDs()) ?? []
             },
             makeDeviceRecoveryFlow: { @MainActor in
-                DeviceRecoveryFlow(
+                // A resolvable key scopes the persisted claim to the
+                // identity that signed it. When no key resolves, the
+                // empty grantee matches no stored claim, and filing
+                // surfaces the signer's error on the form.
+                let grantee = (try? await moderationSigner.userKeyID()) ?? ""
+                return DeviceRecoveryFlow(
                     claimStore: UserDefaultsRecoveryClaimStore(),
+                    grantee: grantee,
                     fileClaim: { contact, statement in
                         try await moderationRepository.fileDeviceRecoveryClaim(
                             contact: contact,

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -52,7 +52,8 @@ struct RootView: View {
                     },
                     makeRecoveryCaseFlow: { caseId in
                         await dependencies.makeModerationRecoveryCaseFlow(caseId)
-                    }
+                    },
+                    makeDeviceRecoveryFlow: dependencies.makeDeviceRecoveryFlow
                 )
             case .checking, .needsConsent, .operational:
                 tabs

--- a/Tests/OnymIOSTests/DeviceRecoveryTests.swift
+++ b/Tests/OnymIOSTests/DeviceRecoveryTests.swift
@@ -1,0 +1,270 @@
+import XCTest
+@testable import OnymModeration
+import OnymModerationUI
+
+/// Device recovery: the grant's reference derivation pinned to a
+/// server-produced fixture, and the claim flow's phase transitions —
+/// the two places a wire mismatch or a UI dead end would show first.
+final class DeviceRecoveryTests: XCTestCase {
+
+    // MARK: - The grant against the reference Authority's bytes
+
+    /// Produced by the reference Authority's `issue_grant`
+    /// (`authority/src/recovery.rs`, onym-moderation#28) with a fixed
+    /// key (seed 0x07 × 32) and a fixed clock: the exact signed bytes
+    /// a device would receive, and the exact `grant_ref` the authority
+    /// recorded for them. If either side's canonicalization drifts,
+    /// this is what fails.
+    private static let serverGrantJSON = #"{"grantVersion":1,"caseId":"case-11111111-2222-3333-4444-555555555555","grantee":"npub1granteegranteegranteegranteegranteegranteegrantee","authority":"authority.example","issuedAt":"2025-08-09T00:40:00Z","signature":"7o/U1cs4JTzVth3wT5RUgQn0aXKQC+Ry1/SmXwRFTiEM9p4wxapCFAlh6fJoZE/udLLqd5iPf/9HJNRdPdy+AA=="}"#
+    private static let serverGrantRef =
+        "1451700a69ca305002fadf747e297cd30f22c02126037d1c466b569af0c6f781"
+
+    func testGrantReferenceMatchesServerProducedFixture() throws {
+        let grant = try RecoveryGrant(raw: Data(Self.serverGrantJSON.utf8))
+        XCTAssertEqual(grant.version, 1)
+        XCTAssertEqual(grant.caseId, "case-11111111-2222-3333-4444-555555555555")
+        XCTAssertEqual(grant.grantee, "npub1granteegranteegranteegranteegranteegranteegrantee")
+        XCTAssertEqual(grant.authority, "authority.example")
+        XCTAssertEqual(grant.issuedAt, "2025-08-09T00:40:00Z")
+        XCTAssertEqual(try grant.reference(), Self.serverGrantRef)
+    }
+
+    func testGrantWithUnknownVersionIsRefusedByName() {
+        let raw = Data(
+            Self.serverGrantJSON.replacingOccurrences(
+                of: #""grantVersion":1"#,
+                with: #""grantVersion":2"#
+            ).utf8
+        )
+        XCTAssertThrowsError(try RecoveryGrant(raw: raw)) { error in
+            guard case let ModerationError.grantInvalid(message) = error else {
+                return XCTFail("expected grantInvalid, got \(error)")
+            }
+            XCTAssertTrue(message.contains("version 2"), message)
+        }
+    }
+
+    /// The authority's decoder defaults an absent version to 1
+    /// (`#[serde(default = "one")]`); the client must derive the same
+    /// signing bytes either way, or an older-shaped grant would fail
+    /// redemption.
+    func testGrantWithAbsentVersionDefaultsToOne() throws {
+        let raw = Data(
+            Self.serverGrantJSON.replacingOccurrences(
+                of: #""grantVersion":1,"#,
+                with: ""
+            ).utf8
+        )
+        let grant = try RecoveryGrant(raw: raw)
+        XCTAssertEqual(grant.version, 1)
+        XCTAssertEqual(try grant.reference(), Self.serverGrantRef)
+    }
+
+    // MARK: - Claim store scoping
+
+    func testStoredClaimIsInvisibleToADifferentGrantee() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let store = UserDefaultsRecoveryClaimStore(defaults: defaults)
+
+        store.save("claim-1", grantee: "key-old")
+        XCTAssertEqual(store.load(grantee: "key-old"), "claim-1")
+        XCTAssertNil(store.load(grantee: "key-new"))
+
+        store.save(nil, grantee: "key-old")
+        XCTAssertNil(store.load(grantee: "key-old"))
+    }
+
+    // MARK: - Flow phase transitions
+
+    private final class InMemoryClaimStore: RecoveryClaimStore, @unchecked Sendable {
+        private var claimId: String?
+        private var grantee: String?
+
+        init(claimId: String? = nil, grantee: String? = nil) {
+            self.claimId = claimId
+            self.grantee = grantee
+        }
+
+        func load(grantee: String) -> String? {
+            guard self.grantee == grantee else { return nil }
+            return claimId
+        }
+
+        func save(_ claimId: String?, grantee: String) {
+            self.claimId = claimId
+            self.grantee = claimId == nil ? nil : grantee
+        }
+    }
+
+    private static func grant() throws -> RecoveryGrant {
+        try RecoveryGrant(raw: Data(serverGrantJSON.utf8))
+    }
+
+    @MainActor
+    private func makeFlow(
+        store: InMemoryClaimStore = InMemoryClaimStore(),
+        grantee: String = "key-1",
+        fileClaim: @escaping @MainActor (String, String) async throws -> String = { _, _ in "claim-1" },
+        claimStatus: @escaping @MainActor (String) async throws -> RecoveryClaimStatus = { _ in
+            RecoveryClaimStatus(state: "open", reasoning: nil, grant: nil)
+        },
+        redeem: @escaping @MainActor (RecoveryGrant) async -> RecoveryRedemption = { _ in
+            .failed("unexpected redeem")
+        }
+    ) -> DeviceRecoveryFlow {
+        DeviceRecoveryFlow(
+            claimStore: store,
+            grantee: grantee,
+            fileClaim: fileClaim,
+            claimStatus: claimStatus,
+            redeem: redeem
+        )
+    }
+
+    @MainActor
+    func testResumesAPersistedClaimOnlyForItsOwnGrantee() {
+        let store = InMemoryClaimStore(claimId: "claim-1", grantee: "key-1")
+        XCTAssertEqual(
+            makeFlow(store: store, grantee: "key-1").phase,
+            .awaitingReview(claimId: "claim-1")
+        )
+        XCTAssertEqual(makeFlow(store: store, grantee: "key-2").phase, .form)
+    }
+
+    @MainActor
+    func testFilingSavesTheClaimScopedToTheGrantee() async {
+        let store = InMemoryClaimStore()
+        let flow = makeFlow(store: store, grantee: "key-1")
+        await flow.submitClaim(contact: "me@example.com", statement: "bought used")
+        XCTAssertEqual(flow.phase, .awaitingReview(claimId: "claim-1"))
+        XCTAssertEqual(store.load(grantee: "key-1"), "claim-1")
+        XCTAssertNil(store.load(grantee: "key-2"))
+    }
+
+    @MainActor
+    func testAGrantedClaimRedeemsAndClearsTheStore() async throws {
+        let grant = try Self.grant()
+        let store = InMemoryClaimStore(claimId: "claim-1", grantee: "key-1")
+        var redeemed = [RecoveryGrant]()
+        let flow = makeFlow(
+            store: store,
+            claimStatus: { _ in RecoveryClaimStatus(state: "granted", reasoning: nil, grant: grant) },
+            redeem: { grant in
+                redeemed.append(grant)
+                return .recovered(.operational(openCases: []))
+            }
+        )
+        await flow.checkClaim()
+        XCTAssertEqual(flow.phase, .recovered)
+        XCTAssertEqual(redeemed, [grant])
+        XCTAssertNil(store.load(grantee: "key-1"))
+    }
+
+    @MainActor
+    func testARefusedClaimShowsReasonsAndClearsTheStore() async {
+        let store = InMemoryClaimStore(claimId: "claim-1", grantee: "key-1")
+        let flow = makeFlow(
+            store: store,
+            claimStatus: { _ in
+                RecoveryClaimStatus(state: "refused", reasoning: "contact unreachable", grant: nil)
+            }
+        )
+        await flow.checkClaim()
+        XCTAssertEqual(flow.phase, .refused(reasons: "contact unreachable"))
+        XCTAssertNil(store.load(grantee: "key-1"))
+    }
+
+    @MainActor
+    func testMarkInForceKeepsTheClaimAndStaysCheckable() async throws {
+        let grant = try Self.grant()
+        let store = InMemoryClaimStore(claimId: "claim-1", grantee: "key-1")
+        var polled = 0
+        let flow = makeFlow(
+            store: store,
+            claimStatus: { _ in
+                polled += 1
+                return RecoveryClaimStatus(state: "granted", reasoning: nil, grant: grant)
+            },
+            redeem: { _ in
+                .markInForce(authorityContact: "mod@example", newHolderURL: nil, appealURL: nil)
+            }
+        )
+        await flow.checkClaim()
+        guard case .markInForce = flow.phase else {
+            return XCTFail("expected markInForce, got \(flow.phase)")
+        }
+        XCTAssertEqual(store.load(grantee: "key-1"), "claim-1")
+
+        // "Check again" from markInForce must actually poll — the
+        // claim id is still in the store.
+        await flow.checkClaim()
+        XCTAssertEqual(polled, 2)
+    }
+
+    @MainActor
+    func testACheckInFlightIsNotReentered() async throws {
+        let grant = try Self.grant()
+        let store = InMemoryClaimStore(claimId: "claim-1", grantee: "key-1")
+        var polls = 0
+        var redemptions = 0
+        var release: CheckedContinuation<Void, Never>?
+        let flow = makeFlow(
+            store: store,
+            claimStatus: { _ in
+                polls += 1
+                await withCheckedContinuation { release = $0 }
+                return RecoveryClaimStatus(state: "granted", reasoning: nil, grant: grant)
+            },
+            redeem: { _ in
+                redemptions += 1
+                return .recovered(.operational(openCases: []))
+            }
+        )
+        let first = Task { await flow.checkClaim() }
+        // Let the first check reach the suspension inside claimStatus.
+        while release == nil { await Task.yield() }
+        XCTAssertEqual(flow.phase, .checking(claimId: "claim-1"))
+
+        // The view's `.task` firing here must not start a second poll
+        // that would redeem the single-use grant twice.
+        await flow.checkClaim()
+        XCTAssertEqual(polls, 1)
+
+        release?.resume()
+        await first.value
+        XCTAssertEqual(polls, 1)
+        XCTAssertEqual(redemptions, 1)
+        XCTAssertEqual(flow.phase, .recovered)
+    }
+
+    @MainActor
+    func testAPollErrorLeavesTheClaimActionable() async {
+        struct Unreachable: Error {}
+        let store = InMemoryClaimStore(claimId: "claim-1", grantee: "key-1")
+        let flow = makeFlow(store: store, claimStatus: { _ in throw Unreachable() })
+        await flow.checkClaim()
+        XCTAssertEqual(flow.phase, .awaitingReview(claimId: "claim-1"))
+        XCTAssertNotNil(flow.errorMessage)
+
+        // From here the view offers "file a new claim" — the exit for
+        // a persisted claim the authority no longer knows.
+        flow.startOver()
+        XCTAssertEqual(flow.phase, .form)
+        XCTAssertNil(flow.errorMessage)
+        XCTAssertNil(store.load(grantee: "key-1"))
+    }
+
+    @MainActor
+    func testAGrantedClaimWithoutBytesStaysAwaiting() async {
+        let store = InMemoryClaimStore(claimId: "claim-1", grantee: "key-1")
+        let flow = makeFlow(
+            store: store,
+            claimStatus: { _ in RecoveryClaimStatus(state: "granted", reasoning: nil, grant: nil) }
+        )
+        await flow.checkClaim()
+        XCTAssertEqual(flow.phase, .awaitingReview(claimId: "claim-1"))
+        XCTAssertNotNil(flow.errorMessage)
+        XCTAssertEqual(store.load(grantee: "key-1"), "claim-1")
+    }
+}


### PR DESCRIPTION
Client half of onymchat/onym-moderation#27–#29: the way back for a marked device whose enrolled identity did not survive a reinstall or a change of hands. **No self-serve unban** — the holder files a claim with a real contact and their account of holding the device; a human moderator decides; only the moderator-signed grant moves anything.

## Flow
1. `gateCheckRequired(.reidentificationRequired)` now offers **Ask a moderator to recover this device** (the case-ID appeal path stays for retained identities).
2. Claim form → `POST /v1/recovery-claims` (signed by the new identity over canonical bytes). Claim id persisted (`UserDefaultsRecoveryClaimStore`) so the screen resumes across relaunches.
3. Poll `GET /v1/recovery-claims/:id` (signed headers; answered only to the claim's key). Refusal shows the moderator's reasons and allows a fresh claim.
4. On grant: `GateCheckRepository.redeemRecoveryGrant` presents the grant's **exact signed bytes** to `POST /v1/recover` in an `onym-moderation-recover-v1` session bound to the grant reference (`RecoveryGrant.reference()` mirrors the server's canonical-bytes hash), folds the backend's reconciled gate answer into published state — success dismisses the blocking screen with no extra round trip. `markInForce` keeps the grant and shows the authority's routes.

## Notes
- `recover` / `fileRecoveryClaim` / `recoveryClaimStatus` are protocol **requirements** with refusing extension defaults — existential dispatch reaches the real clients; stubs and test fakes stay source-compatible.
- Grant bytes travel verbatim end to end; the client never re-encodes what the operator key signed.
- Tests: stacked PR follows. Unit suite: 1038 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)