### PR TITLE
Report a received photo

### DIFF
--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
@@ -94,7 +94,13 @@ public actor ChatImageLoader {
         cacheDir.appendingPathComponent(key).appendingPathExtension("img")
     }
 
+    /// Atomic, because a half-written cache file is no longer only a
+    /// broken thumbnail. `plaintext(for:)` hands these bytes back
+    /// verbatim as evidence, so a truncated file hashes to the wrong
+    /// digest, fails its commitment check, and makes the photo
+    /// permanently unreportable — with the picture still rendering fine
+    /// from whatever decoded.
     private func writeDisk(_ key: String, _ data: Data) {
-        try? data.write(to: fileURL(key), options: .completeFileProtection)
+        try? data.write(to: fileURL(key), options: [.atomic, .completeFileProtection])
     }
 }

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
@@ -46,6 +46,26 @@ public actor ChatImageLoader {
         return image
     }
 
+    /// The **exact** decrypted bytes of `attachment`.
+    ///
+    /// Distinct from `image(for:)` on purpose. A `UIImage` is a decoded
+    /// bitmap, and re-encoding one produces different bytes with a
+    /// different digest — which is precisely the value that
+    /// authenticates a reported photo against the sender's signature.
+    /// Anything disclosing evidence must take the bytes from here and
+    /// never round-trip them through an image.
+    ///
+    /// The disk cache already holds the plaintext verbatim, so a photo
+    /// the user has looked at costs nothing to re-read.
+    public func plaintext(for attachment: ChatImageAttachment) async throws -> Data {
+        let key = attachment.sha256
+        if let cached = try? Data(contentsOf: fileURL(key)) { return cached }
+        let plaintext = try await downloadAndDecrypt(attachment)
+        writeDisk(key, plaintext)
+        if let image = UIImage(data: plaintext) { memory[key] = image }
+        return plaintext
+    }
+
     /// Sender-side warm cache: after uploading, prime the decrypted
     /// image so the sender renders instantly without re-downloading.
     func prime(sha256: String, plaintext: Data) {

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
@@ -130,6 +130,10 @@ public struct ChatThreadView: View {
     /// hands the controller fresh data via `updateUIViewController`.
     @State private var messages: [ChatMessage] = []
     @State private var reportableMessage: ReportableMessage?
+    /// The message whose disclosure is being prepared, if any. Doubles
+    /// as the in-flight indicator and the repeat-tap guard.
+    @State private var preparingReportFor: UUID?
+    @State private var reportUnavailable = false
 
     public var body: some View {
         ChatThreadControllerBridge(
@@ -175,9 +179,32 @@ public struct ChatThreadView: View {
             onReportRequested: { message in
                 // A photo's disclosure needs its decrypted bytes, which
                 // come from an actor, so this is async even though the
-                // menu predicate above is not. Nothing is presented
-                // until the bytes verify against what the sender signed.
-                Task { reportableMessage = await makeReportableMessage(from: message) }
+                // menu predicate above is not. For an uncached photo
+                // that is a blob download and a decrypt — seconds, not
+                // milliseconds — so the tap gets a visible state rather
+                // than an unexplained pause.
+                //
+                // Guarded against repeat taps: the menu predicate is
+                // deliberately optimistic about photos, so a slow or
+                // failing preparation is a normal path here, and a
+                // second tap would otherwise queue a second sheet that
+                // arrives after the user has moved on.
+                guard preparingReportFor == nil else { return }
+                preparingReportFor = message.id
+                Task {
+                    let prepared = await makeReportableMessage(from: message)
+                    guard preparingReportFor == message.id else { return }
+                    preparingReportFor = nil
+                    if let prepared {
+                        reportableMessage = prepared
+                    } else {
+                        // Nothing is presented when the bytes cannot be
+                        // produced or do not match what the sender
+                        // signed. Saying so is the point: silence would
+                        // read as the app ignoring the tap.
+                        reportUnavailable = true
+                    }
+                }
             },
             imageLoader: imageLoader,
             scrollToMessageID: scrollToMessageID,
@@ -282,6 +309,22 @@ public struct ChatThreadView: View {
         }
         .sheet(item: $reportableMessage) { message in
             makeModerationReportView(message)
+        }
+        .overlay {
+            if preparingReportFor != nil {
+                ZStack {
+                    Color.black.opacity(0.2).ignoresSafeArea()
+                    ProgressView("Preparing report…")
+                        .padding(20)
+                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+                }
+                .accessibilityIdentifier("chat.report.preparing")
+            }
+        }
+        .alert("This message can't be reported", isPresented: $reportUnavailable) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Onym couldn't confirm the sender signed this exact content. That can happen if the photo hasn't finished downloading, or if it was sent before Onym started signing attachments.")
         }
         // The chat screen uses the standard SwiftUI navigation bar (its
         // system back button is the only "back" affordance — the UIKit

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
@@ -171,9 +171,13 @@ public struct ChatThreadView: View {
                     await interactor.retry(groupID: groupID, messageID: messageID)
                 }
             },
-            canReportMessage: { makeReportableMessage(from: $0) != nil },
+            canReportMessage: { isReportable($0) },
             onReportRequested: { message in
-                reportableMessage = makeReportableMessage(from: message)
+                // A photo's disclosure needs its decrypted bytes, which
+                // come from an actor, so this is async even though the
+                // menu predicate above is not. Nothing is presented
+                // until the bytes verify against what the sender signed.
+                Task { reportableMessage = await makeReportableMessage(from: message) }
             },
             imageLoader: imageLoader,
             scrollToMessageID: scrollToMessageID,
@@ -462,14 +466,33 @@ public struct ChatThreadView: View {
         chatsFlow.groups.first { $0.id == groupID }?.invitationMessage
     }
 
-    private func makeReportableMessage(from message: ChatMessage) -> ReportableMessage? {
+    private func isReportable(_ message: ChatMessage) -> Bool {
+        guard let group = chatsFlow.groups.first(where: { $0.id == groupID }) else {
+            return false
+        }
+        return ReportableMessageFactory.isReportable(
+            from: message,
+            memberProfiles: currentMemberProfiles,
+            groupSecret: group.groupSecret
+        )
+    }
+
+    private func makeReportableMessage(from message: ChatMessage) async -> ReportableMessage? {
         guard let group = chatsFlow.groups.first(where: { $0.id == groupID }) else {
             return nil
+        }
+        // The exact plaintext, never a re-encoded `UIImage`: the digest
+        // of these bytes is what the sender signed, and a re-encode
+        // would authenticate nothing.
+        var attachmentBytes: Data?
+        if let attachment = message.imageAttachment {
+            attachmentBytes = try? await imageLoader.plaintext(for: attachment)
         }
         return ReportableMessageFactory.make(
             from: message,
             memberProfiles: currentMemberProfiles,
-            groupSecret: group.groupSecret
+            groupSecret: group.groupSecret,
+            attachmentBytes: attachmentBytes
         )
     }
 }

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ReportableMessageFactory.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ReportableMessageFactory.swift
@@ -5,45 +5,154 @@ import OnymGroup
 import OnymModeration
 
 /// Decides whether a chat message is reportable and, if so, packages
-/// it for disclosure. Eligibility: an incoming, text-only message with
-/// a sender proof that actually verifies against the sender's stored
-/// Ed25519 key. Verifying here (not just checking presence) keeps a
-/// sender who ships a garbage proof from getting a Report menu entry
-/// that can only dead-end at submit time.
+/// it for disclosure. Eligibility: an incoming message with a sender
+/// proof that actually verifies against the sender's stored Ed25519
+/// key. Verifying here (not just checking presence) keeps a sender who
+/// ships a garbage proof from getting a Report menu entry that can only
+/// dead-end at submit time.
+///
+/// A single received photo is reportable on the same terms. What makes
+/// that possible is the version 2 proof preimage, which commits to the
+/// attachment's plaintext digest — so the check below is the same one
+/// in a second place: recompute the digest of the bytes actually held
+/// and require the sender to have signed *that*. A photo whose bytes
+/// do not match its commitment is not evidence of anything, and a
+/// Report entry that led there would dead-end at the Authority.
+///
+/// Video, album and voice messages are signed at send time but no
+/// Authority accepts them as evidence yet, so they stay unreportable.
 enum ReportableMessageFactory {
-    static func make(
+    /// Whether a Report entry should appear in the message's menu.
+    ///
+    /// Split from `make` because a photo's verification needs the
+    /// decrypted bytes, which come from an actor, and a context menu
+    /// cannot await. Text is fully verified here exactly as before —
+    /// it costs nothing extra. A photo is checked as far as it can be
+    /// without its bytes; the byte-level check still happens, in `make`,
+    /// before anything is disclosed.
+    ///
+    /// The asymmetry is deliberate and safe in one direction only: this
+    /// may offer Report for a photo that later fails verification, and
+    /// the flow shows nothing rather than filing. It must never refuse
+    /// something `make` would have accepted.
+    static func isReportable(
         from message: ChatMessage,
         memberProfiles: [String: MemberProfile],
         groupSecret: Data
+    ) -> Bool {
+        guard message.direction == .incoming,
+              message.voiceAttachment == nil,
+              message.videoAttachment == nil,
+              message.albumAttachments == nil,
+              message.moderationAuthenticityProof != nil,
+              memberProfiles[message.senderBlsPubkeyHex] != nil
+        else { return false }
+
+        if message.imageAttachment != nil {
+            return message.media.count <= 1
+        }
+        return make(
+            from: message,
+            memberProfiles: memberProfiles,
+            groupSecret: groupSecret
+        ) != nil
+    }
+
+    static func make(
+        from message: ChatMessage,
+        memberProfiles: [String: MemberProfile],
+        groupSecret: Data,
+        attachmentBytes: Data? = nil
     ) -> ReportableMessage? {
         guard message.direction == .incoming,
-              message.media.isEmpty,
               message.voiceAttachment == nil,
-              !message.body.isEmpty,
+              message.videoAttachment == nil,
+              message.albumAttachments == nil,
               let proof = message.moderationAuthenticityProof,
               let signature = Data(base64Encoded: proof),
               let profile = memberProfiles[message.senderBlsPubkeyHex],
               let senderKey = try? Curve25519.Signing.PublicKey(
                 rawRepresentation: profile.sendingPubkey
-              ),
+              )
+        else { return nil }
+
+        let accused = "onym:key:" + profile.sendingPubkey
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let sentAtMillis = ChatModerationProof.sentAtMillis(from: message.sentAt)
+
+        // Photo: the decrypted bytes must be in hand, and must be the
+        // ones the sender committed to.
+        if let attachment = message.imageAttachment {
+            guard let bytes = attachmentBytes,
+                  message.media.count <= 1,
+                  let commitment = try? commitment(for: attachment, bytes: bytes),
+                  let disclosedContent = try? ChatModerationProof.signedContent(
+                    messageID: message.id,
+                    groupID: message.groupID,
+                    groupSecret: groupSecret,
+                    sentAtMillis: sentAtMillis,
+                    body: message.body,
+                    media: [commitment]
+                  ),
+                  senderKey.isValidSignature(signature, for: Data(disclosedContent.utf8))
+            else { return nil }
+
+            return ReportableMessage(
+                id: message.id.uuidString.lowercased(),
+                accused: accused,
+                disclosedContent: disclosedContent,
+                authenticityProof: proof,
+                displayBody: message.body,
+                images: [ReportableMessage.Image(
+                    sha256: commitment.plaintextSha256,
+                    bytes: bytes,
+                    width: attachment.width,
+                    height: attachment.height
+                )]
+            )
+        }
+
+        // Text: unchanged.
+        guard message.media.isEmpty,
+              !message.body.isEmpty,
               let disclosedContent = try? ChatModerationProof.signedContent(
                 messageID: message.id,
                 groupID: message.groupID,
                 groupSecret: groupSecret,
-                sentAtMillis: ChatModerationProof.sentAtMillis(from: message.sentAt),
+                sentAtMillis: sentAtMillis,
                 body: message.body
               ),
               senderKey.isValidSignature(signature, for: Data(disclosedContent.utf8))
         else { return nil }
-        let accused = "onym:key:" + profile.sendingPubkey
-            .map { String(format: "%02x", $0) }
-            .joined()
+
         return ReportableMessage(
             id: message.id.uuidString.lowercased(),
             accused: accused,
             disclosedContent: disclosedContent,
             authenticityProof: proof,
             displayBody: message.body
+        )
+    }
+
+    /// Rebuild the sender's media commitment from the attachment
+    /// descriptor and the bytes this device decrypted.
+    ///
+    /// The digest is computed here rather than taken from anywhere: it
+    /// is the whole point. If these bytes hash to something the sender
+    /// did not sign, the signature check above fails and no Report
+    /// entry appears.
+    private static func commitment(
+        for attachment: ChatImageAttachment,
+        bytes: Data
+    ) throws -> ChatModerationProof.MediaCommitment {
+        ChatModerationProof.MediaCommitment(
+            blobSha256: attachment.sha256,
+            mimeType: attachment.mimeType,
+            plaintextSha256: ChatImageCrypto.sha256Hex(bytes),
+            plaintextByteLength: bytes.count,
+            width: attachment.width,
+            height: attachment.height
         )
     }
 }

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ReportableMessageFactory.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ReportableMessageFactory.swift
@@ -49,7 +49,7 @@ enum ReportableMessageFactory {
         else { return false }
 
         if message.imageAttachment != nil {
-            return message.media.count <= 1
+            return true
         }
         return make(
             from: message,
@@ -85,7 +85,6 @@ enum ReportableMessageFactory {
         // ones the sender committed to.
         if let attachment = message.imageAttachment {
             guard let bytes = attachmentBytes,
-                  message.media.count <= 1,
                   let commitment = try? commitment(for: attachment, bytes: bytes),
                   let disclosedContent = try? ChatModerationProof.signedContent(
                     messageID: message.id,

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationAuthorityClient.swift
@@ -291,6 +291,21 @@ public struct CaseStatus: Codable, Sendable, Equatable {
 public protocol ModerationAuthorityClient: Sendable {
     func registerMandate(_ mandate: ModerationMandate) async throws -> MandateRegistrationReceipt
     func fileReport(_ report: Report) async throws -> ReportReceipt
+
+    /// Upload the bytes of one reported image, addressed by their
+    /// SHA-256.
+    ///
+    /// Evidence bytes travel on their own content-addressed route
+    /// rather than inside the report: they do not fit in the JSON body
+    /// limit, and naming them by digest is what makes the upload safe
+    /// to accept at all. The Authority recomputes the hash and matches
+    /// it against the digest the accused signed, so bytes that hash to
+    /// anything else are simply not the reported photo.
+    ///
+    /// Idempotent by construction — re-uploading the same bytes is the
+    /// same object, so an interrupted upload resumes by sending them
+    /// again.
+    func uploadEvidenceImage(sha256: String, bytes: Data) async throws
     @discardableResult
     func respond(_ response: CaseResponse) async throws -> CaseResponseReceipt
     @discardableResult
@@ -391,6 +406,31 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
             )
         }
         return receipt
+    }
+
+    public func uploadEvidenceImage(sha256: String, bytes: Data) async throws {
+        let timestamp = Self.timestamp(clock())
+        // The exact credential message the reference Authority verifies
+        // (`authority/src/api.rs`, `put_evidence_blob`). It authorizes
+        // the upload — it is not what makes the bytes trustworthy; the
+        // digest in the path does that.
+        let signedBytes = Data("evidence-blob:\(sha256):\(timestamp)".utf8)
+        let key = try await signer.userKeyID()
+        let signature = try await signer.sign(signedBytes).base64EncodedString()
+        _ = try await send(
+            method: "PUT",
+            path: ["v1", "evidence-blobs", sha256],
+            body: bytes,
+            // Opaque bytes, not JSON. The Authority sniffs the real type
+            // from the content and ignores whatever is declared here,
+            // but sending `application/json` would still be a lie.
+            contentType: "application/octet-stream",
+            headers: [
+                "X-Onym-Key": key,
+                "X-Onym-Timestamp": timestamp,
+                "X-Onym-Signature": signature,
+            ]
+        )
     }
 
     @discardableResult
@@ -568,6 +608,7 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         method: String,
         path: [String],
         body: Data? = nil,
+        contentType: String = "application/json",
         headers: [String: String] = [:]
     ) async throws -> Data {
         guard baseURL.scheme?.lowercased() == "https", baseURL.host != nil else {
@@ -583,6 +624,7 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
                 method: method,
                 path: path,
                 body: body,
+                contentType: contentType,
                 headers: headers
             )
         }
@@ -593,6 +635,7 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         method: String,
         path: [String],
         body: Data?,
+        contentType: String,
         headers: [String: String]
     ) async throws -> Data {
         let url = path.reduce(baseURL) { partial, component in
@@ -603,7 +646,7 @@ public struct URLSessionModerationAuthorityClient: ModerationAuthorityClient {
         request.timeoutInterval = 15
         request.httpBody = body
         if body != nil {
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
         }
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         for (name, value) in headers {
@@ -664,6 +707,10 @@ public struct StubModerationAuthorityClient: ModerationAuthorityClient {
 
     public func fileReport(_ report: Report) async throws -> ReportReceipt {
         throw ModerationError.notImplemented("file-report")
+    }
+
+    public func uploadEvidenceImage(sha256: String, bytes: Data) async throws {
+        throw ModerationError.notImplemented("upload-evidence-image")
     }
 
     public func respond(_ response: CaseResponse) async throws -> CaseResponseReceipt {

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -1269,16 +1269,40 @@ public actor ModerationRepository {
         // upload re-sends the same bytes rather than creating anything
         // new, and an upload that never gets referenced expires on the
         // Authority's own sweep.
-        for image in images {
-            try await client.uploadEvidenceImage(sha256: image.sha256, bytes: image.bytes)
-        }
-
+        //
+        // Inside the same `do` as the filing, and not before it: the
+        // record is already inserted and persisted by this point, so an
+        // upload failure that skipped the handling below would strand a
+        // disclosure row on disk that can never be filed and re-fails
+        // identically on every retry — the outcome the discard exists to
+        // prevent, reached through the one call that bypassed it.
         let receipt: ReportReceipt
         do {
+            for image in images {
+                do {
+                    try await client.uploadEvidenceImage(
+                        sha256: image.sha256,
+                        bytes: image.bytes
+                    )
+                } catch let AuthorityClientError.rejected(rejection)
+                    where rejection.statusCode == 409 {
+                    // The Authority already holds these exact bytes.
+                    // Content addressing makes that the *expected*
+                    // outcome of any retry, and there is nothing to
+                    // resend. The merged reference answers 2xx here
+                    // (`INSERT OR IGNORE`), but the contract does not
+                    // require that, and a conflict on a
+                    // content-addressed PUT can only mean agreement.
+                    continue
+                }
+            }
+
             receipt = try await client.fileReport(record.report)
         } catch {
-            // 409: the Authority already holds these exact bytes — a
-            // terminal, benign state, not a rejection. Keep the ledger
+            // 409 from the filing: the Authority already holds this
+            // exact report — a terminal, benign state, not a rejection.
+            // (An upload conflict never reaches here; it is agreement,
+            // and is absorbed above.) Keep the ledger
             // row (it is the idempotency key) and surface it as its own
             // error so the UI can present "already on file" rather than
             // retry advice. The original receipt is unrecoverable until

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -1215,7 +1215,7 @@ public actor ModerationRepository {
                     reportId: existing.report.reportId
                 )
             }
-            return try await submitReport(existing, to: listing)
+            return try await submitReport(existing, to: listing, images: message.images)
         }
 
         var report = Report(
@@ -1250,14 +1250,29 @@ public actor ModerationRepository {
             }
             throw error
         }
-        return try await submitReport(record, to: listing)
+        return try await submitReport(record, to: listing, images: message.images)
     }
 
     private func submitReport(
         _ record: ReportFilingRecord,
-        to listing: AuthorityListing
+        to listing: AuthorityListing,
+        images: [ReportableMessage.Image]
     ) async throws -> ReportReceipt {
         let client = authorityClients.client(for: listing)
+
+        // Bytes first, then the report that names them.
+        //
+        // The other order would leave a filed report pointing at an
+        // image the Authority does not hold — a case opened, and a mark
+        // set, on evidence nobody can look at. Uploading is idempotent
+        // (the digest is the address), so a retry after a partial
+        // upload re-sends the same bytes rather than creating anything
+        // new, and an upload that never gets referenced expires on the
+        // Authority's own sweep.
+        for image in images {
+            try await client.uploadEvidenceImage(sha256: image.sha256, bytes: image.bytes)
+        }
+
         let receipt: ReportReceipt
         do {
             receipt = try await client.fileReport(record.report)

--- a/Packages/OnymModeration/Sources/OnymModeration/ReportableMessage.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ReportableMessage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A recipient-held text message that can be disclosed to an Authority.
+/// A recipient-held message that can be disclosed to an Authority.
 /// `disclosedContent` is the canonical proof preimage — the message
 /// body bound to its message id, group id, and send timestamp — and
 /// `authenticityProof` is the sender's Ed25519 signature over its exact
@@ -8,23 +8,52 @@ import Foundation
 /// `accused` before the content can support a case. `displayBody` is
 /// the bare body, for showing the user what they are disclosing.
 public struct ReportableMessage: Sendable, Equatable, Identifiable {
+    /// A received photo the reporter is disclosing along with the
+    /// message.
+    ///
+    /// The bytes are carried here rather than fetched at submit time
+    /// because they are the *decrypted* attachment the recipient
+    /// already holds: the report screen shows exactly these, and
+    /// exactly these are uploaded. Anything re-fetched between showing
+    /// and sending could differ from what the user agreed to disclose.
+    public struct Image: Sendable, Equatable {
+        /// SHA-256 of `bytes` — and the digest the sender signed, so it
+        /// is both the upload's address and its authenticity binding.
+        public let sha256: String
+        public let bytes: Data
+        public let width: Int
+        public let height: Int
+
+        public init(sha256: String, bytes: Data, width: Int, height: Int) {
+            self.sha256 = sha256
+            self.bytes = bytes
+            self.width = width
+            self.height = height
+        }
+    }
+
     public let id: String
     public let accused: String
     public let disclosedContent: String
     public let authenticityProof: String
     public let displayBody: String
+    /// The disclosed photo, when this is a photo message. Empty for a
+    /// text report.
+    public let images: [Image]
 
     public init(
         id: String,
         accused: String,
         disclosedContent: String,
         authenticityProof: String,
-        displayBody: String
+        displayBody: String,
+        images: [Image] = []
     ) {
         self.id = id
         self.accused = accused
         self.disclosedContent = disclosedContent
         self.authenticityProof = authenticityProof
         self.displayBody = displayBody
+        self.images = images
     }
 }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -26,6 +26,8 @@ public struct ModerationReportView: View {
                         success(receipt)
                     } else if flow.state.alreadyFiled {
                         alreadyFiled
+                    } else if hasUndisplayableImage {
+                        unrenderablePhoto
                     } else {
                         reportForm
                     }
@@ -53,6 +55,33 @@ public struct ModerationReportView: View {
         flow.state.receipt != nil || flow.state.alreadyFiled
     }
 
+    /// Whether any disclosed photo cannot be drawn on this device.
+    ///
+    /// Computed once here rather than per row, because it gates the
+    /// whole form: the invariant this screen exists to uphold is that
+    /// the reporter sees exactly what they are about to send. A row
+    /// that quietly renders nothing while Submit still uploads the
+    /// bytes inverts it — the user would be disclosing a picture they
+    /// were never shown. Refusing to present is the safe direction.
+    private var hasUndisplayableImage: Bool {
+        flow.message.images.contains { UIImage(data: $0.bytes) == nil }
+    }
+
+    private var unrenderablePhoto: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(.orange)
+            Text("This photo can't be displayed.")
+                .font(.title3.weight(.semibold))
+            Text("Onym won't send a photo it can't show you first — you'd be disclosing something you haven't seen. Try opening the photo in the conversation, then reporting it again.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("moderation.report.photoUnavailable")
+    }
+
     private var alreadyFiled: some View {
         VStack(alignment: .leading, spacing: 16) {
             Image(systemName: "checkmark.shield.fill")
@@ -78,16 +107,18 @@ public struct ModerationReportView: View {
                 // will be uploaded — not a thumbnail or a re-fetch.
                 // What the reporter agrees to disclose and what leaves
                 // the device must be the same thing.
-                ForEach(Array(flow.message.images.enumerated()), id: \.element.sha256) { _, image in
-                    if let rendered = UIImage(data: image.bytes) {
-                        Image(uiImage: rendered)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxWidth: .infinity, maxHeight: 260)
-                            .clipShape(RoundedRectangle(cornerRadius: 14))
-                            .accessibilityLabel("The photo you are disclosing")
-                            .accessibilityIdentifier("moderation.report.photo")
-                    }
+                // Force-unwrapped deliberately: the form is only reached
+                // when every image decodes, checked above. A silent
+                // fallback here is what would let an unseen photo be
+                // disclosed.
+                ForEach(flow.message.images, id: \.sha256) { image in
+                    Image(uiImage: UIImage(data: image.bytes) ?? UIImage())
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity, maxHeight: 260)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .accessibilityLabel("The photo you are disclosing")
+                        .accessibilityIdentifier("moderation.report.photo")
                 }
                 if !flow.message.displayBody.isEmpty || flow.message.images.isEmpty {
                     Text(flow.message.displayBody)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationReportView.swift
@@ -71,15 +71,37 @@ public struct ModerationReportView: View {
     private var reportForm: some View {
         VStack(alignment: .leading, spacing: 20) {
             VStack(alignment: .leading, spacing: 8) {
-                Text("MESSAGE TO DISCLOSE")
+                Text(flow.message.images.isEmpty ? "MESSAGE TO DISCLOSE" : "PHOTO TO DISCLOSE")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Text(flow.message.displayBody)
-                    .font(.body)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(16)
-                    .background(.background, in: RoundedRectangle(cornerRadius: 14))
-                    .textSelection(.enabled)
+                // The exact photo, rendered from the very bytes that
+                // will be uploaded — not a thumbnail or a re-fetch.
+                // What the reporter agrees to disclose and what leaves
+                // the device must be the same thing.
+                ForEach(Array(flow.message.images.enumerated()), id: \.element.sha256) { _, image in
+                    if let rendered = UIImage(data: image.bytes) {
+                        Image(uiImage: rendered)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxWidth: .infinity, maxHeight: 260)
+                            .clipShape(RoundedRectangle(cornerRadius: 14))
+                            .accessibilityLabel("The photo you are disclosing")
+                            .accessibilityIdentifier("moderation.report.photo")
+                    }
+                }
+                if !flow.message.displayBody.isEmpty || flow.message.images.isEmpty {
+                    Text(flow.message.displayBody)
+                        .font(.body)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(16)
+                        .background(.background, in: RoundedRectangle(cornerRadius: 14))
+                        .textSelection(.enabled)
+                }
+                if !flow.message.images.isEmpty {
+                    Text("This photo is sent to your authority so a moderator and its model can review it. Nothing else from this conversation is shared.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             VStack(alignment: .leading, spacing: 8) {

--- a/Tests/OnymIOSTests/Fixtures/media-commitment-v2.json
+++ b/Tests/OnymIOSTests/Fixtures/media-commitment-v2.json
@@ -1,0 +1,23 @@
+{
+  "note": "Cross-implementation vector for the version 2 media commitment. The signer (onym-ios) and the verifier (onym-moderation) are written in different languages and agree on these bytes only by construction, so this file is the one thing that would catch drift between them. An identical copy lives at onym-ios/Tests/OnymIOSTests/Fixtures/media-commitment-v2.json; changing either without the other must break both sides' tests.",
+  "inputs": {
+    "messageId": "00000000-0000-0000-0000-000000000001",
+    "groupId": "group-1",
+    "groupSecretHex": "0707070707070707070707070707070707070707070707070707070707070707",
+    "sentAtMillis": 1785580800123,
+    "body": "hello",
+    "media": [
+      {
+        "blobSha256": "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+        "mimeType": "image/jpeg",
+        "plaintextSha256": "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a",
+        "plaintextByteLength": 421337,
+        "width": 1200,
+        "height": 1600
+      }
+    ]
+  },
+  "preimage": "{\"body\":\"hello\",\"group_binding\":\"18413f675da1f5410fa8e199b799c2bf3700575ddac201c9a8d2dfdf8327ce6a\",\"media\":[{\"blob_sha256\":\"0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f\",\"height\":1600,\"mime_type\":\"image\\/jpeg\",\"plaintext_byte_length\":421337,\"plaintext_sha256\":\"1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a\",\"width\":1200}],\"message_id\":\"00000000-0000-0000-0000-000000000001\",\"proof_version\":2,\"sent_at_millis\":1785580800123}",
+  "signerPublicKeyHex": "ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c",
+  "signatureBase64": "+lXjQDhSsaxssuZj6OgodqrKIbmjRz5mxkyE46hmsvBAj5DDsJVhDnuZKXroRtCNHRYLq5StHjrHe5OwLwHXCQ=="
+}

--- a/Tests/OnymIOSTests/MediaCommitmentFixtureTests.swift
+++ b/Tests/OnymIOSTests/MediaCommitmentFixtureTests.swift
@@ -1,0 +1,122 @@
+import CryptoKit
+import XCTest
+import OnymChatsCore
+
+/// The cross-implementation vector for the version 2 media commitment.
+///
+/// This side is the signer; the Authority (Rust) is the verifier. They
+/// agree on these bytes by construction — two encoders, two languages,
+/// a format that exists as prose rather than a schema — so nothing else
+/// in either repository would notice them drifting apart. Without a
+/// shared vector, the first symptom of drift is every photo report
+/// failing authentication in production, with both sides' own tests
+/// still green.
+///
+/// An identical copy lives at `onym-moderation/authority/fixtures/`.
+/// Changing one without the other must break both sides.
+///
+/// The fixture is read from disk by path rather than as a bundle
+/// resource, so it stays a plain file two repositories can diff.
+final class MediaCommitmentFixtureTests: XCTestCase {
+
+    private struct Fixture: Decodable {
+        struct Inputs: Decodable {
+            struct Media: Decodable {
+                let blobSha256: String
+                let mimeType: String
+                let plaintextSha256: String
+                let plaintextByteLength: Int
+                let width: Int
+                let height: Int
+            }
+            let messageId: String
+            let groupId: String
+            let groupSecretHex: String
+            let sentAtMillis: Int64
+            let body: String
+            let media: [Media]
+        }
+        let inputs: Inputs
+        let preimage: String
+        let signerPublicKeyHex: String
+        let signatureBase64: String
+    }
+
+    private func fixture() throws -> Fixture {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/media-commitment-v2.json")
+        return try JSONDecoder().decode(Fixture.self, from: Data(contentsOf: url))
+    }
+
+    /// The producer side: feeding the vector's inputs through the real
+    /// signing path must reproduce its bytes exactly. This is the test
+    /// that fails if the preimage shape, key order, or escaping ever
+    /// changes here.
+    func test_theSignerReproducesTheSharedVectorBytes() throws {
+        let fixture = try fixture()
+        let inputs = fixture.inputs
+
+        let preimage = try ChatModerationProof.signedContent(
+            messageID: try XCTUnwrap(UUID(uuidString: inputs.messageId)),
+            groupID: inputs.groupId,
+            groupSecret: try XCTUnwrap(Data(hexString: inputs.groupSecretHex)),
+            sentAtMillis: inputs.sentAtMillis,
+            body: inputs.body,
+            media: inputs.media.map {
+                ChatModerationProof.MediaCommitment(
+                    blobSha256: $0.blobSha256,
+                    mimeType: $0.mimeType,
+                    plaintextSha256: $0.plaintextSha256,
+                    plaintextByteLength: $0.plaintextByteLength,
+                    width: $0.width,
+                    height: $0.height
+                )
+            }
+        )
+
+        XCTAssertEqual(
+            preimage,
+            fixture.preimage,
+            "the signer no longer produces the bytes the Authority verifies against"
+        )
+    }
+
+    /// And the vector's own signature verifies over those bytes, the
+    /// same way the Authority checks a real one — over the disclosed
+    /// string verbatim, never a re-encoding of it.
+    func test_theSharedVectorSignatureVerifies() throws {
+        let fixture = try fixture()
+        let key = try Curve25519.Signing.PublicKey(
+            rawRepresentation: try XCTUnwrap(Data(hexString: fixture.signerPublicKeyHex))
+        )
+        let signature = try XCTUnwrap(Data(base64Encoded: fixture.signatureBase64))
+
+        XCTAssertTrue(key.isValidSignature(signature, for: Data(fixture.preimage.utf8)))
+    }
+
+    /// The escaped slash is load-bearing, not cosmetic. This encoder
+    /// does not set `withoutEscapingSlashes`, so a MIME type is signed
+    /// as `image\/jpeg`. Since the signature covers these bytes
+    /// verbatim, "tidying" the escaping on either side would invalidate
+    /// every proof already produced.
+    func test_theMediaTypeSlashIsEscapedInTheSignedBytes() throws {
+        XCTAssertTrue(try fixture().preimage.contains(#"image\/jpeg"#))
+    }
+}
+
+private extension Data {
+    init?(hexString: String) {
+        guard hexString.count % 2 == 0 else { return nil }
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(hexString.count / 2)
+        var index = hexString.startIndex
+        while index < hexString.endIndex {
+            let next = hexString.index(index, offsetBy: 2)
+            guard let byte = UInt8(hexString[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        self.init(bytes)
+    }
+}

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -1023,6 +1023,85 @@ final class ModerationRepositoryTests: XCTestCase {
         XCTAssertTrue(authority.reports.isEmpty)
     }
 
+    /// A deterministic upload rejection must go through the same
+    /// discard as a deterministic filing rejection.
+    ///
+    /// The record is inserted and persisted before submission, so an
+    /// upload failure that skipped the discard would leave a disclosure
+    /// row on disk that can never be filed and re-fails identically on
+    /// every retry — the exact outcome the discard exists to prevent.
+    func testADeterministicUploadRejectionDiscardsTheReport() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        authority.failUploads(with: AuthorityClientError.rejected(AuthorityRejection(
+            statusCode: 415,
+            rawCode: "media_unsupported",
+            message: "not an image this authority accepts"
+        )))
+        let reportStore = InMemoryReportFilingStore()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: reportStore
+        )
+        try await repository.refresh()
+        let message = try reportableMessage(images: [ReportableMessage.Image(
+            sha256: "digest-of-the-photo",
+            bytes: Data("bytes".utf8),
+            width: 10,
+            height: 10
+        )])
+
+        do {
+            _ = try await repository.fileReport(message: message, classId: "csam")
+            XCTFail("an unsupported image must not file a report")
+        } catch {}
+
+        XCTAssertTrue(authority.reports.isEmpty)
+        XCTAssertTrue(
+            reportStore.load().isEmpty,
+            "a report that can never be filed must not be retained on disk"
+        )
+    }
+
+    /// A conflict on a content-addressed upload is agreement, not a
+    /// rejection: the Authority already holds these exact bytes and
+    /// there is nothing to resend. Filing must proceed.
+    func testAnUploadConflictIsTreatedAsAgreementAndFilingProceeds() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        authority.failUploads(with: AuthorityClientError.rejected(AuthorityRejection(
+            statusCode: 409,
+            rawCode: "already_stored",
+            message: "these bytes are already on file"
+        )))
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: InMemoryReportFilingStore()
+        )
+        try await repository.refresh()
+        let message = try reportableMessage(images: [ReportableMessage.Image(
+            sha256: "digest-of-the-photo",
+            bytes: Data("bytes".utf8),
+            width: 10,
+            height: 10
+        )])
+
+        let receipt = try await repository.fileReport(message: message, classId: "csam")
+
+        XCTAssertEqual(receipt.caseId, "case-1")
+        XCTAssertEqual(authority.reports.count, 1, "an upload conflict must not block filing")
+    }
+
     func testFileReportSendsAccusedSignedMessageUnderActiveMandate() async throws {
         let componentId = "onym:component:a"
         let bytes = manifestBytes(componentId: componentId)

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -129,12 +129,16 @@ final class ModerationRepositoryTests: XCTestCase {
         private var _rejectedManifestHash: String?
         private var _registrationDelayNanoseconds: UInt64 = 0
         private var _reports: [Report] = []
+        private var _uploads: [(String, Data)] = []
+        private var _uploadError: Error?
         private var _reportShouldFail = false
         private var _reportError: AuthorityClientError?
         private var _reportReceiptId: String?
 
         var mandates: [ModerationMandate] { lock.withLock { _mandates } }
         var reports: [Report] { lock.withLock { _reports } }
+        var uploads: [(String, Data)] { lock.withLock { _uploads } }
+        func failUploads(with error: Error) { lock.withLock { _uploadError = error } }
         var reportShouldFail: Bool {
             get { lock.withLock { _reportShouldFail } }
             set { lock.withLock { _reportShouldFail = newValue } }
@@ -227,6 +231,21 @@ final class ModerationRepositoryTests: XCTestCase {
                 caseId: "case-1"
             )
         }
+        /// Records what was uploaded, and in what order relative to
+        /// the report — the ordering is the invariant under test.
+        func uploadEvidenceImage(sha256: String, bytes: Data) async throws {
+            let failure = lock.withLock { () -> Error? in
+                _uploads.append((sha256, bytes))
+                if _reports.isEmpty == false {
+                    return UploadOrdering.uploadedAfterTheReport
+                }
+                return _uploadError
+            }
+            if let failure { throw failure }
+        }
+
+        enum UploadOrdering: Error { case uploadedAfterTheReport }
+
         func respond(_ response: CaseResponse) async throws -> CaseResponseReceipt {
             throw ModerationError.notImplemented("unused")
         }
@@ -337,7 +356,10 @@ final class ModerationRepositoryTests: XCTestCase {
         )
     }
 
-    private func reportableMessage(body: String = "prohibited content") throws -> ReportableMessage {
+    private func reportableMessage(
+        body: String = "prohibited content",
+        images: [ReportableMessage.Image] = []
+    ) throws -> ReportableMessage {
         let accused = Curve25519.Signing.PrivateKey()
         let proof = try accused.signature(for: Data(body.utf8)).base64EncodedString()
         let keyHex = accused.publicKey.rawRepresentation.map { String(format: "%02x", $0) }.joined()
@@ -346,7 +368,8 @@ final class ModerationRepositoryTests: XCTestCase {
             accused: "onym:key:\(keyHex)",
             disclosedContent: body,
             authenticityProof: proof,
-            displayBody: body
+            displayBody: body,
+            images: images
         )
     }
 
@@ -933,6 +956,72 @@ final class ModerationRepositoryTests: XCTestCase {
     }
 
     // MARK: - Message reporting
+
+    /// Bytes go up before the report that names them.
+    ///
+    /// The other order would leave a filed report pointing at an image
+    /// the Authority does not hold — a case opened, and a mark set, on
+    /// evidence nobody can look at. The fake throws if a report arrives
+    /// first, so the ordering is asserted rather than assumed.
+    func testFileReportUploadsThePhotoBeforeFilingTheReport() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: InMemoryReportFilingStore()
+        )
+        try await repository.refresh()
+        let photo = Data("the exact jpeg bytes".utf8)
+        let message = try reportableMessage(images: [ReportableMessage.Image(
+            sha256: "digest-of-the-photo",
+            bytes: photo,
+            width: 10,
+            height: 10
+        )])
+
+        _ = try await repository.fileReport(message: message, classId: "csam")
+
+        XCTAssertEqual(authority.uploads.count, 1)
+        XCTAssertEqual(authority.uploads[0].0, "digest-of-the-photo")
+        XCTAssertEqual(authority.uploads[0].1, photo)
+        XCTAssertEqual(authority.reports.count, 1)
+    }
+
+    /// A failed upload must not leave a report on file naming bytes
+    /// that never arrived.
+    func testAFailedPhotoUploadFilesNoReport() async throws {
+        let componentId = "onym:component:a"
+        let bytes = manifestBytes(componentId: componentId)
+        let authority = RecordingAuthorityClient()
+        authority.failUploads(with: URLError(.timedOut))
+        let repository = makeRepository(
+            listings: [listing(componentId, name: "A")],
+            bytesByComponent: [componentId: bytes],
+            backend: RecordingBackend(),
+            authorityClient: authority,
+            store: InMemoryMandateStore(records: [activeRecord(componentId: componentId, bytes: bytes)]),
+            reportStore: InMemoryReportFilingStore()
+        )
+        try await repository.refresh()
+        let message = try reportableMessage(images: [ReportableMessage.Image(
+            sha256: "digest-of-the-photo",
+            bytes: Data("bytes".utf8),
+            width: 10,
+            height: 10
+        )])
+
+        do {
+            _ = try await repository.fileReport(message: message, classId: "csam")
+            XCTFail("a report must not be filed when its evidence never uploaded")
+        } catch {}
+
+        XCTAssertTrue(authority.reports.isEmpty)
+    }
 
     func testFileReportSendsAccusedSignedMessageUnderActiveMandate() async throws {
         let componentId = "onym:component:a"

--- a/Tests/OnymIOSTests/ReportableMessageFactoryTests.swift
+++ b/Tests/OnymIOSTests/ReportableMessageFactoryTests.swift
@@ -110,20 +110,101 @@ final class ReportableMessageFactoryTests: XCTestCase {
         ))
     }
 
-    func test_mediaMessage_isNotReportable() throws {
-        let image = ChatImageAttachment(
-            sha256: String(repeating: "cd", count: 32),
-            mimeType: "image/jpeg",
-            byteSize: 1234,
-            width: 10,
-            height: 10,
-            encKey: Data(repeating: 7, count: 32),
-            blurhash: "LEHV6nWB2yk8",
-            server: "https://blossom.onym.app"
-        )
-        let message = try signedMessage(imageAttachment: image)
+    // MARK: - Photos
+
+    /// The happy path: a received photo whose bytes hash to the digest
+    /// its sender signed.
+    func test_receivedPhoto_isReportable() throws {
+        let bytes = Data("the exact jpeg bytes that travelled".utf8)
+        let (message, attachment) = try signedPhotoMessage(bytes: bytes)
+
+        let reportable = try XCTUnwrap(ReportableMessageFactory.make(
+            from: message,
+            memberProfiles: profiles(),
+            groupSecret: groupSecret,
+            attachmentBytes: bytes
+        ))
+
+        XCTAssertEqual(reportable.images.count, 1)
+        XCTAssertEqual(reportable.images[0].bytes, bytes)
+        XCTAssertEqual(reportable.images[0].sha256, ChatImageCrypto.sha256Hex(bytes))
+        XCTAssertEqual(reportable.images[0].width, attachment.width)
+        // And the disclosed content is the v2 preimage the sender
+        // signed, verifying exactly as the Authority will check it.
+        let signature = try XCTUnwrap(Data(base64Encoded: reportable.authenticityProof))
+        XCTAssertTrue(senderKey.publicKey.isValidSignature(
+            signature, for: Data(reportable.disclosedContent.utf8)
+        ))
+        XCTAssertTrue(reportable.disclosedContent.contains("\"proof_version\":2"))
+    }
+
+    /// One flipped byte and this is a different picture, which the
+    /// sender never signed. Catching it here keeps the menu from
+    /// offering a report that could only fail at the Authority.
+    func test_photoWhoseBytesDoNotMatchTheCommitment_isNotReportable() throws {
+        let (message, _) = try signedPhotoMessage(bytes: Data("original".utf8))
+
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message,
+            memberProfiles: profiles(),
+            groupSecret: groupSecret,
+            attachmentBytes: Data("tampered".utf8)
+        ))
+    }
+
+    /// Without the decrypted bytes there is nothing to verify against,
+    /// so there is nothing to disclose.
+    func test_photoWithoutItsBytes_isNotReportable() throws {
+        let (message, _) = try signedPhotoMessage(bytes: Data("the bytes".utf8))
+
         XCTAssertNil(ReportableMessageFactory.make(
             from: message, memberProfiles: profiles(), groupSecret: groupSecret
+        ))
+    }
+
+    /// A photo sent before proof v2 carries a v1 signature that commits
+    /// to the caption alone. It cannot be authenticated, ever.
+    func test_photoSignedBeforeMediaCommitmentsExisted_isNotReportable() throws {
+        let bytes = Data("the bytes".utf8)
+        let image = attachment(for: bytes)
+        // `signedMessage` signs a v1 preimage — exactly what a client
+        // shipped before this feature produced.
+        let message = try signedMessage(body: "caption", imageAttachment: image)
+
+        XCTAssertNil(ReportableMessageFactory.make(
+            from: message,
+            memberProfiles: profiles(),
+            groupSecret: groupSecret,
+            attachmentBytes: bytes
+        ))
+    }
+
+    /// The menu predicate may be optimistic about photos — it cannot
+    /// await the bytes — but it must never be optimistic about a kind
+    /// of message the disclosure path would refuse outright.
+    func test_eligibilityNeverOffersWhatDisclosureWouldRefuse() throws {
+        let voice = ChatVoiceAttachment(
+            sha256: String(repeating: "cd", count: 32),
+            mimeType: "audio/mp4",
+            byteSize: 1234,
+            durationSeconds: 2,
+            encKey: Data(repeating: 7, count: 32),
+            waveform: [1, 2, 3],
+            server: "https://blossom.onym.app"
+        )
+        for message in [
+            try signedMessage(direction: .outgoing),
+            try signedMessage(proofOverride: .some(nil)),
+            try signedMessage(voiceAttachment: voice),
+        ] {
+            XCTAssertFalse(ReportableMessageFactory.isReportable(
+                from: message, memberProfiles: profiles(), groupSecret: groupSecret
+            ))
+        }
+        // And a photo, which it cannot fully check, is offered.
+        let (photo, _) = try signedPhotoMessage(bytes: Data("bytes".utf8))
+        XCTAssertTrue(ReportableMessageFactory.isReportable(
+            from: photo, memberProfiles: profiles(), groupSecret: groupSecret
         ))
     }
 
@@ -157,6 +238,62 @@ final class ReportableMessageFactoryTests: XCTestCase {
     /// signature by `senderKey`, unless overridden. `proofOverride`
     /// distinguishes "leave the valid proof" (nil) from "force this
     /// value, including no proof at all" (.some).
+    /// The attachment descriptor a sender would build for `bytes`.
+    private func attachment(for bytes: Data) -> ChatImageAttachment {
+        ChatImageAttachment(
+            sha256: String(repeating: "cd", count: 32),
+            mimeType: "image/jpeg",
+            byteSize: bytes.count + 28,
+            width: 10,
+            height: 10,
+            encKey: Data(repeating: 7, count: 32),
+            blurhash: "LEHV6nWB2yk8",
+            server: "https://blossom.onym.app"
+        )
+    }
+
+    /// An incoming photo message whose proof is a v2 preimage
+    /// committing to `bytes` — what a post-proof-v2 sender produces.
+    private func signedPhotoMessage(
+        bytes: Data,
+        body: String = ""
+    ) throws -> (ChatMessage, ChatImageAttachment) {
+        let image = attachment(for: bytes)
+        let id = UUID()
+        let sentAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let preimage = try ChatModerationProof.signedContent(
+            messageID: id,
+            groupID: groupID,
+            groupSecret: groupSecret,
+            sentAtMillis: ChatModerationProof.sentAtMillis(from: sentAt),
+            body: body,
+            media: [ChatModerationProof.MediaCommitment(
+                blobSha256: image.sha256,
+                mimeType: image.mimeType,
+                plaintextSha256: ChatImageCrypto.sha256Hex(bytes),
+                plaintextByteLength: bytes.count,
+                width: image.width,
+                height: image.height
+            )]
+        )
+        let message = ChatMessage(
+            id: id,
+            groupID: groupID,
+            ownerIdentityID: IdentityID(),
+            senderBlsPubkeyHex: senderHex,
+            body: body,
+            sentAt: sentAt,
+            direction: .incoming,
+            status: .received,
+            replyToMessageID: nil,
+            groupType: .tyranny,
+            moderationAuthenticityProof: try senderKey
+                .signature(for: Data(preimage.utf8)).base64EncodedString(),
+            imageAttachment: image
+        )
+        return (message, image)
+    }
+
     private func signedMessage(
         body: String = "prohibited content",
         direction: MessageDirection = .incoming,


### PR DESCRIPTION
Stacked on #238 (base branch is `feat/media-authenticity-proof`) and pairs with onymchat/onym-moderation#38.

With a sender commitment in place, a recipient can disclose a received photo on the same terms as text.

## Verification happens where the bytes are

`ReportableMessageFactory` accepts a single-image message, and the check is the same one in a second place: recompute the digest of the bytes **this device actually holds** and require the sender to have signed *that*. A photo whose bytes don't match its commitment produces no Report entry — it isn't evidence of anything and would only dead-end at the Authority.

## Eligibility is split from disclosure

A photo's verification needs decrypted bytes, which come from an actor, and a context menu cannot `await`. So `isReportable` checks a photo as far as it can without bytes, and the byte-level check happens in `make`, before anything leaves the device.

The asymmetry is safe in exactly one direction: the menu may offer Report for a photo that later fails verification, and the flow then presents nothing. It must never refuse something disclosure would have accepted. There's a test asserting that direction.

## `plaintext(for:)` vs `image(for:)`

`ChatImageLoader.image(for:)` returns a decoded `UIImage`. Re-encoding one produces **different bytes with a different digest** — precisely the value that authenticates the photo. So `plaintext(for:)` returns the exact decrypted bytes, and the report screen renders from the same bytes it uploads. What the reporter agrees to disclose and what leaves the device cannot diverge.

## Upload, then file

The other order would leave a filed report pointing at an image the Authority does not hold — a case opened, and a mark set, on evidence nobody can look at.

Uploading is idempotent because the digest is the address, so a retry after a partial upload re-sends the same bytes rather than creating anything new, and an upload that never gets referenced expires on the Authority's own sweep. Two tests cover this: one asserts ordering (the fake throws if a report arrives before its upload), one asserts a failed upload files no report.

## Cross-repo detail worth noting

While wiring this I hit a status-code collision: the Authority's `media_missing` was mapped to **409**, which this client already reads as "these exact bytes are already on file" — a terminal, benign state, and the opposite of "upload and re-file". Changed to **424 Failed Dependency** in onym-moderation#38.

## No PhotosPicker

Deliberately absent from the flow. An arbitrary camera-roll photo has no signed commitment and could never authenticate.

## Known limitation

Photos sent before proof v2 carry a v1 signature over the caption alone. They stay unreportable, and there's a test naming that as the reason rather than leaving it to be rediscovered.

## Testing

`xcodebuild test -only-testing:OnymIOSTests` — 1090 tests, 3 failures, the same pre-existing `DeviceRecoveryTests` ones confirmed unrelated in #238.

New coverage: a received photo is reportable and its disclosed content is the v2 preimage; one flipped byte makes it unreportable; a photo without its bytes is unreportable; a pre-v2 photo is unreportable; eligibility never offers what disclosure would refuse; upload ordering; and a failed upload filing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
