### PR TITLE
Discovery hygiene: fresh default-source comment, fix raw inflection markup

### DIFF
--- a/Packages/OnymDiscovery/Sources/OnymDiscovery/DiscoverySource.swift
+++ b/Packages/OnymDiscovery/Sources/OnymDiscovery/DiscoverySource.swift
@@ -86,9 +86,15 @@ public struct DiscoverySource: Codable, Equatable, Hashable, Identifiable, Senda
     }
 
     /// The Onym-operated default provider, seeded on first run only
-    /// (see `DiscoverySourcesConfiguration`). Ships unpinned — the
-    /// deployment is not live yet, and pinning happens through the
-    /// same TOFU confirmation as any other source.
+    /// (see `DiscoverySourcesConfiguration`). Ships unpinned **by
+    /// design**: pinning is the user's own trust-on-first-use act, so
+    /// even the bundled default goes through the same TOFU
+    /// confirmation as any other source. The deployment is live; for
+    /// maintainers, the operator key it currently serves is
+    /// `onym:key:42b0da001104dd03052c7feddab9520c920c9e40d11b245c46c27cf6be853f24`
+    /// (fingerprint `4d:a9:ec:c9:e8:6f:6e:97` — sha256 of the 32 raw
+    /// key bytes, first 8 bytes colon-hex). Reference only — never
+    /// pre-pin it here.
     public static let onymDefault = DiscoverySource(
         providerId: "onym:component:onym-discovery",
         userLabel: "Onym Discovery",

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoverySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoverySettingsView.swift
@@ -224,9 +224,20 @@ struct DiscoverySettingsView: View {
     }
 
     private func entriesLine(for status: DiscoverySourceStatus) -> String {
-        let count = flow.entryCount(providerId: status.source.providerId)
-        // Automatic grammar agreement — a real plural rule, not an
-        // English-only `== 1` branch.
-        return String(localized: "^[\(count) catalog entries](inflect: true)")
+        DiscoveryEntriesLabel.text(count: flow.entryCount(providerId: status.source.providerId))
+    }
+}
+
+/// Localized "N catalog entries" line for a source row. Pluralization
+/// comes from the app catalog's plural variations for the
+/// `%lld catalog entries` key (`Resources/Localizable.xcstrings`) — a
+/// real per-locale plural rule, not an English-only `== 1` branch.
+/// Deliberately not `^[…](inflect: true)`: that markup had no catalog
+/// entry, so lookup fell through to the literal key and the raw
+/// inflection markup reached the screen under a language override.
+/// Public so the hosted unit tests can pin the rendered forms.
+public enum DiscoveryEntriesLabel {
+    public static func text(count: Int) -> String {
+        String(localized: "\(count) catalog entries")
     }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4211,6 +4211,59 @@
         }
       }
     },
