### PR TITLE
Settings: Restart Onboarding — re-run seat selection, keep identity and chats

### DIFF
--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStore.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStore.swift
@@ -1,30 +1,49 @@
 import Foundation
 
-/// Persistence seam for the one bit the onboarding gate needs: has the
-/// user completed (or been grandfathered past) the first-launch flow.
+/// Persistence seam for the two bits the onboarding gate needs: has
+/// the user completed (or been grandfathered past) the first-launch
+/// flow, and did they explicitly ask to run it again.
 public protocol OnboardingStore: Sendable {
     /// Whether the completion flag is set.
     func hasCompletedOnboarding() -> Bool
-    /// Set the completion flag. Idempotent.
+    /// Set the completion flag. Idempotent. Also ends any pending
+    /// restart request — completion is completion, however the walk
+    /// was entered.
     func markOnboardingCompleted()
-    /// Clear the completion flag, so the next launch onboards again.
-    /// The app's `--reset-keychain` test path calls this instead of
-    /// hardcoding the storage key. Idempotent.
+    /// Clear the completion flag AND any restart request, so the next
+    /// launch onboards again as if fresh. The app's `--reset-keychain`
+    /// test path calls this instead of hardcoding the storage keys.
+    /// Idempotent.
     func resetOnboarding()
+    /// Whether the user explicitly asked to re-run onboarding
+    /// (Settings → Restart Onboarding) and hasn't completed it since.
+    /// Persisted: an app killed mid-restart-walk resumes on next
+    /// launch. This is the signal that OUTRANKS grandfathering in
+    /// `OnboardingGate.shouldOnboard` — an existing user's configured
+    /// state must suppress onboarding they never asked for, never
+    /// onboarding they explicitly requested.
+    func isRestartRequested() -> Bool
+    /// Record an explicit restart request: sets the restart marker and
+    /// clears the completion flag in one intent, so every reading of
+    /// the store agrees the walk is due. Idempotent.
+    func requestRestart()
 }
 
-/// Production `OnboardingStore`. Single boolean under
-/// `app.onym.ios.onboarding.completed` — cleared by the app's
-/// `--reset-keychain` test path alongside the other first-run state.
+/// Production `OnboardingStore`. Two booleans —
+/// `app.onym.ios.onboarding.completed` and
+/// `app.onym.ios.onboarding.restartRequested` — cleared together by
+/// the app's `--reset-keychain` test path alongside the other
+/// first-run state.
 ///
 /// `@unchecked Sendable` for the same reason as the sibling
 /// UserDefaults stores (e.g. `UserDefaultsSeatSelectionStore`):
 /// `UserDefaults` is documented thread-safe but not formally
 /// `Sendable`.
 public struct UserDefaultsOnboardingStore: OnboardingStore, @unchecked Sendable {
-    /// Internal so tests can assert the exact key the app's reset path
-    /// must clear.
+    /// Internal so tests can assert the exact keys the app's reset
+    /// path must clear.
     static let key = "app.onym.ios.onboarding.completed"
+    static let restartKey = "app.onym.ios.onboarding.restartRequested"
 
     private let defaults: UserDefaults
 
@@ -38,9 +57,20 @@ public struct UserDefaultsOnboardingStore: OnboardingStore, @unchecked Sendable 
 
     public func markOnboardingCompleted() {
         defaults.set(true, forKey: Self.key)
+        defaults.removeObject(forKey: Self.restartKey)
     }
 
     public func resetOnboarding() {
+        defaults.removeObject(forKey: Self.key)
+        defaults.removeObject(forKey: Self.restartKey)
+    }
+
+    public func isRestartRequested() -> Bool {
+        defaults.bool(forKey: Self.restartKey)
+    }
+
+    public func requestRestart() {
+        defaults.set(true, forKey: Self.restartKey)
         defaults.removeObject(forKey: Self.key)
     }
 }
