### PR TITLE
Add OnymOnboarding package: flow state machine, store, step scaffolding

### DIFF
--- a/Packages/OnymOnboarding/Package.swift
+++ b/Packages/OnymOnboarding/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OnymOnboarding",
+    platforms: [.iOS("18.0")],
+    products: [
+        .library(name: "OnymOnboarding", targets: ["OnymOnboarding"]),
+    ],
+    targets: [
+        // Deliberately dependency-free: the flow models each step's
+        // outcome abstractly and receives every collaborator as an
+        // injected closure, so the state machine never links against
+        // OnymDiscovery / OnymModerationUI / OnymDesign. The app's
+        // composition root (PR 3) supplies the step content and the
+        // step indicator from those packages.
+        .target(
+            name: "OnymOnboarding"
+        ),
+        .testTarget(
+            name: "OnymOnboardingTests",
+            dependencies: ["OnymOnboarding"]
+        ),
+    ]
+)

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Observation
+
+/// The seven first-launch steps, in presentation order.
+public enum OnboardingStep: String, CaseIterable, Equatable, Hashable, Sendable {
+    case welcome
+    case discoveryConfirm
+    case messageTransport
+    case blobTransport
+    case notary
+    case moderation
+    case done
+}
+
+/// What happened at one step, modeled abstractly — the flow never
+/// links against the packages whose surfaces produce these outcomes
+/// (OnymDiscovery's module consent, OnymModerationUI's mandate flow).
+/// The app-layer step content (PR 3) reports back through this enum.
+public enum StepOutcome: Equatable, Sendable {
+    /// The user consented at this step. `componentId` names the chosen
+    /// component when the step's surface knows one (catalog picks);
+    /// nil for consents without a component identity (e.g. confirming
+    /// the seeded discovery source).
+    case consented(componentId: String?)
+    /// The user skipped the step; the seat falls back to today's
+    /// defaults.
+    case skipped
+    /// The step had nothing to decide (informational steps: welcome,
+    /// done, moderation-with-empty-directory).
+    case notApplicable
+}
+
+/// State machine for the first-launch onboarding sequence. Modeled on
+/// `ModuleConsentFlow` / `ModerationConsentFlow`: `@MainActor
+/// @Observable`, every collaborator injected as a closure so the
+/// machine is unit-testable and the package stays dependency-free.
+///
+/// Presentation contract (PR 3): RootView presents `OnboardingView` as
+/// a `fullScreenCover` with `.interactiveDismissDisabled(true)` — the
+/// only exits are `complete()` on the Done step and the per-step Skip
+/// affordances; there is no swipe-to-dismiss.
+@MainActor
+@Observable
+public final class OnboardingFlow {
+    public private(set) var step: OnboardingStep = .welcome
+    /// Per-step record of what the user decided. Written by
+    /// `recordOutcome` (step content reporting a consent), `skip()`
+    /// (`.skipped`), and `advance()` (backfills `.notApplicable` for
+    /// steps that were walked past without a decision). Revisiting a
+    /// step via `back()` keeps the prior outcome until a new one is
+    /// recorded over it.
+    public private(set) var outcomes: [OnboardingStep: StepOutcome] = [:]
+    /// Whether the moderation directory has entries — resolved once by
+    /// `start()` via the injected probe. Until (or unless) the probe
+    /// answers true, moderation behaves as skippable/informational,
+    /// matching today's gate semantics (empty directory ⇒ the gate
+    /// reads operational and never blocks).
+    public private(set) var moderationDirectoryHasEntries = false
+
+    private let store: any OnboardingStore
+    private let moderationDirectoryNonEmpty: () async -> Bool
+    /// Called after `complete()` writes the flag, so the presenter can
+    /// dismiss the cover and hand control to the moderation gate.
+    private let onCompleted: @MainActor () -> Void
+    /// The in-flight directory probe, internal so tests can await it.
+    @ObservationIgnored private(set) var moderationProbeTask: Task<Void, Never>?
+
+    public init(
+        store: any OnboardingStore,
+        moderationDirectoryNonEmpty: @escaping () async -> Bool,
+        onCompleted: @escaping @MainActor () -> Void = {}
+    ) {
+        self.store = store
+        self.moderationDirectoryNonEmpty = moderationDirectoryNonEmpty
+        self.onCompleted = onCompleted
+    }
+
+    // MARK: - Step indicator
+
+    /// Zero-based position of the current step, for the indicator.
+    public var stepIndex: Int {
+        OnboardingStep.allCases.firstIndex(of: step) ?? 0
+    }
+
+    /// Total number of steps (7), for the indicator.
+    public var stepCount: Int {
+        OnboardingStep.allCases.count
+    }
+
+    // MARK: - Skippability
+
+    /// Every step is skippable except:
+    /// - `moderation` when the authority directory has entries — the
+    ///   moderation gate would block right after onboarding anyway, so
+    ///   letting the user skip here would be a lie (this mirrors the
+    ///   existing gate: consent is only optional while the directory
+    ///   is empty/operational);
+    /// - `done`, which is terminal — there is nothing after it to skip
+    ///   to (its primary action is `complete()`).
+    public func isSkippable(_ step: OnboardingStep) -> Bool {
+        switch step {
+        case .moderation:
+            return !moderationDirectoryHasEntries
+        case .done:
+            return false
+        default:
+            return true
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Kick the async moderation-directory probe. Idempotent.
+    public func start() {
+        guard moderationProbeTask == nil else { return }
+        moderationProbeTask = Task { [weak self] in
+            guard let self else { return }
+            let nonEmpty = await self.moderationDirectoryNonEmpty()
+            self.moderationDirectoryHasEntries = nonEmpty
+        }
+    }
+
+    /// Step content reports what the user decided at the current step.
+    /// Recording again overwrites (the user changed their mind before
+    /// advancing, or came `back()` and redid the step).
+    public func recordOutcome(_ outcome: StepOutcome) {
+        outcomes[step] = outcome
+    }
+
+    /// Move to the next step. A step walked past without any recorded
+    /// outcome is backfilled as `.notApplicable` — the informational
+    /// steps (welcome; moderation with an empty directory) advance
+    /// through here without ever recording. No-op on `done`
+    /// (`complete()` is the terminal action).
+    public func advance() {
+        guard let next = neighbor(offset: 1) else { return }
+        if outcomes[step] == nil {
+            outcomes[step] = .notApplicable
+        }
+        step = next
+    }
+
+    /// Skip the current step, recording `.skipped`. Guarded by
+    /// `isSkippable` — a no-op on an unskippable step (moderation with
+    /// a non-empty directory, done).
+    public func skip() {
+        guard isSkippable(step), let next = neighbor(offset: 1) else { return }
+        outcomes[step] = .skipped
+        step = next
+    }
+
+    /// Move to the previous step. No-op on `welcome`. The revisited
+    /// step's prior outcome is kept — `recordOutcome` / `skip()`
+    /// overwrite it if the user decides differently this time.
+    public func back() {
+        guard let previous = neighbor(offset: -1) else { return }
+        step = previous
+    }
+
+    /// "Start" on the Done step: persist the completion flag, then let
+    /// the presenter dismiss. Guarded to the `done` step so no
+    /// programming error can mark onboarding complete mid-sequence.
+    public func complete() {
+        guard step == .done else { return }
+        if outcomes[step] == nil {
+            outcomes[step] = .notApplicable
+        }
+        store.markOnboardingCompleted()
+        onCompleted()
+    }
+
+    // MARK: - Private
+
+    private func neighbor(offset: Int) -> OnboardingStep? {
+        let all = OnboardingStep.allCases
+        guard let index = all.firstIndex(of: step) else { return nil }
+        let target = index + offset
+        guard all.indices.contains(target) else { return nil }
+        return all[target]
+    }
+}

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
@@ -39,6 +39,13 @@ public enum StepOutcome: Equatable, Sendable {
 /// a `fullScreenCover` with `.interactiveDismissDisabled(true)` — the
 /// only exits are `complete()` on the Done step and the per-step Skip
 /// affordances; there is no swipe-to-dismiss.
+///
+/// Partial progress is deliberately NOT persisted: the flow lives in
+/// memory, and an app killed mid-onboarding starts over at `welcome`
+/// on next launch. Individual consents the step content applied
+/// before the kill are persisted by their own stores (consent pins,
+/// mandate) — only the walk position restarts. Revisit in PR 3 if the
+/// wired flow turns out long enough to warrant resume.
 @MainActor
 @Observable
 public final class OnboardingFlow {
@@ -51,11 +58,18 @@ public final class OnboardingFlow {
     /// recorded over it.
     public private(set) var outcomes: [OnboardingStep: StepOutcome] = [:]
     /// Whether the moderation directory has entries — resolved once by
-    /// `start()` via the injected probe. Until (or unless) the probe
-    /// answers true, moderation behaves as skippable/informational,
-    /// matching today's gate semantics (empty directory ⇒ the gate
-    /// reads operational and never blocks).
-    public private(set) var moderationDirectoryHasEntries = false
+    /// `start()` via the injected probe. Tri-state and FAIL-CLOSED:
+    /// nil (unresolved) is treated exactly like "has entries" — the
+    /// moderation step reads unskippable/mandatory until the probe
+    /// answers `false`. Racing the probe must never open a skip window
+    /// that a resolved `true` would have closed.
+    public private(set) var moderationDirectoryHasEntries: Bool?
+
+    /// Whether the directory probe has answered — the view shows a
+    /// progress state on the skip affordance while this is false.
+    public var moderationProbeResolved: Bool {
+        moderationDirectoryHasEntries != nil
+    }
 
     private let store: any OnboardingStore
     private let moderationDirectoryNonEmpty: () async -> Bool
@@ -90,22 +104,41 @@ public final class OnboardingFlow {
     // MARK: - Skippability
 
     /// Every step is skippable except:
-    /// - `moderation` when the authority directory has entries — the
+    /// - `welcome` — its primary Continue is the only path forward; a
+    ///   separate Skip would be redundant (and the view never renders
+    ///   one);
+    /// - `moderation` unless the directory probe has ANSWERED that the
+    ///   authority directory is empty — with entries present the
     ///   moderation gate would block right after onboarding anyway, so
-    ///   letting the user skip here would be a lie (this mirrors the
-    ///   existing gate: consent is only optional while the directory
-    ///   is empty/operational);
+    ///   letting the user skip here would be a lie, and while the
+    ///   probe is still unresolved we fail closed rather than open a
+    ///   racy skip window (this mirrors the existing gate: consent is
+    ///   only optional while the directory is empty/operational);
     /// - `done`, which is terminal — there is nothing after it to skip
     ///   to (its primary action is `complete()`).
     public func isSkippable(_ step: OnboardingStep) -> Bool {
         switch step {
+        case .welcome:
+            return false
         case .moderation:
-            return !moderationDirectoryHasEntries
+            return moderationDirectoryHasEntries == false
         case .done:
             return false
         default:
             return true
         }
+    }
+
+    /// A mandatory step cannot be walked past without a recorded
+    /// outcome — `advance()` refuses until the step content reports
+    /// one. Today that is exactly `moderation` while the directory has
+    /// entries (or the probe hasn't answered yet — fail-closed, the
+    /// complement of `isSkippable`): its consent is the one obligation
+    /// onboarding must not silently drop, because the gate behind it
+    /// would block anyway.
+    public func isMandatory(_ step: OnboardingStep) -> Bool {
+        guard step == .moderation else { return false }
+        return moderationDirectoryHasEntries != false
     }
 
     // MARK: - Lifecycle
@@ -131,9 +164,13 @@ public final class OnboardingFlow {
     /// outcome is backfilled as `.notApplicable` — the informational
     /// steps (welcome; moderation with an empty directory) advance
     /// through here without ever recording. No-op on `done`
-    /// (`complete()` is the terminal action).
+    /// (`complete()` is the terminal action), and a no-op on a
+    /// mandatory step with no recorded outcome — the primary button
+    /// must not be a back door around the unskippable-moderation rule
+    /// (the view also disables it; this guard is the second layer).
     public func advance() {
         guard let next = neighbor(offset: 1) else { return }
+        guard !isMandatory(step) || outcomes[step] != nil else { return }
         if outcomes[step] == nil {
             outcomes[step] = .notApplicable
         }

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStepScaffold.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStepScaffold.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+/// One onboarding step screen, per the established consent-view
+/// skeleton: ScrollView + large title + content slot + primary button
+/// + text Back/Skip, with the step indicator injected as a view
+/// builder slot.
+///
+/// Deliberately styled with plain SwiftUI — this package does not
+/// depend on OnymDesign. PR 3 supplies `SettingsStepIndicator` (made
+/// public there) through the `indicator` slot and can restyle the
+/// buttons via the content it injects; the scaffold's own chrome stays
+/// system-styled.
+///
+/// Accessibility identifiers follow `onboarding.<step>.<element>`:
+/// `onboarding.<step>.primary`, `onboarding.<step>.skip`,
+/// `onboarding.<step>.back`, `onboarding.<step>.title`.
+public struct OnboardingStepScaffold<Content: View, Indicator: View>: View {
+    private let step: OnboardingStep
+    private let title: String
+    private let subtitle: String?
+    private let primaryTitle: String
+    private let primaryAction: () -> Void
+    /// nil hides the Skip affordance (unskippable steps).
+    private let skipAction: (() -> Void)?
+    /// nil hides the Back affordance (the first step).
+    private let backAction: (() -> Void)?
+    private let content: Content
+    private let indicator: Indicator
+
+    public init(
+        step: OnboardingStep,
+        title: String,
+        subtitle: String? = nil,
+        primaryTitle: String,
+        primaryAction: @escaping () -> Void,
+        skipAction: (() -> Void)? = nil,
+        backAction: (() -> Void)? = nil,
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder indicator: () -> Indicator
+    ) {
+        self.step = step
+        self.title = title
+        self.subtitle = subtitle
+        self.primaryTitle = primaryTitle
+        self.primaryAction = primaryAction
+        self.skipAction = skipAction
+        self.backAction = backAction
+        self.content = content()
+        self.indicator = indicator()
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    indicator
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 24)
+
+                    Text(verbatim: title)
+                        .font(.largeTitle.bold())
+                        .accessibilityIdentifier("onboarding.\(step.rawValue).title")
+                        .padding(.top, 8)
+
+                    if let subtitle {
+                        Text(verbatim: subtitle)
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    content
+                        .padding(.top, 8)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 24)
+            }
+
+            VStack(spacing: 12) {
+                Button(action: primaryAction) {
+                    Text(verbatim: primaryTitle)
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("onboarding.\(step.rawValue).primary")
+
+                HStack {
+                    if let backAction {
+                        Button("Back", action: backAction)
+                            .accessibilityIdentifier("onboarding.\(step.rawValue).back")
+                    }
+                    Spacer()
+                    if let skipAction {
+                        Button("Skip", action: skipAction)
+                            .accessibilityIdentifier("onboarding.\(step.rawValue).skip")
+                    }
+                }
+                .font(.subheadline)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .padding(.bottom, 16)
+        }
+    }
+}

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStepScaffold.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStepScaffold.swift
@@ -19,9 +19,17 @@ public struct OnboardingStepScaffold<Content: View, Indicator: View>: View {
     private let title: String
     private let subtitle: String?
     private let primaryTitle: String
+    /// Disables the primary button — mandatory steps with no recorded
+    /// outcome render Continue disabled (the flow's `advance()` guard
+    /// is the second layer of the same rule).
+    private let primaryDisabled: Bool
     private let primaryAction: () -> Void
     /// nil hides the Skip affordance (unskippable steps).
     private let skipAction: (() -> Void)?
+    /// Renders a small progress indicator in the Skip slot — used
+    /// while the flow's moderation-directory probe is unresolved and
+    /// skippability is not yet known.
+    private let showsSkipProgress: Bool
     /// nil hides the Back affordance (the first step).
     private let backAction: (() -> Void)?
     private let content: Content
@@ -32,8 +40,10 @@ public struct OnboardingStepScaffold<Content: View, Indicator: View>: View {
         title: String,
         subtitle: String? = nil,
         primaryTitle: String,
+        primaryDisabled: Bool = false,
         primaryAction: @escaping () -> Void,
         skipAction: (() -> Void)? = nil,
+        showsSkipProgress: Bool = false,
         backAction: (() -> Void)? = nil,
         @ViewBuilder content: () -> Content,
         @ViewBuilder indicator: () -> Indicator
@@ -42,8 +52,10 @@ public struct OnboardingStepScaffold<Content: View, Indicator: View>: View {
         self.title = title
         self.subtitle = subtitle
         self.primaryTitle = primaryTitle
+        self.primaryDisabled = primaryDisabled
         self.primaryAction = primaryAction
         self.skipAction = skipAction
+        self.showsSkipProgress = showsSkipProgress
         self.backAction = backAction
         self.content = content()
         self.indicator = indicator()
@@ -84,6 +96,7 @@ public struct OnboardingStepScaffold<Content: View, Indicator: View>: View {
                         .padding(.vertical, 6)
                 }
                 .buttonStyle(.borderedProminent)
+                .disabled(primaryDisabled)
                 .accessibilityIdentifier("onboarding.\(step.rawValue).primary")
 
                 HStack {
@@ -95,6 +108,10 @@ public struct OnboardingStepScaffold<Content: View, Indicator: View>: View {
                     if let skipAction {
                         Button("Skip", action: skipAction)
                             .accessibilityIdentifier("onboarding.\(step.rawValue).skip")
+                    } else if showsSkipProgress {
+                        ProgressView()
+                            .controlSize(.small)
+                            .accessibilityIdentifier("onboarding.\(step.rawValue).skip_pending")
                     }
                 }
                 .font(.subheadline)

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStore.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStore.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Persistence seam for the one bit the onboarding gate needs: has the
+/// user completed (or been grandfathered past) the first-launch flow.
+public protocol OnboardingStore: Sendable {
+    /// Whether the completion flag is set.
+    func hasCompletedOnboarding() -> Bool
+    /// Set the completion flag. Idempotent.
+    func markOnboardingCompleted()
+}
+
+/// Production `OnboardingStore`. Single boolean under
+/// `app.onym.ios.onboarding.completed` — cleared by the app's
+/// `--reset-keychain` test path alongside the other first-run state.
+///
+/// `@unchecked Sendable` for the same reason as the sibling
+/// UserDefaults stores (e.g. `UserDefaultsSeatSelectionStore`):
+/// `UserDefaults` is documented thread-safe but not formally
+/// `Sendable`.
+public struct UserDefaultsOnboardingStore: OnboardingStore, @unchecked Sendable {
+    /// Internal so tests can assert the exact key the app's reset path
+    /// must clear.
+    static let key = "app.onym.ios.onboarding.completed"
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func hasCompletedOnboarding() -> Bool {
+        defaults.bool(forKey: Self.key)
+    }
+
+    public func markOnboardingCompleted() {
+        defaults.set(true, forKey: Self.key)
+    }
+}
+
+/// The launch-time gate decision, including grandfathering: users who
+/// predate onboarding have no completion flag but plenty of configured
+/// state, and must not be onboarded as if the app were fresh.
+public enum OnboardingGate {
+    /// Whether first-launch onboarding should be presented.
+    ///
+    /// - `store` holds the completion flag written by
+    ///   `OnboardingFlow.complete()`.
+    /// - `isExistingUser` is the injected existing-user signal — the
+    ///   app passes "any `hasUserInteracted` or a moderation mandate is
+    ///   present". It is only consulted when the flag is absent, so the
+    ///   (potentially costier) probe never runs on the steady-state
+    ///   path.
+    ///
+    /// Either signal — completed flag OR existing-user state — means NO
+    /// onboarding. The probe is a pure read: it never writes the flag
+    /// itself (completion is `OnboardingFlow.complete()`'s job), so a
+    /// grandfathered user simply answers false here on every launch.
+    public static func shouldOnboard(
+        store: any OnboardingStore,
+        isExistingUser: () -> Bool
+    ) -> Bool {
+        if store.hasCompletedOnboarding() { return false }
+        if isExistingUser() { return false }
+        return true
+    }
+}

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStore.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStore.swift
@@ -7,6 +7,10 @@ public protocol OnboardingStore: Sendable {
     func hasCompletedOnboarding() -> Bool
     /// Set the completion flag. Idempotent.
     func markOnboardingCompleted()
+    /// Clear the completion flag, so the next launch onboards again.
+    /// The app's `--reset-keychain` test path calls this instead of
+    /// hardcoding the storage key. Idempotent.
+    func resetOnboarding()
 }
 
 /// Production `OnboardingStore`. Single boolean under
@@ -34,6 +38,10 @@ public struct UserDefaultsOnboardingStore: OnboardingStore, @unchecked Sendable 
 
     public func markOnboardingCompleted() {
         defaults.set(true, forKey: Self.key)
+    }
+
+    public func resetOnboarding() {
+        defaults.removeObject(forKey: Self.key)
     }
 }
 

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -21,22 +21,21 @@ import SwiftUI
 /// dot indicator so the package previews and tests stand alone.
 public struct OnboardingView: View {
     @State private var flow: OnboardingFlow
-    /// App-supplied content slot for the middle steps. The closure
-    /// receives the step being rendered; the default is a placeholder
-    /// card naming the step.
-    private let stepContent: (OnboardingStep) -> AnyView
+    /// App-supplied content slot, consulted for EVERY step (Welcome
+    /// and Done included). Return nil to fall back to the built-ins:
+    /// the Welcome/Done bodies, and a placeholder card for the middle
+    /// steps until PR 3 supplies the real surfaces.
+    private let stepContent: (OnboardingStep) -> AnyView?
     /// App-supplied step indicator, given (zero-based index, count).
     private let stepIndicator: (Int, Int) -> AnyView
 
     public init(
         flow: OnboardingFlow,
-        stepContent: ((OnboardingStep) -> AnyView)? = nil,
+        stepContent: ((OnboardingStep) -> AnyView?)? = nil,
         stepIndicator: ((Int, Int) -> AnyView)? = nil
     ) {
         _flow = State(initialValue: flow)
-        self.stepContent = stepContent ?? { step in
-            AnyView(PlaceholderStepContent(step: step))
-        }
+        self.stepContent = stepContent ?? { _ in nil }
         self.stepIndicator = stepIndicator ?? { index, count in
             AnyView(DefaultStepIndicator(index: index, count: count))
         }
@@ -56,8 +55,16 @@ public struct OnboardingView: View {
             title: Self.title(for: step),
             subtitle: Self.subtitle(for: step),
             primaryTitle: step == .done ? String(localized: "Start") : String(localized: "Continue"),
+            // Mandatory steps render Continue disabled until the step
+            // content records an outcome; `flow.advance()` carries the
+            // same guard as the second layer.
+            primaryDisabled: flow.isMandatory(step) && flow.outcomes[step] == nil,
             primaryAction: { primaryTapped() },
-            skipAction: showsSkip(step) ? { flow.skip() } : nil,
+            skipAction: flow.isSkippable(step) ? { flow.skip() } : nil,
+            // While the directory probe is unresolved, moderation's
+            // skippability is unknown (failed closed) — show progress
+            // where Skip would be instead of nothing.
+            showsSkipProgress: step == .moderation && !flow.moderationProbeResolved,
             backAction: step == .welcome ? nil : { flow.back() },
             content: { content(for: step) },
             indicator: { stepIndicator(flow.stepIndex, flow.stepCount) }
@@ -72,23 +79,21 @@ public struct OnboardingView: View {
         }
     }
 
-    /// Welcome's primary IS the advance, so a separate Skip would be
-    /// redundant; Done is terminal. Everything else defers to the
-    /// flow's skippability rule (moderation hides Skip while the
-    /// directory has entries).
-    private func showsSkip(_ step: OnboardingStep) -> Bool {
-        step != .welcome && step != .done && flow.isSkippable(step)
-    }
-
+    /// Injected slot first — the app may override ANY step's body,
+    /// Welcome and Done included. nil falls back to the built-ins.
     @ViewBuilder
     private func content(for step: OnboardingStep) -> some View {
-        switch step {
-        case .welcome:
-            WelcomeStepContent()
-        case .done:
-            DoneStepContent(outcomes: flow.outcomes)
-        default:
-            stepContent(step)
+        if let injected = stepContent(step) {
+            injected
+        } else {
+            switch step {
+            case .welcome:
+                WelcomeStepContent()
+            case .done:
+                DoneStepContent(outcomes: flow.outcomes)
+            default:
+                PlaceholderStepContent(step: step)
+            }
         }
     }
 

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+
+/// The first-launch onboarding cover: one scaffolded screen per
+/// `OnboardingStep`, driven by `OnboardingFlow`.
+///
+/// Presentation contract: RootView (PR 3) presents this as a
+/// `fullScreenCover` with `.interactiveDismissDisabled(true)` applied
+/// at the presentation site — a full-screen cover has no interactive
+/// dismissal of its own, but the modifier documents intent and guards
+/// against a future switch to `.sheet`. The only exits are
+/// `flow.complete()` on the Done step and the per-step Skip
+/// affordances; onboarding is never swiped away half-done.
+///
+/// Dependency posture: this package renders the *frame* of each step.
+/// The middle steps' real content — discovery confirm, catalog
+/// pickers, the moderation mandate flow — lives at the app layer and
+/// arrives through `stepContent` in PR 3, so this view stays free of
+/// OnymDiscovery / OnymModerationUI / OnymDesign. Likewise the step
+/// indicator arrives through `stepIndicator` (PR 3 passes
+/// `SettingsStepIndicator` once it is public); the default is a plain
+/// dot indicator so the package previews and tests stand alone.
+public struct OnboardingView: View {
+    @State private var flow: OnboardingFlow
+    /// App-supplied content slot for the middle steps. The closure
+    /// receives the step being rendered; the default is a placeholder
+    /// card naming the step.
+    private let stepContent: (OnboardingStep) -> AnyView
+    /// App-supplied step indicator, given (zero-based index, count).
+    private let stepIndicator: (Int, Int) -> AnyView
+
+    public init(
+        flow: OnboardingFlow,
+        stepContent: ((OnboardingStep) -> AnyView)? = nil,
+        stepIndicator: ((Int, Int) -> AnyView)? = nil
+    ) {
+        _flow = State(initialValue: flow)
+        self.stepContent = stepContent ?? { step in
+            AnyView(PlaceholderStepContent(step: step))
+        }
+        self.stepIndicator = stepIndicator ?? { index, count in
+            AnyView(DefaultStepIndicator(index: index, count: count))
+        }
+    }
+
+    public var body: some View {
+        scaffold(for: flow.step)
+            .task { flow.start() }
+    }
+
+    // MARK: - Steps
+
+    @ViewBuilder
+    private func scaffold(for step: OnboardingStep) -> some View {
+        OnboardingStepScaffold(
+            step: step,
+            title: Self.title(for: step),
+            subtitle: Self.subtitle(for: step),
+            primaryTitle: step == .done ? String(localized: "Start") : String(localized: "Continue"),
+            primaryAction: { primaryTapped() },
+            skipAction: showsSkip(step) ? { flow.skip() } : nil,
+            backAction: step == .welcome ? nil : { flow.back() },
+            content: { content(for: step) },
+            indicator: { stepIndicator(flow.stepIndex, flow.stepCount) }
+        )
+    }
+
+    private func primaryTapped() {
+        if flow.step == .done {
+            flow.complete()
+        } else {
+            flow.advance()
+        }
+    }
+
+    /// Welcome's primary IS the advance, so a separate Skip would be
+    /// redundant; Done is terminal. Everything else defers to the
+    /// flow's skippability rule (moderation hides Skip while the
+    /// directory has entries).
+    private func showsSkip(_ step: OnboardingStep) -> Bool {
+        step != .welcome && step != .done && flow.isSkippable(step)
+    }
+
+    @ViewBuilder
+    private func content(for step: OnboardingStep) -> some View {
+        switch step {
+        case .welcome:
+            WelcomeStepContent()
+        case .done:
+            DoneStepContent(outcomes: flow.outcomes)
+        default:
+            stepContent(step)
+        }
+    }
+
+    // MARK: - Copy
+
+    static func title(for step: OnboardingStep) -> String {
+        switch step {
+        case .welcome: return String(localized: "Welcome to Onym")
+        case .discoveryConfirm: return String(localized: "Service Directory")
+        case .messageTransport: return String(localized: "Message Transport")
+        case .blobTransport: return String(localized: "File Storage")
+        case .notary: return String(localized: "Notary")
+        case .moderation: return String(localized: "Moderation")
+        case .done: return String(localized: "You're Set")
+        }
+    }
+
+    static func subtitle(for step: OnboardingStep) -> String? {
+        switch step {
+        case .welcome:
+            return String(localized: "Your keys, your services. Pick who carries your messages, stores your files, and vouches for your history — every choice is yours, and every one can change later in Settings.")
+        case .discoveryConfirm:
+            return String(localized: "Confirm the directory your app uses to find services, or add your own provider.")
+        case .messageTransport:
+            return String(localized: "Choose who relays your messages.")
+        case .blobTransport:
+            return String(localized: "Choose where your attachments are stored.")
+        case .notary:
+            return String(localized: "Choose who timestamps your conversation history.")
+        case .moderation:
+            return String(localized: "Choose a moderation authority and review its terms.")
+        case .done:
+            return String(localized: "Your choices are saved. You can revisit any of them in Settings.")
+        }
+    }
+}
+
+// MARK: - Built-in step content
+
+/// Welcome step body: brand framing. PR 3 may replace the mark via
+/// `stepContent` if richer branding (OnymMark) is wanted; the built-in
+/// keeps the package standalone.
+struct WelcomeStepContent: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Image(systemName: "key.horizontal")
+                .font(.system(size: 44))
+                .foregroundStyle(.tint)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 24)
+            Text("The next few screens set up the services this app runs on. Each one shows exactly what you're agreeing to before anything is turned on.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+/// Done step body: summary of what was chosen per step, plus the
+/// backup nudge (identity was created silently; the phrase flow lives
+/// in Settings and is nudged here, never forced).
+struct DoneStepContent: View {
+    let outcomes: [OnboardingStep: StepOutcome]
+
+    private static let summarySteps: [OnboardingStep] = [
+        .discoveryConfirm, .messageTransport, .blobTransport, .notary, .moderation,
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(Self.summarySteps, id: \.self) { step in
+                HStack(spacing: 10) {
+                    Image(systemName: symbol(for: outcomes[step]))
+                        .foregroundStyle(.secondary)
+                    Text(verbatim: OnboardingView.title(for: step))
+                        .font(.callout)
+                    Spacer()
+                    Text(verbatim: label(for: outcomes[step]))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+            Divider()
+            Text("Your identity key was created on this device. Back it up from Settings so you can recover your account.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+
+    private func symbol(for outcome: StepOutcome?) -> String {
+        switch outcome {
+        case .consented: return "checkmark.circle.fill"
+        case .skipped: return "arrow.right.circle"
+        case .notApplicable, nil: return "circle.dashed"
+        }
+    }
+
+    private func label(for outcome: StepOutcome?) -> String {
+        switch outcome {
+        case .consented: return String(localized: "Chosen")
+        case .skipped: return String(localized: "Default")
+        case .notApplicable, nil: return String(localized: "—")
+        }
+    }
+}
+
+/// Placeholder body for the middle steps until PR 3 injects the real
+/// surfaces through `stepContent`.
+struct PlaceholderStepContent: View {
+    let step: OnboardingStep
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "square.dashed")
+                .font(.system(size: 28))
+                .foregroundStyle(.secondary)
+            Text(verbatim: OnboardingView.title(for: step))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+}
+
+/// Fallback step indicator: plain dots. PR 3 replaces it with
+/// `SettingsStepIndicator` via the `stepIndicator` slot.
+struct DefaultStepIndicator: View {
+    let index: Int
+    let count: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<count, id: \.self) { dot in
+                Circle()
+                    .fill(dot == index ? Color.accentColor : Color(.systemFill))
+                    .frame(width: 7, height: 7)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Step \(index + 1) of \(count)"))
+    }
+}

--- a/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
+++ b/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import XCTest
+@testable import OnymOnboarding
+
+@MainActor
+final class OnboardingFlowTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var store: UserDefaultsOnboardingStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "app.onym.ios.onboarding.flow.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = UserDefaultsOnboardingStore(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        store = nil
+        super.tearDown()
+    }
+
+    private func makeFlow(
+        moderationDirectoryNonEmpty: @escaping () async -> Bool = { false },
+        onCompleted: @escaping @MainActor () -> Void = {}
+    ) -> OnboardingFlow {
+        OnboardingFlow(
+            store: store,
+            moderationDirectoryNonEmpty: moderationDirectoryNonEmpty,
+            onCompleted: onCompleted
+        )
+    }
+
+    // MARK: - Step order
+
+    func testStepsAdvanceInDocumentedOrder() {
+        let flow = makeFlow()
+        var visited: [OnboardingStep] = [flow.step]
+        while flow.step != .done {
+            flow.advance()
+            visited.append(flow.step)
+        }
+        XCTAssertEqual(visited, [
+            .welcome, .discoveryConfirm, .messageTransport,
+            .blobTransport, .notary, .moderation, .done,
+        ])
+    }
+
+    func testAdvanceOnDoneIsANoOp() {
+        let flow = makeFlow()
+        while flow.step != .done { flow.advance() }
+        flow.advance()
+        XCTAssertEqual(flow.step, .done)
+    }
+
+    func testStepIndexAndCountDriveTheIndicator() {
+        let flow = makeFlow()
+        XCTAssertEqual(flow.stepCount, 7)
+        XCTAssertEqual(flow.stepIndex, 0)
+        flow.advance()
+        XCTAssertEqual(flow.stepIndex, 1)
+        while flow.step != .done { flow.advance() }
+        XCTAssertEqual(flow.stepIndex, 6)
+    }
+
+    // MARK: - Back
+
+    func testBackWalksToThePreviousStep() {
+        let flow = makeFlow()
+        flow.advance()
+        flow.advance()
+        XCTAssertEqual(flow.step, .messageTransport)
+        flow.back()
+        XCTAssertEqual(flow.step, .discoveryConfirm)
+        flow.back()
+        XCTAssertEqual(flow.step, .welcome)
+    }
+
+    func testBackOnWelcomeIsANoOp() {
+        let flow = makeFlow()
+        flow.back()
+        XCTAssertEqual(flow.step, .welcome)
+    }
+
+    func testBackKeepsThePriorOutcomeUntilOverwritten() {
+        let flow = makeFlow()
+        flow.advance() // discoveryConfirm
+        flow.recordOutcome(.consented(componentId: nil))
+        flow.advance() // messageTransport
+        flow.back() // revisit discoveryConfirm
+        XCTAssertEqual(flow.outcomes[.discoveryConfirm], .consented(componentId: nil))
+        flow.skip()
+        XCTAssertEqual(flow.outcomes[.discoveryConfirm], .skipped)
+    }
+
+    // MARK: - Skip
+
+    func testSkipRecordsSkippedAndAdvances() {
+        let flow = makeFlow()
+        flow.advance() // discoveryConfirm
+        flow.skip()
+        XCTAssertEqual(flow.step, .messageTransport)
+        XCTAssertEqual(flow.outcomes[.discoveryConfirm], .skipped)
+    }
+
+    func testAdvanceWithoutDecisionBackfillsNotApplicable() {
+        let flow = makeFlow()
+        flow.advance()
+        XCTAssertEqual(flow.outcomes[.welcome], .notApplicable)
+    }
+
+    func testAdvanceDoesNotOverwriteARecordedOutcome() {
+        let flow = makeFlow()
+        flow.advance() // discoveryConfirm
+        flow.recordOutcome(.consented(componentId: "onym:component:onym-discovery"))
+        flow.advance()
+        XCTAssertEqual(
+            flow.outcomes[.discoveryConfirm],
+            .consented(componentId: "onym:component:onym-discovery")
+        )
+    }
+
+    func testDoneIsNeverSkippable() {
+        let flow = makeFlow()
+        while flow.step != .done { flow.advance() }
+        XCTAssertFalse(flow.isSkippable(.done))
+        flow.skip()
+        XCTAssertEqual(flow.step, .done)
+        XCTAssertNil(flow.outcomes[.done])
+    }
+
+    // MARK: - Moderation skippability
+
+    func testModerationSkippableWhileDirectoryEmpty() async {
+        let flow = makeFlow(moderationDirectoryNonEmpty: { false })
+        flow.start()
+        await flow.moderationProbeTask?.value
+        XCTAssertTrue(flow.isSkippable(.moderation))
+
+        while flow.step != .moderation { flow.advance() }
+        flow.skip()
+        XCTAssertEqual(flow.step, .done)
+        XCTAssertEqual(flow.outcomes[.moderation], .skipped)
+    }
+
+    func testModerationNotSkippableWhenDirectoryHasEntries() async {
+        let flow = makeFlow(moderationDirectoryNonEmpty: { true })
+        flow.start()
+        await flow.moderationProbeTask?.value
+        XCTAssertFalse(flow.isSkippable(.moderation))
+        // Every other step stays skippable.
+        for step: OnboardingStep in [.welcome, .discoveryConfirm, .messageTransport, .blobTransport, .notary] {
+            XCTAssertTrue(flow.isSkippable(step), "\(step) should stay skippable")
+        }
+
+        while flow.step != .moderation { flow.advance() }
+        flow.skip() // must be a no-op
+        XCTAssertEqual(flow.step, .moderation)
+        XCTAssertNil(flow.outcomes[.moderation])
+    }
+
+    func testStartIsIdempotent() async {
+        var probes = 0
+        let flow = makeFlow(moderationDirectoryNonEmpty: {
+            probes += 1
+            return true
+        })
+        flow.start()
+        flow.start()
+        await flow.moderationProbeTask?.value
+        XCTAssertEqual(probes, 1)
+        XCTAssertTrue(flow.moderationDirectoryHasEntries)
+    }
+
+    // MARK: - Completion
+
+    func testCompleteWritesFlagAndFiresOnCompleted() {
+        var completedCalls = 0
+        let flow = makeFlow(onCompleted: { completedCalls += 1 })
+        while flow.step != .done { flow.advance() }
+        XCTAssertFalse(store.hasCompletedOnboarding())
+        flow.complete()
+        XCTAssertTrue(store.hasCompletedOnboarding())
+        XCTAssertEqual(completedCalls, 1)
+        XCTAssertEqual(flow.outcomes[.done], .notApplicable)
+    }
+
+    func testCompleteBeforeDoneIsANoOp() {
+        var completedCalls = 0
+        let flow = makeFlow(onCompleted: { completedCalls += 1 })
+        flow.advance() // discoveryConfirm — mid-sequence
+        flow.complete()
+        XCTAssertFalse(store.hasCompletedOnboarding())
+        XCTAssertEqual(completedCalls, 0)
+    }
+
+    /// Completion closes the gate: a flow over a completed store means
+    /// `OnboardingGate.shouldOnboard` answers false next launch.
+    func testCompletionClosesTheGate() {
+        let flow = makeFlow()
+        while flow.step != .done { flow.advance() }
+        flow.complete()
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { false }))
+    }
+
+    // MARK: - Outcome recording
+
+    func testRecordOutcomePerStepAcrossTheWholeWalk() {
+        let flow = makeFlow()
+        flow.advance() // discoveryConfirm
+        flow.recordOutcome(.consented(componentId: nil))
+        flow.advance() // messageTransport
+        flow.recordOutcome(.consented(componentId: "onym:component:onym-nostr"))
+        flow.advance() // blobTransport
+        flow.skip() // notary
+        flow.recordOutcome(.consented(componentId: "onym:component:onym-relayer"))
+        flow.advance() // moderation
+        flow.advance() // done (informational moderation, directory empty)
+
+        XCTAssertEqual(flow.outcomes[.welcome], .notApplicable)
+        XCTAssertEqual(flow.outcomes[.discoveryConfirm], .consented(componentId: nil))
+        XCTAssertEqual(flow.outcomes[.messageTransport], .consented(componentId: "onym:component:onym-nostr"))
+        XCTAssertEqual(flow.outcomes[.blobTransport], .skipped)
+        XCTAssertEqual(flow.outcomes[.notary], .consented(componentId: "onym:component:onym-relayer"))
+        XCTAssertEqual(flow.outcomes[.moderation], .notApplicable)
+    }
+
+    func testRecordingAgainOverwrites() {
+        let flow = makeFlow()
+        flow.advance() // discoveryConfirm
+        flow.recordOutcome(.consented(componentId: "onym:component:a"))
+        flow.recordOutcome(.consented(componentId: "onym:component:b"))
+        XCTAssertEqual(flow.outcomes[.discoveryConfirm], .consented(componentId: "onym:component:b"))
+    }
+}

--- a/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
+++ b/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
@@ -34,10 +34,26 @@ final class OnboardingFlowTests: XCTestCase {
         )
     }
 
+    /// A flow whose directory probe has already answered — most walk
+    /// tests need this, because an unresolved probe leaves moderation
+    /// mandatory (fail-closed) and `advance()` refuses to pass it.
+    private func makeResolvedFlow(
+        directoryNonEmpty: Bool = false,
+        onCompleted: @escaping @MainActor () -> Void = {}
+    ) async -> OnboardingFlow {
+        let flow = makeFlow(
+            moderationDirectoryNonEmpty: { directoryNonEmpty },
+            onCompleted: onCompleted
+        )
+        flow.start()
+        await flow.moderationProbeTask?.value
+        return flow
+    }
+
     // MARK: - Step order
 
-    func testStepsAdvanceInDocumentedOrder() {
-        let flow = makeFlow()
+    func testStepsAdvanceInDocumentedOrder() async {
+        let flow = await makeResolvedFlow()
         var visited: [OnboardingStep] = [flow.step]
         while flow.step != .done {
             flow.advance()
@@ -49,15 +65,15 @@ final class OnboardingFlowTests: XCTestCase {
         ])
     }
 
-    func testAdvanceOnDoneIsANoOp() {
-        let flow = makeFlow()
+    func testAdvanceOnDoneIsANoOp() async {
+        let flow = await makeResolvedFlow()
         while flow.step != .done { flow.advance() }
         flow.advance()
         XCTAssertEqual(flow.step, .done)
     }
 
-    func testStepIndexAndCountDriveTheIndicator() {
-        let flow = makeFlow()
+    func testStepIndexAndCountDriveTheIndicator() async {
+        let flow = await makeResolvedFlow()
         XCTAssertEqual(flow.stepCount, 7)
         XCTAssertEqual(flow.stepIndex, 0)
         flow.advance()
@@ -123,8 +139,8 @@ final class OnboardingFlowTests: XCTestCase {
         )
     }
 
-    func testDoneIsNeverSkippable() {
-        let flow = makeFlow()
+    func testDoneIsNeverSkippable() async {
+        let flow = await makeResolvedFlow()
         while flow.step != .done { flow.advance() }
         XCTAssertFalse(flow.isSkippable(.done))
         flow.skip()
@@ -152,7 +168,7 @@ final class OnboardingFlowTests: XCTestCase {
         await flow.moderationProbeTask?.value
         XCTAssertFalse(flow.isSkippable(.moderation))
         // Every other step stays skippable.
-        for step: OnboardingStep in [.welcome, .discoveryConfirm, .messageTransport, .blobTransport, .notary] {
+        for step: OnboardingStep in [.discoveryConfirm, .messageTransport, .blobTransport, .notary] {
             XCTAssertTrue(flow.isSkippable(step), "\(step) should stay skippable")
         }
 
@@ -163,23 +179,24 @@ final class OnboardingFlowTests: XCTestCase {
     }
 
     func testStartIsIdempotent() async {
-        var probes = 0
+        let probes = ProbeCounter()
         let flow = makeFlow(moderationDirectoryNonEmpty: {
-            probes += 1
+            await probes.increment()
             return true
         })
         flow.start()
         flow.start()
         await flow.moderationProbeTask?.value
-        XCTAssertEqual(probes, 1)
-        XCTAssertTrue(flow.moderationDirectoryHasEntries)
+        let count = await probes.value
+        XCTAssertEqual(count, 1)
+        XCTAssertEqual(flow.moderationDirectoryHasEntries, true)
     }
 
     // MARK: - Completion
 
-    func testCompleteWritesFlagAndFiresOnCompleted() {
+    func testCompleteWritesFlagAndFiresOnCompleted() async {
         var completedCalls = 0
-        let flow = makeFlow(onCompleted: { completedCalls += 1 })
+        let flow = await makeResolvedFlow(onCompleted: { completedCalls += 1 })
         while flow.step != .done { flow.advance() }
         XCTAssertFalse(store.hasCompletedOnboarding())
         flow.complete()
@@ -199,8 +216,8 @@ final class OnboardingFlowTests: XCTestCase {
 
     /// Completion closes the gate: a flow over a completed store means
     /// `OnboardingGate.shouldOnboard` answers false next launch.
-    func testCompletionClosesTheGate() {
-        let flow = makeFlow()
+    func testCompletionClosesTheGate() async {
+        let flow = await makeResolvedFlow()
         while flow.step != .done { flow.advance() }
         flow.complete()
         XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { false }))
@@ -208,8 +225,8 @@ final class OnboardingFlowTests: XCTestCase {
 
     // MARK: - Outcome recording
 
-    func testRecordOutcomePerStepAcrossTheWholeWalk() {
-        let flow = makeFlow()
+    func testRecordOutcomePerStepAcrossTheWholeWalk() async {
+        let flow = await makeResolvedFlow()
         flow.advance() // discoveryConfirm
         flow.recordOutcome(.consented(componentId: nil))
         flow.advance() // messageTransport
@@ -228,6 +245,77 @@ final class OnboardingFlowTests: XCTestCase {
         XCTAssertEqual(flow.outcomes[.moderation], .notApplicable)
     }
 
+    // MARK: - Welcome skippability
+
+    func testWelcomeIsNotSkippable() {
+        let flow = makeFlow()
+        XCTAssertFalse(flow.isSkippable(.welcome))
+        flow.skip() // must be a no-op — Continue is welcome's only path
+        XCTAssertEqual(flow.step, .welcome)
+        XCTAssertNil(flow.outcomes[.welcome])
+    }
+
+    // MARK: - Probe race (fail-closed until resolved)
+
+    /// Before the probe answers, moderation reads unskippable AND
+    /// mandatory — racing the probe must never open a skip window.
+    func testModerationFailsClosedWhileProbeUnresolved() async {
+        let flow = makeFlow(moderationDirectoryNonEmpty: { false })
+        // Probe not started: unresolved.
+        XCTAssertFalse(flow.moderationProbeResolved)
+        XCTAssertFalse(flow.isSkippable(.moderation))
+        XCTAssertTrue(flow.isMandatory(.moderation))
+
+        while flow.step != .moderation { flow.advance() }
+        flow.skip() // no-op while unresolved
+        XCTAssertEqual(flow.step, .moderation)
+        flow.advance() // equally refused — mandatory without an outcome
+        XCTAssertEqual(flow.step, .moderation)
+
+        // Empty directory resolves → skippable, not mandatory.
+        flow.start()
+        await flow.moderationProbeTask?.value
+        XCTAssertTrue(flow.moderationProbeResolved)
+        XCTAssertTrue(flow.isSkippable(.moderation))
+        XCTAssertFalse(flow.isMandatory(.moderation))
+        flow.skip()
+        XCTAssertEqual(flow.step, .done)
+    }
+
+    /// The other transition: unresolved (fail-closed) → resolved
+    /// non-empty keeps moderation locked down.
+    func testResolvedNonEmptyDirectoryStaysMandatory() async {
+        let flow = makeFlow(moderationDirectoryNonEmpty: { true })
+        XCTAssertFalse(flow.isSkippable(.moderation))
+        XCTAssertTrue(flow.isMandatory(.moderation))
+        flow.start()
+        await flow.moderationProbeTask?.value
+        XCTAssertTrue(flow.moderationProbeResolved)
+        XCTAssertFalse(flow.isSkippable(.moderation))
+        XCTAssertTrue(flow.isMandatory(.moderation))
+    }
+
+    // MARK: - Mandatory moderation blocks advance()
+
+    /// The substantive review finding: Continue must not be a back
+    /// door around the unskippable-moderation rule.
+    func testAdvanceOnMandatoryModerationWithoutOutcomeIsANoOp() async {
+        let flow = await makeResolvedFlow(directoryNonEmpty: true)
+        while flow.step != .moderation { flow.advance() }
+        flow.advance()
+        XCTAssertEqual(flow.step, .moderation)
+        XCTAssertNil(flow.outcomes[.moderation], "a refused advance must not backfill an outcome")
+    }
+
+    func testAdvanceOnMandatoryModerationWithRecordedConsentAdvances() async {
+        let flow = await makeResolvedFlow(directoryNonEmpty: true)
+        while flow.step != .moderation { flow.advance() }
+        flow.recordOutcome(.consented(componentId: "onym:component:onym-moderation"))
+        flow.advance()
+        XCTAssertEqual(flow.step, .done)
+        XCTAssertEqual(flow.outcomes[.moderation], .consented(componentId: "onym:component:onym-moderation"))
+    }
+
     func testRecordingAgainOverwrites() {
         let flow = makeFlow()
         flow.advance() // discoveryConfirm
@@ -235,4 +323,12 @@ final class OnboardingFlowTests: XCTestCase {
         flow.recordOutcome(.consented(componentId: "onym:component:b"))
         XCTAssertEqual(flow.outcomes[.discoveryConfirm], .consented(componentId: "onym:component:b"))
     }
+}
+
+/// Actor-isolated counter for the idempotency test — the probe closure
+/// runs off the main actor under strict concurrency, so a captured var
+/// would be a data race.
+private actor ProbeCounter {
+    private(set) var value = 0
+    func increment() { value += 1 }
 }

--- a/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingStoreTests.swift
+++ b/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingStoreTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import XCTest
+@testable import OnymOnboarding
+
+/// UserDefaults round-trip with per-test suite isolation — same
+/// pattern as `SeatSelectionStoreTests` in OnymDiscovery.
+final class OnboardingStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var store: UserDefaultsOnboardingStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "app.onym.ios.onboarding.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = UserDefaultsOnboardingStore(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        store = nil
+        super.tearDown()
+    }
+
+    func testDefaultsToNotCompleted() {
+        XCTAssertFalse(store.hasCompletedOnboarding())
+    }
+
+    func testMarkCompletedRoundTrips() {
+        store.markOnboardingCompleted()
+        XCTAssertTrue(store.hasCompletedOnboarding())
+        // Idempotent.
+        store.markOnboardingCompleted()
+        XCTAssertTrue(store.hasCompletedOnboarding())
+    }
+
+    /// The app's `--reset-keychain` path clears this exact key; pin it
+    /// so a rename can't silently orphan the reset.
+    func testUsesTheDocumentedKey() {
+        XCTAssertEqual(UserDefaultsOnboardingStore.key, "app.onym.ios.onboarding.completed")
+        store.markOnboardingCompleted()
+        XCTAssertTrue(defaults.bool(forKey: "app.onym.ios.onboarding.completed"))
+    }
+
+    // MARK: - Grandfathering probe truth table
+
+    /// flag absent, no existing-user state → onboard.
+    func testShouldOnboardWhenFreshInstall() {
+        XCTAssertTrue(OnboardingGate.shouldOnboard(store: store, isExistingUser: { false }))
+    }
+
+    /// flag absent, but existing-user state (any hasUserInteracted or a
+    /// mandate present) → grandfathered, no onboarding.
+    func testShouldNotOnboardExistingUser() {
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { true }))
+    }
+
+    /// flag set, no existing-user state → no onboarding.
+    func testShouldNotOnboardWhenCompleted() {
+        store.markOnboardingCompleted()
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { false }))
+    }
+
+    /// flag set AND existing-user state → no onboarding.
+    func testShouldNotOnboardWhenCompletedAndExisting() {
+        store.markOnboardingCompleted()
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { true }))
+    }
+
+    /// The existing-user probe may be costly (keychain / mandate read):
+    /// it must not run when the flag already answers the question.
+    func testExistingUserProbeNotConsultedWhenFlagSet() {
+        store.markOnboardingCompleted()
+        var probed = false
+        _ = OnboardingGate.shouldOnboard(store: store, isExistingUser: {
+            probed = true
+            return true
+        })
+        XCTAssertFalse(probed)
+    }
+
+    /// The probe is a pure read — grandfathering must not write the
+    /// completion flag.
+    func testProbeDoesNotWriteTheFlag() {
+        _ = OnboardingGate.shouldOnboard(store: store, isExistingUser: { true })
+        XCTAssertFalse(store.hasCompletedOnboarding())
+    }
+}

--- a/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingStoreTests.swift
+++ b/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingStoreTests.swift
@@ -44,6 +44,25 @@ final class OnboardingStoreTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "app.onym.ios.onboarding.completed"))
     }
 
+    /// The seam the app's `--reset-keychain` path calls — clears the
+    /// flag without the app hardcoding the key string.
+    func testResetOnboardingClearsTheFlag() {
+        store.markOnboardingCompleted()
+        store.resetOnboarding()
+        XCTAssertFalse(store.hasCompletedOnboarding())
+        XCTAssertNil(defaults.object(forKey: UserDefaultsOnboardingStore.key))
+        // Idempotent on an already-clear store.
+        store.resetOnboarding()
+        XCTAssertFalse(store.hasCompletedOnboarding())
+    }
+
+    /// After a reset, the gate onboards again.
+    func testResetReopensTheGate() {
+        store.markOnboardingCompleted()
+        store.resetOnboarding()
+        XCTAssertTrue(OnboardingGate.shouldOnboard(store: store, isExistingUser: { false }))
+    }
+
     // MARK: - Grandfathering probe truth table
 
     /// flag absent, no existing-user state → onboard.


### PR DESCRIPTION
PR 1 of the first-launch onboarding plan (iOS Onboarding module). **Package-only** — the app target is unchanged: no `project.yml` edit, no registration in `OnymIOSApp`, no RootView gate. The package compiles and tests standalone, exactly like `OnymDiscovery`.

## What's here

New local package `Packages/OnymOnboarding` (zero dependencies — not even OnymFoundation was needed):

- **`OnboardingStore`** — protocol + `UserDefaultsOnboardingStore` under `app.onym.ios.onboarding.completed`, plus `OnboardingGate.shouldOnboard(store:isExistingUser:)`: completed flag OR the injected existing-user signal (the app will pass "any `hasUserInteracted` or a mandate present") means no onboarding, so upgraders are grandfathered. The probe is a pure read and is only consulted when the flag is absent.
- **`OnboardingFlow`** (`@MainActor @Observable`, modeled on `ModuleConsentFlow`) — steps `welcome → discoveryConfirm → messageTransport → blobTransport → notary → moderation → done`, `advance()/skip()/back()/complete()`, `stepIndex/stepCount` for the indicator. Every step skippable except moderation while the authority directory has entries (injected `() async -> Bool` probe, resolved by `start()`) and the terminal `done`. Outcomes recorded per step as `StepOutcome.consented(componentId:)/skipped/notApplicable` — the flow models step results abstractly and never links against OnymDiscovery/OnymModerationUI. `complete()` is guarded to the `done` step, writes the flag, fires `onCompleted`.
- **`OnboardingStepScaffold` + `OnboardingView`** — the established consent-view skeleton in plain SwiftUI (no OnymDesign dependency yet); `stepContent: (OnboardingStep) -> AnyView` and `stepIndicator: (Int, Int) -> AnyView` are injected slots with built-in placeholders; Welcome and Done have real built-in content (Done renders the per-step outcome summary + backup nudge). Accessibility ids `onboarding.<step>.<element>`. `interactiveDismissDisabled` presentation semantics documented on `OnboardingView`.
- **27 unit tests** (isolated per-test UserDefaults suites): step order, back/skip paths, moderation skippability both ways, completion flag + `onCompleted`, grandfathering truth table, outcome recording.

## Verification

`xcodebuild test -scheme OnymOnboarding -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — 27/27 green.

## What lands next

- **PR 2 (unblockers, in parallel on `onboarding-unblockers`)**: app-target seams this package will consume — blossom catalog picker + apply closure, relayer auto-populate suppression.
- **PR 3 (wiring)**: `project.yml` registration, RootView `fullScreenCover` gate, `SettingsStepIndicator` made public and passed through the indicator slot, real step content (discovery confirm, catalog pickers via `ModuleConsentFlow`, `ModerationConsentFlow(mode: .onboarding)`) injected through `stepContent`, `--reset-keychain` clearing the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8