### PR TITLE
Discovery Settings UI: providers, module consent, offers

### DIFF
--- a/Packages/OnymDiscovery/Sources/OnymDiscovery/DiscoverySettingsFlow.swift
+++ b/Packages/OnymDiscovery/Sources/OnymDiscovery/DiscoverySettingsFlow.swift
@@ -1,0 +1,210 @@
+import Foundation
+import Observation
+
+/// `@Observable @MainActor` view-model for the Discovery Providers
+/// Settings screen. Drains `DiscoveryRepository` snapshots into local
+/// `state`; intents dispatch to the repository for source mutations.
+///
+/// Also owns the add-provider sub-flow (URL → fetched preview → TOFU
+/// confirm), because its outcome mutates the same source list this
+/// screen renders.
+///
+/// Lives in OnymDiscovery (not OnymSettings, which renders it) so its
+/// state machine is unit-testable — OnymSettings has no test target.
+@MainActor
+@Observable
+public final class DiscoverySettingsFlow {
+    /// Where the add-provider sheet currently stands. The preview is
+    /// fully verified but **nothing is pinned** until the user confirms
+    /// the operator key fingerprint (`DiscoveryRepository.addSource`
+    /// contract).
+    public enum AddPhase {
+        case idle
+        case fetching
+        case confirming(DiscoveryProviderPreview)
+        case added
+    }
+
+    public private(set) var state: DiscoveryState = .empty
+
+    // MARK: Add-provider sub-flow
+
+    public var addDraft: String = ""
+    public private(set) var addPhase: AddPhase = .idle
+    public private(set) var addError: String?
+
+    private let repository: DiscoveryRepository
+    private var snapshotTask: Task<Void, Never>?
+    /// The in-flight add-provider fetch, kept so `resetAdd` can cancel
+    /// it (internal so tests can await its completion).
+    @ObservationIgnored private(set) var addTask: Task<Void, Never>?
+    /// The in-flight TOFU confirm. NOT cancelled by `resetAdd` — the
+    /// user already confirmed the pin, so the persist + targeted
+    /// refresh must run to completion; only the sheet-phase mutation
+    /// is generation-guarded. Internal so tests can await it.
+    @ObservationIgnored private(set) var confirmTask: Task<Void, Never>?
+    /// Stale-completion guard for the add-provider fetch: bumped by
+    /// every fetch AND every reset, so a completion from a superseded
+    /// fetch (cancelled or not — `addSource` may not observe the
+    /// cancellation) can never resurrect a dismissed sheet's phase.
+    private var addGeneration = 0
+    /// Double-tap guard for the Confirm button: set the moment the tap
+    /// is accepted (NOT when `.added` lands), because the phase stays
+    /// `.confirming` while the confirm task runs and a second tap in
+    /// that window would run the whole pin + targeted-refresh pipeline
+    /// again. Cleared when the confirm task finishes (`defer` in the
+    /// task — the guard tracks the PIPELINE, not the sheet, so backing
+    /// out of the preview and fetching a fresh URL must not leave
+    /// Confirm a permanent no-op) and by `resetAdd` for the next sheet.
+    @ObservationIgnored private var isConfirmInFlight = false
+
+    public init(repository: DiscoveryRepository) {
+        self.repository = repository
+    }
+
+    /// Begin draining repository snapshots. Idempotent — safe to call
+    /// from `.task` on every appear.
+    public func start() {
+        guard snapshotTask == nil else { return }
+        snapshotTask = Task { [weak self] in
+            guard let self else { return }
+            for await snapshot in self.repository.snapshots {
+                self.state = snapshot
+            }
+        }
+    }
+
+    public func stop() {
+        snapshotTask?.cancel()
+        snapshotTask = nil
+    }
+
+    // MARK: - Read helpers
+
+    /// How many verified catalog entries a source currently contributes.
+    public func entryCount(providerId: String) -> Int {
+        state.aggregate.count { $0.source.providerId == providerId }
+    }
+
+    // MARK: - Intents
+
+    /// Confirmed removal. Permanent by design: the providerId joins
+    /// `removedDefaultProviderIds`, so no future seeding restores it —
+    /// only an explicit re-add does.
+    public func tappedRemove(providerId: String) {
+        Task { await repository.removeSource(providerId: providerId) }
+    }
+
+    public func tappedRefresh() {
+        Task { await repository.refresh() }
+    }
+
+    /// Awaitable variant for `.refreshable` (pull-to-refresh keeps its
+    /// spinner until the pass completes).
+    public func refresh() async {
+        await repository.refresh()
+    }
+
+    /// "Confirm…" on an UNCONFIRMED source (the seeded default before
+    /// its TOFU confirmation): reuse the add-provider path against the
+    /// source's own manifest URL — fetch + verify, show the operator
+    /// key fingerprint, and only pin on explicit confirm
+    /// (`confirmAddSource` replaces the unpinned source in place).
+    public func tappedConfirmSource(providerId: String) {
+        guard let status = state.sources.first(where: { $0.id == providerId }) else { return }
+        addDraft = status.source.manifestURL.absoluteString
+        tappedFetchProvider()
+    }
+
+    /// "Fetch" in the add-provider sheet: validate the typed URL, fetch
+    /// + verify the manifest, and move to the TOFU confirmation step.
+    public func tappedFetchProvider() {
+        let trimmed = addDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = Self.validate(trimmed) else {
+            addError = String(localized: "Enter a valid https:// URL")
+            return
+        }
+        addError = nil
+        addPhase = .fetching
+        addGeneration += 1
+        let generation = addGeneration
+        addTask?.cancel()
+        addTask = Task { [weak self] in
+            do {
+                let preview = try await self?.repository.addSource(manifestURL: url)
+                guard let self, self.addGeneration == generation, let preview else { return }
+                self.addPhase = .confirming(preview)
+            } catch {
+                guard let self, self.addGeneration == generation else { return }
+                self.addError = DiscoveryUserMessage.message(for: error)
+                self.addPhase = .idle
+            }
+        }
+    }
+
+    /// TOFU confirm: pin the previewed operator key, persist the
+    /// source, and run a TARGETED refresh so its catalogs land in the
+    /// aggregate. `refreshSource` (not `refresh()`) on purpose: a full
+    /// pass already in flight captured its source list before this add
+    /// and a coalescing `refresh()` would silently skip the new source.
+    ///
+    /// The sheet-phase mutation is guarded by `addGeneration` (same as
+    /// the fetch path): dismissing the sheet mid-confirm must not set
+    /// `.added` on a flow the user already walked away from. The pin
+    /// itself still completes — the user explicitly confirmed it.
+    public func tappedConfirmAdd() {
+        guard case .confirming(let preview) = addPhase, !isConfirmInFlight else { return }
+        isConfirmInFlight = true
+        let generation = addGeneration
+        confirmTask = Task { [weak self] in
+            guard let self else { return }
+            // The double-tap guard lasts exactly as long as the
+            // pipeline: cleared on completion so a later Confirm (new
+            // preview after Back → fresh fetch) is live again.
+            defer { self.isConfirmInFlight = false }
+            let source = await self.repository.confirmAddSource(preview)
+            if self.addGeneration == generation {
+                self.addPhase = .added
+            }
+            await self.repository.refreshSource(providerId: source.providerId)
+        }
+    }
+
+    /// Back out of the TOFU confirmation without pinning anything.
+    public func tappedCancelPreview() {
+        if case .confirming = addPhase {
+            // Backing out supersedes this preview the same way a
+            // sheet dismissal does: bump the generation so an
+            // in-flight confirm's completion can never surface
+            // `.added` over whatever the user does next (a fresh
+            // URL's fetch → confirm cycle included). The pin itself
+            // still completes if a confirm was already accepted.
+            addGeneration += 1
+            addPhase = .idle
+        }
+    }
+
+    /// Reset the add-provider sub-flow (sheet dismissed). Invalidates
+    /// any in-flight fetch: the task is cancelled AND the generation
+    /// bump guarantees its completion can't set `addPhase` afterwards,
+    /// so a dismissed sheet never resurrects as `.confirming`.
+    public func resetAdd() {
+        addGeneration += 1
+        addTask?.cancel()
+        addTask = nil
+        addDraft = ""
+        addPhase = .idle
+        addError = nil
+        isConfirmInFlight = false
+    }
+
+    /// Discovery manifests are https-only (profile URI rules) — this
+    /// is stricter than the relayer picker's http allowance on purpose.
+    public static func validate(_ raw: String) -> URL? {
+        guard let url = URL(string: raw),
+              url.scheme?.lowercased() == "https",
+              let host = url.host(), !host.isEmpty
+        else { return nil }
+        return url
+    }
+}

--- a/Packages/OnymDiscovery/Sources/OnymDiscovery/ModuleConsentAcceptance.swift
+++ b/Packages/OnymDiscovery/Sources/OnymDiscovery/ModuleConsentAcceptance.swift
@@ -1,0 +1,90 @@
+import Foundation
+import OnymFoundation
+
+/// Why a generic module consent could not be recorded.
+public enum ModuleConsentError: Error, Equatable, Sendable {
+    /// The moderation seat's consent is a *signed mandate*
+    /// (OnymModeration's flow) — it must never be reduced to this
+    /// generic local pin.
+    case moderationSeatExcluded
+}
+
+/// Why a recorded consent could not be *applied* to the seat's legacy
+/// configuration. Thrown by the seat-specific apply closures so the
+/// flow can tell the user the truth: the consent pin exists, but the
+/// service was not added.
+public enum ModuleApplyError: Error, Equatable, Sendable {
+    /// The consented manifest lists no endpoint with the scheme the
+    /// seat requires (e.g. no https endpoint for a notary, no wss
+    /// endpoint for a message relay).
+    case noUsableEndpoint
+}
+
+/// The accept path of the generalized module consent flow, as a pure
+/// helper so its ordering is unit-testable without any UI: pin the
+/// reviewed manifest, then record the selection provenance that
+/// references it.
+public enum ModuleConsentAcceptance {
+    /// The one seat type this generic consent must refuse.
+    public static let excludedSeatType = "moderation"
+
+    /// Record consent to a reviewed manifest picked from a discovery
+    /// catalog.
+    ///
+    /// Ordering is deliberate: the consent pin is written **first**,
+    /// the `ModuleSelection` second — the selection references the
+    /// consented hash, so an interruption between the two leaves a
+    /// consent without a selection (harmless history) rather than a
+    /// selection whose consent was never pinned. Applying the derived
+    /// endpoint to the seat's legacy configuration is the caller's
+    /// final step, after both records exist.
+    @discardableResult
+    public static func accept(
+        reviewed: ReviewedServiceManifest,
+        source: SourceAttribution,
+        offerId: String?,
+        consentStore: any PinnedConsentStore,
+        selectionStore: any SeatSelectionStore,
+        acceptedAt: Date = Date()
+    ) throws -> (record: PinnedConsentRecord, selection: ModuleSelection) {
+        let manifest = reviewed.signedManifest
+        guard manifest.seat != excludedSeatType else {
+            throw ModuleConsentError.moderationSeatExcluded
+        }
+        let record = try consentStore.accept(
+            reviewed,
+            sourceLabel: source.sourceLabel,
+            offerId: offerId,
+            acceptedAt: acceptedAt
+        )
+        let selection = ModuleSelection(
+            seatType: manifest.seat,
+            componentId: manifest.componentId,
+            providerId: source.providerId,
+            manifestHash: manifest.manifestHash,
+            offerId: offerId,
+            selectedAt: acceptedAt
+        )
+        selectionStore.record(selection)
+        return (record, selection)
+    }
+
+    /// The endpoint a seat's apply step writes into its legacy
+    /// configuration: the first of `endpointURIs` (published order)
+    /// whose URL scheme matches `scheme`, case-insensitively.
+    ///
+    /// Throws `ModuleApplyError.noUsableEndpoint` instead of returning
+    /// nil so a manifest without a usable endpoint surfaces as an
+    /// error the consent flow must show — never as a silent no-op
+    /// behind a "Service added" screen.
+    public static func requiredEndpointURL(
+        in endpointURIs: [String],
+        scheme: String
+    ) throws -> URL {
+        guard let url = endpointURIs
+            .compactMap(URL.init(string:))
+            .first(where: { $0.scheme?.lowercased() == scheme.lowercased() })
+        else { throw ModuleApplyError.noUsableEndpoint }
+        return url
+    }
+}