@@ -63,10 +93,18 @@ public enum OnboardingGate {
     /// onboarding. The probe is a pure read: it never writes the flag
     /// itself (completion is `OnboardingFlow.complete()`'s job), so a
     /// grandfathered user simply answers false here on every launch.
+    ///
+    /// The one thing that OUTRANKS both: an explicit restart request
+    /// (Settings → Restart Onboarding). Grandfathering exists to stop
+    /// configured users being onboarded as if fresh — it must never
+    /// stop onboarding they explicitly asked for, including the resume
+    /// after an app killed mid-restart-walk. Cold-boot behavior for
+    /// upgraders is unchanged: they never carry the marker.
     public static func shouldOnboard(
         store: any OnboardingStore,
         isExistingUser: () -> Bool
     ) -> Bool {
+        if store.isRestartRequested() { return true }
         if store.hasCompletedOnboarding() { return false }
         if isExistingUser() { return false }
         return true

--- a/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingStoreTests.swift
+++ b/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingStoreTests.swift
@@ -106,4 +106,64 @@ final class OnboardingStoreTests: XCTestCase {
         _ = OnboardingGate.shouldOnboard(store: store, isExistingUser: { true })
         XCTAssertFalse(store.hasCompletedOnboarding())
     }
+
+    // MARK: - Restart request (Settings → Restart Onboarding)
+
+    func testRequestRestartSetsMarkerAndClearsCompleted() {
+        store.markOnboardingCompleted()
+        store.requestRestart()
+        XCTAssertTrue(store.isRestartRequested())
+        XCTAssertFalse(store.hasCompletedOnboarding())
+        // Idempotent.
+        store.requestRestart()
+        XCTAssertTrue(store.isRestartRequested())
+    }
+
+    /// Completion ends the restart, however the walk was entered — the
+    /// marker must not survive to re-open the gate on the next launch.
+    func testMarkCompletedClearsRestartMarker() {
+        store.requestRestart()
+        store.markOnboardingCompleted()
+        XCTAssertFalse(store.isRestartRequested())
+        XCTAssertTrue(store.hasCompletedOnboarding())
+        XCTAssertNil(defaults.object(forKey: UserDefaultsOnboardingStore.restartKey))
+    }
+
+    /// The app's `--reset-keychain` path clears BOTH documented keys.
+    func testResetOnboardingClearsRestartMarkerToo() {
+        XCTAssertEqual(
+            UserDefaultsOnboardingStore.restartKey,
+            "app.onym.ios.onboarding.restartRequested"
+        )
+        store.requestRestart()
+        store.resetOnboarding()
+        XCTAssertFalse(store.isRestartRequested())
+        XCTAssertNil(defaults.object(forKey: UserDefaultsOnboardingStore.restartKey))
+    }
+
+    /// The substantive rule: an explicit restart OUTRANKS
+    /// grandfathering. A configured user's state suppresses onboarding
+    /// they never asked for — never onboarding they requested.
+    func testRestartRequestOverridesGrandfathering() {
+        store.requestRestart()
+        XCTAssertTrue(OnboardingGate.shouldOnboard(store: store, isExistingUser: { true }))
+    }
+
+    /// A mid-walk kill resumes: the marker persists until completion,
+    /// so the next cold boot's gate answers onboard again.
+    func testRestartMarkerPersistsUntilCompletion() {
+        store.requestRestart()
+        // Simulate relaunch: a fresh store over the same defaults.
+        let relaunched = UserDefaultsOnboardingStore(defaults: defaults)
+        XCTAssertTrue(OnboardingGate.shouldOnboard(store: relaunched, isExistingUser: { true }))
+        relaunched.markOnboardingCompleted()
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: relaunched, isExistingUser: { true }))
+    }
+
+    /// Cold-boot grandfathering for upgraders is untouched: without
+    /// the marker, existing-user state still suppresses onboarding.
+    func testGrandfatheringUnchangedWithoutRestartMarker() {
+        XCTAssertFalse(store.isRestartRequested())
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { true }))
+    }
 }

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -38,6 +38,14 @@ public struct SettingsView: View {
     /// renders without the discovery stack (the section is hidden
     /// until the app wires this in — same pattern as moderation).
     let makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)?
