### PR TITLE
Wire discovery-backed seat fetchers with legacy fallback

### DIFF
--- a/Packages/OnymDiscovery/Sources/OnymDiscovery/DiscoveryModels.swift
+++ b/Packages/OnymDiscovery/Sources/OnymDiscovery/DiscoveryModels.swift
@@ -688,11 +688,13 @@ struct AnyCodingKey: CodingKey {
 // MARK: - Format rules
 
 /// Identifier / digest / URI syntax from §2 and §7 of the profile.
-enum DiscoveryFormat {
+public enum DiscoveryFormat {
     static let implementationProfileId = "onym:discovery-implementation:static-ed25519-v1"
 
-    /// `onym:key:<64-lowercase-hex>` → the hex, or nil.
-    static func operatorKeyHex(_ value: String) -> String? {
+    /// `onym:key:<64-lowercase-hex>` → the hex, or nil. Public for the
+    /// same reason as `isValidURI`: the app target's seat adapters
+    /// must parse operator keys with THIS parser, not a second one.
+    public static func operatorKeyHex(_ value: String) -> String? {
         guard value.hasPrefix("onym:key:") else { return nil }
         let hex = String(value.dropFirst("onym:key:".count))
         guard hex.count == 64, isLowercaseHex(hex) else { return nil }
@@ -739,15 +741,21 @@ enum DiscoveryFormat {
         }
     }
 
-    /// §7 URI rules: https only, DNS host (no IP literal, including
-    /// integer/hex single-label forms), no userinfo, no query, no
-    /// fragment, no port component in the **raw string** (URL
-    /// libraries normalize a redundant `:443` away before any
-    /// parsed-port check is reachable, so the raw string is checked
-    /// directly).
-    static func isValidURI(_ value: String) -> Bool {
+    /// §7 URI rules: a single allowed scheme (https for every URI the
+    /// discovery documents themselves carry; seat adapters pass "wss"
+    /// for WebSocket endpoints where the seat expects it), DNS host
+    /// (no IP literal, including integer/hex single-label forms), no
+    /// userinfo, no query, no fragment, no port component in the
+    /// **raw string** (URL libraries normalize a redundant default
+    /// port away before any parsed-port check is reachable, so the
+    /// raw string is checked directly).
+    public static func isValidURI(_ value: String, scheme allowedScheme: String = "https") -> Bool {
         guard let components = URLComponents(string: value) else { return false }
-        guard components.scheme == "https" else { return false }
+        // Schemes are case-insensitive (RFC 3986 §3.1) and
+        // `URLComponents` preserves the published case, so compare
+        // lowercased — `WSS://relay.example` must validate, not be
+        // silently dropped.
+        guard components.scheme?.lowercased() == allowedScheme else { return false }
         guard components.user == nil, components.password == nil else { return false }
         guard components.query == nil, components.fragment == nil else { return false }
         guard components.port == nil else { return false }

--- a/Packages/OnymDiscovery/Sources/OnymDiscovery/DiscoveryTrust.swift
+++ b/Packages/OnymDiscovery/Sources/OnymDiscovery/DiscoveryTrust.swift
@@ -447,7 +447,10 @@ public enum DiscoveryTrust {
 
 extension Data {
     /// Strict lowercase-hex decode (the profile's key encoding).
-    init?(lowercaseHex: String) {
+    /// Public for the same reason as `DiscoveryFormat.operatorKeyHex`:
+    /// the app target's seat adapters decode key hex with THIS
+    /// decoder, not a second one.
+    public init?(lowercaseHex: String) {
         guard lowercaseHex.count % 2 == 0,
               DiscoveryFormat.isLowercaseHex(lowercaseHex)
         else { return nil }

--- a/Packages/OnymDiscovery/Sources/OnymDiscovery/SeatSelectionStore.swift
+++ b/Packages/OnymDiscovery/Sources/OnymDiscovery/SeatSelectionStore.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Provenance record for one seat selection made through discovery:
+/// which component the user picked, which provider listed it, and the
+/// exact manifest hash the pick was bound to.
+///
+/// **Provenance only** — the legacy per-seat configurations
+/// (`RelayerConfiguration`, the Nostr fanout list, the Blossom server
+/// list, the moderation mandate) remain the operational source of
+/// truth. A discovery-driven pick writes BOTH this record and the
+/// derived endpoint into the legacy configuration (the dual-write
+/// lands with the consent UI); endpoints present in a legacy
+/// configuration with no matching `ModuleSelection` are "Manual /
+/// legacy" entries.
+public struct ModuleSelection: Codable, Equatable, Hashable, Sendable {
+    /// The seat this selection fills (e.g. "notary",
+    /// "transport.message", "blob.storage", "moderation").
+    public let seatType: String
+    /// `onym:component:<id>` of the selected component.
+    public let componentId: String
+    /// `onym:component:<id>` of the discovery provider whose catalog
+    /// the entry came from (the selection's source).
+    public let providerId: String
+    /// `sha256:<hex>` of the exact manifest bytes the user consented
+    /// to — ties the selection to `PinnedConsentRecord` /
+    /// `CatalogEntry.manifest.digest`.
+    public let manifestHash: String
+    /// The offer accepted at selection time, when the manifest carried
+    /// offers.
+    public let offerId: String?
+    public let selectedAt: Date
+
+    public init(
+        seatType: String,
+        componentId: String,
+        providerId: String,
+        manifestHash: String,
+        offerId: String? = nil,
+        selectedAt: Date
+    ) {
+        self.seatType = seatType
+        self.componentId = componentId
+        self.providerId = providerId
+        self.manifestHash = manifestHash
+        self.offerId = offerId
+        self.selectedAt = selectedAt
+    }
+}
+
+/// Persistence seam for selection provenance. One **active** selection
+/// per seat type (the most recently recorded); prior records for that
+/// seat are kept as bounded history so "what did I run in March, via
+/// which provider?" stays answerable without growing without limit.
+public protocol SeatSelectionStore: Sendable {
+    /// The most recently recorded selection for `seatType`, or nil if
+    /// no discovery-driven selection was ever made for that seat.
+    func activeSelection(seatType: String) -> ModuleSelection?
+    /// The retained selections for `seatType`, oldest first (the last
+    /// element is the active selection).
+    func history(seatType: String) -> [ModuleSelection]
+    /// Record a selection. It becomes the active selection for its
+    /// `seatType`; previously recorded selections stay in (bounded)
+    /// history.
+    func record(_ selection: ModuleSelection)
+}
+
+/// Serializes every `record` in the process — `record` is a
+/// load-modify-save, and without mutual exclusion two concurrent
+/// records read the same array and one selection is silently dropped.
+/// A process-wide lock rather than an actor for the same reason as
+/// `PinnedConsentStore`'s serialization: the flows that record a
+/// selection are synchronous, and an actor hop would force that whole
+/// path async for the same guarantee.
+private enum SeatSelectionStoreSerialization {
+    static let lock = NSLock()
+}
+
+/// Production `SeatSelectionStore`. Single UserDefaults blob under
+/// `app.onym.ios.discovery.selections` — an append-only-shaped array
+/// of records; "active" is a projection (last record per seat), not
+/// separate state that could drift from the history.
+///
+/// Retention mirrors `PinnedConsentStore`'s treatment: per seat type,
+/// the active selection plus the last `maxHistoryRecordsPerSeat`
+/// prior records; the oldest beyond that are evicted on `record`.
+///
+/// `@unchecked Sendable` for the same reason as the sibling stores:
+/// `UserDefaults` is documented thread-safe but not formally `Sendable`.
+public struct UserDefaultsSeatSelectionStore: SeatSelectionStore, @unchecked Sendable {
+    private static let key = "app.onym.ios.discovery.selections"
+
+    /// Prior (non-active) records kept per seat type. Same cap as the
+    /// consent store's per-component history — these records are tiny
+    /// (no manifest bytes), but unbounded re-selection history in a
+    /// UserDefaults blob is the same failure mode.
+    static let maxHistoryRecordsPerSeat = 8
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func activeSelection(seatType: String) -> ModuleSelection? {
+        history(seatType: seatType).last
+    }
+
+    public func history(seatType: String) -> [ModuleSelection] {
+        loadAll().filter { $0.seatType == seatType }
+    }
+
+    public func record(_ selection: ModuleSelection) {
+        SeatSelectionStoreSerialization.lock.lock()
+        defer { SeatSelectionStoreSerialization.lock.unlock() }
+
+        var all = loadAll()
+        all.append(selection)
+        // Retention: evict the oldest records of this seat type beyond
+        // active + cap. Records of other seats are untouched.
+        let seatIndices = all.indices.filter { all[$0].seatType == selection.seatType }
+        let excess = seatIndices.count - (Self.maxHistoryRecordsPerSeat + 1)
+        if excess > 0 {
+            for index in seatIndices.prefix(excess).reversed() {
+                all.remove(at: index)
+            }
+        }
+        guard let data = try? JSONEncoder().encode(all) else { return }
+        defaults.set(data, forKey: Self.key)
+    }
+
+    private func loadAll() -> [ModuleSelection] {
+        guard let data = defaults.data(forKey: Self.key),
+              let all = try? JSONDecoder().decode([ModuleSelection].self, from: data)
+        else { return [] }
+        return all
+    }
+}

--- a/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/DiscoveryModelsTests.swift
+++ b/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/DiscoveryModelsTests.swift
@@ -231,6 +231,9 @@ final class DiscoveryModelsTests: XCTestCase {
 
     func testURIRules() {
         XCTAssertTrue(DiscoveryFormat.isValidURI("https://discovery.onym.app/manifest.json"))
+        // Schemes are case-insensitive (RFC 3986 §3.1): an uppercase
+        // scheme validates instead of being silently dropped.
+        XCTAssertTrue(DiscoveryFormat.isValidURI("HTTPS://discovery.onym.app/manifest.json"))
         // http scheme
         XCTAssertFalse(DiscoveryFormat.isValidURI("http://discovery.onym.app/manifest.json"))
         // IP literals, v4 and v6
@@ -249,6 +252,23 @@ final class DiscoveryModelsTests: XCTestCase {
         XCTAssertFalse(DiscoveryFormat.isValidURI("https://3232235777/m.json"))
         XCTAssertFalse(DiscoveryFormat.isValidURI("https://0xc0a80101/m.json"))
         XCTAssertFalse(DiscoveryFormat.isValidURI("https://192.168.1.0x1/m.json"))
+    }
+
+    func testURIRulesWithAllowedScheme() {
+        // Seat adapters validate WebSocket endpoints under the same §7
+        // rules with the scheme swapped for the one the seat expects.
+        XCTAssertTrue(DiscoveryFormat.isValidURI("wss://relay.example", scheme: "wss"))
+        XCTAssertTrue(DiscoveryFormat.isValidURI("wss://relay.example/inbox", scheme: "wss"))
+        // Case-insensitive: `WSS://…` must validate, not silently drop.
+        XCTAssertTrue(DiscoveryFormat.isValidURI("WSS://relay.example", scheme: "wss"))
+        // The default stays https-only; wss passes only when asked for.
+        XCTAssertFalse(DiscoveryFormat.isValidURI("wss://relay.example"))
+        XCTAssertFalse(DiscoveryFormat.isValidURI("https://relay.example", scheme: "wss"))
+        // The rest of the rules still apply under an allowed scheme.
+        XCTAssertFalse(DiscoveryFormat.isValidURI("wss://relay.example:8443", scheme: "wss"))
+        XCTAssertFalse(DiscoveryFormat.isValidURI("wss://user@relay.example", scheme: "wss"))
+        XCTAssertFalse(DiscoveryFormat.isValidURI("wss://relay.example/x?a=1", scheme: "wss"))
+        XCTAssertFalse(DiscoveryFormat.isValidURI("wss://192.168.1.10/x", scheme: "wss"))
     }
 
     func testIdentifierAndDigestFormats() {

--- a/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/SeatSelectionStoreTests.swift
+++ b/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/SeatSelectionStoreTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import XCTest
+@testable import OnymDiscovery
+
+/// UserDefaults round-trip with per-test suite isolation — same
+/// pattern as the sibling selection-store tests in the app target.
+final class SeatSelectionStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var store: UserDefaultsSeatSelectionStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "app.onym.ios.discovery.selections.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = UserDefaultsSeatSelectionStore(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        store = nil
+        super.tearDown()
+    }
+
+    private func selection(
+        seatType: String = "notary",
+        componentId: String = "onym:component:sample-notary",
+        providerId: String = "onym:component:onym-discovery",
+        manifestHash: String = "sha256:" + String(repeating: "a", count: 64),
+        offerId: String? = nil,
+        selectedAt: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    ) -> ModuleSelection {
+        ModuleSelection(
+            seatType: seatType,
+            componentId: componentId,
+            providerId: providerId,
+            manifestHash: manifestHash,
+            offerId: offerId,
+            selectedAt: selectedAt
+        )
+    }
+
+    func test_activeSelection_isNilWhenNothingRecorded() {
+        XCTAssertNil(store.activeSelection(seatType: "notary"))
+        XCTAssertEqual(store.history(seatType: "notary"), [])
+    }
+
+    func test_record_roundTripsThroughUserDefaults() {
+        let recorded = selection(offerId: "free-tier")
+        store.record(recorded)
+
+        // A fresh store over the same suite sees the persisted record.
+        let reloaded = UserDefaultsSeatSelectionStore(defaults: defaults)
+        XCTAssertEqual(reloaded.activeSelection(seatType: "notary"), recorded)
+        XCTAssertEqual(reloaded.history(seatType: "notary"), [recorded])
+    }
+
+    func test_record_replacesActiveSelectionAndKeepsHistory() {
+        let first = selection(
+            componentId: "onym:component:notary-one",
+            selectedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let second = selection(
+            componentId: "onym:component:notary-two",
+            manifestHash: "sha256:" + String(repeating: "b", count: 64),
+            selectedAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+        store.record(first)
+        store.record(second)
+
+        XCTAssertEqual(store.activeSelection(seatType: "notary"), second)
+        // Oldest-first history keeps the replaced selection.
+        XCTAssertEqual(store.history(seatType: "notary"), [first, second])
+    }
+
+    func test_selectionsAreScopedPerSeatType() {
+        let notary = selection(seatType: "notary")
+        let transport = selection(
+            seatType: "transport.message",
+            componentId: "onym:component:onym-courier"
+        )
+        store.record(notary)
+        store.record(transport)
+
+        XCTAssertEqual(store.activeSelection(seatType: "notary"), notary)
+        XCTAssertEqual(store.activeSelection(seatType: "transport.message"), transport)
+        XCTAssertEqual(store.history(seatType: "notary"), [notary])
+        XCTAssertEqual(store.history(seatType: "transport.message"), [transport])
+        XCTAssertNil(store.activeSelection(seatType: "blob.storage"))
+    }
+
+    func test_malformedPersistedBlobDegradesToEmpty() {
+        defaults.set(Data("not json".utf8), forKey: "app.onym.ios.discovery.selections")
+        XCTAssertNil(store.activeSelection(seatType: "notary"))
+        XCTAssertEqual(store.history(seatType: "notary"), [])
+        // Recording over the malformed blob starts a fresh history.
+        let recorded = selection()
+        store.record(recorded)
+        XCTAssertEqual(store.history(seatType: "notary"), [recorded])
+    }
+
+    func test_record_capsHistoryPerSeatKeepingActivePlusNewest() {
+        let cap = UserDefaultsSeatSelectionStore.maxHistoryRecordsPerSeat
+        // Record cap + 3 selections for one seat, plus one for another
+        // seat that must survive untouched.
+        let other = selection(seatType: "blob.storage", componentId: "onym:component:blob")
+        store.record(other)
+        let recorded = (0..<(cap + 3)).map { index in
+            selection(
+                componentId: "onym:component:notary-\(index)",
+                selectedAt: Date(timeIntervalSince1970: 1_700_000_000 + Double(index))
+            )
+        }
+        recorded.forEach(store.record)
+
+        let history = store.history(seatType: "notary")
+        // Active + the last `cap` prior records; the oldest two evicted.
+        XCTAssertEqual(history.count, cap + 1)
+        XCTAssertEqual(history, Array(recorded.suffix(cap + 1)))
+        XCTAssertEqual(store.activeSelection(seatType: "notary"), recorded.last)
+        // The other seat's record is untouched by the eviction.
+        XCTAssertEqual(store.history(seatType: "blob.storage"), [other])
+    }
+
+    func test_moduleSelectionCodableRoundTrip() throws {
+        let value = selection(offerId: "pro-monthly")
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(ModuleSelection.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+}

--- a/Sources/OnymIOS/DiscoverySeatAdapters.swift
+++ b/Sources/OnymIOS/DiscoverySeatAdapters.swift
@@ -1,0 +1,662 @@
+import Foundation
+import os.log
+import OnymChain
+import OnymDiscovery
+import OnymFoundation
+import OnymModeration
+import OnymTransportBlossom
+import OnymTransportNostr
+
+/// Discovery-backed implementations of the four seat "known list"
+/// fetcher protocols. Lives in the app target — the one place all the
+/// packages meet — so no seat package (OnymChain / OnymTransportNostr /
+/// OnymTransportBlossom / OnymModeration) gains an OnymDiscovery
+/// dependency.
+///
+/// Each adapter asks the verified discovery aggregate for entries of
+/// its seat type, fetches every entry's destination manifest, verifies
+/// it against the catalog-pinned digest and operator key
+/// (`ServiceManifestReviewer` — hard-enforced), cross-checks the
+/// manifest's componentId and seat against the catalog entry, and maps
+/// the manifest to the seat's endpoint type. The result is MERGED with
+/// the wrapped legacy GitHub-releases list — the legacy list is always
+/// fetched, deduped by normalized endpoint URL, with the discovery
+/// entry taking precedence for attribution — so discovery can only
+/// ever *add* to what the app can do today, never take away: a single
+/// surviving discovery entry must not evict the published defaults
+/// from the known list (or from first-launch auto-populate, which
+/// installs the whole fetched list). Per-entry review failures —
+/// unreachable manifests, digest or signature mismatches, operator-key
+/// / componentId / seat mismatches, unusable endpoint fields — drop
+/// only that entry; when nothing survives the legacy list serves
+/// alone, exactly as before discovery existed.
+///
+/// **Consent gate seam**: the known lists the three endpoint adapters
+/// (relayers / Nostr / Blossom) produce don't just *list* endpoints —
+/// they feed each repository's first-launch auto-populate
+/// (`RelayerRepository.refresh` installs the whole fetched list when
+/// no config exists; `NostrRelaysRepository` / `BlossomServersRepository`
+/// `applyDefault` overwrite the config whenever the user never
+/// customized those screens). A catalog entry reaching `fetchLatest`
+/// therefore becomes a LIVE endpoint for default-config users, with
+/// zero taps. So each endpoint adapter takes an optional
+/// `hasActiveConsent` closure: when provided (the consent system is
+/// wired in), only entries whose componentId the closure approves
+/// merge into the known list; when nil (no consent system present in
+/// this build layer), discovery entries are EXCLUDED from `fetchLatest`
+/// entirely — pure legacy passthrough, no catalog review fan-out —
+/// and catalog entries remain reachable only through the separate
+/// catalog-entries surface (`DiscoveryRepository.entries(seatType:)`)
+/// that consent-aware pickers read. The authorities adapter carries
+/// the analogous `discoveryEnabled` seam: its list is a directory the
+/// user picks from and moderation consent stays the signed mandate
+/// downstream of the pick, but a listing's `apiBaseURL` and operator
+/// key are what the mandate flow trusts, so catalog rows enter the
+/// directory only in a build layer that ships the discovery surface
+/// (nil → pure legacy passthrough). On a componentId collision the
+/// LEGACY row always wins there — a catalog entry must never shadow a
+/// published authority's endpoint or key.
+///
+/// `ContractsManifestFetcher` is deliberately NOT adapted: contracts
+/// stay legacy-only in this effort (see the discovery design plan).
+
+// MARK: - Seat vocabulary
+
+/// The pinned mapping from a catalog entry's `seatType` to the `seat`
+/// values a destination manifest may declare for it. The catalog and
+/// the manifests are published by different pipelines, so the accepted
+/// vocabulary is pinned HERE, from the real published manifests —
+/// onym-relayer's `operator-manifest.src.json` declares
+/// `seat: "notary"`, the onym-discovery deploy templates declare
+/// `seat: "transport.message"` (courier) and `seat: "blob.storage"`
+/// (blossom) — plus the historical aliases those seats have gone by
+/// ("courier", "blossom"). A manifest whose `seat` is not in its
+/// catalog entry's accepted set fails review and the entry is skipped:
+/// a catalog must not be able to install, say, a blob server into the
+/// notary seat by mislabeling the entry.
+enum SeatManifestVocabulary {
+    static let acceptedManifestSeats: [String: Set<String>] = [
+        "notary": ["notary"],
+        "transport.message": ["transport.message", "courier"],
+        "blob.storage": ["blob.storage", "blossom"],
+        // The LIVE authority manifest
+        // (https://authority.onym.app/manifest.json) declares
+        // `seat: "moderation"`; "authority" is tolerated as an alias
+        // because `SignedServiceManifest`'s docs and onym-system's
+        // moderation pages name the seat that way.
+        "moderation": ["moderation", "authority"],
+    ]
+
+    /// Unknown catalog seat types (nothing in the table) accept only
+    /// an exactly matching manifest seat — strict by default.
+    static func accepts(catalogSeatType: String, manifestSeat: String) -> Bool {
+        (acceptedManifestSeats[catalogSeatType] ?? [catalogSeatType]).contains(manifestSeat)
+    }
+}
+
+// MARK: - Shared catalog seam
+
+/// The two capabilities every adapter needs, as closures so app-target
+/// tests can stub them without a repository or network:
+/// entry lookup by seat type, and manifest-bytes fetch by URL.
+struct DiscoverySeatCatalog: Sendable {
+    let entries: @Sendable (_ seatType: String) async -> [AttributedCatalogEntry]
+    let fetchManifestBytes: @Sendable (_ url: URL) async throws -> Data
+
+    /// Upper bound on catalog entries reviewed per seat per fetch.
+    /// Each surviving entry costs one manifest fetch; a hostile or
+    /// bloated catalog must not be able to fan a known-list refresh
+    /// out into hundreds of network requests. Entries beyond the cap
+    /// are dropped with a log line (aggregate order, so which entries
+    /// survive is deterministic).
+    static let maxEntriesPerSeat = 16
+
+    private static let log = Logger(subsystem: "app.onym.ios", category: "DiscoverySeatAdapters")
+
+    /// Production wiring: entries from the repository's verified
+    /// aggregate; manifest bytes through the discovery fetcher (seat
+    /// manifests share the provider-manifest size cap — they are small
+    /// signed JSON documents, not media).
+    init(repository: DiscoveryRepository, fetcher: any DiscoveryFetching) {
+        self.entries = { await repository.entries(seatType: $0) }
+        self.fetchManifestBytes = { try await fetcher.fetchProviderManifest(url: $0) }
+    }
+
+    /// Test seam.
+    init(
+        entries: @escaping @Sendable (_ seatType: String) async -> [AttributedCatalogEntry],
+        fetchManifestBytes: @escaping @Sendable (_ url: URL) async throws -> Data
+    ) {
+        self.entries = entries
+        self.fetchManifestBytes = fetchManifestBytes
+    }
+
+    /// Fetch + review the destination manifest of every catalog entry
+    /// for `seatType` (bounded by `maxEntriesPerSeat`), concurrently —
+    /// the manifests live on unrelated hosts, so one slow operator
+    /// must not serialize the rest. Output preserves the aggregate's
+    /// entry order regardless of fetch completion order. Per-entry
+    /// failures (unreachable, digest mismatch, bad signature, expired,
+    /// operator-key / componentId / seat mismatch) skip that entry
+    /// with a log line; the caller merges whatever survives with the
+    /// legacy list.
+    func reviewedEntries(seatType: String) async -> [ReviewedSeatEntry] {
+        // §4.2 entry `status`: a provider-flagged `warning` entry is
+        // excluded from known-list merges outright (before it costs a
+        // manifest fetch or a cap slot) — the provider itself says the
+        // entry is suspect, and no seat endpoint type has a field to
+        // carry that flag on. `review`-flagged entries pass: the flag
+        // stays available on `attributed.entry.status` for the
+        // consent/picker surfaces (settings-UI layer) to render.
+        let all = await entries(seatType).filter { attributed in
+            guard attributed.entry.status?.state == "warning" else { return true }
+            Self.log.error(
+                "Discovery entry \(attributed.entry.componentId, privacy: .public): provider-flagged status \"warning\"; excluding from the known-list merge"
+            )
+            return false
+        }
+        if all.count > Self.maxEntriesPerSeat {
+            Self.log.error(
+                "Discovery seat \(seatType, privacy: .public): \(all.count) catalog entries exceed the per-seat cap (\(Self.maxEntriesPerSeat)); reviewing the first \(Self.maxEntriesPerSeat) only"
+            )
+        }
+        let bounded = Array(all.prefix(Self.maxEntriesPerSeat))
+        let fetchManifestBytes = self.fetchManifestBytes
+        return await withTaskGroup(of: (Int, ReviewedSeatEntry?).self) { group in
+            for (index, attributed) in bounded.enumerated() {
+                group.addTask {
+                    (index, await Self.reviewEntry(attributed, fetchManifestBytes: fetchManifestBytes))
+                }
+            }
+            var slots = [ReviewedSeatEntry?](repeating: nil, count: bounded.count)
+            for await (index, reviewed) in group {
+                slots[index] = reviewed
+            }
+            return slots.compactMap { $0 }
+        }
+    }
+
+    /// One entry's fetch + hard-enforced review: digest pin AND
+    /// operator-key pin from the *verified* catalog entry (the
+    /// verified side of this trust chain — a fetched manifest naming a
+    /// different key is rejected, digest pin notwithstanding),
+    /// embedded operator signature over the exact bytes, expiry, and
+    /// the componentId + seat-vocabulary cross-checks binding the
+    /// manifest to the entry that listed it.
+    private static func reviewEntry(
+        _ attributed: AttributedCatalogEntry,
+        fetchManifestBytes: @Sendable (URL) async throws -> Data
+    ) async -> ReviewedSeatEntry? {
+        let entry = attributed.entry
+        guard let manifestURL = entry.manifest.url else { return nil }
+        do {
+            let bytes = try await fetchManifestBytes(manifestURL)
+            let reviewed = try ServiceManifestReviewer().review(
+                raw: bytes,
+                expectedDigest: entry.manifest.digest,
+                expectedOperatorKey: entry.operatorKey
+            )
+            // The manifest must be the component the catalog listed…
+            guard reviewed.signedManifest.componentId == entry.componentId else {
+                log.error(
+                    "Discovery entry \(entry.componentId, privacy: .public): manifest componentId \(reviewed.signedManifest.componentId, privacy: .public) differs from catalog entry; skipping"
+                )
+                return nil
+            }
+            // …declaring a seat the entry's seat type accepts.
+            guard SeatManifestVocabulary.accepts(
+                catalogSeatType: entry.seatType,
+                manifestSeat: reviewed.signedManifest.seat
+            ) else {
+                log.error(
+                    "Discovery entry \(entry.componentId, privacy: .public): manifest seat \(reviewed.signedManifest.seat, privacy: .public) not accepted for catalog seat type \(entry.seatType, privacy: .public); skipping"
+                )
+                return nil
+            }
+            return ReviewedSeatEntry(
+                attributed: attributed,
+                manifest: reviewed.signedManifest,
+                fields: SeatManifestFields(rawBytes: reviewed.signedManifest.rawBytes)
+            )
+        } catch {
+            log.error(
+                "Discovery entry \(entry.componentId, privacy: .public): manifest review failed (\(String(describing: error), privacy: .public)); skipping"
+            )
+            return nil
+        }
+    }
+}
+
+/// One catalog entry whose destination manifest passed review, with
+/// the seat-specific fields already projected out of the exact bytes.
+struct ReviewedSeatEntry: Sendable {
+    let attributed: AttributedCatalogEntry
+    let manifest: SignedServiceManifest
+    let fields: SeatManifestFields
+
+    /// The endpoint role every published seat template declares for
+    /// its client-facing endpoint (onym-courier / onym-blossom
+    /// `deploy` templates; the notary template predates the field).
+    static let preferredEndpointRole = "read-write"
+
+    /// Display name: the manifest's `name` when the operator published
+    /// one, else the component id minus its `onym:component:` prefix.
+    var displayName: String {
+        if let name = fields.name, !name.isEmpty { return name }
+        let componentId = attributed.entry.componentId
+        let prefix = "onym:component:"
+        return componentId.hasPrefix(prefix)
+            ? String(componentId.dropFirst(prefix.count))
+            : componentId
+    }
+
+    /// The endpoint URL an adapter should use: among endpoints whose
+    /// URI passes the profile URI rules (`DiscoveryFormat.isValidURI`
+    /// — DNS host, no userinfo / query / fragment / port) under a
+    /// scheme in `schemes`, prefer the first with the
+    /// role every published template marks the client-facing endpoint
+    /// with (`preferredEndpointRole`); when no endpoint carries that
+    /// role — older manifests predate the field, and the vocabulary
+    /// isn't closed — fall back to the first scheme-matching endpoint
+    /// of any role, so a manifest that is usable stays usable.
+    /// Scheme-only checks are not enough here: every other URL in
+    /// OnymDiscovery goes through the §7 rules, and this one becomes
+    /// a live connection target.
+    func firstEndpointURL(schemes: Set<String>) -> URL? {
+        func matches(_ endpoint: SeatManifestFields.Endpoint) -> URL? {
+            // `schemes.contains` is the check that restricts the
+            // scheme (lowercased — schemes are case-insensitive on
+            // the wire); `isValidURI` then enforces the remaining §7
+            // rules (DNS host, no userinfo / query / fragment / port)
+            // for that scheme.
+            guard let url = URL(string: endpoint.uri),
+                  let scheme = url.scheme?.lowercased(),
+                  schemes.contains(scheme),
+                  DiscoveryFormat.isValidURI(endpoint.uri, scheme: scheme)
+            else { return nil }
+            return url
+        }
+        let candidates = fields.endpoints.compactMap { endpoint in
+            matches(endpoint).map { (role: endpoint.role, url: $0) }
+        }
+        return candidates.first { $0.role == Self.preferredEndpointRole }?.url
+            ?? candidates.first?.url
+    }
+}
+
+/// Seat-specific fields projected out of a reviewed manifest's exact
+/// bytes. `SignedServiceManifest` only parses the common spine
+/// (componentId / seat / operator / offers / validUntil) and keeps
+/// everything else inside `rawBytes` for seat adapters to interpret —
+/// this is that interpretation. Deliberately tolerant: a manifest
+/// whose seat-specific fields don't match the expected shape yields
+/// empty projections here, the entry maps to nothing, and the legacy
+/// list serves without it.
+struct SeatManifestFields: Sendable {
+    /// One `endpoints[]` element: the URI plus the published `role`
+    /// (e.g. "read-write" in the deployed templates), when present.
+    struct Endpoint: Sendable {
+        let uri: String
+        let role: String?
+    }
+
+    /// Top-level `name`, when published.
+    let name: String?
+    /// `endpoints[]`, in published order.
+    let endpoints: [Endpoint]
+    /// Top-level `networks` (notary seat: which Stellar networks the
+    /// relayer serves), when published.
+    let networks: [String]?
+
+    /// `endpoints[].uri`, in published order. No caller in this layer —
+    /// the settings-UI PR's consent-flow `apply` closures feed it to
+    /// `ModuleConsentAcceptance.requiredEndpointURL` (same deal as
+    /// `ModuleSelection` / `SeatSelectionStore`).
+    var endpointURIs: [String] { endpoints.map(\.uri) }
+
+    init(rawBytes: Data) {
+        let object = ((try? JSONSerialization.jsonObject(with: rawBytes)) as? [String: Any]) ?? [:]
+        name = object["name"] as? String
+        if let endpoints = object["endpoints"] as? [[String: Any]] {
+            self.endpoints = endpoints.compactMap { endpoint in
+                (endpoint["uri"] as? String).map {
+                    Endpoint(uri: $0, role: endpoint["role"] as? String)
+                }
+            }
+        } else {
+            endpoints = []
+        }
+        networks = object["networks"] as? [String]
+    }
+}
+
+// MARK: - Merge
+
+/// Union of the discovery-derived (consented) rows and the legacy
+/// published list, deduped by `dedupeKey`. The legacy fetch starts
+/// FIRST and runs concurrently with `discovered` (which performs the
+/// manifest-review fan-out): one slow catalog operator must not delay
+/// the published list — and with it first-launch auto-populate — by
+/// up to a per-request timeout. The legacy list is ALWAYS fetched —
+/// one surviving discovery entry must never evict the published
+/// defaults (the known list feeds each repository's first-launch
+/// auto-populate and the nostr/blossom `applyDefault` overwrite of
+/// published defaults, so a replace here would make the whole
+/// configuration discovery-only) — and on a duplicate key the
+/// discovery entry wins the row (its reviewed attribution). Duplicate
+/// keys *within* the discovery results (two providers listing the same
+/// endpoint) also collapse to the first, keeping aggregate order. When
+/// the legacy fetch fails, surviving discovery rows still serve
+/// (discovery adds; a GitHub outage doesn't subtract them); with no
+/// discovery rows the failure propagates exactly as the bare
+/// legacy fetcher's would.
+///
+/// `legacyWinsOnCollision` flips who keeps a colliding key: the
+/// endpoint adapters keep the discovery row (same URL, reviewed
+/// attribution — nothing trust-carrying changes hands), but the
+/// authorities adapter keys by componentId and its rows carry
+/// `apiBaseURL` + the operator key, so there the LEGACY row must win —
+/// discovery may only contribute componentIds the published directory
+/// doesn't already list.
+private func mergeDiscoveredWithLegacy<Endpoint: Sendable, Key: Hashable>(
+    discovered: () async -> [Endpoint],
+    dedupeKey: (Endpoint) -> Key,
+    legacyWinsOnCollision: Bool = false,
+    fetchLegacy: @escaping @Sendable () async throws -> [Endpoint]
+) async throws -> [Endpoint] {
+    async let legacyFetch = fetchLegacy()
+    var seen = Set<Key>()
+    let unique = await discovered().filter { seen.insert(dedupeKey($0)).inserted }
+    let legacy: [Endpoint]
+    do {
+        legacy = try await legacyFetch
+    } catch {
+        guard !unique.isEmpty else { throw error }
+        return unique
+    }
+    if legacyWinsOnCollision {
+        let legacyKeys = Set(legacy.map(dedupeKey))
+        return unique.filter { !legacyKeys.contains(dedupeKey($0)) } + legacy
+    }
+    return unique + legacy.filter { !seen.contains(dedupeKey($0)) }
+}
+
+/// Dedupe key for an endpoint URL: scheme and host lowercased (both
+/// case-insensitive on the wire), one trailing slash stripped — so
+/// `wss://Relay.Example/` and `wss://relay.example` collapse to one
+/// row and one connection instead of two.
+private func endpointDedupeKey(_ url: URL) -> String {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        return url.absoluteString
+    }
+    components.scheme = components.scheme?.lowercased()
+    components.host = components.host?.lowercased()
+    var key = components.string ?? url.absoluteString
+    if key.hasSuffix("/") { key.removeLast() }
+    return key
+}
+
+// MARK: - Notary seat (chain relayers)
+
+/// `KnownRelayersFetcher` backed by discovery entries with seat type
+/// "notary", merged with the legacy `relayers.json` list.
+struct DiscoveryBackedKnownRelayersFetcher: KnownRelayersFetcher {
+    static let seatType = "notary"
+    /// A manifest without a `networks` field predates that field; the
+    /// published relayers all serve both networks today, so this
+    /// matches what `relayers.json` would say.
+    static let defaultNetworks = ["testnet", "public"]
+
+    let catalog: DiscoverySeatCatalog
+    let fallback: any KnownRelayersFetcher
+    /// Consent gate seam — see the file header. `true` iff the user
+    /// holds an active consent record for the componentId; nil when no
+    /// consent system is present, which excludes discovery entries
+    /// from this known list entirely.
+    let hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)?
+
+    /// Wrap `fallback` when a discovery catalog is available; identity
+    /// when it isn't (UI-test harness).
+    static func wrapping(
+        _ fallback: any KnownRelayersFetcher,
+        catalog: DiscoverySeatCatalog?,
+        hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)? = nil
+    ) -> any KnownRelayersFetcher {
+        guard let catalog else { return fallback }
+        return DiscoveryBackedKnownRelayersFetcher(
+            catalog: catalog,
+            fallback: fallback,
+            hasActiveConsent: hasActiveConsent
+        )
+    }
+
+    func fetchLatest() async throws -> [RelayerEndpoint] {
+        // No consent system in this build layer → pure legacy
+        // passthrough, no catalog review fan-out (this list feeds
+        // first-launch auto-populate; see the file header).
+        guard let hasActiveConsent else { return try await fallback.fetchLatest() }
+        return try await mergeDiscoveredWithLegacy(
+            discovered: {
+                await catalog.reviewedEntries(seatType: Self.seatType)
+                    .filter { hasActiveConsent($0.attributed.entry.componentId) }
+                    .compactMap { reviewed -> RelayerEndpoint? in
+                        guard let url = reviewed.firstEndpointURL(schemes: ["https"])
+                        else { return nil }
+                        return RelayerEndpoint(
+                            name: reviewed.displayName,
+                            url: url,
+                            networks: reviewed.fields.networks ?? Self.defaultNetworks
+                        )
+                    }
+            },
+            dedupeKey: { endpointDedupeKey($0.url) },
+            fetchLegacy: fallback.fetchLatest
+        )
+    }
+}
+
+// MARK: - Message-transport seat (Nostr relays)
+
+/// `KnownNostrRelaysFetcher` backed by discovery entries with seat
+/// type "transport.message", merged with the legacy
+/// `nostr-relays.json` list.
+struct DiscoveryBackedKnownNostrRelaysFetcher: KnownNostrRelaysFetcher {
+    static let seatType = "transport.message"
+
+    let catalog: DiscoverySeatCatalog
+    let fallback: any KnownNostrRelaysFetcher
+    /// Consent gate seam — see the file header.
+    let hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)?
+
+    static func wrapping(
+        _ fallback: any KnownNostrRelaysFetcher,
+        catalog: DiscoverySeatCatalog?,
+        hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)? = nil
+    ) -> any KnownNostrRelaysFetcher {
+        guard let catalog else { return fallback }
+        return DiscoveryBackedKnownNostrRelaysFetcher(
+            catalog: catalog,
+            fallback: fallback,
+            hasActiveConsent: hasActiveConsent
+        )
+    }
+
+    func fetchLatest() async throws -> [NostrRelayEndpoint] {
+        // No consent system in this build layer → pure legacy
+        // passthrough (see the file header).
+        guard let hasActiveConsent else { return try await fallback.fetchLatest() }
+        return try await mergeDiscoveredWithLegacy(
+            discovered: {
+                await catalog.reviewedEntries(seatType: Self.seatType)
+                    .filter { hasActiveConsent($0.attributed.entry.componentId) }
+                    .compactMap { reviewed -> NostrRelayEndpoint? in
+                        guard let url = reviewed.firstEndpointURL(schemes: ["wss"])
+                        else { return nil }
+                        // `isDefault` means "an Onym-published
+                        // default" (the badge the settings rows
+                        // render); a third-party catalog entry is
+                        // not one, however it entered the list.
+                        return NostrRelayEndpoint(
+                            name: reviewed.displayName,
+                            url: url,
+                            isDefault: false
+                        )
+                    }
+            },
+            dedupeKey: { endpointDedupeKey($0.url) },
+            fetchLegacy: fallback.fetchLatest
+        )
+    }
+}
+
+// MARK: - Blob-storage seat (Blossom servers)
+
+/// `KnownBlossomServersFetcher` backed by discovery entries with seat
+/// type "blob.storage", merged with the legacy `blossom-servers.json`
+/// list.
+struct DiscoveryBackedKnownBlossomServersFetcher: KnownBlossomServersFetcher {
+    static let seatType = "blob.storage"
+
+    let catalog: DiscoverySeatCatalog
+    let fallback: any KnownBlossomServersFetcher
+    /// Consent gate seam — see the file header.
+    let hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)?
+
+    static func wrapping(
+        _ fallback: any KnownBlossomServersFetcher,
+        catalog: DiscoverySeatCatalog?,
+        hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)? = nil
+    ) -> any KnownBlossomServersFetcher {
+        guard let catalog else { return fallback }
+        return DiscoveryBackedKnownBlossomServersFetcher(
+            catalog: catalog,
+            fallback: fallback,
+            hasActiveConsent: hasActiveConsent
+        )
+    }
+
+    func fetchLatest() async throws -> [BlossomServerEndpoint] {
+        // No consent system in this build layer → pure legacy
+        // passthrough (see the file header).
+        guard let hasActiveConsent else { return try await fallback.fetchLatest() }
+        return try await mergeDiscoveredWithLegacy(
+            discovered: {
+                await catalog.reviewedEntries(seatType: Self.seatType)
+                    .filter { hasActiveConsent($0.attributed.entry.componentId) }
+                    .compactMap { reviewed -> BlossomServerEndpoint? in
+                        guard let url = reviewed.firstEndpointURL(schemes: ["https"])
+                        else { return nil }
+                        // Not an Onym-published default — see the
+                        // Nostr adapter's note on `isDefault`.
+                        return BlossomServerEndpoint(
+                            name: reviewed.displayName,
+                            url: url,
+                            isDefault: false
+                        )
+                    }
+            },
+            dedupeKey: { endpointDedupeKey($0.url) },
+            fetchLegacy: fallback.fetchLatest
+        )
+    }
+}
+
+// MARK: - Moderation seat (authorities)
+
+/// `KnownAuthoritiesFetcher` backed by discovery entries with seat
+/// type "moderation", MERGED with the legacy `authorities.json`
+/// directory, keyed by componentId — same "add, never subtract" rule
+/// as the endpoint adapters: a catalog with one moderation entry must
+/// not hide every published authority. The authorities list is a
+/// *directory the user picks from*, and consent for the moderation
+/// seat stays the signed-mandate flow downstream of the pick — but
+/// the directory rows themselves are trust-carrying: a listing's
+/// `apiBaseURL` is where the user's signed mandate is sent, its
+/// operator key is what the authority manifest is pinned against, and
+/// `ModerationRepository` resolves the ACTIVE mandate's authority by
+/// componentId. Two protections follow:
+///
+/// - **Legacy wins on collision**: a catalog entry reusing a published
+///   authority's componentId must never replace that authority's
+///   endpoint or key — discovery contributes only componentIds the
+///   published directory doesn't list.
+/// - **`discoveryEnabled` gate seam** (the authorities analogue of
+///   the endpoint adapters' `hasActiveConsent`): nil — no discovery
+///   surface in this build layer — is a pure legacy passthrough with
+///   no catalog fan-out; the settings-UI layer that ships provider
+///   management enables the merge.
+struct DiscoveryBackedKnownAuthoritiesFetcher: KnownAuthoritiesFetcher {
+    static let seatType = "moderation"
+
+    let catalog: DiscoverySeatCatalog
+    let fallback: any KnownAuthoritiesFetcher
+    /// Gate seam — see the type doc. nil excludes discovery entries
+    /// from the directory entirely.
+    let discoveryEnabled: (@Sendable () -> Bool)?
+
+    static func wrapping(
+        _ fallback: any KnownAuthoritiesFetcher,
+        catalog: DiscoverySeatCatalog?,
+        discoveryEnabled: (@Sendable () -> Bool)? = nil
+    ) -> any KnownAuthoritiesFetcher {
+        guard let catalog else { return fallback }
+        return DiscoveryBackedKnownAuthoritiesFetcher(
+            catalog: catalog,
+            fallback: fallback,
+            discoveryEnabled: discoveryEnabled
+        )
+    }
+
+    func fetchLatest() async throws -> [AuthorityListing] {
+        // No discovery surface in this build layer → pure legacy
+        // passthrough, no catalog review fan-out (see the type doc).
+        guard let discoveryEnabled, discoveryEnabled() else {
+            return try await fallback.fetchLatest()
+        }
+        return try await mergeDiscoveredWithLegacy(
+            discovered: { await discoveredListings() },
+            dedupeKey: \.componentId,
+            legacyWinsOnCollision: true,
+            fetchLegacy: fallback.fetchLatest
+        )
+    }
+
+    private func discoveredListings() async -> [AuthorityListing] {
+        await catalog.reviewedEntries(seatType: Self.seatType)
+            .compactMap { reviewed -> AuthorityListing? in
+                let entry = reviewed.attributed.entry
+                guard let manifestURL = entry.manifest.url,
+                      let apiBaseURL = reviewed.firstEndpointURL(schemes: ["https"])
+                else { return nil }
+                // Same trust shape as the legacy directory: the
+                // operator key is pinned out-of-band from the hosted
+                // manifest — here it comes from the *verified catalog
+                // entry* (signed by the pinned provider key), never
+                // from the fetched manifest, so a MITM that swaps the
+                // hosted manifest can't also swap the key it must
+                // verify against.
+                guard let keyBase64 = Self.operatorKeyBase64(fromOnymKey: entry.operatorKey) else {
+                    return nil
+                }
+                return AuthorityListing(
+                    componentId: entry.componentId,
+                    name: reviewed.displayName,
+                    manifestURL: manifestURL,
+                    apiBaseURL: apiBaseURL,
+                    operatorPublicKeyBase64: keyBase64
+                )
+            }
+    }
+
+    /// `onym:key:<64-lowercase-hex>` → base64 of the raw 32 key bytes
+    /// (the encoding `AuthorityListing` / the mandate flow expect).
+    /// Parsing and hex decoding go through the same verified helpers
+    /// the discovery trust chain uses (`DiscoveryFormat.operatorKeyHex`
+    /// + `Data(lowercaseHex:)`) — no second hand-rolled parser.
+    static func operatorKeyBase64(fromOnymKey value: String) -> String? {
+        guard let hex = DiscoveryFormat.operatorKeyHex(value),
+              let bytes = Data(lowercaseHex: hex)
+        else { return nil }
+        return bytes.base64EncodedString()
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -13,6 +13,7 @@ import OnymChatsUI
 import OnymSettings
 import OnymModeration
 import OnymModerationUI
+import OnymDiscovery
 
 @main
 struct OnymIOSApp: App {
@@ -39,6 +40,11 @@ struct OnymIOSApp: App {
     /// backend is a stub until one is deployed.
     private let moderationRepository: ModerationRepository
     private let gateCheckRepository: GateCheckRepository
+    /// Discovery seat: verified provider catalogs that back the four
+    /// known-list fetchers (see `DiscoverySeatAdapters`). Nil under
+    /// the UI harness, like the other network fetchers — the legacy
+    /// fetchers then run unwrapped.
+    private let discoveryRepository: DiscoveryRepository?
     /// Factory for the per-request SEP contract transport. Normally
     /// `URLSessionSEPContractTransport`; swapped for an in-memory
     /// ledger-backed fake under `--ui-loopback` so a Tyranny group
@@ -74,6 +80,52 @@ struct OnymIOSApp: App {
         _ = args  // silence unused warning in Release
         #endif
 
+        // Discovery seat. The repository owns the user's provider
+        // sources + the verified catalog aggregate; the seat adapters
+        // below wrap the four legacy known-list fetchers with
+        // discovery-backed ones. The three endpoint adapters are
+        // consent-gated: until the consent system provides their
+        // `hasActiveConsent` closure (the settings-UI PR), they serve
+        // the legacy list untouched — catalog entries must not become
+        // live endpoints via first-launch auto-populate with no
+        // consent recorded. The authorities adapter is gated the same
+        // way behind its `discoveryEnabled` seam (nil here → legacy
+        // directory untouched): its rows carry the apiBaseURL + pinned
+        // operator key the mandate flow trusts, so catalog rows join
+        // the directory only when the settings-UI layer that ships
+        // provider management enables the merge — and even then legacy
+        // wins any componentId collision. No network
+        // fetch under the UI harness — same rule as the Nostr /
+        // Blossom fetchers below, so tests stay deterministic +
+        // offline (UI-test discovery fakes land with the settings-UI
+        // PR).
+        // One fetcher instance serves both the repository and the seat
+        // catalog below — same URLSession, same size caps; no second
+        // session to configure and drift.
+        let discoveryFetcher = URLSessionDiscoveryFetcher()
+        let discoveryRepository: DiscoveryRepository?
+        #if DEBUG
+        discoveryRepository = args.contains("--ui-loopback") || args.contains("--ui-testing")
+            ? nil
+            : DiscoveryRepository(
+                fetcher: discoveryFetcher,
+                store: UserDefaultsDiscoveryStore()
+            )
+        #else
+        discoveryRepository = DiscoveryRepository(
+            fetcher: discoveryFetcher,
+            store: UserDefaultsDiscoveryStore()
+        )
+        #endif
+        self.discoveryRepository = discoveryRepository
+        // Shared seam the four seat adapters fetch catalog entries +
+        // destination manifests through. Nil exactly when the
+        // repository is nil — `wrapping(_:catalog:)` then returns the
+        // legacy fetcher unwrapped.
+        let discoveryCatalog = discoveryRepository.map {
+            DiscoverySeatCatalog(repository: $0, fetcher: discoveryFetcher)
+        }
+
         let relayerRepository: RelayerRepository
         let contractsRepository: ContractsRepository
         #if DEBUG
@@ -88,7 +140,10 @@ struct OnymIOSApp: App {
             )
         } else {
             relayerRepository = RelayerRepository(
-                fetcher: GitHubReleasesKnownRelayersFetcher(),
+                fetcher: DiscoveryBackedKnownRelayersFetcher.wrapping(
+                    GitHubReleasesKnownRelayersFetcher(),
+                    catalog: discoveryCatalog
+                ),
                 store: UserDefaultsRelayerSelectionStore()
             )
             contractsRepository = ContractsRepository(
@@ -98,7 +153,10 @@ struct OnymIOSApp: App {
         }
         #else
         relayerRepository = RelayerRepository(
-            fetcher: GitHubReleasesKnownRelayersFetcher(),
+            fetcher: DiscoveryBackedKnownRelayersFetcher.wrapping(
+                GitHubReleasesKnownRelayersFetcher(),
+                catalog: discoveryCatalog
+            ),
             store: UserDefaultsRelayerSelectionStore()
         )
         contractsRepository = ContractsRepository(
@@ -177,7 +235,10 @@ struct OnymIOSApp: App {
             )
             moderationManifestFetcher = URLSessionAuthorityManifestFetcher()
             moderationRepository = ModerationRepository(
-                authoritiesFetcher: GitHubReleasesKnownAuthoritiesFetcher(),
+                authoritiesFetcher: DiscoveryBackedKnownAuthoritiesFetcher.wrapping(
+                    GitHubReleasesKnownAuthoritiesFetcher(),
+                    catalog: discoveryCatalog
+                ),
                 manifestFetcher: moderationManifestFetcher,
                 mandateStore: UserDefaultsMandateStore(),
                 backend: backend,
@@ -199,7 +260,10 @@ struct OnymIOSApp: App {
         let moderationBackend = URLSessionEnforcementBackendClient()
         moderationManifestFetcher = URLSessionAuthorityManifestFetcher()
         moderationRepository = ModerationRepository(
-            authoritiesFetcher: GitHubReleasesKnownAuthoritiesFetcher(),
+            authoritiesFetcher: DiscoveryBackedKnownAuthoritiesFetcher.wrapping(
+                GitHubReleasesKnownAuthoritiesFetcher(),
+                catalog: discoveryCatalog
+            ),
             manifestFetcher: moderationManifestFetcher,
             mandateStore: UserDefaultsMandateStore(),
             backend: moderationBackend,
@@ -301,9 +365,16 @@ struct OnymIOSApp: App {
         let blossomFetcher: (any KnownBlossomServersFetcher)?
         #if DEBUG
         blossomFetcher = args.contains("--ui-loopback") || args.contains("--ui-testing")
-            ? nil : GitHubReleasesKnownBlossomServersFetcher()
+            ? nil
+            : DiscoveryBackedKnownBlossomServersFetcher.wrapping(
+                GitHubReleasesKnownBlossomServersFetcher(),
+                catalog: discoveryCatalog
+            )
         #else
-        blossomFetcher = GitHubReleasesKnownBlossomServersFetcher()
+        blossomFetcher = DiscoveryBackedKnownBlossomServersFetcher.wrapping(
+            GitHubReleasesKnownBlossomServersFetcher(),
+            catalog: discoveryCatalog
+        )
         #endif
         let blossomServersRepository = BlossomServersRepository(
             store: blossomStore,
@@ -381,9 +452,16 @@ struct OnymIOSApp: App {
         let nostrFetcher: (any KnownNostrRelaysFetcher)?
         #if DEBUG
         nostrFetcher = args.contains("--ui-loopback") || args.contains("--ui-testing")
-            ? nil : GitHubReleasesKnownNostrRelaysFetcher()
+            ? nil
+            : DiscoveryBackedKnownNostrRelaysFetcher.wrapping(
+                GitHubReleasesKnownNostrRelaysFetcher(),
+                catalog: discoveryCatalog
+            )
         #else
-        nostrFetcher = GitHubReleasesKnownNostrRelaysFetcher()
+        nostrFetcher = DiscoveryBackedKnownNostrRelaysFetcher.wrapping(
+            GitHubReleasesKnownNostrRelaysFetcher(),
+            catalog: discoveryCatalog
+        )
         #endif
         let nostrRelaysRepository = NostrRelaysRepository(
             store: UserDefaultsNostrRelaysSelectionStore(),
@@ -755,6 +833,26 @@ struct OnymIOSApp: App {
                     // verification resolves the moment its fresh snapshot
                     // materializes.
                     await groupStateVerifier.start()
+                    // Discovery FIRST: seed the default source (first
+                    // run), rebuild the offline aggregate from retained
+                    // snapshots, refresh enabled sources in the
+                    // background. Nil under the UI harness. Ordering
+                    // matters: `start()` rebuilds the retained aggregate
+                    // synchronously (inside the actor call) before it
+                    // spawns the network refresh, and the repositories
+                    // started below read the discovery-backed known-list
+                    // fetchers on THEIR start — so this must run first or
+                    // a cold boot's adapter reads see an empty aggregate
+                    // and serve legacy-only lists.
+                    // Known limitation: entries fetched by the background
+                    // refresh (including a very first launch, which has
+                    // no retained snapshots yet) are not re-pushed into
+                    // the repositories this launch — they surface on the
+                    // next launch's adapter reads (or a manual refresh in
+                    // Settings). Wiring the repositories to the
+                    // repository's snapshot stream is the clean seam if
+                    // this ever needs to be live.
+                    await discoveryRepository?.start()
                     // Kick off both GitHub Releases fetches as soon as the
                     // app is on screen. Failures are silent; the user can
                     // still enter a custom relayer URL / pick an older

--- a/Tests/OnymIOSTests/DiscoverySeatAdaptersTests.swift
+++ b/Tests/OnymIOSTests/DiscoverySeatAdaptersTests.swift
@@ -1,0 +1,1003 @@
+import CryptoKit
+import Foundation
+import XCTest
+@testable import OnymIOS
+import OnymChain
+import OnymDiscovery
+import OnymFoundation
+import OnymModeration
+import OnymTransportBlossom
+import OnymTransportNostr
+
+/// Fallback-ordering + mapping tests for the discovery-backed seat
+/// fetchers in `DiscoverySeatAdapters.swift`. The catalog seam is
+/// stubbed with closures — no repository, no network; destination
+/// manifests are freshly Ed25519-signed the way an operator's
+/// publishing pipeline would sign them, because the reviewer is
+/// hard-enforced (no accept-anyway path to sneak fixtures through).
+final class DiscoverySeatAdaptersTests: XCTestCase {
+    // MARK: - Manifest factory
+
+    /// Serialize, sign the canonical form, embed the signature. Same
+    /// recipe as `ManifestFactory` in OnymFoundationTests.
+    private static func signedManifestBytes(
+        object: [String: Any],
+        key: Curve25519.Signing.PrivateKey
+    ) throws -> Data {
+        var object = object
+        object.removeValue(forKey: "signature")
+        let unsigned = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        let signingBytes = try ServiceManifestCanonical.signingBytes(of: unsigned)
+        let signature = try key.signature(for: signingBytes)
+        object["signature"] = signature.base64EncodedString()
+        return try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.withoutEscapingSlashes]
+        )
+    }
+
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func digest(of data: Data) -> String {
+        "sha256:" + hex(Data(SHA256.hash(data: data)))
+    }
+
+    /// A signed destination manifest plus the matching verified-catalog
+    /// entry wrapped in attribution — everything an adapter consumes.
+    private struct Seeded {
+        let entry: AttributedCatalogEntry
+        let manifestBytes: Data
+        let operatorKeyHex: String
+    }
+
+    private static func seeded(
+        componentId: String = "onym:component:test-component",
+        seatType: String,
+        manifestExtras: [String: Any],
+        manifestURI: String = "https://provider.example/manifests/component.json",
+        providerId: String = "onym:component:test-provider",
+        manifestComponentIdOverride: String? = nil,
+        manifestSeatOverride: String? = nil,
+        entryOperatorOverrideHex: String? = nil,
+        entryDigestOverride: String? = nil,
+        entryStatus: [String: Any]? = nil
+    ) throws -> Seeded {
+        let key = Curve25519.Signing.PrivateKey()
+        let keyHex = hex(key.publicKey.rawRepresentation)
+        var object: [String: Any] = [
+            "componentId": manifestComponentIdOverride ?? componentId,
+            "seat": manifestSeatOverride ?? seatType,
+            "operator": "onym:key:\(keyHex)",
+            "validUntil": "2030-01-01T00:00:00Z",
+        ]
+        object.merge(manifestExtras) { _, new in new }
+        let bytes = try signedManifestBytes(object: object, key: key)
+
+        var entryJSON: [String: Any] = [
+            "componentId": componentId,
+            "seatType": seatType,
+            "manifest": [
+                "uri": manifestURI,
+                "digest": entryDigestOverride ?? digest(of: bytes),
+            ],
+            "operator": "onym:key:\(entryOperatorOverrideHex ?? keyHex)",
+            "profiles": [],
+            "evidence": [],
+            "listedAt": "2026-01-01T00:00:00Z",
+            "relationship": "none",
+            "placement": "neutral",
+        ]
+        if let entryStatus { entryJSON["status"] = entryStatus }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let entry = try decoder.decode(
+            CatalogEntry.self,
+            from: JSONSerialization.data(withJSONObject: entryJSON)
+        )
+        let attributed = AttributedCatalogEntry(
+            entry: entry,
+            source: SourceAttribution(
+                providerId: providerId,
+                sourceLabel: "Test Provider",
+                catalogId: "public",
+                snapshotDigest: "sha256:" + String(repeating: "0", count: 64),
+                relationship: "none",
+                placement: "neutral"
+            )
+        )
+        return Seeded(entry: attributed, manifestBytes: bytes, operatorKeyHex: keyHex)
+    }
+
+    private static func catalog(_ seeded: [Seeded]) -> DiscoverySeatCatalog {
+        DiscoverySeatCatalog(
+            entries: { seatType in
+                seeded.map(\.entry).filter { $0.entry.seatType == seatType }
+            },
+            fetchManifestBytes: { url in
+                guard let match = seeded.first(where: { $0.entry.entry.manifest.url == url }) else {
+                    throw URLError(.fileDoesNotExist)
+                }
+                return match.manifestBytes
+            }
+        )
+    }
+
+    private static let emptyCatalog = DiscoverySeatCatalog(
+        entries: { _ in [] },
+        fetchManifestBytes: { _ in throw URLError(.fileDoesNotExist) }
+    )
+
+    // MARK: - Fallback stubs
+
+    private struct StubRelayersFallback: KnownRelayersFetcher {
+        static let sentinel = [RelayerEndpoint(
+            name: "Legacy Relayer",
+            url: URL(string: "https://legacy.example")!,
+            networks: ["testnet"]
+        )]
+        func fetchLatest() async throws -> [RelayerEndpoint] { Self.sentinel }
+    }
+
+    private struct StubNostrFallback: KnownNostrRelaysFetcher {
+        static let sentinel = [NostrRelayEndpoint(
+            name: "Legacy Nostr",
+            url: URL(string: "wss://legacy.example")!,
+            isDefault: true
+        )]
+        func fetchLatest() async throws -> [NostrRelayEndpoint] { Self.sentinel }
+    }
+
+    private struct StubBlossomFallback: KnownBlossomServersFetcher {
+        static let sentinel = [BlossomServerEndpoint(
+            name: "Legacy Blossom",
+            url: URL(string: "https://legacy-blossom.example")!,
+            isDefault: true
+        )]
+        func fetchLatest() async throws -> [BlossomServerEndpoint] { Self.sentinel }
+    }
+
+    private struct StubAuthoritiesFallback: KnownAuthoritiesFetcher {
+        static let sentinel = [AuthorityListing(
+            componentId: "onym:component:legacy-authority",
+            name: "Legacy Authority",
+            manifestURL: URL(string: "https://legacy.example/manifest.json")!,
+            apiBaseURL: URL(string: "https://legacy.example/api")!,
+            operatorPublicKeyBase64: Data(repeating: 7, count: 32).base64EncodedString()
+        )]
+        func fetchLatest() async throws -> [AuthorityListing] { Self.sentinel }
+    }
+
+    // MARK: - Relayers (notary seat)
+
+    func test_relayers_emptyCatalogFallsBackToLegacy() async throws {
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.emptyCatalog,
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+
+    func test_relayers_mapsVerifiedManifestToEndpoint() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Test Notary",
+                "endpoints": [["role": "submit", "uri": "https://notary.example/api"]],
+                "networks": ["testnet"],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, [RelayerEndpoint(
+            name: "Test Notary",
+            url: URL(string: "https://notary.example/api")!,
+            networks: ["testnet"]
+        )] + StubRelayersFallback.sentinel,
+        "the discovery entry is MERGED with the legacy list, never a replacement for it")
+    }
+
+    /// The replace-vs-add regression: the known list feeds
+    /// `RelayerRepository`'s first-launch auto-populate (and the
+    /// nostr/blossom repositories' `applyDefault`), so one surviving
+    /// discovery entry must not make the fetched list discovery-only —
+    /// the published defaults must survive in the union, discovery
+    /// entries first (aggregate order), legacy after.
+    func test_relayers_multipleEntriesUnionWithLegacyList() async throws {
+        let first = try Self.seeded(
+            componentId: "onym:component:notary-one",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Notary One",
+                "endpoints": [["uri": "https://one.example/api"]],
+            ],
+            manifestURI: "https://provider.example/manifests/one.json"
+        )
+        let second = try Self.seeded(
+            componentId: "onym:component:notary-two",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Notary Two",
+                "endpoints": [["uri": "https://two.example/api"]],
+            ],
+            manifestURI: "https://provider.example/manifests/two.json"
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([first, second]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Notary One", "Notary Two", "Legacy Relayer"])
+        XCTAssertEqual(result.map(\.url), [
+            URL(string: "https://one.example/api")!,
+            URL(string: "https://two.example/api")!,
+            URL(string: "https://legacy.example")!,
+        ])
+    }
+
+    /// Partial failure: one entry's review fails (digest mismatch),
+    /// the other entries — and the legacy list — survive. A bad entry
+    /// costs itself, never the seat.
+    func test_relayers_partialReviewFailureKeepsSurvivorsAndLegacy() async throws {
+        let bad = try Self.seeded(
+            componentId: "onym:component:bad-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Bad Notary",
+                "endpoints": [["uri": "https://bad.example/api"]],
+            ],
+            manifestURI: "https://provider.example/manifests/bad.json",
+            entryDigestOverride: "sha256:" + String(repeating: "e", count: 64)
+        )
+        let good = try Self.seeded(
+            componentId: "onym:component:good-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Good Notary",
+                "endpoints": [["uri": "https://good.example/api"]],
+            ],
+            manifestURI: "https://provider.example/manifests/good.json"
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([bad, good]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Good Notary", "Legacy Relayer"])
+    }
+
+    /// Dedupe by URL across the merge: when a discovery entry serves
+    /// the same endpoint URL a published entry lists, the discovery
+    /// entry wins the row (its reviewed attribution), and the URL
+    /// appears exactly once. Two providers listing the same URL
+    /// (cross-provider duplicate) also collapse to one row — the
+    /// first in aggregate order.
+    func test_relayers_mergeDedupesByURLWithDiscoveryAttributionWinning() async throws {
+        let overlapsLegacy = try Self.seeded(
+            componentId: "onym:component:test-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Catalog Name For Legacy URL",
+                "endpoints": [["uri": "https://legacy.example"]],
+            ],
+            manifestURI: "https://provider.example/manifests/overlap.json",
+            providerId: "onym:component:provider-a"
+        )
+        let crossProviderDuplicate = try Self.seeded(
+            componentId: "onym:component:other-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Same URL, Other Provider",
+                "endpoints": [["uri": "https://legacy.example"]],
+            ],
+            manifestURI: "https://other-provider.example/manifests/overlap.json",
+            providerId: "onym:component:provider-b"
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([overlapsLegacy, crossProviderDuplicate]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.url), [URL(string: "https://legacy.example")!])
+        XCTAssertEqual(result.map(\.name), ["Catalog Name For Legacy URL"])
+    }
+
+    /// A legacy-list outage must not subtract surviving discovery
+    /// endpoints; with no discovery endpoints the failure propagates
+    /// exactly as the bare legacy fetcher's would.
+    func test_relayers_legacyFetchFailureStillServesDiscoveredEndpoints() async throws {
+        struct FailingFallback: KnownRelayersFetcher {
+            func fetchLatest() async throws -> [RelayerEndpoint] {
+                throw URLError(.notConnectedToInternet)
+            }
+        }
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Discovered Notary",
+                "endpoints": [["uri": "https://discovered.example/api"]],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: FailingFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Discovered Notary"])
+
+        let emptyDiscovery = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.emptyCatalog,
+            fallback: FailingFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        do {
+            _ = try await emptyDiscovery.fetchLatest()
+            XCTFail("with nothing discovered, the legacy failure must propagate")
+        } catch {}
+    }
+
+    /// The seat-vocabulary pin: a manifest declaring a seat outside
+    /// its catalog entry's accepted set is skipped — a catalog can't
+    /// install a blob server into the notary seat by mislabeling the
+    /// entry.
+    func test_relayers_manifestSeatOutsideVocabularyIsSkipped() async throws {
+        let mislabeled = try Self.seeded(
+            componentId: "onym:component:test-notary",
+            seatType: "notary",
+            manifestExtras: ["endpoints": [["uri": "https://notary.example/api"]]],
+            manifestSeatOverride: "blob.storage"
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([mislabeled]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+
+    /// The componentId cross-check: the fetched manifest must be the
+    /// component the catalog listed.
+    func test_relayers_manifestComponentIdMismatchIsSkipped() async throws {
+        let swapped = try Self.seeded(
+            componentId: "onym:component:test-notary",
+            seatType: "notary",
+            manifestExtras: ["endpoints": [["uri": "https://notary.example/api"]]],
+            manifestComponentIdOverride: "onym:component:some-other-notary"
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([swapped]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+
+    /// Role preference: among scheme-matching endpoints, the first
+    /// with role "read-write" (what every published template marks the
+    /// client-facing endpoint with) wins over earlier endpoints with
+    /// other roles; with no "read-write" endpoint the first
+    /// scheme-matching endpoint serves (documented fallback).
+    func test_relayers_prefersReadWriteRoleEndpoint() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Test Notary",
+                "endpoints": [
+                    ["role": "metrics", "uri": "https://metrics.example/api"],
+                    ["role": "read-write", "uri": "https://serve.example/api"],
+                ],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.first?.url, URL(string: "https://serve.example/api"))
+
+        let noPreferredRole = try Self.seeded(
+            componentId: "onym:component:test-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "endpoints": [
+                    ["role": "submit", "uri": "https://first.example/api"],
+                    ["role": "api", "uri": "https://second.example/api"],
+                ],
+            ]
+        )
+        let fallbackFetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([noPreferredRole]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let fallbackResult = try await fallbackFetcher.fetchLatest()
+        XCTAssertEqual(fallbackResult.first?.url, URL(string: "https://first.example/api"))
+    }
+
+    /// The per-seat entry cap: entries beyond `maxEntriesPerSeat` are
+    /// dropped (deterministically — aggregate order) instead of
+    /// fanning a refresh out into unbounded manifest fetches.
+    func test_relayers_entriesBeyondPerSeatCapAreDropped() async throws {
+        let count = DiscoverySeatCatalog.maxEntriesPerSeat + 2
+        let seeded = try (0..<count).map { index in
+            try Self.seeded(
+                componentId: "onym:component:notary-\(index)",
+                seatType: "notary",
+                manifestExtras: [
+                    "name": "Notary \(index)",
+                    "endpoints": [["uri": "https://notary-\(index).example/api"]],
+                ],
+                manifestURI: "https://provider.example/manifests/notary-\(index).json"
+            )
+        }
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog(seeded),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        // First `maxEntriesPerSeat` discovery entries in aggregate
+        // order, then the legacy list.
+        XCTAssertEqual(
+            result.map(\.name),
+            (0..<DiscoverySeatCatalog.maxEntriesPerSeat).map { "Notary \($0)" } + ["Legacy Relayer"]
+        )
+    }
+
+    func test_relayers_defaultsNetworksAndNameWhenManifestOmitsThem() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "endpoints": [["uri": "https://notary.example/api"]],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.first?.name, "test-notary")
+        XCTAssertEqual(result.first?.networks, ["testnet", "public"])
+    }
+
+    func test_relayers_digestMismatchFallsBackToLegacy() async throws {
+        let seeded = try Self.seeded(
+            seatType: "notary",
+            manifestExtras: [
+                "endpoints": [["uri": "https://notary.example/api"]],
+            ],
+            entryDigestOverride: "sha256:" + String(repeating: "e", count: 64)
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+
+    func test_relayers_manifestFetchFailureFallsBackToLegacy() async throws {
+        let seeded = try Self.seeded(
+            seatType: "notary",
+            manifestExtras: ["endpoints": [["uri": "https://notary.example/api"]]]
+        )
+        let unreachable = DiscoverySeatCatalog(
+            entries: { _ in [seeded.entry] },
+            fetchManifestBytes: { _ in throw URLError(.notConnectedToInternet) }
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: unreachable,
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+
+    // MARK: - Nostr relays (transport.message seat)
+
+    func test_nostr_mapsWssEndpointAndSkipsNonWss() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-courier",
+            seatType: "transport.message",
+            manifestExtras: [
+                "name": "Test Courier",
+                "endpoints": [
+                    ["role": "http-fallback", "uri": "https://courier.example"],
+                    ["role": "read-write", "uri": "wss://nostr.courier.example"],
+                ],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubNostrFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, [NostrRelayEndpoint(
+            name: "Test Courier",
+            url: URL(string: "wss://nostr.courier.example")!,
+            // Third-party catalog entries must not wear the
+            // Onym-published "Default" badge.
+            isDefault: false
+        )] + StubNostrFallback.sentinel,
+        "the shipped default relays must survive a discovery transport entry")
+    }
+
+    func test_nostr_manifestWithoutWssEndpointFallsBackToLegacy() async throws {
+        let seeded = try Self.seeded(
+            seatType: "transport.message",
+            manifestExtras: ["endpoints": [["uri": "https://courier.example"]]]
+        )
+        let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubNostrFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubNostrFallback.sentinel)
+    }
+
+    // MARK: - Blossom servers (blob.storage seat)
+
+    func test_blossom_mapsHTTPSEndpoint() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-blossom",
+            seatType: "blob.storage",
+            manifestExtras: [
+                "name": "Test Blossom",
+                "endpoints": [["uri": "https://blobs.example"]],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownBlossomServersFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubBlossomFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, [BlossomServerEndpoint(
+            name: "Test Blossom",
+            url: URL(string: "https://blobs.example")!,
+            // Third-party catalog entries must not wear the
+            // Onym-published "Default" badge.
+            isDefault: false
+        )] + StubBlossomFallback.sentinel,
+        "the published default servers must survive a discovery blob entry")
+    }
+
+    func test_blossom_emptyCatalogFallsBackToLegacy() async throws {
+        let fetcher = DiscoveryBackedKnownBlossomServersFetcher(
+            catalog: Self.emptyCatalog,
+            fallback: StubBlossomFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubBlossomFallback.sentinel)
+    }
+
+    // MARK: - Authorities (moderation seat)
+
+    func test_authorities_mapsCatalogEntryWithConvertedOperatorKey() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-authority",
+            seatType: "moderation",
+            manifestExtras: [
+                "name": "Test Authority",
+                "endpoints": [["role": "api", "uri": "https://authority.example/api"]],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownAuthoritiesFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubAuthoritiesFallback(),
+            discoveryEnabled: { true }
+        )
+        let result = try await fetcher.fetchLatest()
+        // Merged by componentId with the legacy directory — the
+        // catalog entry first (aggregate order), the published
+        // authorities after it, never subtracted.
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.last, StubAuthoritiesFallback.sentinel[0])
+        let listing = try XCTUnwrap(result.first)
+        XCTAssertEqual(listing.componentId, "onym:component:test-authority")
+        XCTAssertEqual(listing.name, "Test Authority")
+        XCTAssertEqual(
+            listing.manifestURL,
+            URL(string: "https://provider.example/manifests/component.json")
+        )
+        XCTAssertEqual(listing.apiBaseURL, URL(string: "https://authority.example/api"))
+        // The key must be the CATALOG entry's operator key (base64 of
+        // the raw 32 bytes), not anything read out of the manifest.
+        let expectedKeyData = Data(
+            stride(from: 0, to: seeded.operatorKeyHex.count, by: 2).map { offset -> UInt8 in
+                let start = seeded.operatorKeyHex.index(
+                    seeded.operatorKeyHex.startIndex, offsetBy: offset
+                )
+                let end = seeded.operatorKeyHex.index(start, offsetBy: 2)
+                return UInt8(seeded.operatorKeyHex[start..<end], radix: 16)!
+            }
+        )
+        XCTAssertEqual(listing.operatorPublicKeyBase64, expectedKeyData.base64EncodedString())
+    }
+
+    func test_authorities_operatorKeyMismatchWithManifestFallsBackToLegacy() async throws {
+        // Catalog names a different operator than the manifest is
+        // signed by — the adapter must reject the entry (the catalog
+        // is the verified side) and fall back.
+        let otherKeyHex = Self.hex(Curve25519.Signing.PrivateKey().publicKey.rawRepresentation)
+        let seeded = try Self.seeded(
+            seatType: "moderation",
+            manifestExtras: ["endpoints": [["uri": "https://authority.example/api"]]],
+            entryOperatorOverrideHex: otherKeyHex
+        )
+        let fetcher = DiscoveryBackedKnownAuthoritiesFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubAuthoritiesFallback(),
+            discoveryEnabled: { true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubAuthoritiesFallback.sentinel)
+    }
+
+    func test_operatorKeyBase64Conversion() {
+        let hex = (0..<32).map { String(format: "%02x", $0) }.joined()
+        let expected = Data((0..<32).map { UInt8($0) }).base64EncodedString()
+        XCTAssertEqual(
+            DiscoveryBackedKnownAuthoritiesFetcher.operatorKeyBase64(
+                fromOnymKey: "onym:key:\(hex)"
+            ),
+            expected
+        )
+        XCTAssertNil(
+            DiscoveryBackedKnownAuthoritiesFetcher.operatorKeyBase64(fromOnymKey: "onym:key:short")
+        )
+        XCTAssertNil(
+            DiscoveryBackedKnownAuthoritiesFetcher.operatorKeyBase64(fromOnymKey: hex)
+        )
+    }
+
+    // MARK: - Consent gate seam
+
+    /// With NO consent system present (`hasActiveConsent: nil` — this
+    /// PR standalone), discovery entries are excluded from the known
+    /// list entirely: the adapter is a pure legacy passthrough and
+    /// never even fans out into the catalog. The known list feeds
+    /// first-launch auto-populate and the nostr/blossom
+    /// `applyDefault`, so anything that reaches it becomes a LIVE
+    /// endpoint for default-config users — nothing may reach it
+    /// without a consent record.
+    func test_relayers_nilConsentClosureServesLegacyOnlyWithoutCatalogFanout() async throws {
+        let catalog = DiscoverySeatCatalog(
+            entries: { _ in
+                XCTFail("no consent system present: the catalog must not be consulted")
+                return []
+            },
+            fetchManifestBytes: { _ in
+                XCTFail("no consent system present: no manifest may be fetched")
+                throw URLError(.fileDoesNotExist)
+            }
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: catalog,
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: nil
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+
+    func test_nostr_nilConsentClosureServesLegacyOnly() async throws {
+        let seeded = try Self.seeded(
+            seatType: "transport.message",
+            manifestExtras: ["endpoints": [["uri": "wss://nostr.courier.example"]]]
+        )
+        let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubNostrFallback(),
+            hasActiveConsent: nil
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubNostrFallback.sentinel)
+    }
+
+    func test_blossom_nilConsentClosureServesLegacyOnly() async throws {
+        let seeded = try Self.seeded(
+            seatType: "blob.storage",
+            manifestExtras: ["endpoints": [["uri": "https://blobs.example"]]]
+        )
+        let fetcher = DiscoveryBackedKnownBlossomServersFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubBlossomFallback(),
+            hasActiveConsent: nil
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubBlossomFallback.sentinel)
+    }
+
+    /// With the consent system wired in, only entries the closure
+    /// approves merge into the known list — unconsented entries stay
+    /// picker-only.
+    func test_relayers_consentGateAdmitsOnlyConsentedEntries() async throws {
+        let consented = try Self.seeded(
+            componentId: "onym:component:notary-one",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Notary One",
+                "endpoints": [["uri": "https://one.example/api"]],
+            ],
+            manifestURI: "https://provider.example/manifests/one.json"
+        )
+        let unconsented = try Self.seeded(
+            componentId: "onym:component:notary-two",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Notary Two",
+                "endpoints": [["uri": "https://two.example/api"]],
+            ],
+            manifestURI: "https://provider.example/manifests/two.json"
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([consented, unconsented]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { $0 == "onym:component:notary-one" }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Notary One", "Legacy Relayer"])
+    }
+
+    // MARK: - Endpoint URI rules + dedupe normalization
+
+    /// Manifest endpoint URIs go through the same §7 URI rules as
+    /// every other URL in OnymDiscovery — userinfo, query, fragment,
+    /// and explicit ports are rejected, not just wrong schemes.
+    func test_relayers_endpointURIOutsideProfileRulesIsSkipped() async throws {
+        let seeded = try Self.seeded(
+            seatType: "notary",
+            manifestExtras: [
+                "endpoints": [
+                    ["uri": "https://user:pass@notary.example:8443/x?q=1"],
+                    ["uri": "https://notary.example:8443/api"],
+                    ["uri": "https://notary.example/api?q=1"],
+                ],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+
+    /// Dedupe keys are normalized — scheme+host lowercased, trailing
+    /// slash stripped — so `wss://LEGACY.example/` and
+    /// `wss://legacy.example` collapse to one row (and one relay
+    /// connection), with the discovery attribution winning the row.
+    func test_nostr_mergeDedupeNormalizesCaseAndTrailingSlash() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-courier",
+            seatType: "transport.message",
+            manifestExtras: [
+                "name": "Case Variant Courier",
+                "endpoints": [["uri": "wss://LEGACY.example/"]],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubNostrFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Case Variant Courier"])
+    }
+
+    // MARK: - Entry status
+
+    /// A provider-flagged `warning` entry is excluded from known-list
+    /// merges outright — the provider itself marked it suspect, and no
+    /// seat endpoint type has a field to carry the flag on.
+    func test_relayers_warningStatusEntryIsExcluded() async throws {
+        let flagged = try Self.seeded(
+            componentId: "onym:component:flagged-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Flagged Notary",
+                "endpoints": [["uri": "https://flagged.example/api"]],
+            ],
+            entryStatus: ["state": "warning", "uri": "https://provider.example/warning"]
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([flagged]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+
+    /// A `review`-flagged entry passes the merge — the flag stays on
+    /// `attributed.entry.status` for the consent/picker surfaces to
+    /// render; no endpoint type has a field to carry it further.
+    func test_relayers_reviewStatusEntryStillMerges() async throws {
+        let underReview = try Self.seeded(
+            componentId: "onym:component:review-notary",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Review Notary",
+                "endpoints": [["uri": "https://review.example/api"]],
+            ],
+            entryStatus: ["state": "review"]
+        )
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([underReview]),
+            fallback: StubRelayersFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Review Notary", "Legacy Relayer"])
+    }
+
+    /// Schemes are case-insensitive on the wire: a manifest publishing
+    /// `WSS://…` maps like `wss://…`, instead of being silently
+    /// dropped by an exact-case scheme comparison.
+    func test_nostr_uppercaseSchemeEndpointStillMaps() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-courier",
+            seatType: "transport.message",
+            manifestExtras: [
+                "name": "Shouting Courier",
+                "endpoints": [["uri": "WSS://nostr.courier.example"]],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubNostrFallback(),
+            hasActiveConsent: { _ in true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Shouting Courier", "Legacy Nostr"])
+    }
+
+    // MARK: - Authorities merge semantics
+
+    /// The directory merge is LEGACY-wins on a componentId collision:
+    /// an authority listing's `apiBaseURL` + operator key are what the
+    /// mandate flow trusts, and `ModerationRepository` resolves the
+    /// active mandate's authority by componentId — so a catalog entry
+    /// reusing a published authority's componentId must never shadow
+    /// the published row (which would redirect mandate traffic and
+    /// put an attacker-controlled key behind re-consent). Discovery
+    /// may only contribute componentIds the directory doesn't list.
+    func test_authorities_duplicateComponentIdKeepsLegacyRow() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:legacy-authority",
+            seatType: "moderation",
+            manifestExtras: [
+                "name": "Catalog Authority",
+                "endpoints": [["uri": "https://attacker.example/api"]],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownAuthoritiesFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubAuthoritiesFallback(),
+            discoveryEnabled: { true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubAuthoritiesFallback.sentinel,
+            "the published authority's row — apiBaseURL and operator key included — must survive untouched")
+    }
+
+    /// The authorities gate seam: with no discovery surface in the
+    /// build layer (`discoveryEnabled: nil` — PR #246 standalone), the
+    /// adapter is a pure legacy passthrough and never consults the
+    /// catalog at all.
+    func test_authorities_nilDiscoveryEnabledServesLegacyOnlyWithoutCatalogFanout() async throws {
+        let catalog = DiscoverySeatCatalog(
+            entries: { _ in
+                XCTFail("no discovery surface present: the catalog must not be consulted")
+                return []
+            },
+            fetchManifestBytes: { _ in
+                XCTFail("no discovery surface present: no manifest may be fetched")
+                throw URLError(.fileDoesNotExist)
+            }
+        )
+        let fetcher = DiscoveryBackedKnownAuthoritiesFetcher(
+            catalog: catalog,
+            fallback: StubAuthoritiesFallback(),
+            discoveryEnabled: nil
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result, StubAuthoritiesFallback.sentinel)
+    }
+
+    func test_authorities_legacyFailureStillServesDiscoveredListings() async throws {
+        struct FailingAuthoritiesFallback: KnownAuthoritiesFetcher {
+            func fetchLatest() async throws -> [AuthorityListing] {
+                throw URLError(.notConnectedToInternet)
+            }
+        }
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-authority",
+            seatType: "moderation",
+            manifestExtras: [
+                "name": "Discovered Authority",
+                "endpoints": [["uri": "https://authority.example/api"]],
+            ]
+        )
+        let fetcher = DiscoveryBackedKnownAuthoritiesFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: FailingAuthoritiesFallback(),
+            discoveryEnabled: { true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Discovered Authority"])
+
+        let emptyDiscovery = DiscoveryBackedKnownAuthoritiesFetcher(
+            catalog: Self.emptyCatalog,
+            fallback: FailingAuthoritiesFallback(),
+            discoveryEnabled: { true }
+        )
+        do {
+            _ = try await emptyDiscovery.fetchLatest()
+            XCTFail("with nothing discovered, the legacy failure must propagate")
+        } catch {}
+    }
+
+    /// The LIVE authority manifest (authority.onym.app/manifest.json)
+    /// declares `seat: "moderation"`; "authority" — the name the
+    /// foundation docs use for the seat — is tolerated as an alias.
+    func test_authorities_manifestSeatAuthorityAliasIsAccepted() async throws {
+        let seeded = try Self.seeded(
+            componentId: "onym:component:test-authority",
+            seatType: "moderation",
+            manifestExtras: [
+                "name": "Alias Authority",
+                "endpoints": [["uri": "https://authority.example/api"]],
+            ],
+            manifestSeatOverride: "authority"
+        )
+        let fetcher = DiscoveryBackedKnownAuthoritiesFetcher(
+            catalog: Self.catalog([seeded]),
+            fallback: StubAuthoritiesFallback(),
+            discoveryEnabled: { true }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.map(\.name), ["Alias Authority", "Legacy Authority"])
+    }
+
+    // MARK: - wrapping(_:catalog:)
+
+    func test_wrappingWithNilCatalogReturnsLegacyFetcherUnwrapped() async throws {
+        let wrapped = DiscoveryBackedKnownRelayersFetcher.wrapping(
+            StubRelayersFallback(),
+            catalog: nil
+        )
+        XCTAssertTrue(wrapped is StubRelayersFallback)
+        let result = try await wrapped.fetchLatest()
+        XCTAssertEqual(result, StubRelayersFallback.sentinel)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -34,6 +34,7 @@ packages:
   OnymSettings: {path: Packages/OnymSettings}
   OnymModeration: {path: Packages/OnymModeration}
   OnymModerationUI: {path: Packages/OnymModerationUI}
+  OnymDiscovery: {path: Packages/OnymDiscovery}
 
 targets:
   OnymIOS:
@@ -62,6 +63,7 @@ targets:
       - package: OnymSettings
       - package: OnymModeration
       - package: OnymModerationUI
+      - package: OnymDiscovery
     # Hand-written Info.plist via xcodegen's `info:` block. We tried
     # the GENERATE_INFOPLIST_FILE + INFOPLIST_KEY_* approach first but
     # `INFOPLIST_KEY_UILaunchScreen_BackgroundColor` / `_ImageName` are
@@ -224,6 +226,7 @@ targets:
       - package: OnymSettings
       - package: OnymModeration
       - package: OnymModerationUI
+      - package: OnymDiscovery
 
   OnymIOSUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## Summary

PR 3 of the discovery sequence. **Stacked on #245** (base branch set accordingly; #244 is already merged to main). Restacked 2026-08-15 as a **single commit** on top of `service-consent-primitives` — the diff now shows only this branch's own wiring work, with all eleven review rounds' fixes preserved in the squashed tree.

- `Sources/OnymIOS/DiscoverySeatAdapters.swift`: discovery-backed implementations of all four seat fetcher protocols (relayers, nostr relays, blossom servers, authorities). Each maps verified catalog entries → destination manifests reviewed via `ServiceManifestReviewer` (digest pin + Ed25519 + expiry, plus catalog↔manifest operator-key equality; the authority key is converted from the verified catalog entry, never taken from the fetched manifest). Any failure, or an empty catalog, falls back to the wrapped legacy GitHub fetcher — discovery can only add sources, never make the app worse than today.
- `SeatSelectionStore` in OnymDiscovery: append-only provenance records `{seatType, componentId, providerId, manifestHash, offerId, selectedAt}`; nothing writes it yet — the Settings UI PR does.
- Boot wiring in `OnymIOSApp.swift`: `DiscoveryRepository` constructed (nil under UI-testing flags, matching the existing pattern), started in the repository cluster, legacy fetchers wrapped at their construction sites, UITest slots for the discovery-backed fetchers. `AppDependencies` untouched.
- `project.yml`: app target picks up the OnymDiscovery package product.

## Restack note

The branch previously carried many merge commits tracking #244/#245 review rounds; it is now exactly one commit (2 original wiring commits + the merge-round adaptations, squashed). It sits on #245's tip **including its round-2 throwing `PinnedConsentStore` API** — the wiring layer itself needed no call-site changes for that.

**Merge order: #245 → #246 → #247, squash-merge recommended for each.**

## Testing (re-run after restack)

OnymDiscovery package 91/91, OnymFoundation package 51/51, app-target `DiscoverySeatAdaptersTests` 13/13, full app build for iPhone 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8
