### PR TITLE
Run the app in Simulator: stub moderation seat where DeviceCheck doesn't exist

### DIFF
--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
@@ -135,7 +135,7 @@ public struct GateCheckRequiredView: View {
         case .tokenInvalid:
             return String(localized: "Apple rejected this device's verification token. Retry requests a fresh token; if it keeps failing, the app build and moderation service may be using different DeviceCheck environments.")
         case .attestationUnavailable:
-            return String(localized: "Device verification isn't available in this environment. This is expected on Simulator; use UI-testing mode or a physical device.")
+            return String(localized: "Device verification isn't available in this environment. Plain Simulator runs answer the gate with a stub, so this appears only when pointed at a real enforcement deployment; use a physical device for the full verification loop.")
         case .reidentificationRequired:
             return String(localized: "This device carries a moderation mark, but this install cannot verify its original identity. Reinstalling or retrying will not fix this. Ask a moderator to recover the device below — a person reviews your claim and decides.")
         case .clockRollback:

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -120,7 +120,24 @@ struct OnymIOSApp: App {
         let gateCheckRepository: GateCheckRepository
         let moderationManifestFetcher: any AuthorityManifestFetcher
         #if DEBUG
-        if args.contains("--ui-testing") {
+        // Simulator has no DeviceCheck (`DCDevice.isSupported` is
+        // false there), and the deployed interface answers a
+        // token-less session `check_required(attestationUnavailable)`
+        // — so a Simulator run against the production service can
+        // only ever show the blocking screen. Simulator builds
+        // therefore default the moderation seat to the same stubs as
+        // UI-testing mode (gate clear, seeded mandate); the
+        // UI-testing flags that shape those stubs still apply, and
+        // `--enforcement-base-url` still opts into the real loop
+        // against a local deployment. Compile-time-gated: a simulator
+        // binary cannot run on a device, so this can't ship.
+        #if targetEnvironment(simulator)
+        let stubModerationSeat = args.contains("--ui-testing")
+            || Self.resolveEnforcementBaseURL(args: args) == nil
+        #else
+        let stubModerationSeat = args.contains("--ui-testing")
+        #endif
+        if stubModerationSeat {
             let backend = StubEnforcementBackendClient(
                 scenario: Self.resolveModerationScenario(args: args)
             )


### PR DESCRIPTION
Simulator has no DeviceCheck capability (`DCDevice.isSupported` is false), and the deployed interface answers a token-less session `check_required(attestationUnavailable)` — so a plain Simulator run against the production service can only ever sit on the blocking screen. Development in Simulator required the full `--ui-testing` harness.

## Change

- **Simulator builds default the moderation seat to the UI-testing stubs** (gate clear, seeded mandate, stub authority clients) — everything else in the app stays real. The existing flags compose unchanged: `--moderation-scenario`/`--moderation-needs-consent` still shape the stubs, and `--enforcement-base-url` still opts into the real enforcement loop against a local deployment.
- **Compile-time gated** on `targetEnvironment(simulator)` inside the existing `#if DEBUG` block: a simulator binary cannot run on a device or ship, so the stub seat cannot leak into production behavior. Device builds (debug and release) are byte-for-byte unaffected.
- The `attestationUnavailable` blocking-screen copy no longer tells developers to use UI-testing mode — plain Simulator runs don't reach that screen anymore; it now appears only when a Simulator build points at a real deployment.

Verified: unit suite 1069 pass; the app installs and launches on an iPhone Air simulator (stub gate answers clear by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)