+    /// Settings → Restart Onboarding: re-runs the first-launch seat
+    /// selection. KEEPS identity, chats, messages, and every current
+    /// choice — the walk just runs again over the applied
+    /// configuration. Optional so the row hides when the app runs
+    /// without onboarding (UI-test harness) — same pattern as the
+    /// moderation/discovery factories. The closure fires only after
+    /// the confirmation alert.
+    let onRestartOnboarding: (@MainActor () -> Void)?
 
     public init(
         makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow,
@@ -50,7 +58,8 @@ public struct SettingsView: View {
         makeModerationSettingsFlow: (@MainActor () -> ModerationSettingsFlow)? = nil,
         makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)? = nil,
         makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil,
-        makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)? = nil
+        makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)? = nil,
+        onRestartOnboarding: (@MainActor () -> Void)? = nil
     ) {
         self.makeBackupFlow = makeBackupFlow
         self.makeRelayerSettingsFlow = makeRelayerSettingsFlow
@@ -63,6 +72,7 @@ public struct SettingsView: View {
         self.makeModerationConsentFlow = makeModerationConsentFlow
         self.makeModerationCaseFlow = makeModerationCaseFlow
         self.makeDiscoverySettingsFlow = makeDiscoverySettingsFlow
+        self.onRestartOnboarding = onRestartOnboarding
     }
 
     @State private var showRecoveryPhrase = false
@@ -72,6 +82,11 @@ public struct SettingsView: View {
     /// First / second gate of the "clear message cache" double-confirm.
     @State private var showClearConfirm1 = false
     @State private var showClearConfirm2 = false
+
+    /// Confirmation gate for Restart Onboarding. Single confirm —
+    /// unlike the message-cache clear, nothing is deleted: identity,
+    /// chats, messages, and every current selection are kept.
+    @State private var showRestartOnboardingConfirm = false
 
     /// Persisted in `UserDefaults` under the same key
     /// `UserDefaultsNetworkPreference` reads. Toggling here changes
@@ -224,6 +239,26 @@ public struct SettingsView: View {
                     SettingsFootnote("The moderation authority handles reports of prohibited content under terms you consented to. You can switch to a different authority at any time.")
                 }
 
+                if onRestartOnboarding != nil {
+                    SettingsSectionLabel("SETUP")
+                    SettingsCard {
+                        Button { showRestartOnboardingConfirm = true } label: {
+                            SettingsRow(
+                                title: "Restart Onboarding",
+                                subtitle: "Review your service choices again",
+                                hasChevron: false,
+                                last: true
+                            ) {
+                                SettingsIconTile(symbol: "arrow.counterclockwise.circle.fill",
+                                                 bg: SettingsTile.blue)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("settings.restart_onboarding_row")
+                    }
+                    SettingsFootnote("Runs the first-launch setup again: message transport, file storage, notary, and moderation. Your identity, chats, and messages are kept, and your current choices stay until you change them.")
+                }
+
                 SettingsSectionLabel("DATA")
                 SettingsCard {
                     SettingsRow(
@@ -285,6 +320,12 @@ public struct SettingsView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This permanently deletes every message stored on this device. Your chats stay in the list, but the messages inside them will be gone.\n\nOnym keeps no copy on its servers, and messages can’t be re-downloaded — relay copies are best-effort and may already have expired.")
+        }
+        .alert("Restart onboarding?", isPresented: $showRestartOnboardingConfirm) {
+            Button("Restart Setup") { onRestartOnboarding?() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("The first-launch setup runs again so you can review who carries your messages, stores your files, notarizes your history, and moderates reports.\n\nNothing is deleted: your identity, chats, and messages are kept, and your current choices stay until you change them.")
         }
         .alert("Delete all messages?", isPresented: $showClearConfirm2) {
             Button("Delete All Messages", role: .destructive) {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -594,6 +594,86 @@
         }
       }
     },
+    "Restart Onboarding": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Onboarding"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пройти настройку заново"
+          }
+        }
+      }
+    },
+    "Restart onboarding?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart onboarding?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пройти настройку заново?"
+          }
+        }
+      }
+    },
+    "Restart Setup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Setup"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить настройку"
+          }
+        }
+      }
+    },
+    "Review your service choices again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review your service choices again"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пересмотреть выбор сервисов"
+          }
+        }
+      }
+    },
+    "Runs the first-launch setup again: message transport, file storage, notary, and moderation. Your identity, chats, and messages are kept, and your current choices stay until you change them.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs the first-launch setup again: message transport, file storage, notary, and moderation. Your identity, chats, and messages are kept, and your current choices stay until you change them."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запускает первичную настройку заново: доставка сообщений, хранилище файлов, нотариус и модерация. Ваша идентичность, чаты и сообщения сохраняются, а текущий выбор остаётся в силе, пока вы его не измените."
+          }
+        }
+      }
+    },
     "Service Directory": {
       "localizations": {
         "en": {
@@ -606,6 +686,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Каталог сервисов"
+          }
+        }
+      }
+    },
+    "SETUP": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SETUP"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "НАСТРОЙКА"
           }
         }
       }
