### PR TITLE
Stop escaping slashes in moderation signing bytes

### DIFF
--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationCanonicalEncoder.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationCanonicalEncoder.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The one encoder configuration every moderation signing form uses.
 ///
-/// Three rules, all load-bearing:
+/// Four rules, all load-bearing:
 ///
 /// - **`.sortedKeys`** — `JSONEncoder` sorts keys by UTF-8 byte order.
 ///   Beware that `JSONSerialization` has an option of the same name
@@ -11,6 +11,15 @@ import Foundation
 ///   objects, `Report` is the one where that actually bites
 ///   (`reportId`/`reportVersion` versus `reporter`), so signing bytes
 ///   must never be produced through `JSONSerialization`.
+/// - **`.withoutEscapingSlashes`** — `JSONEncoder` escapes `/` as `\/`
+///   by default. No other JSON library does, and the authority does not
+///   verify the bytes as sent: it parses them, drops the signature
+///   field structurally, and re-serializes (`authority/src/canonical.rs`).
+///   That round trip turns every `\/` back into `/`, so a signature made
+///   over the escaped form cannot verify. Any signed string carrying a
+///   slash breaks it — `EvidenceItem.authenticityProof` is standard
+///   base64, which contains one about three times in four, and a
+///   `statement` breaks the moment someone types a URL or a date.
 /// - **`.iso8601` dates** — seconds precision, UTC, matching the form
 ///   every timestamp crosses the wire in.
 /// - **Nil optionals are omitted** — Swift's synthesized `Encodable`
@@ -29,7 +38,7 @@ import Foundation
 enum ModerationCanonicalEncoder {
     static func encode<T: Encodable>(_ value: T) throws -> Data {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         encoder.dateEncodingStrategy = .iso8601
         return try encoder.encode(value)
     }


### PR DESCRIPTION
## The bug

Filing a report fails with `signature invalid: reporter signature did not verify` for most reports.

`JSONEncoder` escapes `/` as `\/` by default; `.withoutEscapingSlashes` turns that off and `ModerationCanonicalEncoder` never set it. The authority does not verify the bytes as sent — `canonical_bytes` parses them, drops the signature field structurally, and re-serializes, and serde_json does not escape slashes. So the client signs `"...\/..."` and the authority verifies `"...​/..."`.

Reproduced with the real field shapes, encoder config, and a 64-byte base64 proof:

```
--- what Swift signed ---
{...,"authenticityProof":"CzBVep\/E6RM4...qs\/0HkNojb...","disclosedContent":"hey"},...}
--- what the authority reconstructs ---
{...,"authenticityProof":"CzBVep/E6RM4...qs/0HkNojb...","disclosedContent":"hey"},...}
MISMATCH -> signature cannot verify
```

Three differences, all `\/` vs `/`, nothing else. With `.withoutEscapingSlashes` the two are byte-identical.

## Blast radius

| signed object | slash-bearing field | status before |
|---|---|---|
| `Report` | `evidence[].authenticityProof` — standard base64 | broken ~3 filings in 4 |
| `Report` | `evidence[].disclosedContent` | broken whenever the message contains a URL |
| `CaseResponse` / `AppealSubmission` | `statement` | broken on a URL or a date written `11/08` |
| `ModerationMandate` | none | unaffected |

## No mandate changes

Every field a mandate signs is slash-free — `onym:` references, lowercase hex (`manifestHash`), class ids, `deviceBinding` (`enrollment:<uuid>` from `apple/src/store.rs:373`, `stub-enrollment:<uuid>` from the stub client), and ISO 8601 dates. Verified directly: signing bytes and `mandateRef` are byte-identical before and after.

That matters because a changed `mandateRef` would break standing for every registered mandate. It doesn't happen; existing consents survive untouched and need no re-signing.

## Why nothing caught it

`authority/src/canonical.rs:18` already states the contract this restores — serde_json "does not escape `/`, matching `.withoutEscapingSlashes`". The assumption was documented on the side that holds it and never implemented on the side that doesn't. The paired fixtures in both test modules pin key ordering only, so both sides passed while disagreeing.

The obvious follow-up is a matching fixture on both sides with a slash in a value, which is what would have failed here. Kept out of this PR per the usual implementation/tests split — say the word if you'd rather it land with the fix.

## Testing

`OnymIOSTests` green (1154 tests, 0 failures). Reproduction and the mandate-invariance check were run against the real encoder config; the reproduction goes from MISMATCH to IDENTICAL with the one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)