### PR TITLE
Make the discovery surface UI-testable: fixture-backed fakes behind --ui-discovery

### DIFF
--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -105,16 +105,35 @@ struct OnymIOSApp: App {
         // One fetcher instance serves both the repository and the seat
         // catalog below — same URLSession, same size caps; no second
         // session to configure and drift.
-        let discoveryFetcher = URLSessionDiscoveryFetcher()
+        let discoveryFetcher: any DiscoveryFetching
         let discoveryRepository: DiscoveryRepository?
         #if DEBUG
-        discoveryRepository = args.contains("--ui-loopback") || args.contains("--ui-testing")
-            ? nil
-            : DiscoveryRepository(
-                fetcher: discoveryFetcher,
-                store: UserDefaultsDiscoveryStore()
+        if args.contains("--ui-testing") && args.contains("--ui-discovery") {
+            // `--ui-discovery` (with `--ui-testing`): the discovery
+            // surface runs against byte-pinned fixture documents served
+            // offline — real signatures, real `DiscoveryTrust` checks,
+            // fixture-era `now` so the tests outlive the fixtures'
+            // expiry dates. See `UITestDiscoveryFakes.swift`. Without
+            // the flag, `--ui-testing` keeps discovery nil exactly as
+            // before, so every existing UI test is untouched.
+            let fetcher = UITestDiscoveryFetcher()
+            discoveryFetcher = fetcher
+            discoveryRepository = DiscoveryRepository(
+                fetcher: fetcher,
+                store: InMemoryDiscoveryStore(),
+                now: { UITestDiscoveryFixtures.now }
             )
+        } else {
+            discoveryFetcher = URLSessionDiscoveryFetcher()
+            discoveryRepository = args.contains("--ui-loopback") || args.contains("--ui-testing")
+                ? nil
+                : DiscoveryRepository(
+                    fetcher: discoveryFetcher,
+                    store: UserDefaultsDiscoveryStore()
+                )
+        }
         #else
+        discoveryFetcher = URLSessionDiscoveryFetcher()
         discoveryRepository = DiscoveryRepository(
             fetcher: discoveryFetcher,
             store: UserDefaultsDiscoveryStore()

--- a/Sources/OnymIOS/UITestDiscoveryFakes.swift
+++ b/Sources/OnymIOS/UITestDiscoveryFakes.swift
@@ -1,0 +1,134 @@
+#if DEBUG
+import Foundation
+import OnymDiscovery
+
+/// Discovery fakes for the `--ui-discovery` launch flag (honoured only
+/// alongside `--ui-testing`). Sibling of `UITestFakes.swift` — same
+/// rules: production sources because `OnymIOSApp.init` constructs them
+/// directly, `#if DEBUG` so none of it ships to Release.
+///
+/// Unlike the other UI-test fakes these serve REAL signed documents:
+/// the byte-pinned conformance fixtures from
+/// `Packages/OnymDiscovery/Tests/OnymDiscoveryTests/Fixtures` (in turn
+/// copied from onym-discovery's cross-language vectors). Their
+/// signatures verify against the operator key embedded in the provider
+/// manifest, so the app runs the full production `DiscoveryTrust`
+/// pipeline — TOFU preview, key pinning, snapshot chain + expiry,
+/// destination-manifest digest pin — entirely offline.
+///
+/// The fixtures are embedded as raw string literals rather than
+/// bundled resources on purpose: every digest and signature is over
+/// EXACT bytes, a `#"…"#` literal pins those bytes in source (the
+/// files are single-line JSON with no backslashes), and the app target
+/// gains no resource-plumbing through project.yml for test-only data.
+/// If the package fixtures are ever regenerated, re-copy them here —
+/// `UITestDiscoveryFixturesTests` in OnymIOSTests would be the place
+/// to assert the copies stay byte-identical, but for now the embedded
+/// digests below fail the trust checks loudly on any drift.
+enum UITestDiscoveryFixtures {
+    /// The seeded default source's manifest URL
+    /// (`DiscoverySource.onymDefault.manifestURL`) — the flow under
+    /// test TOFU-confirms the seeded default, so the fake must answer
+    /// at exactly this URL.
+    static let providerManifestURL = URL(string: "https://discovery.onym.app/manifest.json")!
+    /// `catalogs[0].snapshot` inside the provider manifest.
+    static let snapshotURL = URL(string: "https://discovery.onym.app/catalogs/public-all-seats.json")!
+    /// `entries[0].manifest.uri` inside the snapshot (the destination
+    /// manifest whose digest the entry pins), so the module-consent
+    /// walk can fetch + review it offline.
+    static let destinationManifestURL = URL(string: "https://discovery.onym.app/manifests/onym-courier.json")!
+
+    /// The fixtures' signing-date neighborhood (2026-08-14T00:00:00Z;
+    /// same instant as `Fixture.now` in OnymDiscoveryTests): validity
+    /// spans 2026-08-13 → snapshot expiry 2026-09-12. Injected as the
+    /// repository's `now` so the UI tests keep passing after the real
+    /// clock passes the fixtures' expiry.
+    static let now = Date(timeIntervalSince1970: 1_786_665_600)
+
+    /// First 16 hex chars of the fixtures' operator key
+    /// (`ea4a6c63e29c520a…`), grouped as the TOFU screen renders it.
+    /// UI tests assert against this exact string.
+    static let operatorKeyFingerprint = "ea4a 6c63 e29c 520a"
+
+    /// `provider-manifest.json`, byte-exact.
+    static let providerManifest = Data(#"{"capabilities":["signed-snapshot-v1","local-filtering-v1"],"catalogs":[{"audience":"public","catalogId":"public-all-seats","policy":"sha256:1111111111111111111111111111111111111111111111111111111111111111","policyUri":"https://discovery.onym.app/policies/public-all-seats.md","seatTypes":["transport.message","notary","moderation"],"snapshot":"https://discovery.onym.app/catalogs/public-all-seats.json"}],"implementationProfileId":"onym:discovery-implementation:static-ed25519-v1","offers":[],"operator":"onym:key:ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c","privacyProfile":"sha256:3333333333333333333333333333333333333333333333333333333333333333","privacyProfileUri":"https://discovery.onym.app/privacy.md","providerId":"onym:component:onym-discovery","seat":"discovery","signature":"G3c5sbqgFpN7X+sq95d2Mkeg8yfy/gjz7w9b5HaPjpFwCKtbmZ8lqy2sJhYIYGlZQ0q9S3XmrpBcRfFLpmsDCQ==","validUntil":"2026-12-31T23:59:59Z","version":1}"#.utf8)
+
+    /// `snapshot-1.json`, byte-exact (sequence 1, no `previousDigest`
+    /// — the clean start of the chain; the in-memory store begins with
+    /// no retained snapshots, so re-serving the same bytes on every
+    /// refresh is a valid no-change chain step).
+    static let snapshot = Data(#"{"catalogId":"public-all-seats","entries":[{"componentId":"onym:component:onym-courier","evidence":[],"listedAt":"2026-08-13T00:00:00Z","manifest":{"digest":"sha256:6536b1a70c859fae21afc610035a924a1a96a842c8b124094ed4978d828f1c45","uri":"https://discovery.onym.app/manifests/onym-courier.json"},"operator":"onym:key:ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c","placement":"policy-ranked","profiles":["onym:message-implementation:nostr-courier-v1"],"relationship":"common-owner","seatType":"transport.message"}],"expiresAt":"2026-09-12T00:00:00Z","generatedAt":"2026-08-13T00:00:00Z","implementationProfileId":"onym:discovery-implementation:static-ed25519-v1","policyDigest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","providerId":"onym:component:onym-discovery","sequence":1,"signature":"tcU3eQryNBpH16Hea/v4h4AixpZNazAv5DzYmYxx3GOAnbL3ePZwboON8s9aJApIdN+JvUC15wzdWR0l3zLCAw==","version":1}"#.utf8)
+
+    /// `destination-manifest.json`, byte-exact — its sha256 must equal
+    /// the `manifest.digest` the snapshot entry pins.
+    static let destinationManifest = Data(#"{"componentId":"onym:component:onym-courier","endpoints":[{"role":"read-write","uri":"wss://nostr.onym.app"}],"offers":[{"model":"free","offerId":"courier-free-v1"}],"operator":"onym:key:ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c","seat":"transport.message","signature":"mDLXl2yEQa8OJvLqgUP8kRNakcIQybq2gKia2UCrGguuWNLPCH4MJ2Pvw1jNlUiM90dtSWHkmjZpxMpb3nAgAQ==","validUntil":"2026-12-31T23:59:59Z","version":1}"#.utf8)
+}
+
+/// `DiscoveryFetching` that serves the fixture bytes by exact URL and
+/// answers 404 for anything else — dumb by design (the seam contract:
+/// bytes out, all parsing/verification stays in the trust layer).
+/// Destination manifests go through `fetchProviderManifest` because
+/// that is the method `DiscoverySeatCatalog` fetches them with (they
+/// share the provider-manifest size cap).
+struct UITestDiscoveryFetcher: DiscoveryFetching {
+    func fetchProviderManifest(url: URL) async throws -> Data {
+        switch url {
+        case UITestDiscoveryFixtures.providerManifestURL:
+            return UITestDiscoveryFixtures.providerManifest
+        case UITestDiscoveryFixtures.destinationManifestURL:
+            return UITestDiscoveryFixtures.destinationManifest
+        default:
+            throw DiscoveryFetchError.badStatus(404)
+        }
+    }
+
+    func fetchSnapshot(url: URL) async throws -> Data {
+        guard url == UITestDiscoveryFixtures.snapshotURL else {
+            throw DiscoveryFetchError.badStatus(404)
+        }
+        return UITestDiscoveryFixtures.snapshot
+    }
+}
+
+/// In-memory `DiscoveryStore` so each UI-test launch starts with no
+/// persisted configuration (the repository then seeds the unconfirmed
+/// default source) and no retained snapshots — same launch-isolation
+/// pattern as the other `UITest*Store`s.
+final class InMemoryDiscoveryStore: DiscoveryStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var configuration: DiscoverySourcesConfiguration = .empty
+    private var snapshots: [String: Data] = [:]
+
+    private static func key(_ providerId: String, _ catalogId: String) -> String {
+        // providerId/catalogId charsets exclude "|" (enforced by the
+        // trust layer's format checks), so the join is unambiguous.
+        providerId + "|" + catalogId
+    }
+
+    func loadConfiguration() -> DiscoverySourcesConfiguration {
+        lock.withLock { configuration }
+    }
+
+    func saveConfiguration(_ configuration: DiscoverySourcesConfiguration) {
+        lock.withLock { self.configuration = configuration }
+    }
+
+    func loadRetainedSnapshot(providerId: String, catalogId: String) -> Data? {
+        lock.withLock { snapshots[Self.key(providerId, catalogId)] }
+    }
+
+    func saveRetainedSnapshot(_ raw: Data, providerId: String, catalogId: String) {
+        lock.withLock { snapshots[Self.key(providerId, catalogId)] = raw }
+    }
+
+    func removeRetainedSnapshots(providerId: String) {
+        lock.withLock {
+            let prefix = providerId + "|"
+            for key in snapshots.keys where key.hasPrefix(prefix) {
+                snapshots.removeValue(forKey: key)
+            }
+        }
+    }
+}
+
+#endif

--- a/Tests/OnymIOSUITests/DiscoverySettingsUITests.swift
+++ b/Tests/OnymIOSUITests/DiscoverySettingsUITests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+/// End-to-end UI test for Settings → Discovery under `--ui-discovery`:
+/// the app serves the byte-pinned OnymDiscovery conformance fixtures
+/// through `UITestDiscoveryFetcher`, so the full production trust
+/// pipeline (TOFU preview → key pin → snapshot verification) runs
+/// offline and deterministically.
+///
+/// The walk: the seeded default source starts UNCONFIRMED (no pinned
+/// key — hard enforcement means it contributes nothing yet); its
+/// "Confirm…" opens the TOFU sheet, whose fingerprint must be exactly
+/// the fixtures' operator key; pinning it triggers the targeted
+/// refresh that verifies and retains the fixture snapshot; back on the
+/// list, the row shows the pinned key and the verified catalog entry
+/// count.
+final class DiscoverySettingsUITests: XCTestCase {
+
+    /// First 16 hex chars of the fixture operator key, grouped as the
+    /// TOFU screen renders it — duplicated from
+    /// `UITestDiscoveryFixtures.operatorKeyFingerprint` so a fixture
+    /// regeneration forces a fix here too (cross-bundle contract, same
+    /// convention as `RelayerSettingsUITests`' fixture URLs).
+    private let fingerprint = "ea4a 6c63 e29c 520a"
+
+    func test_confirmDefaultSource_pinsKeyAndRendersCatalogEntries() throws {
+        let app = AppLauncher.launchFresh(discovery: true)
+        let settings = SettingsScreen(app: app)
+        XCTAssertTrue(settings.waitForReady())
+
+        let discovery = DiscoverySettingsScreen(app: app)
+        discovery.open()
+
+        // The seeded default source is listed, unconfirmed.
+        XCTAssertTrue(discovery.defaultSourceRow.waitForExistence(timeout: 5),
+                      "seeded default discovery source never appeared")
+        XCTAssertTrue(discovery.confirmSourceButton.waitForExistence(timeout: 5),
+                      "unconfirmed default source should offer Confirm…")
+        discovery.confirmSourceButton.tap()
+
+        // TOFU sheet: the fingerprint is the fixtures' operator key.
+        XCTAssertTrue(discovery.fingerprint.waitForExistence(timeout: 5),
+                      "TOFU fingerprint never appeared")
+        XCTAssertEqual(discovery.fingerprint.label, fingerprint,
+                       "TOFU fingerprint must match the fixture operator key")
+
+        // Pin the key. The confirm runs a targeted refresh that
+        // fetches + verifies the fixture snapshot.
+        discovery.pinConfirmButton.tap()
+        XCTAssertTrue(discovery.addDone.waitForExistence(timeout: 5),
+                      "provider-added state never appeared")
+        discovery.dismissSheetButton.tap()
+
+        // Back on the list: the source row shows the pinned key…
+        XCTAssertTrue(app.staticTexts["Key \(fingerprint)"].waitForExistence(timeout: 5),
+                      "source row should show the pinned key fingerprint")
+        // …and the verified fixture snapshot's single entry counts in.
+        let entryCount = discovery.entryCountText(1)
+        if !entryCount.waitForExistence(timeout: 5) {
+            XCTFail("source row should count the verified catalog entry. Hierarchy:\n\(app.debugDescription)")
+        }
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/DiscoverySettingsScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/DiscoverySettingsScreen.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+/// Page object for Settings → Discovery Providers and its add/TOFU
+/// sheet. Only meaningful when the app was launched with
+/// `--ui-discovery` (see `AppLauncher.launchFresh(discovery:)`) —
+/// without it the DISCOVERY section doesn't exist at all.
+struct DiscoverySettingsScreen {
+    let app: XCUIApplication
+
+    /// The seeded default source's providerId — the accessibility ids
+    /// below embed it (`settings.discovery.source.<providerId>`).
+    static let defaultProviderId = "onym:component:onym-discovery"
+
+    // MARK: - Navigation
+
+    /// Settings → DISCOVERY → Discovery Providers row. Sits below the
+    /// fold on the Settings page, so scroll it into view first
+    /// (bounded, same pattern as `SettingsScreen.tapClearMessages`).
+    func open(maxSwipes: Int = 8) {
+        SettingsScreen(app: app).tapSettingsTab()
+        let row = discoveryRow
+        var n = 0
+        while !(row.exists && row.isHittable) && n < maxSwipes {
+            app.swipeUp()
+            n += 1
+        }
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "settings discovery row never appeared")
+        row.tap()
+    }
+
+    var discoveryRow: XCUIElement {
+        firstMatching("settings.discovery_row")
+    }
+
+    // MARK: - Sources list
+
+    /// The seeded default source's row.
+    var defaultSourceRow: XCUIElement {
+        firstMatching("settings.discovery.source.\(Self.defaultProviderId)")
+    }
+
+    /// "Confirm…" on the unconfirmed seeded default (opens the TOFU
+    /// sheet pre-filled with the source's manifest URL).
+    var confirmSourceButton: XCUIElement {
+        app.buttons["settings.discovery.source.\(Self.defaultProviderId).confirm"]
+    }
+
+    // MARK: - Add / TOFU sheet
+
+    /// The operator-key fingerprint on the TOFU confirmation step.
+    var fingerprint: XCUIElement {
+        app.staticTexts["settings.discovery.add.fingerprint"]
+    }
+
+    /// "Pin Key & Add Provider".
+    var pinConfirmButton: XCUIElement {
+        app.buttons["settings.discovery.add.confirm"]
+    }
+
+    /// The "Provider added" done state. The identifier sits on a
+    /// SwiftUI `VStack`, whose element type varies by iOS version —
+    /// match any descendant by identifier.
+    var addDone: XCUIElement {
+        app.descendants(matching: .any)
+            .matching(identifier: "settings.discovery.add.done")
+            .firstMatch
+    }
+
+    /// The source row's verified-entry count line ("1 catalog entry").
+    /// Matched by CONTAINS: the count string goes through automatic
+    /// grammar agreement (`^[…](inflect: true)`), and under the UI-test
+    /// language override the label can surface as the raw inflection
+    /// markup — the count + noun substring is the stable part.
+    func entryCountText(_ count: Int) -> XCUIElement {
+        app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", "\(count) catalog entr")
+        ).firstMatch
+    }
+
+    /// Sheet toolbar dismiss ("Cancel" / "Done").
+    var dismissSheetButton: XCUIElement {
+        app.buttons["settings.discovery.add.dismiss"]
+    }
+
+    /// SwiftUI renders rows/links as different XCUIElement types
+    /// depending on iOS version + container — try the likely queries
+    /// (same helper shape as `SettingsScreen.firstMatching`).
+    private func firstMatching(_ identifier: String) -> XCUIElement {
+        for query in [app.buttons, app.cells, app.otherElements] {
+            let element = query[identifier]
+            if element.exists { return element }
+        }
+        return app.buttons[identifier]
+    }
+}

--- a/Tests/OnymIOSUITests/Support/AppLauncher.swift
+++ b/Tests/OnymIOSUITests/Support/AppLauncher.swift
@@ -13,8 +13,14 @@ import XCTest
 ///
 /// `language` flips Apple's `-AppleLanguages` / `-AppleLocale` user-defaults
 /// so the same test can exercise localized strings.
+///
+/// `discovery: true` adds `--ui-discovery`, wiring the discovery
+/// surface to offline fixture fakes (see `UITestDiscoveryFakes.swift`
+/// in the app target). Default `false` keeps discovery nil — the
+/// pre-existing `--ui-testing` behavior — so existing call sites and
+/// tests are untouched.
 enum AppLauncher {
-    static func launchFresh(language: String = "en") -> XCUIApplication {
+    static func launchFresh(discovery: Bool = false, language: String = "en") -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments = [
             "--ui-testing",
@@ -23,6 +29,9 @@ enum AppLauncher {
             "-AppleLanguages", "(\(language))",
             "-AppleLocale", localeIdentifier(for: language),
         ]
+        if discovery {
+            app.launchArguments.append("--ui-discovery")
+        }
         app.launch()
         return app
     }


### PR DESCRIPTION
First half of onboarding-plan PR 4, with independent value on its own: it makes the discovery surface UI-testable. PR 3's onboarding UI test will build on it.

## Problem

Under `--ui-testing` / `--ui-loopback`, `discoveryRepository` is nil, cascading nils through the catalog, the seat pickers, and the Settings flow — the whole discovery surface (provider management, TOFU confirm, catalog entries, module consent) could not be exercised in UI tests. `UITestFakes.swift` had fakes for every other seam but none for discovery.

## What this adds

- **`UITestDiscoveryFetcher` + `InMemoryDiscoveryStore`** (`Sources/OnymIOS/UITestDiscoveryFakes.swift`, `#if DEBUG` like its sibling `UITestFakes.swift`). The fetcher serves the byte-pinned OnymDiscovery conformance fixtures — provider manifest, `snapshot-1`, and the destination manifest — keyed by exact URL, 404 otherwise. Their signatures verify against the fixture operator key embedded in the provider manifest, so the app runs the **real `DiscoveryTrust` pipeline** (TOFU preview → key pin → snapshot verification → digest-pinned destination manifest) entirely offline. The destination manifest is included so a full add-provider → TOFU → catalog-entries → consent walk works with no network.
- **Fixtures embedded as raw string literals**, not bundled resources — decided deliberately: every digest and signature is over *exact bytes*; a `#"…"#` literal pins those bytes in source (the fixtures are single-line JSON with no backslashes), and the app target gains no resource plumbing through `project.yml` for test-only data. The repository is constructed with the fixture-era `now` (`2026-08-14T00:00:00Z`, same as `Fixture.now` in OnymDiscoveryTests) so the tests keep passing after the real clock passes the fixtures' expiry dates.
- **New launch flag `--ui-discovery`** (honoured only alongside `--ui-testing`): constructs `DiscoveryRepository` with the fakes instead of nil. Without the flag, `--ui-testing` behavior is byte-for-byte unchanged (discovery stays nil), so every existing UI test is untouched.
- **`AppLauncher.launchFresh(discovery:)`** — default `false`, existing call sites unchanged.
- **`DiscoverySettingsUITests`** + `DiscoverySettingsScreen` page object: Settings → DISCOVERY → the seeded default source renders UNCONFIRMED → Confirm… opens the TOFU sheet → fingerprint asserted **equal to the fixture operator key** (`ea4a 6c63 e29c 520a`) → pin → back on the list, the row shows the pinned key and the verified snapshot's catalog entry count.

## Verification

- Full app `build-for-testing` succeeds.
- New `DiscoverySettingsUITests` passes on iPhone 17 Pro simulator.
- Existing `RelayerSettingsUITests/test_firstLaunch_configuredListAutoPopulatedFromManifest` passes (default `--ui-testing` behavior unchanged).
- OnymDiscovery package tests green (iOS simulator destination).

Note for reviewers: `discovery.onym.app` is now live (serving operator key `42b0da00…`), which is exactly why the fakes matter — an early test run on a shared simulator picked up a real fetch and pinned the live key instead of the fixture; the fakes keep the UI tests deterministic and offline regardless of the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8