@@ -670,6 +766,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Шаг %1$lld из %2$lld"
+          }
+        }
+      }
+    },
+    "The first-launch setup runs again so you can review who carries your messages, stores your files, notarizes your history, and moderates reports.\n\nNothing is deleted: your identity, chats, and messages are kept, and your current choices stay until you change them.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The first-launch setup runs again so you can review who carries your messages, stores your files, notarizes your history, and moderates reports.\n\nNothing is deleted: your identity, chats, and messages are kept, and your current choices stay until you change them."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Первичная настройка запустится заново, чтобы вы могли пересмотреть, кто доставляет ваши сообщения, хранит ваши файлы, заверяет вашу историю и модерирует жалобы.\n\nНичего не удаляется: ваша идентичность, чаты и сообщения сохраняются, а текущий выбор остаётся в силе, пока вы его не измените."
           }
         }
       }

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -106,14 +106,23 @@ struct AppDependencies {
     /// renders without the discovery stack (nil under the UI-test
     /// harness — same pattern as the moderation factories).
     let makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)?
-    /// First-launch onboarding flow factory. Non-nil exactly when THIS
-    /// launch should onboard: `OnboardingGate.shouldOnboard` said yes
-    /// (no completion flag, no existing-user state), and the UI-test
-    /// harness didn't veto it (`--ui-testing` keeps this nil unless
-    /// `--ui-onboarding` opts in, so every existing UI test launches
-    /// exactly as before). RootView calls it once and presents the
-    /// cover while the returned flow is incomplete.
+    /// Onboarding flow factory. Non-nil whenever onboarding is
+    /// AVAILABLE in this build (always in production; under
+    /// `--ui-testing` only with `--ui-onboarding`, so every existing
+    /// UI test launches exactly as before). Whether the cover presents
+    /// at launch is `presentOnboardingAtLaunch` — the factory alone no
+    /// longer implies presentation, because Settings → Restart
+    /// Onboarding can present a fresh walk mid-session.
     let makeOnboardingFlow: (@MainActor () -> OnboardingFlow)?
+    /// The cold-boot gate decision (`OnboardingGate.shouldOnboard`,
+    /// grandfathering included): RootView presents the cover on first
+    /// mount exactly when this is true.
+    let presentOnboardingAtLaunch: Bool
+    /// Settings → Restart Onboarding bridge: Settings raises it, the
+    /// RootView observes `pendingRestart` and presents a fresh walk.
+    /// nil exactly when `makeOnboardingFlow` is nil (the Settings row
+    /// hides too).
+    let onboardingRestart: OnboardingRestartController?
     /// Step-content slot for `OnboardingView`: the app-layer surfaces
     /// (discovery TOFU confirm, catalog pickers, the moderation
     /// mandate flow) pre-bound to the same repositories and pickers

