### PR TITLE
Onboarding wiring: RootView gate, step surfaces, first-launch composition

### DIFF
--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
@@ -18,19 +18,8 @@ public struct ModerationConsentView: View {
     public var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    switch flow.state.step {
-                    case .loadingDirectory:
-                        loading
-                    case .pickingAuthority:
-                        picker
-                    case .reviewingManifest, .signing:
-                        review
-                    case .done:
-                        done
-                    }
-                }
-                .padding(.bottom, 32)
+                ModerationConsentContent(flow: flow)
+                    .padding(.bottom, 32)
             }
             .background(OnymTokens.surface.ignoresSafeArea())
             .navigationTitle(navigationTitle)
@@ -69,6 +58,41 @@ public struct ModerationConsentView: View {
         switch flow.state.step {
         case .done: return "Done"
         default: return "Cancel"
+        }
+    }
+
+}
+
+/// The consent surface's step bodies (directory pick → manifest review
+/// → sign → done), extracted from `ModerationConsentView` so the
+/// first-launch onboarding moderation step can embed the exact same
+/// surface — same copy, same accessibility identifiers, same flow —
+/// inside its own scaffold instead of a second implementation.
+/// `ModerationConsentView` remains the standalone presentation
+/// (NavigationStack + dismissal rules) over this content.
+///
+/// The embedder owns the flow's lifecycle: call `flow.start()` /
+/// `flow.stop()` around this view's appearance the way
+/// `ModerationConsentView` does.
+public struct ModerationConsentContent: View {
+    private let flow: ModerationConsentFlow
+
+    public init(flow: ModerationConsentFlow) {
+        self.flow = flow
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            switch flow.state.step {
+            case .loadingDirectory:
+                loading
+            case .pickingAuthority:
+                picker
+            case .reviewingManifest, .signing:
+                review
+            case .done:
+                done
+            }
         }
     }
 

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
@@ -64,6 +64,11 @@ public final class OnboardingFlow {
     /// answers `false`. Racing the probe must never open a skip window
     /// that a resolved `true` would have closed.
     public private(set) var moderationDirectoryHasEntries: Bool?
+    /// Flips exactly once, inside `complete()` — the observable signal
+    /// the presenter dismisses its cover on. `onCompleted` alone can't
+    /// carry the dismissal: it is bound at the composition root, which
+    /// has no handle on the presenting view's state.
+    public private(set) var isCompleted = false
 
     /// Whether the directory probe has answered — the view shows a
     /// progress state on the skip affordance while this is false.
@@ -203,6 +208,7 @@ public final class OnboardingFlow {
             outcomes[step] = .notApplicable
         }
         store.markOnboardingCompleted()
+        isCompleted = true
         onCompleted()
     }
 

--- a/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
+++ b/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
@@ -205,6 +205,20 @@ final class OnboardingFlowTests: XCTestCase {
         XCTAssertEqual(flow.outcomes[.done], .notApplicable)
     }
 
