### PR TITLE
Onboarding unblockers: blossom picker, auto-populate seam, live blossom base URL, step indicator

### DIFF
--- a/Packages/OnymChain/Sources/OnymChain/RelayerRepository.swift
+++ b/Packages/OnymChain/Sources/OnymChain/RelayerRepository.swift
@@ -51,14 +51,28 @@ public struct RelayerState: Equatable, Sendable {
 public actor RelayerRepository {
     private let fetcher: any KnownRelayersFetcher
     private let store: any RelayerSelectionStore
+    /// Seam over the first-launch auto-populate: consulted right
+    /// before a fetch would install the whole published list into an
+    /// untouched configuration. Returning `false` defers it — the
+    /// fetched list still lands in `knownList` (and the on-disk
+    /// cache), but the configuration and `hasUserInteracted` stay
+    /// untouched, so a later fetch (or an explicit user pick, e.g.
+    /// during onboarding) can still populate. Defaults to always-on,
+    /// preserving the historical behavior.
+    private let autoPopulatePolicy: @Sendable () -> Bool
 
     private var cached: RelayerState
     private var continuations: [UUID: AsyncStream<RelayerState>.Continuation] = [:]
     private var startTask: Task<Void, Never>?
 
-    public init(fetcher: any KnownRelayersFetcher, store: any RelayerSelectionStore) {
+    public init(
+        fetcher: any KnownRelayersFetcher,
+        store: any RelayerSelectionStore,
+        autoPopulatePolicy: @escaping @Sendable () -> Bool = { true }
+    ) {
         self.fetcher = fetcher
         self.store = store
+        self.autoPopulatePolicy = autoPopulatePolicy
         self.cached = RelayerState(
             configuration: store.loadConfiguration(),
             knownList: store.loadCachedKnownList(),
@@ -101,6 +115,10 @@ public actor RelayerRepository {
     /// `.random`, and `hasUserInteracted` flips to `true`. The flag is
     /// sticky — subsequent fetches never re-auto-populate, so a user
     /// who explicitly clears the list isn't fought by the next refresh.
+    /// `autoPopulatePolicy` gates the install: when it returns `false`
+    /// the fetched list only lands in `knownList` (configuration and
+    /// flag untouched), leaving the choice to a later fetch or an
+    /// explicit user pick.
     public func refresh() async throws {
         // Mark in-flight so the picker stops showing whatever stale
         // status it had and renders the spinner.
@@ -128,7 +146,7 @@ public actor RelayerRepository {
 
         let current = cached.configuration
         let updatedConfig: RelayerConfiguration
-        if !current.hasUserInteracted && !list.isEmpty {
+        if !current.hasUserInteracted && !list.isEmpty && autoPopulatePolicy() {
             updatedConfig = RelayerConfiguration(
                 endpoints: list,
                 primaryURL: nil,

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/BlossomServerStampPolicy.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/BlossomServerStampPolicy.swift
@@ -1,0 +1,46 @@
+import Foundation
+import OnymTransportBlossom
+
+/// Client selection for a stamped attachment download — the trust
+/// boundary between the peer's metadata and the user's network.
+///
+/// The `server` stamp is an OPTIMIZATION hint for multi-server
+/// consistency — "this blob lives on that one of YOUR servers" — never
+/// an instruction from the peer. It decodes straight off the wire and
+/// bubbles auto-load on render, so honoring an arbitrary stamp would
+/// let a hostile sender choose the download host: an unauthenticated
+/// GET of a per-message-unique path (a read receipt, plus IP/UA) to a
+/// third party the moment the recipient scrolls the thread. The stamp
+/// is therefore honored ONLY when its normalized origin
+/// (scheme+host+port) matches one of the endpoints the USER has
+/// configured/consented to; anything else — unknown hosts, malformed
+/// stamps, legacy nil stamps — downloads through the live client
+/// pointed at the user's own active server.
+enum BlossomServerStampPolicy {
+    /// The client a stamped attachment downloads through: `live` bound
+    /// to the stamp when the stamp's origin is in `allowedServers`,
+    /// plain `live` otherwise.
+    static func client(
+        forStamp server: String?,
+        allowedServers: [URL],
+        live: any BlossomClient
+    ) -> any BlossomClient {
+        guard let server,
+              let stamped = URL(string: server),
+              let stampedKey = originKey(stamped),
+              allowedServers.contains(where: { originKey($0) == stampedKey })
+        else { return live }
+        return live.bound(toServer: server)
+    }
+
+    /// Normalized scheme+host+port comparison key. `nil` when the URL
+    /// has no scheme or host — such a stamp is never comparable and
+    /// never honored.
+    static func originKey(_ url: URL) -> String? {
+        guard let scheme = url.scheme?.lowercased(),
+              let host = url.host()?.lowercased(), !host.isEmpty
+        else { return nil }
+        let port = url.port.map { ":\($0)" } ?? ""
+        return "\(scheme)://\(host)\(port)"
+    }
+}

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/BlossomServerStampPolicy.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/BlossomServerStampPolicy.swift
@@ -18,8 +18,18 @@ import OnymTransportBlossom
 /// pointed at the user's own active server.
 enum BlossomServerStampPolicy {
     /// The client a stamped attachment downloads through: `live` bound
-    /// to the stamp when the stamp's origin is in `allowedServers`,
-    /// plain `live` otherwise.
+    /// to the MATCHED allowlist URL when the stamp is https and its
+    /// origin is in `allowedServers`, plain `live` otherwise.
+    ///
+    /// This is the PEER-influenced trust level: https is required (a
+    /// peer must not be able to steer traffic to cleartext or odd
+    /// schemes), the origin must be one the user configured, and the
+    /// request is built from the allowlist's own URL — the stamp's
+    /// origin proves membership, but its path/query are still
+    /// peer-chosen bytes and must never shape the request, even
+    /// against the user's own server. The user's own hand-typed
+    /// endpoints (send/retry binding) live at the trusted level in
+    /// `bound(toServer:)` instead, where http local-dev URLs are fine.
     static func client(
         forStamp server: String?,
         allowedServers: [URL],
@@ -27,20 +37,24 @@ enum BlossomServerStampPolicy {
     ) -> any BlossomClient {
         guard let server,
               let stamped = URL(string: server),
+              stamped.scheme?.lowercased() == "https",
               let stampedKey = originKey(stamped),
-              allowedServers.contains(where: { originKey($0) == stampedKey })
+              let matched = allowedServers.first(where: { originKey($0) == stampedKey })
         else { return live }
-        return live.bound(toServer: server)
+        return live.bound(toServer: matched.absoluteString)
     }
 
-    /// Normalized scheme+host+port comparison key. `nil` when the URL
+    /// Normalized scheme+host+port comparison key; default ports
+    /// (443/https, 80/http) fold away so `https://a.example` and
+    /// `https://a.example:443` are the same origin. `nil` when the URL
     /// has no scheme or host — such a stamp is never comparable and
     /// never honored.
     static func originKey(_ url: URL) -> String? {
         guard let scheme = url.scheme?.lowercased(),
               let host = url.host()?.lowercased(), !host.isEmpty
         else { return nil }
-        let port = url.port.map { ":\($0)" } ?? ""
+        let defaultPort: Int? = scheme == "https" ? 443 : (scheme == "http" ? 80 : nil)
+        let port = url.port.flatMap { $0 == defaultPort ? nil : ":\($0)" } ?? ""
         return "\(scheme)://\(host)\(port)"
     }
 }

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
@@ -87,6 +87,11 @@ public actor ChatImageLoader {
 
     private func downloadAndDecrypt(_ attachment: ChatImageAttachment) async throws -> Data {
         let key = attachment.sha256
+        // Resolve the allowlist BEFORE the inflight lookup: the await
+        // is a suspension point, and the check-and-insert below must
+        // stay contiguous (actor-atomic) or two concurrent requests
+        // for the same sha both miss `inflight` and double-download.
+        let allowedServers = await allowedStampServers()
         if let existing = inflight[key] { return try await existing.value }
         // Fetch from the server STAMPED into the attachment — the one
         // the sender actually uploaded to — but ONLY when it is one of
@@ -97,7 +102,7 @@ public actor ChatImageLoader {
         // hosts and legacy nil stamps use the live client.
         let client = BlossomServerStampPolicy.client(
             forStamp: attachment.server,
-            allowedServers: await allowedStampServers(),
+            allowedServers: allowedServers,
             live: blossomClient
         )
         let task = Task<Data, Error> {

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
@@ -12,12 +12,22 @@ import OnymTransportBlossom
 /// message never touches the network.
 public actor ChatImageLoader {
     private let blossomClient: any BlossomClient
+    /// The user's configured Blossom endpoints — the ONLY servers an
+    /// attachment's `server` stamp may route a download to (see
+    /// `BlossomServerStampPolicy`). Defaults to empty: stamps are
+    /// ignored unless the composition root wires the configured set.
+    private let allowedStampServers: @Sendable () async -> [URL]
     private let cacheDir: URL
     private var memory: [String: UIImage] = [:]
     private var inflight: [String: Task<Data, Error>] = [:]
 
-    public init(blossomClient: any BlossomClient, cacheDirectory: URL? = nil) {
+    public init(
+        blossomClient: any BlossomClient,
+        cacheDirectory: URL? = nil,
+        allowedStampServers: @escaping @Sendable () async -> [URL] = { [] }
+    ) {
         self.blossomClient = blossomClient
+        self.allowedStampServers = allowedStampServers
         self.cacheDir = cacheDirectory ?? FileManager.default
             .urls(for: .cachesDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("OnymChatImages", isDirectory: true)
@@ -79,12 +89,17 @@ public actor ChatImageLoader {
         let key = attachment.sha256
         if let existing = inflight[key] { return try await existing.value }
         // Fetch from the server STAMPED into the attachment — the one
-        // the sender actually uploaded to — not whatever server is
-        // currently configured (the live client's base URL moves the
-        // moment the user picks a different server). Legacy rows
-        // without a stamp fall back to the live client.
-        let client = attachment.server.map { blossomClient.bound(toServer: $0) }
-            ?? blossomClient
+        // the sender actually uploaded to — but ONLY when it is one of
+        // the user's own configured servers: the stamp arrives off the
+        // wire, so it is a hint for multi-server consistency among
+        // servers the USER trusts, never a peer-chosen download host
+        // (BlossomServerStampPolicy has the full rationale). Unknown
+        // hosts and legacy nil stamps use the live client.
+        let client = BlossomServerStampPolicy.client(
+            forStamp: attachment.server,
+            allowedServers: await allowedStampServers(),
+            live: blossomClient
+        )
         let task = Task<Data, Error> {
             let blob = try await client.download(sha256: attachment.sha256)
             return try ChatImageCrypto.open(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatImageLoader.swift
@@ -78,7 +78,13 @@ public actor ChatImageLoader {
     private func downloadAndDecrypt(_ attachment: ChatImageAttachment) async throws -> Data {
         let key = attachment.sha256
         if let existing = inflight[key] { return try await existing.value }
-        let client = blossomClient
+        // Fetch from the server STAMPED into the attachment — the one
+        // the sender actually uploaded to — not whatever server is
+        // currently configured (the live client's base URL moves the
+        // moment the user picks a different server). Legacy rows
+        // without a stamp fall back to the live client.
+        let client = attachment.server.map { blossomClient.bound(toServer: $0) }
+            ?? blossomClient
         let task = Task<Data, Error> {
             let blob = try await client.download(sha256: attachment.sha256)
             return try ChatImageCrypto.open(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVideoLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVideoLoader.swift
@@ -14,11 +14,19 @@ import OnymTransportBlossom
 /// play it directly.
 public actor ChatVideoLoader {
     private let blossomClient: any BlossomClient
+    /// See `ChatImageLoader.allowedStampServers` — the only servers a
+    /// wire-decoded `server` stamp may route a download to.
+    private let allowedStampServers: @Sendable () async -> [URL]
     private let cacheDir: URL
     private var inflight: [String: Task<URL, Error>] = [:]
 
-    public init(blossomClient: any BlossomClient, cacheDirectory: URL? = nil) {
+    public init(
+        blossomClient: any BlossomClient,
+        cacheDirectory: URL? = nil,
+        allowedStampServers: @escaping @Sendable () async -> [URL] = { [] }
+    ) {
         self.blossomClient = blossomClient
+        self.allowedStampServers = allowedStampServers
         self.cacheDir = cacheDirectory ?? FileManager.default
             .urls(for: .cachesDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("OnymChatVideos", isDirectory: true)
@@ -37,11 +45,13 @@ public actor ChatVideoLoader {
         if FileManager.default.fileExists(atPath: dest.path) { return dest }
         if let existing = inflight[key] { return try await existing.value }
 
-        // Fetch from the server STAMPED into the attachment (where the
-        // sender uploaded), falling back to the live client for legacy
-        // rows without a stamp — see ChatImageLoader.
-        let client = attachment.server.map { blossomClient.bound(toServer: $0) }
-            ?? blossomClient
+        // Stamp honored only within the user's configured server set —
+        // never a peer-chosen host. See BlossomServerStampPolicy.
+        let client = BlossomServerStampPolicy.client(
+            forStamp: attachment.server,
+            allowedServers: await allowedStampServers(),
+            live: blossomClient
+        )
         let task = Task<URL, Error> {
             let blob = try await client.download(sha256: attachment.sha256)
             let plaintext = try ChatImageCrypto.open(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVideoLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVideoLoader.swift
@@ -43,13 +43,18 @@ public actor ChatVideoLoader {
         let key = attachment.sha256
         let dest = cacheFileURL(key)
         if FileManager.default.fileExists(atPath: dest.path) { return dest }
+        // Resolve the allowlist BEFORE the inflight lookup — the await
+        // suspends, and the check-and-insert below must stay contiguous
+        // (actor-atomic) or two concurrent requests double-download and
+        // double-write `dest`. See ChatImageLoader.
+        let allowedServers = await allowedStampServers()
         if let existing = inflight[key] { return try await existing.value }
 
         // Stamp honored only within the user's configured server set —
         // never a peer-chosen host. See BlossomServerStampPolicy.
         let client = BlossomServerStampPolicy.client(
             forStamp: attachment.server,
-            allowedServers: await allowedStampServers(),
+            allowedServers: allowedServers,
             live: blossomClient
         )
         let task = Task<URL, Error> {
@@ -57,7 +62,9 @@ public actor ChatVideoLoader {
             let plaintext = try ChatImageCrypto.open(
                 blob: blob, key: attachment.encKey, expectedSha256Hex: attachment.sha256
             )
-            try plaintext.write(to: dest, options: .completeFileProtection)
+            // `.atomic`: a concurrent reader (AVPlayer) must never open
+            // a partially-written file.
+            try plaintext.write(to: dest, options: [.atomic, .completeFileProtection])
             return dest
         }
         inflight[key] = task

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVideoLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVideoLoader.swift
@@ -37,7 +37,11 @@ public actor ChatVideoLoader {
         if FileManager.default.fileExists(atPath: dest.path) { return dest }
         if let existing = inflight[key] { return try await existing.value }
 
-        let client = blossomClient
+        // Fetch from the server STAMPED into the attachment (where the
+        // sender uploaded), falling back to the live client for legacy
+        // rows without a stamp — see ChatImageLoader.
+        let client = attachment.server.map { blossomClient.bound(toServer: $0) }
+            ?? blossomClient
         let task = Task<URL, Error> {
             let blob = try await client.download(sha256: attachment.sha256)
             let plaintext = try ChatImageCrypto.open(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVoiceLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVoiceLoader.swift
@@ -35,7 +35,11 @@ public actor ChatVoiceLoader {
         if FileManager.default.fileExists(atPath: dest.path) { return dest }
         if let existing = inflight[key] { return try await existing.value }
 
-        let client = blossomClient
+        // Fetch from the server STAMPED into the attachment (where the
+        // sender uploaded), falling back to the live client for legacy
+        // rows without a stamp — see ChatImageLoader.
+        let client = attachment.server.map { blossomClient.bound(toServer: $0) }
+            ?? blossomClient
         let task = Task<URL, Error> {
             let blob = try await client.download(sha256: attachment.sha256)
             let plaintext = try ChatImageCrypto.open(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVoiceLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVoiceLoader.swift
@@ -41,13 +41,18 @@ public actor ChatVoiceLoader {
         let key = attachment.sha256
         let dest = cacheFileURL(key)
         if FileManager.default.fileExists(atPath: dest.path) { return dest }
+        // Resolve the allowlist BEFORE the inflight lookup — the await
+        // suspends, and the check-and-insert below must stay contiguous
+        // (actor-atomic) or two concurrent requests double-download and
+        // double-write `dest`. See ChatImageLoader.
+        let allowedServers = await allowedStampServers()
         if let existing = inflight[key] { return try await existing.value }
 
         // Stamp honored only within the user's configured server set —
         // never a peer-chosen host. See BlossomServerStampPolicy.
         let client = BlossomServerStampPolicy.client(
             forStamp: attachment.server,
-            allowedServers: await allowedStampServers(),
+            allowedServers: allowedServers,
             live: blossomClient
         )
         let task = Task<URL, Error> {
@@ -55,7 +60,9 @@ public actor ChatVoiceLoader {
             let plaintext = try ChatImageCrypto.open(
                 blob: blob, key: attachment.encKey, expectedSha256Hex: attachment.sha256
             )
-            try plaintext.write(to: dest, options: .completeFileProtection)
+            // `.atomic`: a concurrent reader must never open a
+            // partially-written file.
+            try plaintext.write(to: dest, options: [.atomic, .completeFileProtection])
             return dest
         }
         inflight[key] = task

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVoiceLoader.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatVoiceLoader.swift
@@ -12,11 +12,19 @@ import OnymTransportBlossom
 /// descriptor alone, so nothing downloads on receipt.
 public actor ChatVoiceLoader {
     private let blossomClient: any BlossomClient
+    /// See `ChatImageLoader.allowedStampServers` — the only servers a
+    /// wire-decoded `server` stamp may route a download to.
+    private let allowedStampServers: @Sendable () async -> [URL]
     private let cacheDir: URL
     private var inflight: [String: Task<URL, Error>] = [:]
 
-    public init(blossomClient: any BlossomClient, cacheDirectory: URL? = nil) {
+    public init(
+        blossomClient: any BlossomClient,
+        cacheDirectory: URL? = nil,
+        allowedStampServers: @escaping @Sendable () async -> [URL] = { [] }
+    ) {
         self.blossomClient = blossomClient
+        self.allowedStampServers = allowedStampServers
         self.cacheDir = cacheDirectory ?? FileManager.default
             .urls(for: .cachesDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("OnymChatVoice", isDirectory: true)
@@ -35,11 +43,13 @@ public actor ChatVoiceLoader {
         if FileManager.default.fileExists(atPath: dest.path) { return dest }
         if let existing = inflight[key] { return try await existing.value }
 
-        // Fetch from the server STAMPED into the attachment (where the
-        // sender uploaded), falling back to the live client for legacy
-        // rows without a stamp — see ChatImageLoader.
-        let client = attachment.server.map { blossomClient.bound(toServer: $0) }
-            ?? blossomClient
+        // Stamp honored only within the user's configured server set —
+        // never a peer-chosen host. See BlossomServerStampPolicy.
+        let client = BlossomServerStampPolicy.client(
+            forStamp: attachment.server,
+            allowedServers: await allowedStampServers(),
+            live: blossomClient
+        )
         let task = Task<URL, Error> {
             let blob = try await client.download(sha256: attachment.sha256)
             let plaintext = try ChatImageCrypto.open(

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -970,6 +970,15 @@ public actor SendMessageInteractor {
         // currently-configured one — a config change between the failed
         // send and the retry must not strand the descriptor. Falls back
         // to the live client for legacy rows without a stamp.
+        //
+        // Taking the FIRST stamp is deliberate: every send since the
+        // per-send binding landed resolves the URL exactly once, so all
+        // of one message's attachments carry the same stamp and any of
+        // them is representative. A mixed-stamp message could only be a
+        // legacy row from before that guarantee; per-blob binding for
+        // that vanishing case isn't worth the complexity — the retry
+        // then re-uploads all blobs to the first stamp's server, which
+        // at worst re-homes a legacy blob alongside its siblings.
         let stampedServer = message.media.lazy.compactMap { item -> String? in
             switch item {
             case .image(let image): return image.server

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -22,9 +22,13 @@ public actor SendMessageInteractor {
     private let messageRepository: MessageRepository
     private let groupRepository: GroupRepository
     private let blossomClient: any BlossomClient
-    /// Base URL stamped into `ChatImageAttachment.server` so receivers
-    /// fetch from the same server the sender uploaded to.
-    private let blossomServerURL: String
+    /// Resolves the base URL stamped into `ChatImageAttachment.server`
+    /// so receivers fetch from the same server the sender uploaded to.
+    /// A provider (not a frozen string) so it can re-read the current
+    /// Blossom configuration — a server change in Settings applies to
+    /// the next send, not the next launch. Sampled once per send so
+    /// all of one message's attachments agree.
+    private let resolveBlossomServerURL: @Sendable () async -> String
     /// Transcodes + extracts a poster from a picked video. Injected so
     /// the UI-test harness can supply a canned encoding instead of
     /// running AVFoundation on a real clip. Defaults to the real encoder.
@@ -86,7 +90,9 @@ public actor SendMessageInteractor {
             baseURL: URLSessionBlossomClient.defaultBaseURL,
             signerProvider: OnymNostrSignerProvider()
         ),
-        blossomServerURL: String = URLSessionBlossomClient.defaultBaseURL.absoluteString,
+        blossomServerURL: @escaping @Sendable () async -> String = {
+            URLSessionBlossomClient.defaultBaseURL.absoluteString
+        },
         videoEncoder: @escaping @Sendable (URL) async -> ChatVideoEncoder.Encoded? = ChatVideoEncoder.encode(fromVideoURL:),
         voiceEncoder: @escaping @Sendable (URL) async -> ChatVoiceEncoder.Encoded? = ChatVoiceEncoder.encode(fromAudioURL:),
         outbox: ChatOutbox? = nil,
@@ -97,7 +103,7 @@ public actor SendMessageInteractor {
         self.messageRepository = messageRepository
         self.groupRepository = groupRepository
         self.blossomClient = blossomClient
-        self.blossomServerURL = blossomServerURL
+        self.resolveBlossomServerURL = blossomServerURL
         self.outbox = outbox
         self.imageLoader = imageLoader
         self.videoEncoder = videoEncoder
@@ -324,6 +330,7 @@ public actor SendMessageInteractor {
             throw SendError.imageUploadFailed("encrypt: \(error)")
         }
 
+        let blossomServerURL = await resolveBlossomServerURL()
         let attachment = ChatImageAttachment(
             sha256: sealed.sha256Hex,
             mimeType: "image/jpeg",
@@ -460,6 +467,7 @@ public actor SendMessageInteractor {
             throw SendError.videoTooLarge
         }
 
+        let blossomServerURL = await resolveBlossomServerURL()
         let poster = ChatImageAttachment(
             sha256: posterSealed.sha256Hex,
             mimeType: "image/jpeg",
@@ -616,6 +624,7 @@ public actor SendMessageInteractor {
         // from both, which keeps the commitment describing exactly what
         // was sent rather than what was picked.
         var commitments: [ChatModerationProof.MediaCommitment] = []
+        let blossomServerURL = await resolveBlossomServerURL()
         for source in sources {
             switch source {
             case .image(let data):
@@ -786,6 +795,7 @@ public actor SendMessageInteractor {
             throw SendError.videoTooLarge
         }
 
+        let blossomServerURL = await resolveBlossomServerURL()
         let voiceAttachment = ChatVoiceAttachment(
             sha256: sealed.sha256Hex,
             mimeType: "audio/mp4",

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -26,8 +26,11 @@ public actor SendMessageInteractor {
     /// so receivers fetch from the same server the sender uploaded to.
     /// A provider (not a frozen string) so it can re-read the current
     /// Blossom configuration — a server change in Settings applies to
-    /// the next send, not the next launch. Sampled once per send so
-    /// all of one message's attachments agree.
+    /// the next send, not the next launch. Resolved ONCE per send;
+    /// the stamp and every upload of that send go through a client
+    /// bound to the resolved URL (`bound(toServer:)`), so one
+    /// message's attachments and blobs always land together even if
+    /// the configuration changes mid-send.
     private let resolveBlossomServerURL: @Sendable () async -> String
     /// Transcodes + extracts a poster from a picked video. Injected so
     /// the UI-test harness can supply a canned encoding instead of
@@ -331,6 +334,7 @@ public actor SendMessageInteractor {
         }
 
         let blossomServerURL = await resolveBlossomServerURL()
+        let sendClient = blossomClient.bound(toServer: blossomServerURL)
         let attachment = ChatImageAttachment(
             sha256: sealed.sha256Hex,
             mimeType: "image/jpeg",
@@ -401,6 +405,7 @@ public actor SendMessageInteractor {
             .filter { $0.key != myBlsHex }
             .map { $0.value.inboxPublicKey }
         let finalStatus = await uploadAndFanOut(
+            via: sendClient,
             blobs: [(sealed.blob, "image/jpeg")],
             payload: payload,
             recipients: recipients,
@@ -468,6 +473,7 @@ public actor SendMessageInteractor {
         }
 
         let blossomServerURL = await resolveBlossomServerURL()
+        let sendClient = blossomClient.bound(toServer: blossomServerURL)
         let poster = ChatImageAttachment(
             sha256: posterSealed.sha256Hex,
             mimeType: "image/jpeg",
@@ -560,6 +566,7 @@ public actor SendMessageInteractor {
         // Poster first (small, so the recipient's bubble renders quickly),
         // then the video.
         let finalStatus = await uploadAndFanOut(
+            via: sendClient,
             blobs: [
                 (posterSealed.blob, "image/jpeg"),
                 (videoSealed.blob, "video/mp4"),
@@ -625,6 +632,7 @@ public actor SendMessageInteractor {
         // was sent rather than what was picked.
         var commitments: [ChatModerationProof.MediaCommitment] = []
         let blossomServerURL = await resolveBlossomServerURL()
+        let sendClient = blossomClient.bound(toServer: blossomServerURL)
         for source in sources {
             switch source {
             case .image(let data):
@@ -737,6 +745,7 @@ public actor SendMessageInteractor {
             .filter { $0.key != myBlsHex }
             .map { $0.value.inboxPublicKey }
         let finalStatus = await uploadAndFanOut(
+            via: sendClient,
             blobs: uploads, payload: payload, recipients: recipients,
             messageID: messageID, groupID: groupID, owner: group.ownerIdentityID,
             sentBlobShas: shas
@@ -796,6 +805,7 @@ public actor SendMessageInteractor {
         }
 
         let blossomServerURL = await resolveBlossomServerURL()
+        let sendClient = blossomClient.bound(toServer: blossomServerURL)
         let voiceAttachment = ChatVoiceAttachment(
             sha256: sealed.sha256Hex,
             mimeType: "audio/mp4",
@@ -859,6 +869,7 @@ public actor SendMessageInteractor {
             .filter { $0.key != myBlsHex }
             .map { $0.value.inboxPublicKey }
         let finalStatus = await uploadAndFanOut(
+            via: sendClient,
             blobs: [(sealed.blob, "audio/mp4")],
             payload: payload,
             recipients: recipients,
@@ -954,7 +965,22 @@ public actor SendMessageInteractor {
             .filter { $0.key != myBlsHex }
             .map { $0.value.inboxPublicKey }
 
+        // Re-uploads go to the server already STAMPED into the message's
+        // attachments (the descriptor recipients will read), not the
+        // currently-configured one — a config change between the failed
+        // send and the retry must not strand the descriptor. Falls back
+        // to the live client for legacy rows without a stamp.
+        let stampedServer = message.media.lazy.compactMap { item -> String? in
+            switch item {
+            case .image(let image): return image.server
+            case .video(let video): return video.server
+            }
+        }.first ?? message.voiceAttachment?.server
+        let retryClient = stampedServer.map { blossomClient.bound(toServer: $0) }
+            ?? blossomClient
+
         _ = await uploadAndFanOut(
+            via: retryClient,
             blobs: blobs.map { ($0.blob, $0.mimeType) },
             payload: payload,
             recipients: recipients,
@@ -1031,7 +1057,11 @@ public actor SendMessageInteractor {
     /// the outbox blob(s) for a later resend (no fan-out — recipients
     /// never get a descriptor pointing at a missing blob). On a confirmed
     /// `.sent` the outbox blob(s) in `sentBlobShas` are evicted.
+    /// `via` is the client every blob of this operation uploads
+    /// through — bound to the URL stamped into the message's
+    /// attachments, so blobs and stamp can't diverge mid-operation.
     private func uploadAndFanOut(
+        via client: any BlossomClient,
         blobs: [(Data, String)],
         payload: ChatMessagePayload,
         recipients: [Data],
@@ -1042,7 +1072,7 @@ public actor SendMessageInteractor {
     ) async -> MessageStatus {
         for (blob, mimeType) in blobs {
             do {
-                _ = try await blossomClient.upload(blob, mimeType: mimeType)
+                _ = try await client.upload(blob, mimeType: mimeType)
             } catch {
                 await messageRepository.updateStatus(
                     id: messageID, status: .failed, groupID: groupID,

--- a/Packages/OnymDesign/EXTRACTION-NOTES.md
+++ b/Packages/OnymDesign/EXTRACTION-NOTES.md
@@ -90,11 +90,12 @@ Every `public` below is justified by a consumer outside Packages/OnymDesign
   ShareInviteView, tests. Public init(value:size:).
 - `settingsInviteURL(blsPublicKey:)` — ShareKeyView, IdentityCarouselCard,
   IdentityDetailView, SettingsQRCodeTests.
+- `SettingsStepIndicator` — made public (public init(step:count:) + public
+  body) for the onboarding flow's step progress; originally kept internal
+  with zero external consumers.
 
 ## Kept internal / private
 
-- `SettingsStepIndicator` — zero consumers outside the package (appears
-  unused everywhere right now); left internal, not deleted.
 - `PulseModifier` — already `private`.
 - `OnymUIGovernance.sub/.oneLine/.tooltip` — no consumers (CreateGroupView's
   `step.sub` at line 872 is `CreateGroupCreatingStep`, a different type);

--- a/Packages/OnymDesign/Sources/OnymDesign/SettingsDesign.swift
+++ b/Packages/OnymDesign/Sources/OnymDesign/SettingsDesign.swift
@@ -571,12 +571,18 @@ extension SettingsPrimaryButton where Label == Text {
     }
 }
 
-/// Step indicator for the multi-step backup flow. Active dot expands
-/// into a 22pt capsule; visited dots stay filled at 6pt.
-struct SettingsStepIndicator: View {
+/// Step indicator for multi-step flows (backup, onboarding). Active
+/// dot expands into a 22pt capsule; visited dots stay filled at 6pt.
+public struct SettingsStepIndicator: View {
     let step: Int
     var count: Int = 3
-    var body: some View {
+
+    public init(step: Int, count: Int = 3) {
+        self.step = step
+        self.count = count
+    }
+
+    public var body: some View {
         HStack(spacing: 6) {
             ForEach(0..<count, id: \.self) { i in
                 Capsule()

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsFlow.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Observation
 import OnymTransportBlossom
+import OnymDiscovery
+import OnymFoundation
 
 /// `@Observable @MainActor` view-model for the Blossom-servers Settings
 /// screen. Drains `BlossomServersRepository` snapshots into local
@@ -23,29 +25,98 @@ public final class BlossomRelaySettingsFlow {
     }
 
     public private(set) var state: State
+    /// Discovery-sourced "blob.storage" entries for the "From catalog"
+    /// section. Empty when the app runs without discovery.
+    public private(set) var catalogEntries: [AttributedCatalogEntry] = []
+    /// Consent state per componentId, memoized once per catalog
+    /// refresh — `activeConsent` decodes the whole consent store and
+    /// the offer a pinned manifest, far too heavy per row per render.
+    private var consentRecords: [String: PinnedConsentRecord] = [:]
+    private var consentedOffers: [String: ServiceOffer] = [:]
 
     private let repository: BlossomServersRepository
+    /// Optional discovery seam — nil keeps this screen exactly as it
+    /// was before discovery existed.
+    let discovery: DiscoveryModulePicker?
     private var snapshotTask: Task<Void, Never>?
+    private var catalogTask: Task<Void, Never>?
 
-    public init(repository: BlossomServersRepository) {
+    public init(repository: BlossomServersRepository, discovery: DiscoveryModulePicker? = nil) {
         self.repository = repository
+        self.discovery = discovery
         self.state = State(snapshot: .empty, customDraft: "", customDraftError: nil)
     }
 
-    /// Begin draining repository snapshots. Idempotent.
+    /// Begin draining repository snapshots AND discovery catalog
+    /// updates. Idempotent. The catalog is a stream, not a one-shot
+    /// read, so the "From catalog" section populates when the
+    /// boot-time discovery refresh lands while this screen is open.
     public func start() {
-        guard snapshotTask == nil else { return }
-        snapshotTask = Task { [weak self] in
-            guard let self else { return }
-            for await snapshot in self.repository.snapshots {
-                self.state.snapshot = snapshot
+        if snapshotTask == nil {
+            snapshotTask = Task { [weak self] in
+                guard let self else { return }
+                for await snapshot in self.repository.snapshots {
+                    self.state.snapshot = snapshot
+                }
             }
         }
+        if catalogTask == nil, let discovery {
+            catalogTask = Task { [weak self] in
+                for await entries in discovery.entriesStream() {
+                    self?.applyCatalog(entries)
+                }
+            }
+        }
+    }
+
+    /// Re-read the discovery aggregate once (consent-sheet dismiss — a
+    /// fresh consent changes the rows' badges without any catalog
+    /// change to push through the stream).
+    public func refreshCatalog() {
+        guard let discovery else { return }
+        Task { [weak self] in
+            let entries = await discovery.entries()
+            self?.applyCatalog(entries)
+        }
+    }
+
+    /// Install a catalog aggregate, memoizing the per-component
+    /// consent lookups so rendering a row is a dictionary hit instead
+    /// of a full consent-store decode.
+    private func applyCatalog(_ entries: [AttributedCatalogEntry]) {
+        guard let discovery else { return }
+        var records: [String: PinnedConsentRecord] = [:]
+        var offers: [String: ServiceOffer] = [:]
+        for componentId in Set(entries.map(\.entry.componentId)) {
+            guard let record = discovery.activeConsent(componentId) else { continue }
+            records[componentId] = record
+            if let offerId = record.offerId {
+                offers[componentId] = record.consentedManifest()?
+                    .offers.first { $0.offerId == offerId }
+            }
+        }
+        catalogEntries = entries
+        consentRecords = records
+        consentedOffers = offers
+    }
+
+    /// The active pinned consent for a catalog entry's component, when
+    /// discovery is wired (memoized per catalog refresh).
+    public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
+        consentRecords[entry.entry.componentId]
+    }
+
+    /// The offer accepted at consent time, resolved from the pinned
+    /// manifest snapshot (memoized per catalog refresh).
+    public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
+        consentedOffers[entry.entry.componentId]
     }
 
     func stop() {
         snapshotTask?.cancel()
         snapshotTask = nil
+        catalogTask?.cancel()
+        catalogTask = nil
     }
 
     // MARK: - Intents

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsFlow.swift
@@ -25,25 +25,23 @@ public final class BlossomRelaySettingsFlow {
     }
 
     public private(set) var state: State
+    /// Catalog-section state (entries + memoized consent lookups),
+    /// shared plumbing with the relayer/Nostr flows.
+    private let catalog: DiscoveryCatalogState
     /// Discovery-sourced "blob.storage" entries for the "From catalog"
     /// section. Empty when the app runs without discovery.
-    public private(set) var catalogEntries: [AttributedCatalogEntry] = []
-    /// Consent state per componentId, memoized once per catalog
-    /// refresh — `activeConsent` decodes the whole consent store and
-    /// the offer a pinned manifest, far too heavy per row per render.
-    private var consentRecords: [String: PinnedConsentRecord] = [:]
-    private var consentedOffers: [String: ServiceOffer] = [:]
+    public var catalogEntries: [AttributedCatalogEntry] { catalog.entries }
 
     private let repository: BlossomServersRepository
     /// Optional discovery seam — nil keeps this screen exactly as it
     /// was before discovery existed.
     let discovery: DiscoveryModulePicker?
     private var snapshotTask: Task<Void, Never>?
-    private var catalogTask: Task<Void, Never>?
 
     public init(repository: BlossomServersRepository, discovery: DiscoveryModulePicker? = nil) {
         self.repository = repository
         self.discovery = discovery
+        self.catalog = DiscoveryCatalogState(discovery: discovery)
         self.state = State(snapshot: .empty, customDraft: "", customDraftError: nil)
     }
 
@@ -60,63 +58,32 @@ public final class BlossomRelaySettingsFlow {
                 }
             }
         }
-        if catalogTask == nil, let discovery {
-            catalogTask = Task { [weak self] in
-                for await entries in discovery.entriesStream() {
-                    self?.applyCatalog(entries)
-                }
-            }
-        }
+        catalog.start()
     }
 
     /// Re-read the discovery aggregate once (consent-sheet dismiss — a
     /// fresh consent changes the rows' badges without any catalog
     /// change to push through the stream).
     public func refreshCatalog() {
-        guard let discovery else { return }
-        Task { [weak self] in
-            let entries = await discovery.entries()
-            self?.applyCatalog(entries)
-        }
-    }
-
-    /// Install a catalog aggregate, memoizing the per-component
-    /// consent lookups so rendering a row is a dictionary hit instead
-    /// of a full consent-store decode.
-    private func applyCatalog(_ entries: [AttributedCatalogEntry]) {
-        guard let discovery else { return }
-        var records: [String: PinnedConsentRecord] = [:]
-        var offers: [String: ServiceOffer] = [:]
-        for componentId in Set(entries.map(\.entry.componentId)) {
-            guard let record = discovery.activeConsent(componentId) else { continue }
-            records[componentId] = record
-            if let offerId = record.offerId {
-                offers[componentId] = record.consentedManifest()?
-                    .offers.first { $0.offerId == offerId }
-            }
-        }
-        catalogEntries = entries
-        consentRecords = records
-        consentedOffers = offers
+        catalog.refresh()
     }
 
     /// The active pinned consent for a catalog entry's component, when
     /// discovery is wired (memoized per catalog refresh).
     public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
-        consentRecords[entry.entry.componentId]
+        catalog.activeConsent(for: entry)
     }
 
     /// The offer accepted at consent time, resolved from the pinned
     /// manifest snapshot (memoized per catalog refresh).
     public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
-        consentedOffers[entry.entry.componentId]
+        catalog.consentedOffer(for: entry)
     }
 
     func stop() {
         snapshotTask?.cancel()
         snapshotTask = nil
-        catalogTask?.cancel()
-        catalogTask = nil
+        catalog.stop()
     }
 
     // MARK: - Intents
@@ -142,6 +109,12 @@ public final class BlossomRelaySettingsFlow {
     /// Swipe-to-delete on a configured row.
     func tappedRemove(url: URL) {
         Task { await repository.removeEndpoint(url: url) }
+    }
+
+    /// "Make Active" on a non-first configured row — moves the server
+    /// to the head of the list, i.e. the upload/download target.
+    public func tappedMakeActive(url: URL) {
+        Task { await repository.makeActive(url: url) }
     }
 
     /// Restore default — re-installs the Onym Official seed and clears

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
@@ -1,16 +1,19 @@
 import SwiftUI
 import OnymDesign
+import OnymDiscovery
 
 /// Settings → Transport → Blossom Relays. Lists configured Blossom
 /// media servers, lets the user add a custom URL or remove any entry,
 /// and surfaces a "Restore default" affordance that re-installs the
 /// Onym Official seed. Mirrors `NostrRelaySettingsView`.
 ///
-/// V1 limitation: changes apply on the next app launch — the Blossom
-/// client's base URL is chosen once at boot (the first configured
-/// server). A footnote at the bottom surfaces this.
+/// Changes apply immediately — the Blossom client re-reads the first
+/// configured server per upload/download, so the next media operation
+/// targets whatever is configured right now.
 struct BlossomRelaySettingsView: View {
     @State private var flow: BlossomRelaySettingsFlow
+    /// The catalog entry whose consent sheet is presented, if any.
+    @State private var consentEntry: AttributedCatalogEntry?
 
     init(flow: BlossomRelaySettingsFlow) {
         _flow = State(initialValue: flow)
@@ -26,6 +29,15 @@ struct BlossomRelaySettingsView: View {
                 )
                 configuredCard
 
+                DiscoveryCatalogSection(
+                    entries: flow.catalogEntries,
+                    activeConsent: { flow.activeConsent(for: $0) },
+                    consentedOffer: { flow.consentedOffer(for: $0) },
+                    tileSymbol: "photo.on.rectangle.angled",
+                    accessibilityPrefix: "blossom.catalog",
+                    onSelect: { consentEntry = $0 }
+                )
+
                 SettingsSectionLabel("ADD CUSTOM URL")
                 customURLCard
                 SettingsFootnote(
@@ -34,7 +46,7 @@ struct BlossomRelaySettingsView: View {
 
                 resetCard
                 SettingsFootnote(
-                    "Changes apply on the next app launch. Uploads target the first configured server."
+                    "Changes apply to the next upload or download. Uploads target the first configured server."
                 )
 
                 SettingsSectionLabel("SELF-HOST")
@@ -66,6 +78,13 @@ struct BlossomRelaySettingsView: View {
         // finishes on its own, so without this the continuation would
         // accumulate on every visit.
         .onDisappear { flow.stop() }
+        // Consent runs as a sheet; on dismiss the catalog badges
+        // refresh so a fresh consent shows immediately.
+        .sheet(item: $consentEntry, onDismiss: { flow.refreshCatalog() }) { entry in
+            if let discovery = flow.discovery {
+                ModuleConsentView(flow: discovery.makeConsentFlow(entry))
+            }
+        }
     }
 
     // MARK: - Configured list

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
@@ -46,7 +46,7 @@ struct BlossomRelaySettingsView: View {
 
                 resetCard
                 SettingsFootnote(
-                    "Changes apply to the next upload or download. Uploads target the first configured server."
+                    "Uploads and downloads target the active server — the first in the list. Picking a server from the catalog makes it active; tap Make Active on any other row to switch. Changes apply to the next upload or download."
                 )
 
                 SettingsSectionLabel("SELF-HOST")
@@ -123,6 +123,20 @@ struct BlossomRelaySettingsView: View {
                                         Text(endpoint.name)
                                             .font(.system(size: 15, weight: .semibold))
                                             .foregroundStyle(OnymTokens.text)
+                                        // First endpoint is the one
+                                        // uploads/downloads target.
+                                        if idx == 0 {
+                                            Text("ACTIVE")
+                                                .font(.system(size: 10, weight: .bold))
+                                                .foregroundStyle(OnymAccent.blue.color)
+                                                .padding(.horizontal, 6)
+                                                .padding(.vertical, 2)
+                                                .background(
+                                                    OnymAccent.blue.color.opacity(0.12),
+                                                    in: RoundedRectangle(cornerRadius: 4)
+                                                )
+                                                .accessibilityIdentifier("blossom.active_badge")
+                                        }
                                         if endpoint.isDefault {
                                             Text("DEFAULT")
                                                 .font(.system(size: 10, weight: .bold))
@@ -141,6 +155,27 @@ struct BlossomRelaySettingsView: View {
                                         .lineLimit(1)
                                 }
                                 Spacer(minLength: 0)
+                                // Non-first rows can be promoted to
+                                // the upload/download target.
+                                if idx != 0 {
+                                    Button {
+                                        flow.tappedMakeActive(url: endpoint.url)
+                                    } label: {
+                                        Text("Make Active")
+                                            .font(.system(size: 12, weight: .semibold))
+                                            .foregroundStyle(OnymAccent.blue.color)
+                                            .padding(.horizontal, 10)
+                                            .padding(.vertical, 6)
+                                            .background(
+                                                OnymTokens.surface3,
+                                                in: RoundedRectangle(cornerRadius: 8)
+                                            )
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityIdentifier(
+                                        "blossom.make_active.\(endpoint.url.absoluteString)"
+                                    )
+                                }
                             }
                             .padding(.horizontal, 14)
                             .padding(.vertical, 10)

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
@@ -46,7 +46,7 @@ struct BlossomRelaySettingsView: View {
 
                 resetCard
                 SettingsFootnote(
-                    "Uploads and downloads target the active server — the first in the list. Picking a server from the catalog makes it active; tap Make Active on any other row to switch. Changes apply to the next upload or download."
+                    "Uploads and downloads use the active server. Changes apply to the next upload or download."
                 )
 
                 SettingsSectionLabel("SELF-HOST")

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogSection.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogSection.swift
@@ -4,7 +4,7 @@ import OnymDiscovery
 import OnymFoundation
 
 /// "FROM CATALOG" section shared by the per-seat pickers (relayer,
-/// nostr): discovery-sourced entries with their source label,
+/// nostr, blossom): discovery-sourced entries with their source label,
 /// relationship disclosure, consent state, and — once consented — the
 /// accepted offer's badge. Tapping a row hands the entry to the
 /// presenting view, which runs `ModuleConsentFlow` as a sheet.

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogState.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogState.swift
@@ -21,10 +21,10 @@ import OnymFoundation
 /// far too heavy per row per render.
 @MainActor
 @Observable
-public final class DiscoveryCatalogState {
+final class DiscoveryCatalogState {
     /// Entries for the "From catalog" section. Empty when the app runs
     /// without discovery.
-    public private(set) var entries: [AttributedCatalogEntry] = []
+    private(set) var entries: [AttributedCatalogEntry] = []
     /// Endpoint URLs of the CONSENTED catalog entries, derived from
     /// the pinned consent records' exact manifest bytes. Used by flows
     /// that also render a published list to hide catalog-sourced rows
@@ -32,7 +32,7 @@ public final class DiscoveryCatalogState {
     /// and consent state instead). Derived from `entries`, not any
     /// fetch-time registry, so it can never race a known list rendered
     /// from cache before a fetch completes.
-    public private(set) var consentedEndpointURLs: Set<URL> = []
+    private(set) var consentedEndpointURLs: Set<URL> = []
 
     private var consentRecords: [String: PinnedConsentRecord] = [:]
     private var consentedOffers: [String: ServiceOffer] = [:]
@@ -41,12 +41,12 @@ public final class DiscoveryCatalogState {
 
     /// `nil` discovery keeps the state permanently empty — the seam
     /// the flows already expose for running without discovery.
-    public init(discovery: DiscoveryModulePicker?) {
+    init(discovery: DiscoveryModulePicker?) {
         self.discovery = discovery
     }
 
     /// Begin draining the picker's entries stream. Idempotent.
-    public func start() {
+    func start() {
         guard task == nil, let discovery else { return }
         task = Task { [weak self] in
             for await entries in discovery.entriesStream() {
@@ -55,13 +55,13 @@ public final class DiscoveryCatalogState {
         }
     }
 
-    public func stop() {
+    func stop() {
         task?.cancel()
         task = nil
     }
 
     /// Re-read the discovery aggregate once.
-    public func refresh() {
+    func refresh() {
         guard let discovery else { return }
         Task { [weak self] in
             let entries = await discovery.entries()
@@ -71,13 +71,13 @@ public final class DiscoveryCatalogState {
 
     /// The active pinned consent for a catalog entry's component
     /// (memoized per catalog install).
-    public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
+    func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
         consentRecords[entry.entry.componentId]
     }
 
     /// The offer accepted at consent time, resolved from the pinned
     /// manifest snapshot (memoized per catalog install).
-    public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
+    func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
         consentedOffers[entry.entry.componentId]
     }
 

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogState.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogState.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Observation
+import OnymDiscovery
+import OnymFoundation
+
+/// Catalog-section state shared by the transport Settings flows
+/// (relayer / Nostr / Blossom): the discovery-sourced entries for one
+/// seat plus the memoized per-component consent lookups. Extracted
+/// because the plumbing was previously copied verbatim into each flow.
+///
+/// Lifecycle mirrors the flows': `start()` drains the picker's entries
+/// stream (so the section populates when the boot-time discovery
+/// refresh lands while the screen is open), `refresh()` re-reads the
+/// aggregate once (consent-sheet dismiss — a fresh consent changes row
+/// badges without a catalog change to push through the stream), and
+/// `stop()` cancels the drain so continuations don't accumulate
+/// across visits.
+///
+/// All lookups are memoized once per catalog install — `activeConsent`
+/// decodes the whole consent store and the offer a pinned manifest,
+/// far too heavy per row per render.
+@MainActor
+@Observable
+public final class DiscoveryCatalogState {
+    /// Entries for the "From catalog" section. Empty when the app runs
+    /// without discovery.
+    public private(set) var entries: [AttributedCatalogEntry] = []
+    /// Endpoint URLs of the CONSENTED catalog entries, derived from
+    /// the pinned consent records' exact manifest bytes. Used by flows
+    /// that also render a published list to hide catalog-sourced rows
+    /// from it (they render in the catalog section with attribution
+    /// and consent state instead). Derived from `entries`, not any
+    /// fetch-time registry, so it can never race a known list rendered
+    /// from cache before a fetch completes.
+    public private(set) var consentedEndpointURLs: Set<URL> = []
+
+    private var consentRecords: [String: PinnedConsentRecord] = [:]
+    private var consentedOffers: [String: ServiceOffer] = [:]
+    private let discovery: DiscoveryModulePicker?
+    private var task: Task<Void, Never>?
+
+    /// `nil` discovery keeps the state permanently empty — the seam
+    /// the flows already expose for running without discovery.
+    public init(discovery: DiscoveryModulePicker?) {
+        self.discovery = discovery
+    }
+
+    /// Begin draining the picker's entries stream. Idempotent.
+    public func start() {
+        guard task == nil, let discovery else { return }
+        task = Task { [weak self] in
+            for await entries in discovery.entriesStream() {
+                self?.apply(entries)
+            }
+        }
+    }
+
+    public func stop() {
+        task?.cancel()
+        task = nil
+    }
+
+    /// Re-read the discovery aggregate once.
+    public func refresh() {
+        guard let discovery else { return }
+        Task { [weak self] in
+            let entries = await discovery.entries()
+            self?.apply(entries)
+        }
+    }
+
+    /// The active pinned consent for a catalog entry's component
+    /// (memoized per catalog install).
+    public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
+        consentRecords[entry.entry.componentId]
+    }
+
+    /// The offer accepted at consent time, resolved from the pinned
+    /// manifest snapshot (memoized per catalog install).
+    public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
+        consentedOffers[entry.entry.componentId]
+    }
+
+    /// Install a catalog aggregate, memoizing the per-component
+    /// consent lookups so rendering a row is a dictionary hit instead
+    /// of a full consent-store decode.
+    private func apply(_ entries: [AttributedCatalogEntry]) {
+        guard let discovery else { return }
+        var records: [String: PinnedConsentRecord] = [:]
+        var offers: [String: ServiceOffer] = [:]
+        var consentedURLs: Set<URL> = []
+        for componentId in Set(entries.map(\.entry.componentId)) {
+            guard let record = discovery.activeConsent(componentId) else { continue }
+            records[componentId] = record
+            consentedURLs.formUnion(record.consentedEndpointURLs())
+            if let offerId = record.offerId {
+                offers[componentId] = record.consentedManifest()?
+                    .offers.first { $0.offerId == offerId }
+            }
+        }
+        self.entries = entries
+        consentRecords = records
+        consentedOffers = offers
+        consentedEndpointURLs = consentedURLs
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsFlow.swift
@@ -26,25 +26,23 @@ public final class NostrRelaySettingsFlow {
     }
 
     public private(set) var state: State
+    /// Catalog-section state (entries + memoized consent lookups),
+    /// shared plumbing with the relayer/Blossom flows.
+    private let catalog: DiscoveryCatalogState
     /// Discovery-sourced "transport.message" entries for the "From
     /// catalog" section. Empty when the app runs without discovery.
-    public private(set) var catalogEntries: [AttributedCatalogEntry] = []
-    /// Consent state per componentId, memoized once per catalog
-    /// refresh — `activeConsent` decodes the whole consent store and
-    /// the offer a pinned manifest, far too heavy per row per render.
-    private var consentRecords: [String: PinnedConsentRecord] = [:]
-    private var consentedOffers: [String: ServiceOffer] = [:]
+    public var catalogEntries: [AttributedCatalogEntry] { catalog.entries }
 
     private let repository: NostrRelaysRepository
     /// Optional discovery seam — nil keeps this screen exactly as it
     /// was before discovery existed.
     let discovery: DiscoveryModulePicker?
     private var snapshotTask: Task<Void, Never>?
-    private var catalogTask: Task<Void, Never>?
 
     public init(repository: NostrRelaysRepository, discovery: DiscoveryModulePicker? = nil) {
         self.repository = repository
         self.discovery = discovery
+        self.catalog = DiscoveryCatalogState(discovery: discovery)
         self.state = State(snapshot: .empty, customDraft: "", customDraftError: nil)
     }
 
@@ -61,63 +59,32 @@ public final class NostrRelaySettingsFlow {
                 }
             }
         }
-        if catalogTask == nil, let discovery {
-            catalogTask = Task { [weak self] in
-                for await entries in discovery.entriesStream() {
-                    self?.applyCatalog(entries)
-                }
-            }
-        }
+        catalog.start()
     }
 
     /// Re-read the discovery aggregate once (consent-sheet dismiss — a
     /// fresh consent changes the rows' badges without any catalog
     /// change to push through the stream).
     public func refreshCatalog() {
-        guard let discovery else { return }
-        Task { [weak self] in
-            let entries = await discovery.entries()
-            self?.applyCatalog(entries)
-        }
-    }
-
-    /// Install a catalog aggregate, memoizing the per-component
-    /// consent lookups so rendering a row is a dictionary hit instead
-    /// of a full consent-store decode.
-    private func applyCatalog(_ entries: [AttributedCatalogEntry]) {
-        guard let discovery else { return }
-        var records: [String: PinnedConsentRecord] = [:]
-        var offers: [String: ServiceOffer] = [:]
-        for componentId in Set(entries.map(\.entry.componentId)) {
-            guard let record = discovery.activeConsent(componentId) else { continue }
-            records[componentId] = record
-            if let offerId = record.offerId {
-                offers[componentId] = record.consentedManifest()?
-                    .offers.first { $0.offerId == offerId }
-            }
-        }
-        catalogEntries = entries
-        consentRecords = records
-        consentedOffers = offers
+        catalog.refresh()
     }
 
     /// The active pinned consent for a catalog entry's component, when
     /// discovery is wired (memoized per catalog refresh).
     public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
-        consentRecords[entry.entry.componentId]
+        catalog.activeConsent(for: entry)
     }
 
     /// The offer accepted at consent time, resolved from the pinned
     /// manifest snapshot (memoized per catalog refresh).
     public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
-        consentedOffers[entry.entry.componentId]
+        catalog.consentedOffer(for: entry)
     }
 
     func stop() {
         snapshotTask?.cancel()
         snapshotTask = nil
-        catalogTask?.cancel()
-        catalogTask = nil
+        catalog.stop()
     }
 
     // MARK: - Intents

--- a/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsFlow.swift
@@ -21,33 +21,28 @@ public final class RelayerSettingsFlow {
     }
 
     public private(set) var state: State
+    /// Catalog-section state (entries + memoized consent lookups),
+    /// shared plumbing with the Nostr/Blossom flows.
+    private let catalog: DiscoveryCatalogState
     /// Discovery-sourced "notary" entries for the "From catalog"
     /// section. Empty when the app runs without discovery.
-    public private(set) var catalogEntries: [AttributedCatalogEntry] = []
-    /// Consent state per componentId, memoized once per catalog
-    /// refresh — `activeConsent` decodes the whole consent store and
-    /// the offer a pinned manifest, far too heavy per row per render.
-    private var consentRecords: [String: PinnedConsentRecord] = [:]
-    private var consentedOffers: [String: ServiceOffer] = [:]
-    /// Endpoint URLs of the CONSENTED catalog entries, derived from
-    /// the pinned consent records' exact manifest bytes. Those rows
-    /// are hidden from the tap-to-add published list — a catalog
-    /// entry renders in the "From catalog" section with attribution
-    /// and consent state instead. Derived from `catalogEntries`, not
-    /// from any fetch-time registry, so it can never race the known
-    /// list rendering from cache before a fetch completes.
-    private var discoverySourcedKnownURLs: Set<URL> = []
+    public var catalogEntries: [AttributedCatalogEntry] { catalog.entries }
+    /// Endpoint URLs of the CONSENTED catalog entries. Those rows are
+    /// hidden from the tap-to-add published list — a catalog entry
+    /// renders in the "From catalog" section with attribution and
+    /// consent state instead.
+    private var discoverySourcedKnownURLs: Set<URL> { catalog.consentedEndpointURLs }
 
     private let repository: RelayerRepository
     /// Optional discovery seam — nil keeps this screen exactly as it
     /// was before discovery existed.
     let discovery: DiscoveryModulePicker?
     private var snapshotTask: Task<Void, Never>?
-    private var catalogTask: Task<Void, Never>?
 
     public init(repository: RelayerRepository, discovery: DiscoveryModulePicker? = nil) {
         self.repository = repository
         self.discovery = discovery
+        self.catalog = DiscoveryCatalogState(discovery: discovery)
         self.state = State(snapshot: .empty, customDraft: "", customDraftError: nil)
     }
 
@@ -65,67 +60,32 @@ public final class RelayerSettingsFlow {
                 }
             }
         }
-        if catalogTask == nil, let discovery {
-            catalogTask = Task { [weak self] in
-                for await entries in discovery.entriesStream() {
-                    self?.applyCatalog(entries)
-                }
-            }
-        }
+        catalog.start()
     }
 
     /// Re-read the discovery aggregate once (consent-sheet dismiss — a
     /// fresh consent changes the rows' badges without any catalog
     /// change to push through the stream).
     public func refreshCatalog() {
-        guard let discovery else { return }
-        Task { [weak self] in
-            let entries = await discovery.entries()
-            self?.applyCatalog(entries)
-        }
-    }
-
-    /// Install a catalog aggregate: memoize the per-component consent
-    /// lookups (so rendering a row is a dictionary hit instead of a
-    /// full consent-store decode) and rebuild the published-list
-    /// dedupe set from the consented manifests' endpoint URLs.
-    private func applyCatalog(_ entries: [AttributedCatalogEntry]) {
-        guard let discovery else { return }
-        var records: [String: PinnedConsentRecord] = [:]
-        var offers: [String: ServiceOffer] = [:]
-        var consentedURLs: Set<URL> = []
-        for componentId in Set(entries.map(\.entry.componentId)) {
-            guard let record = discovery.activeConsent(componentId) else { continue }
-            records[componentId] = record
-            consentedURLs.formUnion(record.consentedEndpointURLs())
-            if let offerId = record.offerId {
-                offers[componentId] = record.consentedManifest()?
-                    .offers.first { $0.offerId == offerId }
-            }
-        }
-        catalogEntries = entries
-        consentRecords = records
-        consentedOffers = offers
-        discoverySourcedKnownURLs = consentedURLs
+        catalog.refresh()
     }
 
     /// The active pinned consent for a catalog entry's component, when
     /// discovery is wired (memoized per catalog refresh).
     public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
-        consentRecords[entry.entry.componentId]
+        catalog.activeConsent(for: entry)
     }
 
     /// The offer accepted at consent time, resolved from the pinned
     /// manifest snapshot (memoized per catalog refresh).
     public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
-        consentedOffers[entry.entry.componentId]
+        catalog.consentedOffer(for: entry)
     }
 
     public func stop() {
         snapshotTask?.cancel()
         snapshotTask = nil
-        catalogTask?.cancel()
-        catalogTask = nil
+        catalog.stop()
     }
 
     // MARK: - Intents

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomClient.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomClient.swift
@@ -31,6 +31,18 @@ public protocol BlossomClient: Sendable {
     func upload(_ blob: Data, mimeType: String) async throws -> BlobDescriptor
     /// `GET /<sha256>` the blob. Callers verify the hash before use.
     func download(sha256: String) async throws -> Data
+    /// A client pinned to `serverURL` for the duration of a multi-blob
+    /// operation. Callers that stamp a server URL into metadata (e.g.
+    /// a chat message's attachments) resolve the URL once, stamp it,
+    /// and run every upload of that operation through the bound client
+    /// so the stamp and the blobs' actual location can never diverge —
+    /// even if the configured server changes mid-operation. Clients
+    /// with a fixed base URL return `self` (the default).
+    func bound(toServer serverURL: String) -> any BlossomClient
+}
+
+extension BlossomClient {
+    public func bound(toServer serverURL: String) -> any BlossomClient { self }
 }
 
 public enum BlossomError: Error, Equatable {

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomClient.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomClient.swift
@@ -38,6 +38,12 @@ public protocol BlossomClient: Sendable {
     /// so the stamp and the blobs' actual location can never diverge —
     /// even if the configured server changes mid-operation. Clients
     /// with a fixed base URL return `self` (the default).
+    ///
+    /// TRUST NOTE: this is the trusted binding level — the URL must
+    /// come from the user's own configuration (or their own earlier
+    /// stamp), never from peer-influenced bytes. Peer stamps are gated
+    /// upstream by `BlossomServerStampPolicy` (https + allowlist,
+    /// binding to the allowlist's URL).
     func bound(toServer serverURL: String) -> any BlossomClient
 }
 

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomServersConfiguration.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomServersConfiguration.swift
@@ -5,10 +5,11 @@ import Foundation
 /// sticky "user has interacted" flag so the next app boot doesn't
 /// re-seed the default if the user explicitly cleared the list.
 ///
-/// V1 uploads to the **first** configured server (the client takes one
-/// base URL); the rest of the list is there so a user can swap Onym's
-/// default for their own self-hosted Blossom server. Changes apply on
-/// the next app launch. Mirrors `NostrRelaysConfiguration`.
+/// V1 uploads to the **first** configured server (the client resolves
+/// one base URL per operation); the rest of the list is there so a user
+/// can swap Onym's default for their own self-hosted Blossom server.
+/// Changes apply to the next upload/download. Mirrors
+/// `NostrRelaysConfiguration`.
 public struct BlossomServersConfiguration: Codable, Equatable, Sendable {
     public var endpoints: [BlossomServerEndpoint]
     /// Flips to `true` after the first user mutation (add / remove).

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomServersRepository.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomServersRepository.swift
@@ -85,15 +85,31 @@ public actor BlossomServersRepository {
     /// Idempotent on URL — re-adding an existing URL replaces its
     /// metadata (display name) but doesn't duplicate the row.
     /// Returns true on insert, false on update.
+    ///
+    /// `makeActive: true` places the endpoint at the HEAD of the list
+    /// (moving it there when it already exists). The first endpoint is
+    /// the one uploads/downloads target, so this is how a pick — e.g.
+    /// a consented catalog module — actually takes effect; a plain
+    /// append behind the seeded default would be silently inert.
+    /// Other entries keep their relative order.
     @discardableResult
-    public func addEndpoint(_ endpoint: BlossomServerEndpoint) -> Bool {
+    public func addEndpoint(_ endpoint: BlossomServerEndpoint, makeActive: Bool = false) -> Bool {
         var endpoints = cached.endpoints
         let inserted: Bool
         if let index = endpoints.firstIndex(where: { $0.url == endpoint.url }) {
-            endpoints[index] = endpoint
+            if makeActive {
+                endpoints.remove(at: index)
+                endpoints.insert(endpoint, at: 0)
+            } else {
+                endpoints[index] = endpoint
+            }
             inserted = false
         } else {
-            endpoints.append(endpoint)
+            if makeActive {
+                endpoints.insert(endpoint, at: 0)
+            } else {
+                endpoints.append(endpoint)
+            }
             inserted = true
         }
         applyConfiguration(BlossomServersConfiguration(
@@ -101,6 +117,24 @@ public actor BlossomServersRepository {
             hasUserInteracted: true
         ))
         return inserted
+    }
+
+    /// Move the configured endpoint with `url` to the head of the list
+    /// so it becomes the upload/download target. No-op when the URL
+    /// isn't configured (callers add first) or is already active — in
+    /// both cases nothing is persisted and `hasUserInteracted` is left
+    /// alone. An actual move counts as a user mutation.
+    public func makeActive(url: URL) {
+        guard let index = cached.endpoints.firstIndex(where: { $0.url == url }),
+              index != 0
+        else { return }
+        var endpoints = cached.endpoints
+        let endpoint = endpoints.remove(at: index)
+        endpoints.insert(endpoint, at: 0)
+        applyConfiguration(BlossomServersConfiguration(
+            endpoints: endpoints,
+            hasUserInteracted: true
+        ))
     }
 
     public func removeEndpoint(url: URL) {

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomServersRepository.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/BlossomServersRepository.swift
@@ -10,12 +10,12 @@ import Foundation
 ///   2. On init, if the persisted config is empty and the user hasn't
 ///      interacted yet, seed with `.seed` (Onym's official Blossom
 ///      server). Subsequent launches restore the user's actual list.
-///   3. App boot reads `currentEndpoints()` once and points the
-///      `URLSessionBlossomClient` base URL at the first configured
-///      server (uploads + downloads).
+///   3. The app's `DynamicBaseURLBlossomClient` re-reads
+///      `currentEndpoints()` per operation and targets the first
+///      configured server (uploads + downloads).
 ///   4. Settings → Transport → Blossom drives `addEndpoint` /
-///      `removeEndpoint`. Changes apply on the next app launch (V1
-///      doesn't rebuild the client live — Settings shows a banner).
+///      `removeEndpoint`. Changes apply to the very next
+///      upload/download — no relaunch needed.
 public actor BlossomServersRepository {
     private let store: any BlossomServersSelectionStore
     /// Fetches the Onym-published default list from GitHub. `nil` disables

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
@@ -36,16 +36,26 @@ public struct DynamicBaseURLBlossomClient: BlossomClient {
     /// Pin to `serverURL`: returns the inner client built for exactly
     /// that URL, so a multi-blob send that stamped the URL into its
     /// metadata uploads every blob there even if the configuration
-    /// changes mid-send. Falls back to `self` (live resolution) when
-    /// the string isn't a usable https base URL — `URL(string:)`
-    /// happily parses a schemeless stamp like "blossom.example" as a
-    /// relative URL that every request would then fail against, and
-    /// anything non-https (cleartext http, odd schemes) is rejected
-    /// outright, matching the consent apply path's
-    /// `requiredEndpointURL(in:scheme:"https")`.
+    /// changes mid-send.
+    ///
+    /// This is the TRUSTED binding level: callers vouch for the URL —
+    /// it comes from the user's own configuration (the per-send upload
+    /// pin, retry's re-upload to the self-stamped server), never from
+    /// peer-influenced bytes. The scheme is deliberately NOT
+    /// second-guessed here, so a hand-typed http://192.168.x local-dev
+    /// endpoint binds exactly as the user configured it.
+    /// Peer-influenced stamps must never reach this directly — they go
+    /// through `BlossomServerStampPolicy` (OnymChatsCore), which
+    /// enforces https + the user's configured allowlist and then binds
+    /// to the allowlist's own URL.
+    ///
+    /// Falls back to `self` (live resolution) when the string isn't a
+    /// usable absolute URL — `URL(string:)` happily parses a schemeless
+    /// "blossom.example" as a relative URL that every request would
+    /// then fail against, so scheme and host are required.
     public func bound(toServer serverURL: String) -> any BlossomClient {
         guard let url = URL(string: serverURL),
-              url.scheme?.lowercased() == "https",
+              url.scheme != nil,
               let host = url.host(), !host.isEmpty
         else { return self }
         return makeClient(url)

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
@@ -37,9 +37,15 @@ public struct DynamicBaseURLBlossomClient: BlossomClient {
     /// that URL, so a multi-blob send that stamped the URL into its
     /// metadata uploads every blob there even if the configuration
     /// changes mid-send. Falls back to `self` (live resolution) when
-    /// the string isn't a URL.
+    /// the string isn't a usable base URL — `URL(string:)` happily
+    /// parses a schemeless stamp like "blossom.example" as a relative
+    /// URL that every request would then fail against, so scheme and
+    /// host are required explicitly.
     public func bound(toServer serverURL: String) -> any BlossomClient {
-        guard let url = URL(string: serverURL) else { return self }
+        guard let url = URL(string: serverURL),
+              url.scheme != nil,
+              let host = url.host(), !host.isEmpty
+        else { return self }
         return makeClient(url)
     }
 }

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
@@ -37,13 +37,15 @@ public struct DynamicBaseURLBlossomClient: BlossomClient {
     /// that URL, so a multi-blob send that stamped the URL into its
     /// metadata uploads every blob there even if the configuration
     /// changes mid-send. Falls back to `self` (live resolution) when
-    /// the string isn't a usable base URL — `URL(string:)` happily
-    /// parses a schemeless stamp like "blossom.example" as a relative
-    /// URL that every request would then fail against, so scheme and
-    /// host are required explicitly.
+    /// the string isn't a usable https base URL — `URL(string:)`
+    /// happily parses a schemeless stamp like "blossom.example" as a
+    /// relative URL that every request would then fail against, and
+    /// anything non-https (cleartext http, odd schemes) is rejected
+    /// outright, matching the consent apply path's
+    /// `requiredEndpointURL(in:scheme:"https")`.
     public func bound(toServer serverURL: String) -> any BlossomClient {
         guard let url = URL(string: serverURL),
-              url.scheme != nil,
+              url.scheme?.lowercased() == "https",
               let host = url.host(), !host.isEmpty
         else { return self }
         return makeClient(url)

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
@@ -32,4 +32,14 @@ public struct DynamicBaseURLBlossomClient: BlossomClient {
     public func download(sha256: String) async throws -> Data {
         try await makeClient(await resolveBaseURL()).download(sha256: sha256)
     }
+
+    /// Pin to `serverURL`: returns the inner client built for exactly
+    /// that URL, so a multi-blob send that stamped the URL into its
+    /// metadata uploads every blob there even if the configuration
+    /// changes mid-send. Falls back to `self` (live resolution) when
+    /// the string isn't a URL.
+    public func bound(toServer serverURL: String) -> any BlossomClient {
+        guard let url = URL(string: serverURL) else { return self }
+        return makeClient(url)
+    }
 }

--- a/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
+++ b/Packages/OnymTransportBlossom/Sources/OnymTransportBlossom/DynamicBaseURLBlossomClient.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// `BlossomClient` that resolves its base URL per operation instead of
+/// freezing it at construction. Wraps a base-URL provider (typically
+/// "the first endpoint in `BlossomServersRepository` right now") and a
+/// client factory (typically `URLSessionBlossomClient.init`), so a
+/// server change in Settings — or a pick made during onboarding —
+/// takes effect on the very next upload/download, no relaunch needed.
+///
+/// `URLSessionBlossomClient` is a cheap value type over a shared
+/// `URLSession`, so building one per operation costs nothing; the
+/// factory seam exists so tests can capture the resolved URL with a
+/// fake inner client.
+public struct DynamicBaseURLBlossomClient: BlossomClient {
+    /// Resolves the base URL to use for the next operation.
+    private let resolveBaseURL: @Sendable () async -> URL
+    /// Builds the underlying client for a resolved base URL.
+    private let makeClient: @Sendable (URL) -> any BlossomClient
+
+    public init(
+        resolveBaseURL: @escaping @Sendable () async -> URL,
+        makeClient: @escaping @Sendable (URL) -> any BlossomClient
+    ) {
+        self.resolveBaseURL = resolveBaseURL
+        self.makeClient = makeClient
+    }
+
+    public func upload(_ blob: Data, mimeType: String) async throws -> BlobDescriptor {
+        try await makeClient(await resolveBaseURL()).upload(blob, mimeType: mimeType)
+    }
+
+    public func download(sha256: String) async throws -> Data {
+        try await makeClient(await resolveBaseURL()).download(sha256: sha256)
+    }
+}

--- a/Sources/OnymIOS/BlossomCatalogConsent.swift
+++ b/Sources/OnymIOS/BlossomCatalogConsent.swift
@@ -1,0 +1,52 @@
+import Foundation
+import OnymDiscovery
+import OnymFoundation
+import OnymTransportBlossom
+
+/// Apply step of the blossom catalog picker's consent flow, extracted
+/// from the `OnymIOSApp` composition root so the one piece with real
+/// behavior — endpoint extraction + ORDERING — is unit-testable.
+///
+/// A consented pick becomes the ACTIVE (first) server: uploads and
+/// downloads only ever target `currentEndpoints().first`, and the
+/// first launch seeds Onym Official at the head, so a plain append
+/// would leave the user's pick configured but inert. Making it active
+/// is the evident intent of picking a blob-storage module (onboarding
+/// step 4, or the Settings catalog row).
+enum BlossomCatalogConsent {
+    /// Throws `ModuleApplyError.noUsableEndpoint` when the manifest has
+    /// no https endpoint — the consent flow surfaces it instead of
+    /// showing "Service added" over a no-op.
+    @MainActor
+    static func apply(
+        manifest: SignedServiceManifest,
+        to repository: BlossomServersRepository
+    ) async throws {
+        let fields = SeatManifestFields(rawBytes: manifest.rawBytes)
+        let url = try ModuleConsentAcceptance.requiredEndpointURL(
+            in: fields.endpointURIs,
+            scheme: "https"
+        )
+        // Not a published default — no "Default" badge; `addEndpoint`
+        // marks the configuration user-interacted so a refresh never
+        // auto-populates over the choice. `makeActive` puts the pick
+        // at the head (the upload/download target); the seeded default
+        // stays in the list right behind it.
+        await repository.addEndpoint(
+            BlossomServerEndpoint(
+                name: displayName(fields, componentId: manifest.componentId),
+                url: url,
+                isDefault: false
+            ),
+            makeActive: true
+        )
+    }
+
+    /// Manifest `name` when published and non-empty, else the component
+    /// id minus its prefix — same rule as the seat adapters.
+    @MainActor
+    private static func displayName(_ fields: SeatManifestFields, componentId: String) -> String {
+        if let name = fields.name, !name.isEmpty { return name }
+        return ModuleConsentFlow.shortComponentId(componentId)
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -427,8 +427,16 @@ struct OnymIOSApp: App {
         // now*, falling back to the app default when the list is empty.
         // Shared by the client below and the `server` stamp on outgoing
         // attachments, so both always agree.
+        // https-only, matching `bound(toServer:)` and the consent
+        // apply's `requiredEndpointURL(in:scheme:"https")`: a non-https
+        // endpoint would stamp a URL the per-send pin can never bind
+        // to, silently degrading to live resolution — the exact
+        // mid-send divergence the pin exists to prevent. Unpinnable is
+        // unusable for sends, so non-https entries are skipped in
+        // favor of the first https one (or the app default).
         let resolveBlossomBaseURL: @Sendable () async -> URL = {
-            await blossomServersRepository.currentEndpoints().first?.url
+            await blossomServersRepository.currentEndpoints()
+                .first { $0.url.scheme?.lowercased() == "https" }?.url
                 ?? URLSessionBlossomClient.defaultBaseURL
         }
 

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -773,24 +773,15 @@ struct OnymIOSApp: App {
                         selectionStore: seatSelectionStore,
                         makeEntitlements: makeEntitlements,
                         apply: { manifest in
-                            let fields = SeatManifestFields(rawBytes: manifest.rawBytes)
-                            // Throws `ModuleApplyError.noUsableEndpoint`
-                            // when the manifest has no https endpoint —
-                            // surfaced by the flow, never a silent no-op.
-                            let url = try ModuleConsentAcceptance.requiredEndpointURL(
-                                in: fields.endpointURIs,
-                                scheme: "https"
+                            // Extracted (BlossomCatalogConsent) so the
+                            // endpoint extraction + make-active ordering
+                            // is unit-tested: the pick becomes the FIRST
+                            // endpoint — the upload/download target —
+                            // not an inert append behind the seed.
+                            try await BlossomCatalogConsent.apply(
+                                manifest: manifest,
+                                to: blossomServersRepository
                             )
-                            // A consent-picked server is the user's own
-                            // choice, not a published default — no
-                            // "Default" badge, and `addEndpoint` marks
-                            // the configuration user-interacted so a
-                            // refresh never auto-populates over it.
-                            await blossomServersRepository.addEndpoint(BlossomServerEndpoint(
-                                name: discoveryDisplayName(fields, componentId: manifest.componentId),
-                                url: url,
-                                isDefault: false
-                            ))
                         }
                     )
                 }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -395,10 +395,10 @@ struct OnymIOSApp: App {
 
         // User-configurable Blossom servers (Settings → Transport →
         // Blossom Relays). Constructing the repository seeds the store on
-        // first launch, so reading it back synchronously here yields the
-        // effective server list. Uploads/downloads target the first
-        // configured server; changes apply on the next launch (the client
-        // base URL is chosen once here).
+        // first launch. Uploads/downloads target the first configured
+        // server; the client re-reads the repository per operation, so
+        // changes in Settings (or an onboarding pick) apply to the very
+        // next upload/download — no relaunch needed.
         let blossomStore = UserDefaultsBlossomServersSelectionStore()
         // No network fetch under the UI harness — the hardcoded seed
         // stays the default so tests are deterministic + offline.
@@ -423,28 +423,41 @@ struct OnymIOSApp: App {
             fetcher: blossomFetcher
         )
         self.blossomServersRepository = blossomServersRepository
-        let blossomBaseURL = blossomStore.load().endpoints.first?.url
-            ?? URLSessionBlossomClient.defaultBaseURL
+        // Live base-URL resolution: the first configured server *right
+        // now*, falling back to the app default when the list is empty.
+        // Shared by the client below and the `server` stamp on outgoing
+        // attachments, so both always agree.
+        let resolveBlossomBaseURL: @Sendable () async -> URL = {
+            await blossomServersRepository.currentEndpoints().first?.url
+                ?? URLSessionBlossomClient.defaultBaseURL
+        }
 
         // Blossom client + image loader for image messages. Swapped for
         // an in-memory store under `--ui-loopback` so image send/receive
         // round-trips with no network; one shared instance so the loader
-        // can read back what the sender uploaded.
+        // can read back what the sender uploaded. The production client
+        // resolves its base URL per operation via the repository, so a
+        // server change takes effect without a relaunch.
+        let makeLiveBlossomClient: () -> any BlossomClient = {
+            DynamicBaseURLBlossomClient(
+                resolveBaseURL: resolveBlossomBaseURL,
+                makeClient: {
+                    URLSessionBlossomClient(
+                        baseURL: $0,
+                        signerProvider: OnymNostrSignerProvider()
+                    )
+                }
+            )
+        }
         let blossomClient: any BlossomClient
         #if DEBUG
         if args.contains("--ui-loopback") {
             blossomClient = UITestBlossomClient()
         } else {
-            blossomClient = URLSessionBlossomClient(
-                baseURL: blossomBaseURL,
-                signerProvider: OnymNostrSignerProvider()
-            )
+            blossomClient = makeLiveBlossomClient()
         }
         #else
-        blossomClient = URLSessionBlossomClient(
-            baseURL: blossomBaseURL,
-            signerProvider: OnymNostrSignerProvider()
-        )
+        blossomClient = makeLiveBlossomClient()
         #endif
         let imageLoader = ChatImageLoader(blossomClient: blossomClient)
         self.imageLoader = imageLoader
@@ -745,6 +758,45 @@ struct OnymIOSApp: App {
             )
         }
 
+        let blossomCatalogPicker = discoveryCatalog.map { catalog in
+            DiscoveryModulePicker(
+                entries: { await catalog.entries(DiscoveryBackedKnownBlossomServersFetcher.seatType) },
+                activeConsent: { try? pinnedConsentStore.activeRecord(componentId: $0) },
+                entriesStream: makeSeatEntriesStream.map { make in
+                    { make(DiscoveryBackedKnownBlossomServersFetcher.seatType) }
+                },
+                makeConsentFlow: { entry in
+                    ModuleConsentFlow(
+                        entry: entry,
+                        fetchManifestBytes: catalog.fetchManifestBytes,
+                        consentStore: pinnedConsentStore,
+                        selectionStore: seatSelectionStore,
+                        makeEntitlements: makeEntitlements,
+                        apply: { manifest in
+                            let fields = SeatManifestFields(rawBytes: manifest.rawBytes)
+                            // Throws `ModuleApplyError.noUsableEndpoint`
+                            // when the manifest has no https endpoint —
+                            // surfaced by the flow, never a silent no-op.
+                            let url = try ModuleConsentAcceptance.requiredEndpointURL(
+                                in: fields.endpointURIs,
+                                scheme: "https"
+                            )
+                            // A consent-picked server is the user's own
+                            // choice, not a published default — no
+                            // "Default" badge, and `addEndpoint` marks
+                            // the configuration user-interacted so a
+                            // refresh never auto-populates over it.
+                            await blossomServersRepository.addEndpoint(BlossomServerEndpoint(
+                                name: discoveryDisplayName(fields, componentId: manifest.componentId),
+                                url: url,
+                                isDefault: false
+                            ))
+                        }
+                    )
+                }
+            )
+        }
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -759,7 +811,7 @@ struct OnymIOSApp: App {
                 NostrRelaySettingsFlow(repository: nostrRelaysRepository, discovery: nostrCatalogPicker)
             },
             makeBlossomRelaySettingsFlow: { @MainActor in
-                BlossomRelaySettingsFlow(repository: blossomServersRepository)
+                BlossomRelaySettingsFlow(repository: blossomServersRepository, discovery: blossomCatalogPicker)
             },
             makeAnchorsPickerFlow: { @MainActor in
                 AnchorsPickerFlow(repository: contractsRepository)
@@ -822,7 +874,7 @@ struct OnymIOSApp: App {
                 messageRepository: messageRepository,
                 groupRepository: groupRepository,
                 blossomClient: blossomClient,
-                blossomServerURL: blossomBaseURL.absoluteString,
+                blossomServerURL: { await resolveBlossomBaseURL().absoluteString },
                 videoEncoder: videoEncoder,
                 voiceEncoder: voiceEncoder,
                 outbox: chatOutbox,

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -459,11 +459,26 @@ struct OnymIOSApp: App {
         #else
         blossomClient = makeLiveBlossomClient()
         #endif
-        let imageLoader = ChatImageLoader(blossomClient: blossomClient)
+        // The loaders may honor an attachment's `server` stamp only
+        // within this set — the user's own configured servers — never
+        // a peer-chosen host (see BlossomServerStampPolicy).
+        let allowedStampServers: @Sendable () async -> [URL] = {
+            await blossomServersRepository.currentEndpoints().map(\.url)
+        }
+        let imageLoader = ChatImageLoader(
+            blossomClient: blossomClient,
+            allowedStampServers: allowedStampServers
+        )
         self.imageLoader = imageLoader
-        let videoLoader = ChatVideoLoader(blossomClient: blossomClient)
+        let videoLoader = ChatVideoLoader(
+            blossomClient: blossomClient,
+            allowedStampServers: allowedStampServers
+        )
         self.videoLoader = videoLoader
-        let voiceLoader = ChatVoiceLoader(blossomClient: blossomClient)
+        let voiceLoader = ChatVoiceLoader(
+            blossomClient: blossomClient,
+            allowedStampServers: allowedStampServers
+        )
         self.voiceLoader = voiceLoader
 
         // Video encoder for outgoing videos. The real encoder runs

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -427,16 +427,17 @@ struct OnymIOSApp: App {
         // now*, falling back to the app default when the list is empty.
         // Shared by the client below and the `server` stamp on outgoing
         // attachments, so both always agree.
-        // https-only, matching `bound(toServer:)` and the consent
-        // apply's `requiredEndpointURL(in:scheme:"https")`: a non-https
-        // endpoint would stamp a URL the per-send pin can never bind
-        // to, silently degrading to live resolution — the exact
-        // mid-send divergence the pin exists to prevent. Unpinnable is
-        // unusable for sends, so non-https entries are skipped in
-        // favor of the first https one (or the app default).
+        // Plain first endpoint: the user's OWN configuration is
+        // trusted as typed — the scheme is not second-guessed here
+        // (`BlossomRelaySettingsFlow.validate` deliberately accepts
+        // http for local dev / loopback), and Settings' ACTIVE badge
+        // is first-row-based, so badge and target agree by
+        // construction. https-only enforcement belongs to the
+        // PEER-influenced paths (download stamps via
+        // BlossomServerStampPolicy, catalog applies via
+        // requiredEndpointURL) — never to hand-typed endpoints.
         let resolveBlossomBaseURL: @Sendable () async -> URL = {
-            await blossomServersRepository.currentEndpoints()
-                .first { $0.url.scheme?.lowercased() == "https" }?.url
+            await blossomServersRepository.currentEndpoints().first?.url
                 ?? URLSessionBlossomClient.defaultBaseURL
         }
 

--- a/Tests/OnymIOSTests/BlossomCatalogConsentTests.swift
+++ b/Tests/OnymIOSTests/BlossomCatalogConsentTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import OnymIOS
+import OnymDiscovery
+import OnymFoundation
+import OnymTransportBlossom
+
+/// The blossom catalog picker's consent-`apply` step
+/// (`BlossomCatalogConsent.apply`): https-endpoint extraction, display
+/// naming, and — the part that made the pick real instead of silently
+/// inert — ORDERING: the consented server must land FIRST, ahead of
+/// the seeded default, because uploads/downloads only ever target
+/// `currentEndpoints().first`.
+final class BlossomCatalogConsentTests: XCTestCase {
+
+    func test_apply_placesPickedServerFirst_keepsSeededDefault() async throws {
+        // Fresh first-launch repository: Onym Official seeded at head.
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)
+
+        let manifest = try Self.manifest(
+            name: "Picked Blobs",
+            endpoints: ["https://blobs.picked.example"]
+        )
+        try await BlossomCatalogConsent.apply(manifest: manifest, to: repo)
+
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.first?.url.absoluteString, "https://blobs.picked.example",
+                       "the consented pick must become the ACTIVE (first) server")
+        XCTAssertEqual(endpoints.first?.name, "Picked Blobs")
+        XCTAssertEqual(endpoints.first?.isDefault, false,
+                       "a consent pick is the user's choice, not a published default")
+        XCTAssertEqual(endpoints.count, 2)
+        XCTAssertEqual(endpoints.last?.url.absoluteString, "https://blossom.onym.app",
+                       "the seeded default stays configured behind the pick")
+        XCTAssertTrue(store.load().hasUserInteracted,
+                      "the pick counts as user interaction so refreshes never clobber it")
+    }
+
+    func test_apply_prefersFirstHttpsEndpoint_skipsOtherSchemes() async throws {
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)
+
+        let manifest = try Self.manifest(
+            name: "Mixed",
+            endpoints: ["wss://relay.example", "https://first.example", "https://second.example"]
+        )
+        try await BlossomCatalogConsent.apply(manifest: manifest, to: repo)
+
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.first?.url.absoluteString, "https://first.example",
+                       "first https endpoint in published order wins")
+    }
+
+    func test_apply_noHttpsEndpoint_throwsAndLeavesConfigurationUntouched() async throws {
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)
+
+        let manifest = try Self.manifest(name: "Wss only", endpoints: ["wss://relay.example"])
+        do {
+            try await BlossomCatalogConsent.apply(manifest: manifest, to: repo)
+            XCTFail("expected ModuleApplyError.noUsableEndpoint")
+        } catch let error as ModuleApplyError {
+            XCTAssertEqual(error, .noUsableEndpoint)
+        }
+
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.map(\.url.absoluteString), ["https://blossom.onym.app"],
+                       "a failed apply must not touch the configuration")
+        XCTAssertFalse(store.load().hasUserInteracted)
+    }
+
+    func test_apply_missingName_fallsBackToShortComponentId() async throws {
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)
+
+        let manifest = try Self.manifest(name: nil, endpoints: ["https://anon.example"])
+        try await BlossomCatalogConsent.apply(manifest: manifest, to: repo)
+
+        let endpoints = await repo.currentEndpoints()
+        let expected = await MainActor.run {
+            ModuleConsentFlow.shortComponentId("onym:component:test-blobs")
+        }
+        XCTAssertEqual(endpoints.first?.name, expected,
+                       "no published name falls back to the short component id")
+    }
+
+    func test_apply_reappliedAfterDemotion_promotesBackToFirst() async throws {
+        // Consent once, user later makes another server active, then
+        // re-runs the consent apply (e.g. re-consents from the catalog
+        // row) — the pick must promote back to the head, not duplicate.
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)
+        let manifest = try Self.manifest(name: "Picked", endpoints: ["https://picked.example"])
+
+        try await BlossomCatalogConsent.apply(manifest: manifest, to: repo)
+        await repo.makeActive(url: URL(string: "https://blossom.onym.app")!)
+        try await BlossomCatalogConsent.apply(manifest: manifest, to: repo)
+
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.map(\.url.absoluteString),
+                       ["https://picked.example", "https://blossom.onym.app"],
+                       "re-apply promotes the existing row, no duplicates")
+    }
+
+    // MARK: - helpers
+
+    /// Minimal signed-manifest spine + blob-storage fields. No
+    /// signature verification happens in `SignedServiceManifest(raw:)`
+    /// or the apply step — review already ran upstream in the flow.
+    private static func manifest(
+        name: String?,
+        endpoints: [String],
+        componentId: String = "onym:component:test-blobs"
+    ) throws -> SignedServiceManifest {
+        var object: [String: Any] = [
+            "componentId": componentId,
+            "seat": "blob.storage",
+            "operator": "onym:key:" + String(repeating: "ab", count: 32),
+            "validUntil": "2030-01-01T00:00:00Z",
+            "endpoints": endpoints.map { ["uri": $0, "role": "read-write"] },
+        ]
+        if let name { object["name"] = name }
+        let bytes = try JSONSerialization.data(withJSONObject: object)
+        return try SignedServiceManifest(raw: bytes)
+    }
+}

--- a/Tests/OnymIOSTests/BlossomRelaySettingsFlowTests.swift
+++ b/Tests/OnymIOSTests/BlossomRelaySettingsFlowTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 @testable import OnymIOS
+import OnymDiscovery
+import OnymFoundation
 import OnymTransportBlossom
 import OnymSettings
 
@@ -51,6 +53,136 @@ final class BlossomRelaySettingsFlowTests: XCTestCase {
         let flow = BlossomRelaySettingsFlow(repository: repo)
         flow.start()
         try await waitFor { flow.state.snapshot.endpoints.count == 1 }
+    }
+
+    // MARK: - make active
+
+    func test_tappedMakeActive_promotesEndpointToHead() async throws {
+        let a = BlossomServerEndpoint.custom(url: URL(string: "https://a.example")!)
+        let b = BlossomServerEndpoint.custom(url: URL(string: "https://b.example")!)
+        let store = InMemoryBlossomServersSelectionStore(
+            initial: BlossomServersConfiguration(endpoints: [a, b], hasUserInteracted: true)
+        )
+        let repo = BlossomServersRepository(store: store)
+        let flow = BlossomRelaySettingsFlow(repository: repo)
+
+        flow.tappedMakeActive(url: b.url)
+
+        try await waitFor { store.load().endpoints.first?.url == b.url }
+        XCTAssertEqual(store.load().endpoints.map(\.url), [b.url, a.url])
+    }
+
+    // MARK: - catalog surface
+
+    func test_start_installsCatalogEntriesFromStream() async throws {
+        let repo = BlossomServersRepository(
+            store: InMemoryBlossomServersSelectionStore(initial: .empty)
+        )
+        let entry = try Self.catalogEntry(componentId: "onym:component:blobs-one")
+        let flow = BlossomRelaySettingsFlow(
+            repository: repo,
+            discovery: Self.picker(entries: { [entry] })
+        )
+
+        XCTAssertTrue(flow.catalogEntries.isEmpty, "empty before start")
+        flow.start()
+
+        try await waitFor { flow.catalogEntries.count == 1 }
+        XCTAssertEqual(flow.catalogEntries.first?.entry.componentId, "onym:component:blobs-one")
+        XCTAssertNil(flow.activeConsent(for: entry), "no pinned consent in this fixture")
+        XCTAssertNil(flow.consentedOffer(for: entry))
+    }
+
+    func test_refreshCatalog_reReadsAggregateOnce() async throws {
+        let repo = BlossomServersRepository(
+            store: InMemoryBlossomServersSelectionStore(initial: .empty)
+        )
+        let first = try Self.catalogEntry(componentId: "onym:component:blobs-one")
+        let second = try Self.catalogEntry(componentId: "onym:component:blobs-two")
+        // Mutable backing list: the one-shot stream serves the initial
+        // aggregate; refreshCatalog must re-read and see the growth.
+        let served = ServedEntries(entries: [first])
+        let flow = BlossomRelaySettingsFlow(
+            repository: repo,
+            discovery: Self.picker(entries: { served.entries })
+        )
+        flow.start()
+        try await waitFor { flow.catalogEntries.count == 1 }
+
+        served.entries = [first, second]
+        flow.refreshCatalog()
+
+        try await waitFor { flow.catalogEntries.count == 2 }
+        XCTAssertEqual(
+            flow.catalogEntries.map(\.entry.componentId),
+            ["onym:component:blobs-one", "onym:component:blobs-two"]
+        )
+    }
+
+    func test_noDiscovery_catalogStaysEmptyAfterStartAndRefresh() async throws {
+        let repo = BlossomServersRepository(
+            store: InMemoryBlossomServersSelectionStore(initial: .empty)
+        )
+        let flow = BlossomRelaySettingsFlow(repository: repo)
+        flow.start()
+        flow.refreshCatalog()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertTrue(flow.catalogEntries.isEmpty)
+    }
+
+    // MARK: - catalog fixtures
+
+    /// Mutable entries the picker closures read — @MainActor-confined,
+    /// the flow only calls the closures on the main actor.
+    @MainActor
+    private final class ServedEntries {
+        var entries: [AttributedCatalogEntry]
+        init(entries: [AttributedCatalogEntry]) { self.entries = entries }
+    }
+
+    private static func picker(
+        entries: @escaping @MainActor () -> [AttributedCatalogEntry]
+    ) -> DiscoveryModulePicker {
+        DiscoveryModulePicker(
+            entries: { await entries() },
+            activeConsent: { _ in nil },
+            makeConsentFlow: { _ in fatalError("consent flow not exercised by these tests") }
+        )
+    }
+
+    private static func catalogEntry(componentId: String) throws -> AttributedCatalogEntry {
+        let json: [String: Any] = [
+            "componentId": componentId,
+            "seatType": "blob.storage",
+            "manifest": [
+                "uri": "https://provider.example/manifests/"
+                    + componentId.replacingOccurrences(of: ":", with: "-") + ".json",
+                "digest": "sha256:" + String(repeating: "0", count: 64),
+            ],
+            "operator": "onym:key:" + String(repeating: "ab", count: 32),
+            "profiles": [],
+            "evidence": [],
+            "listedAt": "2026-01-01T00:00:00Z",
+            "relationship": "none",
+            "placement": "neutral",
+        ]
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let entry = try decoder.decode(
+            CatalogEntry.self,
+            from: JSONSerialization.data(withJSONObject: json)
+        )
+        return AttributedCatalogEntry(
+            entry: entry,
+            source: SourceAttribution(
+                providerId: "onym:component:test-provider",
+                sourceLabel: "Test Provider",
+                catalogId: "public",
+                snapshotDigest: "sha256:" + String(repeating: "0", count: 64),
+                relationship: "none",
+                placement: "neutral"
+            )
+        )
     }
 
     private func waitFor(

--- a/Tests/OnymIOSTests/BlossomServersRepositoryTests.swift
+++ b/Tests/OnymIOSTests/BlossomServersRepositoryTests.swift
@@ -159,6 +159,101 @@ final class BlossomServersRepositoryTests: XCTestCase {
         XCTAssertEqual(endpoints, [Self.published])
     }
 
+    // MARK: - makeActive / addEndpoint(makeActive:)
+
+    func test_addEndpoint_makeActive_insertsNewEndpointAtHead() async {
+        // First launch seeds Onym Official at index 0; a make-active
+        // add (the catalog consent pick) must land FIRST — the
+        // upload/download target — with the seed kept right behind.
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)
+        let picked = BlossomServerEndpoint(
+            name: "Picked", url: URL(string: "https://picked.example")!, isDefault: false
+        )
+
+        let inserted = await repo.addEndpoint(picked, makeActive: true)
+
+        XCTAssertTrue(inserted)
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.first, picked,
+                       "make-active add must place the pick at the head")
+        XCTAssertEqual(endpoints.count, 2)
+        XCTAssertEqual(endpoints.last?.url.absoluteString, "https://blossom.onym.app",
+                       "the seeded default stays in the list behind the pick")
+        XCTAssertTrue(store.load().hasUserInteracted)
+    }
+
+    func test_addEndpoint_makeActive_movesExistingEndpointToHead() async {
+        let a = BlossomServerEndpoint.custom(url: URL(string: "https://a.example")!)
+        let b = BlossomServerEndpoint.custom(url: URL(string: "https://b.example")!)
+        let store = InMemoryBlossomServersSelectionStore(
+            initial: BlossomServersConfiguration(endpoints: [a, b], hasUserInteracted: true)
+        )
+        let repo = BlossomServersRepository(store: store)
+
+        let renamed = BlossomServerEndpoint(name: "B renamed", url: b.url, isDefault: false)
+        let inserted = await repo.addEndpoint(renamed, makeActive: true)
+
+        XCTAssertFalse(inserted, "same URL is an update, not an insert")
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.map(\.url), [b.url, a.url],
+                       "existing endpoint moves to the head, others keep order")
+        XCTAssertEqual(endpoints.first?.name, "B renamed",
+                       "metadata still updates on a make-active re-add")
+    }
+
+    func test_addEndpoint_withoutMakeActive_stillAppends() async {
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)
+        let added = BlossomServerEndpoint.custom(url: URL(string: "https://added.example")!)
+
+        await repo.addEndpoint(added)
+
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.first?.url.absoluteString, "https://blossom.onym.app",
+                       "plain add keeps the current active server")
+        XCTAssertEqual(endpoints.last, added)
+    }
+
+    func test_makeActive_movesConfiguredEndpointToHead() async {
+        let a = BlossomServerEndpoint.custom(url: URL(string: "https://a.example")!)
+        let b = BlossomServerEndpoint.custom(url: URL(string: "https://b.example")!)
+        let c = BlossomServerEndpoint.custom(url: URL(string: "https://c.example")!)
+        let store = InMemoryBlossomServersSelectionStore(
+            initial: BlossomServersConfiguration(endpoints: [a, b, c], hasUserInteracted: true)
+        )
+        let repo = BlossomServersRepository(store: store)
+
+        await repo.makeActive(url: c.url)
+
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints, [c, a, b],
+                       "promoted endpoint heads the list; the rest keep relative order")
+        XCTAssertEqual(store.load().endpoints, [c, a, b], "promotion is persisted")
+    }
+
+    func test_makeActive_unknownURL_isNoOp() async {
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)  // seeds Onym Official
+
+        await repo.makeActive(url: URL(string: "https://stranger.example")!)
+
+        let endpoints = await repo.currentEndpoints()
+        XCTAssertEqual(endpoints.first?.url.absoluteString, "https://blossom.onym.app")
+        XCTAssertFalse(store.load().hasUserInteracted,
+                       "a no-op promotion must not count as user interaction")
+    }
+
+    func test_makeActive_alreadyFirst_doesNotFlipUserInteracted() async {
+        let store = InMemoryBlossomServersSelectionStore(initial: .empty)
+        let repo = BlossomServersRepository(store: store)  // seeds Onym Official at head
+
+        await repo.makeActive(url: URL(string: "https://blossom.onym.app")!)
+
+        XCTAssertFalse(store.load().hasUserInteracted,
+                       "promoting the already-active server changes nothing")
+    }
+
     func test_resetToDefault_offline_fallsBackToSeed() async {
         struct Boom: Error {}
         let store = InMemoryBlossomServersSelectionStore(initial: .empty)

--- a/Tests/OnymIOSTests/ChatMediaLoaderServerBindingTests.swift
+++ b/Tests/OnymIOSTests/ChatMediaLoaderServerBindingTests.swift
@@ -5,11 +5,12 @@ import OnymChatsCore
 import OnymTransportBlossom
 
 /// The read half of the server-stamp contract: all three media loaders
-/// must download a stamped attachment through a client BOUND to the
-/// attachment's `server` — the one the sender actually uploaded to —
-/// not the live client, whose base URL moves the moment the user picks
-/// a different Blossom server. Legacy rows without a stamp fall back
-/// to the live client.
+/// download a stamped attachment through a client BOUND to the
+/// attachment's `server` — but ONLY when that server is one of the
+/// user's configured endpoints. The stamp arrives off the wire, so an
+/// unrecognized stamp (a peer-chosen host) must NEVER receive a
+/// request: it falls back to the live client, as do legacy nil-server
+/// rows and loaders with no allowlist wired.
 final class ChatMediaLoaderServerBindingTests: XCTestCase {
     private static let stampedServer = "https://stamped.example"
 
@@ -18,7 +19,11 @@ final class ChatMediaLoaderServerBindingTests: XCTestCase {
     func test_imageLoader_stampedAttachment_downloadsViaBoundClient() async throws {
         let sealed = try ChatImageCrypto.seal(Data("image-bytes".utf8))
         let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
-        let loader = ChatImageLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+        let loader = ChatImageLoader(
+            blossomClient: client,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: Self.stampedServer)!] }
+        )
 
         let plaintext = try await loader.plaintext(
             for: Self.imageAttachment(sealed: sealed, server: Self.stampedServer)
@@ -44,12 +49,85 @@ final class ChatMediaLoaderServerBindingTests: XCTestCase {
                        "no stamp → the live (unbound) client")
     }
 
+    func test_imageLoader_stampNotInConfiguredSet_usesLiveClient_neverContactsStamp() async throws {
+        // The security property: a peer-chosen stamp outside the
+        // user's configured servers must not receive ANY request —
+        // the download goes through the live client instead.
+        let sealed = try ChatImageCrypto.seal(Data("hostile-stamp".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatImageLoader(
+            blossomClient: client,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: "https://mine.example")!] }
+        )
+
+        _ = try await loader.plaintext(
+            for: Self.imageAttachment(sealed: sealed, server: "https://tracker.example")
+        )
+
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: nil, sha256: sealed.sha256Hex)],
+                       "an unconfigured stamp must fall back to the live client, with zero requests bound to the stamp")
+    }
+
+    func test_imageLoader_noAllowlistWired_ignoresStamp() async throws {
+        // Default (empty) allowlist — e.g. a composition root that
+        // never wires the provider — must ignore every stamp.
+        let sealed = try ChatImageCrypto.seal(Data("unwired".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatImageLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+
+        _ = try await loader.plaintext(
+            for: Self.imageAttachment(sealed: sealed, server: Self.stampedServer)
+        )
+
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: nil, sha256: sealed.sha256Hex)])
+    }
+
+    func test_stampMatchingIsByNormalizedOrigin() async throws {
+        // Same scheme+host+port with different case and a trailing
+        // path/slash still matches; a different port does not.
+        let sealed = try ChatImageCrypto.seal(Data("origin".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatImageLoader(
+            blossomClient: client,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: "https://Stamped.Example/")!] }
+        )
+
+        _ = try await loader.plaintext(
+            for: Self.imageAttachment(sealed: sealed, server: Self.stampedServer)
+        )
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: Self.stampedServer, sha256: sealed.sha256Hex)],
+                       "case-insensitive origin match must honor the stamp")
+
+        let other = try ChatImageCrypto.seal(Data("origin-port".utf8))
+        let portClient = ServerRecordingBlossomClient(blobs: [other.sha256Hex: other.blob])
+        let portLoader = ChatImageLoader(
+            blossomClient: portClient,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: "https://stamped.example:8443")!] }
+        )
+        _ = try await portLoader.plaintext(
+            for: Self.imageAttachment(sealed: other, server: Self.stampedServer)
+        )
+        let portDownloads = await portClient.downloads
+        XCTAssertEqual(portDownloads, [.init(server: nil, sha256: other.sha256Hex)],
+                       "a different port is a different origin — stamp not honored")
+    }
+
     // MARK: - Video loader
 
     func test_videoLoader_stampedAttachment_downloadsViaBoundClient() async throws {
         let sealed = try ChatImageCrypto.seal(Data("video-bytes".utf8))
         let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
-        let loader = ChatVideoLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+        let loader = ChatVideoLoader(
+            blossomClient: client,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: Self.stampedServer)!] }
+        )
 
         let poster = Self.imageAttachment(
             sealed: try ChatImageCrypto.seal(Data("poster".utf8)),
@@ -77,7 +155,11 @@ final class ChatMediaLoaderServerBindingTests: XCTestCase {
     func test_voiceLoader_stampedAttachment_downloadsViaBoundClient() async throws {
         let sealed = try ChatImageCrypto.seal(Data("voice-bytes".utf8))
         let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
-        let loader = ChatVoiceLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+        let loader = ChatVoiceLoader(
+            blossomClient: client,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: Self.stampedServer)!] }
+        )
 
         let attachment = ChatVoiceAttachment(
             sha256: sealed.sha256Hex,

--- a/Tests/OnymIOSTests/ChatMediaLoaderServerBindingTests.swift
+++ b/Tests/OnymIOSTests/ChatMediaLoaderServerBindingTests.swift
@@ -177,6 +177,90 @@ final class ChatMediaLoaderServerBindingTests: XCTestCase {
         XCTAssertEqual(downloads, [.init(server: Self.stampedServer, sha256: sealed.sha256Hex)])
     }
 
+    // MARK: - In-flight deduplication
+
+    func test_imageLoader_concurrentRequestsSameSha_downloadOnce() async throws {
+        // Two simultaneous requests for the same blob must share ONE
+        // download — the allowlist await is a suspension point, so the
+        // inflight check-and-insert has to stay contiguous after it.
+        let sealed = try ChatImageCrypto.seal(Data("dedup-image".utf8))
+        let client = ServerRecordingBlossomClient(
+            blobs: [sealed.sha256Hex: sealed.blob],
+            delayNanos: 200_000_000
+        )
+        let loader = ChatImageLoader(
+            blossomClient: client,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: Self.stampedServer)!] }
+        )
+        let attachment = Self.imageAttachment(sealed: sealed, server: Self.stampedServer)
+
+        try await withThrowingTaskGroup(of: Data.self) { group in
+            group.addTask { try await loader.plaintext(for: attachment) }
+            group.addTask { try await loader.plaintext(for: attachment) }
+            for try await plaintext in group {
+                XCTAssertEqual(plaintext, Data("dedup-image".utf8))
+            }
+        }
+
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads.count, 1,
+                       "concurrent requests for one sha must share a single download")
+    }
+
+    func test_videoLoader_concurrentRequestsSameSha_downloadOnce() async throws {
+        let sealed = try ChatImageCrypto.seal(Data("dedup-video".utf8))
+        let client = ServerRecordingBlossomClient(
+            blobs: [sealed.sha256Hex: sealed.blob],
+            delayNanos: 200_000_000
+        )
+        let loader = ChatVideoLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+        let poster = Self.imageAttachment(
+            sealed: try ChatImageCrypto.seal(Data("p".utf8)), server: nil
+        )
+        let attachment = ChatVideoAttachment(
+            sha256: sealed.sha256Hex, mimeType: "video/mp4",
+            byteSize: sealed.blob.count, width: 4, height: 4,
+            durationSeconds: 1, encKey: sealed.key, poster: poster, server: nil
+        )
+
+        try await withThrowingTaskGroup(of: URL.self) { group in
+            group.addTask { try await loader.fileURL(for: attachment) }
+            group.addTask { try await loader.fileURL(for: attachment) }
+            for try await url in group {
+                XCTAssertEqual(try Data(contentsOf: url), Data("dedup-video".utf8))
+            }
+        }
+
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads.count, 1)
+    }
+
+    func test_voiceLoader_concurrentRequestsSameSha_downloadOnce() async throws {
+        let sealed = try ChatImageCrypto.seal(Data("dedup-voice".utf8))
+        let client = ServerRecordingBlossomClient(
+            blobs: [sealed.sha256Hex: sealed.blob],
+            delayNanos: 200_000_000
+        )
+        let loader = ChatVoiceLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+        let attachment = ChatVoiceAttachment(
+            sha256: sealed.sha256Hex, mimeType: "audio/mp4",
+            byteSize: sealed.blob.count, durationSeconds: 1,
+            encKey: sealed.key, waveform: [0, 1], server: nil
+        )
+
+        try await withThrowingTaskGroup(of: URL.self) { group in
+            group.addTask { try await loader.fileURL(for: attachment) }
+            group.addTask { try await loader.fileURL(for: attachment) }
+            for try await url in group {
+                XCTAssertEqual(try Data(contentsOf: url), Data("dedup-voice".utf8))
+            }
+        }
+
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads.count, 1)
+    }
+
     // MARK: - fixtures
 
     private static func imageAttachment(
@@ -209,10 +293,14 @@ final class ChatMediaLoaderServerBindingTests: XCTestCase {
         }
 
         private let blobs: [String: Data]
+        /// Artificial per-download latency so concurrency tests can
+        /// guarantee both callers overlap the in-flight window.
+        private let delayNanos: UInt64
         private(set) var downloads: [Download] = []
 
-        init(blobs: [String: Data]) {
+        init(blobs: [String: Data], delayNanos: UInt64 = 0) {
             self.blobs = blobs
+            self.delayNanos = delayNanos
         }
 
         func upload(_ blob: Data, mimeType: String) async throws -> BlobDescriptor {
@@ -220,15 +308,16 @@ final class ChatMediaLoaderServerBindingTests: XCTestCase {
         }
 
         func download(sha256: String) async throws -> Data {
-            try serve(sha256: sha256, server: nil)
+            try await serve(sha256: sha256, server: nil)
         }
 
         nonisolated func bound(toServer serverURL: String) -> any BlossomClient {
             Bound(server: serverURL, recorder: self)
         }
 
-        fileprivate func serve(sha256: String, server: String?) throws -> Data {
+        fileprivate func serve(sha256: String, server: String?) async throws -> Data {
             downloads.append(Download(server: server, sha256: sha256))
+            if delayNanos > 0 { try await Task.sleep(nanoseconds: delayNanos) }
             guard let blob = blobs[sha256] else { throw BlossomError.badStatus(404) }
             return blob
         }

--- a/Tests/OnymIOSTests/ChatMediaLoaderServerBindingTests.swift
+++ b/Tests/OnymIOSTests/ChatMediaLoaderServerBindingTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import XCTest
+@testable import OnymIOS
+import OnymChatsCore
+import OnymTransportBlossom
+
+/// The read half of the server-stamp contract: all three media loaders
+/// must download a stamped attachment through a client BOUND to the
+/// attachment's `server` — the one the sender actually uploaded to —
+/// not the live client, whose base URL moves the moment the user picks
+/// a different Blossom server. Legacy rows without a stamp fall back
+/// to the live client.
+final class ChatMediaLoaderServerBindingTests: XCTestCase {
+    private static let stampedServer = "https://stamped.example"
+
+    // MARK: - Image loader
+
+    func test_imageLoader_stampedAttachment_downloadsViaBoundClient() async throws {
+        let sealed = try ChatImageCrypto.seal(Data("image-bytes".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatImageLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+
+        let plaintext = try await loader.plaintext(
+            for: Self.imageAttachment(sealed: sealed, server: Self.stampedServer)
+        )
+
+        XCTAssertEqual(plaintext, Data("image-bytes".utf8))
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: Self.stampedServer, sha256: sealed.sha256Hex)],
+                       "a stamped attachment must fetch through the bound client")
+    }
+
+    func test_imageLoader_legacyNilServer_downloadsViaLiveClient() async throws {
+        let sealed = try ChatImageCrypto.seal(Data("legacy-bytes".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatImageLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+
+        _ = try await loader.plaintext(
+            for: Self.imageAttachment(sealed: sealed, server: nil)
+        )
+
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: nil, sha256: sealed.sha256Hex)],
+                       "no stamp → the live (unbound) client")
+    }
+
+    // MARK: - Video loader
+
+    func test_videoLoader_stampedAttachment_downloadsViaBoundClient() async throws {
+        let sealed = try ChatImageCrypto.seal(Data("video-bytes".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatVideoLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+
+        let poster = Self.imageAttachment(
+            sealed: try ChatImageCrypto.seal(Data("poster".utf8)),
+            server: Self.stampedServer
+        )
+        let attachment = ChatVideoAttachment(
+            sha256: sealed.sha256Hex,
+            mimeType: "video/mp4",
+            byteSize: sealed.blob.count,
+            width: 4, height: 4,
+            durationSeconds: 1,
+            encKey: sealed.key,
+            poster: poster,
+            server: Self.stampedServer
+        )
+        let url = try await loader.fileURL(for: attachment)
+
+        XCTAssertEqual(try Data(contentsOf: url), Data("video-bytes".utf8))
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: Self.stampedServer, sha256: sealed.sha256Hex)])
+    }
+
+    // MARK: - Voice loader
+
+    func test_voiceLoader_stampedAttachment_downloadsViaBoundClient() async throws {
+        let sealed = try ChatImageCrypto.seal(Data("voice-bytes".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatVoiceLoader(blossomClient: client, cacheDirectory: Self.tempDir())
+
+        let attachment = ChatVoiceAttachment(
+            sha256: sealed.sha256Hex,
+            mimeType: "audio/mp4",
+            byteSize: sealed.blob.count,
+            durationSeconds: 1,
+            encKey: sealed.key,
+            waveform: [0, 1, 2],
+            server: Self.stampedServer
+        )
+        let url = try await loader.fileURL(for: attachment)
+
+        XCTAssertEqual(try Data(contentsOf: url), Data("voice-bytes".utf8))
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: Self.stampedServer, sha256: sealed.sha256Hex)])
+    }
+
+    // MARK: - fixtures
+
+    private static func imageAttachment(
+        sealed: ChatImageCrypto.Sealed,
+        server: String?
+    ) -> ChatImageAttachment {
+        ChatImageAttachment(
+            sha256: sealed.sha256Hex,
+            mimeType: "image/jpeg",
+            byteSize: sealed.blob.count,
+            width: 4, height: 4,
+            encKey: sealed.key,
+            blurhash: "LEHV6nWB2yk8",
+            server: server
+        )
+    }
+
+    private static func tempDir() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("loader-binding-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    /// Serves sealed blobs by sha and records, for every download, the
+    /// server the client was `bound(toServer:)` to — `nil` for a
+    /// download through the live (unbound) client.
+    private actor ServerRecordingBlossomClient: BlossomClient {
+        struct Download: Equatable {
+            let server: String?
+            let sha256: String
+        }
+
+        private let blobs: [String: Data]
+        private(set) var downloads: [Download] = []
+
+        init(blobs: [String: Data]) {
+            self.blobs = blobs
+        }
+
+        func upload(_ blob: Data, mimeType: String) async throws -> BlobDescriptor {
+            throw BlossomError.badStatus(500)
+        }
+
+        func download(sha256: String) async throws -> Data {
+            try serve(sha256: sha256, server: nil)
+        }
+
+        nonisolated func bound(toServer serverURL: String) -> any BlossomClient {
+            Bound(server: serverURL, recorder: self)
+        }
+
+        fileprivate func serve(sha256: String, server: String?) throws -> Data {
+            downloads.append(Download(server: server, sha256: sha256))
+            guard let blob = blobs[sha256] else { throw BlossomError.badStatus(404) }
+            return blob
+        }
+
+        private struct Bound: BlossomClient {
+            let server: String
+            let recorder: ServerRecordingBlossomClient
+
+            func upload(_ blob: Data, mimeType: String) async throws -> BlobDescriptor {
+                throw BlossomError.badStatus(500)
+            }
+
+            func download(sha256: String) async throws -> Data {
+                try await recorder.serve(sha256: sha256, server: server)
+            }
+        }
+    }
+}

--- a/Tests/OnymIOSTests/ChatMediaLoaderServerBindingTests.swift
+++ b/Tests/OnymIOSTests/ChatMediaLoaderServerBindingTests.swift
@@ -100,8 +100,8 @@ final class ChatMediaLoaderServerBindingTests: XCTestCase {
             for: Self.imageAttachment(sealed: sealed, server: Self.stampedServer)
         )
         let downloads = await client.downloads
-        XCTAssertEqual(downloads, [.init(server: Self.stampedServer, sha256: sealed.sha256Hex)],
-                       "case-insensitive origin match must honor the stamp")
+        XCTAssertEqual(downloads, [.init(server: "https://Stamped.Example/", sha256: sealed.sha256Hex)],
+                       "case-insensitive origin match honors the stamp, binding to the ALLOWLIST URL")
 
         let other = try ChatImageCrypto.seal(Data("origin-port".utf8))
         let portClient = ServerRecordingBlossomClient(blobs: [other.sha256Hex: other.blob])
@@ -175,6 +175,83 @@ final class ChatMediaLoaderServerBindingTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: url), Data("voice-bytes".utf8))
         let downloads = await client.downloads
         XCTAssertEqual(downloads, [.init(server: Self.stampedServer, sha256: sealed.sha256Hex)])
+    }
+
+    func test_stampWithPathAndQuery_bindsToAllowlistURL_notRawStamp() async throws {
+        // The stamp's origin proves allowlist membership, but its
+        // path/query are peer-chosen bytes — the request must be built
+        // from the allowlist's own URL, never the raw stamp.
+        let sealed = try ChatImageCrypto.seal(Data("path-query".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatImageLoader(
+            blossomClient: client,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: Self.stampedServer)!] }
+        )
+
+        _ = try await loader.plaintext(
+            for: Self.imageAttachment(
+                sealed: sealed,
+                server: Self.stampedServer + "/evil/prefix?track=1"
+            )
+        )
+
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: Self.stampedServer, sha256: sealed.sha256Hex)],
+                       "binding must use the allowlist URL, stripping the peer's path/query")
+    }
+
+    func test_httpStamp_neverHonored_evenWhenHTTPEndpointConfigured() async throws {
+        // The peer-influenced path is https-only regardless of what
+        // the user configured — an http local-dev endpoint still works
+        // through the LIVE client, it just can't be stamp-routed.
+        let sealed = try ChatImageCrypto.seal(Data("http-stamp".utf8))
+        let client = ServerRecordingBlossomClient(blobs: [sealed.sha256Hex: sealed.blob])
+        let loader = ChatImageLoader(
+            blossomClient: client,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: "http://192.168.1.10:3000")!] }
+        )
+
+        _ = try await loader.plaintext(
+            for: Self.imageAttachment(sealed: sealed, server: "http://192.168.1.10:3000")
+        )
+
+        let downloads = await client.downloads
+        XCTAssertEqual(downloads, [.init(server: nil, sha256: sealed.sha256Hex)],
+                       "http stamps fall back to the live client even when the endpoint is configured")
+    }
+
+    func test_defaultPortNormalization_bothDirections() async throws {
+        // "https://a.example:443" and "https://a.example" are the same
+        // origin — explicit default port on either side still matches.
+        let sealedA = try ChatImageCrypto.seal(Data("port-a".utf8))
+        let clientA = ServerRecordingBlossomClient(blobs: [sealedA.sha256Hex: sealedA.blob])
+        let loaderA = ChatImageLoader(
+            blossomClient: clientA,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: "https://stamped.example")!] }
+        )
+        _ = try await loaderA.plaintext(
+            for: Self.imageAttachment(sealed: sealedA, server: "https://stamped.example:443")
+        )
+        let downloadsA = await clientA.downloads
+        XCTAssertEqual(downloadsA, [.init(server: "https://stamped.example", sha256: sealedA.sha256Hex)],
+                       "stamp with explicit :443 matches the portless allowlist entry")
+
+        let sealedB = try ChatImageCrypto.seal(Data("port-b".utf8))
+        let clientB = ServerRecordingBlossomClient(blobs: [sealedB.sha256Hex: sealedB.blob])
+        let loaderB = ChatImageLoader(
+            blossomClient: clientB,
+            cacheDirectory: Self.tempDir(),
+            allowedStampServers: { [URL(string: "https://stamped.example:443")!] }
+        )
+        _ = try await loaderB.plaintext(
+            for: Self.imageAttachment(sealed: sealedB, server: Self.stampedServer)
+        )
+        let downloadsB = await clientB.downloads
+        XCTAssertEqual(downloadsB, [.init(server: "https://stamped.example:443", sha256: sealedB.sha256Hex)],
+                       "portless stamp matches the allowlist entry with explicit :443")
     }
 
     // MARK: - In-flight deduplication

--- a/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
+++ b/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
@@ -110,6 +110,25 @@ final class DynamicBaseURLBlossomClientTests: XCTestCase {
         XCTAssertEqual(recorder.operations, [.download(baseURL: serverB, sha256: "aa")])
     }
 
+    func test_boundToServer_schemelessStamp_fallsBackToLiveResolution() async throws {
+        // `URL(string: "blossom.example")` parses fine as a relative
+        // URL — binding to it would fail every request. It must fall
+        // back to live resolution instead.
+        let recorder = Recorder()
+        let client = DynamicBaseURLBlossomClient(
+            resolveBaseURL: { [serverB] in serverB },
+            makeClient: { recorder.make(baseURL: $0) }
+        )
+
+        _ = try await client.bound(toServer: "blossom.example").download(sha256: "bb")
+        _ = try await client.bound(toServer: "https://").download(sha256: "cc")
+
+        XCTAssertEqual(recorder.operations, [
+            .download(baseURL: serverB, sha256: "bb"),
+            .download(baseURL: serverB, sha256: "cc"),
+        ])
+    }
+
     // MARK: - fakes
 
     /// Records every operation, tagged with the base URL the inner

--- a/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
+++ b/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
@@ -129,6 +129,25 @@ final class DynamicBaseURLBlossomClientTests: XCTestCase {
         ])
     }
 
+    func test_boundToServer_nonHTTPSScheme_fallsBackToLiveResolution() async throws {
+        // Only https is bindable — cleartext http (no ATS exception
+        // ships) and odd schemes fall back to live resolution, same
+        // rule as the consent apply's requiredEndpointURL.
+        let recorder = Recorder()
+        let client = DynamicBaseURLBlossomClient(
+            resolveBaseURL: { [serverB] in serverB },
+            makeClient: { recorder.make(baseURL: $0) }
+        )
+
+        _ = try await client.bound(toServer: "http://blossom.example").download(sha256: "dd")
+        _ = try await client.bound(toServer: "ftp://blossom.example").download(sha256: "ee")
+
+        XCTAssertEqual(recorder.operations, [
+            .download(baseURL: serverB, sha256: "dd"),
+            .download(baseURL: serverB, sha256: "ee"),
+        ])
+    }
+
     // MARK: - fakes
 
     /// Records every operation, tagged with the base URL the inner

--- a/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
+++ b/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import OnymIOS
+import OnymTransportBlossom
+
+/// `DynamicBaseURLBlossomClient` resolves its base URL per operation —
+/// the seam that makes a Blossom server change in Settings (or an
+/// onboarding pick) apply to the very next upload/download instead of
+/// the next launch. Tests use a recording inner client so the resolved
+/// URL each operation was built against is observable.
+final class DynamicBaseURLBlossomClientTests: XCTestCase {
+    private let serverA = URL(string: "https://a.blossom.example")!
+    private let serverB = URL(string: "https://b.blossom.example")!
+
+    func test_upload_resolvesBaseURLAndForwards() async throws {
+        let recorder = Recorder()
+        let client = DynamicBaseURLBlossomClient(
+            resolveBaseURL: { [serverA] in serverA },
+            makeClient: { recorder.make(baseURL: $0) }
+        )
+
+        let descriptor = try await client.upload(Data([1, 2, 3]), mimeType: "image/jpeg")
+
+        XCTAssertEqual(recorder.operations, [.upload(baseURL: serverA, byteCount: 3, mimeType: "image/jpeg")])
+        XCTAssertEqual(descriptor, Recorder.cannedDescriptor)
+    }
+
+    func test_download_resolvesBaseURLAndForwards() async throws {
+        let recorder = Recorder()
+        let client = DynamicBaseURLBlossomClient(
+            resolveBaseURL: { [serverA] in serverA },
+            makeClient: { recorder.make(baseURL: $0) }
+        )
+
+        let data = try await client.download(sha256: "cafe")
+
+        XCTAssertEqual(recorder.operations, [.download(baseURL: serverA, sha256: "cafe")])
+        XCTAssertEqual(data, Recorder.cannedBlob)
+    }
+
+    func test_baseURLChangeBetweenOperations_takesEffectImmediately() async throws {
+        // The whole point of the seam: swap the resolved URL between
+        // two operations and the second one targets the new server —
+        // no client reconstruction, no relaunch.
+        let recorder = Recorder()
+        let current = CurrentURL(serverA)
+        let client = DynamicBaseURLBlossomClient(
+            resolveBaseURL: { current.value },
+            makeClient: { recorder.make(baseURL: $0) }
+        )
+
+        _ = try await client.upload(Data([9]), mimeType: "image/jpeg")
+        current.set(serverB)
+        _ = try await client.download(sha256: "beef")
+
+        XCTAssertEqual(recorder.operations, [
+            .upload(baseURL: serverA, byteCount: 1, mimeType: "image/jpeg"),
+            .download(baseURL: serverB, sha256: "beef"),
+        ])
+    }
+
+    func test_errorsFromInnerClientPropagate() async {
+        let recorder = Recorder(failWith: BlossomError.badStatus(503))
+        let client = DynamicBaseURLBlossomClient(
+            resolveBaseURL: { [serverA] in serverA },
+            makeClient: { recorder.make(baseURL: $0) }
+        )
+
+        do {
+            _ = try await client.upload(Data(), mimeType: "image/jpeg")
+            XCTFail("expected the inner client's error to propagate")
+        } catch let error as BlossomError {
+            XCTAssertEqual(error, .badStatus(503))
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - fakes
+
+    /// Records every operation, tagged with the base URL the inner
+    /// client was constructed with.
+    private final class Recorder: @unchecked Sendable {
+        enum Operation: Equatable {
+            case upload(baseURL: URL, byteCount: Int, mimeType: String)
+            case download(baseURL: URL, sha256: String)
+        }
+
+        static let cannedDescriptor = BlobDescriptor(
+            sha256: "aa", url: "https://a.blossom.example/aa", size: 2
+        )
+        static let cannedBlob = Data([0xCA, 0xFE])
+
+        private let lock = NSLock()
+        private var _operations: [Operation] = []
+        private let failWith: BlossomError?
+
+        init(failWith: BlossomError? = nil) {
+            self.failWith = failWith
+        }
+
+        var operations: [Operation] { lock.withLock { _operations } }
+
+        func make(baseURL: URL) -> any BlossomClient {
+            Inner(baseURL: baseURL, recorder: self)
+        }
+
+        fileprivate func record(_ operation: Operation) throws {
+            lock.withLock { _operations.append(operation) }
+            if let failWith { throw failWith }
+        }
+
+        private struct Inner: BlossomClient {
+            let baseURL: URL
+            let recorder: Recorder
+
+            func upload(_ blob: Data, mimeType: String) async throws -> BlobDescriptor {
+                try recorder.record(.upload(
+                    baseURL: baseURL, byteCount: blob.count, mimeType: mimeType
+                ))
+                return Recorder.cannedDescriptor
+            }
+
+            func download(sha256: String) async throws -> Data {
+                try recorder.record(.download(baseURL: baseURL, sha256: sha256))
+                return Recorder.cannedBlob
+            }
+        }
+    }
+
+    /// Mutable `@Sendable`-capturable URL for the resolver closure.
+    private final class CurrentURL: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value: URL
+        init(_ value: URL) { _value = value }
+        var value: URL { lock.withLock { _value } }
+        func set(_ newValue: URL) { lock.withLock { _value = newValue } }
+    }
+}

--- a/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
+++ b/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
@@ -75,6 +75,41 @@ final class DynamicBaseURLBlossomClientTests: XCTestCase {
         }
     }
 
+    func test_boundToServer_pinsAllOperationsToThatURL_ignoringResolver() async throws {
+        // `bound(toServer:)` is the per-send pin: even though the
+        // resolver now points at B, the bound client keeps operating
+        // against A — the URL a message's attachments were stamped with.
+        let recorder = Recorder()
+        let current = CurrentURL(serverA)
+        let client = DynamicBaseURLBlossomClient(
+            resolveBaseURL: { current.value },
+            makeClient: { recorder.make(baseURL: $0) }
+        )
+
+        let pinned = client.bound(toServer: serverA.absoluteString)
+        current.set(serverB)
+        _ = try await pinned.upload(Data([7]), mimeType: "image/jpeg")
+        _ = try await pinned.download(sha256: "feed")
+
+        XCTAssertEqual(recorder.operations, [
+            .upload(baseURL: serverA, byteCount: 1, mimeType: "image/jpeg"),
+            .download(baseURL: serverA, sha256: "feed"),
+        ])
+    }
+
+    func test_boundToServer_unparseableURL_fallsBackToLiveResolution() async throws {
+        let recorder = Recorder()
+        let client = DynamicBaseURLBlossomClient(
+            resolveBaseURL: { [serverB] in serverB },
+            makeClient: { recorder.make(baseURL: $0) }
+        )
+
+        let fallback = client.bound(toServer: "")
+        _ = try await fallback.download(sha256: "aa")
+
+        XCTAssertEqual(recorder.operations, [.download(baseURL: serverB, sha256: "aa")])
+    }
+
     // MARK: - fakes
 
     /// Records every operation, tagged with the base URL the inner

--- a/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
+++ b/Tests/OnymIOSTests/DynamicBaseURLBlossomClientTests.swift
@@ -129,23 +129,23 @@ final class DynamicBaseURLBlossomClientTests: XCTestCase {
         ])
     }
 
-    func test_boundToServer_nonHTTPSScheme_fallsBackToLiveResolution() async throws {
-        // Only https is bindable — cleartext http (no ATS exception
-        // ships) and odd schemes fall back to live resolution, same
-        // rule as the consent apply's requiredEndpointURL.
+    func test_boundToServer_httpLocalDevURL_bindsAsTyped() async throws {
+        // TRUSTED binding level: the caller vouches for the URL (own
+        // configuration), so a hand-typed http local-dev endpoint
+        // binds exactly as configured — the https-only rule lives on
+        // the peer-influenced stamp path (BlossomServerStampPolicy),
+        // not here.
         let recorder = Recorder()
+        let localDev = URL(string: "http://192.168.1.10:3000")!
         let client = DynamicBaseURLBlossomClient(
             resolveBaseURL: { [serverB] in serverB },
             makeClient: { recorder.make(baseURL: $0) }
         )
 
-        _ = try await client.bound(toServer: "http://blossom.example").download(sha256: "dd")
-        _ = try await client.bound(toServer: "ftp://blossom.example").download(sha256: "ee")
+        _ = try await client.bound(toServer: localDev.absoluteString)
+            .download(sha256: "dd")
 
-        XCTAssertEqual(recorder.operations, [
-            .download(baseURL: serverB, sha256: "dd"),
-            .download(baseURL: serverB, sha256: "ee"),
-        ])
+        XCTAssertEqual(recorder.operations, [.download(baseURL: localDev, sha256: "dd")])
     }
 
     // MARK: - fakes

--- a/Tests/OnymIOSTests/RelayerRepositoryTests.swift
+++ b/Tests/OnymIOSTests/RelayerRepositoryTests.swift
@@ -306,6 +306,75 @@ final class RelayerRepositoryTests: XCTestCase {
                        "the known-list cache still updates so the picker can offer them via Add From Published List")
     }
 
+    func test_refresh_autoPopulateSuppressed_updatesKnownListButNotConfiguration() async throws {
+        // Onboarding seam: while the policy returns false, a first-launch
+        // fetch must NOT install endpoints nor flip hasUserInteracted —
+        // the published list only lands in knownList so a picker can
+        // still offer it.
+        let store = InMemoryRelayerSelectionStore()  // .empty config; not interacted
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([a, b, c]))
+        let repo = RelayerRepository(
+            fetcher: fetcher,
+            store: store,
+            autoPopulatePolicy: { false }
+        )
+
+        try await repo.refresh()
+
+        let state = await repo.currentState()
+        XCTAssertTrue(state.configuration.endpoints.isEmpty,
+                      "suppressed auto-populate must not install any endpoints")
+        XCTAssertFalse(state.configuration.hasUserInteracted,
+                       "suppressed auto-populate must not flip hasUserInteracted — a later fetch (policy allowing) can still populate")
+        XCTAssertEqual(state.knownList, [a, b, c],
+                       "the fetched list still lands in knownList")
+        XCTAssertEqual(state.fetchStatus, .success)
+        XCTAssertEqual(store.loadCachedKnownList(), [a, b, c],
+                       "the fetched list is still cached on disk")
+        XCTAssertTrue(store.loadConfiguration().endpoints.isEmpty,
+                      "no configuration write while suppressed")
+    }
+
+    func test_refresh_autoPopulatePolicyFlipsToTrue_nextRefreshPopulates() async throws {
+        // Deferred, not cancelled: once the policy allows it again
+        // (e.g. onboarding finished without an explicit pick), the next
+        // refresh performs the normal first-launch auto-populate.
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([a, b]))
+        let allow = AllowFlag()
+        let repo = RelayerRepository(
+            fetcher: fetcher,
+            store: store,
+            autoPopulatePolicy: { allow.value }
+        )
+
+        try await repo.refresh()
+        var state = await repo.currentState()
+        XCTAssertTrue(state.configuration.endpoints.isEmpty)
+
+        allow.set(true)
+        try await repo.refresh()
+        state = await repo.currentState()
+        XCTAssertEqual(state.configuration.endpoints, [a, b],
+                       "auto-populate proceeds once the policy allows it")
+        XCTAssertTrue(state.configuration.hasUserInteracted)
+    }
+
+    func test_refresh_defaultPolicy_behavesAsBefore() async throws {
+        // The seam's default preserves the historical behavior — same
+        // assertions as test_refresh_onEmptyConfig_autoPopulates…, but
+        // through the defaulted initializer explicitly.
+        let store = InMemoryRelayerSelectionStore()
+        let fetcher = FakeKnownRelayersFetcher(mode: .succeeds([a]))
+        let repo = RelayerRepository(fetcher: fetcher, store: store)
+
+        try await repo.refresh()
+
+        let state = await repo.currentState()
+        XCTAssertEqual(state.configuration.endpoints, [a])
+        XCTAssertTrue(state.configuration.hasUserInteracted)
+    }
+
     func test_addEndpoint_promotesHasUserInteracted() async {
         let store = InMemoryRelayerSelectionStore()  // .empty / not interacted
         let repo = makeRepo(store: store)
@@ -396,6 +465,14 @@ final class RelayerRepositoryTests: XCTestCase {
     }
 
     // MARK: - helpers
+
+    /// Mutable `@Sendable`-capturable flag for the auto-populate policy.
+    private final class AllowFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value = false
+        var value: Bool { lock.withLock { _value } }
+        func set(_ newValue: Bool) { lock.withLock { _value = newValue } }
+    }
 
     private func makeRepo(
         store: InMemoryRelayerSelectionStore = InMemoryRelayerSelectionStore(),

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -227,6 +227,121 @@ final class SendMessageInteractorTests: XCTestCase {
         XCTAssertNotNil(result.imageAttachment)
     }
 
+    // MARK: - Per-send server binding
+
+    func test_sendAlbum_serverChangeMidSend_stampAndAllUploadsUseSendStartURL() async throws {
+        // The resolver returns the send-start URL exactly once, then a
+        // "changed" URL forever after — simulating a configuration
+        // change immediately after the send began. The guarantee: the
+        // URL is resolved ONCE, stamped, and every upload goes through
+        // a client BOUND to it; nothing re-resolves live mid-send.
+        let groupID = await seedGroupWithTwoPeers()
+        let tagging = ServerTaggingBlossomClient()
+        let provider = FlippingURLProvider(
+            first: "https://send-start.test", rest: "https://changed.test"
+        )
+        let boundInteractor = SendMessageInteractor(
+            identity: identity,
+            inboxTransport: transport,
+            messageRepository: messages,
+            groupRepository: groups,
+            blossomClient: tagging,
+            blossomServerURL: { provider.next() },
+            outbox: outbox
+        )
+
+        let result = try await boundInteractor.sendAlbum(
+            groupID: groupID,
+            sources: [.image(Self.makeJPEG()), .image(Self.makeJPEG())],
+            caption: "album"
+        )
+
+        XCTAssertEqual(result.status, .sent)
+        let album = try XCTUnwrap(result.albumAttachments)
+        for item in album {
+            switch item {
+            case .image(let image):
+                XCTAssertEqual(image.server, "https://send-start.test",
+                               "every attachment stamps the send-start URL")
+            case .video(let video):
+                XCTAssertEqual(video.server, "https://send-start.test")
+            }
+        }
+        let uploadServers = await tagging.uploadServers
+        XCTAssertEqual(uploadServers,
+                       ["https://send-start.test", "https://send-start.test"],
+                       "both blobs upload through the client bound to the send-start URL")
+        let unbound = await tagging.unboundUploads
+        XCTAssertEqual(unbound, 0,
+                       "no upload may bypass the bound client and re-resolve live")
+    }
+
+    /// `BlossomClient` that tags every upload with the server URL the
+    /// client was `bound(toServer:)` to; direct (unbound) uploads are
+    /// counted separately because the per-send guarantee forbids them.
+    private actor ServerTaggingBlossomClient: BlossomClient {
+        private(set) var uploadServers: [String] = []
+        private(set) var unboundUploads = 0
+
+        func upload(_ blob: Data, mimeType: String) async throws -> BlobDescriptor {
+            unboundUploads += 1
+            return Self.descriptor(for: blob)
+        }
+
+        func download(sha256: String) async throws -> Data {
+            throw BlossomError.badStatus(404)
+        }
+
+        nonisolated func bound(toServer serverURL: String) -> any BlossomClient {
+            Bound(server: serverURL, recorder: self)
+        }
+
+        fileprivate func recordBoundUpload(server: String) {
+            uploadServers.append(server)
+        }
+
+        static func descriptor(for blob: Data) -> BlobDescriptor {
+            let sha = ChatImageCrypto.sha256Hex(blob)
+            return BlobDescriptor(sha256: sha, url: "https://tagged.test/\(sha)", size: blob.count)
+        }
+
+        private struct Bound: BlossomClient {
+            let server: String
+            let recorder: ServerTaggingBlossomClient
+
+            func upload(_ blob: Data, mimeType: String) async throws -> BlobDescriptor {
+                await recorder.recordBoundUpload(server: server)
+                return ServerTaggingBlossomClient.descriptor(for: blob)
+            }
+
+            func download(sha256: String) async throws -> Data {
+                throw BlossomError.badStatus(404)
+            }
+        }
+    }
+
+    /// Returns `first` exactly once, then `rest` forever — the seam
+    /// for simulating a configuration change mid-send.
+    private final class FlippingURLProvider: @unchecked Sendable {
+        private let lock = NSLock()
+        private var served = false
+        private let first: String
+        private let rest: String
+
+        init(first: String, rest: String) {
+            self.first = first
+            self.rest = rest
+        }
+
+        func next() -> String {
+            lock.withLock {
+                if served { return rest }
+                served = true
+                return first
+            }
+        }
+    }
+
     nonisolated private static func makeJPEG() -> Data {
         let format = UIGraphicsImageRendererFormat.default()
         format.scale = 1

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -93,7 +93,7 @@ final class SendMessageInteractorTests: XCTestCase {
             messageRepository: messages,
             groupRepository: groups,
             blossomClient: blossom,
-            blossomServerURL: "https://blossom.test",
+            blossomServerURL: { "https://blossom.test" },
             outbox: outbox
         )
     }
@@ -259,7 +259,7 @@ final class SendMessageInteractorTests: XCTestCase {
             messageRepository: messages,
             groupRepository: groups,
             blossomClient: blossom,
-            blossomServerURL: "https://blossom.test",
+            blossomServerURL: { "https://blossom.test" },
             videoEncoder: encoder,
             outbox: outbox
         )
@@ -368,7 +368,7 @@ final class SendMessageInteractorTests: XCTestCase {
             messageRepository: messages,
             groupRepository: groups,
             blossomClient: blossom,
-            blossomServerURL: "https://blossom.test",
+            blossomServerURL: { "https://blossom.test" },
             voiceEncoder: encoder,
             outbox: outbox
         )

--- a/Tests/OnymIOSTests/SendMessageInteractorTests.swift
+++ b/Tests/OnymIOSTests/SendMessageInteractorTests.swift
@@ -276,6 +276,105 @@ final class SendMessageInteractorTests: XCTestCase {
                        "no upload may bypass the bound client and re-resolve live")
     }
 
+    func test_retry_reuploadsThroughClientBoundToStampedServer() async throws {
+        // The retry re-upload must pin to the server STAMPED into the
+        // failed message's attachments — not whatever the provider
+        // resolves at retry time.
+        let groupID = await seedGroupWithTwoPeers()
+        let tagging = ServerTaggingBlossomClient()
+        let provider = FlippingURLProvider(
+            first: "https://stamped-at-send.test", rest: "https://changed-since.test"
+        )
+        let boundInteractor = SendMessageInteractor(
+            identity: identity,
+            inboxTransport: transport,
+            messageRepository: messages,
+            groupRepository: groups,
+            blossomClient: tagging,
+            blossomServerURL: { provider.next() },
+            outbox: outbox
+        )
+
+        // Fail at fan-out (uploads succeed, relays reject) so the
+        // outbox keeps the blob for the retry.
+        await transport.setAcceptedBy(0)
+        let failed = try await boundInteractor.sendImage(
+            groupID: groupID, imageData: Self.makeJPEG()
+        )
+        XCTAssertEqual(failed.status, .failed)
+        XCTAssertEqual(failed.imageAttachment?.server, "https://stamped-at-send.test")
+
+        await transport.setAcceptedBy(1)
+        await boundInteractor.retry(groupID: groupID, messageID: failed.id)
+
+        let stored = await messages.currentMessages(groupID: groupID, owner: currentIdentityID)
+        XCTAssertEqual(stored.first?.status, .sent)
+        let uploadServers = await tagging.uploadServers
+        XCTAssertEqual(uploadServers,
+                       ["https://stamped-at-send.test", "https://stamped-at-send.test"],
+                       "the retry re-upload must bind to the stamped server, not the provider's current URL")
+        let unbound = await tagging.unboundUploads
+        XCTAssertEqual(unbound, 0)
+    }
+
+    func test_retry_legacyNilStampRow_fallsBackToLiveClient() async throws {
+        // Rows persisted before stamping existed carry server == nil;
+        // their retry re-uploads through the live (unbound) client.
+        let groupID = await seedGroupWithTwoPeers()
+        let tagging = ServerTaggingBlossomClient()
+
+        // Hand-craft the legacy failed row + its outbox blob (written
+        // straight into a dedicated outbox directory — `store` is
+        // internal to the package).
+        let blob = Data("legacy-ciphertext".utf8)
+        let sha = ChatImageCrypto.sha256Hex(blob)
+        let outboxDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("outbox-legacy-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: outboxDir, withIntermediateDirectories: true
+        )
+        try blob.write(
+            to: outboxDir.appendingPathComponent(sha).appendingPathExtension("blob")
+        )
+        let boundInteractor = SendMessageInteractor(
+            identity: identity,
+            inboxTransport: transport,
+            messageRepository: messages,
+            groupRepository: groups,
+            blossomClient: tagging,
+            blossomServerURL: { "https://current.test" },
+            outbox: ChatOutbox(directory: outboxDir)
+        )
+        let legacy = ChatMessage(
+            id: UUID(),
+            groupID: groupID,
+            ownerIdentityID: currentIdentityID,
+            senderBlsPubkeyHex: myBlsHex,
+            body: "",
+            sentAt: Date(),
+            direction: .outgoing,
+            status: .failed,
+            replyToMessageID: nil,
+            groupType: .tyranny,
+            imageAttachment: ChatImageAttachment(
+                sha256: sha, mimeType: "image/jpeg", byteSize: blob.count,
+                width: 4, height: 4, encKey: Data(repeating: 7, count: 32),
+                blurhash: "LEHV6nWB2yk8", server: nil
+            )
+        )
+        await messages.insert(legacy)
+
+        await transport.setAcceptedBy(1)
+        await boundInteractor.retry(groupID: groupID, messageID: legacy.id)
+
+        let uploadServers = await tagging.uploadServers
+        XCTAssertTrue(uploadServers.isEmpty,
+                      "a nil-stamp legacy row must not bind to any server")
+        let unbound = await tagging.unboundUploads
+        XCTAssertEqual(unbound, 1,
+                       "the legacy re-upload goes through the live (unbound) client")
+    }
+
     /// `BlossomClient` that tags every upload with the server URL the
     /// client was `bound(toServer:)` to; direct (unbound) uploads are
     /// counted separately because the per-send guarantee forbids them.


### PR DESCRIPTION
Four pieces of the iOS onboarding plan (PR 2 of the sequence, plus the design prerequisite), refined across two review rounds. **Live-behavior summary**: the two *seams* (blossom catalog picker wiring, relayer auto-populate policy) default to current behavior until PR 3 wires them — but pieces of this PR ARE live immediately: the Blossom base URL resolves per operation (server changes apply to the next upload/download instead of the next launch), downloads honor each attachment's server stamp, and the Blossom settings screen gains a FROM CATALOG section, an ACTIVE badge, and a Make Active affordance.

## What each piece does / unblocks

### 1. Blossom catalog picker + make-active semantics (unblocks onboarding step 4, blob transport)
The "blob.storage" seat was the one without a consent picker. `blossomCatalogPicker` in `OnymIOSApp` mirrors the relayer/nostr pickers; the consent apply is extracted into `BlossomCatalogConsent.apply` (unit-tested): required **https** endpoint from the manifest → `blossomServersRepository.addEndpoint(..., makeActive: true)`. **Make-active semantics** (added after review — a plain append behind the seeded default left the pick silently inert since uploads/downloads only target the FIRST endpoint): `addEndpoint(_:makeActive:)` inserts/moves the endpoint to the head, and `makeActive(url:)` promotes any configured row (no-op for unknown/already-first URLs, which doesn't count as user interaction). `BlossomRelaySettingsFlow`/`View` gain the optional `discovery:` seam (default nil), a FROM CATALOG section, an ACTIVE badge on the first row, and a Make Active button on the rest.

### 2. Relayer auto-populate suppression seam (unblocks onboarding step 5, notary)
`RelayerRepository` takes `autoPopulatePolicy: @Sendable () -> Bool` (default `{ true }` — today's behavior; the app passes nothing yet). When false, a first-launch fetch updates `knownList` (and the disk cache) only — no endpoint install, no `hasUserInteracted` flip — deferred, not cancelled. PR 3 sets it to "false while onboarding is incomplete".

### 3. Live blossom base URL + server-stamp contract (LIVE in this PR; unblocks step 4's "active immediately" copy)
`DynamicBaseURLBlossomClient` resolves its base URL per operation from the repository's first endpoint (fallback: app default) — server changes apply to the next upload/download, no relaunch. The stamp contract holds on both halves:
- **Write**: each send resolves the URL once, stamps it into the attachments, and uploads every blob through `BlossomClient.bound(toServer:)` (new protocol requirement, default `self`), so stamp and blobs can't diverge mid-send; `retry` re-uploads to the stamped server.
- **Read**: all three loaders (image/video/voice) download through the client bound to `attachment.server`, falling back to the live client for legacy nil-server rows — so switching servers never 404s already-uploaded history (own or peers'). Superseded and closed #251.
- `bound(toServer:)` rejects schemeless/hostless stamps and falls back to live resolution.
The `--ui-loopback` in-memory client path is untouched.

### 4. `SettingsStepIndicator` public (design prerequisite)
Public struct + init(step:count:) + body in OnymDesign for the onboarding package's step progress; EXTRACTION-NOTES.md updated.

Also: the three transport settings flows' catalog plumbing is deduplicated into an internal `DiscoveryCatalogState` (OnymSettings), behavior-identical.

## Verification (all green, after round-3 fixes)
- App-target OnymIOSTests: 1222 passed, 0 failures (3 pre-existing skips) — includes BlossomCatalogConsentTests, ChatMediaLoaderServerBindingTests, DynamicBaseURLBlossomClientTests, RelayerRepositoryTests (auto-populate seam), SendMessageInteractorTests (mid-send binding), DiscoverySeatAdaptersTests
- OnymDiscovery package tests: 117 passed; OnymFoundation: 53 passed (OnymChain has no package test target — covered in the app suite)
- Full app build (iPhone 17 Pro simulator): succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8