### PR TITLE
Force fresh consent when the authority's terms change

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -339,12 +339,14 @@ public actor ModerationRepository {
 
     private func performTermsCheck() async {
         guard let record = activeMandateRecord() else { return }
-        if fetchStatus != .success {
-            // The directory names the operator key each manifest is
-            // pinned against, so there is no authenticated fetch
-            // without it.
-            try? await refresh()
-        }
+        // Always re-read the directory, not just when it has never
+        // loaded. It is what says the authority is still designated,
+        // and it carries the operator key the manifest below is
+        // authenticated against — a cached copy makes delisting a
+        // cold-start-only discovery and pins the check to a key that
+        // may since have rotated. Callers share one fetch, so a
+        // foreground that races the launch check costs nothing.
+        try? await refresh()
         guard fetchStatus == .success else { return }
 
         guard let listing = authorities.first(where: {
@@ -355,6 +357,13 @@ public actor ModerationRepository {
             noteAuthorityDelisted(record.mandate.authority)
             return
         }
+        // Presence in the directory is the same quality of answer as
+        // absence from it, so it retires the delisting here rather than
+        // hostage to the manifest fetch below. Otherwise a relisted
+        // authority whose manifest momentarily fails to fetch keeps
+        // showing "Authority Unavailable", whose only offered remedy is
+        // switching away from an authority that is in fact listed.
+        noteAuthorityListed(listing.componentId)
 
         let published: SignedManifest
         do {
@@ -404,6 +413,13 @@ public actor ModerationRepository {
         let before = termsCurrency
         publishedManifest = (authority: authority, hash: hash)
         if delistedAuthority == authority { delistedAuthority = nil }
+        if termsCurrency != before { publish() }
+    }
+
+    private func noteAuthorityListed(_ authority: String) {
+        guard delistedAuthority == authority else { return }
+        let before = termsCurrency
+        delistedAuthority = nil
         if termsCurrency != before { publish() }
     }
 
@@ -493,12 +509,26 @@ public actor ModerationRepository {
 
         // These bytes were fetched, authenticated, and validated moments
         // ago, so they are the freshest observation this repository has
-        // of what the authority publishes. Recording it here — before
+        // of what this authority publishes. Recording it here — before
         // any of the paths below activate a record — is what lets
         // currency stay derived: whichever record ends up active is
         // compared against this, and consenting to current terms comes
         // out `.current` without anyone having to say so.
-        notePublishedManifest(signedManifest.manifestHash, for: listing.componentId)
+        //
+        // Only for the authority the active mandate already names. The
+        // other remedy the re-consent copy offers is moving to a
+        // different authority, and an observation about *that* one
+        // makes the derived currency `.unknown` — dropping the
+        // undismissable gate while this method is still enrolling and
+        // signing. A failure after that point would return the user to
+        // the app under the stale mandate, ungated, without ever
+        // showing the signing error. The gate must stay up until a new
+        // record is actually active, and with the observation withheld
+        // it does: currency keeps reading the old record against the
+        // old authority's published hash.
+        if listing.componentId == activeMandateRecord()?.mandate.authority {
+            notePublishedManifest(signedManifest.manifestHash, for: listing.componentId)
+        }
 
         // Resolve every older ambiguous registration for this Authority
         // before minting under newly reviewed terms. A manifest rotation

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -209,9 +209,13 @@ public actor ModerationRepository {
     private var caseAppealTasks: [CaseSubmissionKey: Task<AppealReceipt, Error>] = [:]
     private var refreshTask: Task<Void, Error>?
     private var termsCheckTask: Task<Void, Never>?
-    /// Last authenticated, consentable manifest seen for an authority.
+    /// Last authenticated, consentable manifest seen for an authority,
+    /// and the authority the directory has stopped listing. Each holds
+    /// one authority, not a table: they are observations about the one
+    /// the active mandate names, and are only ever read through
+    /// `termsCurrency`, which discards them when they describe anyone
+    /// else. Reading either directly would need that check restated.
     private var publishedManifest: (authority: String, hash: String)?
-    /// Authority the directory has stopped listing, if any.
     private var delistedAuthority: String?
 
     public init(
@@ -298,7 +302,25 @@ public actor ModerationRepository {
             throw error
         }
         refreshTask = nil
+        // Every successful directory read is evidence about the active
+        // mandate's authority, wherever it was asked for. The consent
+        // flow refreshes on appear and on its retry button without ever
+        // going through the terms check, so leaving reconciliation
+        // there let a stale `publishedManifest` outlive the listing it
+        // came from — an undismissable "these terms have changed" over
+        // a picker reading "No authorities are published yet", with no
+        // remedy on screen.
+        reconcileDirectoryWithActiveMandate()
         publish()
+    }
+
+    private func reconcileDirectoryWithActiveMandate() {
+        guard let record = activeMandateRecord() else { return }
+        if authorities.contains(where: { $0.componentId == record.mandate.authority }) {
+            noteAuthorityListed(record.mandate.authority)
+        } else {
+            noteAuthorityDelisted(record.mandate.authority)
+        }
     }
 
     // MARK: - Terms currency
@@ -319,6 +341,12 @@ public actor ModerationRepository {
     /// first foreground notification) share one check.
     public func refreshActiveTerms() async {
         if let task = termsCheckTask {
+            // A foreground arriving mid-check takes that check's answer
+            // even though its fetches may predate the backgrounding. A
+            // deliberate gap: the alternative is queueing a second full
+            // round of fetches behind every one already running, and
+            // the verdict this returns is at worst one foreground
+            // stale, which the next one corrects.
             await task.value
             return
         }
@@ -349,21 +377,17 @@ public actor ModerationRepository {
         try? await refresh()
         guard fetchStatus == .success else { return }
 
+        // Listing and delisting were both settled by the refresh above,
+        // which reconciles them for every caller. Presence is the same
+        // quality of answer as absence and is recorded the moment the
+        // directory lands — never held hostage to the manifest fetch
+        // below, which would leave a relisted authority whose manifest
+        // momentarily fails to fetch showing "Authority Unavailable",
+        // offering only the remedy of switching away from an authority
+        // the directory does list.
         guard let listing = authorities.first(where: {
             $0.componentId == record.mandate.authority
-        }) else {
-            // A published directory that no longer lists this authority
-            // is a definitive answer, not a fetch failure.
-            noteAuthorityDelisted(record.mandate.authority)
-            return
-        }
-        // Presence in the directory is the same quality of answer as
-        // absence from it, so it retires the delisting here rather than
-        // hostage to the manifest fetch below. Otherwise a relisted
-        // authority whose manifest momentarily fails to fetch keeps
-        // showing "Authority Unavailable", whose only offered remedy is
-        // switching away from an authority that is in fact listed.
-        noteAuthorityListed(listing.componentId)
+        }) else { return }
 
         let published: SignedManifest
         do {

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -11,6 +11,31 @@ public enum AuthorityFetchStatus: Equatable, Sendable {
     case failed(message: String)
 }
 
+/// Whether the active mandate still pins the manifest its authority
+/// publishes today.
+///
+/// A mandate stays valid under the bytes it signed — the reference
+/// Authority judges every case under the manifest that mandate pinned,
+/// so superseded terms are not an outage and nothing in flight breaks.
+/// What they are is stale *consent*: the user is operating under terms
+/// the authority no longer stands behind, and only fresh consent can
+/// move them onto the new ones.
+public enum TermsCurrency: Sendable, Equatable {
+    /// Not established yet — no active mandate, the directory hasn't
+    /// loaded, or the manifest couldn't be fetched. Never blocks: an
+    /// unreachable authority must not lock the user out of the app.
+    case unknown
+    /// The active mandate's hash equals the published manifest's.
+    case current
+    /// The authority publishes a different manifest than the one this
+    /// mandate consented to.
+    case superseded(publishedHash: String)
+    /// The active mandate's authority is no longer in the designated
+    /// directory. There are no new terms to re-sign — the only way
+    /// forward is a different authority.
+    case authorityDelisted
+}
+
 /// Combined snapshot for consent and settings UI: the designated
 /// authorities, the fetch state of that list, and the mandate
 /// history for this device.
@@ -23,6 +48,8 @@ public struct ModerationState: Sendable, Equatable {
     /// still ambiguous, newest first. Definitively refused attempts are
     /// not mandates and are removed from this retained state.
     public let history: [MandateRecord]
+    /// Result of the most recent `refreshActiveTerms()`.
+    public let termsCurrency: TermsCurrency
 
     public static let empty = ModerationState(
         authorities: [],
@@ -35,12 +62,14 @@ public struct ModerationState: Sendable, Equatable {
         authorities: [AuthorityListing],
         fetchStatus: AuthorityFetchStatus,
         activeMandate: MandateRecord?,
-        history: [MandateRecord]
+        history: [MandateRecord],
+        termsCurrency: TermsCurrency = .unknown
     ) {
         self.authorities = authorities
         self.fetchStatus = fetchStatus
         self.activeMandate = activeMandate
         self.history = history
+        self.termsCurrency = termsCurrency
     }
 }
 
@@ -178,6 +207,8 @@ public actor ModerationRepository {
     private var caseStatusTasks: [CaseStatusKey: Task<CaseStatus, Error>] = [:]
     private var caseResponseTasks: [CaseSubmissionKey: Task<CaseResponseReceipt, Error>] = [:]
     private var caseAppealTasks: [CaseSubmissionKey: Task<AppealReceipt, Error>] = [:]
+    private var termsCurrency: TermsCurrency = .unknown
+    private var termsCheckTask: Task<Void, Never>?
 
     public init(
         authoritiesFetcher: any KnownAuthoritiesFetcher,
@@ -243,6 +274,83 @@ public actor ModerationRepository {
             publish()
             throw error
         }
+        publish()
+    }
+
+    // MARK: - Terms currency
+
+    /// Re-establish whether the active mandate still pins the manifest
+    /// its authority publishes today. Called on app open and on every
+    /// return to the foreground.
+    ///
+    /// Never throws and never blocks the app on a bad answer: an
+    /// unreachable authority, a directory that hasn't loaded, or a
+    /// manifest that fails verification all leave the last known
+    /// currency in place. Only a manifest that authenticates and hashes
+    /// to something other than the mandate's can supersede it — a
+    /// forged or corrupted document must not be able to push the user
+    /// into re-signing.
+    ///
+    /// Idempotent while in flight: overlapping calls (launch racing the
+    /// first foreground notification) share one check.
+    public func refreshActiveTerms() async {
+        if let task = termsCheckTask {
+            await task.value
+            return
+        }
+        let task = Task { await self.performTermsCheck() }
+        termsCheckTask = task
+        await task.value
+        termsCheckTask = nil
+    }
+
+    private func performTermsCheck() async {
+        guard let record = activeMandateRecord() else {
+            // No mandate is the consent gate's business, not this one.
+            setTermsCurrency(.unknown)
+            return
+        }
+        if fetchStatus != .success {
+            // The directory names the operator key each manifest is
+            // pinned against, so there is no authenticated fetch
+            // without it.
+            try? await refresh()
+        }
+        guard fetchStatus == .success else { return }
+
+        guard let listing = authorities.first(where: {
+            $0.componentId == record.mandate.authority
+        }) else {
+            // A published directory that no longer lists this authority
+            // is a definitive answer, not a fetch failure.
+            setTermsCurrency(.authorityDelisted)
+            return
+        }
+
+        let published: SignedManifest
+        do {
+            published = try await manifestFetcher.fetch(listing)
+        } catch {
+            Self.logger.debug("terms check: manifest unavailable, keeping last known currency")
+            return
+        }
+        // The active record can have changed while the fetch was in
+        // flight (actor reentrancy) — compare against the record that
+        // is active now, not the one this check started with.
+        guard let current = activeMandateRecord(),
+              current.mandate.authority == listing.componentId
+        else { return }
+
+        if published.manifestHash == current.mandate.manifestHash {
+            setTermsCurrency(.current)
+        } else {
+            setTermsCurrency(.superseded(publishedHash: published.manifestHash))
+        }
+    }
+
+    private func setTermsCurrency(_ currency: TermsCurrency) {
+        guard termsCurrency != currency else { return }
+        termsCurrency = currency
         publish()
     }
 
@@ -437,7 +545,13 @@ public actor ModerationRepository {
             records.insert(record, at: 0)
             mandateStore.save(records)
             publish()
-            return try await registerPending(record, with: listing, activate: true)
+            let registered = try await registerPending(record, with: listing, activate: true)
+            // The record that just became active pins bytes fetched
+            // moments ago, so its terms are current by construction.
+            // Saying so here is what dismisses the re-consent gate
+            // without waiting for the next foreground check.
+            setTermsCurrency(.current)
+            return registered
         }
 
         // Deactivate the previous active record without touching
@@ -449,6 +563,7 @@ public actor ModerationRepository {
         }
         records.insert(record, at: 0)
         mandateStore.save(records)
+        setTermsCurrency(.current)
         publish()
         return record
     }
@@ -464,7 +579,8 @@ public actor ModerationRepository {
             authorities: authorities,
             fetchStatus: fetchStatus,
             activeMandate: activeMandateRecord(),
-            history: records
+            history: records,
+            termsCurrency: termsCurrency
         )
     }
 

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -207,7 +207,7 @@ public actor ModerationRepository {
     private var caseStatusTasks: [CaseStatusKey: Task<CaseStatus, Error>] = [:]
     private var caseResponseTasks: [CaseSubmissionKey: Task<CaseResponseReceipt, Error>] = [:]
     private var caseAppealTasks: [CaseSubmissionKey: Task<AppealReceipt, Error>] = [:]
-    private var refreshTask: Task<Void, Error>?
+    private var refreshTask: Task<[AuthorityListing], Error>?
     private var termsCheckTask: Task<Void, Never>?
     /// Last authenticated, consentable manifest seen for an authority,
     /// and the authority the directory has stopped listing. Each holds
@@ -266,7 +266,20 @@ public actor ModerationRepository {
                 // published/persisted by their individual operations.
                 // A later consent attempt resumes safely.
             }
+            await self.checkTermsIfNotYetEstablished()
         }
+    }
+
+    /// An install whose active mandate only appears when a pending
+    /// registration resolves has already missed the launch terms check,
+    /// which returned immediately on finding no active record. Nothing
+    /// else re-triggers one, so those installs would run unchecked
+    /// until the next foreground. Narrow by design: it does nothing
+    /// when a check has already produced an answer for the record that
+    /// is active now.
+    private func checkTermsIfNotYetEstablished() async {
+        guard activeMandateRecord() != nil, termsCurrency == .unknown else { return }
+        await refreshActiveTerms()
     }
 
     /// Fetch the latest directory. Throws so consent UI can surface
@@ -278,27 +291,54 @@ public actor ModerationRepository {
     /// `.failed` land after a winner's `.success` and put a spurious
     /// "Couldn't load the authority list." under the onboarding picker.
     public func refresh() async throws {
+        _ = try await refreshedAuthorities()
+    }
+
+    /// `refresh()` for callers that need to act on the list it fetched.
+    /// The list comes back as a value rather than being read off the
+    /// actor afterwards: with fetches coalesced, another caller can
+    /// start a new one in the suspension between this task finishing
+    /// and its awaiter resuming, so `fetchStatus` at that point may
+    /// describe a fetch that has nothing to do with this call.
+    @discardableResult
+    private func refreshedAuthorities() async throws -> [AuthorityListing] {
         if let task = refreshTask {
             return try await task.value
         }
         let task = Task { try await self.performRefresh() }
         refreshTask = task
-        try await task.value
+        return try await task.value
     }
 
-    private func performRefresh() async throws {
-        fetchStatus = .fetching
-        publish()
+    private func performRefresh() async throws -> [AuthorityListing] {
+        // A list already on screen is not replaced by a spinner for a
+        // background re-read, and is not replaced by an error if that
+        // read fails. The terms check re-reads the directory on every
+        // foreground, and without this the consent picker — which is
+        // exactly what is on screen when the re-consent gate is up —
+        // would flicker through its loading and failure affordances on
+        // each resume.
+        let hadList = fetchStatus == .success
+        if !hadList {
+            fetchStatus = .fetching
+            publish()
+        }
         do {
             authorities = try await authoritiesFetcher.fetchLatest()
             fetchStatus = .success
         } catch {
-            fetchStatus = .failed(message: String(localized: "Couldn't load the authority list."))
             // Cleared before the task's value becomes available, so a
             // caller that arrives while this one is finishing starts a
             // fresh fetch instead of awaiting a settled one.
             refreshTask = nil
-            publish()
+            if hadList {
+                Self.logger.debug("directory re-read failed; keeping the list already loaded")
+            } else {
+                fetchStatus = .failed(
+                    message: String(localized: "Couldn't load the authority list.")
+                )
+                publish()
+            }
             throw error
         }
         refreshTask = nil
@@ -312,6 +352,7 @@ public actor ModerationRepository {
         // remedy on screen.
         reconcileDirectoryWithActiveMandate()
         publish()
+        return authorities
     }
 
     private func reconcileDirectoryWithActiveMandate() {
@@ -374,8 +415,7 @@ public actor ModerationRepository {
         // cold-start-only discovery and pins the check to a key that
         // may since have rotated. Callers share one fetch, so a
         // foreground that races the launch check costs nothing.
-        try? await refresh()
-        guard fetchStatus == .success else { return }
+        guard let listings = try? await refreshedAuthorities() else { return }
 
         // Listing and delisting were both settled by the refresh above,
         // which reconciles them for every caller. Presence is the same
@@ -385,7 +425,7 @@ public actor ModerationRepository {
         // momentarily fails to fetch showing "Authority Unavailable",
         // offering only the remedy of switching away from an authority
         // the directory does list.
-        guard let listing = authorities.first(where: {
+        guard let listing = listings.first(where: {
             $0.componentId == record.mandate.authority
         }) else { return }
 
@@ -531,29 +571,6 @@ public actor ModerationRepository {
         // pinned by a signed mandate.
         try manifestValidator.validateForConsent(signedManifest, now: clock())
 
-        // These bytes were fetched, authenticated, and validated moments
-        // ago, so they are the freshest observation this repository has
-        // of what this authority publishes. Recording it here — before
-        // any of the paths below activate a record — is what lets
-        // currency stay derived: whichever record ends up active is
-        // compared against this, and consenting to current terms comes
-        // out `.current` without anyone having to say so.
-        //
-        // Only for the authority the active mandate already names. The
-        // other remedy the re-consent copy offers is moving to a
-        // different authority, and an observation about *that* one
-        // makes the derived currency `.unknown` — dropping the
-        // undismissable gate while this method is still enrolling and
-        // signing. A failure after that point would return the user to
-        // the app under the stale mandate, ungated, without ever
-        // showing the signing error. The gate must stay up until a new
-        // record is actually active, and with the observation withheld
-        // it does: currency keeps reading the old record against the
-        // old authority's published hash.
-        if listing.componentId == activeMandateRecord()?.mandate.authority {
-            notePublishedManifest(signedManifest.manifestHash, for: listing.componentId)
-        }
-
         // Resolve every older ambiguous registration for this Authority
         // before minting under newly reviewed terms. A manifest rotation
         // must not orphan hidden pending bytes or create a replacement
@@ -564,7 +581,7 @@ public actor ModerationRepository {
                 && $0.registrationPending
         }) {
             if pending.mandate.manifestHash == signedManifest.manifestHash {
-                return try await registerPending(pending, with: listing, activate: true)
+                return try await activate(pending, with: listing, publishing: signedManifest)
             }
             do {
                 _ = try await registerPending(pending, with: listing, activate: false)
@@ -668,7 +685,7 @@ public actor ModerationRepository {
             records.insert(record, at: 0)
             mandateStore.save(records)
             publish()
-            return try await registerPending(record, with: listing, activate: true)
+            return try await activate(record, with: listing, publishing: signedManifest)
         }
 
         // Deactivate the previous active record without touching
@@ -680,8 +697,45 @@ public actor ModerationRepository {
         }
         records.insert(record, at: 0)
         mandateStore.save(records)
+        noteConsentedManifest(signedManifest, for: listing)
         publish()
         return record
+    }
+
+    /// Register a pending record and, once it is actually the active
+    /// one, record the manifest it consented to.
+    ///
+    /// The observation belongs *at* activation, not before it. Recorded
+    /// earlier, it would drop the undismissable gate while this method
+    /// is still enrolling and signing — a failure after that point
+    /// returns the user to the app under the stale mandate, ungated,
+    /// never seeing the error. Recorded earlier but withheld for other
+    /// authorities (the previous shape of this) it would survive a
+    /// switch away and describe an authority no record names, ready to
+    /// fire a false `.superseded` against a stale hash if the user ever
+    /// switched back. Tying it to activation gives both properties for
+    /// free: no observation outlives the record it describes, and none
+    /// exists before one does.
+    private func activate(
+        _ record: MandateRecord,
+        with listing: AuthorityListing,
+        publishing signedManifest: SignedManifest
+    ) async throws -> MandateRecord {
+        let activated = try await registerPending(record, with: listing, activate: true)
+        noteConsentedManifest(signedManifest, for: listing)
+        return activated
+    }
+
+    /// These bytes were fetched, authenticated, and validated moments
+    /// ago, so they are the freshest observation this repository has of
+    /// what the authority publishes — and the record that just became
+    /// active pins them, so derived currency reads `.current` without
+    /// anyone having to say so.
+    private func noteConsentedManifest(
+        _ signedManifest: SignedManifest,
+        for listing: AuthorityListing
+    ) {
+        notePublishedManifest(signedManifest.manifestHash, for: listing.componentId)
     }
 
     // MARK: - Read

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -207,8 +207,12 @@ public actor ModerationRepository {
     private var caseStatusTasks: [CaseStatusKey: Task<CaseStatus, Error>] = [:]
     private var caseResponseTasks: [CaseSubmissionKey: Task<CaseResponseReceipt, Error>] = [:]
     private var caseAppealTasks: [CaseSubmissionKey: Task<AppealReceipt, Error>] = [:]
-    private var termsCurrency: TermsCurrency = .unknown
+    private var refreshTask: Task<Void, Error>?
     private var termsCheckTask: Task<Void, Never>?
+    /// Last authenticated, consentable manifest seen for an authority.
+    private var publishedManifest: (authority: String, hash: String)?
+    /// Authority the directory has stopped listing, if any.
+    private var delistedAuthority: String?
 
     public init(
         authoritiesFetcher: any KnownAuthoritiesFetcher,
@@ -263,7 +267,22 @@ public actor ModerationRepository {
 
     /// Fetch the latest directory. Throws so consent UI can surface
     /// failure with a retry affordance.
+    ///
+    /// One fetch at a time, shared by every caller: launch, the consent
+    /// flow, and the terms check all ask for the directory within the
+    /// same moment of a cold start. Racing fetches let a loser's
+    /// `.failed` land after a winner's `.success` and put a spurious
+    /// "Couldn't load the authority list." under the onboarding picker.
     public func refresh() async throws {
+        if let task = refreshTask {
+            return try await task.value
+        }
+        let task = Task { try await self.performRefresh() }
+        refreshTask = task
+        try await task.value
+    }
+
+    private func performRefresh() async throws {
         fetchStatus = .fetching
         publish()
         do {
@@ -271,9 +290,14 @@ public actor ModerationRepository {
             fetchStatus = .success
         } catch {
             fetchStatus = .failed(message: String(localized: "Couldn't load the authority list."))
+            // Cleared before the task's value becomes available, so a
+            // caller that arrives while this one is finishing starts a
+            // fresh fetch instead of awaiting a settled one.
+            refreshTask = nil
             publish()
             throw error
         }
+        refreshTask = nil
         publish()
     }
 
@@ -298,18 +322,23 @@ public actor ModerationRepository {
             await task.value
             return
         }
-        let task = Task { await self.performTermsCheck() }
+        let task = Task { await self.runTermsCheck() }
         termsCheckTask = task
         await task.value
+    }
+
+    /// Clears the in-flight marker *before* returning, so it is already
+    /// nil by the time any awaiter resumes. Clearing after `await
+    /// task.value` in the caller instead would leave a suspension-wide
+    /// window in which an arriving foreground event joins a finished
+    /// check, returns its stale verdict, and never runs one of its own.
+    private func runTermsCheck() async {
+        await performTermsCheck()
         termsCheckTask = nil
     }
 
     private func performTermsCheck() async {
-        guard let record = activeMandateRecord() else {
-            // No mandate is the consent gate's business, not this one.
-            setTermsCurrency(.unknown)
-            return
-        }
+        guard let record = activeMandateRecord() else { return }
         if fetchStatus != .success {
             // The directory names the operator key each manifest is
             // pinned against, so there is no authenticated fetch
@@ -323,7 +352,7 @@ public actor ModerationRepository {
         }) else {
             // A published directory that no longer lists this authority
             // is a definitive answer, not a fetch failure.
-            setTermsCurrency(.authorityDelisted)
+            noteAuthorityDelisted(record.mandate.authority)
             return
         }
 
@@ -334,24 +363,55 @@ public actor ModerationRepository {
             Self.logger.debug("terms check: manifest unavailable, keeping last known currency")
             return
         }
-        // The active record can have changed while the fetch was in
-        // flight (actor reentrancy) — compare against the record that
-        // is active now, not the one this check started with.
-        guard let current = activeMandateRecord(),
-              current.mandate.authority == listing.componentId
-        else { return }
-
-        if published.manifestHash == current.mandate.manifestHash {
-            setTermsCurrency(.current)
-        } else {
-            setTermsCurrency(.superseded(publishedHash: published.manifestHash))
+        // Terms that cannot be consented to must not supersede consent.
+        // The same validity conditions gate signing, so an authority
+        // republishing an expired or unsupported manifest would
+        // otherwise gate every install on a re-consent whose only
+        // remedy — reviewing those very bytes — `manifestForReview`
+        // then refuses. Leaving the mandate current is both the honest
+        // reading (nothing consentable has replaced it) and the only
+        // one with a way out.
+        do {
+            try manifestValidator.validateForConsent(published, now: clock())
+        } catch {
+            Self.logger.debug("terms check: published manifest is not consentable, ignoring")
+            return
         }
+        notePublishedManifest(published.manifestHash, for: listing.componentId)
     }
 
-    private func setTermsCurrency(_ currency: TermsCurrency) {
-        guard termsCurrency != currency else { return }
-        termsCurrency = currency
-        publish()
+    // MARK: Derived currency
+
+    /// Currency is *derived* from the last authenticated observation and
+    /// whichever record is active right now — never latched at the
+    /// moments consent happens to pass through. Every path that can
+    /// activate a record (fresh consent, a resolved pending
+    /// registration, a retried one) would otherwise have to remember to
+    /// update it, and the one that forgot would strand the user on an
+    /// undismissable gate.
+    private var termsCurrency: TermsCurrency {
+        guard let record = activeMandateRecord() else { return .unknown }
+        if delistedAuthority == record.mandate.authority { return .authorityDelisted }
+        guard let observed = publishedManifest,
+              observed.authority == record.mandate.authority
+        else { return .unknown }
+        return observed.hash == record.mandate.manifestHash
+            ? .current
+            : .superseded(publishedHash: observed.hash)
+    }
+
+    private func notePublishedManifest(_ hash: String, for authority: String) {
+        let before = termsCurrency
+        publishedManifest = (authority: authority, hash: hash)
+        if delistedAuthority == authority { delistedAuthority = nil }
+        if termsCurrency != before { publish() }
+    }
+
+    private func noteAuthorityDelisted(_ authority: String) {
+        let before = termsCurrency
+        delistedAuthority = authority
+        if publishedManifest?.authority == authority { publishedManifest = nil }
+        if termsCurrency != before { publish() }
     }
 
     // MARK: - Consent
@@ -430,6 +490,15 @@ public actor ModerationRepository {
         // not just the consent UI. An invalid manifest must never end up
         // pinned by a signed mandate.
         try manifestValidator.validateForConsent(signedManifest, now: clock())
+
+        // These bytes were fetched, authenticated, and validated moments
+        // ago, so they are the freshest observation this repository has
+        // of what the authority publishes. Recording it here — before
+        // any of the paths below activate a record — is what lets
+        // currency stay derived: whichever record ends up active is
+        // compared against this, and consenting to current terms comes
+        // out `.current` without anyone having to say so.
+        notePublishedManifest(signedManifest.manifestHash, for: listing.componentId)
 
         // Resolve every older ambiguous registration for this Authority
         // before minting under newly reviewed terms. A manifest rotation
@@ -545,13 +614,7 @@ public actor ModerationRepository {
             records.insert(record, at: 0)
             mandateStore.save(records)
             publish()
-            let registered = try await registerPending(record, with: listing, activate: true)
-            // The record that just became active pins bytes fetched
-            // moments ago, so its terms are current by construction.
-            // Saying so here is what dismisses the re-consent gate
-            // without waiting for the next foreground check.
-            setTermsCurrency(.current)
-            return registered
+            return try await registerPending(record, with: listing, activate: true)
         }
 
         // Deactivate the previous active record without touching
@@ -563,7 +626,6 @@ public actor ModerationRepository {
         }
         records.insert(record, at: 0)
         mandateStore.save(records)
-        setTermsCurrency(.current)
         publish()
         return record
     }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentFlow.swift
@@ -2,14 +2,21 @@ import Foundation
 import OnymModeration
 
 /// Drives the authority pick → manifest review → sign sequence, used
-/// both at onboarding (`.onboarding`, blocking gate) and from Settings
-/// (`.switching`, signs a fresh mandate; the old record stays pinned).
+/// at onboarding (`.onboarding`, blocking gate), from Settings
+/// (`.switching`, signs a fresh mandate; the old record stays pinned),
+/// and when standing consent has gone stale (`.reconsent`, blocking).
 @MainActor
 @Observable
 public final class ModerationConsentFlow {
     public enum Mode: Equatable {
         case onboarding
         case switching
+        /// The user holds a mandate, but not one that matches what its
+        /// authority publishes today. Mechanically identical to
+        /// switching — consent is always a fresh mandate, never an edit
+        /// (spec §12) — and differs only in being unskippable and in
+        /// naming what changed.
+        case reconsent(ReconsentReason)
     }
 
     public enum Step: Equatable {
@@ -34,10 +41,20 @@ public final class ModerationConsentFlow {
         /// repository's verified fetch.
         public var reviewingManifest: ReviewedManifest?
         public var errorMessage: String?
+        /// The authority the current mandate names, when there is one.
+        /// The re-consent picker marks its row: "the terms you already
+        /// agreed to, restated" is a different offer from the rest of
+        /// the list, and hiding which is which would make re-signing
+        /// look like switching.
+        public var currentAuthorityId: String?
     }
 
     public let mode: Mode
     public private(set) var state = State()
+
+    /// Settings can be walked away from; a gate cannot. Re-consent is a
+    /// gate — the app is running on consent the authority has withdrawn.
+    public var isDismissable: Bool { mode == .switching }
 
     private let repository: ModerationRepository
     private var snapshotTask: Task<Void, Never>?
@@ -62,6 +79,7 @@ public final class ModerationConsentFlow {
             for await snapshot in self.repository.snapshots {
                 self.state.authorities = snapshot.authorities
                 self.state.fetchStatus = snapshot.fetchStatus
+                self.state.currentAuthorityId = snapshot.activeMandate?.mandate.authority
                 if self.state.step == .loadingDirectory {
                     switch snapshot.fetchStatus {
                     case .success, .failed:

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentFlow.swift
@@ -47,6 +47,13 @@ public final class ModerationConsentFlow {
         /// the list, and hiding which is which would make re-signing
         /// look like switching.
         public var currentAuthorityId: String?
+        /// The hash the current mandate pins, and the one its authority
+        /// publishes now. Shown side by side on the re-consent surface:
+        /// "the terms changed" is a claim about two specific documents,
+        /// and the user is entitled to see which two — the same hash
+        /// `ModerationSettingsView` already shows for the mandate.
+        public var pinnedManifestHash: String?
+        public var publishedManifestHash: String?
     }
 
     public let mode: Mode
@@ -80,6 +87,12 @@ public final class ModerationConsentFlow {
                 self.state.authorities = snapshot.authorities
                 self.state.fetchStatus = snapshot.fetchStatus
                 self.state.currentAuthorityId = snapshot.activeMandate?.mandate.authority
+                self.state.pinnedManifestHash = snapshot.activeMandate?.mandate.manifestHash
+                if case .superseded(let published) = snapshot.termsCurrency {
+                    self.state.publishedManifestHash = published
+                } else {
+                    self.state.publishedManifestHash = nil
+                }
                 if self.state.step == .loadingDirectory {
                     switch snapshot.fetchStatus {
                     case .success, .failed:

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
@@ -131,6 +131,10 @@ public struct ModerationConsentView: View {
                         SettingsRow(
                             titleText: listing.name,
                             subtitle: rowSubtitle(for: listing),
+                            // The re-consent marker is prepended to the
+                            // component id, which already fills the
+                            // single default line on its own.
+                            subtitleLineLimit: 2,
                             last: idx == flow.state.authorities.count - 1
                         ) {
                             SettingsIconTile(symbol: "checkmark.shield", bg: SettingsTile.indigo)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
@@ -95,6 +95,8 @@ public struct ModerationConsentView: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 16)
 
+        supersededHashes
+
         switch flow.state.fetchStatus {
         case .failed(let message):
             SettingsCard {
@@ -145,6 +147,38 @@ public struct ModerationConsentView: View {
         }
     }
 
+    /// The two documents the "terms have changed" claim is about. Only
+    /// on the re-consent surface, and only once both are known — on
+    /// every other path there is no prior hash to contrast.
+    @ViewBuilder
+    private var supersededHashes: some View {
+        if case .reconsent(.termsChanged) = flow.mode,
+           let pinned = flow.state.pinnedManifestHash,
+           let published = flow.state.publishedManifestHash {
+            SettingsSectionLabel("WHAT CHANGED")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    hashRow("Terms you signed", pinned)
+                    hashRow("Published now", published)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+        }
+    }
+
+    private func hashRow(_ label: LocalizedStringKey, _ hash: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(hash)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(OnymTokens.text2)
+                .textSelection(.enabled)
+        }
+    }
+
     private var pickerTitle: LocalizedStringKey {
         switch flow.mode {
         case .onboarding, .switching:
@@ -168,7 +202,7 @@ public struct ModerationConsentView: View {
         case .reconsent(.termsChanged):
             return "Your authority now publishes terms that differ from the ones you signed. The mandate you hold is untouched — anything already under way is still judged by the terms you agreed to, and no one can edit them. Onym won't keep running on consent that no longer matches what's published, so read the new terms and sign them, or move to another authority."
         case .reconsent(.authorityDelisted):
-            return "The authority your mandate names is no longer designated, so it can't publish terms or answer for you any more. Choose an authority below to review its terms and sign a fresh mandate."
+            return "The authority your mandate names is no longer a designated authority here. It remains bound by the mandate you signed — what has changed is that Onym no longer routes anything through it, so reports and cases can't reach it from this app. Choose an authority below to review its terms and sign a fresh mandate."
         }
     }
 

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
@@ -33,15 +33,15 @@ public struct ModerationConsentView: View {
                 .padding(.bottom, 32)
             }
             .background(OnymTokens.surface.ignoresSafeArea())
-            .navigationTitle(flow.mode == .onboarding ? "Moderation" : "Switch Authority")
+            .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 // Switching is a normal, abandonable settings task, and
                 // the `.done` step has no other way out — `onConsented`
                 // belongs to the app factory and can't dismiss us.
-                // Onboarding deliberately has no escape: consent is the
-                // gate.
-                if flow.mode == .switching {
+                // Onboarding and re-consent deliberately have no escape:
+                // consent is the gate.
+                if flow.isDismissable {
                     ToolbarItem(placement: .topBarTrailing) {
                         Button(dismissLabel) { dismiss() }
                             .accessibilityIdentifier("moderation.consent.dismiss")
@@ -51,7 +51,16 @@ public struct ModerationConsentView: View {
             .task { flow.start() }
             .onDisappear { flow.stop() }
         }
-        .interactiveDismissDisabled(flow.mode == .onboarding)
+        .interactiveDismissDisabled(!flow.isDismissable)
+    }
+
+    private var navigationTitle: LocalizedStringKey {
+        switch flow.mode {
+        case .onboarding: return "Moderation"
+        case .switching: return "Switch Authority"
+        case .reconsent(.termsChanged): return "Terms Updated"
+        case .reconsent(.authorityDelisted): return "Authority Unavailable"
+        }
     }
 
     /// "Cancel" while the task can still be abandoned; "Done" once the
@@ -78,8 +87,8 @@ public struct ModerationConsentView: View {
 
     @ViewBuilder
     private var picker: some View {
-        SettingsLargeTitle("Choose a moderation authority")
-        Text("Onym requires a moderation authority to handle reports of prohibited content. You choose who that is. Its entire power over you is written in the terms you'll review next — nothing can be added to them later without your fresh consent.")
+        SettingsLargeTitle(pickerTitle)
+        Text(pickerBlurb)
             .font(.system(size: 14))
             .foregroundStyle(OnymTokens.text2)
             .lineSpacing(3)
@@ -119,7 +128,7 @@ public struct ModerationConsentView: View {
                     Button { flow.selectedAuthority(listing) } label: {
                         SettingsRow(
                             titleText: listing.name,
-                            subtitle: listing.componentId,
+                            subtitle: rowSubtitle(for: listing),
                             last: idx == flow.state.authorities.count - 1
                         ) {
                             SettingsIconTile(symbol: "checkmark.shield", bg: SettingsTile.indigo)
@@ -134,6 +143,42 @@ public struct ModerationConsentView: View {
         if let error = flow.state.errorMessage {
             SettingsFootnote(verbatim: error)
         }
+    }
+
+    private var pickerTitle: LocalizedStringKey {
+        switch flow.mode {
+        case .onboarding, .switching:
+            return "Choose a moderation authority"
+        case .reconsent(.termsChanged):
+            return "These terms have changed"
+        case .reconsent(.authorityDelisted):
+            return "Your authority is no longer listed"
+        }
+    }
+
+    /// The re-consent copy has one job beyond explaining itself: not to
+    /// frighten. Nothing the user signed has been altered and no case
+    /// has been re-termed — the mandate they hold is still honoured on
+    /// its own terms. What has run out is its currency, and only fresh
+    /// consent renews that.
+    private var pickerBlurb: LocalizedStringKey {
+        switch flow.mode {
+        case .onboarding, .switching:
+            return "Onym requires a moderation authority to handle reports of prohibited content. You choose who that is. Its entire power over you is written in the terms you'll review next — nothing can be added to them later without your fresh consent."
+        case .reconsent(.termsChanged):
+            return "Your authority now publishes terms that differ from the ones you signed. The mandate you hold is untouched — anything already under way is still judged by the terms you agreed to, and no one can edit them. Onym won't keep running on consent that no longer matches what's published, so read the new terms and sign them, or move to another authority."
+        case .reconsent(.authorityDelisted):
+            return "The authority your mandate names is no longer designated, so it can't publish terms or answer for you any more. Choose an authority below to review its terms and sign a fresh mandate."
+        }
+    }
+
+    /// Runtime data, so never a localization key — the marker is
+    /// localized and the component id appended verbatim.
+    private func rowSubtitle(for listing: AuthorityListing) -> String {
+        guard case .reconsent = flow.mode,
+              listing.componentId == flow.state.currentAuthorityId
+        else { return listing.componentId }
+        return String(localized: "Your current authority") + " · " + listing.componentId
     }
 
     @ViewBuilder

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
@@ -43,6 +43,7 @@ public final class ModerationGateFlow {
     private let gateCheck: GateCheckRepository
     private var moderationTask: Task<Void, Never>?
     private var gateTask: Task<Void, Never>?
+    private var termsTask: Task<Void, Never>?
 
     private var hasMandate: Bool?
     private var authoritiesAvailable = false
@@ -67,8 +68,12 @@ public final class ModerationGateFlow {
             }
         }
         // App open is the first of the two moments the terms check
-        // runs; `appForegrounded` is the other.
-        Task { await moderation.refreshActiveTerms() }
+        // runs; `appForegrounded` is the other. Tracked like the two
+        // drains above so `stop()` cancels it and a repeated `start()`
+        // doesn't re-fire it.
+        termsTask = Task { [weak self] in
+            await self?.moderation.refreshActiveTerms()
+        }
         gateTask = Task { [weak self] in
             guard let self else { return }
             for await status in self.gateCheck.snapshots {
@@ -83,6 +88,8 @@ public final class ModerationGateFlow {
         moderationTask = nil
         gateTask?.cancel()
         gateTask = nil
+        termsTask?.cancel()
+        termsTask = nil
     }
 
     // MARK: - Intents

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
@@ -113,7 +113,9 @@ public final class ModerationGateFlow {
         Task { await gateCheck.checkNow() }
         // Same handle as the launch check: the repository coalesces
         // overlapping checks anyway, so this only keeps `stop()` able to
-        // drop the flow's interest in the newest one.
+        // drop the flow's interest in the newest one. Cancel before
+        // replacing rather than dropping the old handle on the floor.
+        termsTask?.cancel()
         termsTask = Task { [weak self] in
             await self?.moderation.refreshActiveTerms()
         }
@@ -158,7 +160,13 @@ public final class ModerationGateFlow {
             // thing a cold launch shows on a flaky network.
             switch termsCurrency {
             case .superseded:
-                gate = .needsReconsent(.termsChanged)
+                // Same softening as every other blocking branch: with
+                // nobody in the directory the re-consent picker has no
+                // row to offer and no dismiss, so it would be a dead
+                // end rather than a gate.
+                gate = authoritiesAvailable
+                    ? .needsReconsent(.termsChanged)
+                    : .operational(openCases: openCases)
             case .authorityDelisted:
                 // A directory that lists nobody leaves the user no move
                 // to make; the same reasoning that keeps consent from

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
@@ -111,7 +111,12 @@ public final class ModerationGateFlow {
     /// while the app was away get noticed.
     public func appForegrounded() {
         Task { await gateCheck.checkNow() }
-        Task { await moderation.refreshActiveTerms() }
+        // Same handle as the launch check: the repository coalesces
+        // overlapping checks anyway, so this only keeps `stop()` able to
+        // drop the flow's interest in the newest one.
+        termsTask = Task { [weak self] in
+            await self?.moderation.refreshActiveTerms()
+        }
     }
 
     // MARK: - Private

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationGateFlow.swift
@@ -1,6 +1,17 @@
 import Foundation
 import OnymModeration
 
+/// Why the re-consent surface is up — the two cases differ in what the
+/// user can actually do about it.
+public enum ReconsentReason: Equatable, Sendable {
+    /// The authority publishes a new manifest. Re-signing with the same
+    /// authority is available, and is the expected answer.
+    case termsChanged
+    /// The authority left the directory. There is nothing to re-sign;
+    /// only another authority will do.
+    case authorityDelisted
+}
+
 /// Merges `ModerationRepository` and `GateCheckRepository` snapshots
 /// into the single state the app root switches on. The root gate is
 /// the enforcement surface: consent before use, ban screen on bit1,
@@ -19,6 +30,9 @@ public final class ModerationGateFlow {
         case banned(BanState)
         /// No trustworthy gate answer and grace exhausted (blocking).
         case gateCheckRequired(CheckRequiredReason)
+        /// The active mandate's terms are no longer the ones its
+        /// authority publishes: re-sign or move (blocking).
+        case needsReconsent(ReconsentReason)
         /// Operating; non-empty `openCases` shows the case banner.
         case operational(openCases: [CaseNotice])
     }
@@ -33,6 +47,7 @@ public final class ModerationGateFlow {
     private var hasMandate: Bool?
     private var authoritiesAvailable = false
     private var gateStatus: GateStatus?
+    private var termsCurrency: TermsCurrency = .unknown
 
     public init(moderation: ModerationRepository, gateCheck: GateCheckRepository) {
         self.moderation = moderation
@@ -47,9 +62,13 @@ public final class ModerationGateFlow {
             for await state in self.moderation.snapshots {
                 self.hasMandate = state.activeMandate != nil
                 self.authoritiesAvailable = !state.authorities.isEmpty
+                self.termsCurrency = state.termsCurrency
                 self.recompute()
             }
         }
+        // App open is the first of the two moments the terms check
+        // runs; `appForegrounded` is the other.
+        Task { await moderation.refreshActiveTerms() }
         gateTask = Task { [weak self] in
             guard let self else { return }
             for await status in self.gateCheck.snapshots {
@@ -80,9 +99,12 @@ public final class ModerationGateFlow {
     }
 
     /// App returned to foreground: refresh the gate (covers the P1D
-    /// cadence across relaunches and long backgrounding).
+    /// cadence across relaunches and long backgrounding) and re-read
+    /// the authority's published manifest, which is how terms changed
+    /// while the app was away get noticed.
     public func appForegrounded() {
         Task { await gateCheck.checkNow() }
+        Task { await moderation.refreshActiveTerms() }
     }
 
     // MARK: - Private
@@ -115,7 +137,26 @@ public final class ModerationGateFlow {
             // Mandate exists but the gate hasn't answered yet.
             gate = .checking
         case .operational(let openCases):
-            gate = .operational(openCases: openCases)
+            // Stale consent gates an otherwise operating app, and only
+            // there. It deliberately ranks below every enforcement
+            // answer: a banned user re-signing terms is still banned,
+            // and an unanswered gate check is the more urgent block.
+            // It also never pre-empts `.checking` — a re-consent screen
+            // thrown up before the gate has spoken would be the first
+            // thing a cold launch shows on a flaky network.
+            switch termsCurrency {
+            case .superseded:
+                gate = .needsReconsent(.termsChanged)
+            case .authorityDelisted:
+                // A directory that lists nobody leaves the user no move
+                // to make; the same reasoning that keeps consent from
+                // bricking an install on an empty directory applies.
+                gate = authoritiesAvailable
+                    ? .needsReconsent(.authorityDelisted)
+                    : .operational(openCases: openCases)
+            case .current, .unknown:
+                gate = .operational(openCases: openCases)
+            }
         case .banned(let state):
             gate = .banned(state)
         case .gateCheckRequired(.enrollmentLost):

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -85,7 +85,22 @@ struct RootView: View {
         }
         .task { dependencies.moderationGateFlow.start() }
         .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
-            consentPresentation = Self.presentation(for: gate)
+            let next = Self.presentation(for: gate)
+            guard next?.id != consentPresentation?.id else { return }
+            guard consentPresentation != nil, next != nil else {
+                consentPresentation = next
+                return
+            }
+            // One gate replacing another while a cover is already up
+            // (terms change, then the authority leaves the directory).
+            // `fullScreenCover(item:)` is not dependable about
+            // re-presenting on an identity change alone, and the failure
+            // is silent — the old reason and old flow stay on screen.
+            // Dismissing first makes the swap explicit.
+            consentPresentation = nil
+            Task { @MainActor in
+                consentPresentation = next
+            }
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -27,10 +27,26 @@ struct RootView: View {
     @State private var selectedTab: RootTab = .chats
     @Environment(\.scenePhase) private var scenePhase
 
-    /// Whether the blocking consent sheet is up. Driven by the gate;
-    /// a `Bool` binding because `fullScreenCover(isPresented:)` wants
-    /// one, with the gate as the single source of truth.
-    @State private var showConsent = false
+    /// The blocking consent sheet, when one is up. Driven by the gate,
+    /// which stays the single source of truth: `needsConsent` presents
+    /// onboarding, `needsReconsent` presents the same surface with the
+    /// reason attached, and anything else dismisses it.
+    @State private var consentPresentation: ConsentPresentation?
+
+    /// `fullScreenCover(item:)` needs identity. The mode *is* the
+    /// identity here — swapping between onboarding and re-consent
+    /// should rebuild the flow, not reuse it.
+    private struct ConsentPresentation: Identifiable, Equatable {
+        let mode: ModerationConsentFlow.Mode
+        var id: String {
+            switch mode {
+            case .onboarding: return "onboarding"
+            case .switching: return "switching"
+            case .reconsent(.termsChanged): return "reconsent.termsChanged"
+            case .reconsent(.authorityDelisted): return "reconsent.authorityDelisted"
+            }
+        }
+    }
 
     var body: some View {
         // The moderation gate is the enforcement surface (DeviceCheck
@@ -55,23 +71,39 @@ struct RootView: View {
                     },
                     makeDeviceRecoveryFlow: dependencies.makeDeviceRecoveryFlow
                 )
-            case .checking, .needsConsent, .operational:
+            case .checking, .needsConsent, .needsReconsent, .operational:
                 tabs
             }
         }
         .task { dependencies.moderationGateFlow.start() }
         .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
-            showConsent = gate == .needsConsent
+            consentPresentation = Self.presentation(for: gate)
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
                 dependencies.moderationGateFlow.appForegrounded()
             }
         }
-        .fullScreenCover(isPresented: $showConsent) {
+        .fullScreenCover(item: $consentPresentation) { presentation in
             ModerationConsentView(
-                flow: dependencies.makeModerationConsentFlow(.onboarding)
+                flow: dependencies.makeModerationConsentFlow(presentation.mode)
             )
+        }
+    }
+
+    /// Both consent gates present the same surface; only the gate
+    /// decides which one, so a mandate signed (or a terms check coming
+    /// back current) takes the cover down on its own.
+    private static func presentation(
+        for gate: ModerationGateFlow.RootGate
+    ) -> ConsentPresentation? {
+        switch gate {
+        case .needsConsent:
+            return ConsentPresentation(mode: .onboarding)
+        case .needsReconsent(let reason):
+            return ConsentPresentation(mode: .reconsent(reason))
+        case .checking, .banned, .gateCheckRequired, .operational:
+            return nil
         }
     }
 

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -33,17 +33,25 @@ struct RootView: View {
     /// reason attached, and anything else dismisses it.
     @State private var consentPresentation: ConsentPresentation?
 
-    /// `fullScreenCover(item:)` needs identity. The mode *is* the
-    /// identity here — swapping between onboarding and re-consent
-    /// should rebuild the flow, not reuse it.
+    /// `fullScreenCover(item:)` needs identity, and the two consent
+    /// gates the root can host are exactly "no mandate yet" and "the
+    /// mandate is stale, for this reason" — switching is a Settings
+    /// task with its own cover and is deliberately not expressible
+    /// here. Changing between them rebuilds the flow rather than
+    /// reusing it.
     private struct ConsentPresentation: Identifiable, Equatable {
-        let mode: ModerationConsentFlow.Mode
+        /// `nil` when there is no mandate at all.
+        let reason: ReconsentReason?
+
+        var mode: ModerationConsentFlow.Mode {
+            reason.map { .reconsent($0) } ?? .onboarding
+        }
+
         var id: String {
-            switch mode {
-            case .onboarding: return "onboarding"
-            case .switching: return "switching"
-            case .reconsent(.termsChanged): return "reconsent.termsChanged"
-            case .reconsent(.authorityDelisted): return "reconsent.authorityDelisted"
+            switch reason {
+            case nil: return "onboarding"
+            case .termsChanged: return "reconsent.termsChanged"
+            case .authorityDelisted: return "reconsent.authorityDelisted"
             }
         }
     }
@@ -99,9 +107,9 @@ struct RootView: View {
     ) -> ConsentPresentation? {
         switch gate {
         case .needsConsent:
-            return ConsentPresentation(mode: .onboarding)
+            return ConsentPresentation(reason: nil)
         case .needsReconsent(let reason):
-            return ConsentPresentation(mode: .reconsent(reason))
+            return ConsentPresentation(reason: reason)
         case .checking, .banned, .gateCheckRequired, .operational:
             return nil
         }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -83,31 +83,17 @@ struct RootView: View {
                 tabs
             }
         }
-        .task { dependencies.moderationGateFlow.start() }
+        .task {
+            dependencies.moderationGateFlow.start()
+            // The gate can already be decided by the time this view
+            // appears, and `onChange` alone would never present for a
+            // value that never changes.
+            consentPresentation = Self.presentation(
+                for: dependencies.moderationGateFlow.gate
+            )
+        }
         .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
-            let next = Self.presentation(for: gate)
-            guard next?.id != consentPresentation?.id else { return }
-            guard consentPresentation != nil, next != nil else {
-                consentPresentation = next
-                return
-            }
-            // One gate replacing another while a cover is already up
-            // (terms change, then the authority leaves the directory).
-            // `fullScreenCover(item:)` is not dependable about
-            // re-presenting on an identity change alone, and the failure
-            // is silent — the old reason and old flow stay on screen.
-            // Dismissing first makes the swap explicit.
-            consentPresentation = nil
-            Task { @MainActor in
-                // Re-derive rather than replaying the captured value:
-                // the gate can move again before this turn runs (the
-                // stale mandate resolving, a swap back), and applying a
-                // superseded decision would put an undismissable cover
-                // back over an app that no longer needs one.
-                consentPresentation = Self.presentation(
-                    for: dependencies.moderationGateFlow.gate
-                )
-            }
+            consentPresentation = Self.presentation(for: gate)
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
@@ -115,9 +101,19 @@ struct RootView: View {
             }
         }
         .fullScreenCover(item: $consentPresentation) { presentation in
+            // `.id` rather than a dismiss-and-re-present dance: one gate
+            // can replace another while the cover is up (terms change,
+            // then the authority leaves the directory), and
+            // `fullScreenCover(item:)` is not dependable about rebuilding
+            // on an identity change alone. Taking the cover down and
+            // putting it back lands inside the dismiss animation, where
+            // the likely outcome is no cover at all — an ungated app,
+            // strictly worse than a stale reason. This rebuilds the view
+            // and its flow in place instead.
             ModerationConsentView(
                 flow: dependencies.makeModerationConsentFlow(presentation.mode)
             )
+            .id(presentation.id)
         }
     }
 

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -99,7 +99,14 @@ struct RootView: View {
             // Dismissing first makes the swap explicit.
             consentPresentation = nil
             Task { @MainActor in
-                consentPresentation = next
+                // Re-derive rather than replaying the captured value:
+                // the gate can move again before this turn runs (the
+                // stale mandate resolving, a swap back), and applying a
+                // superseded decision would put an undismissable cover
+                // back over an app that no longer needs one.
+                consentPresentation = Self.presentation(
+                    for: dependencies.moderationGateFlow.gate
+                )
             }
         }
         .onChange(of: scenePhase) { _, phase in


### PR DESCRIPTION
## Why

A mandate binds to the exact manifest bytes it signed, and the reference Authority keeps judging it under those bytes forever (`consented_manifest`). That is the right design — republishing a manifest with a longer ban term must not silently re-term everyone who consented earlier — but it left a gap on this side: republishing was **invisible** to every install that had already consented.

Nothing in the app ever re-read the published manifest. `manifestForReview` is the only fetch, and it only runs once the user is already inside the consent flow; the stored `MandateRecord.manifestHash` was never compared against anything. So an authority could update its terms and existing iPhone/iPad installs would go on operating under terms it no longer stands behind, with no signal at all.

## What

Check the published manifest against the active mandate's hash **on app open and on every return to the foreground**, and block on the consent surface when they disagree.

**Detection — `ModerationRepository`**

New `TermsCurrency` on `ModerationState` (`unknown` / `current` / `superseded(publishedHash:)` / `authorityDelisted`), established by `refreshActiveTerms()`: resolve the active mandate's authority in the directory, fetch its manifest through the existing verified fetcher, compare against the pinned hash.

Deliberately unable to lock anyone out on a bad answer — an unreachable authority, a directory that hasn't loaded, or a manifest that fails signature verification all leave the last known currency in place. Only an authenticated manifest that hashes differently can supersede consent, so a forged or corrupted document cannot push a user into re-signing. Overlapping calls (launch racing the first foreground notification) share one check, and a mandate that changes mid-fetch is re-read before the verdict lands.

**Gate — `ModerationGateFlow`**

New blocking `RootGate.needsReconsent(ReconsentReason)`, reached only from within the `.operational` branch. It therefore ranks below every enforcement answer: a banned user re-signing terms is still banned, an unanswered gate check is still the more urgent block, and it never pre-empts `.checking` — a re-consent screen thrown up before the gate has spoken would be the first thing a cold launch shows on a flaky network. `authorityDelisted` falls back to operational when the directory lists nobody, matching the existing "don't brick an install on an empty directory" softening.

**UI**

`ModerationConsentFlow.Mode.reconsent(reason)` — mechanically identical to switching, since consent is always a fresh mandate and never an edit (spec §12), differing only in being undismissable and in naming what changed. The picker marks the current authority's row so re-signing reads as re-signing rather than switching. `RootView` moves from a `Bool` cover to `fullScreenCover(item:)` keyed on the mode, so both consent gates share one surface and it drops as soon as the gate says so.

The re-consent copy leads with what is *not* happening — the mandate is untouched, anything already under way is still judged by the agreed terms — before asking for a signature. Worth a read; it is the part most likely to want wording changes.

## Two reasons to re-consent

| | user can re-sign same authority | remedy |
|---|---|---|
| `termsChanged` | yes, and it's the expected answer | review new terms, sign |
| `authorityDelisted` | no — it can't publish terms any more | pick another authority |

## Testing

Implementation only, per the usual split — tests land in the follow-up PR. Verified: app and `OnymModerationUI` build clean for iOS; existing `GateHardeningTests` pass unchanged.

## Not in this PR

The `signature invalid: reporter signature did not verify` failure on report filing is unrelated and still open. `ModerationCanonicalEncoder` sets `.sortedKeys` but not `.withoutEscapingSlashes`, so Swift signs `"...\/..."` while the authority's `canonical_bytes` re-serializes to `"...​/..."` — any signed string containing a slash breaks, which for a base64 `authenticityProof` is roughly three reports in four. `authority/src/canonical.rs` already documents the assumption the encoder never implements. Separate branch off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)