### PR TITLE
Sign attachment bytes at send time (proof v2)

### DIFF
--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatMessagePayload.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatMessagePayload.swift
@@ -99,6 +99,11 @@ public struct ChatMessagePayload: Codable, Equatable, Sendable {
     /// contract's authenticity rule without exposing an envelope or
     /// any recipient secrets. Optional for wire compatibility with
     /// messages sent before reporting existed.
+    ///
+    /// When the payload carries media the preimage is v2, which also
+    /// commits to each attached blob's plaintext digest, MIME type and
+    /// byte length — the only sender commitment to attachment bytes
+    /// that exists anywhere in the system.
     public let moderationAuthenticityProof: String?
 
     public init(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatModerationProof.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatModerationProof.swift
@@ -13,6 +13,16 @@ import Foundation
 /// `groupID`, and `sentAtMillis` into the signed bytes pins the proof
 /// to one concrete send.
 ///
+/// A message carrying media signs a v2 preimage, which adds a `media`
+/// array committing to each attached blob's exact bytes. Without it an
+/// attachment is unreportable in principle, not merely unimplemented:
+/// nothing else in the system is a sender commitment to those bytes.
+/// The transport envelope is not one — `SealedEnvelope` signs only the
+/// ephemeral key it carries, so it authenticates who sent an envelope
+/// but produces nothing a third party could later verify against the
+/// content. Media sent before v2 therefore cannot be authenticated,
+/// ever, and recipients simply cannot report it.
+///
 /// The preimage is a JSON object with **UTF-8 byte-ordered keys**
 /// (`JSONEncoder.OutputFormatting.sortedKeys`), matching the canonical
 /// form every other moderation signing payload uses. The Authority
@@ -39,12 +49,102 @@ public enum ChatModerationProof {
     /// change can't be confused with this one.
     public static let version = 1
 
+    /// Version emitted when the message carries media. A v2 preimage is
+    /// a v1 preimage plus a `media` array committing to the exact bytes
+    /// of every blob the message references.
+    ///
+    /// The version — not the mere presence of the field — is what a
+    /// verifier dispatches on. A `media` array riding along in a v1
+    /// preimage must be refused rather than honoured, or the
+    /// discriminator would buy nothing.
+    public static let mediaVersion = 2
+
+    /// The sender's commitment to one attached blob's exact bytes.
+    ///
+    /// Two hashes, because they answer different questions.
+    /// `plaintextSha256` is over the bytes a recipient actually decrypts
+    /// and sees, so it is what an Authority re-derives from disclosed
+    /// evidence without ever needing the attachment key.
+    /// `blobSha256` is the ciphertext digest that already addresses the
+    /// blob on the blob server, so the commitment stays tied to the
+    /// stored object a recipient really fetched.
+    ///
+    /// Note that "plaintext" means the encoded bytes that travelled —
+    /// `ChatImageEncoder`'s downscaled, re-encoded JPEG — not the
+    /// original camera file. The evidence is what was received, which is
+    /// the only thing a recipient can honestly disclose.
+    ///
+    /// `width`/`height` are omitted where they have no meaning (voice),
+    /// which drops the keys from the preimage entirely rather than
+    /// encoding a placeholder.
+    public struct MediaCommitment: Encodable, Sendable, Equatable {
+        public let blobSha256: String
+        public let height: Int?
+        public let mimeType: String
+        public let plaintextByteLength: Int
+        public let plaintextSha256: String
+        public let width: Int?
+
+        public init(
+            blobSha256: String,
+            mimeType: String,
+            plaintextSha256: String,
+            plaintextByteLength: Int,
+            width: Int? = nil,
+            height: Int? = nil
+        ) {
+            self.blobSha256 = blobSha256
+            self.height = height
+            self.mimeType = mimeType
+            self.plaintextByteLength = plaintextByteLength
+            self.plaintextSha256 = plaintextSha256
+            self.width = width
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case blobSha256 = "blob_sha256"
+            case height
+            case mimeType = "mime_type"
+            case plaintextByteLength = "plaintext_byte_length"
+            case plaintextSha256 = "plaintext_sha256"
+            case width
+        }
+    }
+
+    /// Text-message preimage — unchanged v1 bytes.
+    ///
+    /// Kept as its own entry point so every existing text call site and
+    /// its pinned bytes stay exactly as they were: a message with no
+    /// media must still produce a v1 preimage, byte for byte.
     public static func signedContent(
         messageID: UUID,
         groupID: String,
         groupSecret: Data,
         sentAtMillis: Int64,
         body: String
+    ) throws -> String {
+        try signedContent(
+            messageID: messageID,
+            groupID: groupID,
+            groupSecret: groupSecret,
+            sentAtMillis: sentAtMillis,
+            body: body,
+            media: []
+        )
+    }
+
+    /// Preimage for a message that may carry media.
+    ///
+    /// Empty `media` yields the v1 shape; a non-empty one yields v2.
+    /// Media order is the message's own order and is part of the signed
+    /// bytes, so an album cannot be reordered after the fact.
+    public static func signedContent(
+        messageID: UUID,
+        groupID: String,
+        groupSecret: Data,
+        sentAtMillis: Int64,
+        body: String,
+        media: [MediaCommitment]
     ) throws -> String {
         struct Preimage: Encodable {
             let body: String
@@ -61,23 +161,70 @@ public enum ChatModerationProof {
                 case sentAtMillis = "sent_at_millis"
             }
         }
+        /// v2 adds exactly one key. `media` sorts between
+        /// `group_binding` and `message_id` by UTF-8 byte order, which
+        /// `MediaPreimageKeyOrderTests` pins.
+        struct MediaPreimage: Encodable {
+            let body: String
+            let groupBinding: String
+            let media: [MediaCommitment]
+            let messageID: String
+            let proofVersion: Int
+            let sentAtMillis: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case body
+                case groupBinding = "group_binding"
+                case media
+                case messageID = "message_id"
+                case proofVersion = "proof_version"
+                case sentAtMillis = "sent_at_millis"
+            }
+        }
         let messageIDString = messageID.uuidString.lowercased()
+        let binding = groupBinding(
+            groupID: groupID,
+            groupSecret: groupSecret,
+            messageIDString: messageIDString
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data: Data
+        if media.isEmpty {
+            data = try encoder.encode(Preimage(
+                body: body,
+                groupBinding: binding,
+                messageID: messageIDString,
+                proofVersion: version,
+                sentAtMillis: sentAtMillis
+            ))
+        } else {
+            data = try encoder.encode(MediaPreimage(
+                body: body,
+                groupBinding: binding,
+                media: media,
+                messageID: messageIDString,
+                proofVersion: mediaVersion,
+                sentAtMillis: sentAtMillis
+            ))
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// The keyed group binding shared by every preimage version. The
+    /// domain string stays `v1`: it separates this hash from other uses
+    /// of the group secret, and it is not the preimage's own version.
+    private static func groupBinding(
+        groupID: String,
+        groupSecret: Data,
+        messageIDString: String
+    ) -> String {
         var hasher = SHA256()
         hasher.update(data: Data("onym-moderation-proof-v1|".utf8))
         hasher.update(data: groupSecret)
         hasher.update(data: Data("|\(groupID)|\(messageIDString)".utf8))
-        let binding = hasher.finalize()
+        return hasher.finalize()
             .map { String(format: "%02x", $0) }.joined()
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        let data = try encoder.encode(Preimage(
-            body: body,
-            groupBinding: binding,
-            messageID: messageIDString,
-            proofVersion: version,
-            sentAtMillis: sentAtMillis
-        ))
-        return String(decoding: data, as: UTF8.self)
     }
 
     /// Millisecond timestamp recovered from a stored `sentAt` date.

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -157,24 +157,13 @@ public actor SendMessageInteractor {
         // message. Best-effort by design: a signing failure ships the
         // message without a proof (recipients just can't report it)
         // rather than adding a crypto dependency to every text send.
-        let moderationAuthenticityProof: String?
-        do {
-            moderationAuthenticityProof = try await identity.signWithStellarKey(
-                Data(ChatModerationProof.signedContent(
-                    messageID: messageID,
-                    groupID: groupID,
-                    groupSecret: group.groupSecret,
-                    sentAtMillis: sentAtMillis,
-                    body: body
-                ).utf8)
-            ).base64EncodedString()
-        } catch {
-            // A systematic failure (e.g. keychain) must be visible in
-            // diagnostics. Error only — no message/group identifiers,
-            // per the no-activity-logging policy.
-            Self.logger.error("moderation proof signing failed: \(error, privacy: .private)")
-            moderationAuthenticityProof = nil
-        }
+        let moderationAuthenticityProof = await moderationProof(
+            messageID: messageID,
+            groupID: groupID,
+            groupSecret: group.groupSecret,
+            sentAtMillis: sentAtMillis,
+            body: body
+        )
         let payload = ChatMessagePayload(
             version: 1,
             messageID: messageID,
@@ -246,6 +235,47 @@ public actor SendMessageInteractor {
         )
     }
 
+    /// Sign the moderation proof preimage for one send.
+    ///
+    /// Best-effort by design, matching the text path this was factored
+    /// out of: a signing failure ships the message without a proof —
+    /// recipients just can't report it — rather than making every send
+    /// depend on the keychain succeeding.
+    ///
+    /// Passing a non-empty `media` produces a v2 preimage committing to
+    /// those exact bytes. Every media send supplies it, including video,
+    /// album, and voice, whose evidence the Authority does not accept
+    /// yet: the commitment is only creatable at send time, so omitting
+    /// it now would make today's sends permanently unauthenticable and
+    /// force a third preimage version later.
+    private func moderationProof(
+        messageID: UUID,
+        groupID: String,
+        groupSecret: Data,
+        sentAtMillis: Int64,
+        body: String,
+        media: [ChatModerationProof.MediaCommitment] = []
+    ) async -> String? {
+        do {
+            return try await identity.signWithStellarKey(
+                Data(ChatModerationProof.signedContent(
+                    messageID: messageID,
+                    groupID: groupID,
+                    groupSecret: groupSecret,
+                    sentAtMillis: sentAtMillis,
+                    body: body,
+                    media: media
+                ).utf8)
+            ).base64EncodedString()
+        } catch {
+            // A systematic failure (e.g. keychain) must be visible in
+            // diagnostics. Error only — no message/group identifiers,
+            // per the no-activity-logging policy.
+            Self.logger.error("moderation proof signing failed: \(error, privacy: .private)")
+            return nil
+        }
+    }
+
     /// Send an image message. Encodes + AES-GCM-encrypts the image, then
     /// inserts the optimistic bubble **before** the upload so the sender
     /// sees the image immediately (rendered from the primed plaintext)
@@ -313,6 +343,21 @@ public actor SendMessageInteractor {
 
         let messageID = UUID()
         let sentAtMillis = Int64(now.timeIntervalSince1970 * 1000)
+        let moderationAuthenticityProof = await moderationProof(
+            messageID: messageID,
+            groupID: groupID,
+            groupSecret: group.groupSecret,
+            sentAtMillis: sentAtMillis,
+            body: caption,
+            media: [ChatModerationProof.MediaCommitment(
+                blobSha256: sealed.sha256Hex,
+                mimeType: "image/jpeg",
+                plaintextSha256: ChatImageCrypto.sha256Hex(encoded.jpeg),
+                plaintextByteLength: encoded.jpeg.count,
+                width: encoded.width,
+                height: encoded.height
+            )]
+        )
         let payload = ChatMessagePayload(
             version: 1,
             messageID: messageID,
@@ -321,7 +366,8 @@ public actor SendMessageInteractor {
             sentAtMillis: sentAtMillis,
             replyToMessageID: nil,
             variant: variant,
-            attachment: attachment
+            attachment: attachment,
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
         let pending = ChatMessage(
             id: messageID,
@@ -329,11 +375,15 @@ public actor SendMessageInteractor {
             ownerIdentityID: group.ownerIdentityID,
             senderBlsPubkeyHex: myBlsHex,
             body: caption,
-            sentAt: now,
+            // From the wire millis, not the raw `now`: the proof signs
+            // the truncated value, so the stored date must reconstruct
+            // exactly what every recipient derives.
+            sentAt: Date(timeIntervalSince1970: TimeInterval(sentAtMillis) / 1000.0),
             direction: .outgoing,
             status: .pending,
             replyToMessageID: nil,
             groupType: group.groupType,
+            moderationAuthenticityProof: moderationAuthenticityProof,
             imageAttachment: attachment
         )
         // Optimistic insert BEFORE the upload — the bubble appears
@@ -441,6 +491,33 @@ public actor SendMessageInteractor {
 
         let messageID = UUID()
         let sentAtMillis = Int64(now.timeIntervalSince1970 * 1000)
+        // Poster first, then the video — the same order they upload in,
+        // and the order is inside the signed bytes.
+        let moderationAuthenticityProof = await moderationProof(
+            messageID: messageID,
+            groupID: groupID,
+            groupSecret: group.groupSecret,
+            sentAtMillis: sentAtMillis,
+            body: caption,
+            media: [
+                ChatModerationProof.MediaCommitment(
+                    blobSha256: posterSealed.sha256Hex,
+                    mimeType: "image/jpeg",
+                    plaintextSha256: ChatImageCrypto.sha256Hex(encoded.poster.jpeg),
+                    plaintextByteLength: encoded.poster.jpeg.count,
+                    width: encoded.poster.width,
+                    height: encoded.poster.height
+                ),
+                ChatModerationProof.MediaCommitment(
+                    blobSha256: videoSealed.sha256Hex,
+                    mimeType: "video/mp4",
+                    plaintextSha256: ChatImageCrypto.sha256Hex(encoded.mp4),
+                    plaintextByteLength: encoded.mp4.count,
+                    width: encoded.width,
+                    height: encoded.height
+                ),
+            ]
+        )
         let payload = ChatMessagePayload(
             version: 1,
             messageID: messageID,
@@ -449,7 +526,8 @@ public actor SendMessageInteractor {
             sentAtMillis: sentAtMillis,
             replyToMessageID: nil,
             variant: variant,
-            videoAttachment: videoAttachment
+            videoAttachment: videoAttachment,
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
         let pending = ChatMessage(
             id: messageID,
@@ -457,11 +535,12 @@ public actor SendMessageInteractor {
             ownerIdentityID: group.ownerIdentityID,
             senderBlsPubkeyHex: myBlsHex,
             body: caption,
-            sentAt: now,
+            sentAt: Date(timeIntervalSince1970: TimeInterval(sentAtMillis) / 1000.0),
             direction: .outgoing,
             status: .pending,
             replyToMessageID: nil,
             groupType: group.groupType,
+            moderationAuthenticityProof: moderationAuthenticityProof,
             videoAttachment: videoAttachment
         )
         // Optimistic insert BEFORE upload.
@@ -532,6 +611,11 @@ public actor SendMessageInteractor {
         var items: [ChatMediaAttachment] = []
         var uploads: [(Data, String)] = []
         var shas: [String] = []
+        // Accumulated in lockstep with `uploads`/`shas`, so the signed
+        // media order is the album's own order. A skipped item is absent
+        // from both, which keeps the commitment describing exactly what
+        // was sent rather than what was picked.
+        var commitments: [ChatModerationProof.MediaCommitment] = []
         for source in sources {
             switch source {
             case .image(let data):
@@ -547,6 +631,14 @@ public actor SendMessageInteractor {
                 items.append(.image(attachment))
                 uploads.append((sealed.blob, "image/jpeg"))
                 shas.append(sealed.sha256Hex)
+                commitments.append(ChatModerationProof.MediaCommitment(
+                    blobSha256: sealed.sha256Hex,
+                    mimeType: "image/jpeg",
+                    plaintextSha256: ChatImageCrypto.sha256Hex(encoded.jpeg),
+                    plaintextByteLength: encoded.jpeg.count,
+                    width: encoded.width,
+                    height: encoded.height
+                ))
             case .video(let url):
                 guard let encoded = await videoEncoder(url),
                       let posterSealed = try? ChatImageCrypto.seal(encoded.poster.jpeg),
@@ -572,6 +664,22 @@ public actor SendMessageInteractor {
                 uploads.append((videoSealed.blob, "video/mp4"))
                 shas.append(posterSealed.sha256Hex)
                 shas.append(videoSealed.sha256Hex)
+                commitments.append(ChatModerationProof.MediaCommitment(
+                    blobSha256: posterSealed.sha256Hex,
+                    mimeType: "image/jpeg",
+                    plaintextSha256: ChatImageCrypto.sha256Hex(encoded.poster.jpeg),
+                    plaintextByteLength: encoded.poster.jpeg.count,
+                    width: encoded.poster.width,
+                    height: encoded.poster.height
+                ))
+                commitments.append(ChatModerationProof.MediaCommitment(
+                    blobSha256: videoSealed.sha256Hex,
+                    mimeType: "video/mp4",
+                    plaintextSha256: ChatImageCrypto.sha256Hex(encoded.mp4),
+                    plaintextByteLength: encoded.mp4.count,
+                    width: encoded.width,
+                    height: encoded.height
+                ))
             }
         }
         guard !items.isEmpty else { throw SendError.imageEncodeFailed }
@@ -583,6 +691,14 @@ public actor SendMessageInteractor {
         let singleImage: ChatImageAttachment? = items.count == 1 ? items[0].asImage : nil
         let singleVideo: ChatVideoAttachment? = items.count == 1 ? items[0].asVideo : nil
         let album: [ChatMediaAttachment]? = items.count > 1 ? items : nil
+        let moderationAuthenticityProof = await moderationProof(
+            messageID: messageID,
+            groupID: groupID,
+            groupSecret: group.groupSecret,
+            sentAtMillis: sentAtMillis,
+            body: caption,
+            media: commitments
+        )
         let payload = ChatMessagePayload(
             version: 1,
             messageID: messageID,
@@ -593,13 +709,16 @@ public actor SendMessageInteractor {
             variant: variant,
             attachment: singleImage,
             videoAttachment: singleVideo,
-            attachments: album
+            attachments: album,
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
         let pending = ChatMessage(
             id: messageID, groupID: groupID, ownerIdentityID: group.ownerIdentityID,
-            senderBlsPubkeyHex: myBlsHex, body: caption, sentAt: now,
+            senderBlsPubkeyHex: myBlsHex, body: caption,
+            sentAt: Date(timeIntervalSince1970: TimeInterval(sentAtMillis) / 1000.0),
             direction: .outgoing, status: .pending, replyToMessageID: nil,
             groupType: group.groupType,
+            moderationAuthenticityProof: moderationAuthenticityProof,
             imageAttachment: singleImage, videoAttachment: singleVideo,
             albumAttachments: album
         )
@@ -683,6 +802,21 @@ public actor SendMessageInteractor {
 
         let messageID = UUID()
         let sentAtMillis = Int64(now.timeIntervalSince1970 * 1000)
+        // No width/height: those keys are absent from the preimage for
+        // audio rather than carrying a placeholder value.
+        let moderationAuthenticityProof = await moderationProof(
+            messageID: messageID,
+            groupID: groupID,
+            groupSecret: group.groupSecret,
+            sentAtMillis: sentAtMillis,
+            body: "",
+            media: [ChatModerationProof.MediaCommitment(
+                blobSha256: sealed.sha256Hex,
+                mimeType: "audio/mp4",
+                plaintextSha256: ChatImageCrypto.sha256Hex(encoded.m4a),
+                plaintextByteLength: encoded.m4a.count
+            )]
+        )
         let payload = ChatMessagePayload(
             version: 1,
             messageID: messageID,
@@ -691,7 +825,8 @@ public actor SendMessageInteractor {
             sentAtMillis: sentAtMillis,
             replyToMessageID: nil,
             variant: variant,
-            voiceAttachment: voiceAttachment
+            voiceAttachment: voiceAttachment,
+            moderationAuthenticityProof: moderationAuthenticityProof
         )
         let pending = ChatMessage(
             id: messageID,
@@ -699,11 +834,12 @@ public actor SendMessageInteractor {
             ownerIdentityID: group.ownerIdentityID,
             senderBlsPubkeyHex: myBlsHex,
             body: "",
-            sentAt: now,
+            sentAt: Date(timeIntervalSince1970: TimeInterval(sentAtMillis) / 1000.0),
             direction: .outgoing,
             status: .pending,
             replyToMessageID: nil,
             groupType: group.groupType,
+            moderationAuthenticityProof: moderationAuthenticityProof,
             voiceAttachment: voiceAttachment
         )
         // Optimistic insert BEFORE the upload.

--- a/Tests/OnymIOSTests/ChatModerationProofTests.swift
+++ b/Tests/OnymIOSTests/ChatModerationProofTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+import OnymChatsCore
+
+/// The exact bytes a sender signs as a moderation authenticity proof.
+///
+/// These are golden-byte tests on purpose. The preimage is verified by
+/// an Authority written in another language (Rust, today), and the
+/// Authority never reconstructs it — it verifies a signature over the
+/// disclosed string verbatim and parses fields out. So drift here does
+/// not surface as a parse error on either side; it surfaces as "every
+/// report signature for media is invalid", silently, in production.
+///
+/// Two properties are load-bearing and neither is obvious from reading
+/// the encoder call:
+///
+///  - Keys sort by **UTF-8 byte order** (`JSONEncoder`'s `.sortedKeys`,
+///    not `JSONSerialization`'s case-insensitive option of the same
+///    name), so `media` lands between `group_binding` and `message_id`.
+///  - Forward slashes are **escaped** (`image\/jpeg`), because the
+///    preimage encoder deliberately does not set
+///    `.withoutEscapingSlashes`. Adding that option would be a silent
+///    breaking change: a v1 body containing "/" would stop reproducing
+///    the bytes its sender already signed, retroactively invalidating
+///    the proof on every such message already delivered.
+final class ChatModerationProofTests: XCTestCase {
+    private let messageID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    private let groupID = "group-1"
+    private let groupSecret = Data(repeating: 0x07, count: 32)
+    private let sentAtMillis: Int64 = 1_785_580_800_123
+
+    /// SHA-256 over `"onym-moderation-proof-v1|" ‖ secret ‖ "|<group>|<message>"`
+    /// for the fixture above, computed independently of this code.
+    private let binding = "18413f675da1f5410fa8e199b799c2bf3700575ddac201c9a8d2dfdf8327ce6a"
+
+    private let blobSha = String(repeating: "0f", count: 32)
+    private let plaintextSha = String(repeating: "1a", count: 32)
+
+    private func imageCommitment() -> ChatModerationProof.MediaCommitment {
+        ChatModerationProof.MediaCommitment(
+            blobSha256: blobSha,
+            mimeType: "image/jpeg",
+            plaintextSha256: plaintextSha,
+            plaintextByteLength: 421_337,
+            width: 1200,
+            height: 1600
+        )
+    }
+
+    private func content(
+        body: String = "hello",
+        media: [ChatModerationProof.MediaCommitment]
+    ) throws -> String {
+        try ChatModerationProof.signedContent(
+            messageID: messageID,
+            groupID: groupID,
+            groupSecret: groupSecret,
+            sentAtMillis: sentAtMillis,
+            body: body,
+            media: media
+        )
+    }
+
+    /// A message with no media must still produce v1 bytes, exactly.
+    /// Every text proof already signed by a shipped client depends on
+    /// this, so it is the one assertion that must never be "updated to
+    /// match" a new implementation.
+    func test_textMessage_producesTheExactV1Preimage() throws {
+        let expected = #"{"body":"hello","group_binding":"\#(binding)","message_id":"00000000-0000-0000-0000-000000000001","proof_version":1,"sent_at_millis":1785580800123}"#
+        XCTAssertEqual(try content(media: []), expected)
+    }
+
+    /// The convenience entry point text sends use must be identical to
+    /// passing no media, or the two call paths would drift apart.
+    func test_theTextEntryPoint_matchesAnEmptyMediaList() throws {
+        let viaTextPath = try ChatModerationProof.signedContent(
+            messageID: messageID,
+            groupID: groupID,
+            groupSecret: groupSecret,
+            sentAtMillis: sentAtMillis,
+            body: "hello"
+        )
+        XCTAssertEqual(viaTextPath, try content(media: []))
+    }
+
+    /// The full v2 shape: `media` sorted into place, entry keys in byte
+    /// order, and the escaped slash in the MIME type.
+    func test_mediaMessage_producesTheExactV2Preimage() throws {
+        let expected = #"{"body":"hello","group_binding":"\#(binding)","media":[{"blob_sha256":"\#(blobSha)","height":1600,"mime_type":"image\/jpeg","plaintext_byte_length":421337,"plaintext_sha256":"\#(plaintextSha)","width":1200}],"message_id":"00000000-0000-0000-0000-000000000001","proof_version":2,"sent_at_millis":1785580800123}"#
+        XCTAssertEqual(try content(media: [imageCommitment()]), expected)
+    }
+
+    /// `media` must sort between `group_binding` and `message_id`.
+    /// Case-insensitive sorting would also place it there, so this is
+    /// not the test that catches a `JSONSerialization` swap — it pins
+    /// the position a verifier's field scan depends on.
+    func test_mediaKeySortsBetweenGroupBindingAndMessageID() throws {
+        let text = try content(media: [imageCommitment()])
+        let group = try XCTUnwrap(text.range(of: "\"group_binding\""))
+        let media = try XCTUnwrap(text.range(of: "\"media\""))
+        let message = try XCTUnwrap(text.range(of: "\"message_id\""))
+        XCTAssertTrue(group.lowerBound < media.lowerBound)
+        XCTAssertTrue(media.lowerBound < message.lowerBound)
+    }
+
+    /// Audio has no pixel dimensions, so those keys are absent rather
+    /// than carrying a zero a verifier might read as a real value.
+    func test_mediaWithoutDimensions_omitsWidthAndHeight() throws {
+        let voice = ChatModerationProof.MediaCommitment(
+            blobSha256: blobSha,
+            mimeType: "audio/mp4",
+            plaintextSha256: plaintextSha,
+            plaintextByteLength: 9
+        )
+        let expected = #"{"body":"","group_binding":"\#(binding)","media":[{"blob_sha256":"\#(blobSha)","mime_type":"audio\/mp4","plaintext_byte_length":9,"plaintext_sha256":"\#(plaintextSha)"}],"message_id":"00000000-0000-0000-0000-000000000001","proof_version":2,"sent_at_millis":1785580800123}"#
+        XCTAssertEqual(try content(body: "", media: [voice]), expected)
+    }
+
+    /// Album order is inside the signed bytes, so a reporter cannot
+    /// present item 2 as item 1 and a sender cannot later claim a
+    /// different arrangement.
+    func test_mediaOrderIsSigned() throws {
+        let second = ChatModerationProof.MediaCommitment(
+            blobSha256: String(repeating: "ee", count: 32),
+            mimeType: "image/jpeg",
+            plaintextSha256: String(repeating: "dd", count: 32),
+            plaintextByteLength: 10,
+            width: 4,
+            height: 5
+        )
+        let forward = try content(media: [imageCommitment(), second])
+        let reversed = try content(media: [second, imageCommitment()])
+        XCTAssertNotEqual(forward, reversed)
+    }
+
+    /// Each committed field must actually change the bytes. A field
+    /// that silently fell out of the preimage would leave the Authority
+    /// checking a value nobody signed.
+    func test_everyCommittedFieldChangesTheSignedBytes() throws {
+        let base = try content(media: [imageCommitment()])
+        let variants: [ChatModerationProof.MediaCommitment] = [
+            .init(blobSha256: String(repeating: "cc", count: 32), mimeType: "image/jpeg",
+                  plaintextSha256: plaintextSha, plaintextByteLength: 421_337,
+                  width: 1200, height: 1600),
+            .init(blobSha256: blobSha, mimeType: "image/png",
+                  plaintextSha256: plaintextSha, plaintextByteLength: 421_337,
+                  width: 1200, height: 1600),
+            .init(blobSha256: blobSha, mimeType: "image/jpeg",
+                  plaintextSha256: String(repeating: "cc", count: 32), plaintextByteLength: 421_337,
+                  width: 1200, height: 1600),
+            .init(blobSha256: blobSha, mimeType: "image/jpeg",
+                  plaintextSha256: plaintextSha, plaintextByteLength: 421_338,
+                  width: 1200, height: 1600),
+            .init(blobSha256: blobSha, mimeType: "image/jpeg",
+                  plaintextSha256: plaintextSha, plaintextByteLength: 421_337,
+                  width: 1201, height: 1600),
+            .init(blobSha256: blobSha, mimeType: "image/jpeg",
+                  plaintextSha256: plaintextSha, plaintextByteLength: 421_337,
+                  width: 1200, height: 1601),
+        ]
+        for variant in variants {
+            XCTAssertNotEqual(try content(media: [variant]), base)
+        }
+    }
+
+    /// The version discriminator, not the presence of the field, is
+    /// what a verifier dispatches on — so it must actually move.
+    func test_versionDiscriminatorDistinguishesTheTwoShapes() throws {
+        XCTAssertTrue(try content(media: []).contains("\"proof_version\":1"))
+        XCTAssertTrue(try content(media: [imageCommitment()]).contains("\"proof_version\":2"))
+    }
+}

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -509,6 +509,82 @@ final class SendMessageInteractorTests: XCTestCase {
         XCTAssertEqual(stored.first?.moderationAuthenticityProof, encodedProof)
     }
 
+    func test_sendImage_signsThePhotoBytes_notJustTheCaption() async throws {
+        let groupID = await seedGroupWithTwoPeers()
+        let imageData = Self.makeJPEG()
+        let caption = "pic"
+
+        let result = try await interactor.sendImage(
+            groupID: groupID, imageData: imageData, caption: caption
+        )
+
+        let encodedProof = try XCTUnwrap(
+            result.moderationAuthenticityProof,
+            "an image send must carry a proof — without one the photo is unreportable in principle"
+        )
+        let proof = try XCTUnwrap(Data(base64Encoded: encodedProof))
+        let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: mySendingPubkey)
+        let attachment = try XCTUnwrap(result.imageAttachment)
+        let encoded = try XCTUnwrap(ChatImageEncoder.encode(fromImageData: imageData))
+
+        let preimage = try ChatModerationProof.signedContent(
+            messageID: result.id,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),  // seedGroup's secret
+            sentAtMillis: ChatModerationProof.sentAtMillis(from: result.sentAt),
+            body: caption,
+            media: [ChatModerationProof.MediaCommitment(
+                blobSha256: attachment.sha256,
+                mimeType: "image/jpeg",
+                plaintextSha256: ChatImageCrypto.sha256Hex(encoded.jpeg),
+                plaintextByteLength: encoded.jpeg.count,
+                width: encoded.width,
+                height: encoded.height
+            )]
+        )
+        XCTAssertTrue(publicKey.isValidSignature(proof, for: Data(preimage.utf8)))
+
+        // The caption alone must NOT verify. This is the whole point:
+        // a proof that covered only the caption would let an Authority
+        // believe it had authenticated a photo it had no commitment to.
+        let captionOnly = try ChatModerationProof.signedContent(
+            messageID: result.id,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),
+            sentAtMillis: ChatModerationProof.sentAtMillis(from: result.sentAt),
+            body: caption
+        )
+        XCTAssertFalse(publicKey.isValidSignature(proof, for: Data(captionOnly.utf8)))
+
+        let stored = await messages.currentMessages(groupID: groupID, owner: currentIdentityID)
+        XCTAssertEqual(stored.first?.moderationAuthenticityProof, encodedProof)
+    }
+
+    func test_sendVoice_signsTheAudioBytes() async throws {
+        // Voice evidence is not accepted by any Authority yet, but the
+        // commitment is only creatable at send time — so it is made now
+        // rather than stranding today's sends behind a future version.
+        let groupID = await seedGroupWithTwoPeers()
+        let sut = makeVoiceInteractor { _ in Self.cannedVoiceEncoded() }
+
+        let result = try await sut.sendVoice(
+            groupID: groupID, audioURL: Self.dummyVoiceURL()
+        )
+
+        let encodedProof = try XCTUnwrap(result.moderationAuthenticityProof)
+        let proof = try XCTUnwrap(Data(base64Encoded: encodedProof))
+        let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: mySendingPubkey)
+        let empty = try ChatModerationProof.signedContent(
+            messageID: result.id,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),
+            sentAtMillis: ChatModerationProof.sentAtMillis(from: result.sentAt),
+            body: ""
+        )
+        XCTAssertFalse(publicKey.isValidSignature(proof, for: Data(empty.utf8)),
+                       "a voice proof must commit to the audio, not just an empty body")
+    }
+
     func test_send_skipsSelfRecipient() async throws {
         // Even though our profile is in memberProfiles, we must not
         // send a copy to our own inbox.


### PR DESCRIPTION
A recipient can report a text message but not a photo. The reason is not a missing screen — **nothing in the system is a sender commitment to attachment bytes**, so a reported photo could never be authenticated against the accused.

## What is missing today

- `ChatModerationProof` v1 signs `{body, group_binding, message_id, proof_version, sent_at_millis}`. No attachment digest, type, or length.
- Only the plain-text `send(...)` path produces a proof at all. `sendImage`, `sendVideo`, `sendAlbum` and `sendVoice` construct `ChatMessagePayload` without one, so it defaults to `nil`.
- `SealedEnvelope.ephemeralKeySignature` covers the ephemeral key, not the ciphertext. It authenticates who sent an envelope; it yields nothing transferable a third party could verify against the content.

The commitment can only be made **at send time**, which is why this ships alone and first: every day it is not merged adds attachments that can never be authenticated. That cost is not recoverable — a sender can only be *asked* to re-sign later, and a bad actor never will.

## What this adds

A v2 preimage — v1 plus a `media` array:

```json
{
  "body": "<caption, may be empty>",
  "group_binding": "<unchanged v1 derivation>",
  "media": [{
    "blob_sha256": "<ciphertext digest — the blob address>",
    "height": 1600,
    "mime_type": "image/jpeg",
    "plaintext_byte_length": 421337,
    "plaintext_sha256": "<digest of the decrypted bytes>",
    "width": 1200
  }],
  "message_id": "<uuid lowercase>",
  "proof_version": 2,
  "sent_at_millis": 1785580800123
}
```

Two hashes because they answer different questions. `plaintext_sha256` is what an Authority re-derives from disclosed evidence **without ever needing the attachment key**. `blob_sha256` keeps the commitment tied to the stored object a recipient actually fetched.

All four media paths sign — including video, album and voice, whose evidence no Authority accepts yet. The commitment is only creatable at send time, so omitting them now would strand today's sends and force a `proof_version: 3` later.

## Compatibility

A message with no media produces **v1 bytes, byte for byte**. This is pinned by a golden-bytes test whose group binding was computed independently of the implementation. Every proof already signed by a shipped client keeps verifying.

The version — not the presence of the field — is what a verifier dispatches on. Honouring a `media` array inside a v1 preimage would let a sender choose which rules their own signed bytes were read under.

## Two deliberate choices worth reviewing

**Slashes stay escaped** (`image\/jpeg`). The preimage encoder does not set `.withoutEscapingSlashes`. Adding it would be a silent breaking change: a v1 body containing `/` would stop reproducing the bytes its sender already signed, retroactively invalidating the proof on every such message already delivered.

**"Plaintext" means the encoded JPEG that travelled** — `ChatImageEncoder`'s downscaled, re-encoded output — not the camera original. The evidence is what was received, which is the only thing a recipient can honestly disclose.

## Incidental fix

The media paths persisted `sentAt` from the raw clock rather than the truncated wire millis, which the text path deliberately derives so a stored row can reconstruct its own preimage. Harmless before; a latent trap once media is signed.

## Known limitation

Attachments sent before this cannot be authenticated, ever. That is documented on the type rather than worked around.

## Testing

`xcodebuild test -only-testing:OnymIOSTests` — 1084 tests, 3 failures, all in `DeviceRecoveryTests` (grant canonical bytes / server fixture). Confirmed identical on a clean tree with these changes stashed: pre-existing and unrelated.

New coverage: golden v1 and v2 preimage bytes, `media` key position, per-field digest sensitivity, album ordering inside the signed bytes, dimension keys absent for audio, and send-path tests asserting an image proof does **not** verify against the caption-only preimage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
