### PR TITLE
Report screen UX: violation class as a visible, deliberate choice

### DIFF
--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/MarkdownDocumentView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/MarkdownDocumentView.swift
@@ -1,0 +1,230 @@
+import SwiftUI
+
+/// One block of a parsed markdown document. Foundation's markdown
+/// parser (`AttributedString(markdown:)` with `.full` syntax) styles
+/// inlines but only *annotates* block structure via
+/// `PresentationIntent` — `Text` renders it all as one flow. This
+/// splits the parse into blocks a view can lay out, using nothing but
+/// the system parser.
+public struct MarkdownBlock: Identifiable, Equatable {
+    public enum Kind: Equatable {
+        case paragraph
+        case heading(level: Int)
+        /// `ordinal` is set for ordered lists, nil for bullets.
+        case listItem(ordinal: Int?, depth: Int)
+        case codeBlock
+        case quote
+        case divider
+    }
+
+    public let id: Int
+    public let kind: Kind
+    public let text: AttributedString
+
+    public static func blocks(from markdown: String) -> [MarkdownBlock] {
+        let options = AttributedString.MarkdownParsingOptions(
+            allowsExtendedAttributes: false,
+            interpretedSyntax: .full,
+            failurePolicy: .returnPartiallyParsedIfPossible
+        )
+        guard let parsed = try? AttributedString(markdown: markdown, options: options) else {
+            // Unparseable input is still readable input.
+            return [MarkdownBlock(id: 0, kind: .paragraph, text: AttributedString(markdown))]
+        }
+        var blocks: [MarkdownBlock] = []
+        for (intent, range) in parsed.runs[\.presentationIntent] {
+            let slice = AttributedString(parsed[range])
+            var kind = Kind.paragraph
+            var ordinal: Int?
+            var ordered = false
+            var listDepth = 0
+            var isDivider = false
+            for component in intent?.components ?? [] {
+                switch component.kind {
+                case .header(let level):
+                    kind = .heading(level: level)
+                case .codeBlock:
+                    kind = .codeBlock
+                case .blockQuote:
+                    kind = .quote
+                case .listItem(let value):
+                    ordinal = value
+                case .orderedList:
+                    ordered = true
+                    listDepth += 1
+                case .unorderedList:
+                    listDepth += 1
+                case .thematicBreak:
+                    isDivider = true
+                default:
+                    break
+                }
+            }
+            if isDivider {
+                blocks.append(MarkdownBlock(id: blocks.count, kind: .divider, text: AttributedString()))
+                continue
+            }
+            if ordinal != nil || listDepth > 0 {
+                kind = .listItem(ordinal: ordered ? ordinal : nil, depth: max(listDepth, 1))
+            }
+            guard !slice.characters.allSatisfy(\.isWhitespace) else { continue }
+            blocks.append(MarkdownBlock(id: blocks.count, kind: kind, text: slice))
+        }
+        return blocks
+    }
+}
+
+/// In-app viewer for a fetched markdown document — the system parser
+/// only, no rendering dependency. An HTML answer (the address turned
+/// out to be a web page, not a document) hands off to the browser
+/// instead of pretending to render it.
+public struct MarkdownDocumentView: View {
+    private enum Phase {
+        case loading
+        case document([MarkdownBlock])
+        case webPage
+        case failed
+    }
+
+    private let title: String
+    private let url: URL
+
+    @State private var phase: Phase = .loading
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    public init(title: String, url: URL) {
+        self.title = title
+        self.url = url
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Group {
+                switch phase {
+                case .loading:
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                case .document(let blocks):
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 12) {
+                            ForEach(blocks) { block in
+                                blockView(block)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(20)
+                    }
+                case .webPage:
+                    handOff(
+                        message: String(localized: "This document is a web page.")
+                    )
+                case .failed:
+                    handOff(
+                        message: String(localized: "The document could not be fetched.")
+                    )
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .task { await load() }
+        .accessibilityIdentifier("moderation.document")
+    }
+
+    private func handOff(message: String) -> some View {
+        VStack(spacing: 12) {
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Button {
+                openURL(url)
+            } label: {
+                Label("Open in browser", systemImage: "safari")
+            }
+            .accessibilityIdentifier("moderation.document.open_in_browser")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: MarkdownBlock) -> some View {
+        switch block.kind {
+        case .heading(let level):
+            Text(block.text)
+                .font(headingFont(level))
+                .padding(.top, level <= 2 ? 8 : 4)
+        case .paragraph:
+            Text(block.text)
+                .font(.body)
+                .lineSpacing(3)
+        case .listItem(let ordinal, let depth):
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(ordinal.map { "\($0)." } ?? "•")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                Text(block.text)
+                    .font(.body)
+                    .lineSpacing(3)
+            }
+            .padding(.leading, CGFloat(depth - 1) * 16 + 4)
+        case .codeBlock:
+            Text(block.text)
+                .font(.system(.footnote, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
+        case .quote:
+            HStack(alignment: .top, spacing: 10) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(.tertiary)
+                    .frame(width: 3)
+                Text(block.text)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .lineSpacing(3)
+            }
+        case .divider:
+            Divider()
+        }
+    }
+
+    private func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: return .title2.weight(.semibold)
+        case 2: return .title3.weight(.semibold)
+        case 3: return .headline
+        default: return .subheadline.weight(.semibold)
+        }
+    }
+
+    private func load() async {
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let http = response as? HTTPURLResponse,
+                  (200..<300).contains(http.statusCode) else {
+                phase = .failed
+                return
+            }
+            let contentType = http.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
+            let text = String(decoding: data, as: UTF8.self)
+            let looksLikeHTML = contentType.contains("text/html")
+                || text.range(
+                    of: #"^\s*<(!doctype|html)"#,
+                    options: [.regularExpression, .caseInsensitive]
+                ) != nil
+            if looksLikeHTML {
+                phase = .webPage
+            } else {
+                phase = .document(MarkdownBlock.blocks(from: text))
+            }
+        } catch {
+            phase = .failed
+        }
+    }
+}

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportFlow.swift
@@ -39,7 +39,11 @@ public final class ModerationReportFlow {
         do {
             let classes = try await repository.availableReportClasses()
             state.classes = classes
-            state.selectedClassId = classes.first?.classId
+            // Deliberately no preselection: the class is the substance
+            // of the report, and the first class in a manifest is often
+            // the gravest (the live manifest leads with CSAM). Filing
+            // must require an explicit choice, never survive a reflex
+            // double-tap.
             if classes.isEmpty {
                 state.errorMessage = String(
                     localized: "Your current authority offers no reportable classes."

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -3,7 +3,15 @@ import OnymDesign
 import OnymModeration
 
 public struct ModerationReportView: View {
+    /// A definition document being read in-app.
+    private struct DefinitionDocument: Identifiable {
+        let title: String
+        let url: URL
+        var id: String { url.absoluteString }
+    }
+
     @State private var flow: ModerationReportFlow
+    @State private var definitionDocument: DefinitionDocument?
     @Environment(\.dismiss) private var dismiss
 
     public init(flow: ModerationReportFlow) {
@@ -34,6 +42,9 @@ public struct ModerationReportView: View {
             }
         }
         .task { await flow.start() }
+        .sheet(item: $definitionDocument) { document in
+            MarkdownDocumentView(title: document.title, url: document.url)
+        }
     }
 
     /// Both terminal outcomes: accepted with a receipt, or confirmed
@@ -192,8 +203,17 @@ public struct ModerationReportView: View {
     private func definitionLine(for item: ViolationClass) -> some View {
         if let url = URL(string: item.definition),
            url.scheme == "https" || url.scheme == "http" {
-            Link(destination: url) {
-                Label("What counts as this?", systemImage: "arrow.up.right.square")
+            // Read in-app: the reporter shouldn't have to leave a
+            // half-written report to learn what the class means. The
+            // viewer hands off to the browser itself when the address
+            // answers with a web page instead of a document.
+            Button {
+                definitionDocument = DefinitionDocument(
+                    title: Self.displayName(for: item.classId),
+                    url: url
+                )
+            } label: {
+                Label("What counts as this?", systemImage: "text.magnifyingglass")
                     .font(.footnote)
             }
             .accessibilityIdentifier("moderation.report.definition")

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -80,9 +80,12 @@ public struct ModerationReportView: View {
                 // the options and choose — not discover them one menu
                 // tap at a time, or inherit a default.
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(flow.state.classes, id: \.classId) { item in
+                    ForEach(
+                        Array(flow.state.classes.enumerated()),
+                        id: \.element.classId
+                    ) { index, item in
                         classRow(item)
-                        if item.classId != flow.state.classes.last?.classId {
+                        if index < flow.state.classes.count - 1 {
                             Divider().padding(.leading, 48)
                         }
                     }
@@ -133,42 +136,52 @@ public struct ModerationReportView: View {
     /// statutory-reporting notice for classes that declare one.
     private func classRow(_ item: ViolationClass) -> some View {
         let isSelected = item.classId == flow.state.selectedClassId
-        return Button {
-            flow.selectClass(item.classId)
-        } label: {
-            HStack(alignment: .top, spacing: 12) {
-                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 20))
-                    .foregroundStyle(isSelected ? AnyShapeStyle(.tint) : AnyShapeStyle(.tertiary))
-                    .padding(.top, 1)
-                VStack(alignment: .leading, spacing: 6) {
+        // The expanded details live BELOW the Button, not inside its
+        // label: SwiftUI renders controls nested in a button label
+        // inert, so a `Link` in there would never receive the tap —
+        // the row would swallow it as a re-select.
+        return VStack(alignment: .leading, spacing: 0) {
+            Button {
+                flow.selectClass(item.classId)
+            } label: {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 20))
+                        .foregroundStyle(isSelected ? AnyShapeStyle(.tint) : AnyShapeStyle(.tertiary))
+                        .padding(.top, 1)
                     Text(Self.displayName(for: item.classId))
                         .font(.body.weight(isSelected ? .semibold : .regular))
                         .foregroundStyle(.primary)
                         .multilineTextAlignment(.leading)
-                    if isSelected {
-                        definitionLine(for: item)
-                        if item.lawfulReporting != nil {
-                            Label(
-                                "The authority files legally required reports for this class.",
-                                systemImage: "building.columns"
-                            )
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .accessibilityIdentifier("moderation.report.lawful")
-                        }
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(flow.state.isSubmitting)
+            .accessibilityIdentifier("moderation.report.class.\(item.classId)")
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+            if isSelected {
+                VStack(alignment: .leading, spacing: 6) {
+                    definitionLine(for: item)
+                    if item.lawfulReporting != nil {
+                        Label(
+                            "The authority files legally required reports for this class.",
+                            systemImage: "building.columns"
+                        )
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("moderation.report.lawful")
                     }
                 }
-                Spacer(minLength: 0)
+                .padding(.leading, 48)
+                .padding(.trailing, 16)
+                .padding(.bottom, 12)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .disabled(flow.state.isSubmitting)
-        .accessibilityIdentifier("moderation.report.class.\(item.classId)")
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     /// The consented definition of the class. `definition` is a

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -72,47 +72,23 @@ public struct ModerationReportView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("VIOLATION CLASS")
+                Text("WHAT DOES IT VIOLATE?")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Picker(
-                    "Violation class",
-                    selection: Binding(
-                        get: { flow.state.selectedClassId ?? "" },
-                        set: { flow.selectClass($0) }
-                    )
-                ) {
+                // All classes visible at once, none preselected: the
+                // class IS the report, so the reporter should compare
+                // the options and choose — not discover them one menu
+                // tap at a time, or inherit a default.
+                VStack(alignment: .leading, spacing: 0) {
                     ForEach(flow.state.classes, id: \.classId) { item in
-                        Text(item.classId).tag(item.classId)
-                    }
-                }
-                .pickerStyle(.menu)
-                .disabled(flow.state.classes.isEmpty || flow.state.isSubmitting)
-                .accessibilityIdentifier("moderation.report.class")
-
-                // The consented definition of the selected class.
-                // `definition` is a content address (hash-or-url,
-                // AuthorityManifest): a URL opens the consented
-                // prohibited-content definition; a bare hash can only
-                // be shown as the address the user consented to.
-                if let selected = flow.state.classes.first(where: {
-                    $0.classId == flow.state.selectedClassId
-                }) {
-                    if let url = URL(string: selected.definition),
-                       url.scheme == "https" || url.scheme == "http" {
-                        Link(destination: url) {
-                            Label("Read the consented definition of this class", systemImage: "arrow.up.right.square")
-                                .font(.footnote)
+                        classRow(item)
+                        if item.classId != flow.state.classes.last?.classId {
+                            Divider().padding(.leading, 48)
                         }
-                        .accessibilityIdentifier("moderation.report.definition")
-                    } else {
-                        Text("Consented definition (content address): \(selected.definition)")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
-                            .accessibilityIdentifier("moderation.report.definition")
                     }
                 }
+                .background(.background, in: RoundedRectangle(cornerRadius: 14))
+                .accessibilityIdentifier("moderation.report.class")
             }
 
             Label(
@@ -147,6 +123,89 @@ public struct ModerationReportView: View {
             )
             .accessibilityIdentifier("moderation.report.submit")
         }
+    }
+
+    /// One selectable class. The name shown is the consented
+    /// `classId` with typography only — hyphens to spaces, known
+    /// acronyms uppercased — never a renaming: the id is the exact
+    /// vocabulary the mandate consented to. The selected row expands
+    /// with what choosing it means: the consented definition, and the
+    /// statutory-reporting notice for classes that declare one.
+    private func classRow(_ item: ViolationClass) -> some View {
+        let isSelected = item.classId == flow.state.selectedClassId
+        return Button {
+            flow.selectClass(item.classId)
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(isSelected ? AnyShapeStyle(.tint) : AnyShapeStyle(.tertiary))
+                    .padding(.top, 1)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(Self.displayName(for: item.classId))
+                        .font(.body.weight(isSelected ? .semibold : .regular))
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.leading)
+                    if isSelected {
+                        definitionLine(for: item)
+                        if item.lawfulReporting != nil {
+                            Label(
+                                "The authority files legally required reports for this class.",
+                                systemImage: "building.columns"
+                            )
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("moderation.report.lawful")
+                        }
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(flow.state.isSubmitting)
+        .accessibilityIdentifier("moderation.report.class.\(item.classId)")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    /// The consented definition of the class. `definition` is a
+    /// content address (hash-or-url, AuthorityManifest): a URL opens
+    /// the consented prohibited-content definition; a bare hash can
+    /// only be shown as the address the user consented to.
+    @ViewBuilder
+    private func definitionLine(for item: ViolationClass) -> some View {
+        if let url = URL(string: item.definition),
+           url.scheme == "https" || url.scheme == "http" {
+            Link(destination: url) {
+                Label("What counts as this?", systemImage: "arrow.up.right.square")
+                    .font(.footnote)
+            }
+            .accessibilityIdentifier("moderation.report.definition")
+        } else {
+            Text("Definition pinned to content address \(item.definition)")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .accessibilityIdentifier("moderation.report.definition")
+        }
+    }
+
+    /// Typography-only rendering of a consented class id: hyphens
+    /// become spaces, the leading word is capitalized, and short ids
+    /// known to be acronyms are uppercased. No translation, no
+    /// paraphrase — the words stay the manifest's words.
+    static func displayName(for classId: String) -> String {
+        let acronyms: Set<Substring> = ["csam", "ncii"]
+        let words = classId.split(separator: "-")
+        return words.enumerated().map { index, word in
+            if acronyms.contains(word) {
+                return word.uppercased()
+            }
+            return index == 0 ? word.prefix(1).uppercased() + word.dropFirst() : String(word)
+        }.joined(separator: " ")
     }
 
     private func success(_ receipt: ReportReceipt) -> some View {

--- a/Tests/OnymIOSTests/MarkdownBlockTests.swift
+++ b/Tests/OnymIOSTests/MarkdownBlockTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import OnymModerationUI
+
+/// The block splitter over Foundation's markdown parse: block
+/// structure recovered from PresentationIntent, inline styling left
+/// to AttributedString.
+final class MarkdownBlockTests: XCTestCase {
+
+    func testSplitsHeadingsParagraphsAndLists() {
+        let blocks = MarkdownBlock.blocks(from: """
+        # Policy
+
+        What this class prohibits.
+
+        - first
+        - second
+
+        1. step one
+        """)
+
+        XCTAssertEqual(blocks.count, 5)
+        XCTAssertEqual(blocks[0].kind, .heading(level: 1))
+        XCTAssertEqual(String(blocks[0].text.characters), "Policy")
+        XCTAssertEqual(blocks[1].kind, .paragraph)
+        XCTAssertEqual(blocks[2].kind, .listItem(ordinal: nil, depth: 1))
+        XCTAssertEqual(String(blocks[2].text.characters), "first")
+        XCTAssertEqual(blocks[3].kind, .listItem(ordinal: nil, depth: 1))
+        XCTAssertEqual(blocks[4].kind, .listItem(ordinal: 1, depth: 1))
+        XCTAssertEqual(String(blocks[4].text.characters), "step one")
+    }
+
+    func testRecognizesCodeQuoteAndDivider() {
+        let blocks = MarkdownBlock.blocks(from: """
+        > quoted term
+
+        ```
+        exact bytes
+        ```
+
+        ---
+        """)
+
+        XCTAssertEqual(blocks[0].kind, .quote)
+        XCTAssertEqual(blocks[1].kind, .codeBlock)
+        XCTAssertTrue(String(blocks[1].text.characters).contains("exact bytes"))
+        XCTAssertEqual(blocks[2].kind, .divider)
+    }
+
+    func testInlineStylingSurvivesTheSplit() throws {
+        let blocks = MarkdownBlock.blocks(from: "A **bold** claim with a [link](https://example.org).")
+        XCTAssertEqual(blocks.count, 1)
+        XCTAssertEqual(blocks[0].kind, .paragraph)
+        let text = blocks[0].text
+        XCTAssertEqual(String(text.characters), "A bold claim with a link.")
+        let linked = text.runs.compactMap(\.link)
+        XCTAssertEqual(linked, [URL(string: "https://example.org")!])
+        XCTAssertTrue(
+            text.runs.contains { run in
+                run.inlinePresentationIntent?.contains(.stronglyEmphasized) == true
+            },
+            "bold must survive as inline presentation"
+        )
+    }
+
+    func testUnparseableInputFallsBackToPlainParagraph() {
+        // Nothing markdown can't represent as *something*; the
+        // guarantee is no crash and no dropped content.
+        let blocks = MarkdownBlock.blocks(from: "just text")
+        XCTAssertEqual(blocks.count, 1)
+        XCTAssertEqual(String(blocks[0].text.characters), "just text")
+    }
+}


### PR DESCRIPTION
## What was wrong

- The class picker rendered **raw manifest slugs** (`csam`, `credible-violence`, `unsolicited-pornography`) verbatim in a `.menu` picker.
- `start()` **preselected the first class** — the live manifest orders gravest-first, so opening the sheet and tapping Submit filed a **CSAM report with no deliberate choice ever made**.
- The menu hid the options; three high-stakes choices should be comparable at a glance.
- Jargon copy: "VIOLATION CLASS", "Consented definition (content address): …".

## What it is now

- **No preselection** — Submit stays disabled until the reporter explicitly chooses (the disabled state existed; the default made it dead).
- **Radio-style list card** showing every class at once, checkmark on the selected row, matching the message card above it.
- **Names are typography only** — hyphens→spaces, sentence case, known acronyms uppercased ("CSAM", "Credible violence"). Deliberately not a renaming: the class id is consented vocabulary, so the words stay the manifest's words.
- **The selected row expands with what choosing it means**: a "What counts as this?" link to the consented definition (or the pinned content address for a bare hash), and a statutory-reporting notice for classes declaring `lawfulReporting` (e.g. CSAM) — the reporter learns the report may go beyond the authority *before* filing.
- Accessibility ids preserved (`moderation.report.class` group + per-row `moderation.report.class.<id>`); rows carry `.isSelected` and disable while submitting.

Full app build passes. Known limitation: the acronym set (`csam`, `ncii`) is a hardcoded allowlist — a new acronym class an authority coins would render capitalized-first until added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)