+    "%lld catalog entries": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld catalog entry"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld catalog entries"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld записи каталога"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld записей каталога"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld запись каталога"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld записей каталога"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "%lld join requests": {
       "extractionState": "manual",
       "localizations": {

--- a/Tests/OnymIOSTests/DiscoveryEntriesLabelTests.swift
+++ b/Tests/OnymIOSTests/DiscoveryEntriesLabelTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+import OnymSettings
+
+/// Pins the rendered forms of the discovery source row's entry-count
+/// line. Regression coverage for the raw-markup bug: the line used
+/// `^[…](inflect: true)` automatic grammar agreement with no entry in
+/// `Localizable.xcstrings`, so under an `-AppleLanguages` override the
+/// label surfaced as the literal `^[1 catalog entries](inflect: true)`.
+/// It now goes through the catalog's plural variations for the
+/// `%lld catalog entries` key, which these hosted tests resolve against
+/// the real app bundle (`TEST_HOST` = OnymIOS.app).
+final class DiscoveryEntriesLabelTests: XCTestCase {
+
+    /// Whatever the run locale, inflection markup must never leak into
+    /// the label, and the count must be present.
+    func test_label_neverLeaksInflectionMarkup() {
+        for count in [0, 1, 2, 5, 21] {
+            let label = DiscoveryEntriesLabel.text(count: count)
+            XCTAssertFalse(label.contains("^["),
+                           "raw inflection markup leaked: \(label)")
+            XCTAssertFalse(label.contains("inflect"),
+                           "raw inflection markup leaked: \(label)")
+            XCTAssertTrue(label.contains("\(count)"),
+                          "count missing from label: \(label)")
+        }
+    }
+
+    /// Exact English forms — the plural rule must be the catalog's
+    /// one/other variation, not a raw `%lld catalog entries` fallback
+    /// for count == 1. Meaningful only when the test host resolves to
+    /// English.
+    func test_label_englishPluralForms() throws {
+        guard Bundle.main.preferredLocalizations.first?.hasPrefix("en") == true else {
+            throw XCTSkip("test host is not resolving English localizations")
+        }
+        XCTAssertEqual(DiscoveryEntriesLabel.text(count: 1), "1 catalog entry")
+        XCTAssertEqual(DiscoveryEntriesLabel.text(count: 0), "0 catalog entries")
+        XCTAssertEqual(DiscoveryEntriesLabel.text(count: 2), "2 catalog entries")
+    }
+}

--- a/Tests/OnymIOSUITests/PageObjects/DiscoverySettingsScreen.swift
+++ b/Tests/OnymIOSUITests/PageObjects/DiscoverySettingsScreen.swift
@@ -68,10 +68,11 @@ struct DiscoverySettingsScreen {
     }
 
     /// The source row's verified-entry count line ("1 catalog entry").
-    /// Matched by CONTAINS: the count string goes through automatic
-    /// grammar agreement (`^[…](inflect: true)`), and under the UI-test
-    /// language override the label can surface as the raw inflection
-    /// markup — the count + noun substring is the stable part.
+    /// Matched by CONTAINS so the assertion doesn't care whether the
+    /// plural rule picked "entry" or "entries" — the count + noun stem
+    /// is the stable part. (The line uses the catalog's plural
+    /// variations for `%lld catalog entries`; the tests launch under
+    /// the `en` override, where both forms start with this substring.)
     func entryCountText(_ count: Int) -> XCUIElement {
         app.staticTexts.matching(
             NSPredicate(format: "label CONTAINS %@", "\(count) catalog entr")


### PR DESCRIPTION
Two small cleanups around the discovery surface, zero overlap with `onboarding-unblockers`:

**Stale comment on `DiscoverySource.onymDefault`** — it claimed the deployment "is not live yet". `discovery.onym.app` is live; the comment now states the actual design (the default ships unpinned because pinning is the user's own trust-on-first-use act) and records the currently-served operator key `onym:key:42b0da00…853f24` / fingerprint `4d:a9:ec:c9:e8:6f:6e:97` for maintainers, explicitly marked reference-only, never to be pre-pinned.

**Raw inflection markup in the entry-count label** — UI tests saw `^[1 catalog entries](inflect: true)` rendered literally under the `-AppleLanguages` override. Root cause: the automatic-grammar-agreement string had no entry in any strings catalog (OnymSettings ships no localization resources, and the key was never added to `Resources/Localizable.xcstrings`), so `String(localized:)` fell through to the literal key and the markup reached the screen un-inflected. Fix: a real plural rule via the catalog — new `%lld catalog entries` key with en `one`/`other` and ru `one`/`few`/`many`/`other` variations, resolved through `Bundle.main` like every other app string — extracted into a public `DiscoveryEntriesLabel` helper so the hosted unit tests can pin the rendered forms (`1 catalog entry`, `2 catalog entries`, and never any `^[`/`inflect` leakage in any locale). The page object's stale comment is refreshed; its CONTAINS predicate still matches.

**Verified**: `xcodebuild test` on the OnymDiscovery package scheme (117/117 green) and the app scheme with `-only-testing:OnymIOSTests/DiscoveryEntriesLabelTests` (build + 2/2 green), iPhone 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8