--- a/Packages/OnymDiscovery/Sources/OnymDiscovery/ModuleConsentFlow.swift
+++ b/Packages/OnymDiscovery/Sources/OnymDiscovery/ModuleConsentFlow.swift
@@ -1,0 +1,405 @@
+import Foundation
+import Observation
+import OnymFoundation
+
+/// Everything a per-seat picker needs to render its "From catalog"
+/// section, bundled so the app's composition root can hand one value
+/// to each settings flow. Optional everywhere it's consumed — when the
+/// app runs without discovery (UI-test harness), the pickers render
+/// exactly as before.
+@MainActor
+public struct DiscoveryModulePicker {
+    /// Verified catalog entries for this picker's seat type (the app
+    /// pre-binds the seat).
+    public let entries: () async -> [AttributedCatalogEntry]
+    /// The active pinned consent for a componentId, if any — drives
+    /// the consent-state text on catalog rows.
+    public let activeConsent: (_ componentId: String) -> PinnedConsentRecord?
+    /// Build the consent flow for one entry. The app pre-binds the
+    /// seat-specific `apply` closure that writes the endpoint into the
+    /// legacy configuration.
+    public let makeConsentFlow: @MainActor (AttributedCatalogEntry) -> ModuleConsentFlow
+    /// Live stream of this seat's catalog entries: yields the current
+    /// aggregate immediately, then again after every discovery refresh
+    /// — so the picker's "From catalog" section populates when the
+    /// boot-time refresh lands while the screen is already open. The
+    /// default wraps `entries` as a one-shot stream (test seams that
+    /// never refresh).
+    public let entriesStream: @MainActor () -> AsyncStream<[AttributedCatalogEntry]>
+
+    public init(
+        entries: @escaping () async -> [AttributedCatalogEntry],
+        activeConsent: @escaping (_ componentId: String) -> PinnedConsentRecord?,
+        entriesStream: (@MainActor () -> AsyncStream<[AttributedCatalogEntry]>)? = nil,
+        makeConsentFlow: @escaping @MainActor (AttributedCatalogEntry) -> ModuleConsentFlow
+    ) {
+        self.entries = entries
+        self.activeConsent = activeConsent
+        self.makeConsentFlow = makeConsentFlow
+        self.entriesStream = entriesStream ?? {
+            AsyncStream { continuation in
+                let task = Task { @MainActor in
+                    continuation.yield(await entries())
+                    continuation.finish()
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+        }
+    }
+}
+
+/// Generalized consent flow for non-moderation seats (transport,
+/// notary, blob storage): fetch the catalog entry's manifest, verify
+/// it against the catalog-pinned digest, put the exact reviewed terms
+/// on screen, and on accept pin the consent + record the selection +
+/// apply the endpoint to the seat's legacy configuration.
+///
+/// Modeled on `ModerationConsentFlow` minus the picker and the signing
+/// step — consent here is a local pin, not a signed mandate. The
+/// moderation seat must never route through this flow
+/// (`ModuleConsentAcceptance.excludedSeatType`); moderation entries go
+/// to the existing mandate flow.
+///
+/// Lives in OnymDiscovery (not OnymSettings, which renders it) so its
+/// state machine is unit-testable — OnymSettings has no test target.
+@MainActor
+@Observable
+public final class ModuleConsentFlow {
+    public enum Step: Equatable {
+        case loading
+        /// Reviewing the fetched, digest-pinned manifest — the consent
+        /// surface itself.
+        case reviewing
+        case applying
+        case done
+        /// Terminal: the entry can never be consented through this
+        /// surface — either no fetch could happen (moderation seat, no
+        /// fetchable manifest URL), the fetched manifest failed an
+        /// entry cross-check (operator key / seat / componentId), or
+        /// the consent store is corrupt (every accept is refused until
+        /// the history is explicitly cleared elsewhere). The
+        /// fetch is digest-pinned to the catalog entry, so a refetch
+        /// can only return the same bytes and repeat the mismatch — no
+        /// retry can change the outcome, and the view renders the
+        /// error WITHOUT a Retry button. Distinct from `.loading` +
+        /// `errorMessage`, which is a failed fetch that retrying may
+        /// well fix.
+        case failed
+    }
+
+    public let entry: AttributedCatalogEntry
+
+    public private(set) var step: Step = .loading
+    /// The exact manifest on the consent surface. Being a
+    /// `ReviewedServiceManifest`, it can only have come from the
+    /// reviewer's verified path — what's shown is what gets pinned.
+    public private(set) var reviewed: ReviewedServiceManifest?
+    public private(set) var errorMessage: String?
+    /// Offers the entitlement layer currently grants (free tier today).
+    public private(set) var entitledOfferIds: Set<String> = []
+    /// The offer the accept will record, when the manifest carries any.
+    public var selectedOfferId: String?
+
+    private let fetchManifestBytes: @Sendable (URL) async throws -> Data
+    private let consentStore: any PinnedConsentStore
+    private let selectionStore: any SeatSelectionStore
+    /// Entitlement provider for the manifest under review. A factory,
+    /// not an instance, because the right provider depends on the
+    /// manifest being reviewed: a consent-store-backed provider alone
+    /// is circular on first consent (no record exists yet, so every
+    /// offer — free ones included — would gate as not-entitled exactly
+    /// when this surface needs an answer). The composition root passes
+    /// `FreeTierEntitlementProvider(reviewing:consentStore:)`.
+    private let makeEntitlements: @Sendable (SignedServiceManifest) -> any EntitlementProviding
+    /// Seat-specific: write the consented manifest's endpoint into the
+    /// seat's legacy configuration (the operational source of truth).
+    /// Throwing — a manifest without a usable endpoint must surface as
+    /// an error, never as a silent no-op behind "Service added".
+    private let apply: (SignedServiceManifest) async throws -> Void
+    /// Called after a successful accept so the presenter can dismiss
+    /// and refresh its consent badges.
+    private let onAccepted: @MainActor () -> Void
+    /// Internal so tests can await completion.
+    @ObservationIgnored private(set) var loadTask: Task<Void, Never>?
+    /// The in-flight accept, internal so tests can await completion.
+    @ObservationIgnored private(set) var acceptTask: Task<Void, Never>?
+
+    public init(
+        entry: AttributedCatalogEntry,
+        fetchManifestBytes: @escaping @Sendable (URL) async throws -> Data,
+        consentStore: any PinnedConsentStore,
+        selectionStore: any SeatSelectionStore,
+        makeEntitlements: @escaping @Sendable (SignedServiceManifest) -> any EntitlementProviding,
+        apply: @escaping (SignedServiceManifest) async throws -> Void,
+        onAccepted: @escaping @MainActor () -> Void = {}
+    ) {
+        self.entry = entry
+        self.fetchManifestBytes = fetchManifestBytes
+        self.consentStore = consentStore
+        self.selectionStore = selectionStore
+        self.makeEntitlements = makeEntitlements
+        self.apply = apply
+        self.onAccepted = onAccepted
+    }
+
+    // MARK: - Read helpers
+
+    /// Display name: the manifest's `name` when published, else the
+    /// component id minus its `onym:component:` prefix.
+    public var displayName: String {
+        if let reviewed,
+           let object = try? JSONSerialization.jsonObject(with: reviewed.signedManifest.rawBytes) as? [String: Any],
+           let name = object["name"] as? String, !name.isEmpty {
+            return name
+        }
+        return Self.shortComponentId(entry.entry.componentId)
+    }
+
+    /// `terms` / `termsUri` https URL out of the manifest's raw bytes,
+    /// when the operator linked terms.
+    public var termsURL: URL? {
+        guard let reviewed,
+              let object = try? JSONSerialization.jsonObject(with: reviewed.signedManifest.rawBytes) as? [String: Any]
+        else { return nil }
+        for key in ["termsUri", "terms"] {
+            if let value = object[key] as? String,
+               let url = URL(string: value),
+               url.scheme?.lowercased() == "https" {
+                return url
+            }
+        }
+        return nil
+    }
+
+    /// Grouped fingerprint of the operator key the manifest is signed
+    /// by — same format as the provider TOFU screen.
+    public var operatorKeyFingerprint: String? {
+        reviewed.map { DiscoverySource.fingerprint(ofKeyHex: $0.signedManifest.operatorPublicKeyHex) }
+    }
+
+    public static func shortComponentId(_ componentId: String) -> String {
+        let prefix = "onym:component:"
+        return componentId.hasPrefix(prefix)
+            ? String(componentId.dropFirst(prefix.count))
+            : componentId
+    }
+
+    /// Whether Accept may be tapped. A manifest without offers is
+    /// acceptable as-is; a manifest WITH offers requires a selected,
+    /// entitled offer — otherwise accepting would adopt a service under
+    /// commercial terms the user never (or could never) pick, e.g. a
+    /// paid-only manifest pre-StoreKit.
+    public var canAccept: Bool {
+        guard let reviewed else { return false }
+        let offers = reviewed.signedManifest.offers
+        if offers.isEmpty { return true }
+        guard let selectedOfferId else { return false }
+        return entitledOfferIds.contains(selectedOfferId)
+    }
+
+    // MARK: - Lifecycle
+
+    /// Fetch + review the entry's manifest. Idempotent while loading;
+    /// `tappedRetry` re-arms after a failure.
+    public func start() {
+        guard loadTask == nil, reviewed == nil else { return }
+        loadTask = Task { [weak self] in
+            await self?.load()
+            self?.loadTask = nil
+        }
+    }
+
+    public func tappedRetry() {
+        // `.failed` is terminal — nothing about the entry changes on a
+        // refetch, so there is no retry to arm.
+        guard step != .failed else { return }
+        errorMessage = nil
+        step = .loading
+        start()
+    }
+
+    private func load() async {
+        // Defense in depth: the pickers only pass transport / notary /
+        // blob entries, but a moderation entry must never reach this
+        // surface — its consent is a signed mandate. Terminal: no
+        // retry can make this entry acceptable here.
+        guard entry.entry.seatType != ModuleConsentAcceptance.excludedSeatType else {
+            errorMessage = String(localized: "Moderation authorities are consented through the moderation flow.")
+            step = .failed
+            return
+        }
+        // Equally terminal: the entry carries no fetchable manifest
+        // URL, so a retry has nothing to fetch.
+        guard let url = entry.entry.manifest.url else {
+            errorMessage = String(localized: "This entry has no fetchable manifest URL.")
+            step = .failed
+            return
+        }
+        do {
+            let bytes = try await fetchManifestBytes(url)
+            // Hard-enforced review: digest pin from the verified
+            // catalog entry, embedded operator signature over the
+            // exact bytes, expiry.
+            let token = try ServiceManifestReviewer().review(
+                raw: bytes,
+                expectedDigest: entry.entry.manifest.digest
+            )
+            // The catalog is the verified side of this trust chain:
+            // a fetched manifest naming a different operator key than
+            // the entry is rejected, digest pin notwithstanding.
+            // Terminal (`.failed`, no Retry): the fetch is pinned to
+            // the entry's digest, so a refetch can only return the
+            // same bytes and repeat the mismatch — same
+            // no-retry-that-can't-succeed rule as the guards above.
+            guard token.signedManifest.operatorKey == entry.entry.operatorKey else {
+                errorMessage = String(localized: "The service's manifest names a different operator key than the catalog entry. Not safe to accept.")
+                step = .failed
+                return
+            }
+            guard token.signedManifest.seat == entry.entry.seatType else {
+                errorMessage = String(localized: "The service's manifest declares a different seat than the catalog entry. Not safe to accept.")
+                step = .failed
+                return
+            }
+            // Same hard rule for the component identity: a manifest
+            // naming a different componentId than the entry would
+            // record consent under one id while the catalog rows look
+            // it up by the other — the row would stay "REVIEW" forever
+            // and every accept would append another consent record.
+            guard token.signedManifest.componentId == entry.entry.componentId else {
+                errorMessage = String(localized: "The service's manifest names a different component than the catalog entry. Not safe to accept.")
+                step = .failed
+                return
+            }
+            reviewed = token
+            // A reload after a failure must not carry a stale
+            // selection into the fresh entitlement computation: the
+            // preselect-first-entitled logic only runs on nil, and a
+            // leftover id could name an offer this manifest no longer
+            // carries (or no longer entitles).
+            selectedOfferId = nil
+            await computeEntitlements(for: token.signedManifest)
+            step = .reviewing
+        } catch {
+            errorMessage = Self.message(for: error)
+        }
+    }
+
+    private func computeEntitlements(for manifest: SignedServiceManifest) async {
+        // Resolved against the manifest CURRENTLY under review — see
+        // `makeEntitlements`. On first consent there is no pinned
+        // record, and on re-review the record may describe an older
+        // manifest; the reviewed offers are the authority either way.
+        let entitlements = makeEntitlements(manifest)
+        var entitled = Set<String>()
+        for offer in manifest.offers {
+            if await entitlements.entitlement(for: offer.offerId, component: manifest.componentId) != nil {
+                entitled.insert(offer.offerId)
+            }
+        }
+        entitledOfferIds = entitled
+        // Preselect the first offer the user could actually take.
+        if selectedOfferId == nil {
+            selectedOfferId = manifest.offers.first { entitled.contains($0.offerId) }?.offerId
+        }
+    }
+
+    // MARK: - Accept
+
+    /// "Accept" on the consent surface. Pins the exact reviewed bytes,
+    /// records the selection provenance, then applies the endpoint to
+    /// the seat's legacy configuration.
+    public func tappedAccept() {
+        guard let reviewed, step == .reviewing, canAccept else { return }
+        step = .applying
+        errorMessage = nil
+        acceptTask = Task {
+            // Retry-after-apply-failure guard: when the ACTIVE consent
+            // already pins these exact bytes AND the same offer (a
+            // previous accept succeeded and only `apply` failed, e.g.
+            // `noUsableEndpoint`), retry ONLY the apply — re-running
+            // accept would append a fresh consent record + selection
+            // per tap for the same manifest. The offerId is part of
+            // the check on purpose: a retry after the user changed
+            // `selectedOfferId` must take the FULL accept path (the
+            // store's accept deactivates-and-appends, superseding the
+            // record), or the pinned record and `ModuleSelection`
+            // would keep the ORIGINAL offer while the screen shows
+            // the new selection.
+            let manifest = reviewed.signedManifest
+            // `try?` is fail-closed here: a store that throws (corrupt
+            // records) reads as "not already pinned", so the accept
+            // below runs and surfaces the store's refusal honestly
+            // instead of skipping straight to apply.
+            let activeRecord = try? consentStore
+                .activeRecord(componentId: manifest.componentId)
+            let alreadyPinned = activeRecord?.manifestHash == manifest.manifestHash
+                && activeRecord?.offerId == selectedOfferId
+            if !alreadyPinned {
+                do {
+                    try ModuleConsentAcceptance.accept(
+                        reviewed: reviewed,
+                        source: entry.source,
+                        offerId: selectedOfferId,
+                        consentStore: consentStore,
+                        selectionStore: selectionStore
+                    )
+                } catch ModuleConsentError.moderationSeatExcluded {
+                    // Not transient — retrying can never succeed. The
+                    // pickers shouldn't let a moderation entry reach
+                    // this surface, but if one does, say what's wrong
+                    // instead of "Try again".
+                    step = .reviewing
+                    errorMessage = String(localized: "This is a moderation authority — its consent is a signed mandate, so it can't be added here. Use the moderation settings instead.")
+                    return
+                } catch PinnedConsentStoreError.corruptStore {
+                    // Not transient either — the store refuses every
+                    // accept until the corrupt history is explicitly
+                    // cleared, so nothing this surface can do makes
+                    // another attempt succeed. TERMINAL `.failed`
+                    // (rendered without any retry affordance), same
+                    // no-retry-that-can't-succeed rule as the entry
+                    // cross-check failures.
+                    step = .failed
+                    errorMessage = String(localized: "Your consent history couldn't be read, so this consent can't be recorded. Nothing was changed.")
+                    return
+                } catch {
+                    step = .reviewing
+                    errorMessage = String(localized: "Couldn't record consent. Try again.")
+                    return
+                }
+            }
+            do {
+                try await apply(reviewed.signedManifest)
+                step = .done
+                onAccepted()
+            } catch ModuleApplyError.noUsableEndpoint {
+                // The consent IS pinned (accept succeeded); only the
+                // configuration write failed. Be honest about both
+                // halves rather than showing "Service added".
+                step = .reviewing
+                errorMessage = String(localized: "The service was reviewed and your consent was recorded, but it wasn't added: its manifest lists no endpoint this seat can use.")
+            } catch {
+                step = .reviewing
+                errorMessage = String(localized: "The service was reviewed and your consent was recorded, but it couldn't be added to your configuration.")
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private static func message(for error: Error) -> String {
+        switch error {
+        case ServiceManifestError.digestMismatch:
+            return String(localized: "The fetched manifest doesn't match the bytes the catalog reviewed. Not safe to accept.")
+        case let ServiceManifestError.signatureInvalid(reason):
+            return String(localized: "The manifest's signature failed verification (\(reason)).")
+        case let ServiceManifestError.manifestInvalid(reason):
+            return String(localized: "The manifest is malformed (\(reason)).")
+        case ServiceManifestError.expired:
+            return String(localized: "The manifest has expired. The operator needs to publish a fresh one.")
+        default:
+            return String(localized: "Couldn't load the service's manifest. Try again.")
+        }
+    }
+}

--- a/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/DiscoverySettingsFlowTests.swift
+++ b/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/DiscoverySettingsFlowTests.swift
@@ -1,0 +1,329 @@
+import Foundation
+import XCTest
+@testable import OnymDiscovery
+
+/// The add-provider sub-flow of `DiscoverySettingsFlow` — specifically
+/// that dismissing the sheet (`resetAdd`) invalidates an in-flight
+/// fetch, so its later completion can never resurrect the phase the
+/// user already walked away from.
+final class DiscoverySettingsFlowTests: XCTestCase {
+    private let manifestURL = URL(string: "https://discovery.onym.app/manifest.json")!
+
+    /// Suspends manifest fetches until the gate opens — holds the
+    /// add-provider fetch mid-flight deterministically.
+    private actor FetchGate {
+        private var isOpen = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func open() {
+            isOpen = true
+            for waiter in waiters { waiter.resume() }
+            waiters = []
+        }
+
+        func wait() async {
+            guard !isOpen else { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+    }
+
+    private final class GatedFetcher: DiscoveryFetching, @unchecked Sendable {
+        let gate = FetchGate()
+        private let responses: [URL: Data]
+        private let lock = NSLock()
+        private var _manifestFetchCount = 0
+
+        var manifestFetchCount: Int {
+            lock.withLock { _manifestFetchCount }
+        }
+
+        init(responses: [URL: Data]) {
+            self.responses = responses
+        }
+
+        func fetchProviderManifest(url: URL) async throws -> Data {
+            lock.withLock { _manifestFetchCount += 1 }
+            await gate.wait()
+            guard let data = responses[url] else { throw DiscoveryFetchError.badStatus(404) }
+            return data
+        }
+
+        func fetchSnapshot(url: URL) async throws -> Data {
+            guard let data = responses[url] else { throw DiscoveryFetchError.badStatus(404) }
+            return data
+        }
+    }
+
+    /// In-memory store; no UserDefaults so tests stay hermetic.
+    private final class MemoryStore: DiscoveryStore, @unchecked Sendable {
+        private let lock = NSLock()
+        private var configuration: DiscoverySourcesConfiguration = .empty
+        private var snapshots: [String: Data] = [:]
+
+        func loadConfiguration() -> DiscoverySourcesConfiguration {
+            lock.withLock { configuration }
+        }
+        func saveConfiguration(_ configuration: DiscoverySourcesConfiguration) {
+            lock.withLock { self.configuration = configuration }
+        }
+        func loadRetainedSnapshot(providerId: String, catalogId: String) -> Data? {
+            lock.withLock { snapshots[providerId + "|" + catalogId] }
+        }
+        func saveRetainedSnapshot(_ raw: Data, providerId: String, catalogId: String) {
+            lock.withLock { snapshots[providerId + "|" + catalogId] = raw }
+        }
+        func removeRetainedSnapshots(providerId: String) {
+            lock.withLock {
+                snapshots = snapshots.filter { !$0.key.hasPrefix(providerId + "|") }
+            }
+        }
+    }
+
+    private let snapshotURL = URL(string: "https://discovery.onym.app/catalogs/public-all-seats.json")!
+
+    @MainActor
+    private func makeFlow() throws -> (DiscoverySettingsFlow, GatedFetcher, MemoryStore) {
+        let fetcher = GatedFetcher(responses: [
+            manifestURL: try Fixture.bytes("provider-manifest.json"),
+            snapshotURL: try Fixture.bytes("snapshot-1.json"),
+        ])
+        let store = MemoryStore()
+        let repository = DiscoveryRepository(fetcher: fetcher, store: store) { Fixture.now }
+        return (DiscoverySettingsFlow(repository: repository), fetcher, store)
+    }
+
+    /// Wait until the flow's fetch task has actually reached the
+    /// fetcher (bounded, so a regression fails rather than hangs).
+    private func waitForFetchStart(_ fetcher: GatedFetcher) async throws {
+        for _ in 0..<1_000 {
+            if fetcher.manifestFetchCount > 0 { return }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("add-provider fetch never started")
+    }
+
+    /// Control case: with no reset, the held fetch completes into
+    /// `.confirming` — proves the gate harness exercises the real path.
+    @MainActor
+    func testFetchCompletesIntoConfirming() async throws {
+        let (flow, fetcher, _) = try makeFlow()
+        flow.addDraft = manifestURL.absoluteString
+        flow.tappedFetchProvider()
+        guard case .fetching = flow.addPhase else {
+            return XCTFail("expected .fetching, got \(flow.addPhase)")
+        }
+        try await waitForFetchStart(fetcher)
+
+        await fetcher.gate.open()
+        await flow.addTask?.value
+
+        guard case .confirming(let preview) = flow.addPhase else {
+            return XCTFail("expected .confirming, got \(flow.addPhase)")
+        }
+        XCTAssertEqual(preview.providerId, "onym:component:onym-discovery")
+    }
+
+    /// The reviewed regression: dismissing the sheet while the fetch
+    /// is in flight must invalidate it — the stale completion must not
+    /// flip a reset flow back to `.confirming` (or clobber the state
+    /// of a NEW fetch started afterwards).
+    @MainActor
+    func testResetDuringFetchDoesNotResurrectConfirming() async throws {
+        let (flow, fetcher, _) = try makeFlow()
+        flow.addDraft = manifestURL.absoluteString
+        flow.tappedFetchProvider()
+        try await waitForFetchStart(fetcher)
+        let inFlight = try XCTUnwrap(flow.addTask)
+
+        flow.resetAdd()
+        guard case .idle = flow.addPhase else {
+            return XCTFail("reset must return the sheet to .idle")
+        }
+        XCTAssertNil(flow.addTask, "reset must drop (and cancel) the in-flight fetch")
+
+        // Let the superseded fetch run to completion.
+        await fetcher.gate.open()
+        await inFlight.value
+
+        guard case .idle = flow.addPhase else {
+            return XCTFail("stale completion resurrected \(flow.addPhase) after reset")
+        }
+        XCTAssertNil(flow.addError)
+        XCTAssertEqual(flow.addDraft, "")
+    }
+
+    /// Drive the flow to the `.confirming` TOFU step (gate opened).
+    @MainActor
+    private func reachConfirming(_ flow: DiscoverySettingsFlow, _ fetcher: GatedFetcher) async throws {
+        flow.addDraft = manifestURL.absoluteString
+        flow.tappedFetchProvider()
+        try await waitForFetchStart(fetcher)
+        await fetcher.gate.open()
+        await flow.addTask?.value
+        guard case .confirming = flow.addPhase else {
+            XCTFail("expected .confirming, got \(flow.addPhase)")
+            throw CancellationError()
+        }
+    }
+
+    /// Control case for the confirm path: an undisturbed confirm pins
+    /// the source, reaches `.added`, and the targeted refresh lands
+    /// the source's catalog entries in the aggregate.
+    @MainActor
+    func testConfirmCompletesIntoAddedAndFetchesTheSource() async throws {
+        let (flow, fetcher, store) = try makeFlow()
+        flow.start()
+        try await reachConfirming(flow, fetcher)
+
+        flow.tappedConfirmAdd()
+        await flow.confirmTask?.value
+
+        guard case .added = flow.addPhase else {
+            return XCTFail("expected .added, got \(flow.addPhase)")
+        }
+        XCTAssertEqual(store.loadConfiguration().sources.count, 1)
+        XCTAssertNotNil(store.loadConfiguration().sources.first?.pinnedOperatorKeyHex)
+        XCTAssertNotNil(
+            store.loadRetainedSnapshot(
+                providerId: "onym:component:onym-discovery",
+                catalogId: "public-all-seats"
+            ),
+            "the confirm's targeted refresh must fetch the source's catalogs"
+        )
+    }
+
+    /// Double-tapping Confirm while the first confirm is still in
+    /// flight must be a no-op: the phase stays `.confirming` until the
+    /// task finishes, so without the in-flight guard the second tap
+    /// would run the whole pin + targeted-refresh pipeline again.
+    ///
+    /// Deterministic (no sleep): both taps happen synchronously on the
+    /// main actor before either confirm task can run, and BOTH task
+    /// handles observed across the taps are awaited — if a buggy
+    /// second tap spawned its own pipeline, `confirmTask` would be a
+    /// different task, awaiting it would run that pipeline to
+    /// completion, and the fetch count would deterministically read 3.
+    @MainActor
+    func testDoubleTapConfirmRunsThePipelineOnce() async throws {
+        let (flow, fetcher, store) = try makeFlow()
+        try await reachConfirming(flow, fetcher)
+        XCTAssertEqual(fetcher.manifestFetchCount, 1, "the preview fetch")
+
+        flow.tappedConfirmAdd()
+        let firstConfirm = flow.confirmTask
+        flow.tappedConfirmAdd() // double tap before the first task runs
+        let taskAfterSecondTap = flow.confirmTask
+
+        await firstConfirm?.value
+        await taskAfterSecondTap?.value
+
+        guard case .added = flow.addPhase else {
+            return XCTFail("expected .added, got \(flow.addPhase)")
+        }
+        XCTAssertEqual(
+            fetcher.manifestFetchCount, 2,
+            "one preview fetch + ONE targeted refresh — a double tap must not run a second confirm"
+        )
+        XCTAssertEqual(store.loadConfiguration().sources.count, 1)
+    }
+
+    /// The round-4 continuation-leak regression: `stop()` (wired to
+    /// the view's `onDisappear`) must cancel the snapshot drain, and
+    /// the cancellation must remove the drain's continuation from the
+    /// repository — otherwise every settings-screen visit would leave
+    /// one behind (the stream never finishes on its own) and pin the
+    /// flow forever.
+    @MainActor
+    func testStopRemovesTheSnapshotContinuationFromTheRepository() async throws {
+        let fetcher = GatedFetcher(responses: [:])
+        let repository = DiscoveryRepository(fetcher: fetcher, store: MemoryStore()) { Fixture.now }
+        let flow = DiscoverySettingsFlow(repository: repository)
+
+        flow.start()
+        try await waitFor("the drain to subscribe") {
+            await repository.subscriberCount == 1
+        }
+
+        flow.stop()
+        try await waitFor("the cancelled drain's continuation to be removed") {
+            await repository.subscriberCount == 0
+        }
+    }
+
+    /// Bounded poll so a regression fails rather than hangs.
+    private func waitFor(
+        _ what: String,
+        _ condition: () async -> Bool
+    ) async throws {
+        for _ in 0..<1_000 {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("timed out waiting for \(what)")
+    }
+
+    /// The reviewed regression on the CONFIRM path: dismissing the
+    /// sheet mid-confirm must not set `.added` afterwards — reopening
+    /// Add would otherwise show a stale "Provider added" screen. The
+    /// pin itself still completes (the user explicitly confirmed it).
+    @MainActor
+    func testResetDuringConfirmDoesNotSetAdded() async throws {
+        let (flow, fetcher, store) = try makeFlow()
+        try await reachConfirming(flow, fetcher)
+
+        flow.tappedConfirmAdd()
+        // Dismiss the sheet before the confirm task runs.
+        flow.resetAdd()
+        await flow.confirmTask?.value
+
+        guard case .idle = flow.addPhase else {
+            return XCTFail("dismiss mid-confirm must not surface \(flow.addPhase)")
+        }
+        // The explicit confirmation is still honored durably.
+        XCTAssertEqual(store.loadConfiguration().sources.count, 1)
+        XCTAssertNotNil(store.loadConfiguration().sources.first?.pinnedOperatorKeyHex)
+    }
+
+    /// The fifth-review regression, exact sequence: Confirm → Back
+    /// (cancel preview) → type a URL → Fetch → Confirm. The in-flight
+    /// guard must clear when the first confirm task finishes (defer),
+    /// or the second Confirm is a permanent silent no-op; and Back
+    /// must bump the generation, so the superseded confirm's
+    /// completion never surfaces `.added` over the new cycle.
+    @MainActor
+    func testConfirmThenBackThenNewFetchCanConfirmAgain() async throws {
+        let (flow, fetcher, store) = try makeFlow()
+        try await reachConfirming(flow, fetcher)
+
+        flow.tappedConfirmAdd()
+        let firstConfirm = flow.confirmTask
+        // Back out of the preview before the confirm task runs.
+        flow.tappedCancelPreview()
+        guard case .idle = flow.addPhase else {
+            return XCTFail("Back must return the sheet to .idle, got \(flow.addPhase)")
+        }
+        await firstConfirm?.value
+        guard case .idle = flow.addPhase else {
+            return XCTFail("the superseded confirm resurrected \(flow.addPhase) after Back")
+        }
+        // The pin the user explicitly confirmed still completed.
+        XCTAssertEqual(store.loadConfiguration().sources.count, 1)
+
+        // A fresh URL → Fetch → Confirm cycle must be live, not a
+        // silent no-op left behind by the first confirm's guard.
+        flow.addDraft = manifestURL.absoluteString
+        flow.tappedFetchProvider()
+        await flow.addTask?.value
+        guard case .confirming = flow.addPhase else {
+            return XCTFail("expected .confirming for the new fetch, got \(flow.addPhase)")
+        }
+        flow.tappedConfirmAdd()
+        XCTAssertNotNil(flow.confirmTask, "the second Confirm must start a confirm task")
+        await flow.confirmTask?.value
+        guard case .added = flow.addPhase else {
+            return XCTFail("the second Confirm must complete into .added, got \(flow.addPhase)")
+        }
+        XCTAssertEqual(store.loadConfiguration().sources.count, 1,
+                       "re-confirming the same provider replaces the source in place")
+    }
+}

--- a/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/ModuleConsentAcceptanceTests.swift
+++ b/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/ModuleConsentAcceptanceTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+import CryptoKit
+import OnymFoundation
+@testable import OnymDiscovery
+
+/// The generalized consent accept path (`ModuleConsentAcceptance`):
+/// pins the reviewed manifest first, records the selection provenance
+/// second, and refuses the moderation seat outright.
+final class ModuleConsentAcceptanceTests: XCTestCase {
+    /// Shared mutable box behind the store fakes, with an event log so
+    /// the write *ordering* is observable.
+    final class StoreBox: @unchecked Sendable {
+        var records: [PinnedConsentRecord] = []
+        var selections: [ModuleSelection] = []
+        var events: [String] = []
+    }
+
+    struct FakePinnedConsentStore: PinnedConsentStore, @unchecked Sendable {
+        let box: StoreBox
+        func load() -> [PinnedConsentRecord] { box.records }
+        func save(_ records: [PinnedConsentRecord]) {
+            box.records = records
+            box.events.append("consent")
+        }
+    }
+
+    struct FakeSeatSelectionStore: SeatSelectionStore, @unchecked Sendable {
+        let box: StoreBox
+        func activeSelection(seatType: String) -> ModuleSelection? {
+            history(seatType: seatType).last
+        }
+        func history(seatType: String) -> [ModuleSelection] {
+            box.selections.filter { $0.seatType == seatType }
+        }
+        func record(_ selection: ModuleSelection) {
+            box.selections.append(selection)
+            box.events.append("selection")
+        }
+    }
+
+    private let attribution = SourceAttribution(
+        providerId: "onym:component:onym-discovery",
+        sourceLabel: "Onym Discovery",
+        catalogId: "main",
+        snapshotDigest: "sha256:" + String(repeating: "0", count: 64),
+        relationship: "common-owner",
+        placement: "organic"
+    )
+
+    /// Reviewed token minted from the byte-exact destination-manifest
+    /// fixture (seat "transport.message", one free offer).
+    private func reviewedFixture() throws -> ReviewedServiceManifest {
+        let raw = try Fixture.bytes("destination-manifest.json")
+        return try ServiceManifestReviewer().review(raw: raw, now: Fixture.now)
+    }
+
+    /// Reviewed token over a freshly self-signed manifest, for shapes
+    /// the byte-pinned fixture set doesn't carry (e.g. a paid offer).
+    private func selfSignedManifest(
+        seat: String,
+        offers: [[String: Any]] = []
+    ) throws -> ReviewedServiceManifest {
+        let key = Curve25519.Signing.PrivateKey()
+        let keyHex = key.publicKey.rawRepresentation
+            .map { String(format: "%02x", $0) }.joined()
+        var object: [String: Any] = [
+            "componentId": "onym:component:sample-service",
+            "seat": seat,
+            "operator": "onym:key:\(keyHex)",
+            "validUntil": "2027-01-01T00:00:00Z",
+        ]
+        if !offers.isEmpty { object["offers"] = offers }
+        let unsigned = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        let signature = try key.signature(
+            for: ServiceManifestCanonical.signingBytes(of: unsigned)
+        )
+        object["signature"] = signature.base64EncodedString()
+        let raw = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.withoutEscapingSlashes]
+        )
+        return try ServiceManifestReviewer().review(raw: raw, now: Fixture.now)
+    }
+
+    func testAcceptPinsConsentThenRecordsSelection() throws {
+        let box = StoreBox()
+        let reviewed = try reviewedFixture()
+        let acceptedAt = Fixture.now
+
+        let (record, selection) = try ModuleConsentAcceptance.accept(
+            reviewed: reviewed,
+            source: attribution,
+            offerId: "courier-free-v1",
+            consentStore: FakePinnedConsentStore(box: box),
+            selectionStore: FakeSeatSelectionStore(box: box),
+            acceptedAt: acceptedAt
+        )
+
+        // Ordering: the consent pin lands before the selection that
+        // references it.
+        XCTAssertEqual(box.events, ["consent", "selection"])
+
+        // The pin is active and byte-exact.
+        XCTAssertTrue(record.isActive)
+        XCTAssertEqual(record.componentId, "onym:component:onym-courier")
+        XCTAssertEqual(record.seatType, "transport.message")
+        XCTAssertEqual(record.manifestBytes, reviewed.signedManifest.rawBytes)
+        XCTAssertEqual(record.sourceLabel, "Onym Discovery")
+        XCTAssertEqual(record.offerId, "courier-free-v1")
+        XCTAssertEqual(box.records, [record])
+
+        // The selection provenance ties back to the same hash, the
+        // listing provider, and the accepted offer.
+        XCTAssertEqual(selection.manifestHash, record.manifestHash)
+        XCTAssertEqual(selection.seatType, "transport.message")
+        XCTAssertEqual(selection.componentId, "onym:component:onym-courier")
+        XCTAssertEqual(selection.providerId, "onym:component:onym-discovery")
+        XCTAssertEqual(selection.offerId, "courier-free-v1")
+        XCTAssertEqual(selection.selectedAt, acceptedAt)
+        XCTAssertEqual(box.selections, [selection])
+    }
+
+    /// The headline first-consent path: NO consent record exists for
+    /// the component, the manifest under review carries one free
+    /// offer. The review-scoped entitlement provider must grant it
+    /// (i.e. the radio is selectable), and accepting with it must land
+    /// the offerId in BOTH the pinned record and the selection.
+    func testFirstConsentFreeOnlyManifestOfferIsGrantedAndRecorded() async throws {
+        let box = StoreBox()
+        let consentStore = FakePinnedConsentStore(box: box)
+        let reviewed = try reviewedFixture()
+        let manifest = reviewed.signedManifest
+
+        // Before ANY consent exists — the moment the consent surface
+        // computes its entitlements.
+        XCTAssertNil(try consentStore.activeRecord(componentId: manifest.componentId))
+        let provider = FreeTierEntitlementProvider(reviewing: manifest, consentStore: consentStore)
+        let entitlement = await provider.entitlement(
+            for: "courier-free-v1",
+            component: manifest.componentId
+        )
+        XCTAssertNotNil(entitlement, "the free offer must be selectable on first consent")
+
+        let (record, selection) = try ModuleConsentAcceptance.accept(
+            reviewed: reviewed,
+            source: attribution,
+            offerId: entitlement?.offerId,
+            consentStore: consentStore,
+            selectionStore: FakeSeatSelectionStore(box: box),
+            acceptedAt: Fixture.now
+        )
+        XCTAssertEqual(record.offerId, "courier-free-v1")
+        XCTAssertEqual(selection.offerId, "courier-free-v1")
+    }
+
+    /// Same first-consent moment, manifest carrying a paid offer next
+    /// to the free one: the paid offer must stay unselectable.
+    func testFirstConsentPaidOfferStaysDisabled() async throws {
+        let manifest = try selfSignedManifest(
+            seat: "notary",
+            offers: [
+                ["offerId": "free-tier", "model": "free"],
+                ["offerId": "pro-monthly", "model": "subscription", "period": "monthly"],
+            ]
+        ).signedManifest
+
+        let provider = FreeTierEntitlementProvider(
+            reviewing: manifest,
+            consentStore: FakePinnedConsentStore(box: StoreBox())
+        )
+        let free = await provider.entitlement(for: "free-tier", component: manifest.componentId)
+        XCTAssertNotNil(free)
+        let paid = await provider.entitlement(for: "pro-monthly", component: manifest.componentId)
+        XCTAssertNil(paid, "paid offers must not be selectable pre-StoreKit")
+    }
+
+    // MARK: - Apply endpoint
+
+    func testRequiredEndpointURLPicksFirstMatchingSchemeCaseInsensitively() throws {
+        let url = try ModuleConsentAcceptance.requiredEndpointURL(
+            in: ["wss://relay.example", "HTTPS://second.example/a", "https://third.example"],
+            scheme: "https"
+        )
+        XCTAssertEqual(url.absoluteString, "HTTPS://second.example/a")
+    }
+
+    func testRequiredEndpointURLThrowsWhenNoEndpointMatches() {
+        // The no-endpoint manifest path: the apply step must throw —
+        // never silently no-op behind a "Service added" screen.
+        for uris in [[String](), ["https://relay.example"], ["not a uri"]] {
+            XCTAssertThrowsError(
+                try ModuleConsentAcceptance.requiredEndpointURL(in: uris, scheme: "wss")
+            ) { error in
+                XCTAssertEqual(error as? ModuleApplyError, .noUsableEndpoint)
+            }
+        }
+    }
+
+    func testAcceptWithoutOfferRecordsNilOffer() throws {
+        let box = StoreBox()
+        let (record, selection) = try ModuleConsentAcceptance.accept(
+            reviewed: try reviewedFixture(),
+            source: attribution,
+            offerId: nil,
+            consentStore: FakePinnedConsentStore(box: box),
+            selectionStore: FakeSeatSelectionStore(box: box),
+            acceptedAt: Fixture.now
+        )
+        XCTAssertNil(record.offerId)
+        XCTAssertNil(selection.offerId)
+    }
+
+    func testModerationSeatIsExcludedAndWritesNothing() throws {
+        // Self-signed manifest claiming the moderation seat — its
+        // consent is a signed mandate, never this generic pin.
+        let reviewed = try selfSignedManifest(seat: "moderation")
+
+        let box = StoreBox()
+        XCTAssertThrowsError(try ModuleConsentAcceptance.accept(
+            reviewed: reviewed,
+            source: attribution,
+            offerId: nil,
+            consentStore: FakePinnedConsentStore(box: box),
+            selectionStore: FakeSeatSelectionStore(box: box),
+            acceptedAt: Fixture.now
+        )) { error in
+            XCTAssertEqual(error as? ModuleConsentError, .moderationSeatExcluded)
+        }
+        XCTAssertTrue(box.records.isEmpty)
+        XCTAssertTrue(box.selections.isEmpty)
+        XCTAssertTrue(box.events.isEmpty)
+    }
+}

--- a/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/ModuleConsentFlowTests.swift
+++ b/Packages/OnymDiscovery/Tests/OnymDiscoveryTests/ModuleConsentFlowTests.swift
@@ -1,0 +1,454 @@
+import CryptoKit
+import Foundation
+import OnymFoundation
+import XCTest
+@testable import OnymDiscovery
+
+/// The `ModuleConsentFlow` state machine around review + accept: the
+/// entry↔manifest identity cross-checks, entitlement gating of the
+/// Accept button, and the retry-after-apply-failure guard that must
+/// never append a second consent record for the same bytes.
+final class ModuleConsentFlowTests: XCTestCase {
+    /// Shared mutable box behind the store fakes.
+    final class StoreBox: @unchecked Sendable {
+        var records: [PinnedConsentRecord] = []
+        var selections: [ModuleSelection] = []
+        var events: [String] = []
+    }
+
+    struct FakePinnedConsentStore: PinnedConsentStore, @unchecked Sendable {
+        let box: StoreBox
+        func load() -> [PinnedConsentRecord] { box.records }
+        func save(_ records: [PinnedConsentRecord]) {
+            box.records = records
+            box.events.append("consent")
+        }
+    }
+
+    struct FakeSeatSelectionStore: SeatSelectionStore, @unchecked Sendable {
+        let box: StoreBox
+        func activeSelection(seatType: String) -> ModuleSelection? {
+            history(seatType: seatType).last
+        }
+        func history(seatType: String) -> [ModuleSelection] {
+            box.selections.filter { $0.seatType == seatType }
+        }
+        func record(_ selection: ModuleSelection) {
+            box.selections.append(selection)
+            box.events.append("selection")
+        }
+    }
+
+    private let attribution = SourceAttribution(
+        providerId: "onym:component:onym-discovery",
+        sourceLabel: "Onym Discovery",
+        catalogId: "main",
+        snapshotDigest: "sha256:" + String(repeating: "0", count: 64),
+        relationship: "common-owner",
+        placement: "organic"
+    )
+
+    /// A verified catalog entry pointing at `raw`'s exact bytes.
+    private func catalogEntry(
+        componentId: String,
+        seatType: String,
+        raw: Data,
+        operatorKey: String
+    ) throws -> CatalogEntry {
+        let digest = DiscoveryFormat.sha256Digest(of: raw)
+        let json = """
+        {"componentId":"\(componentId)","seatType":"\(seatType)",\
+        "manifest":{"uri":"https://service.example.app/manifest.json","digest":"\(digest)"},\
+        "operator":"\(operatorKey)","listedAt":"2026-01-01T00:00:00Z",\
+        "relationship":"common-owner","placement":"organic"}
+        """
+        return try DiscoveryJSON.decoder().decode(CatalogEntry.self, from: Data(json.utf8))
+    }
+
+    /// Raw bytes of a freshly self-signed service manifest, for shapes
+    /// the byte-pinned fixture set doesn't carry (paid-only offers, no
+    /// offers).
+    private func selfSignedRaw(
+        seat: String,
+        offers: [[String: Any]] = []
+    ) throws -> Data {
+        let key = Curve25519.Signing.PrivateKey()
+        let keyHex = key.publicKey.rawRepresentation
+            .map { String(format: "%02x", $0) }.joined()
+        var object: [String: Any] = [
+            "componentId": "onym:component:sample-service",
+            "seat": seat,
+            "operator": "onym:key:\(keyHex)",
+            "validUntil": "2027-01-01T00:00:00Z",
+        ]
+        if !offers.isEmpty { object["offers"] = offers }
+        let unsigned = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        let signature = try key.signature(
+            for: ServiceManifestCanonical.signingBytes(of: unsigned)
+        )
+        object["signature"] = signature.base64EncodedString()
+        return try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.withoutEscapingSlashes]
+        )
+    }
+
+    /// Flow over `raw`, with the entry naming `entryComponentId` when
+    /// it should deliberately mismatch the manifest.
+    @MainActor
+    private func makeFlow(
+        raw: Data,
+        box: StoreBox,
+        entryComponentId: String? = nil,
+        entryOperatorKey: String? = nil,
+        fetchManifestBytes: (@Sendable (URL) async throws -> Data)? = nil,
+        apply: @escaping (SignedServiceManifest) async throws -> Void = { _ in }
+    ) throws -> ModuleConsentFlow {
+        let manifest = try SignedServiceManifest(raw: raw)
+        let consentStore = FakePinnedConsentStore(box: box)
+        let entry = try catalogEntry(
+            componentId: entryComponentId ?? manifest.componentId,
+            seatType: manifest.seat,
+            raw: raw,
+            operatorKey: entryOperatorKey ?? manifest.operatorKey
+        )
+        return ModuleConsentFlow(
+            entry: AttributedCatalogEntry(entry: entry, source: attribution),
+            fetchManifestBytes: fetchManifestBytes ?? { _ in raw },
+            consentStore: consentStore,
+            selectionStore: FakeSeatSelectionStore(box: box),
+            makeEntitlements: { manifest in
+                FreeTierEntitlementProvider(reviewing: manifest, consentStore: consentStore)
+            },
+            apply: apply
+        )
+    }
+
+    // MARK: - Entitlement gating (Accept)
+
+    /// Free-only manifest: the free offer is auto-selected and Accept
+    /// is enabled — first consent, no record in the store yet.
+    @MainActor
+    func testFreeOnlyManifestAutoSelectsItsFreeOfferAndEnablesAccept() async throws {
+        let flow = try makeFlow(raw: try Fixture.bytes("destination-manifest.json"), box: StoreBox())
+        flow.start()
+        await flow.loadTask?.value
+
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertEqual(flow.selectedOfferId, "courier-free-v1")
+        XCTAssertTrue(flow.canAccept)
+    }
+
+    /// Paid-only manifest: nothing is selectable pre-StoreKit, so
+    /// Accept must be disabled AND tapping it must write nothing —
+    /// never a consent with `offerId: nil` for a paid-only service.
+    @MainActor
+    func testPaidOnlyManifestDisablesAcceptAndTapWritesNothing() async throws {
+        let box = StoreBox()
+        let raw = try selfSignedRaw(seat: "notary", offers: [
+            ["offerId": "pro-monthly", "model": "subscription", "period": "monthly"],
+        ])
+        let flow = try makeFlow(raw: raw, box: box)
+        flow.start()
+        await flow.loadTask?.value
+
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertNil(flow.selectedOfferId)
+        XCTAssertFalse(flow.canAccept)
+
+        flow.tappedAccept()
+        XCTAssertNil(flow.acceptTask, "a gated Accept must not start an accept task")
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertTrue(box.records.isEmpty)
+        XCTAssertTrue(box.selections.isEmpty)
+    }
+
+    /// A manifest without offers carries no commercial terms to pick —
+    /// Accept stays available.
+    @MainActor
+    func testManifestWithoutOffersCanAccept() async throws {
+        let flow = try makeFlow(raw: try selfSignedRaw(seat: "notary"), box: StoreBox())
+        flow.start()
+        await flow.loadTask?.value
+
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertTrue(flow.canAccept)
+    }
+
+    // MARK: - Entry ↔ manifest identity
+
+    /// A fetched manifest naming a different componentId than the
+    /// catalog entry is a hard failure: consent would be recorded
+    /// under one id while the catalog rows look it up by the other —
+    /// the row would read "REVIEW" forever and every accept would
+    /// append another record. TERMINAL `.failed`, not a retryable
+    /// fetch error: the fetch is pinned to the entry's digest, so a
+    /// refetch can only return the same bytes and repeat the mismatch.
+    @MainActor
+    func testComponentIdMismatchIsTerminalFailed() async throws {
+        let flow = try makeFlow(
+            raw: try Fixture.bytes("destination-manifest.json"),
+            box: StoreBox(),
+            entryComponentId: "onym:component:other-service"
+        )
+        flow.start()
+        await flow.loadTask?.value
+
+        XCTAssertEqual(flow.step, .failed, "a mismatched manifest must never reach .reviewing")
+        XCTAssertNil(flow.reviewed)
+        let message = try XCTUnwrap(flow.errorMessage)
+        XCTAssertTrue(message.contains("different component"), message)
+        XCTAssertFalse(flow.canAccept)
+
+        flow.tappedRetry()
+        XCTAssertEqual(flow.step, .failed, "retry must not re-arm a digest-pinned mismatch")
+        XCTAssertNil(flow.loadTask, "retry must not start another load")
+    }
+
+    /// Same terminal shape for the operator-key cross-check: the entry
+    /// (the verified side) names one key, the digest-pinned manifest
+    /// another — no refetch changes either.
+    @MainActor
+    func testOperatorKeyMismatchIsTerminalFailed() async throws {
+        let otherKeyHex = (0..<32).map { _ in String(format: "%02x", UInt8.random(in: 0...255)) }.joined()
+        let flow = try makeFlow(
+            raw: try Fixture.bytes("destination-manifest.json"),
+            box: StoreBox(),
+            entryOperatorKey: "onym:key:\(otherKeyHex)"
+        )
+        flow.start()
+        await flow.loadTask?.value
+
+        XCTAssertEqual(flow.step, .failed)
+        XCTAssertNil(flow.reviewed)
+        let message = try XCTUnwrap(flow.errorMessage)
+        XCTAssertTrue(message.contains("operator key"), message)
+
+        flow.tappedRetry()
+        XCTAssertEqual(flow.step, .failed, "retry must not re-arm a digest-pinned mismatch")
+        XCTAssertNil(flow.loadTask)
+    }
+
+    // MARK: - Reload after fetch failure
+
+    /// A retry after a FETCH failure (genuinely retryable) reloads the
+    /// manifest and recomputes entitlements — any offer id left over
+    /// in `selectedOfferId` must be cleared first, or the
+    /// preselect-on-nil logic would keep a selection the reloaded
+    /// manifest doesn't entitle (or carry).
+    @MainActor
+    func testRetryAfterFetchFailureClearsStaleOfferSelection() async throws {
+        final class FailOnce: @unchecked Sendable {
+            private let lock = NSLock()
+            private var hasFailed = false
+            func shouldFail() -> Bool {
+                lock.withLock {
+                    if hasFailed { return false }
+                    hasFailed = true
+                    return true
+                }
+            }
+        }
+        let raw = try Fixture.bytes("destination-manifest.json")
+        let failOnce = FailOnce()
+        let flow = try makeFlow(
+            raw: raw,
+            box: StoreBox(),
+            fetchManifestBytes: { _ in
+                if failOnce.shouldFail() { throw URLError(.notConnectedToInternet) }
+                return raw
+            }
+        )
+        flow.start()
+        await flow.loadTask?.value
+        XCTAssertEqual(flow.step, .loading, "a fetch failure stays retryable")
+        XCTAssertNotNil(flow.errorMessage)
+
+        // Stale state from a previous render (e.g. a row the UI keyed
+        // to an offer id that this reload no longer resolves).
+        flow.selectedOfferId = "stale-offer"
+
+        flow.tappedRetry()
+        await flow.loadTask?.value
+
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertEqual(
+            flow.selectedOfferId, "courier-free-v1",
+            "the reload must recompute the selection, not keep the stale id"
+        )
+        XCTAssertTrue(flow.canAccept)
+    }
+
+    // MARK: - Terminal failures (no Retry that can't succeed)
+
+    /// A moderation entry can never be consented through this surface
+    /// — its consent is a signed mandate. The step must be the
+    /// TERMINAL `.failed` (rendered without a Retry button), and
+    /// `tappedRetry` must not re-arm it: no refetch changes the
+    /// entry's seat.
+    @MainActor
+    func testModerationEntryIsTerminalFailedWithoutRetry() async throws {
+        let flow = try makeFlow(raw: try selfSignedRaw(seat: "moderation"), box: StoreBox())
+        flow.start()
+        await flow.loadTask?.value
+
+        XCTAssertEqual(flow.step, .failed)
+        XCTAssertNil(flow.reviewed)
+        let message = try XCTUnwrap(flow.errorMessage)
+        XCTAssertTrue(message.lowercased().contains("moderation"), message)
+
+        flow.tappedRetry()
+        XCTAssertEqual(flow.step, .failed, "retry must not re-arm a terminal failure")
+        XCTAssertEqual(flow.errorMessage, message)
+        XCTAssertNil(flow.loadTask, "retry must not start another load")
+    }
+
+    // (The missing-manifest-URL guard is the same terminal `.failed`
+    // shape, but `CatalogEntry`'s decoder rejects any entry whose
+    // `manifest.uri` violates the profile URI rules, so an entry with
+    // an unparseable URL cannot be constructed to exercise it — the
+    // guard is pure defense in depth.)
+
+    // MARK: - Retry after apply failure
+
+    /// `noUsableEndpoint` leaves the consent pinned and returns to
+    /// `.reviewing`; a second Accept must retry ONLY the apply — two
+    /// attempts end with exactly one consent record and one selection.
+    @MainActor
+    func testApplyFailureRetryDoesNotReappendConsentOrSelection() async throws {
+        let box = StoreBox()
+        let flow = try makeFlow(
+            raw: try Fixture.bytes("destination-manifest.json"),
+            box: box,
+            apply: { _ in throw ModuleApplyError.noUsableEndpoint }
+        )
+        flow.start()
+        await flow.loadTask?.value
+        XCTAssertEqual(flow.step, .reviewing)
+
+        flow.tappedAccept()
+        await flow.acceptTask?.value
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertNotNil(flow.errorMessage)
+        XCTAssertEqual(box.records.count, 1)
+        XCTAssertEqual(box.selections.count, 1)
+
+        flow.tappedAccept()
+        await flow.acceptTask?.value
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertEqual(box.records.count, 1, "retry must not append a second consent record")
+        XCTAssertEqual(box.selections.count, 1, "retry must not append a second selection")
+        XCTAssertEqual(box.events, ["consent", "selection"])
+        XCTAssertTrue(try XCTUnwrap(box.records.first).isActive)
+    }
+
+    /// The already-pinned probe keys on the manifest hash AND the
+    /// selected offer: a retry after the user CHANGED the selection
+    /// must take the full accept path (the store's accept supersedes
+    /// the active record), so the recorded offerId always matches
+    /// what the screen shows — never the original selection.
+    @MainActor
+    func testRetryWithChangedOfferRecordsTheNewOffer() async throws {
+        let box = StoreBox()
+        let raw = try selfSignedRaw(seat: "notary", offers: [
+            ["offerId": "free-a", "model": "free"],
+            ["offerId": "free-b", "model": "free"],
+        ])
+        let flow = try makeFlow(
+            raw: raw,
+            box: box,
+            apply: { _ in throw ModuleApplyError.noUsableEndpoint }
+        )
+        flow.start()
+        await flow.loadTask?.value
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertEqual(flow.selectedOfferId, "free-a", "first entitled offer preselects")
+
+        flow.tappedAccept()
+        await flow.acceptTask?.value
+        XCTAssertEqual(flow.step, .reviewing, "apply failed; consent for free-a is pinned")
+        XCTAssertEqual(box.records.count, 1)
+        XCTAssertEqual(box.records.last?.offerId, "free-a")
+
+        // The user picks the other offer, then retries.
+        flow.selectedOfferId = "free-b"
+        flow.tappedAccept()
+        await flow.acceptTask?.value
+
+        let active = try XCTUnwrap(box.records.last { $0.isActive })
+        XCTAssertEqual(
+            active.offerId, "free-b",
+            "the ACTIVE record must carry the offer on screen, not the original selection"
+        )
+        XCTAssertEqual(box.records.count, 2, "changed selection supersedes: deactivate-and-append")
+        XCTAssertEqual(box.records.filter(\.isActive).count, 1)
+        XCTAssertEqual(box.selections.last?.offerId, "free-b",
+                       "the ModuleSelection must record the new offer too")
+    }
+
+    // MARK: - Corrupt store on accept
+
+    /// A store that throws on every load — the UserDefaults store's
+    /// behavior once its blob stops decoding (accepts are refused
+    /// until the history is explicitly cleared).
+    struct CorruptPinnedConsentStore: PinnedConsentStore, @unchecked Sendable {
+        func load() throws -> [PinnedConsentRecord] {
+            throw PinnedConsentStoreError.corruptStore(reason: "test corruption")
+        }
+        func save(_ records: [PinnedConsentRecord]) throws {
+            XCTFail("a corrupt store must never be overwritten by accept")
+        }
+    }
+
+    /// The corrupt-store accept branch: nothing this surface can do
+    /// makes another attempt succeed (the store refuses every accept
+    /// until the corrupt history is explicitly cleared), so the step
+    /// must be the TERMINAL `.failed` — rendered without any retry
+    /// affordance — with the honest nothing-was-changed message.
+    @MainActor
+    func testCorruptStoreOnAcceptIsTerminalFailedWithHonestMessage() async throws {
+        let box = StoreBox()
+        let raw = try Fixture.bytes("destination-manifest.json")
+        let manifest = try SignedServiceManifest(raw: raw)
+        let corruptStore = CorruptPinnedConsentStore()
+        let entry = try catalogEntry(
+            componentId: manifest.componentId,
+            seatType: manifest.seat,
+            raw: raw,
+            operatorKey: manifest.operatorKey
+        )
+        let flow = ModuleConsentFlow(
+            entry: AttributedCatalogEntry(entry: entry, source: attribution),
+            fetchManifestBytes: { _ in raw },
+            consentStore: corruptStore,
+            selectionStore: FakeSeatSelectionStore(box: box),
+            makeEntitlements: { manifest in
+                // The reviewing convenience answers free offers from
+                // the manifest itself, so the corrupt store doesn't
+                // gate the review step — only the accept.
+                FreeTierEntitlementProvider(reviewing: manifest, consentStore: corruptStore)
+            },
+            apply: { _ in XCTFail("apply must not run when consent could not be recorded") }
+        )
+        flow.start()
+        await flow.loadTask?.value
+        XCTAssertEqual(flow.step, .reviewing)
+        XCTAssertTrue(flow.canAccept)
+
+        flow.tappedAccept()
+        await flow.acceptTask?.value
+
+        XCTAssertEqual(flow.step, .failed, "a corrupt store is terminal for this surface")
+        let message = try XCTUnwrap(flow.errorMessage)
+        XCTAssertTrue(message.contains("couldn't be read"), message)
+        XCTAssertTrue(message.contains("Nothing was changed"), message)
+        XCTAssertTrue(box.selections.isEmpty, "no selection may reference an unpinned consent")
+
+        flow.tappedRetry()
+        XCTAssertEqual(flow.step, .failed, "retry must not re-arm a corrupt-store failure")
+        XCTAssertNil(flow.loadTask, "retry must not start another load")
+    }
+}

--- a/Packages/OnymFoundation/Sources/OnymFoundation/Entitlement.swift
+++ b/Packages/OnymFoundation/Sources/OnymFoundation/Entitlement.swift
@@ -43,6 +43,12 @@ public struct FreeTierEntitlementProvider: EntitlementProviding {
     /// Convenience over the consent store: resolves offers from the
     /// active pinned manifest of the component in question.
     ///
+    /// NOT fit for a consent surface — on *first* consent the store
+    /// has no record for the component yet, so every offer (free ones
+    /// included) resolves as not-entitled at exactly the moment the
+    /// screen needs an answer. Use `init(reviewing:consentStore:)`
+    /// there.
+    ///
     /// Cost note: every check is a full store `load()` (defaults read
     /// + JSON decode of all records) plus a manifest re-decode — by
     /// design, so entitlement answers can never go stale against the
@@ -54,6 +60,30 @@ public struct FreeTierEntitlementProvider: EntitlementProviding {
     public init(consentStore: any PinnedConsentStore) {
         self.init { offerId, componentId in
             (try? consentStore.activeRecord(componentId: componentId))?
+                .consentedManifest()?
+                .offers
+                .first { $0.offerId == offerId }
+        }
+    }
+
+    /// Convenience for a consent surface reviewing `manifest`: the
+    /// manifest under review is the authority on which offers exist
+    /// (and which are free) for its own component — it must answer
+    /// even when no consent record exists yet (first consent) and even
+    /// when the active record describes an older manifest. The consent
+    /// store answers only for offers the reviewed manifest doesn't
+    /// carry — i.e. other components, or re-reviewing without a
+    /// manifest change.
+    public init(reviewing manifest: SignedServiceManifest, consentStore: any PinnedConsentStore) {
+        self.init { offerId, componentId in
+            if componentId == manifest.componentId,
+               let offer = manifest.offers.first(where: { $0.offerId == offerId }) {
+                return offer
+            }
+            // Same fail-closed rule as above: a store that throws
+            // (corrupt records) resolves to no offer, i.e. not
+            // entitled.
+            return (try? consentStore.activeRecord(componentId: componentId))?
                 .consentedManifest()?
                 .offers
                 .first { $0.offerId == offerId }

--- a/Packages/OnymFoundation/Sources/OnymFoundation/PinnedConsentRecord.swift
+++ b/Packages/OnymFoundation/Sources/OnymFoundation/PinnedConsentRecord.swift
@@ -74,4 +74,20 @@ public struct PinnedConsentRecord: Codable, Sendable, Equatable {
         guard let validUntil else { return false }
         return validUntil < now
     }
+
+    /// `endpoints[].uri` of the pinned manifest bytes, as URLs. The
+    /// seat-specific endpoint fields live outside the common manifest
+    /// spine, so they are read straight from the exact consented
+    /// bytes. Settings screens use this to dedupe a seat's published
+    /// list against its "From catalog" section: a consented catalog
+    /// service's endpoint may also appear in the seat's known list
+    /// (that list is discovery-derived for consented components), and
+    /// the catalog row — with attribution and consent state — is the
+    /// one that should render.
+    public func consentedEndpointURLs() -> Set<URL> {
+        guard let object = (try? JSONSerialization.jsonObject(with: manifestBytes)) as? [String: Any],
+              let endpoints = object["endpoints"] as? [[String: Any]]
+        else { return [] }
+        return Set(endpoints.compactMap { ($0["uri"] as? String).flatMap(URL.init(string:)) })
+    }
 }

--- a/Packages/OnymFoundation/Tests/OnymFoundationTests/EntitlementTests.swift
+++ b/Packages/OnymFoundation/Tests/OnymFoundationTests/EntitlementTests.swift
@@ -37,6 +37,51 @@ final class EntitlementTests: XCTestCase {
         XCTAssertNil(unknownComponent)
     }
 
+    /// The first-consent moment: NO consent record exists yet, so a
+    /// store-backed lookup answers nil for everything — the manifest
+    /// under review must be the authority on its own offers, or free
+    /// offers can never be selected the first time around.
+    func testReviewingProviderGrantsFreeOfferBeforeAnyConsentExists() async throws {
+        let suiteName = "EntitlementTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let emptyStore = UserDefaultsPinnedConsentStore(defaults: defaults)
+        let manifest = try ManifestFactory.reviewedSample().signedManifest
+
+        let provider = FreeTierEntitlementProvider(reviewing: manifest, consentStore: emptyStore)
+        let free = await provider.entitlement(for: "free-tier", component: manifest.componentId)
+        XCTAssertEqual(
+            free,
+            ServiceEntitlement(offerId: "free-tier", componentId: manifest.componentId, expiresAt: nil),
+            "a free offer of the manifest under review must be granted on first consent"
+        )
+        let paid = await provider.entitlement(for: "pro-monthly", component: manifest.componentId)
+        XCTAssertNil(paid, "paid offers stay refused until a real entitlement layer exists")
+        let unknown = await provider.entitlement(for: "no-such-offer", component: manifest.componentId)
+        XCTAssertNil(unknown)
+    }
+
+    /// For components OTHER than the one under review, the active
+    /// consent record remains the offer source.
+    func testReviewingProviderFallsBackToConsentStoreForOtherComponents() async throws {
+        let suiteName = "EntitlementTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = UserDefaultsPinnedConsentStore(defaults: defaults)
+        // The store knows sample-notary; the review is over another
+        // component entirely.
+        try store.accept(try ManifestFactory.reviewedSample(), acceptedAt: ManifestFactory.now)
+        let reviewing = try ManifestFactory.reviewedSample { object in
+            object["componentId"] = "onym:component:other-notary"
+        }.signedManifest
+
+        let provider = FreeTierEntitlementProvider(reviewing: reviewing, consentStore: store)
+        let storeBacked = await provider.entitlement(for: "free-tier", component: Self.componentId)
+        XCTAssertNotNil(storeBacked, "other components still resolve through the active record")
+        let reviewed = await provider.entitlement(for: "free-tier", component: reviewing.componentId)
+        XCTAssertNotNil(reviewed)
+    }
+
     func testConsentStoreBackedProviderGrantsFreeAndRefusesPaid() async throws {
         let suiteName = "EntitlementTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/Packages/OnymSettings/Package.swift
+++ b/Packages/OnymSettings/Package.swift
@@ -18,6 +18,8 @@ let package = Package(
         .package(path: "../OnymDesign"),
         .package(path: "../OnymModeration"),
         .package(path: "../OnymModerationUI"),
+        .package(path: "../OnymDiscovery"),
+        .package(path: "../OnymFoundation"),
     ],
     targets: [
         .target(
@@ -33,6 +35,8 @@ let package = Package(
                 "OnymDesign",
                 "OnymModeration",
                 "OnymModerationUI",
+                "OnymDiscovery",
+                "OnymFoundation",
             ]
         ),
     ]

--- a/Packages/OnymSettings/Sources/OnymSettings/AddDiscoveryProviderView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/AddDiscoveryProviderView.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+import OnymDesign
+import OnymDiscovery
+
+/// Add-provider sheet: type the manifest URL, fetch + verify it, then
+/// confirm the operator key fingerprint (trust-on-first-use) before
+/// anything is pinned. Nothing about the provider is persisted until
+/// the Confirm step.
+struct AddDiscoveryProviderView: View {
+    @Bindable var flow: DiscoverySettingsFlow
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    switch flow.addPhase {
+                    case .idle, .fetching:
+                        urlEntry
+                    case .confirming(let preview):
+                        confirm(preview)
+                    case .added:
+                        done
+                    }
+                }
+                .padding(.bottom, 32)
+            }
+            .background(OnymTokens.surface.ignoresSafeArea())
+            .navigationTitle("Add Provider")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(dismissLabel) { dismiss() }
+                        .accessibilityIdentifier("settings.discovery.add.dismiss")
+                }
+            }
+        }
+    }
+
+    private var dismissLabel: LocalizedStringKey {
+        if case .added = flow.addPhase { return "Done" }
+        return "Cancel"
+    }
+
+    // MARK: - Step 1: URL
+
+    @ViewBuilder
+    private var urlEntry: some View {
+        SettingsLargeTitle("Add Discovery Provider")
+        Text("Paste the provider's manifest URL. Its manifest and catalogs are signed — you'll review the operator key fingerprint before this app trusts anything it publishes.")
+            .font(.system(size: 14))
+            .foregroundStyle(OnymTokens.text2)
+            .lineSpacing(3)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+
+        SettingsCard {
+            TextField("https://discovery.example.com/manifest.json",
+                      text: $flow.addDraft)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .font(.system(size: 15, design: .monospaced))
+                .padding(.horizontal, 16).padding(.vertical, 12)
+                .accessibilityIdentifier("settings.discovery.add.field")
+        }
+
+        if let error = flow.addError {
+            SettingsFootnote(verbatim: error)
+        }
+
+        SettingsPrimaryButton(action: { flow.tappedFetchProvider() }) {
+            if case .fetching = flow.addPhase {
+                ProgressView().tint(OnymTokens.onAccent)
+            } else {
+                Text("Fetch Provider")
+            }
+        }
+        .disabled(isFetching)
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .accessibilityIdentifier("settings.discovery.add.fetch")
+    }
+
+    private var isFetching: Bool {
+        if case .fetching = flow.addPhase { return true }
+        return false
+    }
+
+    // MARK: - Step 2: TOFU confirmation
+
+    @ViewBuilder
+    private func confirm(_ preview: DiscoveryProviderPreview) -> some View {
+        SettingsLargeTitle("Confirm Operator Key")
+
+        Text("This fingerprint identifies the provider's operator key. Verify it out-of-band — the provider's website, documentation, or the operator directly — before confirming. It's pinned on confirm: a later manifest signed by any other key will be rejected.")
+            .font(.system(size: 14))
+            .foregroundStyle(OnymTokens.text2)
+            .lineSpacing(3)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+
+        SettingsSectionLabel("OPERATOR KEY FINGERPRINT")
+        SettingsCard {
+            Text(verbatim: preview.operatorKeyFingerprint)
+                .font(.system(size: 28, weight: .semibold, design: .monospaced))
+                .foregroundStyle(OnymTokens.text)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 20)
+                .accessibilityIdentifier("settings.discovery.add.fingerprint")
+        }
+        SettingsFootnote("First 16 characters of the operator's Ed25519 public key.")
+
+        SettingsSectionLabel("PROVIDER")
+        SettingsCard {
+            summaryRow("Provider", preview.providerId)
+            summaryRow("Manifest URL", preview.manifestURL.absoluteString)
+            summaryRow(
+                "Valid until",
+                preview.signed.manifest.validUntil.formatted(date: .abbreviated, time: .omitted)
+            )
+            catalogsRow(preview, last: true)
+        }
+
+        VStack(spacing: 10) {
+            SettingsPrimaryButton("Pin Key & Add Provider") {
+                flow.tappedConfirmAdd()
+            }
+            .accessibilityIdentifier("settings.discovery.add.confirm")
+
+            Button("Back") { flow.tappedCancelPreview() }
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text2)
+                .accessibilityIdentifier("settings.discovery.add.back")
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+    }
+
+    private func summaryRow(_ label: LocalizedStringKey, _ value: String, last: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(label)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text(verbatim: value)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(OnymTokens.text2)
+                    .textSelection(.enabled)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            if !last { SettingsRowDivider(inset: 16) }
+        }
+    }
+
+    private func catalogsRow(_ preview: DiscoveryProviderPreview, last: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text("Catalogs")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            ForEach(preview.signed.manifest.catalogs, id: \.catalogId) { catalog in
+                Text(verbatim: "\(catalog.catalogId) · \(catalog.seatTypes.joined(separator: ", "))")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .padding(.bottom, 6)
+    }
+
+    // MARK: - Step 3: done
+
+    private var done: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(OnymTokens.green)
+            Text("Provider added")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text("Its catalogs are being fetched and verified now.")
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 120)
+        .accessibilityIdentifier("settings.discovery.add.done")
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
@@ -61,6 +61,11 @@ struct BlossomRelaySettingsView: View {
         .navigationTitle("Blossom Relays")
         .navigationBarTitleDisplayMode(.inline)
         .task { flow.start() }
+        // Paired with `start()` (ModerationSettingsView precedent):
+        // the drain retains the flow and the repository stream never
+        // finishes on its own, so without this the continuation would
+        // accumulate on every visit.
+        .onDisappear { flow.stop() }
     }
 
     // MARK: - Configured list

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogSection.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogSection.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import OnymDesign
+import OnymDiscovery
+import OnymFoundation
+
+/// "FROM CATALOG" section shared by the per-seat pickers (relayer,
+/// nostr): discovery-sourced entries with their source label,
+/// relationship disclosure, consent state, and — once consented — the
+/// accepted offer's badge. Tapping a row hands the entry to the
+/// presenting view, which runs `ModuleConsentFlow` as a sheet.
+///
+/// Renders nothing when `entries` is empty, so pickers without
+/// discovery wired (or with an empty aggregate) look exactly as they
+/// did before this section existed.
+struct DiscoveryCatalogSection: View {
+    let entries: [AttributedCatalogEntry]
+    /// Cached lookups (computed once per catalog refresh in the flow,
+    /// not per row per render — `activeConsent` decodes the whole
+    /// consent store and `consentedOffer` a pinned manifest).
+    let activeConsent: (AttributedCatalogEntry) -> PinnedConsentRecord?
+    let consentedOffer: (AttributedCatalogEntry) -> ServiceOffer?
+    let tileSymbol: String
+    let accessibilityPrefix: String
+    let onSelect: (AttributedCatalogEntry) -> Void
+
+    var body: some View {
+        if !entries.isEmpty {
+            SettingsSectionLabel("FROM CATALOG")
+            SettingsCard {
+                ForEach(Array(entries.enumerated()), id: \.element.id) { idx, entry in
+                    row(entry, last: idx == entries.count - 1)
+                }
+            }
+            SettingsFootnote("Published by the discovery providers you trust. Tapping an entry shows the operator's manifest and terms — nothing is added without your explicit acceptance.")
+        }
+    }
+
+    private func row(_ entry: AttributedCatalogEntry, last: Bool) -> some View {
+        let record = activeConsent(entry)
+        return SettingsRow(
+            titleText: ModuleConsentFlow.shortComponentId(entry.entry.componentId),
+            subtitle: subtitle(for: entry),
+            subtitleLineLimit: 2,
+            hasChevron: false,
+            inset: 56,
+            last: last,
+            onTap: { onSelect(entry) }
+        ) {
+            SettingsIconTile(symbol: tileSymbol, bg: SettingsTile.purple)
+        } right: {
+            HStack(spacing: 4) {
+                if let status = entry.entry.status {
+                    statusChip(status)
+                }
+                if let offer = consentedOffer(entry) {
+                    OfferBadge(offer: offer)
+                }
+                consentChip(for: entry, record: record)
+            }
+        }
+        .accessibilityIdentifier("\(accessibilityPrefix).\(entry.id)")
+    }
+
+    /// §4.2 disclosed warning/review status: rendered distinctly, in
+    /// text — the field exists precisely so a warned entry never
+    /// renders indistinguishable from a clean one.
+    private func statusChip(_ status: EntryStatus) -> some View {
+        SettingsChip(
+            text: (status.state == "warning"
+                ? String(localized: "WARNING")
+                : String(localized: "UNDER REVIEW")).uppercased(),
+            fg: SettingsTile.amber,
+            bg: SettingsTile.amber.opacity(0.15)
+        )
+    }
+
+    /// Source + relationship disclosure, in text (not color) so the
+    /// disclosure survives every rendering.
+    private func subtitle(for entry: AttributedCatalogEntry) -> String {
+        String(localized: "Listed by \(entry.source.sourceLabel) — \(ModuleConsentView.disclosureText(entry.source.relationship))")
+    }
+
+    /// Consent state relative to the exact digest the catalog pins:
+    /// same hash → consented; older consent for the component → the
+    /// published terms changed; none → not yet reviewed.
+    @ViewBuilder
+    private func consentChip(for entry: AttributedCatalogEntry, record: PinnedConsentRecord?) -> some View {
+        if let record, record.manifestHash == entry.entry.manifest.digest {
+            SettingsChip(text: String(localized: "CONSENTED").uppercased(),
+                         fg: OnymTokens.green, bg: OnymTokens.green.opacity(0.15))
+        } else if record != nil {
+            SettingsChip(text: String(localized: "TERMS CHANGED").uppercased(),
+                         fg: SettingsTile.amber, bg: SettingsTile.amber.opacity(0.15))
+        } else {
+            SettingsChip(text: String(localized: "REVIEW").uppercased(),
+                         fg: SettingsTile.gray, bg: SettingsTile.gray.opacity(0.15))
+        }
+    }
+
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoverySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoverySettingsView.swift
@@ -1,0 +1,232 @@
+import SwiftUI
+import OnymDesign
+import OnymDiscovery
+
+/// Settings → Discovery Providers. Lists the user's configured
+/// discovery sources with per-source status (fetching / ok / failed /
+/// integrity warning), the pinned operator key fingerprint, and how
+/// many verified catalog entries each contributes. Swipe a row to
+/// remove (behind a confirmation — removal is permanent by design),
+/// or add a new provider by manifest URL through the TOFU sheet.
+struct DiscoverySettingsView: View {
+    @State private var flow: DiscoverySettingsFlow
+    @State private var showAddSheet = false
+    /// The providerId pending the remove confirmation, if any.
+    @State private var pendingRemoval: DiscoverySourceStatus?
+
+    init(flow: DiscoverySettingsFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SettingsLargeTitle("Discovery")
+
+                SettingsSectionLabel("PROVIDERS · \(flow.state.sources.count)")
+                sourcesCard
+                SettingsFootnote("Providers publish signed catalogs of relays and services this app can adopt. Every catalog is verified against the operator key you pinned when you added the provider.")
+
+                SettingsSectionLabel("ADD")
+                SettingsCard {
+                    SettingsRow(
+                        title: "Add Discovery Provider",
+                        subtitle: "Fetch a provider manifest by URL",
+                        hasChevron: false,
+                        last: true,
+                        onTap: { showAddSheet = true }
+                    ) {
+                        Circle().fill(OnymAccent.blue.color)
+                            .frame(width: 30, height: 30)
+                            .overlay(Image(systemName: "plus")
+                                .font(.system(size: 14, weight: .bold))
+                                .foregroundStyle(OnymTokens.onAccent))
+                    }
+                    .accessibilityIdentifier("settings.discovery.add")
+                }
+                SettingsFootnote("You'll see the provider's operator key fingerprint before anything is trusted. Verify it out-of-band — the fingerprint is pinned on first use.")
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .navigationTitle("Discovery")
+        .navigationBarTitleDisplayMode(.inline)
+        .refreshable { await flow.refresh() }
+        .task { flow.start() }
+        // Paired with `start()` (ModerationSettingsView precedent):
+        // the snapshot drain retains the flow and the repository's
+        // stream never finishes on its own, so without this the
+        // continuation would accumulate on every visit.
+        .onDisappear { flow.stop() }
+        .sheet(isPresented: $showAddSheet, onDismiss: { flow.resetAdd() }) {
+            AddDiscoveryProviderView(flow: flow)
+        }
+        .alert(
+            "Remove this provider?",
+            isPresented: Binding(
+                get: { pendingRemoval != nil },
+                set: { if !$0 { pendingRemoval = nil } }
+            ),
+            presenting: pendingRemoval
+        ) { status in
+            Button("Remove Provider", role: .destructive) {
+                flow.tappedRemove(providerId: status.source.providerId)
+                pendingRemoval = nil
+            }
+            Button("Cancel", role: .cancel) { pendingRemoval = nil }
+        } message: { status in
+            Text("\(status.source.userLabel) and its catalogs will be removed, along with its pinned key. It won't come back automatically — you'd have to add it again and re-verify its fingerprint.")
+        }
+    }
+
+    // MARK: - Sources
+
+    @ViewBuilder
+    private var sourcesCard: some View {
+        let sources = flow.state.sources
+        if sources.isEmpty {
+            SettingsCard {
+                Text("No discovery providers configured. Add one below.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text3)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 16).padding(.vertical, 14)
+                    .accessibilityIdentifier("settings.discovery.empty")
+            }
+        } else {
+            // Clipped rounded stack (not SettingsCard) so each row can
+            // swipe left to reveal a Delete action masked to the card's
+            // corners — same construction as the relayer / nostr lists.
+            VStack(spacing: 0) {
+                ForEach(Array(sources.enumerated()), id: \.element.id) { idx, status in
+                    // One stable identifier per row, on the outermost
+                    // row element (the delete affordance derives its
+                    // own "<id>.delete") — PR-7's UI-test queries must
+                    // never match nested duplicates.
+                    SwipeToDeleteRow(
+                        accessibilityID: "settings.discovery.source.\(status.source.providerId)",
+                        onDelete: { pendingRemoval = status }
+                    ) {
+                        sourceRow(status, last: idx == sources.count - 1)
+                    }
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier("settings.discovery.source.\(status.source.providerId)")
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .padding(.horizontal, 16)
+        }
+    }
+
+    private func sourceRow(_ status: DiscoverySourceStatus, last: Bool) -> some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                SettingsIconTile(symbol: "antenna.radiowaves.left.and.right", bg: SettingsTile.purple)
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        Text(verbatim: status.source.userLabel)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text)
+                        statusChip(for: status)
+                    }
+                    Text(status.source.manifestURL.absoluteString)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text3)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let fingerprint = status.source.operatorKeyFingerprint {
+                        Text(verbatim: String(localized: "Key \(fingerprint)"))
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(OnymTokens.text2)
+                    } else {
+                        Text("Key not yet confirmed")
+                            .font(.system(size: 12))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                    Text(entriesLine(for: status))
+                        .font(.system(size: 12))
+                        .foregroundStyle(OnymTokens.text3)
+                    // Integrity/completeness notes from the last
+                    // refresh: needs-confirmation, skipped catalogs and
+                    // entries (result_incomplete), forward-jumps,
+                    // policy transitions. The repository computes these
+                    // precisely so a partly-skipped or unconfirmed
+                    // source never reads as a silently empty one.
+                    ForEach(status.notes, id: \.self) { note in
+                        Text(verbatim: note)
+                            .font(.system(size: 12))
+                            .foregroundStyle(SettingsTile.amber)
+                            .lineLimit(3)
+                    }
+                    if let error = status.lastError {
+                        Text(verbatim: error)
+                            .font(.system(size: 12))
+                            .foregroundStyle(status.lastErrorIsIntegrity ? OnymTokens.red : OnymTokens.text2)
+                            .lineLimit(3)
+                    }
+                    if status.lastError != nil {
+                        // Retry path for a FAILED / INTEGRITY source —
+                        // relaunching the app must never be the only
+                        // way to re-attempt a fetch.
+                        Button("Retry") { flow.tappedRefresh() }
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(OnymAccent.blue.color)
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("settings.discovery.source.\(status.source.providerId).retry")
+                    } else if status.source.pinnedOperatorKeyHex == nil {
+                        // An UNCONFIRMED source (the seeded default) is
+                        // advanced through the same TOFU screen as an
+                        // added provider: fetch, show the fingerprint,
+                        // pin only on explicit confirm.
+                        Button("Confirm…") {
+                            flow.tappedConfirmSource(providerId: status.source.providerId)
+                            showAddSheet = true
+                        }
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(OnymAccent.blue.color)
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("settings.discovery.source.\(status.source.providerId).confirm")
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            if !last {
+                Divider()
+                    .background(OnymTokens.hairline)
+                    .padding(.leading, 56)
+            }
+        }
+    }
+
+    /// One word of status per source. Integrity findings outrank plain
+    /// fetch failures — a failing signature is about the provider, not
+    /// the network.
+    @ViewBuilder
+    private func statusChip(for status: DiscoverySourceStatus) -> some View {
+        if status.lastError != nil, status.lastErrorIsIntegrity {
+            SettingsChip(text: String(localized: "INTEGRITY").uppercased(),
+                         fg: OnymTokens.red, bg: OnymTokens.red.opacity(0.15))
+        } else if status.lastError != nil {
+            SettingsChip(text: String(localized: "FAILED").uppercased(),
+                         fg: SettingsTile.amber, bg: SettingsTile.amber.opacity(0.15))
+        } else if flow.state.fetchStatus == .fetching {
+            SettingsChip(text: String(localized: "FETCHING").uppercased(),
+                         fg: SettingsTile.gray, bg: SettingsTile.gray.opacity(0.15))
+        } else if status.source.pinnedOperatorKeyHex == nil {
+            SettingsChip(text: String(localized: "UNCONFIRMED").uppercased(),
+                         fg: SettingsTile.gray, bg: SettingsTile.gray.opacity(0.15))
+        } else {
+            SettingsChip(text: String(localized: "OK").uppercased(),
+                         fg: OnymTokens.green, bg: OnymTokens.green.opacity(0.15))
+        }
+    }
+
+    private func entriesLine(for status: DiscoverySourceStatus) -> String {
+        let count = flow.entryCount(providerId: status.source.providerId)
+        // Automatic grammar agreement — a real plural rule, not an
+        // English-only `== 1` branch.
+        return String(localized: "^[\(count) catalog entries](inflect: true)")
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/ModuleConsentView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/ModuleConsentView.swift
@@ -1,0 +1,375 @@
+import SwiftUI
+import OnymDesign
+import OnymDiscovery
+import OnymFoundation
+import OnymModerationUI
+
+/// The generalized consent surface for a catalog-listed service
+/// (transport / notary / blob storage): who listed it and under what
+/// relationship, the operator key fingerprint, the offers, the linked
+/// terms when the operator published any, and the exact manifest hash
+/// the acceptance pins. One explicit accept button.
+struct ModuleConsentView: View {
+    @State private var flow: ModuleConsentFlow
+    @Environment(\.dismiss) private var dismiss
+
+    init(flow: ModuleConsentFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    switch flow.step {
+                    case .loading:
+                        loading
+                    case .reviewing, .applying:
+                        review
+                    case .done:
+                        done
+                    case .failed:
+                        failed
+                    }
+                }
+                .padding(.bottom, 32)
+            }
+            .background(OnymTokens.surface.ignoresSafeArea())
+            .navigationTitle("Review Service")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(flow.step == .done ? "Done" : "Cancel") { dismiss() }
+                        .accessibilityIdentifier("settings.module_consent.dismiss")
+                }
+            }
+            .task { flow.start() }
+        }
+    }
+
+    // MARK: - Loading
+
+    @ViewBuilder
+    private var loading: some View {
+        if let error = flow.errorMessage {
+            SettingsCard {
+                VStack(spacing: 10) {
+                    Text(verbatim: error)
+                        .font(.system(size: 14))
+                        .foregroundStyle(OnymTokens.text2)
+                    Button("Retry") { flow.tappedRetry() }
+                        .accessibilityIdentifier("settings.module_consent.retry")
+                }
+                .frame(maxWidth: .infinity)
+                .padding(16)
+            }
+            .padding(.top, 24)
+        } else {
+            VStack(spacing: 12) {
+                ProgressView()
+                Text("Fetching and verifying the service's manifest…")
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 120)
+        }
+    }
+
+    // MARK: - Failed (terminal)
+
+    /// Terminal failure: this entry can never be consented through
+    /// this surface (moderation seat, no manifest URL, or a
+    /// digest-pinned manifest failing an entry cross-check). No Retry
+    /// — retrying could never succeed, so offering the button would be
+    /// a lie. Cancel in the toolbar remains the way out.
+    private var failed: some View {
+        SettingsCard {
+            VStack(spacing: 10) {
+                Image(systemName: "xmark.octagon")
+                    .font(.system(size: 28))
+                    .foregroundStyle(OnymTokens.text3)
+                Text(verbatim: flow.errorMessage ?? String(localized: "This entry can't be added."))
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(16)
+        }
+        .padding(.top, 24)
+        .accessibilityIdentifier("settings.module_consent.failed")
+    }
+
+    // MARK: - Review
+
+    @ViewBuilder
+    private var review: some View {
+        if let reviewed = flow.reviewed {
+            let manifest = reviewed.signedManifest
+
+            SettingsLargeTitle(verbatim: flow.displayName)
+
+            attributionBanner
+
+            // §4.2 disclosed warning/review status, repeated ON the
+            // consent surface — the disclosure must be strongest at
+            // the accept step, not only on the picker row.
+            if let status = flow.entry.entry.status {
+                statusBanner(status)
+            }
+
+            SettingsSectionLabel("SERVICE")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    termRow("Seat", manifest.seat)
+                    termRow("Component", manifest.componentId)
+                    termRow("Operator key fingerprint", flow.operatorKeyFingerprint ?? "—")
+                    if let validUntil = manifest.validUntil {
+                        termRow("Valid until", validUntil.formatted(date: .abbreviated, time: .omitted))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+
+            if !manifest.offers.isEmpty {
+                offersSection(manifest)
+            }
+
+            if let termsURL = flow.termsURL {
+                SettingsSectionLabel("TERMS")
+                SettingsCard {
+                    NavigationLink {
+                        MarkdownDocumentView(title: String(localized: "Terms"), url: termsURL)
+                    } label: {
+                        SettingsRow(
+                            title: "Linked terms",
+                            subtitle: termsURL.absoluteString,
+                            subtitleMono: true,
+                            last: true
+                        ) {
+                            SettingsIconTile(symbol: "doc.text", bg: SettingsTile.gray)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("settings.module_consent.terms")
+                }
+            }
+
+            SettingsSectionLabel("WHAT YOU'RE ACCEPTING")
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Manifest hash")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text)
+                    Text(verbatim: manifest.manifestHash)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text2)
+                        .textSelection(.enabled)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+            SettingsFootnote("Your acceptance pins this hash of these exact bytes and adds the service's endpoint to your configuration. Nothing is signed and nothing leaves this device — you can remove the endpoint at any time.")
+
+            if let error = flow.errorMessage {
+                SettingsFootnote(verbatim: error)
+            }
+
+            VStack(spacing: 10) {
+                SettingsPrimaryButton(action: { flow.tappedAccept() }) {
+                    if flow.step == .applying {
+                        ProgressView().tint(OnymTokens.onAccent)
+                    } else {
+                        Text("Accept and Add")
+                    }
+                }
+                .disabled(flow.step == .applying || !flow.canAccept)
+                .accessibilityIdentifier("settings.module_consent.accept")
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+
+            if !flow.canAccept, !manifest.offers.isEmpty {
+                // Paid-only manifest (no entitled offer to select):
+                // Accept stays disabled, and the screen says why
+                // instead of leaving a dead button.
+                SettingsFootnote("None of this service's offers can be selected yet — purchasing is not yet available in this app, so this service can't be added.")
+            }
+        }
+    }
+
+    /// The §4.2 status disclosure on the accept surface: the chip, an
+    /// explanation, and the provider's published details link when the
+    /// status carries a `uri`.
+    private func statusBanner(_ status: EntryStatus) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                SettingsChip(
+                    text: (status.state == "warning"
+                        ? String(localized: "WARNING")
+                        : String(localized: "UNDER REVIEW")).uppercased(),
+                    fg: SettingsTile.amber,
+                    bg: SettingsTile.amber.opacity(0.15)
+                )
+                Text(status.state == "warning"
+                     ? "The listing provider has attached a warning to this service."
+                     : "The listing provider has this service under review.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text)
+            }
+            if let uri = status.uri, let url = URL(string: uri) {
+                Link(destination: url) {
+                    Text(verbatim: uri)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(OnymAccent.blue.color)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .accessibilityIdentifier("settings.module_consent.status.uri")
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(SettingsTile.amber.opacity(0.1),
+                    in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .accessibilityIdentifier("settings.module_consent.status")
+    }
+
+    /// Who listed this entry, and their declared relationship to it —
+    /// text, not color, so the disclosure survives every rendering.
+    private var attributionBanner: some View {
+        Text(verbatim: attributionText)
+            .font(.system(size: 13))
+            .foregroundStyle(OnymTokens.text2)
+            .lineSpacing(2)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .padding(.horizontal, 16)
+            .accessibilityIdentifier("settings.module_consent.attribution")
+    }
+
+    private var attributionText: String {
+        let source = flow.entry.source
+        var text = String(localized: "Listed by \(source.sourceLabel) — \(Self.disclosureText(source.relationship))")
+        if source.placement.lowercased() != "organic" {
+            text += String(localized: " · placement: \(Self.disclosureText(source.placement))")
+        }
+        return text
+    }
+
+    /// Wire values like `common-owner` read as "common owner". Unknown
+    /// future values pass through verbatim (minus hyphens) — the
+    /// disclosure must never be dropped for being unrecognized.
+    static func disclosureText(_ wireValue: String) -> String {
+        wireValue.replacingOccurrences(of: "-", with: " ")
+    }
+
+    // MARK: - Offers
+
+    @ViewBuilder
+    private func offersSection(_ manifest: SignedServiceManifest) -> some View {
+        SettingsSectionLabel("OFFERS")
+        SettingsCard {
+            ForEach(Array(manifest.offers.enumerated()), id: \.element.offerId) { idx, offer in
+                offerRow(
+                    offer,
+                    isEntitled: flow.entitledOfferIds.contains(offer.offerId),
+                    last: idx == manifest.offers.count - 1
+                )
+            }
+        }
+        if manifest.offers.contains(where: { !flow.entitledOfferIds.contains($0.offerId) }) {
+            SettingsFootnote("Paid offers can't be selected yet — purchasing is not yet available in this app.")
+        }
+    }
+
+    private func offerRow(_ offer: ServiceOffer, isEntitled: Bool, last: Bool) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Button {
+                    guard isEntitled else { return }
+                    flow.selectedOfferId = offer.offerId
+                } label: {
+                    Image(systemName: flow.selectedOfferId == offer.offerId
+                          ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 20))
+                        .foregroundStyle(isEntitled
+                                         ? (flow.selectedOfferId == offer.offerId
+                                            ? OnymTokens.green : OnymTokens.text3)
+                                         : OnymTokens.text3.opacity(0.4))
+                }
+                .buttonStyle(.plain)
+                .disabled(!isEntitled)
+                .accessibilityIdentifier("settings.module_consent.offer.select.\(offer.offerId)")
+
+                NavigationLink {
+                    OfferDetailView(offer: offer, isEntitled: isEntitled)
+                } label: {
+                    HStack(spacing: 8) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(verbatim: offer.offerId)
+                                .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(isEntitled ? OnymTokens.text : OnymTokens.text3)
+                            if let period = offer.period {
+                                Text(verbatim: period)
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(OnymTokens.text3)
+                            }
+                        }
+                        Spacer(minLength: 4)
+                        OfferBadge(offer: offer)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text3)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("settings.module_consent.offer.\(offer.offerId)")
+
+            if !last { SettingsRowDivider(inset: 48) }
+        }
+    }
+
+    private func termRow(_ label: LocalizedStringKey, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(verbatim: value)
+                .font(.system(size: 13, design: .monospaced))
+                .foregroundStyle(OnymTokens.text2)
+                .textSelection(.enabled)
+        }
+    }
+
+    // MARK: - Done
+
+    private var done: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(OnymTokens.green)
+            Text("Service added")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text("Its endpoint is now in your configured list.")
+                .font(.system(size: 13))
+                .foregroundStyle(OnymTokens.text2)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 120)
+        .accessibilityIdentifier("settings.module_consent.done")
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsFlow.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Observation
 import OnymTransportNostr
+import OnymDiscovery
+import OnymFoundation
 
 /// `@Observable @MainActor` view-model for the Nostr-relays Settings
 /// screen. Drains `NostrRelaysRepository` snapshots into local
@@ -24,29 +26,98 @@ public final class NostrRelaySettingsFlow {
     }
 
     public private(set) var state: State
+    /// Discovery-sourced "transport.message" entries for the "From
+    /// catalog" section. Empty when the app runs without discovery.
+    public private(set) var catalogEntries: [AttributedCatalogEntry] = []
+    /// Consent state per componentId, memoized once per catalog
+    /// refresh — `activeConsent` decodes the whole consent store and
+    /// the offer a pinned manifest, far too heavy per row per render.
+    private var consentRecords: [String: PinnedConsentRecord] = [:]
+    private var consentedOffers: [String: ServiceOffer] = [:]
 
     private let repository: NostrRelaysRepository
+    /// Optional discovery seam — nil keeps this screen exactly as it
+    /// was before discovery existed.
+    let discovery: DiscoveryModulePicker?
     private var snapshotTask: Task<Void, Never>?
+    private var catalogTask: Task<Void, Never>?
 
-    public init(repository: NostrRelaysRepository) {
+    public init(repository: NostrRelaysRepository, discovery: DiscoveryModulePicker? = nil) {
         self.repository = repository
+        self.discovery = discovery
         self.state = State(snapshot: .empty, customDraft: "", customDraftError: nil)
     }
 
-    /// Begin draining repository snapshots. Idempotent.
+    /// Begin draining repository snapshots AND discovery catalog
+    /// updates. Idempotent. The catalog is a stream, not a one-shot
+    /// read, so the "From catalog" section populates when the
+    /// boot-time discovery refresh lands while this screen is open.
     public func start() {
-        guard snapshotTask == nil else { return }
-        snapshotTask = Task { [weak self] in
-            guard let self else { return }
-            for await snapshot in self.repository.snapshots {
-                self.state.snapshot = snapshot
+        if snapshotTask == nil {
+            snapshotTask = Task { [weak self] in
+                guard let self else { return }
+                for await snapshot in self.repository.snapshots {
+                    self.state.snapshot = snapshot
+                }
             }
         }
+        if catalogTask == nil, let discovery {
+            catalogTask = Task { [weak self] in
+                for await entries in discovery.entriesStream() {
+                    self?.applyCatalog(entries)
+                }
+            }
+        }
+    }
+
+    /// Re-read the discovery aggregate once (consent-sheet dismiss — a
+    /// fresh consent changes the rows' badges without any catalog
+    /// change to push through the stream).
+    public func refreshCatalog() {
+        guard let discovery else { return }
+        Task { [weak self] in
+            let entries = await discovery.entries()
+            self?.applyCatalog(entries)
+        }
+    }
+
+    /// Install a catalog aggregate, memoizing the per-component
+    /// consent lookups so rendering a row is a dictionary hit instead
+    /// of a full consent-store decode.
+    private func applyCatalog(_ entries: [AttributedCatalogEntry]) {
+        guard let discovery else { return }
+        var records: [String: PinnedConsentRecord] = [:]
+        var offers: [String: ServiceOffer] = [:]
+        for componentId in Set(entries.map(\.entry.componentId)) {
+            guard let record = discovery.activeConsent(componentId) else { continue }
+            records[componentId] = record
+            if let offerId = record.offerId {
+                offers[componentId] = record.consentedManifest()?
+                    .offers.first { $0.offerId == offerId }
+            }
+        }
+        catalogEntries = entries
+        consentRecords = records
+        consentedOffers = offers
+    }
+
+    /// The active pinned consent for a catalog entry's component, when
+    /// discovery is wired (memoized per catalog refresh).
+    public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
+        consentRecords[entry.entry.componentId]
+    }
+
+    /// The offer accepted at consent time, resolved from the pinned
+    /// manifest snapshot (memoized per catalog refresh).
+    public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
+        consentedOffers[entry.entry.componentId]
     }
 
     func stop() {
         snapshotTask?.cancel()
         snapshotTask = nil
+        catalogTask?.cancel()
+        catalogTask = nil
     }
 
     // MARK: - Intents

--- a/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import OnymDesign
+import OnymDiscovery
 
 /// Settings → Transport → Nostr Relays. Lists configured Nostr
 /// WebSocket endpoints, lets the user add a custom URL or remove
@@ -12,6 +13,8 @@ import OnymDesign
 /// reconnect-on-config-change is wired in a follow-up.
 struct NostrRelaySettingsView: View {
     @State private var flow: NostrRelaySettingsFlow
+    /// The catalog entry whose consent sheet is presented, if any.
+    @State private var consentEntry: AttributedCatalogEntry?
 
     init(flow: NostrRelaySettingsFlow) {
         _flow = State(initialValue: flow)
@@ -26,6 +29,15 @@ struct NostrRelaySettingsView: View {
                     "CONFIGURED · \(flow.state.snapshot.endpoints.count)"
                 )
                 configuredCard
+
+                DiscoveryCatalogSection(
+                    entries: flow.catalogEntries,
+                    activeConsent: { flow.activeConsent(for: $0) },
+                    consentedOffer: { flow.consentedOffer(for: $0) },
+                    tileSymbol: "antenna.radiowaves.left.and.right.circle.fill",
+                    accessibilityPrefix: "nostr.catalog",
+                    onSelect: { consentEntry = $0 }
+                )
 
                 SettingsSectionLabel("ADD CUSTOM URL")
                 customURLCard
@@ -62,6 +74,18 @@ struct NostrRelaySettingsView: View {
         .navigationTitle("Nostr Relays")
         .navigationBarTitleDisplayMode(.inline)
         .task { flow.start() }
+        // Paired with `start()` (ModerationSettingsView precedent):
+        // the drains retain the flow and the repository streams never
+        // finish on their own, so without this the continuations would
+        // accumulate on every visit.
+        .onDisappear { flow.stop() }
+        // Consent runs as a sheet; on dismiss the catalog badges
+        // refresh so a fresh consent shows immediately.
+        .sheet(item: $consentEntry, onDismiss: { flow.refreshCatalog() }) { entry in
+            if let discovery = flow.discovery {
+                ModuleConsentView(flow: discovery.makeConsentFlow(entry))
+            }
+        }
     }
 
     // MARK: - Configured list

--- a/Packages/OnymSettings/Sources/OnymSettings/OfferBadge.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/OfferBadge.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import OnymDesign
+import OnymFoundation
+
+/// Small capsule summarizing one offer's pricing model — "FREE" in
+/// green, the model name ("SUBSCRIPTION", …) in gray for paid tiers.
+/// Used on catalog rows and the consent surface's offers list.
+struct OfferBadge: View {
+    let offer: ServiceOffer
+
+    var body: some View {
+        SettingsChip(
+            text: Self.modelDisplayName(offer.model).uppercased(),
+            fg: offer.isFree ? OnymTokens.green : SettingsTile.gray,
+            bg: (offer.isFree ? OnymTokens.green : SettingsTile.gray).opacity(0.15)
+        )
+    }
+
+    /// Localized display name for a wire pricing-model token. Known
+    /// models get a real localization; an unknown future token falls
+    /// back to the capitalized wire value — displayed, never dropped.
+    static func modelDisplayName(_ model: String) -> String {
+        switch model {
+        case "free": return String(localized: "Free")
+        case "subscription": return String(localized: "Subscription")
+        case "consumable": return String(localized: "Consumable")
+        default: return model.capitalized
+        }
+    }
+}
+
+/// Detail screen for one offer out of a service manifest: identifier,
+/// pricing model, billing period, and the seat-specific `service`
+/// object rendered opaquely. Free offers are selectable from the
+/// consent surface; paid offers render disabled until purchasing
+/// exists (`EntitlementProviding` gates them — the free-tier stub
+/// grants only free models).
+struct OfferDetailView: View {
+    let offer: ServiceOffer
+    let isEntitled: Bool
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SettingsLargeTitle(verbatim: offer.offerId)
+
+                SettingsSectionLabel("OFFER")
+                SettingsCard {
+                    VStack(alignment: .leading, spacing: 8) {
+                        detailRow("Offer ID", offer.offerId)
+                        detailRow("Model", OfferBadge.modelDisplayName(offer.model))
+                        if let period = offer.period {
+                            detailRow("Period", period)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+                }
+
+                if let service = serviceSummary {
+                    SettingsSectionLabel("SERVICE TERMS")
+                    SettingsCard {
+                        Text(verbatim: service)
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(OnymTokens.text2)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(16)
+                    }
+                    SettingsFootnote("Published by the operator as part of the signed manifest. This app doesn't interpret it — it's shown exactly as offered.")
+                }
+
+                if !isEntitled {
+                    SettingsFootnote("Purchasing is not yet available in this app. Paid offers become selectable once in-app purchases land.")
+                }
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .navigationTitle("Offer")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func detailRow(_ label: LocalizedStringKey, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(verbatim: value)
+                .font(.system(size: 13, design: .monospaced))
+                .foregroundStyle(OnymTokens.text2)
+        }
+    }
+
+    /// Pretty-printed `service` object, when the offer carries one.
+    private var serviceSummary: String? {
+        guard let data = offer.serviceData,
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let pretty = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+              )
+        else { return nil }
+        return String(decoding: pretty, as: UTF8.self)
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsFlow.swift
@@ -1,5 +1,7 @@
 import Foundation
 import OnymChain
+import OnymDiscovery
+import OnymFoundation
 
 /// Stateless interactor backing the relayer Settings screen. Drains
 /// `RelayerRepository` snapshots into local `state.snapshot`; intents
@@ -19,30 +21,111 @@ public final class RelayerSettingsFlow {
     }
 
     public private(set) var state: State
+    /// Discovery-sourced "notary" entries for the "From catalog"
+    /// section. Empty when the app runs without discovery.
+    public private(set) var catalogEntries: [AttributedCatalogEntry] = []
+    /// Consent state per componentId, memoized once per catalog
+    /// refresh — `activeConsent` decodes the whole consent store and
+    /// the offer a pinned manifest, far too heavy per row per render.
+    private var consentRecords: [String: PinnedConsentRecord] = [:]
+    private var consentedOffers: [String: ServiceOffer] = [:]
+    /// Endpoint URLs of the CONSENTED catalog entries, derived from
+    /// the pinned consent records' exact manifest bytes. Those rows
+    /// are hidden from the tap-to-add published list — a catalog
+    /// entry renders in the "From catalog" section with attribution
+    /// and consent state instead. Derived from `catalogEntries`, not
+    /// from any fetch-time registry, so it can never race the known
+    /// list rendering from cache before a fetch completes.
+    private var discoverySourcedKnownURLs: Set<URL> = []
 
     private let repository: RelayerRepository
+    /// Optional discovery seam — nil keeps this screen exactly as it
+    /// was before discovery existed.
+    let discovery: DiscoveryModulePicker?
     private var snapshotTask: Task<Void, Never>?
+    private var catalogTask: Task<Void, Never>?
 
-    public init(repository: RelayerRepository) {
+    public init(repository: RelayerRepository, discovery: DiscoveryModulePicker? = nil) {
         self.repository = repository
+        self.discovery = discovery
         self.state = State(snapshot: .empty, customDraft: "", customDraftError: nil)
     }
 
-    /// Begin draining repository snapshots. Idempotent — safe to call
-    /// from `.task` on every appear.
+    /// Begin draining repository snapshots AND discovery catalog
+    /// updates. Idempotent — safe to call from `.task` on every
+    /// appear. The catalog is a stream, not a one-shot read, so the
+    /// "From catalog" section populates when the boot-time discovery
+    /// refresh lands while this screen is already open.
     public func start() {
-        guard snapshotTask == nil else { return }
-        snapshotTask = Task { [weak self] in
-            guard let self else { return }
-            for await snapshot in self.repository.snapshots {
-                self.state.snapshot = snapshot
+        if snapshotTask == nil {
+            snapshotTask = Task { [weak self] in
+                guard let self else { return }
+                for await snapshot in self.repository.snapshots {
+                    self.state.snapshot = snapshot
+                }
             }
         }
+        if catalogTask == nil, let discovery {
+            catalogTask = Task { [weak self] in
+                for await entries in discovery.entriesStream() {
+                    self?.applyCatalog(entries)
+                }
+            }
+        }
+    }
+
+    /// Re-read the discovery aggregate once (consent-sheet dismiss — a
+    /// fresh consent changes the rows' badges without any catalog
+    /// change to push through the stream).
+    public func refreshCatalog() {
+        guard let discovery else { return }
+        Task { [weak self] in
+            let entries = await discovery.entries()
+            self?.applyCatalog(entries)
+        }
+    }
+
+    /// Install a catalog aggregate: memoize the per-component consent
+    /// lookups (so rendering a row is a dictionary hit instead of a
+    /// full consent-store decode) and rebuild the published-list
+    /// dedupe set from the consented manifests' endpoint URLs.
+    private func applyCatalog(_ entries: [AttributedCatalogEntry]) {
+        guard let discovery else { return }
+        var records: [String: PinnedConsentRecord] = [:]
+        var offers: [String: ServiceOffer] = [:]
+        var consentedURLs: Set<URL> = []
+        for componentId in Set(entries.map(\.entry.componentId)) {
+            guard let record = discovery.activeConsent(componentId) else { continue }
+            records[componentId] = record
+            consentedURLs.formUnion(record.consentedEndpointURLs())
+            if let offerId = record.offerId {
+                offers[componentId] = record.consentedManifest()?
+                    .offers.first { $0.offerId == offerId }
+            }
+        }
+        catalogEntries = entries
+        consentRecords = records
+        consentedOffers = offers
+        discoverySourcedKnownURLs = consentedURLs
+    }
+
+    /// The active pinned consent for a catalog entry's component, when
+    /// discovery is wired (memoized per catalog refresh).
+    public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
+        consentRecords[entry.entry.componentId]
+    }
+
+    /// The offer accepted at consent time, resolved from the pinned
+    /// manifest snapshot (memoized per catalog refresh).
+    public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
+        consentedOffers[entry.entry.componentId]
     }
 
     public func stop() {
         snapshotTask?.cancel()
         snapshotTask = nil
+        catalogTask?.cancel()
+        catalogTask = nil
     }
 
     // MARK: - Intents
@@ -97,10 +180,16 @@ public final class RelayerSettingsFlow {
     /// Configured endpoints that aren't already in the user's list —
     /// drives the "Add from published list" section. Hides published
     /// entries the user has already added so adding a duplicate
-    /// doesn't ghost as a no-op.
+    /// doesn't ghost as a no-op, AND consented catalog entries'
+    /// endpoints (the only discovery-derived URLs the known-list
+    /// fetcher can serve — its consent gate excludes the rest): those
+    /// render in the "From catalog" section with attribution + consent
+    /// state, and a bare duplicate row here would obscure that.
     public var unconfiguredKnownList: [RelayerEndpoint] {
         let configuredURLs = Set(state.snapshot.configuration.endpoints.map { $0.url })
-        return state.snapshot.knownList.filter { !configuredURLs.contains($0.url) }
+        return state.snapshot.knownList.filter {
+            !configuredURLs.contains($0.url) && !discoverySourcedKnownURLs.contains($0.url)
+        }
     }
 
     public func isPrimary(_ endpoint: RelayerEndpoint) -> Bool {

--- a/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import OnymDesign
 import OnymChain
+import OnymDiscovery
 
 /// Settings → Relayer. Reskinned to the Onym design — segmented
 /// strategy toggle, configured-relayers card with star-to-promote and
@@ -13,6 +14,8 @@ import OnymChain
 /// identifiers are preserved so existing UI tests still bind.
 struct RelayerSettingsView: View {
     @State private var flow: RelayerSettingsFlow
+    /// The catalog entry whose consent sheet is presented, if any.
+    @State private var consentEntry: AttributedCatalogEntry?
 
     init(flow: RelayerSettingsFlow) {
         _flow = State(initialValue: flow)
@@ -32,6 +35,15 @@ struct RelayerSettingsView: View {
                 publishedCard
                 SettingsFootnote("Published by the onym-relayer project. Tap to add.")
 
+                DiscoveryCatalogSection(
+                    entries: flow.catalogEntries,
+                    activeConsent: { flow.activeConsent(for: $0) },
+                    consentedOffer: { flow.consentedOffer(for: $0) },
+                    tileSymbol: "antenna.radiowaves.left.and.right",
+                    accessibilityPrefix: "relayer.catalog",
+                    onSelect: { consentEntry = $0 }
+                )
+
                 SettingsSectionLabel("ADD CUSTOM URL")
                 customURLCard
                 SettingsFootnote("Use a private deployment, localhost, or any relayer not in the published list.")
@@ -44,6 +56,18 @@ struct RelayerSettingsView: View {
         .navigationTitle("Relayer")
         .navigationBarTitleDisplayMode(.inline)
         .task { flow.start() }
+        // Paired with `start()` (ModerationSettingsView precedent):
+        // the drains retain the flow and the repository streams never
+        // finish on their own, so without this the continuations would
+        // accumulate on every visit.
+        .onDisappear { flow.stop() }
+        // Consent runs as a sheet; on dismiss the catalog badges
+        // refresh so a fresh consent shows immediately.
+        .sheet(item: $consentEntry, onDismiss: { flow.refreshCatalog() }) { entry in
+            if let discovery = flow.discovery {
+                ModuleConsentView(flow: discovery.makeConsentFlow(entry))
+            }
+        }
     }
 
     // MARK: - Strategy toggle (segmented capsule)

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -7,6 +7,7 @@ import OnymRecovery
 import OnymChatsCore
 import OnymModeration
 import OnymModerationUI
+import OnymDiscovery
 
 /// Settings tab — Onym design home. Identity hero (active identity
 /// avatar + truncated BLS fingerprint) and a per-identity invite QR
@@ -33,6 +34,10 @@ public struct SettingsView: View {
     let makeModerationSettingsFlow: (@MainActor () -> ModerationSettingsFlow)?
     let makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)?
     let makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)?
+    /// Discovery drill-down factory. Optional so the Settings screen
+    /// renders without the discovery stack (the section is hidden
+    /// until the app wires this in — same pattern as moderation).
+    let makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)?
 
     public init(
         makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow,
@@ -44,7 +49,8 @@ public struct SettingsView: View {
         onClearAllMessages: @escaping () async -> Void,
         makeModerationSettingsFlow: (@MainActor () -> ModerationSettingsFlow)? = nil,
         makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)? = nil,
-        makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil
+        makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil,
+        makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)? = nil
     ) {
         self.makeBackupFlow = makeBackupFlow
         self.makeRelayerSettingsFlow = makeRelayerSettingsFlow
@@ -56,6 +62,7 @@ public struct SettingsView: View {
         self.makeModerationSettingsFlow = makeModerationSettingsFlow
         self.makeModerationConsentFlow = makeModerationConsentFlow
         self.makeModerationCaseFlow = makeModerationCaseFlow
+        self.makeDiscoverySettingsFlow = makeDiscoverySettingsFlow
     }
 
     @State private var showRecoveryPhrase = false
@@ -94,6 +101,27 @@ public struct SettingsView: View {
                 // Recovery Phrase) was removed: recovery-phrase backup now
                 // lives on each identity's carousel page (its Backup
                 // action), and the informational Privacy screen is gone.
+
+                if let makeDiscoverySettingsFlow {
+                    SettingsSectionLabel("DISCOVERY")
+                    SettingsCard {
+                        NavigationLink {
+                            DiscoverySettingsView(flow: makeDiscoverySettingsFlow())
+                        } label: {
+                            SettingsRow(
+                                title: "Discovery Providers",
+                                subtitle: "Catalogs of relays and services",
+                                last: true
+                            ) {
+                                SettingsIconTile(symbol: "sparkle.magnifyingglass",
+                                                 bg: SettingsTile.purple)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("settings.discovery_row")
+                    }
+                    SettingsFootnote("Discovery providers publish signed catalogs of services you can adopt. You choose which providers to trust — each one's key is pinned when you add it.")
+                }
 
                 SettingsSectionLabel("ANCHORS")
                 SettingsCard {

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -9,6 +9,7 @@ import OnymChatsUI
 import OnymSettings
 import OnymModerationUI
 import OnymModeration
+import OnymDiscovery
 
 /// App-wide composition root. Constructed exactly once by `OnymIOSApp`
 /// and threaded down to views via `RootView`. Each member is a factory
@@ -100,4 +101,8 @@ struct AppDependencies {
     /// with the authority's human moderator, poll it, and redeem the
     /// signed grant at the enforcement backend. Nothing self-serve.
     let makeDeviceRecoveryFlow: @MainActor () async -> DeviceRecoveryFlow
+    /// Discovery Providers drill-down factory. Optional so Settings
+    /// renders without the discovery stack (nil under the UI-test
+    /// harness — same pattern as the moderation factories).
+    let makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)?
 }

--- a/Sources/OnymIOS/DiscoverySeatAdapters.swift
+++ b/Sources/OnymIOS/DiscoverySeatAdapters.swift
@@ -40,9 +40,20 @@ import OnymTransportNostr
 /// customized those screens). A catalog entry reaching `fetchLatest`
 /// therefore becomes a LIVE endpoint for default-config users, with
 /// zero taps. So each endpoint adapter takes an optional
-/// `hasActiveConsent` closure: when provided (the consent system is
-/// wired in), only entries whose componentId the closure approves
-/// merge into the known list; when nil (no consent system present in
+/// `makeConsentGate` factory: when provided (the consent system is
+/// wired in), only entries the gate approves merge into the known
+/// list. The gate answers per entry with BOTH the componentId and the
+/// catalog entry's manifest digest, because consent pins exact bytes:
+/// an active consent record for a componentId whose pinned
+/// `manifestHash` no longer equals the entry's current digest means
+/// the operator republished under terms the user never reviewed — the
+/// gate must refuse (the pickers render that state as TERMS CHANGED
+/// and route through re-consent), or a republish would silently swap
+/// an unreviewed endpoint into the known lists and auto-populate
+/// under the old record's authority. The factory is invoked once per
+/// `fetchLatest` pass, so one consent-store load answers the whole
+/// pass (never per entry) while staying fresh across passes. When nil
+/// (no consent system present in
 /// this build layer), discovery entries are EXCLUDED from `fetchLatest`
 /// entirely — pure legacy passthrough, no catalog review fan-out —
 /// and catalog entries remain reachable only through the separate
@@ -93,6 +104,19 @@ enum SeatManifestVocabulary {
         (acceptedManifestSeats[catalogSeatType] ?? [catalogSeatType]).contains(manifestSeat)
     }
 }
+
+// MARK: - Consent gate
+
+/// One fetch pass's consent check: `true` iff the user's ACTIVE
+/// pinned consent record for `componentId` pins exactly the bytes the
+/// catalog entry currently lists (`manifestHash == manifestDigest`).
+/// Built by an adapter's `makeConsentGate` factory once per
+/// `fetchLatest` pass — the factory is where the composition root
+/// loads the consent store into a lookup, so the per-entry checks
+/// cost a dictionary hit, not a store decode each.
+typealias DiscoveryConsentCheck = @Sendable (
+    _ componentId: String, _ manifestDigest: String
+) -> Bool
 
 // MARK: - Shared catalog seam
 
@@ -409,24 +433,26 @@ struct DiscoveryBackedKnownRelayersFetcher: KnownRelayersFetcher {
 
     let catalog: DiscoverySeatCatalog
     let fallback: any KnownRelayersFetcher
-    /// Consent gate seam — see the file header. `true` iff the user
-    /// holds an active consent record for the componentId; nil when no
-    /// consent system is present, which excludes discovery entries
-    /// from this known list entirely.
-    let hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)?
+    /// Consent gate seam — see the file header. Invoked once per
+    /// fetch pass; the returned check must be `true` only when the
+    /// ACTIVE consent record pins the exact bytes the entry lists
+    /// (componentId AND manifest digest). nil when no consent system
+    /// is present, which excludes discovery entries from this known
+    /// list entirely.
+    let makeConsentGate: (@Sendable () -> DiscoveryConsentCheck)?
 
     /// Wrap `fallback` when a discovery catalog is available; identity
     /// when it isn't (UI-test harness).
     static func wrapping(
         _ fallback: any KnownRelayersFetcher,
         catalog: DiscoverySeatCatalog?,
-        hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)? = nil
+        makeConsentGate: (@Sendable () -> DiscoveryConsentCheck)? = nil
     ) -> any KnownRelayersFetcher {
         guard let catalog else { return fallback }
         return DiscoveryBackedKnownRelayersFetcher(
             catalog: catalog,
             fallback: fallback,
-            hasActiveConsent: hasActiveConsent
+            makeConsentGate: makeConsentGate
         )
     }
 
@@ -434,11 +460,17 @@ struct DiscoveryBackedKnownRelayersFetcher: KnownRelayersFetcher {
         // No consent system in this build layer → pure legacy
         // passthrough, no catalog review fan-out (this list feeds
         // first-launch auto-populate; see the file header).
-        guard let hasActiveConsent else { return try await fallback.fetchLatest() }
+        guard let makeConsentGate else { return try await fallback.fetchLatest() }
         return try await mergeDiscoveredWithLegacy(
             discovered: {
-                await catalog.reviewedEntries(seatType: Self.seatType)
-                    .filter { hasActiveConsent($0.attributed.entry.componentId) }
+                let hasActiveConsent = makeConsentGate()
+                return await catalog.reviewedEntries(seatType: Self.seatType)
+                    .filter {
+                        hasActiveConsent(
+                            $0.attributed.entry.componentId,
+                            $0.attributed.entry.manifest.digest
+                        )
+                    }
                     .compactMap { reviewed -> RelayerEndpoint? in
                         guard let url = reviewed.firstEndpointURL(schemes: ["https"])
                         else { return nil }
@@ -466,29 +498,35 @@ struct DiscoveryBackedKnownNostrRelaysFetcher: KnownNostrRelaysFetcher {
     let catalog: DiscoverySeatCatalog
     let fallback: any KnownNostrRelaysFetcher
     /// Consent gate seam — see the file header.
-    let hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)?
+    let makeConsentGate: (@Sendable () -> DiscoveryConsentCheck)?
 
     static func wrapping(
         _ fallback: any KnownNostrRelaysFetcher,
         catalog: DiscoverySeatCatalog?,
-        hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)? = nil
+        makeConsentGate: (@Sendable () -> DiscoveryConsentCheck)? = nil
     ) -> any KnownNostrRelaysFetcher {
         guard let catalog else { return fallback }
         return DiscoveryBackedKnownNostrRelaysFetcher(
             catalog: catalog,
             fallback: fallback,
-            hasActiveConsent: hasActiveConsent
+            makeConsentGate: makeConsentGate
         )
     }
 
     func fetchLatest() async throws -> [NostrRelayEndpoint] {
         // No consent system in this build layer → pure legacy
         // passthrough (see the file header).
-        guard let hasActiveConsent else { return try await fallback.fetchLatest() }
+        guard let makeConsentGate else { return try await fallback.fetchLatest() }
         return try await mergeDiscoveredWithLegacy(
             discovered: {
-                await catalog.reviewedEntries(seatType: Self.seatType)
-                    .filter { hasActiveConsent($0.attributed.entry.componentId) }
+                let hasActiveConsent = makeConsentGate()
+                return await catalog.reviewedEntries(seatType: Self.seatType)
+                    .filter {
+                        hasActiveConsent(
+                            $0.attributed.entry.componentId,
+                            $0.attributed.entry.manifest.digest
+                        )
+                    }
                     .compactMap { reviewed -> NostrRelayEndpoint? in
                         guard let url = reviewed.firstEndpointURL(schemes: ["wss"])
                         else { return nil }
@@ -520,29 +558,35 @@ struct DiscoveryBackedKnownBlossomServersFetcher: KnownBlossomServersFetcher {
     let catalog: DiscoverySeatCatalog
     let fallback: any KnownBlossomServersFetcher
     /// Consent gate seam — see the file header.
-    let hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)?
+    let makeConsentGate: (@Sendable () -> DiscoveryConsentCheck)?
 
     static func wrapping(
         _ fallback: any KnownBlossomServersFetcher,
         catalog: DiscoverySeatCatalog?,
-        hasActiveConsent: (@Sendable (_ componentId: String) -> Bool)? = nil
+        makeConsentGate: (@Sendable () -> DiscoveryConsentCheck)? = nil
     ) -> any KnownBlossomServersFetcher {
         guard let catalog else { return fallback }
         return DiscoveryBackedKnownBlossomServersFetcher(
             catalog: catalog,
             fallback: fallback,
-            hasActiveConsent: hasActiveConsent
+            makeConsentGate: makeConsentGate
         )
     }
 
     func fetchLatest() async throws -> [BlossomServerEndpoint] {
         // No consent system in this build layer → pure legacy
         // passthrough (see the file header).
-        guard let hasActiveConsent else { return try await fallback.fetchLatest() }
+        guard let makeConsentGate else { return try await fallback.fetchLatest() }
         return try await mergeDiscoveredWithLegacy(
             discovered: {
-                await catalog.reviewedEntries(seatType: Self.seatType)
-                    .filter { hasActiveConsent($0.attributed.entry.componentId) }
+                let hasActiveConsent = makeConsentGate()
+                return await catalog.reviewedEntries(seatType: Self.seatType)
+                    .filter {
+                        hasActiveConsent(
+                            $0.attributed.entry.componentId,
+                            $0.attributed.entry.manifest.digest
+                        )
+                    }
                     .compactMap { reviewed -> BlossomServerEndpoint? in
                         guard let url = reviewed.firstEndpointURL(schemes: ["https"])
                         else { return nil }
@@ -581,7 +625,7 @@ struct DiscoveryBackedKnownBlossomServersFetcher: KnownBlossomServersFetcher {
 ///   endpoint or key — discovery contributes only componentIds the
 ///   published directory doesn't list.
 /// - **`discoveryEnabled` gate seam** (the authorities analogue of
-///   the endpoint adapters' `hasActiveConsent`): nil — no discovery
+///   the endpoint adapters' `makeConsentGate`): nil — no discovery
 ///   surface in this build layer — is a pure legacy passthrough with
 ///   no catalog fan-out; the settings-UI layer that ships provider
 ///   management enables the merge.

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -14,6 +14,7 @@ import OnymSettings
 import OnymModeration
 import OnymModerationUI
 import OnymDiscovery
+import OnymFoundation
 
 @main
 struct OnymIOSApp: App {
@@ -83,18 +84,20 @@ struct OnymIOSApp: App {
         // Discovery seat. The repository owns the user's provider
         // sources + the verified catalog aggregate; the seat adapters
         // below wrap the four legacy known-list fetchers with
-        // discovery-backed ones. The three endpoint adapters are
-        // consent-gated: until the consent system provides their
-        // `hasActiveConsent` closure (the settings-UI PR), they serve
-        // the legacy list untouched — catalog entries must not become
-        // live endpoints via first-launch auto-populate with no
-        // consent recorded. The authorities adapter is gated the same
-        // way behind its `discoveryEnabled` seam (nil here → legacy
-        // directory untouched): its rows carry the apiBaseURL + pinned
-        // operator key the mandate flow trusts, so catalog rows join
-        // the directory only when the settings-UI layer that ships
-        // provider management enables the merge — and even then legacy
-        // wins any componentId collision. No network
+        // discovery-backed ones that MERGE consented catalog endpoints
+        // into the legacy list (and serve legacy alone on any
+        // failure): this layer provides the `makeConsentGate`
+        // factory the adapters' consent-gate seam takes (declared
+        // below), so a discovery endpoint reaches a known list — and
+        // first-launch auto-populate — only with an active pinned
+        // consent record pinning the exact bytes the catalog entry
+        // currently lists. This layer likewise enables the authorities
+        // adapter's `discoveryEnabled` seam (this build ships the
+        // discovery surface): the catalog directory merges with the
+        // legacy one, with LEGACY winning any componentId collision —
+        // a catalog entry must never shadow a published authority's
+        // apiBaseURL or operator key. Picking stays consent-free; the
+        // signed mandate downstream is the consent step. No network
         // fetch under the UI harness — same rule as the Nostr /
         // Blossom fetchers below, so tests stay deterministic +
         // offline (UI-test discovery fakes land with the settings-UI
@@ -125,6 +128,35 @@ struct OnymIOSApp: App {
         let discoveryCatalog = discoveryRepository.map {
             DiscoverySeatCatalog(repository: $0, fetcher: discoveryFetcher)
         }
+        // Consent gate for the discovery-backed known-list fetchers:
+        // a discovery-derived endpoint may only enter a known list —
+        // and thereby the repositories' first-launch auto-populate —
+        // when the user holds an active pinned consent whose
+        // `manifestHash` equals the exact digest the catalog entry
+        // currently lists. Consent is consent to BYTES, not to a
+        // componentId: after an operator republishes (new digest, new
+        // endpoint, same componentId), the old record must not admit
+        // the unreviewed manifest — the pickers render that state as
+        // TERMS CHANGED and only a fresh consent re-admits the entry.
+        // A factory rather than a bare closure so each fetch pass
+        // loads + decodes the consent store ONCE (the check runs per
+        // entry) while staying fresh across passes. Declared up here
+        // because the fetchers below are constructed before the
+        // consent UI wiring; the store is the same one the module
+        // consent flow writes to.
+        let pinnedConsentStore = UserDefaultsPinnedConsentStore()
+        let makeDiscoveryConsentGate: @Sendable () -> DiscoveryConsentCheck = {
+            // `try?` is fail-closed: a corrupt consent store gates
+            // every discovery-derived endpoint out of the known lists.
+            let activeHashes = ((try? pinnedConsentStore.load()) ?? [])
+                .reduce(into: [String: String]()) { hashes, record in
+                    guard record.isActive else { return }
+                    hashes[record.componentId] = record.manifestHash
+                }
+            return { componentId, manifestDigest in
+                activeHashes[componentId] == manifestDigest
+            }
+        }
 
         let relayerRepository: RelayerRepository
         let contractsRepository: ContractsRepository
@@ -142,7 +174,8 @@ struct OnymIOSApp: App {
             relayerRepository = RelayerRepository(
                 fetcher: DiscoveryBackedKnownRelayersFetcher.wrapping(
                     GitHubReleasesKnownRelayersFetcher(),
-                    catalog: discoveryCatalog
+                    catalog: discoveryCatalog,
+                    makeConsentGate: makeDiscoveryConsentGate
                 ),
                 store: UserDefaultsRelayerSelectionStore()
             )
@@ -155,7 +188,8 @@ struct OnymIOSApp: App {
         relayerRepository = RelayerRepository(
             fetcher: DiscoveryBackedKnownRelayersFetcher.wrapping(
                 GitHubReleasesKnownRelayersFetcher(),
-                catalog: discoveryCatalog
+                catalog: discoveryCatalog,
+                makeConsentGate: makeDiscoveryConsentGate
             ),
             store: UserDefaultsRelayerSelectionStore()
         )
@@ -237,7 +271,10 @@ struct OnymIOSApp: App {
             moderationRepository = ModerationRepository(
                 authoritiesFetcher: DiscoveryBackedKnownAuthoritiesFetcher.wrapping(
                     GitHubReleasesKnownAuthoritiesFetcher(),
-                    catalog: discoveryCatalog
+                    catalog: discoveryCatalog,
+                    // This build layer ships the discovery surface —
+                    // enable the (legacy-wins) directory merge.
+                    discoveryEnabled: { true }
                 ),
                 manifestFetcher: moderationManifestFetcher,
                 mandateStore: UserDefaultsMandateStore(),
@@ -262,7 +299,10 @@ struct OnymIOSApp: App {
         moderationRepository = ModerationRepository(
             authoritiesFetcher: DiscoveryBackedKnownAuthoritiesFetcher.wrapping(
                 GitHubReleasesKnownAuthoritiesFetcher(),
-                catalog: discoveryCatalog
+                catalog: discoveryCatalog,
+                // This build layer ships the discovery surface —
+                // enable the (legacy-wins) directory merge.
+                discoveryEnabled: { true }
             ),
             manifestFetcher: moderationManifestFetcher,
             mandateStore: UserDefaultsMandateStore(),
@@ -368,12 +408,14 @@ struct OnymIOSApp: App {
             ? nil
             : DiscoveryBackedKnownBlossomServersFetcher.wrapping(
                 GitHubReleasesKnownBlossomServersFetcher(),
-                catalog: discoveryCatalog
+                catalog: discoveryCatalog,
+                makeConsentGate: makeDiscoveryConsentGate
             )
         #else
         blossomFetcher = DiscoveryBackedKnownBlossomServersFetcher.wrapping(
             GitHubReleasesKnownBlossomServersFetcher(),
-            catalog: discoveryCatalog
+            catalog: discoveryCatalog,
+            makeConsentGate: makeDiscoveryConsentGate
         )
         #endif
         let blossomServersRepository = BlossomServersRepository(
@@ -455,12 +497,14 @@ struct OnymIOSApp: App {
             ? nil
             : DiscoveryBackedKnownNostrRelaysFetcher.wrapping(
                 GitHubReleasesKnownNostrRelaysFetcher(),
-                catalog: discoveryCatalog
+                catalog: discoveryCatalog,
+                makeConsentGate: makeDiscoveryConsentGate
             )
         #else
         nostrFetcher = DiscoveryBackedKnownNostrRelaysFetcher.wrapping(
             GitHubReleasesKnownNostrRelaysFetcher(),
-            catalog: discoveryCatalog
+            catalog: discoveryCatalog,
+            makeConsentGate: makeDiscoveryConsentGate
         )
         #endif
         let nostrRelaysRepository = NostrRelaysRepository(
@@ -575,6 +619,132 @@ struct OnymIOSApp: App {
             gateCheck: gateCheckRepository
         )
 
+        // Discovery-driven module consent (Settings UI). The stores are
+        // the app-wide consent + selection provenance; the entitlement
+        // stub grants free offers only (StoreKit slots in behind the
+        // same seam later). Each picker pre-binds its seat type and the
+        // seat-specific `apply` closure that writes a consented
+        // manifest's endpoint into the legacy configuration — the
+        // operational source of truth stays where it always was. All
+        // nil when discovery is nil (UI-test harness), which leaves
+        // every settings screen exactly as it was.
+        // (`pinnedConsentStore` itself is declared next to the seat
+        // adapters above — the known-list consent gate reads it.)
+        let seatSelectionStore = UserDefaultsSeatSelectionStore()
+        /// Live per-seat catalog entries for the pickers' "From
+        /// catalog" sections: the repository's snapshot stream mapped
+        /// to one seat type, yielding the current aggregate on
+        /// subscribe and again after every refresh — so an open picker
+        /// populates when the boot-time refresh lands.
+        let makeSeatEntriesStream = discoveryRepository.map { repo in
+            { @Sendable (seatType: String) -> AsyncStream<[AttributedCatalogEntry]> in
+                AsyncStream { continuation in
+                    let task = Task {
+                        for await state in repo.snapshots {
+                            continuation.yield(
+                                state.aggregate.filter { $0.entry.seatType == seatType }
+                            )
+                        }
+                        continuation.finish()
+                    }
+                    continuation.onTermination = { _ in task.cancel() }
+                }
+            }
+        }
+        /// Entitlements for the consent surface, resolved against the
+        /// manifest currently under review — the consent store alone
+        /// can't answer on FIRST consent (no record exists yet, so
+        /// even free offers would gate as not-entitled); the store is
+        /// only the fallback for offers the reviewed manifest doesn't
+        /// carry. StoreKit slots in behind the same seam later.
+        let makeEntitlements: @Sendable (SignedServiceManifest) -> any EntitlementProviding = { manifest in
+            FreeTierEntitlementProvider(reviewing: manifest, consentStore: pinnedConsentStore)
+        }
+
+        /// Manifest `name` when published and non-empty, else the
+        /// component id minus its prefix — same rule as the adapters.
+        func discoveryDisplayName(_ fields: SeatManifestFields, componentId: String) -> String {
+            if let name = fields.name, !name.isEmpty { return name }
+            return ModuleConsentFlow.shortComponentId(componentId)
+        }
+
+        let relayerCatalogPicker = discoveryCatalog.map { catalog in
+            DiscoveryModulePicker(
+                entries: { await catalog.entries(DiscoveryBackedKnownRelayersFetcher.seatType) },
+                activeConsent: { try? pinnedConsentStore.activeRecord(componentId: $0) },
+                entriesStream: makeSeatEntriesStream.map { make in
+                    { make(DiscoveryBackedKnownRelayersFetcher.seatType) }
+                },
+                makeConsentFlow: { entry in
+                    ModuleConsentFlow(
+                        entry: entry,
+                        fetchManifestBytes: catalog.fetchManifestBytes,
+                        consentStore: pinnedConsentStore,
+                        selectionStore: seatSelectionStore,
+                        makeEntitlements: makeEntitlements,
+                        apply: { manifest in
+                            let fields = SeatManifestFields(rawBytes: manifest.rawBytes)
+                            // Throws `ModuleApplyError.noUsableEndpoint`
+                            // when the manifest has no https endpoint —
+                            // the flow surfaces it instead of showing
+                            // "Service added" over a no-op.
+                            let url = try ModuleConsentAcceptance.requiredEndpointURL(
+                                in: fields.endpointURIs,
+                                scheme: "https"
+                            )
+                            // `addEndpoint` flips the configuration's
+                            // `hasUserInteracted` to true, so a refresh
+                            // never auto-populates over this choice.
+                            await relayerRepository.addEndpoint(RelayerEndpoint(
+                                name: discoveryDisplayName(fields, componentId: manifest.componentId),
+                                url: url,
+                                networks: fields.networks
+                                    ?? DiscoveryBackedKnownRelayersFetcher.defaultNetworks
+                            ))
+                        }
+                    )
+                }
+            )
+        }
+
+        let nostrCatalogPicker = discoveryCatalog.map { catalog in
+            DiscoveryModulePicker(
+                entries: { await catalog.entries(DiscoveryBackedKnownNostrRelaysFetcher.seatType) },
+                activeConsent: { try? pinnedConsentStore.activeRecord(componentId: $0) },
+                entriesStream: makeSeatEntriesStream.map { make in
+                    { make(DiscoveryBackedKnownNostrRelaysFetcher.seatType) }
+                },
+                makeConsentFlow: { entry in
+                    ModuleConsentFlow(
+                        entry: entry,
+                        fetchManifestBytes: catalog.fetchManifestBytes,
+                        consentStore: pinnedConsentStore,
+                        selectionStore: seatSelectionStore,
+                        makeEntitlements: makeEntitlements,
+                        apply: { manifest in
+                            let fields = SeatManifestFields(rawBytes: manifest.rawBytes)
+                            // Throws `ModuleApplyError.noUsableEndpoint`
+                            // when the manifest has no wss endpoint —
+                            // surfaced by the flow, never a silent no-op.
+                            let url = try ModuleConsentAcceptance.requiredEndpointURL(
+                                in: fields.endpointURIs,
+                                scheme: "wss"
+                            )
+                            // A consent-picked relay is the user's own
+                            // choice, not a published default — no
+                            // "Default" badge, and `addEndpoint` marks
+                            // the configuration user-interacted.
+                            await nostrRelaysRepository.addEndpoint(NostrRelayEndpoint(
+                                name: discoveryDisplayName(fields, componentId: manifest.componentId),
+                                url: url,
+                                isDefault: false
+                            ))
+                        }
+                    )
+                }
+            )
+        }
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -583,10 +753,10 @@ struct OnymIOSApp: App {
                 )
             },
             makeRelayerSettingsFlow: { @MainActor in
-                RelayerSettingsFlow(repository: relayerRepository)
+                RelayerSettingsFlow(repository: relayerRepository, discovery: relayerCatalogPicker)
             },
             makeNostrRelaySettingsFlow: { @MainActor in
-                NostrRelaySettingsFlow(repository: nostrRelaysRepository)
+                NostrRelaySettingsFlow(repository: nostrRelaysRepository, discovery: nostrCatalogPicker)
             },
             makeBlossomRelaySettingsFlow: { @MainActor in
                 BlossomRelaySettingsFlow(repository: blossomServersRepository)
@@ -739,6 +909,9 @@ struct OnymIOSApp: App {
                         await gateCheckRepository.redeemRecoveryGrant(grant)
                     }
                 )
+            },
+            makeDiscoverySettingsFlow: discoveryRepository.map { repo in
+                { @MainActor in DiscoverySettingsFlow(repository: repo) }
             }
         )
     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -3,6 +3,7 @@ import OnymSearch
 import OnymChatsUI
 import OnymSettings
 import OnymModerationUI
+import OnymDiscovery
 
 /// App shell — `TabView` with the iOS 18+ `Tab(_, systemImage:, value:)`
 /// syntax. The `.search` role places its tab in the system's bottom-right
@@ -173,7 +174,8 @@ struct RootView: View {
                         onClearAllMessages: { await dependencies.messageRepository.removeAll() },
                         makeModerationSettingsFlow: dependencies.makeModerationSettingsFlow,
                         makeModerationConsentFlow: dependencies.makeModerationConsentFlow,
-                        makeModerationCaseFlow: dependencies.makeModerationCaseFlow
+                        makeModerationCaseFlow: dependencies.makeModerationCaseFlow,
+                        makeDiscoverySettingsFlow: dependencies.makeDiscoverySettingsFlow
                     )
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/Tests/OnymIOSTests/DiscoverySeatAdaptersTests.swift
+++ b/Tests/OnymIOSTests/DiscoverySeatAdaptersTests.swift
@@ -178,7 +178,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.emptyCatalog,
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
@@ -197,7 +197,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, [RelayerEndpoint(
@@ -236,7 +236,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([first, second]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.map(\.name), ["Notary One", "Notary Two", "Legacy Relayer"])
@@ -273,7 +273,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([bad, good]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.map(\.name), ["Good Notary", "Legacy Relayer"])
@@ -309,7 +309,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([overlapsLegacy, crossProviderDuplicate]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.map(\.url), [URL(string: "https://legacy.example")!])
@@ -336,7 +336,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([seeded]),
             fallback: FailingFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.map(\.name), ["Discovered Notary"])
@@ -344,7 +344,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let emptyDiscovery = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.emptyCatalog,
             fallback: FailingFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         do {
             _ = try await emptyDiscovery.fetchLatest()
@@ -366,7 +366,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([mislabeled]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
@@ -384,7 +384,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([swapped]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
@@ -410,7 +410,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.first?.url, URL(string: "https://serve.example/api"))
@@ -428,7 +428,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fallbackFetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([noPreferredRole]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let fallbackResult = try await fallbackFetcher.fetchLatest()
         XCTAssertEqual(fallbackResult.first?.url, URL(string: "https://first.example/api"))
@@ -453,7 +453,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog(seeded),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         // First `maxEntriesPerSeat` discovery entries in aggregate
@@ -475,7 +475,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.first?.name, "test-notary")
@@ -493,7 +493,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
@@ -511,7 +511,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: unreachable,
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
@@ -534,7 +534,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubNostrFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, [NostrRelayEndpoint(
@@ -555,7 +555,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubNostrFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubNostrFallback.sentinel)
@@ -575,7 +575,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownBlossomServersFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubBlossomFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, [BlossomServerEndpoint(
@@ -592,7 +592,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownBlossomServersFetcher(
             catalog: Self.emptyCatalog,
             fallback: StubBlossomFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubBlossomFallback.sentinel)
@@ -680,7 +680,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
 
     // MARK: - Consent gate seam
 
-    /// With NO consent system present (`hasActiveConsent: nil` — this
+    /// With NO consent system present (`makeConsentGate: nil` — this
     /// PR standalone), discovery entries are excluded from the known
     /// list entirely: the adapter is a pure legacy passthrough and
     /// never even fans out into the catalog. The known list feeds
@@ -702,7 +702,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: catalog,
             fallback: StubRelayersFallback(),
-            hasActiveConsent: nil
+            makeConsentGate: nil
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
@@ -716,7 +716,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubNostrFallback(),
-            hasActiveConsent: nil
+            makeConsentGate: nil
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubNostrFallback.sentinel)
@@ -730,7 +730,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownBlossomServersFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubBlossomFallback(),
-            hasActiveConsent: nil
+            makeConsentGate: nil
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubBlossomFallback.sentinel)
@@ -761,10 +761,96 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([consented, unconsented]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { $0 == "onym:component:notary-one" }
+            makeConsentGate: { { componentId, _ in componentId == "onym:component:notary-one" } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.map(\.name), ["Notary One", "Legacy Relayer"])
+    }
+
+    /// THE consent-to-bytes rule: consent pins exact manifest bytes,
+    /// so the gate compares the entry's CURRENT digest against the
+    /// active record's pinned hash. An operator republishing under the
+    /// same componentId (new digest, new endpoint) must not ride the
+    /// old record into the known list — that entry is excluded until
+    /// the user re-consents (the pickers render it as TERMS CHANGED),
+    /// while an entry whose digest still matches its pinned hash
+    /// merges as before.
+    func test_relayers_consentGateExcludesRepublishedManifestWithStaleConsent() async throws {
+        let stillConsented = try Self.seeded(
+            componentId: "onym:component:notary-one",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Still Consented",
+                "endpoints": [["uri": "https://one.example/api"]],
+            ],
+            manifestURI: "https://provider.example/manifests/one.json"
+        )
+        let republished = try Self.seeded(
+            componentId: "onym:component:notary-two",
+            seatType: "notary",
+            manifestExtras: [
+                "name": "Republished Notary",
+                "endpoints": [["uri": "https://two-new.example/api"]],
+            ],
+            manifestURI: "https://provider.example/manifests/two.json"
+        )
+        // The app-shaped gate: active pinned hash per componentId. The
+        // republished component's ACTIVE record pins the digest of the
+        // manifest the user reviewed — which is no longer the digest
+        // the catalog entry lists.
+        let activeHashes = [
+            "onym:component:notary-one": stillConsented.entry.entry.manifest.digest,
+            "onym:component:notary-two": "sha256:" + String(repeating: "a", count: 64),
+        ]
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog([stillConsented, republished]),
+            fallback: StubRelayersFallback(),
+            makeConsentGate: { { componentId, digest in activeHashes[componentId] == digest } }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(
+            result.map(\.name), ["Still Consented", "Legacy Relayer"],
+            "an active consent record must not admit a republished (unreviewed) manifest's endpoint"
+        )
+        XCTAssertFalse(
+            result.contains { $0.url == URL(string: "https://two-new.example/api")! },
+            "the republished endpoint must stay out of the known list (and auto-populate) until re-consent"
+        )
+    }
+
+    /// The gate factory is invoked once per `fetchLatest` pass — the
+    /// per-entry checks answer from that one gate (one consent-store
+    /// load per pass), never one store load per entry.
+    func test_relayers_consentGateFactoryRunsOncePerFetchPass() async throws {
+        let seeded = try (0..<3).map { index in
+            try Self.seeded(
+                componentId: "onym:component:notary-\(index)",
+                seatType: "notary",
+                manifestExtras: [
+                    "name": "Notary \(index)",
+                    "endpoints": [["uri": "https://notary-\(index).example/api"]],
+                ],
+                manifestURI: "https://provider.example/manifests/notary-\(index).json"
+            )
+        }
+        final class Counter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = 0
+            func increment() { lock.withLock { value += 1 } }
+            var count: Int { lock.withLock { value } }
+        }
+        let factoryCalls = Counter()
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: Self.catalog(seeded),
+            fallback: StubRelayersFallback(),
+            makeConsentGate: {
+                factoryCalls.increment()
+                return { _, _ in true }
+            }
+        )
+        let result = try await fetcher.fetchLatest()
+        XCTAssertEqual(result.count, 4, "three discovery entries + the legacy row")
+        XCTAssertEqual(factoryCalls.count, 1, "one gate (one store load) per fetch pass")
     }
 
     // MARK: - Endpoint URI rules + dedupe normalization
@@ -786,7 +872,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
@@ -808,7 +894,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubNostrFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.map(\.name), ["Case Variant Courier"])
@@ -832,7 +918,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([flagged]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
@@ -854,7 +940,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownRelayersFetcher(
             catalog: Self.catalog([underReview]),
             fallback: StubRelayersFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.map(\.name), ["Review Notary", "Legacy Relayer"])
@@ -875,7 +961,7 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let fetcher = DiscoveryBackedKnownNostrRelaysFetcher(
             catalog: Self.catalog([seeded]),
             fallback: StubNostrFallback(),
-            hasActiveConsent: { _ in true }
+            makeConsentGate: { { _, _ in true } }
         )
         let result = try await fetcher.fetchLatest()
         XCTAssertEqual(result.map(\.name), ["Shouting Courier", "Legacy Nostr"])

--- a/Tests/OnymIOSTests/RelayerSettingsFlowTests.swift
+++ b/Tests/OnymIOSTests/RelayerSettingsFlowTests.swift
@@ -1,6 +1,9 @@
+import CryptoKit
 import XCTest
 @testable import OnymIOS
 import OnymChain
+import OnymDiscovery
+import OnymFoundation
 import OnymSettings
 
 /// Settings flow against a real `RelayerRepository` backed by the
@@ -175,6 +178,216 @@ final class RelayerSettingsFlowTests: XCTestCase {
         defer { flow.stop() }
         try await waitFor { flow.state.snapshot.configuration.primaryURL != nil }
         XCTAssertTrue(flow.isPrimary(testEndpoint))
+    }
+
+    /// The consent-derived dedupe: a published-list row whose URL is
+    /// an endpoint of a CONSENTED catalog entry's pinned manifest is
+    /// hidden — that service renders in the "From catalog" section
+    /// with attribution and consent state instead. Keyed off the
+    /// catalog entries + consent records the flow already holds, not
+    /// a fetch-time registry, so it can't race the known list
+    /// rendering from cache before any fetch.
+    func test_unconfiguredKnownList_hidesConsentedCatalogEndpointURLs() async throws {
+        let consentedURL = URL(string: "https://consented.example/api")!
+        let (entry, record) = try Self.consentedCatalogFixture(endpointURL: consentedURL)
+        let known = [
+            RelayerEndpoint(name: "Consented", url: consentedURL, networks: ["testnet"]),
+            RelayerEndpoint(name: "Other", url: URL(string: "https://other.example")!, networks: ["public"]),
+        ]
+        let store = InMemoryRelayerSelectionStore(
+            configuration: RelayerConfiguration(endpoints: [], primaryURL: nil, strategy: .primary),
+            cachedList: known
+        )
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds(known))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+        let discovery = DiscoveryModulePicker(
+            entries: { [entry] },
+            activeConsent: { $0 == entry.entry.componentId ? record : nil },
+            makeConsentFlow: { _ in fatalError("not exercised") }
+        )
+        let flow = RelayerSettingsFlow(repository: repo, discovery: discovery)
+        flow.start()
+        defer { flow.stop() }
+
+        try await waitFor { !flow.state.snapshot.knownList.isEmpty && !flow.catalogEntries.isEmpty }
+        XCTAssertEqual(
+            flow.unconfiguredKnownList.map(\.url), [URL(string: "https://other.example")],
+            "a consented catalog endpoint must render in the catalog section, not as a bare published row"
+        )
+    }
+
+    /// The fix-1 regression at the SCREEN level (the reviewed
+    /// duplicate-row bug): an operator republished — the ACTIVE
+    /// consent record pins the OLD manifest bytes while the catalog
+    /// entry now lists a NEW digest with a NEW endpoint URL. The
+    /// catalog row renders in its TERMS CHANGED state (record present,
+    /// hash != entry digest), and because the adapter's consent gate
+    /// compares digests, the new URL never enters the known list — so
+    /// the published section must NOT offer it as a bare tap-to-add
+    /// row next to the TERMS CHANGED catalog row.
+    func test_unconfiguredKnownList_termsChangedEntryDoesNotOfferNewURLAsPublishedRow() async throws {
+        struct LegacyStub: KnownRelayersFetcher {
+            let list: [RelayerEndpoint]
+            func fetchLatest() async throws -> [RelayerEndpoint] { list }
+        }
+        let componentId = "onym:component:republished-notary"
+        let key = Curve25519.Signing.PrivateKey()
+        let oldRaw = try Self.signedManifestRaw(
+            key: key, componentId: componentId,
+            endpointURL: URL(string: "https://old.example/api")!
+        )
+        let newURL = URL(string: "https://new.example/api")!
+        let newRaw = try Self.signedManifestRaw(
+            key: key, componentId: componentId, endpointURL: newURL
+        )
+        // Consent pins the OLD bytes; the catalog lists the NEW digest.
+        let reviewedOld = try ServiceManifestReviewer().review(
+            raw: oldRaw, expectedDigest: Self.digest(of: oldRaw)
+        )
+        let record = PinnedConsentRecord(reviewed: reviewedOld, acceptedAt: Date())
+        let entry = try Self.attributedEntry(
+            componentId: componentId,
+            keyHex: Self.hex(key.publicKey.rawRepresentation),
+            digest: Self.digest(of: newRaw)
+        )
+        XCTAssertNotEqual(
+            record.manifestHash, entry.entry.manifest.digest,
+            "fixture must model a republish: pinned hash differs from the listed digest"
+        )
+
+        let legacy = RelayerEndpoint(
+            name: "Other", url: URL(string: "https://other.example")!, networks: ["public"]
+        )
+        let activeHashes = [componentId: record.manifestHash]
+        let fetcher = DiscoveryBackedKnownRelayersFetcher(
+            catalog: DiscoverySeatCatalog(
+                entries: { seatType in seatType == "notary" ? [entry] : [] },
+                fetchManifestBytes: { _ in newRaw }
+            ),
+            fallback: LegacyStub(list: [legacy]),
+            // The app-shaped gate: componentId AND digest must match
+            // the active record.
+            makeConsentGate: { { id, digest in activeHashes[id] == digest } }
+        )
+        // `hasUserInteracted` (the init default) so the refresh below
+        // exercises the known-list path, not first-launch
+        // auto-populate — a populated config would hide every row from
+        // `unconfiguredKnownList` regardless of the gate.
+        let repo = RelayerRepository(
+            fetcher: fetcher,
+            store: InMemoryRelayerSelectionStore(
+                configuration: RelayerConfiguration(endpoints: [], primaryURL: nil, strategy: .primary)
+            )
+        )
+        let discovery = DiscoveryModulePicker(
+            entries: { [entry] },
+            activeConsent: { $0 == componentId ? record : nil },
+            makeConsentFlow: { _ in fatalError("not exercised") }
+        )
+        let flow = RelayerSettingsFlow(repository: repo, discovery: discovery)
+        flow.start()
+        defer { flow.stop() }
+        try? await repo.refresh()
+        try await waitFor { !flow.state.snapshot.knownList.isEmpty && !flow.catalogEntries.isEmpty }
+
+        // The catalog row is present, in its TERMS CHANGED condition
+        // (active record whose hash no longer matches the digest).
+        let rowRecord = try XCTUnwrap(flow.activeConsent(for: entry))
+        XCTAssertNotEqual(rowRecord.manifestHash, entry.entry.manifest.digest)
+        // …and the published section does not offer the unreviewed
+        // new endpoint: the digest-comparing gate kept it out of the
+        // known list entirely, closing the duplicate-row hole.
+        XCTAssertEqual(
+            flow.unconfiguredKnownList.map(\.url), [legacy.url],
+            "the republished manifest's new URL must not render as a bare tap-to-add published row"
+        )
+        XCTAssertFalse(flow.state.snapshot.knownList.contains { $0.url == newURL })
+    }
+
+    // MARK: - Catalog fixtures
+
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func digest(of raw: Data) -> String {
+        "sha256:" + hex(Data(SHA256.hash(data: raw)))
+    }
+
+    /// Raw bytes of a freshly signed notary manifest with one endpoint.
+    private static func signedManifestRaw(
+        key: Curve25519.Signing.PrivateKey,
+        componentId: String,
+        endpointURL: URL
+    ) throws -> Data {
+        var object: [String: Any] = [
+            "componentId": componentId,
+            "seat": "notary",
+            "operator": "onym:key:\(hex(key.publicKey.rawRepresentation))",
+            "validUntil": "2030-01-01T00:00:00Z",
+            "endpoints": [["uri": endpointURL.absoluteString]],
+        ]
+        let unsigned = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        let signature = try key.signature(for: ServiceManifestCanonical.signingBytes(of: unsigned))
+        object["signature"] = signature.base64EncodedString()
+        return try JSONSerialization.data(withJSONObject: object, options: [.withoutEscapingSlashes])
+    }
+
+    /// A verified catalog entry (notary seat) listing `digest` under
+    /// `componentId`, wrapped in test attribution.
+    private static func attributedEntry(
+        componentId: String,
+        keyHex: String,
+        digest: String
+    ) throws -> AttributedCatalogEntry {
+        let entryJSON: [String: Any] = [
+            "componentId": componentId,
+            "seatType": "notary",
+            "manifest": ["uri": "https://provider.example/manifests/consented.json", "digest": digest],
+            "operator": "onym:key:\(keyHex)",
+            "listedAt": "2026-01-01T00:00:00Z",
+            "relationship": "none",
+            "placement": "neutral",
+        ]
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let entry = try decoder.decode(
+            CatalogEntry.self,
+            from: JSONSerialization.data(withJSONObject: entryJSON)
+        )
+        return AttributedCatalogEntry(
+            entry: entry,
+            source: SourceAttribution(
+                providerId: "onym:component:test-provider",
+                sourceLabel: "Test Provider",
+                catalogId: "public",
+                snapshotDigest: "sha256:" + String(repeating: "0", count: 64),
+                relationship: "none",
+                placement: "neutral"
+            )
+        )
+    }
+
+    /// A reviewed + pinned consent over a freshly signed manifest with
+    /// one endpoint URI, plus the matching catalog entry.
+    private static func consentedCatalogFixture(
+        endpointURL: URL
+    ) throws -> (AttributedCatalogEntry, PinnedConsentRecord) {
+        let key = Curve25519.Signing.PrivateKey()
+        let raw = try signedManifestRaw(
+            key: key, componentId: "onym:component:consented-notary", endpointURL: endpointURL
+        )
+        let reviewed = try ServiceManifestReviewer().review(raw: raw, expectedDigest: digest(of: raw))
+        let record = PinnedConsentRecord(reviewed: reviewed, acceptedAt: Date())
+        let entry = try attributedEntry(
+            componentId: "onym:component:consented-notary",
+            keyHex: hex(key.publicKey.rawRepresentation),
+            digest: digest(of: raw)
+        )
+        return (entry, record)
     }
 
     // MARK: - validate


### PR DESCRIPTION
## Summary

PRs 4–6 of the discovery sequence, **stacked on #246** (base branch set accordingly). Restacked 2026-08-15 as a **single commit** on top of the restacked `discovery-wiring` — the diff now shows only this branch's own Settings/consent/offers work, with all review-round fixes preserved in the squashed tree.

- **DISCOVERY section** in Settings: provider list with status chips (OK/FETCHING/FAILED/INTEGRITY/UNCONFIRMED), pinned-key fingerprints, permanent remove with confirm; **Add Discovery Provider** — https URL → TOFU screen with the operator fingerprint rendered large → confirm pins the key. Errors mapped from the typed trust/fetch errors, integrity failures distinguished by a typed flag.
- **Module consent flow** (loading → reviewing → applying → done, plus a terminal failed state for entries that can never be consented here): manifest reviewed against the catalog-pinned digest via `ServiceManifestReviewer`, operator-key/seat/componentId cross-checks against the verified catalog entry, attribution + relationship disclosure, linked terms via MarkdownDocumentView, manifest-hash card, one explicit accept → consent pin, then selection record, then seat-specific apply closure. Moderation seat excluded at three layers (picker filter, flow refusal, persistence throw).
- **Consent is the only path for catalog entries** — enforced at the adapter level: the discovery-backed known-list fetchers include a discovery-derived endpoint only when an active `PinnedConsentRecord` exists for its componentId, and serve the legacy list otherwise; consented catalogs merge into the legacy lists. The published-list dedupe is keyed off the consented entries' pinned manifest endpoints — no fetch-time registry, no read-timing dependency.
- **Offers**: FREE/model badges + detail view; free selectable through `EntitlementProviding` (incl. `FreeTierEntitlementProvider.init(reviewing:consentStore:)` so first consent can grant a manifest's free offer before any record exists), paid disabled with "purchasing not yet available".
- "FROM CATALOG" sections in the relayer and nostr pickers with consent-state chips (CONSENTED / TERMS CHANGED / REVIEW by hash match), fed by a live stream of the discovery aggregate. All new UI behind nil-default factory params — the app is unchanged when discovery is absent.

## Restack note

The branch previously carried many merge commits from the review rounds; it is now exactly one commit containing the five original review-round commits squashed (initial UI; entitlements-at-review-time + honest apply failures; surfaced notes + closed consent-gate holes; adapter-level consent gate + registry-free dedupe; legacy-list merge + terminal cross-checks + drain lifecycle), **fixed forward onto #245's round-2 throwing `PinnedConsentStore` API**: accept paths adopt `try`, gating/entitlement reads are fail-closed via `try?`, and a corrupt consent store surfaces as a non-transient error on the consent surface instead of "Try again".

**Merge order: #245 → #246 → #247, squash-merge recommended for each.**

## Testing (re-run after restack)

OnymDiscovery package 112/112, OnymFoundation package 53/53, app-target `DiscoverySeatAdaptersTests` + `RelayerSettingsFlowTests` 38/38, full app build for iPhone 17 Pro simulator. Testable logic lives in OnymDiscovery / the app test target since OnymSettings has no test target. Remaining from the plan: PR 7 (UI-test fakes + instrumented flows), blossom catalog section deliberately not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8