--- a/Sources/OnymIOS/OnboardingLaunch.swift
+++ b/Sources/OnymIOS/OnboardingLaunch.swift
@@ -1,8 +1,53 @@
 import Foundation
+import Observation
 import OnymChain
 import OnymModeration
+import OnymOnboarding
 import OnymTransportBlossom
 import OnymTransportNostr
+
+/// Settings → Restart Onboarding. Bridges the Settings action to the
+/// RootView cover WITHOUT re-running the cold-boot gate: the launch
+/// gate's grandfathering probe exists to stop configured users being
+/// onboarded as if fresh, and would (correctly) answer "existing
+/// user" here — so an explicit restart goes through its own
+/// observable signal plus a persisted marker, never through a
+/// weakened probe.
+///
+/// Restart KEEPS everything: identity, chats, messages, and every
+/// current seat selection. Only the walk re-runs — the step surfaces
+/// render the applied configuration (ACTIVE badges, configured rows)
+/// and change nothing until the user does.
+///
+/// - `requestRestart()` writes the persisted restart marker (which
+///   also clears the completion flag — `OnboardingStore` contract)
+///   and raises `pendingRestart` for RootView to present the cover
+///   this session. The marker makes a mid-walk kill resume on next
+///   launch through the normal gate (`OnboardingGate.shouldOnboard`
+///   checks it before grandfathering).
+/// - `consumeRestart()` lowers only the in-session signal; the
+///   persisted marker is cleared by `markOnboardingCompleted()` when
+///   the walk finishes, exactly like a first run.
+@MainActor
+@Observable
+final class OnboardingRestartController {
+    private(set) var pendingRestart = false
+
+    private let store: any OnboardingStore
+
+    init(store: any OnboardingStore) {
+        self.store = store
+    }
+
+    func requestRestart() {
+        store.requestRestart()
+        pendingRestart = true
+    }
+
+    func consumeRestart() {
+        pendingRestart = false
+    }
+}
 
 /// The launch-time existing-user probe behind
 /// `OnboardingGate.shouldOnboard`: users who predate onboarding have

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -939,6 +939,18 @@ struct OnboardingModerationContent: View {
                     ))
                 }
             }
+            // A restarted walk (Settings → Restart Onboarding) arrives
+            // here with a mandate already active. Standing consent
+            // satisfies the step as-is — re-consent is only for
+            // changing authority (the pick → review → sign path above,
+            // which overwrites this outcome when taken). First runs
+            // are untouched: no mandate, no currentAuthorityId.
+            .onChange(of: flow.state.currentAuthorityId) { _, current in
+                guard let current,
+                      onboarding.outcomes[.moderation] == nil
+                else { return }
+                onboarding.recordOutcome(.consented(componentId: current))
+            }
     }
 }
 

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -214,15 +214,36 @@ struct OnymIOSApp: App {
             isExistingUser: { OnboardingLaunch.isExistingUser() }
         )
         #endif
-        // While onboarding is incomplete, a background relayer fetch
-        // must not install the whole published list over the notary
-        // step's empty configuration — the step IS the choice. The
-        // policy re-reads the flag per fetch pass, so the very first
-        // refresh after `complete()` (kicked by the flow's onCompleted)
-        // installs the defaults when the user skipped the step.
+        // Whether onboarding is AVAILABLE in this build — factories,
+        // restart controller, and the Settings row all key off this.
+        // Distinct from `shouldOnboard` (the launch-time presentation
+        // decision) since Settings → Restart Onboarding can start a
+        // walk mid-session on a launch that didn't onboard.
+        #if DEBUG
+        let onboardingAvailable = args.contains("--ui-testing")
+            ? args.contains("--ui-onboarding")
+            : true
+        #else
+        let onboardingAvailable = true
+        #endif
+        // While an onboarding walk is (or will be) active, a
+        // background relayer fetch must not install the whole
+        // published list over the notary step's empty configuration —
+        // the step IS the choice. The policy re-reads the store per
+        // fetch pass, so the very first refresh after `complete()`
+        // (kicked by the flow's onCompleted) installs the defaults
+        // when the user skipped the step. On steady-state launches the
+        // suppressor is the restart marker alone: the completion flag
+        // can't serve there, because grandfathered users never carry
+        // it and must keep today's auto-populate behavior.
         let relayerAutoPopulatePolicy: @Sendable () -> Bool
         if shouldOnboard {
-            relayerAutoPopulatePolicy = { onboardingStore.hasCompletedOnboarding() }
+            relayerAutoPopulatePolicy = {
+                onboardingStore.hasCompletedOnboarding()
+                    && !onboardingStore.isRestartRequested()
+            }
+        } else if onboardingAvailable {
+            relayerAutoPopulatePolicy = { !onboardingStore.isRestartRequested() }
         } else {
             relayerAutoPopulatePolicy = { true }
         }
