### PR TITLE
Onboarding: moderation step loses its skip path entirely

### DIFF
--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
@@ -26,8 +26,16 @@ public enum StepOutcome: Equatable, Sendable {
     /// defaults.
     case skipped
     /// The step had nothing to decide (informational steps: welcome,
-    /// done, moderation-with-empty-directory).
+    /// done).
     case notApplicable
+    /// The step's obligation exists but could not be offered — today
+    /// exactly moderation with an EMPTY authority directory: there is
+    /// no authority to pick, so the user acknowledges with Continue.
+    /// Distinct from `.skipped` (a choice the user declined to make)
+    /// and `.notApplicable` (nothing to decide at all) so downstream
+    /// state never mistakes "moderation wasn't available" for
+    /// "the user opted out" — opting out of moderation is not a thing.
+    case unavailable
 }
 
 /// State machine for the first-launch onboarding sequence. Modeled on
@@ -112,22 +120,19 @@ public final class OnboardingFlow {
     /// - `welcome` — its primary Continue is the only path forward; a
     ///   separate Skip would be redundant (and the view never renders
     ///   one);
-    /// - `moderation` unless the directory probe has ANSWERED that the
-    ///   authority directory is empty — with entries present the
-    ///   moderation gate would block right after onboarding anyway, so
-    ///   letting the user skip here would be a lie, and while the
-    ///   probe is still unresolved we fail closed rather than open a
-    ///   racy skip window (this mirrors the existing gate: consent is
-    ///   only optional while the directory is empty/operational);
+    /// - `moderation` — NEVER skippable, in any directory state.
+    ///   Moderation-authority selection is not optional: with entries
+    ///   present the user must pick and sign (the gate would block
+    ///   right after onboarding anyway), and with an EMPTY directory
+    ///   there is nothing to decline — the step turns Continue-only
+    ///   informational instead (`isMandatory` answers false and
+    ///   `advance()` records `.unavailable`), which is an
+    ///   acknowledgment, not a skip;
     /// - `done`, which is terminal — there is nothing after it to skip
     ///   to (its primary action is `complete()`).
     public func isSkippable(_ step: OnboardingStep) -> Bool {
         switch step {
-        case .welcome:
-            return false
-        case .moderation:
-            return moderationDirectoryHasEntries == false
-        case .done:
+        case .welcome, .moderation, .done:
             return false
         default:
             return true
@@ -137,10 +142,15 @@ public final class OnboardingFlow {
     /// A mandatory step cannot be walked past without a recorded
     /// outcome — `advance()` refuses until the step content reports
     /// one. Today that is exactly `moderation` while the directory has
-    /// entries (or the probe hasn't answered yet — fail-closed, the
-    /// complement of `isSkippable`): its consent is the one obligation
-    /// onboarding must not silently drop, because the gate behind it
-    /// would block anyway.
+    /// entries (or the probe hasn't answered yet — fail-closed): its
+    /// consent is the one obligation onboarding must not silently
+    /// drop, because the gate behind it would block anyway. Only a
+    /// RESOLVED-empty directory relaxes this — there is no authority
+    /// to pick, so hard-blocking would brick onboarding; the step
+    /// becomes Continue-only informational and `advance()` records
+    /// the distinct `.unavailable` outcome. Note this is deliberately
+    /// NOT the complement of `isSkippable` anymore: moderation is
+    /// never skippable in any state.
     public func isMandatory(_ step: OnboardingStep) -> Bool {
         guard step == .moderation else { return false }
         return moderationDirectoryHasEntries != false
@@ -166,18 +176,22 @@ public final class OnboardingFlow {
     }
 
     /// Move to the next step. A step walked past without any recorded
-    /// outcome is backfilled as `.notApplicable` — the informational
-    /// steps (welcome; moderation with an empty directory) advance
-    /// through here without ever recording. No-op on `done`
-    /// (`complete()` is the terminal action), and a no-op on a
-    /// mandatory step with no recorded outcome — the primary button
-    /// must not be a back door around the unskippable-moderation rule
-    /// (the view also disables it; this guard is the second layer).
+    /// outcome is backfilled — `.notApplicable` for the informational
+    /// steps (welcome), except moderation over a RESOLVED-empty
+    /// directory, whose Continue-only acknowledgment records the
+    /// distinct `.unavailable` (moderation wasn't offered; the user
+    /// did not opt out). No-op on `done` (`complete()` is the
+    /// terminal action), and a no-op on a mandatory step with no
+    /// recorded outcome — the primary button must not be a back door
+    /// around the must-consent moderation rule (the view also
+    /// disables it; this guard is the second layer).
     public func advance() {
         guard let next = neighbor(offset: 1) else { return }
         guard !isMandatory(step) || outcomes[step] != nil else { return }
         if outcomes[step] == nil {
-            outcomes[step] = .notApplicable
+            outcomes[step] = step == .moderation && moderationDirectoryHasEntries == false
+                ? .unavailable
+                : .notApplicable
         }
         step = next
     }

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -192,6 +192,7 @@ struct DoneStepContent: View {
         switch outcome {
         case .consented: return "checkmark.circle.fill"
         case .skipped: return "arrow.right.circle"
+        case .unavailable: return "minus.circle"
         case .notApplicable, nil: return "circle.dashed"
         }
     }
@@ -200,6 +201,7 @@ struct DoneStepContent: View {
         switch outcome {
         case .consented: return String(localized: "Chosen")
         case .skipped: return String(localized: "Default")
+        case .unavailable: return String(localized: "Unavailable")
         case .notApplicable, nil: return String(localized: "—")
         }
     }

--- a/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
+++ b/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
@@ -148,26 +148,53 @@ final class OnboardingFlowTests: XCTestCase {
         XCTAssertNil(flow.outcomes[.done])
     }
 
-    // MARK: - Moderation skippability
+    // MARK: - Moderation is never skippable
 
-    func testModerationSkippableWhileDirectoryEmpty() async {
-        let flow = makeFlow(moderationDirectoryNonEmpty: { false })
-        flow.start()
-        await flow.moderationProbeTask?.value
-        XCTAssertTrue(flow.isSkippable(.moderation))
+    /// The rule, across every probe state: moderation offers NO skip
+    /// path. Unresolved, resolved-empty, resolved-non-empty — always
+    /// unskippable, and `skip()` is always a no-op there.
+    func testModerationNeverSkippableInAnyProbeState() async {
+        // Unresolved (probe not started).
+        let unresolved = makeFlow(moderationDirectoryNonEmpty: { false })
+        XCTAssertFalse(unresolved.isSkippable(.moderation))
 
-        while flow.step != .moderation { flow.advance() }
-        flow.skip()
-        XCTAssertEqual(flow.step, .done)
-        XCTAssertEqual(flow.outcomes[.moderation], .skipped)
+        // Resolved empty.
+        let empty = await makeResolvedFlow(directoryNonEmpty: false)
+        XCTAssertFalse(empty.isSkippable(.moderation))
+        while empty.step != .moderation { empty.advance() }
+        empty.skip() // no-op — there is no skip path
+        XCTAssertEqual(empty.step, .moderation)
+        XCTAssertNil(empty.outcomes[.moderation])
+
+        // Resolved non-empty.
+        let nonEmpty = await makeResolvedFlow(directoryNonEmpty: true)
+        XCTAssertFalse(nonEmpty.isSkippable(.moderation))
     }
 
-    func testModerationNotSkippableWhenDirectoryHasEntries() async {
+    /// EMPTY directory: nothing is selectable, so the step must not
+    /// hard-block — it turns Continue-only informational. The advance
+    /// is an acknowledgment, recorded as the distinct `.unavailable`
+    /// (never `.skipped` — opting out of moderation is not a thing).
+    func testModerationEmptyDirectoryIsContinueOnlyAcknowledgment() async {
+        let flow = await makeResolvedFlow(directoryNonEmpty: false)
+        XCTAssertFalse(flow.isMandatory(.moderation))
+        XCTAssertFalse(flow.isSkippable(.moderation))
+
+        while flow.step != .moderation { flow.advance() }
+        flow.advance() // plain Continue
+        XCTAssertEqual(flow.step, .done)
+        XCTAssertEqual(flow.outcomes[.moderation], .unavailable)
+    }
+
+    /// Non-empty directory: must consent — no skip, and Continue
+    /// refuses until the consent outcome is recorded.
+    func testModerationMustConsentWhenDirectoryHasEntries() async {
         let flow = makeFlow(moderationDirectoryNonEmpty: { true })
         flow.start()
         await flow.moderationProbeTask?.value
         XCTAssertFalse(flow.isSkippable(.moderation))
-        // Every other step stays skippable.
+        XCTAssertTrue(flow.isMandatory(.moderation))
+        // Every other middle step stays skippable.
         for step: OnboardingStep in [.discoveryConfirm, .messageTransport, .blobTransport, .notary] {
             XCTAssertTrue(flow.isSkippable(step), "\(step) should stay skippable")
         }
@@ -176,6 +203,12 @@ final class OnboardingFlowTests: XCTestCase {
         flow.skip() // must be a no-op
         XCTAssertEqual(flow.step, .moderation)
         XCTAssertNil(flow.outcomes[.moderation])
+        flow.advance() // equally refused without a consent outcome
+        XCTAssertEqual(flow.step, .moderation)
+
+        flow.recordOutcome(.consented(componentId: "onym:component:authority"))
+        flow.advance()
+        XCTAssertEqual(flow.step, .done)
     }
 
     func testStartIsIdempotent() async {
@@ -249,14 +282,14 @@ final class OnboardingFlowTests: XCTestCase {
         flow.skip() // notary
         flow.recordOutcome(.consented(componentId: "onym:component:onym-relayer"))
         flow.advance() // moderation
-        flow.advance() // done (informational moderation, directory empty)
+        flow.advance() // done (Continue-only moderation, directory empty)
 
         XCTAssertEqual(flow.outcomes[.welcome], .notApplicable)
         XCTAssertEqual(flow.outcomes[.discoveryConfirm], .consented(componentId: nil))
         XCTAssertEqual(flow.outcomes[.messageTransport], .consented(componentId: "onym:component:onym-nostr"))
         XCTAssertEqual(flow.outcomes[.blobTransport], .skipped)
         XCTAssertEqual(flow.outcomes[.notary], .consented(componentId: "onym:component:onym-relayer"))
-        XCTAssertEqual(flow.outcomes[.moderation], .notApplicable)
+        XCTAssertEqual(flow.outcomes[.moderation], .unavailable)
     }
 
     // MARK: - Welcome skippability
@@ -272,7 +305,7 @@ final class OnboardingFlowTests: XCTestCase {
     // MARK: - Probe race (fail-closed until resolved)
 
     /// Before the probe answers, moderation reads unskippable AND
-    /// mandatory — racing the probe must never open a skip window.
+    /// mandatory — racing the probe must never open an advance window.
     func testModerationFailsClosedWhileProbeUnresolved() async {
         let flow = makeFlow(moderationDirectoryNonEmpty: { false })
         // Probe not started: unresolved.
@@ -281,19 +314,22 @@ final class OnboardingFlowTests: XCTestCase {
         XCTAssertTrue(flow.isMandatory(.moderation))
 
         while flow.step != .moderation { flow.advance() }
-        flow.skip() // no-op while unresolved
+        flow.skip() // no-op — always, on moderation
         XCTAssertEqual(flow.step, .moderation)
-        flow.advance() // equally refused — mandatory without an outcome
+        flow.advance() // refused — mandatory without an outcome
         XCTAssertEqual(flow.step, .moderation)
 
-        // Empty directory resolves → skippable, not mandatory.
+        // Empty directory resolves → Continue-only informational:
+        // still not skippable, no longer mandatory, and the plain
+        // Continue records the distinct `.unavailable` outcome.
         flow.start()
         await flow.moderationProbeTask?.value
         XCTAssertTrue(flow.moderationProbeResolved)
-        XCTAssertTrue(flow.isSkippable(.moderation))
+        XCTAssertFalse(flow.isSkippable(.moderation))
         XCTAssertFalse(flow.isMandatory(.moderation))
-        flow.skip()
+        flow.advance()
         XCTAssertEqual(flow.step, .done)
+        XCTAssertEqual(flow.outcomes[.moderation], .unavailable)
     }
 
     /// The other transition: unresolved (fail-closed) → resolved

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -850,6 +850,22 @@
         }
       }
     },
+    "Unavailable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unavailable"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недоступно"
+          }
+        }
+      }
+    },
     "Verify & Confirm": {
       "localizations": {
         "en": {


### PR DESCRIPTION
Moderation-authority selection is no longer skippable during onboarding — in any directory state.

## What / why

#249/#255 made the moderation step mandatory when the authority directory has entries (tri-state probe, fail-closed while unresolved) but offered a Skip when the directory was empty. This removes the skip path entirely:

- **Directory non-empty, or probe unresolved** — unchanged mandatory semantics: the user must pick an authority and complete the pick → review → sign consent to advance. `skip()` and `advance()` both refuse until the consent outcome is recorded; the probe stays fail-closed (unresolved = mandatory).
- **Directory EMPTY** — nothing is selectable, so hard-blocking would brick onboarding. The step becomes **Continue-only informational**: no Skip button, no `.skipped` outcome. The plain Continue is an acknowledgment, recorded as the new distinct `StepOutcome.unavailable`, so downstream state never reads "moderation wasn't available yet" as "the user opted out" — opting out of moderation is not a thing. The Done summary renders it as "Unavailable" (en + ru).

Changed at the layer that declares skippability — `OnboardingFlow.isSkippable` in the OnymOnboarding package; the view's Skip slot keys off it, so no view-layer change was needed beyond the summary label. `isMandatory`, the probe, and #249's other hardened semantics (welcome/done unskippable, advance gating, `complete()` only from done) are untouched.

Tests: the moderation skip-path tests became must-consent tests; added the empty-directory Continue-only/`.unavailable` test and a never-skippable sweep across all three probe states (unresolved / resolved-empty / resolved-non-empty).

## Verification

- `OnymOnboarding` package suite: **42 tests, 0 failures**
- App unit suite (`OnymIOSTests`): **1248 tests (3 skipped), 0 failures**
- App builds clean (iPhone 17 Pro sim, Xcode 26)
- The onboarding walk UI test lives in the open #256 and is not on main yet, so this change is covered by the unit suites here.

## #256 / #257 interaction

- **#256** (onboarding UI tests): its walk runs under `--moderation-needs-consent` (non-empty directory) and already asserts Continue-disabled + **no Skip** on the moderation step — that assertion becomes universally true and survives unchanged. This PR touches `OnboardingFlow.swift` / `OnboardingView.swift` / the flow tests, none of #256's files; expect at most a clean rebase. No follow-up tweak needed.
- **#257** (restart onboarding): merged into this base already. Its standing-mandate behavior composes cleanly — on a restart walk the active mandate records `.consented(...)`, which satisfies the (now stricter) step without re-signing; switching authority still overwrites via the normal consent path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GupFt7f1hWn4zSP2HJEXB8
