### PR TITLE
Onboarding: center Back under the primary button

### DIFF
--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStepScaffold.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStepScaffold.swift
@@ -112,22 +112,27 @@ public struct OnboardingStepScaffold<Content: View, Indicator: View>: View {
                 .disabled(primaryDisabled)
                 .accessibilityIdentifier("onboarding.\(step.rawValue).primary")
 
-                HStack {
-                    if let backAction {
-                        Button("Back", action: backAction)
-                            .accessibilityIdentifier("onboarding.\(step.rawValue).back")
-                    }
-                    Spacer()
-                    if let skipAction {
-                        Button(action: skipAction) { Text(verbatim: skipTitle) }
-                            .accessibilityIdentifier("onboarding.\(step.rawValue).skip")
-                    } else if showsSkipProgress {
-                        ProgressView()
-                            .controlSize(.small)
-                            .accessibilityIdentifier("onboarding.\(step.rawValue).skip_pending")
-                    }
+                // Secondary actions stack centered under the primary
+                // (the design's quiet text buttons) — a corner-pinned
+                // Back read as page chrome, not as this screen's
+                // alternative action.
+                if let skipAction {
+                    Button(action: skipAction) { Text(verbatim: skipTitle) }
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                        .accessibilityIdentifier("onboarding.\(step.rawValue).skip")
+                } else if showsSkipProgress {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(maxWidth: .infinity)
+                        .accessibilityIdentifier("onboarding.\(step.rawValue).skip_pending")
                 }
-                .font(.subheadline)
+                if let backAction {
+                    Button("Back", action: backAction)
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                        .accessibilityIdentifier("onboarding.\(step.rawValue).back")
+                }
             }
             .padding(.horizontal, 20)
             .padding(.top, 12)


### PR DESCRIPTION
Follow-up to the merged onboarding stack (#259–#261). The scaffold's bottom row (`HStack { Back, Spacer, Skip }`) left Back stranded in the corner — it read as page chrome, not as the screen's alternative action.

Secondary actions now stack centered under the primary: the skip affordance (or its probe progress) first, Back below, both as quiet full-width-centered text buttons per the design. Accessibility identifiers are unchanged; verified visually in the simulator and 3/3 onboarding UI tests pass.

| Before | After |
|---|---|
| Back pinned bottom-left | Back centered under Continue |

🤖 Generated with [Claude Code](https://claude.com/claude-code)