@@ -909,12 +930,15 @@ struct OnymIOSApp: App {
             { @MainActor in DiscoverySettingsFlow(repository: repo) }
         }
 
-        // First-launch onboarding factories. Both nil when this launch
-        // doesn't onboard (flag set, existing user, or the UI-test
-        // harness without `--ui-onboarding`).
+        // Onboarding factories. Built whenever onboarding is AVAILABLE
+        // (not only when this launch presents it): Settings → Restart
+        // Onboarding needs them on steady-state launches too. All nil
+        // only under the UI-test harness without `--ui-onboarding`.
         let makeOnboardingFlow: (@MainActor () -> OnboardingFlow)?
         let makeOnboardingStepContent: (@MainActor (OnboardingFlow, OnboardingStep) -> AnyView?)?
-        if shouldOnboard {
+        let onboardingRestartController: OnboardingRestartController?
+        if onboardingAvailable {
+            onboardingRestartController = OnboardingRestartController(store: onboardingStore)
             makeOnboardingFlow = { @MainActor in
                 OnboardingFlow(
                     store: onboardingStore,
@@ -1002,6 +1026,7 @@ struct OnymIOSApp: App {
         } else {
             makeOnboardingFlow = nil
             makeOnboardingStepContent = nil
+            onboardingRestartController = nil
         }
 
         self.dependencies = AppDependencies(
@@ -1159,6 +1184,8 @@ struct OnymIOSApp: App {
             },
             makeDiscoverySettingsFlow: makeDiscoverySettingsFlow,
             makeOnboardingFlow: makeOnboardingFlow,
+            presentOnboardingAtLaunch: shouldOnboard,
+            onboardingRestart: onboardingRestartController,
             makeOnboardingStepContent: makeOnboardingStepContent
         )
     }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -41,7 +41,11 @@ struct RootView: View {
 
     init(dependencies: AppDependencies) {
         self.dependencies = dependencies
-        _onboardingFlow = State(initialValue: dependencies.makeOnboardingFlow?())
+        _onboardingFlow = State(
+            initialValue: dependencies.presentOnboardingAtLaunch
+                ? dependencies.makeOnboardingFlow?()
+                : nil
+        )
     }
 
     /// The blocking consent sheet, when one is up. Driven by the gate,
@@ -116,6 +120,25 @@ struct RootView: View {
             if phase == .active {
                 dependencies.moderationGateFlow.appForegrounded()
             }
+        }
+        // Settings → Restart Onboarding: present a fresh walk
+        // mid-session. The persisted restart marker (written before
+        // this signal fires) already re-armed the auto-populate
+        // suppression and makes a mid-walk kill resume on the next
+        // launch through the normal gate. Identity, chats, messages,
+        // and every current selection are untouched — the step
+        // surfaces render the applied configuration and change
+        // nothing until the user does.
+        .onChange(of: dependencies.onboardingRestart?.pendingRestart ?? false) { _, pending in
+            guard pending, let restart = dependencies.onboardingRestart else { return }
+            restart.consumeRestart()
+            guard onboardingFlow == nil, let make = dependencies.makeOnboardingFlow else { return }
+            // The onboarding cover replaces any moderation consent
+            // cover for the duration of the walk — its moderation
+            // step is the same surface (same suppression as at
+            // launch; the gate is re-read on completion).
+            consentPresentation = nil
+            onboardingFlow = make()
         }
         .fullScreenCover(item: $consentPresentation) { presentation in
             // `.id` rather than a dismiss-and-re-present dance: one gate
@@ -241,7 +264,10 @@ struct RootView: View {
                         makeModerationSettingsFlow: dependencies.makeModerationSettingsFlow,
                         makeModerationConsentFlow: dependencies.makeModerationConsentFlow,
                         makeModerationCaseFlow: dependencies.makeModerationCaseFlow,
-                        makeDiscoverySettingsFlow: dependencies.makeDiscoverySettingsFlow
+                        makeDiscoverySettingsFlow: dependencies.makeDiscoverySettingsFlow,
+                        onRestartOnboarding: dependencies.onboardingRestart.map { restart in
+                            { restart.requestRestart() }
+                        }
                     )
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/Tests/OnymIOSTests/OnboardingRestartControllerTests.swift
+++ b/Tests/OnymIOSTests/OnboardingRestartControllerTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import OnymIOS
+import OnymOnboarding
+
+/// The Settings → Restart Onboarding bridge: the action must present
+/// the cover THIS session (the `pendingRestart` signal RootView
+/// observes), persist the restart across a mid-walk kill, and override
+/// the launch gate's grandfathering — all without touching identity,
+/// chats, or the cold-boot behavior of users who never asked.
+@MainActor
+final class OnboardingRestartControllerTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var store: UserDefaultsOnboardingStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "app.onym.ios.onboarding.restart.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = UserDefaultsOnboardingStore(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        store = nil
+        super.tearDown()
+    }
+
+    /// The Settings action's observable effect: `pendingRestart` is
+    /// exactly the signal RootView presents the onboarding cover on.
+    func test_requestRestart_raisesThePresentationSignal() {
+        let controller = OnboardingRestartController(store: store)
+        XCTAssertFalse(controller.pendingRestart)
+        controller.requestRestart()
+        XCTAssertTrue(controller.pendingRestart,
+                      "the Settings action must raise the cover-presentation signal")
+    }
+
+    /// The persisted half: the marker is written and the completion
+    /// flag cleared, so every reader of the store agrees a walk is due.
+    func test_requestRestart_persistsMarkerAndClearsFlag() {
+        store.markOnboardingCompleted()
+        let controller = OnboardingRestartController(store: store)
+        controller.requestRestart()
+        XCTAssertTrue(store.isRestartRequested())
+        XCTAssertFalse(store.hasCompletedOnboarding())
+    }
+
+    /// CRITICAL: a configured user (grandfathering probe answers
+    /// "existing") must still onboard after an explicit restart — the
+    /// probe suppresses onboarding nobody asked for, never onboarding
+    /// the user requested.
+    func test_requestRestart_overridesGrandfathering() {
+        let controller = OnboardingRestartController(store: store)
+        controller.requestRestart()
+        XCTAssertTrue(
+            OnboardingGate.shouldOnboard(store: store, isExistingUser: { true }),
+            "restart must outrank the existing-user probe"
+        )
+    }
+
+    /// Consuming the in-session signal (RootView presented the cover)
+    /// must NOT clear the persisted marker: an app killed mid-walk
+    /// resumes onboarding on the next launch.
+    func test_consumeRestart_lowersSignalButKeepsMarker() {
+        let controller = OnboardingRestartController(store: store)
+        controller.requestRestart()
+        controller.consumeRestart()
+        XCTAssertFalse(controller.pendingRestart)
+        XCTAssertTrue(store.isRestartRequested(),
+                      "mid-walk kill must resume: the marker outlives the signal")
+        // Simulated relaunch still onboards, grandfathering included.
+        let relaunched = UserDefaultsOnboardingStore(defaults: defaults)
+        XCTAssertTrue(OnboardingGate.shouldOnboard(store: relaunched, isExistingUser: { true }))
+    }
+
+    /// Completion (identical to a first run) closes everything: flag
+    /// set, marker cleared, gate shut — for grandfathered and fresh
+    /// users alike.
+    func test_completion_endsTheRestart() {
+        let controller = OnboardingRestartController(store: store)
+        controller.requestRestart()
+        controller.consumeRestart()
+        store.markOnboardingCompleted()
+        XCTAssertFalse(store.isRestartRequested())
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { true }))
+        XCTAssertFalse(OnboardingGate.shouldOnboard(store: store, isExistingUser: { false }))
+    }
+}


### PR DESCRIPTION
Adds **Settings → SETUP → Restart Onboarding**: re-run the first-launch seat selection while keeping everything else.

## What / why

- **Settings row + confirmation** — new SETUP section above DATA (house style: card row + footnote, alert like the message-cache clear but single-step, because nothing is deleted). The alert states the contract explicitly: identity, chats, and messages are kept; transport / file storage / notary / moderation selection re-runs; current choices stay until changed. Row and section hide when onboarding isn't wired (UI harness without `--ui-onboarding`) — same optional-factory pattern as the moderation/discovery rows.
- **Overriding grandfathering without weakening it** — the cold-boot gate's existing-user probe would (correctly) suppress onboarding for any configured user, so restart cannot simply clear the flag and re-run the gate. Design: `OnboardingStore` gains a persisted restart marker (`app.onym.ios.onboarding.restartRequested`). `requestRestart()` sets it and clears the completion flag in one intent; `OnboardingGate.shouldOnboard` now checks the marker **before** the flag and the probe. An explicit request outranks grandfathering; upgraders never carry the marker, so their cold-boot behavior is byte-for-byte unchanged (pinned by tests).
- **Presentation** — new `OnboardingRestartController` (@Observable) in the composition root: Settings raises `pendingRestart`, RootView observes it and presents a fresh walk via the same factories the launch path uses. The factories now exist whenever onboarding is *available* (decoupled from the new `presentOnboardingAtLaunch` flag), not only on launches that onboard.
- **During the re-run** — nothing is deleted up front: the step surfaces already render the applied configuration (seeded/ACTIVE rows, configured lists). The moderation step now records a standing active mandate as satisfying the step — re-consent happens only if the user changes authority through the existing pick → review → sign path (ModerationConsentFlow's own switch semantics; nothing new invented). First runs are unaffected (no mandate → unchanged mandatory behavior).
- **Auto-populate** — the #250 relayer `autoPopulatePolicy` re-arms while a restart walk is active (the policy reads the persisted marker — on steady-state launches the marker is the *only* valid suppressor, since grandfathered users never carry the completion flag) and restores on completion, identical to a first run.
- **Mid-walk kill** — the marker persists until `markOnboardingCompleted()` clears it, so the next launch resumes onboarding through the normal gate; chats/tabs remain intact underneath the cover, and the completion path (gate poke + relayer refresh) is the first-run path.

## Verification

- `OnymOnboarding` package suite: **41 tests, 0 failures** (+6 new: marker/flag transitions, restart-outranks-grandfathering, persist-until-completion, upgrader behavior pinned)
- App unit suite (`OnymIOSTests`): **1248 tests (3 skipped), 0 failures** (+5 new `OnboardingRestartControllerTests`, incl. the Settings-action → cover-presentation signal)
- Settings-touching UI suites re-run: `ClearMessageCacheUITests` **1/0**, `DiscoverySettingsUITests` **1/0** (row correctly absent under the harness)
- App builds (iPhone 17 Pro sim, Xcode 26)

## Overlap note

Deliberately does **not** touch `AppLauncher` or the onboarding UI-test files — those belong to the open #256. This PR edits `OnymIOSApp.swift`'s gate block (availability split + policy), which #256 also touches for `--skip-onboarding`; whichever lands second takes a small, mechanical rebase — the two changes compose (`--skip-onboarding` vetoes launch presentation; availability stays keyed on `--ui-onboarding`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8