+    /// `isCompleted` is the presenter's dismissal signal: false for the
+    /// whole walk, true only after `complete()` on the Done step — and
+    /// never from a mid-sequence `complete()` call.
+    func testIsCompletedFlipsOnlyFromDone() async {
+        let flow = await makeResolvedFlow()
+        XCTAssertFalse(flow.isCompleted)
+        flow.advance()
+        flow.complete() // mid-sequence — refused
+        XCTAssertFalse(flow.isCompleted)
+        while flow.step != .done { flow.advance() }
+        flow.complete()
+        XCTAssertTrue(flow.isCompleted)
+    }
+
     func testCompleteBeforeDoneIsANoOp() {
         var completedCalls = 0
         let flow = makeFlow(onCompleted: { completedCalls += 1 })

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsFlow.swift
@@ -80,7 +80,9 @@ public final class BlossomRelaySettingsFlow {
         catalog.consentedOffer(for: entry)
     }
 
-    func stop() {
+    /// Public like `RelayerSettingsFlow.stop()` — the onboarding
+    /// blob-transport step drives this flow's lifecycle too.
+    public func stop() {
         snapshotTask?.cancel()
         snapshotTask = nil
         catalog.stop()

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogSection.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogSection.swift
@@ -12,7 +12,11 @@ import OnymFoundation
 /// Renders nothing when `entries` is empty, so pickers without
 /// discovery wired (or with an empty aggregate) look exactly as they
 /// did before this section existed.
-struct DiscoveryCatalogSection: View {
+///
+/// Public since the onboarding wiring: the first-launch transport /
+/// blob / notary steps render the same catalog section the Settings
+/// pickers do.
+public struct DiscoveryCatalogSection: View {
     let entries: [AttributedCatalogEntry]
     /// Cached lookups (computed once per catalog refresh in the flow,
     /// not per row per render — `activeConsent` decodes the whole
@@ -23,7 +27,23 @@ struct DiscoveryCatalogSection: View {
     let accessibilityPrefix: String
     let onSelect: (AttributedCatalogEntry) -> Void
 
-    var body: some View {
+    public init(
+        entries: [AttributedCatalogEntry],
+        activeConsent: @escaping (AttributedCatalogEntry) -> PinnedConsentRecord?,
+        consentedOffer: @escaping (AttributedCatalogEntry) -> ServiceOffer?,
+        tileSymbol: String,
+        accessibilityPrefix: String,
+        onSelect: @escaping (AttributedCatalogEntry) -> Void
+    ) {
+        self.entries = entries
+        self.activeConsent = activeConsent
+        self.consentedOffer = consentedOffer
+        self.tileSymbol = tileSymbol
+        self.accessibilityPrefix = accessibilityPrefix
+        self.onSelect = onSelect
+    }
+
+    public var body: some View {
         if !entries.isEmpty {
             SettingsSectionLabel("FROM CATALOG")
             SettingsCard {

--- a/Packages/OnymSettings/Sources/OnymSettings/ModuleConsentView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/ModuleConsentView.swift
@@ -9,15 +9,19 @@ import OnymModerationUI
 /// relationship, the operator key fingerprint, the offers, the linked
 /// terms when the operator published any, and the exact manifest hash
 /// the acceptance pins. One explicit accept button.
-struct ModuleConsentView: View {
+///
+/// Public since the onboarding wiring: the first-launch transport /
+/// blob / notary steps present the same consent sheet the Settings
+/// pickers do, so catalog picks consent identically in both places.
+public struct ModuleConsentView: View {
     @State private var flow: ModuleConsentFlow
     @Environment(\.dismiss) private var dismiss
 
-    init(flow: ModuleConsentFlow) {
+    public init(flow: ModuleConsentFlow) {
         _flow = State(initialValue: flow)
     }
 
-    var body: some View {
+    public var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {

--- a/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsFlow.swift
@@ -81,7 +81,9 @@ public final class NostrRelaySettingsFlow {
         catalog.consentedOffer(for: entry)
     }
 
-    func stop() {
+    /// Public like `RelayerSettingsFlow.stop()` — the onboarding
+    /// message-transport step drives this flow's lifecycle too.
+    public func stop() {
         snapshotTask?.cancel()
         snapshotTask = nil
         catalog.stop()

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -34,6 +34,854 @@
         }
       }
     },
+    "ADD CUSTOM URL": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ADD CUSTOM URL"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "СВОЙ URL"
+          }
+        }
+      }
+    },
+    "Add your own provider URL": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add your own provider URL"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить URL своего провайдера"
+          }
+        }
+      }
+    },
+    "All published notaries added.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All published notaries added."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все опубликованные нотариусы добавлены."
+          }
+        }
+      }
+    },
+    "Already confirmed — its key is pinned.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Already confirmed — its key is pinned."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уже подтверждён — его ключ закреплён."
+          }
+        }
+      }
+    },
+    "Back": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назад"
+          }
+        }
+      }
+    },
+    "Back up your recovery phrase": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back up your recovery phrase"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сделайте резервную копию фразы восстановления"
+          }
+        }
+      }
+    },
+    "Choose a moderation authority and review its terms.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a moderation authority and review its terms."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите орган модерации и ознакомьтесь с его условиями."
+          }
+        }
+      }
+    },
+    "Choose where your attachments are stored.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose where your attachments are stored."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите, где хранятся ваши вложения."
+          }
+        }
+      }
+    },
+    "Choose who relays your messages.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose who relays your messages."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите, кто доставляет ваши сообщения."
+          }
+        }
+      }
+    },
+    "Choose who timestamps your conversation history.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose who timestamps your conversation history."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите, кто заверяет историю ваших переписок."
+          }
+        }
+      }
+    },
+    "Chosen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chosen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрано"
+          }
+        }
+      }
+    },
+    "Confirm the directory your app uses to find services, or add your own provider.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm the directory your app uses to find services, or add your own provider."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подтвердите каталог, через который приложение находит сервисы, или добавьте собственного провайдера."
+          }
+        }
+      }
+    },
+    "Continue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
+          }
+        }
+      }
+    },
+    "Default": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        }
+      }
+    },
+    "Fetch Provider": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetch Provider"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузить провайдера"
+          }
+        }
+      }
+    },
+    "Fetching the provider's manifest…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fetching the provider's manifest…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загружаем манифест провайдера…"
+          }
+        }
+      }
+    },
+    "File Storage": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File Storage"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранилище файлов"
+          }
+        }
+      }
+    },
+    "FROM CATALOG": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FROM CATALOG"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ИЗ КАТАЛОГА"
+          }
+        }
+      }
+    },
+    "FROM PUBLISHED LIST": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FROM PUBLISHED LIST"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ИЗ ОПУБЛИКОВАННОГО СПИСКА"
+          }
+        }
+      }
+    },
+    "Its catalogs are being fetched and verified now — the next steps can offer what it lists.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Its catalogs are being fetched and verified now — the next steps can offer what it lists."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Его каталоги уже загружаются и проверяются — следующие шаги смогут предложить то, что он публикует."
+          }
+        }
+      }
+    },
+    "Key %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ключ %@"
+          }
+        }
+      }
+    },
+    "Message Transport": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message Transport"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доставка сообщений"
+          }
+        }
+      }
+    },
+    "Moderation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moderation"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Модерация"
+          }
+        }
+      }
+    },
+    "No discovery provider is configured yet. Add your own below, or continue with the built-in defaults.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No discovery provider is configured yet. Add your own below, or continue with the built-in defaults."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Провайдер каталога ещё не настроен. Добавьте собственного ниже или продолжайте со встроенными значениями по умолчанию."
+          }
+        }
+      }
+    },
+    "No notary chosen yet. Pick one below, or skip to use the published defaults.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No notary chosen yet. Pick one below, or skip to use the published defaults."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нотариус ещё не выбран. Выберите его ниже или пропустите, чтобы использовать опубликованные значения по умолчанию."
+          }
+        }
+      }
+    },
+    "No relay configured yet. Add one below, or skip to use the default.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No relay configured yet. Add one below, or skip to use the default."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Релей ещё не настроен. Добавьте его ниже или пропустите, чтобы использовать вариант по умолчанию."
+          }
+        }
+      }
+    },
+    "No server configured yet. Add one below, or skip to use the default.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No server configured yet. Add one below, or skip to use the default."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сервер ещё не настроен. Добавьте его ниже или пропустите, чтобы использовать вариант по умолчанию."
+          }
+        }
+      }
+    },
+    "None": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет"
+          }
+        }
+      }
+    },
+    "None configured": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None configured"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не настроено"
+          }
+        }
+      }
+    },
+    "Not now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not now"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не сейчас"
+          }
+        }
+      }
+    },
+    "Notary": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notary"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нотариус"
+          }
+        }
+      }
+    },
+    "Nothing is final — every choice can change later in Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing is final — every choice can change later in Settings."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ничего не окончательно — любой выбор можно изменить позже в настройках."
+          }
+        }
+      }
+    },
+    "Pin Key & Confirm": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin Key & Confirm"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрепить ключ и подтвердить"
+          }
+        }
+      }
+    },
+    "Provider confirmed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider confirmed"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Провайдер подтверждён"
+          }
+        }
+      }
+    },
+    "Published defaults": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Published defaults"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опубликованные значения по умолчанию"
+          }
+        }
+      }
+    },
+    "Service Directory": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Service Directory"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каталог сервисов"
+          }
+        }
+      }
+    },
+    "Skip": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропустить"
+          }
+        }
+      }
+    },
+    "Skip to use the published defaults — they're installed automatically once setup finishes.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip to use the published defaults — they're installed automatically once setup finishes."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропустите, чтобы использовать опубликованные значения по умолчанию — они будут установлены автоматически после завершения настройки."
+          }
+        }
+      }
+    },
+    "Start": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать"
+          }
+        }
+      }
+    },
+    "Step %lld of %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step %lld of %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шаг %1$lld из %2$lld"
+          }
+        }
+      }
+    },
+    "The next few screens set up the services this app runs on. Each one shows exactly what you're agreeing to before anything is turned on.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The next few screens set up the services this app runs on. Each one shows exactly what you're agreeing to before anything is turned on."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующие несколько экранов настраивают сервисы, на которых работает приложение. Каждый показывает, с чем именно вы соглашаетесь, прежде чем что-либо будет включено."
+          }
+        }
+      }
+    },
+    "The next screens set up the services this app runs on. Each one shows exactly what you're agreeing to before anything is turned on.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The next screens set up the services this app runs on. Each one shows exactly what you're agreeing to before anything is turned on."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующие экраны настраивают сервисы, на которых работает приложение. Каждый показывает, с чем именно вы соглашаетесь, прежде чем что-либо будет включено."
+          }
+        }
+      }
+    },
+    "This build runs without a service directory. Continue — the app uses its built-in defaults.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This build runs without a service directory. Continue — the app uses its built-in defaults."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта сборка работает без каталога сервисов. Продолжайте — приложение использует встроенные значения по умолчанию."
+          }
+        }
+      }
+    },
+    "This fingerprint identifies the provider's operator key. Verify it out-of-band before confirming — it's pinned on confirm, and a later manifest signed by any other key will be rejected.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This fingerprint identifies the provider's operator key. Verify it out-of-band before confirming — it's pinned on confirm, and a later manifest signed by any other key will be rejected."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот отпечаток идентифицирует операторский ключ провайдера. Проверьте его по независимому каналу перед подтверждением — при подтверждении он закрепляется, и манифест, подписанный любым другим ключом, будет отклонён."
+          }
+        }
+      }
+    },
+    "Verify & Confirm": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verify & Confirm"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить и подтвердить"
+          }
+        }
+      }
+    },
+    "Welcome to Onym": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to Onym"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добро пожаловать в Onym"
+          }
+        }
+      }
+    },
+    "You're Set": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're Set"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё готово"
+          }
+        }
+      }
+    },
+    "Your choices are saved. You can revisit any of them in Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your choices are saved. You can revisit any of them in Settings."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваш выбор сохранён. Любой пункт можно изменить в настройках."
+          }
+        }
+      }
+    },
+    "Your identity key is created on this device. No account, no phone number.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your identity key is created on this device. No account, no phone number."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ключ вашей идентичности создаётся на этом устройстве. Ни аккаунта, ни номера телефона."
+          }
+        }
+      }
+    },
+    "Your identity key was created on this device and exists nowhere else. Back it up from Settings → Back Up Recovery Phrase so you can recover your account.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your identity key was created on this device and exists nowhere else. Back it up from Settings → Back Up Recovery Phrase so you can recover your account."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ключ вашей идентичности создан на этом устройстве и больше нигде не существует. Сделайте резервную копию (Настройки → Резервная копия фразы восстановления), чтобы можно было восстановить аккаунт."
+          }
+        }
+      }
+    },
+    "Your identity key was created on this device. Back it up from Settings so you can recover your account.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your identity key was created on this device. Back it up from Settings so you can recover your account."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ключ вашей идентичности создан на этом устройстве. Сделайте резервную копию в настройках, чтобы можно было восстановить аккаунт."
+          }
+        }
+      }
+    },
+    "Your keys, your services. Pick who carries your messages, stores your files, and vouches for your history — every choice is yours, and every one can change later in Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your keys, your services. Pick who carries your messages, stores your files, and vouches for your history — every choice is yours, and every one can change later in Settings."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваши ключи — ваши сервисы. Выберите, кто доставляет ваши сообщения, хранит ваши файлы и заверяет вашу историю. Каждый выбор — ваш, и любой можно изменить позже в настройках."
+          }
+        }
+      }
+    },
+    "YOUR OWN PROVIDER": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YOUR OWN PROVIDER"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "СВОЙ ПРОВАЙДЕР"
+          }
+        }
+      }
+    },
     "—": {
       "localizations": {
         "en": {

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -10,6 +10,7 @@ import OnymSettings
 import OnymModerationUI
 import OnymModeration
 import OnymDiscovery
+import OnymOnboarding
 
 /// App-wide composition root. Constructed exactly once by `OnymIOSApp`
 /// and threaded down to views via `RootView`. Each member is a factory
@@ -105,4 +106,18 @@ struct AppDependencies {
     /// renders without the discovery stack (nil under the UI-test
     /// harness — same pattern as the moderation factories).
     let makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)?
+    /// First-launch onboarding flow factory. Non-nil exactly when THIS
+    /// launch should onboard: `OnboardingGate.shouldOnboard` said yes
+    /// (no completion flag, no existing-user state), and the UI-test
+    /// harness didn't veto it (`--ui-testing` keeps this nil unless
+    /// `--ui-onboarding` opts in, so every existing UI test launches
+    /// exactly as before). RootView calls it once and presents the
+    /// cover while the returned flow is incomplete.
+    let makeOnboardingFlow: (@MainActor () -> OnboardingFlow)?
+    /// Step-content slot for `OnboardingView`: the app-layer surfaces
+    /// (discovery TOFU confirm, catalog pickers, the moderation
+    /// mandate flow) pre-bound to the same repositories and pickers
+    /// the Settings screens use. nil falls back to the package's
+    /// built-in step bodies.
+    let makeOnboardingStepContent: (@MainActor (OnboardingFlow, OnboardingStep) -> AnyView?)?
 }

--- a/Sources/OnymIOS/OnboardingLaunch.swift
+++ b/Sources/OnymIOS/OnboardingLaunch.swift
@@ -1,0 +1,38 @@
+import Foundation
+import OnymChain
+import OnymModeration
+import OnymTransportBlossom
+import OnymTransportNostr
+
+/// The launch-time existing-user probe behind
+/// `OnboardingGate.shouldOnboard`: users who predate onboarding have
+/// no completion flag but plenty of configured state, and must never
+/// be onboarded as if the install were fresh.
+///
+/// The probe is a PURE READ of the synchronous stores (the gate
+/// decision happens in `OnymIOSApp.init`, before any repository
+/// exists) and it never writes the completion flag — completion is
+/// `OnboardingFlow.complete()`'s job alone, so a grandfathered user
+/// simply answers true here on every launch.
+///
+/// Deliberately NOT part of the signal: the seeded defaults. The
+/// Nostr / Blossom repositories seed their configuration with
+/// `hasUserInteracted == false` on first construction, so a fresh
+/// install still reads as fresh after the seed lands.
+enum OnboardingLaunch {
+    /// Any `hasUserInteracted` across the transport/notary
+    /// configurations, or any moderation mandate record — either one
+    /// proves a user who already ran (and shaped) this app.
+    static func isExistingUser(
+        relayerStore: any RelayerSelectionStore = UserDefaultsRelayerSelectionStore(),
+        nostrStore: any NostrRelaysSelectionStore = UserDefaultsNostrRelaysSelectionStore(),
+        blossomStore: any BlossomServersSelectionStore = UserDefaultsBlossomServersSelectionStore(),
+        mandateStore: any MandateStore = UserDefaultsMandateStore()
+    ) -> Bool {
+        if relayerStore.loadConfiguration().hasUserInteracted { return true }
+        if nostrStore.load().hasUserInteracted { return true }
+        if blossomStore.load().hasUserInteracted { return true }
+        if !mandateStore.load().isEmpty { return true }
+        return false
+    }
+}

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -1,0 +1,1028 @@
+import SwiftUI
+import OnymChain
+import OnymDesign
+import OnymDiscovery
+import OnymFoundation
+import OnymModerationUI
+import OnymOnboarding
+import OnymSettings
+import OnymTransportBlossom
+import OnymTransportNostr
+
+// App-layer step content for the first-launch onboarding cover.
+//
+// `OnboardingView` (Packages/OnymOnboarding) renders the frame of each
+// step — title, subtitle, Continue / Skip / Back, the step indicator —
+// and takes each step's body through its `stepContent` slot. The
+// bodies here are the real surfaces, pre-bound by `OnymIOSApp` to the
+// SAME repositories, catalog pickers, and consent flows the Settings
+// screens use: a choice made during onboarding and a choice made later
+// in Settings run the exact same code.
+//
+// Accessibility identifiers follow the scaffold's convention:
+// `onboarding.<step>.<element>`.
+
+/// Everything the step bodies need, bundled so `OnymIOSApp` hands one
+/// value to `AppDependencies.makeOnboardingStepContent`. Each factory
+/// is the verbatim closure the corresponding Settings screen uses.
+@MainActor
+struct OnboardingStepContentBuilder {
+    /// nil when the app runs without discovery (UI-test harness) —
+    /// the discovery step then renders an informational body and the
+    /// catalog sections stay empty, exactly like Settings.
+    let makeDiscoveryFlow: (@MainActor () -> DiscoverySettingsFlow)?
+    let makeNostrFlow: @MainActor () -> NostrRelaySettingsFlow
+    let nostrPicker: DiscoveryModulePicker?
+    let makeBlossomFlow: @MainActor () -> BlossomRelaySettingsFlow
+    let blossomPicker: DiscoveryModulePicker?
+    let makeRelayerFlow: @MainActor () -> RelayerSettingsFlow
+    let relayerPicker: DiscoveryModulePicker?
+    let makeModerationConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
+    let loadSummary: @MainActor () async -> [OnboardingSummaryRow]
+
+    func content(for step: OnboardingStep, flow: OnboardingFlow) -> AnyView? {
+        switch step {
+        case .welcome:
+            return AnyView(OnboardingWelcomeContent())
+        case .discoveryConfirm:
+            return AnyView(OnboardingDiscoveryContent(
+                onboarding: flow,
+                makeFlow: makeDiscoveryFlow
+            ))
+        case .messageTransport:
+            return AnyView(OnboardingNostrContent(
+                onboarding: flow,
+                makeFlow: makeNostrFlow,
+                picker: nostrPicker
+            ))
+        case .blobTransport:
+            return AnyView(OnboardingBlossomContent(
+                onboarding: flow,
+                makeFlow: makeBlossomFlow,
+                picker: blossomPicker
+            ))
+        case .notary:
+            return AnyView(OnboardingNotaryContent(
+                onboarding: flow,
+                makeFlow: makeRelayerFlow,
+                picker: relayerPicker
+            ))
+        case .moderation:
+            return AnyView(OnboardingModerationContent(
+                onboarding: flow,
+                makeConsentFlow: makeModerationConsentFlow
+            ))
+        case .done:
+            return AnyView(OnboardingDoneContent(loadSummary: loadSummary))
+        }
+    }
+}
+
+// MARK: - Shared bits
+
+/// Plain informational card used by steps with nothing actionable
+/// (discovery absent, empty lists).
+private struct OnboardingInfoCard: View {
+    let text: LocalizedStringKey
+    var accessibilityID: String? = nil
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 14))
+            .foregroundStyle(OnymTokens.text2)
+            .lineSpacing(3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .accessibilityIdentifier(accessibilityID ?? "onboarding.info")
+    }
+}
+
+/// One configured-endpoint row (name + badge + URL), shared by the
+/// transport steps. The check mark on the first row is the
+/// "preselected default" affordance — the seed is already installed,
+/// tapping Continue keeps it.
+private struct OnboardingEndpointRow: View {
+    let name: String
+    let url: URL
+    let badge: LocalizedStringKey?
+    let selected: Bool
+    var last: Bool = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(selected ? OnymAccent.blue.color : OnymTokens.text3)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(verbatim: name)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(OnymTokens.text)
+                        if let badge {
+                            Text(badge)
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundStyle(OnymTokens.text2)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(OnymTokens.surface3,
+                                            in: RoundedRectangle(cornerRadius: 4))
+                        }
+                    }
+                    Text(url.absoluteString)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text3)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            if !last {
+                Divider()
+                    .background(OnymTokens.hairline)
+                    .padding(.leading, 46)
+            }
+        }
+    }
+}
+
+/// Custom-URL entry row (field + Add button) shared by the transport /
+/// notary steps — same behavior as the Settings screens' custom-URL
+/// cards, driven by the same flow intents.
+private struct OnboardingCustomURLField: View {
+    let placeholder: String
+    let draft: Binding<String>
+    let error: String?
+    let accessibilityPrefix: String
+    let onAdd: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                TextField(placeholder, text: draft)
+                    .textFieldStyle(.plain)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+                    .font(.system(size: 14, design: .monospaced))
+                    .foregroundStyle(OnymTokens.text)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 10)
+                    .background(OnymTokens.surface3,
+                                in: RoundedRectangle(cornerRadius: 8))
+                    .accessibilityIdentifier("\(accessibilityPrefix).custom_url_field")
+                Button(action: onAdd) {
+                    Text("Add")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(OnymTokens.onAccent)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(OnymAccent.blue.color,
+                                    in: RoundedRectangle(cornerRadius: 8))
+                }
+                .accessibilityIdentifier("\(accessibilityPrefix).add_custom")
+            }
+            if let error {
+                Text(verbatim: error)
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.red)
+                    .accessibilityIdentifier("\(accessibilityPrefix).custom_error")
+            }
+        }
+        .padding(14)
+        .background(OnymTokens.surface2,
+                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+}
+
+/// Section header used inside step bodies (the scaffold already
+/// applies the page's horizontal padding, so no extra inset here).
+private struct OnboardingSectionLabel: View {
+    let text: LocalizedStringKey
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 12.5, weight: .medium))
+            .foregroundStyle(OnymTokens.text2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 16)
+            .padding(.bottom, 6)
+    }
+}
+
+// MARK: - Welcome
+
+/// Brand framing over the scaffold's "your keys, your services"
+/// subtitle. The identity bootstrap stays silent — it already runs in
+/// the WindowGroup task; nothing here mentions or blocks on it.
+struct OnboardingWelcomeContent: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            OnymMark(size: 88, color: OnymAccent.blue.color, strokeRatio: 0.14)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 28)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 14) {
+                row(symbol: "key.fill",
+                    text: "Your identity key is created on this device. No account, no phone number.")
+                row(symbol: "antenna.radiowaves.left.and.right",
+                    text: "The next screens set up the services this app runs on. Each one shows exactly what you're agreeing to before anything is turned on.")
+                row(symbol: "gearshape",
+                    text: "Nothing is final — every choice can change later in Settings.")
+            }
+            .padding(16)
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
+
+    private func row(symbol: String, text: LocalizedStringKey) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: symbol)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(OnymAccent.blue.color)
+                .frame(width: 24)
+            Text(text)
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text2)
+                .lineSpacing(2)
+        }
+    }
+}
+
+// MARK: - Discovery confirm
+
+/// TOFU-confirm the seeded default discovery source — the same
+/// fetch → fingerprint hero → pin-on-explicit-confirm path the
+/// Settings "Confirm…" affordance drives, through the same
+/// `DiscoverySettingsFlow` — plus an "add your own provider" secondary
+/// that feeds the same add path. Skippable: later steps fall back to
+/// the legacy published lists exactly as the app does today.
+struct OnboardingDiscoveryContent: View {
+    let onboarding: OnboardingFlow
+    @State private var flow: DiscoverySettingsFlow?
+    @State private var showAddOwn = false
+
+    init(onboarding: OnboardingFlow, makeFlow: (@MainActor () -> DiscoverySettingsFlow)?) {
+        self.onboarding = onboarding
+        _flow = State(initialValue: makeFlow?())
+    }
+
+    var body: some View {
+        if let flow {
+            content(flow)
+                .task { flow.start() }
+                .onDisappear { flow.stop() }
+                .onChange(of: isAdded(flow)) { _, added in
+                    // Pinning the key IS the consent at this step —
+                    // there's no componentId; the pin is to a provider
+                    // source, not a catalog component.
+                    if added {
+                        onboarding.recordOutcome(.consented(componentId: nil))
+                    }
+                }
+        } else {
+            OnboardingInfoCard(
+                text: "This build runs without a service directory. Continue — the app uses its built-in defaults.",
+                accessibilityID: "onboarding.discoveryConfirm.unavailable"
+            )
+        }
+    }
+
+    private func isAdded(_ flow: DiscoverySettingsFlow) -> Bool {
+        if case .added = flow.addPhase { return true }
+        return false
+    }
+
+    @ViewBuilder
+    private func content(_ flow: DiscoverySettingsFlow) -> some View {
+        switch flow.addPhase {
+        case .idle:
+            idle(flow)
+        case .fetching:
+            HStack(spacing: 10) {
+                ProgressView()
+                Text("Fetching the provider's manifest…")
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 32)
+        case .confirming(let preview):
+            confirm(flow, preview: preview)
+        case .added:
+            VStack(spacing: 10) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 40))
+                    .foregroundStyle(OnymTokens.green)
+                Text("Provider confirmed")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("Its catalogs are being fetched and verified now — the next steps can offer what it lists.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
+            .accessibilityIdentifier("onboarding.discoveryConfirm.added")
+        }
+    }
+
+    @ViewBuilder
+    private func idle(_ flow: DiscoverySettingsFlow) -> some View {
+        if let status = flow.state.sources.first {
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(verbatim: status.source.userLabel)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text)
+                    Text(status.source.manifestURL.absoluteString)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(OnymTokens.text3)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let fingerprint = status.source.operatorKeyFingerprint {
+                        Text(verbatim: String(localized: "Key \(fingerprint)"))
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(OnymTokens.text2)
+                    }
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .accessibilityIdentifier("onboarding.discoveryConfirm.source")
+
+            if status.source.pinnedOperatorKeyHex == nil {
+                SettingsPrimaryButton("Verify & Confirm") {
+                    flow.tappedConfirmSource(providerId: status.source.providerId)
+                }
+                .padding(.top, 12)
+                .accessibilityIdentifier("onboarding.discoveryConfirm.confirm")
+            } else {
+                Label("Already confirmed — its key is pinned.", systemImage: "checkmark.seal.fill")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.green)
+                    .padding(.top, 12)
+                    .accessibilityIdentifier("onboarding.discoveryConfirm.pinned")
+            }
+        } else {
+            OnboardingInfoCard(
+                text: "No discovery provider is configured yet. Add your own below, or continue with the built-in defaults.",
+                accessibilityID: "onboarding.discoveryConfirm.empty"
+            )
+        }
+
+        if let error = flow.addError {
+            Text(verbatim: error)
+                .font(.system(size: 12.5))
+                .foregroundStyle(OnymTokens.red)
+                .padding(.top, 8)
+                .accessibilityIdentifier("onboarding.discoveryConfirm.error")
+        }
+
+        addOwn(flow)
+    }
+
+    /// "Add your own provider URL" secondary — the same
+    /// fetch-then-TOFU path, aimed at a URL the user types.
+    @ViewBuilder
+    private func addOwn(_ flow: DiscoverySettingsFlow) -> some View {
+        @Bindable var flow = flow
+        if showAddOwn {
+            OnboardingSectionLabel(text: "YOUR OWN PROVIDER")
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("https://discovery.example.com/manifest.json", text: $flow.addDraft)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+                    .font(.system(size: 14, design: .monospaced))
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 10)
+                    .background(OnymTokens.surface3,
+                                in: RoundedRectangle(cornerRadius: 8))
+                    .accessibilityIdentifier("onboarding.discoveryConfirm.add_url_field")
+                Button {
+                    flow.tappedFetchProvider()
+                } label: {
+                    Text("Fetch Provider")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(OnymAccent.blue.color)
+                }
+                .accessibilityIdentifier("onboarding.discoveryConfirm.fetch")
+            }
+            .padding(14)
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        } else {
+            Button {
+                showAddOwn = true
+            } label: {
+                Text("Add your own provider URL")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(OnymAccent.blue.color)
+            }
+            .padding(.top, 12)
+            .accessibilityIdentifier("onboarding.discoveryConfirm.add_own")
+        }
+    }
+
+    /// The TOFU confirmation: fingerprint hero + provider summary.
+    /// Nothing is pinned until "Pin Key & Confirm".
+    @ViewBuilder
+    private func confirm(_ flow: DiscoverySettingsFlow, preview: DiscoveryProviderPreview) -> some View {
+        Text("This fingerprint identifies the provider's operator key. Verify it out-of-band before confirming — it's pinned on confirm, and a later manifest signed by any other key will be rejected.")
+            .font(.system(size: 13.5))
+            .foregroundStyle(OnymTokens.text2)
+            .lineSpacing(3)
+
+        Text(verbatim: preview.operatorKeyFingerprint)
+            .font(.system(size: 26, weight: .semibold, design: .monospaced))
+            .foregroundStyle(OnymTokens.text)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 20)
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .padding(.top, 12)
+            .accessibilityIdentifier("onboarding.discoveryConfirm.fingerprint")
+
+        VStack(alignment: .leading, spacing: 6) {
+            Text(verbatim: preview.providerId)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+            Text(preview.manifestURL.absoluteString)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(OnymTokens.text3)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(OnymTokens.surface2,
+                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .padding(.top, 8)
+
+        SettingsPrimaryButton("Pin Key & Confirm") {
+            flow.tappedConfirmAdd()
+        }
+        .padding(.top, 12)
+        .accessibilityIdentifier("onboarding.discoveryConfirm.pin")
+
+        Button("Not now") { flow.tappedCancelPreview() }
+            .font(.system(size: 14))
+            .foregroundStyle(OnymTokens.text2)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 8)
+            .accessibilityIdentifier("onboarding.discoveryConfirm.cancel_preview")
+    }
+}
+
+// MARK: - Message transport (Nostr)
+
+/// Choose who relays messages. The seeded Onym Official relay renders
+/// preselected; the discovery catalog section runs `ModuleConsentFlow`
+/// (as a sheet, like Settings); a custom URL adds without consent —
+/// the user's own typed endpoint is their own choice, not a
+/// catalog-published module.
+struct OnboardingNostrContent: View {
+    let onboarding: OnboardingFlow
+    @State private var flow: NostrRelaySettingsFlow
+    let picker: DiscoveryModulePicker?
+    @State private var consentEntry: AttributedCatalogEntry?
+    @State private var lastConsentEntry: AttributedCatalogEntry?
+
+    init(
+        onboarding: OnboardingFlow,
+        makeFlow: @MainActor () -> NostrRelaySettingsFlow,
+        picker: DiscoveryModulePicker?
+    ) {
+        self.onboarding = onboarding
+        _flow = State(initialValue: makeFlow())
+        self.picker = picker
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            configured
+
+            catalogSection(prefix: "onboarding.messageTransport.catalog")
+
+            OnboardingSectionLabel(text: "ADD CUSTOM URL")
+            OnboardingCustomURLField(
+                placeholder: "wss://relay.example.com",
+                draft: Binding(
+                    get: { flow.state.customDraft },
+                    set: { flow.customDraftChanged($0) }
+                ),
+                error: flow.state.customDraftError,
+                accessibilityPrefix: "onboarding.messageTransport",
+                onAdd: {
+                    flow.tappedAddCustom()
+                    if flow.state.customDraftError == nil {
+                        onboarding.recordOutcome(.consented(componentId: nil))
+                    }
+                }
+            )
+        }
+        .task { flow.start() }
+        .onDisappear { flow.stop() }
+        .sheet(item: $consentEntry, onDismiss: { consentDismissed() }) { entry in
+            if let picker {
+                ModuleConsentView(flow: picker.makeConsentFlow(entry))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var configured: some View {
+        let endpoints = flow.state.snapshot.endpoints
+        if endpoints.isEmpty {
+            OnboardingInfoCard(
+                text: "No relay configured yet. Add one below, or skip to use the default.",
+                accessibilityID: "onboarding.messageTransport.empty"
+            )
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(endpoints.enumerated()), id: \.element.url) { idx, endpoint in
+                    OnboardingEndpointRow(
+                        name: endpoint.name,
+                        url: endpoint.url,
+                        badge: endpoint.isDefault ? "DEFAULT" : nil,
+                        selected: idx == 0,
+                        last: idx == endpoints.count - 1
+                    )
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier("onboarding.messageTransport.configured.\(endpoint.url.absoluteString)")
+                }
+            }
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
+
+    @ViewBuilder
+    private func catalogSection(prefix: String) -> some View {
+        if !flow.catalogEntries.isEmpty {
+            OnboardingSectionLabel(text: "FROM CATALOG")
+            DiscoveryCatalogSection(
+                entries: flow.catalogEntries,
+                activeConsent: { flow.activeConsent(for: $0) },
+                consentedOffer: { flow.consentedOffer(for: $0) },
+                tileSymbol: "antenna.radiowaves.left.and.right.circle.fill",
+                accessibilityPrefix: prefix,
+                onSelect: { entry in
+                    lastConsentEntry = entry
+                    consentEntry = entry
+                }
+            )
+            // DiscoveryCatalogSection carries the Settings pages' own
+            // horizontal insets; pull them back to the scaffold's.
+            .padding(.horizontal, -16)
+        }
+    }
+
+    private func consentDismissed() {
+        flow.refreshCatalog()
+        guard let entry = lastConsentEntry,
+              let record = picker?.activeConsent(entry.entry.componentId),
+              record.manifestHash == entry.entry.manifest.digest
+        else { return }
+        onboarding.recordOutcome(.consented(componentId: entry.entry.componentId))
+    }
+}
+
+// MARK: - Blob transport (Blossom)
+
+/// Choose where attachments are stored. Same shape as the message
+/// transport step; a consented catalog pick becomes the ACTIVE (first)
+/// server via `BlossomCatalogConsent.apply` — the picker's `apply`
+/// closure from the composition root, unchanged.
+struct OnboardingBlossomContent: View {
+    let onboarding: OnboardingFlow
+    @State private var flow: BlossomRelaySettingsFlow
+    let picker: DiscoveryModulePicker?
+    @State private var consentEntry: AttributedCatalogEntry?
+    @State private var lastConsentEntry: AttributedCatalogEntry?
+
+    init(
+        onboarding: OnboardingFlow,
+        makeFlow: @MainActor () -> BlossomRelaySettingsFlow,
+        picker: DiscoveryModulePicker?
+    ) {
+        self.onboarding = onboarding
+        _flow = State(initialValue: makeFlow())
+        self.picker = picker
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            configured
+
+            if !flow.catalogEntries.isEmpty {
+                OnboardingSectionLabel(text: "FROM CATALOG")
+                DiscoveryCatalogSection(
+                    entries: flow.catalogEntries,
+                    activeConsent: { flow.activeConsent(for: $0) },
+                    consentedOffer: { flow.consentedOffer(for: $0) },
+                    tileSymbol: "photo.on.rectangle.angled",
+                    accessibilityPrefix: "onboarding.blobTransport.catalog",
+                    onSelect: { entry in
+                        lastConsentEntry = entry
+                        consentEntry = entry
+                    }
+                )
+                .padding(.horizontal, -16)
+            }
+
+            OnboardingSectionLabel(text: "ADD CUSTOM URL")
+            OnboardingCustomURLField(
+                placeholder: "https://blossom.example.com",
+                draft: Binding(
+                    get: { flow.state.customDraft },
+                    set: { flow.customDraftChanged($0) }
+                ),
+                error: flow.state.customDraftError,
+                accessibilityPrefix: "onboarding.blobTransport",
+                onAdd: {
+                    flow.tappedAddCustom()
+                    if flow.state.customDraftError == nil {
+                        onboarding.recordOutcome(.consented(componentId: nil))
+                    }
+                }
+            )
+        }
+        .task { flow.start() }
+        .onDisappear { flow.stop() }
+        .sheet(item: $consentEntry, onDismiss: { consentDismissed() }) { entry in
+            if let picker {
+                ModuleConsentView(flow: picker.makeConsentFlow(entry))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var configured: some View {
+        let endpoints = flow.state.snapshot.endpoints
+        if endpoints.isEmpty {
+            OnboardingInfoCard(
+                text: "No server configured yet. Add one below, or skip to use the default.",
+                accessibilityID: "onboarding.blobTransport.empty"
+            )
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(endpoints.enumerated()), id: \.element.url) { idx, endpoint in
+                    OnboardingEndpointRow(
+                        name: endpoint.name,
+                        url: endpoint.url,
+                        // First endpoint is the upload/download target.
+                        badge: idx == 0 ? "ACTIVE" : (endpoint.isDefault ? "DEFAULT" : nil),
+                        selected: idx == 0,
+                        last: idx == endpoints.count - 1
+                    )
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier("onboarding.blobTransport.configured.\(endpoint.url.absoluteString)")
+                }
+            }
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
+
+    private func consentDismissed() {
+        flow.refreshCatalog()
+        guard let entry = lastConsentEntry,
+              let record = picker?.activeConsent(entry.entry.componentId),
+              record.manifestHash == entry.entry.manifest.digest
+        else { return }
+        onboarding.recordOutcome(.consented(componentId: entry.entry.componentId))
+    }
+}
+
+// MARK: - Notary (relayer)
+
+/// Choose who timestamps conversation history. While onboarding is
+/// incomplete the relayer repository's first-launch auto-populate is
+/// suppressed (the `autoPopulatePolicy` seam), so the configured list
+/// starts empty here: the published list and the catalog section are
+/// the offers, and skipping installs the published defaults right
+/// after completion.
+struct OnboardingNotaryContent: View {
+    let onboarding: OnboardingFlow
+    @State private var flow: RelayerSettingsFlow
+    let picker: DiscoveryModulePicker?
+    @State private var consentEntry: AttributedCatalogEntry?
+    @State private var lastConsentEntry: AttributedCatalogEntry?
+
+    init(
+        onboarding: OnboardingFlow,
+        makeFlow: @MainActor () -> RelayerSettingsFlow,
+        picker: DiscoveryModulePicker?
+    ) {
+        self.onboarding = onboarding
+        _flow = State(initialValue: makeFlow())
+        self.picker = picker
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            configured
+
+            OnboardingSectionLabel(text: "FROM PUBLISHED LIST")
+            published
+
+            if !flow.catalogEntries.isEmpty {
+                OnboardingSectionLabel(text: "FROM CATALOG")
+                DiscoveryCatalogSection(
+                    entries: flow.catalogEntries,
+                    activeConsent: { flow.activeConsent(for: $0) },
+                    consentedOffer: { flow.consentedOffer(for: $0) },
+                    tileSymbol: "antenna.radiowaves.left.and.right",
+                    accessibilityPrefix: "onboarding.notary.catalog",
+                    onSelect: { entry in
+                        lastConsentEntry = entry
+                        consentEntry = entry
+                    }
+                )
+                .padding(.horizontal, -16)
+            }
+
+            OnboardingSectionLabel(text: "ADD CUSTOM URL")
+            OnboardingCustomURLField(
+                placeholder: "https://relayer.example.com",
+                draft: Binding(
+                    get: { flow.state.customDraft },
+                    set: { flow.customDraftChanged($0) }
+                ),
+                error: flow.state.customDraftError,
+                accessibilityPrefix: "onboarding.notary",
+                onAdd: {
+                    flow.tappedAddCustom()
+                    if flow.state.customDraftError == nil {
+                        onboarding.recordOutcome(.consented(componentId: nil))
+                    }
+                }
+            )
+
+            Text("Skip to use the published defaults — they're installed automatically once setup finishes.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(OnymTokens.text2)
+                .padding(.top, 10)
+        }
+        .task { flow.start() }
+        .onDisappear { flow.stop() }
+        .sheet(item: $consentEntry, onDismiss: { consentDismissed() }) { entry in
+            if let picker {
+                ModuleConsentView(flow: picker.makeConsentFlow(entry))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var configured: some View {
+        let endpoints = flow.state.snapshot.configuration.endpoints
+        if endpoints.isEmpty {
+            OnboardingInfoCard(
+                text: "No notary chosen yet. Pick one below, or skip to use the published defaults.",
+                accessibilityID: "onboarding.notary.empty"
+            )
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(endpoints.enumerated()), id: \.element.url) { idx, endpoint in
+                    OnboardingEndpointRow(
+                        name: endpoint.name,
+                        url: endpoint.url,
+                        badge: nil,
+                        selected: true,
+                        last: idx == endpoints.count - 1
+                    )
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier("onboarding.notary.configured.\(endpoint.url.absoluteString)")
+                }
+            }
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
+
+    /// The legacy published list — tap to add, no consent sheet: these
+    /// entries are published by the onym-relayer project, not consented
+    /// catalog modules.
+    @ViewBuilder
+    private var published: some View {
+        let unconfigured = flow.unconfiguredKnownList
+        VStack(spacing: 0) {
+            switch flow.state.snapshot.fetchStatus {
+            case .idle, .fetching:
+                HStack(spacing: 8) {
+                    ProgressView()
+                    Text("Fetching list…")
+                        .font(.system(size: 14))
+                        .foregroundStyle(OnymTokens.text2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(14)
+                .accessibilityIdentifier("onboarding.notary.published.fetching")
+            case .failed(let message):
+                Text(verbatim: message)
+                    .font(.system(size: 13.5))
+                    .foregroundStyle(OnymTokens.text2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(14)
+                    .accessibilityIdentifier("onboarding.notary.published.failed")
+            case .success where unconfigured.isEmpty:
+                Text("All published notaries added.")
+                    .font(.system(size: 13.5))
+                    .foregroundStyle(OnymTokens.text3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(14)
+                    .accessibilityIdentifier("onboarding.notary.published.all_added")
+            case .success:
+                ForEach(Array(unconfigured.enumerated()), id: \.element.url) { idx, endpoint in
+                    Button {
+                        flow.tappedAddKnown(endpoint)
+                        onboarding.recordOutcome(.consented(componentId: nil))
+                    } label: {
+                        VStack(spacing: 0) {
+                            HStack(spacing: 12) {
+                                Circle().fill(OnymAccent.blue.color)
+                                    .frame(width: 24, height: 24)
+                                    .overlay(Image(systemName: "plus")
+                                        .font(.system(size: 12, weight: .bold))
+                                        .foregroundStyle(OnymTokens.onAccent))
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(verbatim: endpoint.name)
+                                        .font(.system(size: 15, weight: .semibold))
+                                        .foregroundStyle(OnymTokens.text)
+                                    Text(endpoint.url.absoluteString)
+                                        .font(.system(size: 12, design: .monospaced))
+                                        .foregroundStyle(OnymTokens.text3)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                }
+                                Spacer(minLength: 4)
+                                HStack(spacing: 4) {
+                                    ForEach(endpoint.networks, id: \.self) { net in
+                                        SettingsChip(
+                                            text: net.uppercased(),
+                                            fg: net == "public" ? OnymTokens.red : OnymTokens.green,
+                                            bg: (net == "public" ? OnymTokens.red : OnymTokens.green).opacity(0.15)
+                                        )
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 10)
+                            if idx != unconfigured.count - 1 {
+                                Divider()
+                                    .background(OnymTokens.hairline)
+                                    .padding(.leading, 50)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("onboarding.notary.published.\(endpoint.url.absoluteString)")
+                }
+            }
+        }
+        .background(OnymTokens.surface2,
+                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func consentDismissed() {
+        flow.refreshCatalog()
+        guard let entry = lastConsentEntry,
+              let record = picker?.activeConsent(entry.entry.componentId),
+              record.manifestHash == entry.entry.manifest.digest
+        else { return }
+        onboarding.recordOutcome(.consented(componentId: entry.entry.componentId))
+    }
+}
+
+// MARK: - Moderation
+
+/// The moderation mandate flow, embedded: directory pick → hash-pinned
+/// manifest review → sign, rendered by the same
+/// `ModerationConsentContent` the blocking consent cover uses. A signed
+/// mandate records the consent outcome, which is what unlocks Continue
+/// while the directory has entries (the flow's mandatory rule). With an
+/// empty directory the surface is informational and the step skippable.
+struct OnboardingModerationContent: View {
+    let onboarding: OnboardingFlow
+    @State private var flow: ModerationConsentFlow
+
+    init(
+        onboarding: OnboardingFlow,
+        makeConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow
+    ) {
+        self.onboarding = onboarding
+        _flow = State(initialValue: makeConsentFlow(.onboarding))
+    }
+
+    var body: some View {
+        ModerationConsentContent(flow: flow)
+            // The content carries the Settings pages' own horizontal
+            // insets; pull them back to the scaffold's.
+            .padding(.horizontal, -16)
+            .task { flow.start() }
+            .onDisappear { flow.stop() }
+            .onChange(of: flow.state.step) { _, step in
+                if step == .done {
+                    onboarding.recordOutcome(.consented(
+                        componentId: flow.state.selectedListing?.componentId
+                    ))
+                }
+            }
+    }
+}
+
+// MARK: - Done
+
+/// One summary row on the Done step: which seat, what was chosen, and
+/// the identifying detail (endpoint URL / key fingerprint / manifest
+/// hash) so the summary is checkable, not just reassuring.
+struct OnboardingSummaryRow: Identifiable, Sendable {
+    let id: String
+    let title: String
+    let value: String
+    let detail: String?
+}
+
+/// Summary of the chosen components + the backup-phrase nudge. The
+/// recovery-phrase flow itself stays in Settings (it takes biometrics
+/// and its own confirmation walk — not something to inline at the end
+/// of onboarding).
+struct OnboardingDoneContent: View {
+    let loadSummary: @MainActor () async -> [OnboardingSummaryRow]
+    @State private var rows: [OnboardingSummaryRow] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(spacing: 0) {
+                ForEach(Array(rows.enumerated()), id: \.element.id) { idx, row in
+                    VStack(spacing: 0) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                Text(verbatim: row.title)
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundStyle(OnymTokens.text2)
+                                Spacer()
+                                Text(verbatim: row.value)
+                                    .font(.system(size: 13.5, weight: .semibold))
+                                    .foregroundStyle(OnymTokens.text)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+                            if let detail = row.detail {
+                                Text(verbatim: detail)
+                                    .font(.system(size: 11.5, design: .monospaced))
+                                    .foregroundStyle(OnymTokens.text3)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        if idx != rows.count - 1 {
+                            Divider()
+                                .background(OnymTokens.hairline)
+                                .padding(.leading, 14)
+                        }
+                    }
+                }
+            }
+            .background(OnymTokens.surface2,
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("onboarding.done.summary")
+
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "key.viewfinder")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(SettingsTile.amber)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Back up your recovery phrase")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(OnymTokens.text)
+                    Text("Your identity key was created on this device and exists nowhere else. Back it up from Settings → Back Up Recovery Phrase so you can recover your account.")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(OnymTokens.text2)
+                        .lineSpacing(2)
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(SettingsTile.amber.opacity(0.10),
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .padding(.top, 12)
+            .accessibilityIdentifier("onboarding.done.backup_nudge")
+        }
+        .task { rows = await loadSummary() }
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -15,6 +15,7 @@ import OnymModeration
 import OnymModerationUI
 import OnymDiscovery
 import OnymFoundation
+import OnymOnboarding
 
 @main
 struct OnymIOSApp: App {
@@ -177,13 +178,63 @@ struct OnymIOSApp: App {
             }
         }
 
+        // Onboarding gate — decided ONCE per launch, before the relayer
+        // repository exists because its first-launch auto-populate
+        // policy depends on the decision. `shouldOnboard` is a pure
+        // read: completed flag OR existing-user state (any
+        // `hasUserInteracted`, or a moderation mandate) means no
+        // onboarding — users who predate the flow are grandfathered,
+        // never re-onboarded (see `OnboardingGate`).
+        let onboardingStore = UserDefaultsOnboardingStore()
+        let shouldOnboard: Bool
+        #if DEBUG
+        if args.contains("--ui-testing") {
+            // `--reset-keychain` starts each UI test from the same
+            // first-launch shape — the onboarding flag resets through
+            // the store rather than a hardcoded key (OnboardingStore
+            // contract).
+            if args.contains("--reset-keychain") {
+                onboardingStore.resetOnboarding()
+            }
+            // The UI harness never onboards unless `--ui-onboarding`
+            // opts in, so every existing UI test launches exactly as
+            // before. Under the opt-in the fakes are a fresh world, so
+            // the existing-user probe answers false by construction.
+            shouldOnboard = args.contains("--ui-onboarding")
+                && OnboardingGate.shouldOnboard(store: onboardingStore, isExistingUser: { false })
+        } else {
+            shouldOnboard = OnboardingGate.shouldOnboard(
+                store: onboardingStore,
+                isExistingUser: { OnboardingLaunch.isExistingUser() }
+            )
+        }
+        #else
+        shouldOnboard = OnboardingGate.shouldOnboard(
+            store: onboardingStore,
+            isExistingUser: { OnboardingLaunch.isExistingUser() }
+        )
+        #endif
+        // While onboarding is incomplete, a background relayer fetch
+        // must not install the whole published list over the notary
+        // step's empty configuration — the step IS the choice. The
+        // policy re-reads the flag per fetch pass, so the very first
+        // refresh after `complete()` (kicked by the flow's onCompleted)
+        // installs the defaults when the user skipped the step.
+        let relayerAutoPopulatePolicy: @Sendable () -> Bool
+        if shouldOnboard {
+            relayerAutoPopulatePolicy = { onboardingStore.hasCompletedOnboarding() }
+        } else {
+            relayerAutoPopulatePolicy = { true }
+        }
+
         let relayerRepository: RelayerRepository
         let contractsRepository: ContractsRepository
         #if DEBUG
         if args.contains("--ui-testing") {
             relayerRepository = RelayerRepository(
                 fetcher: UITestKnownRelayersFetcher(),
-                store: UITestRelayerSelectionStore()
+                store: UITestRelayerSelectionStore(),
+                autoPopulatePolicy: relayerAutoPopulatePolicy
             )
             contractsRepository = ContractsRepository(
                 fetcher: UITestContractsManifestFetcher(),
@@ -196,7 +247,8 @@ struct OnymIOSApp: App {
                     catalog: discoveryCatalog,
                     makeConsentGate: makeDiscoveryConsentGate
                 ),
-                store: UserDefaultsRelayerSelectionStore()
+                store: UserDefaultsRelayerSelectionStore(),
+                autoPopulatePolicy: relayerAutoPopulatePolicy
             )
             contractsRepository = ContractsRepository(
                 fetcher: GitHubReleasesContractsManifestFetcher(),
@@ -210,7 +262,8 @@ struct OnymIOSApp: App {
                 catalog: discoveryCatalog,
                 makeConsentGate: makeDiscoveryConsentGate
             ),
-            store: UserDefaultsRelayerSelectionStore()
+            store: UserDefaultsRelayerSelectionStore(),
+            autoPopulatePolicy: relayerAutoPopulatePolicy
         )
         contractsRepository = ContractsRepository(
             fetcher: GitHubReleasesContractsManifestFetcher(),
@@ -831,6 +884,126 @@ struct OnymIOSApp: App {
             )
         }
 
+        // Settings-flow factories, declared once because the
+        // onboarding steps reuse them VERBATIM: a step surface and its
+        // Settings screen are the same flow over the same repository +
+        // catalog picker, so a choice consents and applies identically
+        // in both places.
+        let makeRelayerSettingsFlow: @MainActor () -> RelayerSettingsFlow = { @MainActor in
+            RelayerSettingsFlow(repository: relayerRepository, discovery: relayerCatalogPicker)
+        }
+        let makeNostrRelaySettingsFlow: @MainActor () -> NostrRelaySettingsFlow = { @MainActor in
+            NostrRelaySettingsFlow(repository: nostrRelaysRepository, discovery: nostrCatalogPicker)
+        }
+        let makeBlossomRelaySettingsFlow: @MainActor () -> BlossomRelaySettingsFlow = { @MainActor in
+            BlossomRelaySettingsFlow(repository: blossomServersRepository, discovery: blossomCatalogPicker)
+        }
+        let makeModerationConsentFlow: @MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow = { @MainActor mode in
+            ModerationConsentFlow(
+                mode: mode,
+                repository: moderationRepository,
+                onConsented: { moderationGateFlow.consentCompleted() }
+            )
+        }
+        let makeDiscoverySettingsFlow = discoveryRepository.map { repo in
+            { @MainActor in DiscoverySettingsFlow(repository: repo) }
+        }
+
+        // First-launch onboarding factories. Both nil when this launch
+        // doesn't onboard (flag set, existing user, or the UI-test
+        // harness without `--ui-onboarding`).
+        let makeOnboardingFlow: (@MainActor () -> OnboardingFlow)?
+        let makeOnboardingStepContent: (@MainActor (OnboardingFlow, OnboardingStep) -> AnyView?)?
+        if shouldOnboard {
+            makeOnboardingFlow = { @MainActor in
+                OnboardingFlow(
+                    store: onboardingStore,
+                    moderationDirectoryNonEmpty: {
+                        // The flow fails closed until this answers; a
+                        // failed refresh falls back to whatever the
+                        // repository already holds (cached directory
+                        // or empty).
+                        try? await moderationRepository.refresh()
+                        return await !moderationRepository.currentState().authorities.isEmpty
+                    },
+                    onCompleted: { @MainActor in
+                        // The moderation step signed through the same
+                        // repository the gate watches; poke the gate so
+                        // it re-checks immediately instead of
+                        // re-prompting — same call the standalone
+                        // consent cover makes.
+                        moderationGateFlow.consentCompleted()
+                        // Completion flips the relayer auto-populate
+                        // policy back on — install the published notary
+                        // defaults now if the user skipped that step.
+                        Task { try? await relayerRepository.refresh() }
+                    }
+                )
+            }
+            let builder = OnboardingStepContentBuilder(
+                makeDiscoveryFlow: makeDiscoverySettingsFlow,
+                makeNostrFlow: makeNostrRelaySettingsFlow,
+                nostrPicker: nostrCatalogPicker,
+                makeBlossomFlow: makeBlossomRelaySettingsFlow,
+                blossomPicker: blossomCatalogPicker,
+                makeRelayerFlow: makeRelayerSettingsFlow,
+                relayerPicker: relayerCatalogPicker,
+                makeModerationConsentFlow: makeModerationConsentFlow,
+                loadSummary: { @MainActor in
+                    // The Done step's summary is read from the
+                    // repositories, not the walk's outcomes — what the
+                    // app will actually use is the checkable claim.
+                    var rows: [OnboardingSummaryRow] = []
+                    if let discoveryRepository {
+                        let state = await discoveryRepository.currentState()
+                        if let source = state.sources.first {
+                            rows.append(OnboardingSummaryRow(
+                                id: "discovery",
+                                title: String(localized: "Service Directory"),
+                                value: source.source.userLabel,
+                                detail: source.source.operatorKeyFingerprint
+                            ))
+                        }
+                    }
+                    let nostr = await nostrRelaysRepository.currentEndpoints().first
+                    rows.append(OnboardingSummaryRow(
+                        id: "messageTransport",
+                        title: String(localized: "Message Transport"),
+                        value: nostr?.name ?? String(localized: "None configured"),
+                        detail: nostr?.url.absoluteString
+                    ))
+                    let blossom = await blossomServersRepository.currentEndpoints().first
+                    rows.append(OnboardingSummaryRow(
+                        id: "blobTransport",
+                        title: String(localized: "File Storage"),
+                        value: blossom?.name ?? String(localized: "None configured"),
+                        detail: blossom?.url.absoluteString
+                    ))
+                    let relayer = await relayerRepository.currentState().configuration.endpoints.first
+                    rows.append(OnboardingSummaryRow(
+                        id: "notary",
+                        title: String(localized: "Notary"),
+                        value: relayer?.name ?? String(localized: "Published defaults"),
+                        detail: relayer?.url.absoluteString
+                    ))
+                    let mandate = await moderationRepository.currentState().activeMandate
+                    rows.append(OnboardingSummaryRow(
+                        id: "moderation",
+                        title: String(localized: "Moderation"),
+                        value: mandate?.authorityName ?? String(localized: "None"),
+                        detail: mandate?.mandate.manifestHash
+                    ))
+                    return rows
+                }
+            )
+            makeOnboardingStepContent = { @MainActor flow, step in
+                builder.content(for: step, flow: flow)
+            }
+        } else {
+            makeOnboardingFlow = nil
+            makeOnboardingStepContent = nil
+        }
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -838,15 +1011,9 @@ struct OnymIOSApp: App {
                     authenticator: authenticator
                 )
             },
-            makeRelayerSettingsFlow: { @MainActor in
-                RelayerSettingsFlow(repository: relayerRepository, discovery: relayerCatalogPicker)
-            },
-            makeNostrRelaySettingsFlow: { @MainActor in
-                NostrRelaySettingsFlow(repository: nostrRelaysRepository, discovery: nostrCatalogPicker)
-            },
-            makeBlossomRelaySettingsFlow: { @MainActor in
-                BlossomRelaySettingsFlow(repository: blossomServersRepository, discovery: blossomCatalogPicker)
-            },
+            makeRelayerSettingsFlow: makeRelayerSettingsFlow,
+            makeNostrRelaySettingsFlow: makeNostrRelaySettingsFlow,
+            makeBlossomRelaySettingsFlow: makeBlossomRelaySettingsFlow,
             makeAnchorsPickerFlow: { @MainActor in
                 AnchorsPickerFlow(repository: contractsRepository)
             },
@@ -925,13 +1092,7 @@ struct OnymIOSApp: App {
                 await groupAvatarBroadcaster.setName(groupIDHex: groupIDHex, name: name)
             },
             moderationGateFlow: moderationGateFlow,
-            makeModerationConsentFlow: { @MainActor mode in
-                ModerationConsentFlow(
-                    mode: mode,
-                    repository: moderationRepository,
-                    onConsented: { moderationGateFlow.consentCompleted() }
-                )
-            },
+            makeModerationConsentFlow: makeModerationConsentFlow,
             makeModerationSettingsFlow: { @MainActor in
                 ModerationSettingsFlow(
                     repository: moderationRepository,
@@ -996,9 +1157,9 @@ struct OnymIOSApp: App {
                     }
                 )
             },
-            makeDiscoverySettingsFlow: discoveryRepository.map { repo in
-                { @MainActor in DiscoverySettingsFlow(repository: repo) }
-            }
+            makeDiscoverySettingsFlow: makeDiscoverySettingsFlow,
+            makeOnboardingFlow: makeOnboardingFlow,
+            makeOnboardingStepContent: makeOnboardingStepContent
         )
     }
 

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -4,6 +4,8 @@ import OnymChatsUI
 import OnymSettings
 import OnymModerationUI
 import OnymDiscovery
+import OnymDesign
+import OnymOnboarding
 
 /// App shell — `TabView` with the iOS 18+ `Tab(_, systemImage:, value:)`
 /// syntax. The `.search` role places its tab in the system's bottom-right
@@ -27,6 +29,20 @@ struct RootView: View {
 
     @State private var selectedTab: RootTab = .chats
     @Environment(\.scenePhase) private var scenePhase
+
+    /// The first-launch onboarding walk, when THIS launch should
+    /// onboard (`AppDependencies.makeOnboardingFlow` non-nil — the
+    /// gate + grandfathering + UI-test veto were already decided in
+    /// `OnymIOSApp.init`). Presented as a full-screen cover over the
+    /// tab bar; set back to nil on `complete()`, which dismisses it.
+    /// Never re-presented within the session — the flow deliberately
+    /// restarts only on a relaunch that still has no completion flag.
+    @State private var onboardingFlow: OnboardingFlow?
+
+    init(dependencies: AppDependencies) {
+        self.dependencies = dependencies
+        _onboardingFlow = State(initialValue: dependencies.makeOnboardingFlow?())
+    }
 
     /// The blocking consent sheet, when one is up. Driven by the gate,
     /// which stays the single source of truth: `needsConsent` presents
@@ -89,12 +105,12 @@ struct RootView: View {
             // The gate can already be decided by the time this view
             // appears, and `onChange` alone would never present for a
             // value that never changes.
-            consentPresentation = Self.presentation(
+            consentPresentation = presentationUnlessOnboarding(
                 for: dependencies.moderationGateFlow.gate
             )
         }
         .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
-            consentPresentation = Self.presentation(for: gate)
+            consentPresentation = presentationUnlessOnboarding(for: gate)
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
@@ -116,6 +132,56 @@ struct RootView: View {
             )
             .id(presentation.id)
         }
+        // First-launch onboarding, over everything (the moderation
+        // gate's own cover stays suppressed while this is up — the
+        // walk's moderation step is the consent surface). A
+        // full-screen cover has no interactive dismissal, but the
+        // modifier documents intent and guards a future switch to
+        // `.sheet`: the only exits are `complete()` on Done and the
+        // per-step Skips.
+        .fullScreenCover(
+            isPresented: Binding(
+                get: { onboardingFlow != nil },
+                set: { if !$0 { onboardingFlow = nil } }
+            )
+        ) {
+            if let flow = onboardingFlow {
+                OnboardingView(
+                    flow: flow,
+                    stepContent: dependencies.makeOnboardingStepContent.map { make in
+                        { step in make(flow, step) }
+                    },
+                    stepIndicator: { index, count in
+                        AnyView(SettingsStepIndicator(step: index, count: count))
+                    }
+                )
+                .interactiveDismissDisabled(true)
+                .onChange(of: flow.isCompleted) { _, completed in
+                    guard completed else { return }
+                    // Dismiss, then hand control back to the
+                    // moderation gate: if its answer still demands a
+                    // cover (it shouldn't after the walk's consent,
+                    // but the gate stays the single source of truth),
+                    // it goes up now instead of never.
+                    onboardingFlow = nil
+                    consentPresentation = Self.presentation(
+                        for: dependencies.moderationGateFlow.gate
+                    )
+                }
+            }
+        }
+    }
+
+    /// The moderation gate's cover is suppressed while onboarding is
+    /// up: the walk's moderation step embeds the same consent surface,
+    /// so presenting both would stack two identical obligations. The
+    /// gate itself keeps running — its answer is re-read the moment
+    /// onboarding completes.
+    private func presentationUnlessOnboarding(
+        for gate: ModerationGateFlow.RootGate
+    ) -> ConsentPresentation? {
+        guard onboardingFlow == nil else { return nil }
+        return Self.presentation(for: gate)
     }
 
     /// Both consent gates present the same surface; only the gate

--- a/Tests/OnymIOSTests/OnboardingLaunchTests.swift
+++ b/Tests/OnymIOSTests/OnboardingLaunchTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import OnymIOS
+import OnymChain
+import OnymModeration
+import OnymOnboarding
+import OnymTransportBlossom
+import OnymTransportNostr
+
+/// The launch-time existing-user probe behind
+/// `OnboardingGate.shouldOnboard`: a fresh install onboards; any
+/// touched configuration or a moderation mandate grandfathers the
+/// user past the walk. All pure reads — the probe writes nothing.
+final class OnboardingLaunchTests: XCTestCase {
+
+    // MARK: - Fresh install
+
+    func test_freshInstall_isNotExistingUser() {
+        XCTAssertFalse(OnboardingLaunch.isExistingUser(
+            relayerStore: FakeRelayerStore(),
+            nostrStore: FakeNostrStore(),
+            blossomStore: FakeBlossomStore(),
+            mandateStore: FakeMandateStore()
+        ))
+    }
+
+    /// The Nostr/Blossom repositories seed their configuration with
+    /// `hasUserInteracted == false` — a seeded-but-untouched install
+    /// must still onboard.
+    func test_seededDefaults_doNotCountAsExistingUser() {
+        let url = URL(string: "https://official.example")!
+        XCTAssertFalse(OnboardingLaunch.isExistingUser(
+            relayerStore: FakeRelayerStore(),
+            nostrStore: FakeNostrStore(configuration: NostrRelaysConfiguration(
+                endpoints: [NostrRelayEndpoint.custom(url: url)],
+                hasUserInteracted: false
+            )),
+            blossomStore: FakeBlossomStore(configuration: BlossomServersConfiguration(
+                endpoints: [BlossomServerEndpoint.custom(url: url)],
+                hasUserInteracted: false
+            )),
+            mandateStore: FakeMandateStore()
+        ))
+    }
+
+    // MARK: - Grandfathering signals
+
+    func test_relayerInteraction_grandfathers() {
+        let store = FakeRelayerStore(configuration: RelayerConfiguration(
+            endpoints: [],
+            primaryURL: nil,
+            strategy: .primary,
+            hasUserInteracted: true
+        ))
+        XCTAssertTrue(OnboardingLaunch.isExistingUser(
+            relayerStore: store,
+            nostrStore: FakeNostrStore(),
+            blossomStore: FakeBlossomStore(),
+            mandateStore: FakeMandateStore()
+        ))
+    }
+
+    func test_nostrInteraction_grandfathers() {
+        XCTAssertTrue(OnboardingLaunch.isExistingUser(
+            relayerStore: FakeRelayerStore(),
+            nostrStore: FakeNostrStore(configuration: NostrRelaysConfiguration(
+                endpoints: [], hasUserInteracted: true
+            )),
+            blossomStore: FakeBlossomStore(),
+            mandateStore: FakeMandateStore()
+        ))
+    }
+
+    func test_blossomInteraction_grandfathers() {
+        XCTAssertTrue(OnboardingLaunch.isExistingUser(
+            relayerStore: FakeRelayerStore(),
+            nostrStore: FakeNostrStore(),
+            blossomStore: FakeBlossomStore(configuration: BlossomServersConfiguration(
+                endpoints: [], hasUserInteracted: true
+            )),
+            mandateStore: FakeMandateStore()
+        ))
+    }
+
+    func test_mandatePresence_grandfathers() {
+        XCTAssertTrue(OnboardingLaunch.isExistingUser(
+            relayerStore: FakeRelayerStore(),
+            nostrStore: FakeNostrStore(),
+            blossomStore: FakeBlossomStore(),
+            mandateStore: FakeMandateStore(records: [Self.mandateRecord()])
+        ))
+    }
+
+    // MARK: - Gate composition
+
+    func test_gate_onboardsExactlyOnFreshWorld() {
+        let suite = "onboarding.launch.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = UserDefaultsOnboardingStore(defaults: defaults)
+
+        XCTAssertTrue(OnboardingGate.shouldOnboard(store: store, isExistingUser: { false }))
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { true }))
+        store.markOnboardingCompleted()
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { false }))
+    }
+
+    // MARK: - Fakes
+
+    private struct FakeRelayerStore: RelayerSelectionStore {
+        var configuration: RelayerConfiguration = .empty
+        func loadConfiguration() -> RelayerConfiguration { configuration }
+        func saveConfiguration(_ configuration: RelayerConfiguration) {}
+        func loadCachedKnownList() -> [RelayerEndpoint] { [] }
+        func saveCachedKnownList(_ list: [RelayerEndpoint]) {}
+    }
+
+    private struct FakeNostrStore: NostrRelaysSelectionStore {
+        var configuration: NostrRelaysConfiguration = .empty
+        func load() -> NostrRelaysConfiguration { configuration }
+        func save(_ configuration: NostrRelaysConfiguration) {}
+    }
+
+    private struct FakeBlossomStore: BlossomServersSelectionStore {
+        var configuration: BlossomServersConfiguration = .empty
+        func load() -> BlossomServersConfiguration { configuration }
+        func save(_ configuration: BlossomServersConfiguration) {}
+    }
+
+    private struct FakeMandateStore: MandateStore {
+        var records: [MandateRecord] = []
+        func load() -> [MandateRecord] { records }
+        func save(_ records: [MandateRecord]) {}
+    }
+
+    private static func mandateRecord() -> MandateRecord {
+        MandateRecord(
+            mandate: ModerationMandate(
+                user: "onym:key:user",
+                interface: "onym:component:onym-ios",
+                authority: "onym:component:authority",
+                manifestHash: "aa",
+                classes: ["csam"],
+                deviceBinding: "enrollment-1",
+                acceptedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                signatures: ["user-sig"]
+            ),
+            manifestBytes: Data("{}".utf8),
+            authorityName: "A",
+            countersigned: false,
+            isActive: true,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -35,6 +35,7 @@ packages:
   OnymModeration: {path: Packages/OnymModeration}
   OnymModerationUI: {path: Packages/OnymModerationUI}
   OnymDiscovery: {path: Packages/OnymDiscovery}
+  OnymOnboarding: {path: Packages/OnymOnboarding}
 
 targets:
   OnymIOS:
@@ -64,6 +65,7 @@ targets:
       - package: OnymModeration
       - package: OnymModerationUI
       - package: OnymDiscovery
+      - package: OnymOnboarding
     # Hand-written Info.plist via xcodegen's `info:` block. We tried
     # the GENERATE_INFOPLIST_FILE + INFOPLIST_KEY_* approach first but
     # `INFOPLIST_KEY_UILaunchScreen_BackgroundColor` / `_ImageName` are
@@ -227,6 +229,7 @@ targets:
       - package: OnymModeration
       - package: OnymModerationUI
       - package: OnymDiscovery
+      - package: OnymOnboarding
 
   OnymIOSUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
PR 3 of the onboarding sequence (after #249's state machine and #250's unblockers): first-launch, Apple-new-device-style onboarding, fully wired.

## What / why

A fresh install now walks a seven-step full-screen cover before landing in the app. Every step surface is the *same* flow/repository/picker code the Settings screens use — a choice made during onboarding and one made later in Settings run identical paths, so nothing consents, pins, or applies differently.

- **RootView gate** — `OnboardingGate.shouldOnboard` (decided once in `OnymIOSApp.init`, pure read) drives a `fullScreenCover` + `.interactiveDismissDisabled(true)` over the tab bar, same pattern as the moderation consent cover. While onboarding is up the moderation gate's own cover is suppressed (the walk's step 6 *is* that surface); on completion the flow sets the flag, the cover dismisses on the new `OnboardingFlow.isCompleted` signal, and `moderationGateFlow.consentCompleted()` runs so the gate re-checks instead of re-prompting.
- **Grandfathering** — `OnboardingLaunch.isExistingUser` (new, unit-tested): any `hasUserInteracted` across relayer/Nostr/Blossom configurations, or any mandate record, means no onboarding, ever. Seeded-but-untouched defaults deliberately do **not** count.
- **`AppDependencies.makeOnboardingFlow`** — `(@MainActor () -> OnboardingFlow)?`, nil under `--ui-testing` unless `--ui-onboarding`, so every existing UI test launches exactly as before (`--reset-keychain` also clears the completion flag through the store). A sibling `makeOnboardingStepContent` slot carries the step bodies.
- **Notary auto-populate** — the relayer repository's #250 `autoPopulatePolicy` seam now answers false while onboarding is incomplete; `complete()` kicks one `refresh()`, which installs the published defaults iff the user skipped the step (an explicit pick already flipped `hasUserInteracted`).

## Steps

1. **Welcome** — OnymMark brand framing, "your keys, your services"; identity bootstrap stays silent. Unskippable, Continue only.
2. **Service Directory** — TOFU-confirm of the seeded default source through `DiscoverySettingsFlow`'s own confirm path (fetch → fingerprint hero → pin on explicit confirm), plus "add your own provider URL". Skippable → legacy lists.
3. **Message Transport** — seeded Onym Official preselected; discovery catalog entries consent through `ModuleConsentFlow` (sheet, exactly like Settings); custom URL adds without consent.
4. **File Storage** — Blossom catalog picker from #250; a consented pick becomes the ACTIVE first server via `BlossomCatalogConsent.apply` (addEndpoint makeActive).
5. **Notary** — published list + catalog + custom URL over an auto-populate-suppressed configuration; skip installs published defaults after completion.
6. **Moderation** — the mandate flow embedded via the newly extracted public `ModerationConsentContent` (same copy, same accessibility ids as the blocking cover); mandatory while the directory has entries (tri-state fail-closed probe), informational + skippable when empty.
7. **Done** — summary card read back from the repositories (names + endpoint/fingerprint/manifest-hash details) and the backup-phrase nudge pointing at Settings → Back Up Recovery Phrase (deliberately not inlined — that flow takes biometrics).

Progress renders through `SettingsStepIndicator` (count 7). Accessibility ids follow `onboarding.<step>.<element>`.

`OnboardingFlow`'s #249 semantics are untouched except one addition: `isCompleted`, flipped only inside `complete()`, as the presenter's dismissal signal (covered by a new flow test).

Small enablers: `ModuleConsentView`, `DiscoveryCatalogSection`, and the Nostr/Blossom flows' `stop()` are now public; `ModerationConsentContent` extracted from `ModerationConsentView` (pure move, view delegates to it). `project.yml` registers OnymOnboarding for the app + unit-test targets. All new user-facing copy is in `Resources/Localizable.xcstrings` with en + ru (including #249's step titles/subtitles, which had no catalog entries yet).

## Verification

- `OnymOnboarding` package suite: **35 tests, 0 failures** (incl. new `isCompleted` test)
- `OnymDiscovery` package suite: **117 tests, 0 failures**
- `OnymFoundation` package suite: **53 tests, 0 failures**
- App unit suite (`OnymIOSTests`): **1243 tests (3 skipped), 0 failures** (incl. new `OnboardingLaunchTests`)
- App target builds (iPhone 17 Pro simulator, Xcode 26)
- UI-test posture: every existing suite launches via `AppLauncher` with `--ui-testing` and no `--ui-onboarding`, so `makeOnboardingFlow` is nil and no cover presents; representative run of `RelayerSettingsUITests` (exercises the relayer config + auto-populate path under `--ui-testing`): **4 tests, 0 failures** — no onboarding cover presented. The full UI matrix runs in the release workflow as usual.

PR 4 (the UI-test walk of the flow + a `--skip-onboarding` convenience for other suites) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8
