### PR TITLE
Support case-free unban grants

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/DeviceRecovery.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/DeviceRecovery.swift
@@ -83,46 +83,71 @@ public struct RecoveryGrant: Sendable, Equatable {
     /// (every field except `signature`, sorted keys). The enforcement
     /// backend derives the same value from the raw bytes to make the
     /// grant single-use, and the session signature binds it — so the
-    /// two derivations must agree. Reconstructed through a typed
-    /// mirror, like `Verdict.signingBytes()`: JSONEncoder's
-    /// `.sortedKeys` is UTF-8 byte order, matching serde's map order.
-    /// A grant carrying fields this mirror doesn't know would derive a
-    /// different reference and fail the session — acceptable, since
-    /// grants are consumed by the interface whose vocabulary this is.
+    /// two derivations must agree. Canonicalize the raw JSON itself
+    /// rather than reconstructing a typed subset: fields such as
+    /// `grantType` are part of the signature and must not be silently
+    /// omitted when the wire schema grows.
     public func reference() throws -> String {
-        struct CaseUnsigned: Encodable {
-            let grantVersion: Int
-            let caseId, grantee, authority, issuedAt: String
+        guard var object = try JSONSerialization.jsonObject(with: raw) as? [String: Any] else {
+            throw ModerationError.grantInvalid("recovery grant is not a JSON object")
         }
-        struct UnbanUnsigned: Encodable {
-            let grantVersion: Int
-            let claimId, grantee, authority, issuedAt: String
-        }
-        let bytes: Data
-        if grantType == "onym-recovery-grant-v1", !caseId.isEmpty {
-            bytes = try ModerationCanonicalEncoder.encode(
-                CaseUnsigned(
-                    grantVersion: version,
-                    caseId: caseId,
-                    grantee: grantee,
-                    authority: authority,
-                    issuedAt: issuedAt
-                )
-            )
-        } else if grantType == "onym-unban-grant-v1", let claimId {
-            bytes = try ModerationCanonicalEncoder.encode(
-                UnbanUnsigned(
-                    grantVersion: version,
-                    claimId: claimId,
-                    grantee: grantee,
-                    authority: authority,
-                    issuedAt: issuedAt
-                )
-            )
-        } else {
-            throw ModerationError.grantInvalid("grant has neither caseId nor claimId")
-        }
+        object.removeValue(forKey: "signature")
+        let bytes = try ModerationCanonicalEncoder.encode(RecoveryCanonicalJSON(object))
         return SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// An Encodable bridge for the raw JSON object in a grant. Using a
+/// dynamically keyed value keeps every signed field, while
+/// `ModerationCanonicalEncoder` still supplies the same sorted-key and
+/// number encoding as the Rust implementation.
+private struct RecoveryCanonicalJSON: Encodable {
+    private let value: Any
+
+    init(_ value: Any) {
+        self.value = value
+    }
+
+    private struct Key: CodingKey {
+        let stringValue: String
+        init?(stringValue: String) { self.stringValue = stringValue }
+        let intValue: Int? = nil
+        init?(intValue: Int) { return nil }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        switch value {
+        case let value as [String: Any]:
+            var container = encoder.container(keyedBy: Key.self)
+            for (key, value) in value {
+                try container.encode(RecoveryCanonicalJSON(value), forKey: Key(stringValue: key)!)
+            }
+        case let value as [Any]:
+            var container = encoder.unkeyedContainer()
+            for value in value {
+                try container.encode(RecoveryCanonicalJSON(value))
+            }
+        case let value as String:
+            var container = encoder.singleValueContainer()
+            try container.encode(value)
+        case let value as NSNumber:
+            var container = encoder.singleValueContainer()
+            if CFGetTypeID(value) == CFBooleanGetTypeID() {
+                try container.encode(value.boolValue)
+            } else if value.doubleValue.rounded() == value.doubleValue {
+                try container.encode(value.int64Value)
+            } else {
+                try container.encode(value.doubleValue)
+            }
+        case _ as NSNull:
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+        default:
+            throw EncodingError.invalidValue(
+                value,
+                EncodingError.Context(codingPath: encoder.codingPath, debugDescription: "unsupported JSON value")
+            )
+        }
     }
 }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/DeviceRecovery.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/DeviceRecovery.swift
@@ -21,7 +21,9 @@ public struct RecoveryGrant: Sendable, Equatable {
     /// to 1, and so does this decode (`RecoveryGrant` in
     /// `apple/src/types.rs`, `#[serde(default = "one")]`).
     public let version: Int
+    public let grantType: String
     public let caseId: String
+    public let claimId: String?
     /// The identity key the grant was issued to. The enforcement
     /// backend refuses a session by any other key, so a stolen grant
     /// is inert.
@@ -32,7 +34,10 @@ public struct RecoveryGrant: Sendable, Equatable {
     public init(raw: Data) throws {
         struct Wire: Decodable {
             let grantVersion: Int?
-            let caseId, grantee, authority, issuedAt, signature: String
+            let grantType: String?
+            let caseId: String?
+            let claimId: String?
+            let grantee, authority, issuedAt, signature: String
         }
         let wire: Wire
         do {
@@ -51,9 +56,24 @@ public struct RecoveryGrant: Sendable, Equatable {
                 "unsupported recovery grant version \(version); this client implements 1"
             )
         }
+        let grantType = wire.grantType ?? "onym-recovery-grant-v1"
+        guard grantType == "onym-recovery-grant-v1" || grantType == "onym-unban-grant-v1" else {
+            throw ModerationError.grantInvalid("unsupported recovery grant type \(grantType)")
+        }
+        if grantType == "onym-recovery-grant-v1" {
+            guard wire.caseId != nil else {
+                throw ModerationError.grantInvalid("case-bound recovery grant has no caseId")
+            }
+        } else {
+            guard wire.claimId != nil else {
+                throw ModerationError.grantInvalid("unban grant has no claimId")
+            }
+        }
         self.raw = raw
         self.version = version
-        self.caseId = wire.caseId
+        self.grantType = grantType
+        self.caseId = wire.caseId ?? ""
+        self.claimId = wire.claimId
         self.grantee = wire.grantee
         self.authority = wire.authority
         self.issuedAt = wire.issuedAt
@@ -70,19 +90,38 @@ public struct RecoveryGrant: Sendable, Equatable {
     /// different reference and fail the session — acceptable, since
     /// grants are consumed by the interface whose vocabulary this is.
     public func reference() throws -> String {
-        struct Unsigned: Encodable {
+        struct CaseUnsigned: Encodable {
             let grantVersion: Int
             let caseId, grantee, authority, issuedAt: String
         }
-        let bytes = try ModerationCanonicalEncoder.encode(
-            Unsigned(
-                grantVersion: version,
-                caseId: caseId,
-                grantee: grantee,
-                authority: authority,
-                issuedAt: issuedAt
+        struct UnbanUnsigned: Encodable {
+            let grantVersion: Int
+            let claimId, grantee, authority, issuedAt: String
+        }
+        let bytes: Data
+        if grantType == "onym-recovery-grant-v1", !caseId.isEmpty {
+            bytes = try ModerationCanonicalEncoder.encode(
+                CaseUnsigned(
+                    grantVersion: version,
+                    caseId: caseId,
+                    grantee: grantee,
+                    authority: authority,
+                    issuedAt: issuedAt
+                )
             )
-        )
+        } else if grantType == "onym-unban-grant-v1", let claimId {
+            bytes = try ModerationCanonicalEncoder.encode(
+                UnbanUnsigned(
+                    grantVersion: version,
+                    claimId: claimId,
+                    grantee: grantee,
+                    authority: authority,
+                    issuedAt: issuedAt
+                )
+            )
+        } else {
+            throw ModerationError.grantInvalid("grant has neither caseId nor claimId")
+        }
         return SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
     }
 }
@@ -272,4 +311,3 @@ public enum RecoveryRedemption: Sendable, Equatable {
     case markInForce(authorityContact: String, newHolderURL: URL?, appealURL: URL?)
     case failed(String)
 }
-

--- a/Tests/OnymIOSTests/DeviceRecoveryTests.swift
+++ b/Tests/OnymIOSTests/DeviceRecoveryTests.swift
@@ -30,6 +30,7 @@ final class DeviceRecoveryTests: XCTestCase {
     /// Grantee matches `CapturingSigner.userKeyID()` — the repository
     /// refuses to present a grant issued to any other key.
     private static let grantJSON = #"{"grantVersion":1,"caseId":"case-1","grantee":"onym:key:test","authority":"onym:component:authority","issuedAt":"2026-08-09T00:00:00Z","signature":"c2ln"}"#
+    private static let unbanGrantJSON = #"{"grantType":"onym-unban-grant-v1","grantVersion":1,"claimId":"claim-1","grantee":"onym:key:test","authority":"onym:component:authority","issuedAt":"2026-08-09T00:00:00Z","signature":"c2ln"}"#
 
     func testGrantParsesAndKeepsTheExactBytes() throws {
         let raw = Data(Self.grantJSON.utf8)
@@ -39,6 +40,21 @@ final class DeviceRecoveryTests: XCTestCase {
         XCTAssertEqual(grant.grantee, "onym:key:test")
         XCTAssertEqual(grant.authority, "onym:component:authority")
         XCTAssertEqual(grant.raw, raw, "the signed bytes travel verbatim")
+    }
+
+    func testCaseFreeUnbanGrantParsesWithoutACaseId() throws {
+        let raw = Data(Self.unbanGrantJSON.utf8)
+        let grant = try RecoveryGrant(raw: raw)
+        XCTAssertEqual(grant.grantType, "onym-unban-grant-v1")
+        XCTAssertEqual(grant.caseId, "")
+        XCTAssertEqual(grant.claimId, "claim-1")
+        XCTAssertEqual(grant.grantee, "onym:key:test")
+        XCTAssertEqual(grant.raw, raw)
+
+        let canonical = #"{"authority":"onym:component:authority","claimId":"claim-1","grantVersion":1,"grantee":"onym:key:test","issuedAt":"2026-08-09T00:00:00Z"}"#
+        let expected = SHA256.hash(data: Data(canonical.utf8))
+            .map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(try grant.reference(), expected)
     }
 
     /// The reference must equal SHA-256 over the server's canonical

--- a/Tests/OnymIOSTests/DeviceRecoveryTests.swift
+++ b/Tests/OnymIOSTests/DeviceRecoveryTests.swift
@@ -51,7 +51,7 @@ final class DeviceRecoveryTests: XCTestCase {
         XCTAssertEqual(grant.grantee, "onym:key:test")
         XCTAssertEqual(grant.raw, raw)
 
-        let canonical = #"{"authority":"onym:component:authority","claimId":"claim-1","grantVersion":1,"grantee":"onym:key:test","issuedAt":"2026-08-09T00:00:00Z"}"#
+        let canonical = #"{"authority":"onym:component:authority","claimId":"claim-1","grantType":"onym-unban-grant-v1","grantVersion":1,"grantee":"onym:key:test","issuedAt":"2026-08-09T00:00:00Z"}"#
         let expected = SHA256.hash(data: Data(canonical.utf8))
             .map { String(format: "%02x", $0) }.joined()
         XCTAssertEqual(try grant.reference(), expected)
@@ -64,7 +64,7 @@ final class DeviceRecoveryTests: XCTestCase {
     /// spot where a wrong canonicalization would diverge from serde.
     func testGrantReferenceMatchesTheCanonicalBytesHash() throws {
         let grant = try RecoveryGrant(raw: Data(Self.grantJSON.utf8))
-        let canonical = #"{"authority":"onym:component:authority","caseId":"case-1","grantVersion":1,"grantee":"onym:key:test","issuedAt":"2026-08-09T00:00:00Z"}"#
+        let canonical = #"{"authority":"onym:component:authority","caseId":"case-1","grantType":"onym-recovery-grant-v1","grantVersion":1,"grantee":"onym:key:test","issuedAt":"2026-08-09T00:00:00Z"}"#
         let expected = SHA256.hash(data: Data(canonical.utf8))
             .map { String(format: "%02x", $0) }.joined()
         XCTAssertEqual(try grant.reference(), expected)
@@ -78,9 +78,13 @@ final class DeviceRecoveryTests: XCTestCase {
     /// a device would receive, and the exact `grant_ref` the authority
     /// recorded for them. If either side's canonicalization drifts,
     /// this is what fails.
-    private static let serverGrantJSON = #"{"grantVersion":1,"caseId":"case-11111111-2222-3333-4444-555555555555","grantee":"npub1granteegranteegranteegranteegranteegranteegrantee","authority":"authority.example","issuedAt":"2025-08-09T00:40:00Z","signature":"7o/U1cs4JTzVth3wT5RUgQn0aXKQC+Ry1/SmXwRFTiEM9p4wxapCFAlh6fJoZE/udLLqd5iPf/9HJNRdPdy+AA=="}"#
+    private static let serverGrantJSON = #"{"grantType":"onym-recovery-grant-v1","grantVersion":1,"caseId":"case-11111111-2222-3333-4444-555555555555","grantee":"npub1granteegranteegranteegranteegranteegranteegrantee","authority":"authority.example","issuedAt":"2025-08-09T06:13:20Z","signature":"KKfCE9ub1yVm9XpPya9R/bP4NcEmwxjpBWKYJ+mfgwboHITFuPdzGYoOpImIJBsXFROta4Zr1erxnzz9O46VBw=="}"#
     private static let serverGrantRef =
-        "1451700a69ca305002fadf747e297cd30f22c02126037d1c466b569af0c6f781"
+        "e5cabc809d33e6216cb18d9282e9f6d9ca51dea46843e431b2a28216f0dfdd72"
+
+    private static let serverUnbanGrantJSON = #"{"grantType":"onym-unban-grant-v1","grantVersion":1,"claimId":"claim-1","grantee":"onym:key:g","authority":"onym:component:a","issuedAt":"2025-12-06T05:46:40Z","signature":"JBa9BruZ1xc1ekZrJKF4qrFg06UDpqotwdYM43mPtFDEgW35BD1Q9tICt/N5V915a9iyQeI0jjX81zrORhTzDA=="}"#
+    private static let serverUnbanGrantRef =
+        "fea6391989b8a2784bed76de96faa018f910be9def5d5f50c27038f9e93202e1"
 
     func testGrantReferenceMatchesServerProducedFixture() throws {
         let grant = try RecoveryGrant(raw: Data(Self.serverGrantJSON.utf8))
@@ -90,6 +94,16 @@ final class DeviceRecoveryTests: XCTestCase {
         XCTAssertEqual(grant.authority, "authority.example")
         XCTAssertEqual(grant.issuedAt, "2025-08-09T00:40:00Z")
         XCTAssertEqual(try grant.reference(), Self.serverGrantRef)
+    }
+
+    func testUnbanGrantReferenceMatchesServerProducedFixture() throws {
+        let grant = try RecoveryGrant(raw: Data(Self.serverUnbanGrantJSON.utf8))
+        XCTAssertEqual(grant.grantType, "onym-unban-grant-v1")
+        XCTAssertEqual(grant.claimId, "claim-1")
+        XCTAssertEqual(grant.grantee, "onym:key:g")
+        XCTAssertEqual(grant.authority, "onym:component:a")
+        XCTAssertEqual(grant.issuedAt, "2025-12-06T05:46:40Z")
+        XCTAssertEqual(try grant.reference(), Self.serverUnbanGrantRef)
     }
 
     func testGrantThatDoesNotParseIsRefused() {
@@ -112,10 +126,9 @@ final class DeviceRecoveryTests: XCTestCase {
         }
     }
 
-    /// The authority's decoder defaults an absent version to 1
-    /// (`#[serde(default = "one")]`); the client must derive the same
-    /// signing bytes either way, or an older-shaped grant would fail
-    /// redemption.
+    /// A legacy grant may omit the version. The decoded property still
+    /// defaults to 1, but canonicalization follows the exact raw bytes,
+    /// just as the interface does.
     func testGrantWithAbsentVersionDefaultsToOne() throws {
         let raw = Data(
             Self.serverGrantJSON.replacingOccurrences(
@@ -125,7 +138,10 @@ final class DeviceRecoveryTests: XCTestCase {
         )
         let grant = try RecoveryGrant(raw: raw)
         XCTAssertEqual(grant.version, 1)
-        XCTAssertEqual(try grant.reference(), Self.serverGrantRef)
+        let canonical = #"{"authority":"authority.example","caseId":"case-11111111-2222-3333-4444-555555555555","grantType":"onym-recovery-grant-v1","grantee":"npub1granteegranteegranteegranteegranteegranteegrantee","issuedAt":"2025-08-09T00:40:00Z"}"#
+        let expected = SHA256.hash(data: Data(canonical.utf8))
+            .map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(try grant.reference(), expected)
     }
 
     // MARK: - Session payload


### PR DESCRIPTION
## Summary
- decode the new `onym-unban-grant-v1` format
- preserve exact signed bytes and derive its claim-bound reference
- keep legacy case-bound recovery grants compatible

Depends on [onym-moderation#37](https://github.com/onymchat/onym-moderation/pull/37).

## Validation
- Swift package test invocation is blocked here by pre-existing macOS availability errors in `OnymFoundation`