### PR TITLE
Onboarding: phrase lifetime, honest hub footnote, cancellation guard

### DIFF
--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
@@ -219,6 +219,20 @@ public final class OnboardingFlow {
         }
     }
 
+    /// Whether the recorded outcome actually satisfies an
+    /// outcome-gated step. `.skipped` deliberately does NOT: skipping
+    /// records a decision, but revisiting the step must re-gate its
+    /// primary — an earlier "Remind me later" must never leave
+    /// "I've written it down" enabled over a phrase that was never
+    /// revealed. The honest exits from a re-gated step are the same
+    /// as the first visit: satisfy the gate, or skip again.
+    public func outcomeSatisfiesGate(_ step: OnboardingStep) -> Bool {
+        switch outcomes[step] {
+        case nil, .skipped?: return false
+        default: return true
+        }
+    }
+
     // MARK: - Lifecycle
 
     /// Kick the async moderation-directory probe. Idempotent.
@@ -250,7 +264,7 @@ public final class OnboardingFlow {
     /// (the view also disables it; this guard is the second layer).
     public func advance() {
         guard let next = neighbor(offset: 1) else { return }
-        guard !requiresOutcomeToAdvance(step) || outcomes[step] != nil else { return }
+        guard !requiresOutcomeToAdvance(step) || outcomeSatisfiesGate(step) else { return }
         if outcomes[step] == nil {
             outcomes[step] = step == .moderation && moderationDirectoryHasEntries == false
                 ? .unavailable

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -61,7 +61,7 @@ public struct OnboardingView: View {
             // the step content records one (moderation's consent, the
             // recovery reveal); `flow.advance()` carries the same
             // guard as the second layer.
-            primaryDisabled: flow.requiresOutcomeToAdvance(step) && flow.outcomes[step] == nil,
+            primaryDisabled: flow.requiresOutcomeToAdvance(step) && !flow.outcomeSatisfiesGate(step),
             primaryAction: { primaryTapped() },
             skipTitle: Self.skipTitle(for: step),
             skipAction: flow.isSkippable(step) ? { flow.skip() } : nil,

--- a/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
+++ b/Packages/OnymOnboarding/Tests/OnymOnboardingTests/OnboardingFlowTests.swift
@@ -443,6 +443,29 @@ final class OnboardingFlowTests: XCTestCase {
         XCTAssertEqual(flow.step, .done)
     }
 
+    /// A `.skipped` outcome must NOT satisfy the gate: after
+    /// "Remind me later" → Done → Back, the recovery step's primary
+    /// ("I've written it down") re-locks — the recorded skip survives
+    /// (back-preservation), but it must never enable a claim about a
+    /// phrase that was never revealed. Regression for the gate hole
+    /// dev-onym found on the Android port.
+    func testSkipThenBackReGatesTheRecoveryPrimary() async {
+        let flow = await makeResolvedFlow()
+        walk(flow, to: .recoveryPhrase)
+        flow.skip()
+        XCTAssertEqual(flow.step, .done)
+        flow.back()
+        XCTAssertEqual(flow.step, .recoveryPhrase)
+        XCTAssertEqual(flow.outcomes[.recoveryPhrase], .skipped,
+                       "the skip decision survives Back")
+        XCTAssertFalse(flow.outcomeSatisfiesGate(.recoveryPhrase),
+                       "a skip must not satisfy the reveal gate")
+        flow.advance() // refused — the primary is re-locked
+        XCTAssertEqual(flow.step, .recoveryPhrase)
+        flow.skip() // skipping again remains the honest exit
+        XCTAssertEqual(flow.step, .done)
+    }
+
     /// The outcome-gate matrix: identity and recovery always;
     /// moderation only while mandatory; nothing else ever.
     func testRequiresOutcomeToAdvanceMatrix() async {

--- a/Packages/OnymRecovery/Sources/OnymRecovery/RecoveryPhraseBackupFlow.swift
+++ b/Packages/OnymRecovery/Sources/OnymRecovery/RecoveryPhraseBackupFlow.swift
@@ -86,17 +86,32 @@ public final class RecoveryPhraseBackupFlow {
         }
     }
 
-    /// Cancel any in-flight tasks. Call on view disappear if the flow's
-    /// lifetime exceeds the view's; for the first-cut single-screen app,
-    /// the flow lives for the App's lifetime so this is mostly a hook for
-    /// future composition.
+    /// Tear down AND scrub. Called on view disappear (the view pairs
+    /// it with `start()`): cancels the retaining tasks so the flow can
+    /// deallocate, drops the cached identity, and rewinds to `.intro`
+    /// so the revealed phrase never outlives the screen and every
+    /// re-entry goes back through the biometric gate. `start()` is
+    /// idempotent, so a reappearing view simply re-arms.
     public func stop() {
+        // `snapshotTask` strongly retains self for the life of a
+        // never-finishing AsyncStream — cancelling it here is what
+        // actually lets the flow deallocate when the presenting view
+        // releases its reference.
         snapshotTask?.cancel()
         snapshotTask = nil
         verifyAdvanceTask?.cancel()
         verifyAdvanceTask = nil
-        clipboardClearTask?.cancel()
-        clipboardClearTask = nil
+        // The clipboard clear task is deliberately NOT cancelled: it
+        // captures only the pasteboard and the phrase (no self, so no
+        // retain), and cancelling it would skip the early in-app clear.
+        // It self-completes; the OS-enforced expiry remains the real
+        // guarantee either way.
+        // Scrub: drop the plaintext phrase and the cached identity so
+        // the secret does not stay resident even if something else
+        // still holds the flow, and so any re-entry starts at Intro
+        // behind the biometric gate.
+        currentIdentity = nil
+        step = .intro
     }
 
     // MARK: - Intents (called from the view)

--- a/Packages/OnymRecovery/Sources/OnymRecovery/RecoveryPhraseBackupView.swift
+++ b/Packages/OnymRecovery/Sources/OnymRecovery/RecoveryPhraseBackupView.swift
@@ -40,6 +40,12 @@ public struct RecoveryPhraseBackupView: View {
                     obscured = phase != .active
                 }
                 .task { flow.start() }
+                // Every flow view pairs start with stop; this one
+                // additionally relies on stop() to scrub the revealed
+                // phrase and break the snapshot task's self-retain —
+                // without it the flow (and the plaintext words in
+                // `.reveal`) outlive the screen.
+                .onDisappear { flow.stop() }
         }
     }
 

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
@@ -126,7 +126,10 @@ struct BlossomRelaySettingsView: View {
                                         // First endpoint is the one
                                         // uploads/downloads target.
                                         if idx == 0 {
-                                            Text("ACTIVE")
+                                            // Keyed: bare "ACTIVE"'s ru
+                                            // is feminine (identity);
+                                            // a server is masculine.
+                                            Text("ACTIVE_SERVICE_CHIP")
                                                 .font(.system(size: 10, weight: .bold))
                                                 .foregroundStyle(OnymAccent.blue.color)
                                                 .padding(.horizontal, 6)

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -6464,23 +6464,6 @@
         }
       }
     },
-    "Anything you already added here stays configured — remove it from the lists above if you've changed your mind.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anything you already added here stays configured — remove it from the lists above if you've changed your mind."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Всё, что вы уже добавили, остаётся настроенным — удалите из списков выше, если передумали."
-          }
-        }
-      }
-    },
     "No relay configured yet. Add one below, or go back to keep the default.": {
       "extractionState": "manual",
       "localizations": {
@@ -7127,6 +7110,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Несколько сервисов работают по-разному в каждой категории: релеи используются все вместе, дополнительные медиасервисы — доверенные источники для скачивания, а нотариус для каждой новой группы выбирается из вашего списка."
+          }
+        }
+      }
+    },
+    "Anything you already added here stays configured — you can remove it later in Settings → Services.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anything you already added here stays configured — you can remove it later in Settings → Services."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё, что вы уже добавили, остаётся настроенным — удалить это можно позже в Настройки → Сервисы."
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7130,6 +7130,23 @@
           }
         }
       }
+    },
+    "ACTIVE_SERVICE_CHIP": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ACTIVE"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "АКТИВНЫЙ"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -1227,7 +1227,10 @@ struct OnboardingBlossomContent: View {
                         // allowlist of hosts you'll accept downloads
                         // from — not upload fallbacks, so no "backup"
                         // chip.
-                        badge: idx == 0 ? "ACTIVE" : nil,
+                        // Keyed entry, not the bare "ACTIVE" literal:
+                        // that key's ru is feminine (АКТИВНАЯ, for the
+                        // identity card); a service is masculine.
+                        badge: idx == 0 ? "ACTIVE_SERVICE_CHIP" : nil,
                         selected: idx == 0,
                         badgeColor: OnymTokens.green,
                         last: idx == endpoints.count - 1
@@ -1642,8 +1645,12 @@ struct OnboardingRecoveryContent: View {
                 .padding(.top, 12)
         }
         .sheet(isPresented: $showBackup, onDismiss: {
-            // Release the flow — and with it the plaintext phrase —
-            // the moment the sheet goes away, however it was closed.
+            // stop() breaks the snapshot task's self-retain (dropping
+            // the reference alone would leak an immortal flow holding
+            // the plaintext phrase) and scrubs back to Intro; nilling
+            // then releases our reference. The view's own onDisappear
+            // also stops — this is the belt to that suspender.
+            flow?.stop()
             flow = nil
         }) {
             if let flow {

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -330,7 +330,12 @@ struct OnboardingIdentityContent: View {
         }
         .task(id: attempt) {
             phase = .checking
-            if await identityReady() {
+            let ready = await identityReady()
+            // A cancelled probe (navigation tore the task down while
+            // `try?` inside identityReady swallowed CancellationError)
+            // must not masquerade as a bootstrap failure.
+            guard !Task.isCancelled else { return }
+            if ready {
                 phase = .ready
                 // Unlocks the step's Continue — nothing was decided
                 // here, but the gate needs proof the keys exist.
@@ -662,7 +667,7 @@ struct OnboardingServicesHub: View {
                     // This switches the selection back, it does NOT
                     // undo anything — say so, or the affordance reads
                     // as a revert.
-                    Text("Anything you already added here stays configured — remove it from the lists above if you've changed your mind.")
+                    Text("Anything you already added here stays configured — you can remove it later in Settings → Services.")
                         .font(.system(size: 11.5))
                         .foregroundStyle(OnymTokens.text3)
                         .multilineTextAlignment(.center)
@@ -1577,7 +1582,13 @@ struct OnboardingModerationContent: View {
 /// Settings nudge behavior.
 struct OnboardingRecoveryContent: View {
     let onboarding: OnboardingFlow
-    @State private var flow: RecoveryPhraseBackupFlow
+    private let makeBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
+    /// Created fresh on every presentation and released on dismiss —
+    /// the flow holds the plaintext phrase once revealed, so it must
+    /// not outlive the sheet: a retained `.reveal` step would let
+    /// "View it again" re-show the words without the biometric gate.
+    /// Every entry starts at Intro and re-authenticates.
+    @State private var flow: RecoveryPhraseBackupFlow?
     @State private var showBackup = false
 
     /// Derived from the flow, never view-local — the step content is
@@ -1589,10 +1600,10 @@ struct OnboardingRecoveryContent: View {
 
     init(
         onboarding: OnboardingFlow,
-        makeBackupFlow: @MainActor () -> RecoveryPhraseBackupFlow
+        makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow
     ) {
         self.onboarding = onboarding
-        _flow = State(initialValue: makeBackupFlow())
+        self.makeBackupFlow = makeBackupFlow
     }
 
     var body: some View {
@@ -1618,6 +1629,7 @@ struct OnboardingRecoveryContent: View {
             .accessibilityIdentifier("onboarding.recoveryPhrase.status")
 
             SettingsPrimaryButton(sawPhrase || backedUp ? "View it again" : "Reveal my recovery phrase") {
+                flow = makeBackupFlow()
                 showBackup = true
             }
             .padding(.top, 12)
@@ -1629,10 +1641,16 @@ struct OnboardingRecoveryContent: View {
                 .lineSpacing(2)
                 .padding(.top, 12)
         }
-        .sheet(isPresented: $showBackup) {
-            RecoveryPhraseBackupView(flow: flow)
+        .sheet(isPresented: $showBackup, onDismiss: {
+            // Release the flow — and with it the plaintext phrase —
+            // the moment the sheet goes away, however it was closed.
+            flow = nil
+        }) {
+            if let flow {
+                RecoveryPhraseBackupView(flow: flow)
+            }
         }
-        .onChange(of: flow.step) { old, step in
+        .onChange(of: flow?.step) { old, step in
             // recordOutcome writes to the flow's CURRENT step — same
             // async-callback hazard OnboardingIdentityContent guards
             // against; refuse to record from anywhere else.
@@ -1642,20 +1660,20 @@ struct OnboardingRecoveryContent: View {
             // moment the words are actually on screen. The backup
             // state never downgrades: a verified backup stays
             // verified across re-reveals.
-            if case .reveal(_, true) = step {
+            if case .reveal(_, true)? = step {
                 if onboarding.recoveryBackupState == .none {
                     onboarding.recoveryBackupState = .revealed
                 }
                 onboarding.recordOutcome(.consented(componentId: nil))
             }
-            if case .done = step {
+            if case .done? = step {
                 onboarding.recoveryBackupState = .verified
                 onboarding.recordOutcome(.consented(componentId: nil))
             }
             // The backup flow's DoneScreen "Done" resets it to .intro
             // (a Settings-era loop) — in onboarding that must dismiss
             // the sheet, not strand the user back at the intro.
-            if case .done = old, case .intro = step {
+            if case .done? = old, case .intro? = step {
                 showBackup = false
             }
         }

--- a/Tests/OnymIOSTests/RecoveryPhraseBackupFlowTests.swift
+++ b/Tests/OnymIOSTests/RecoveryPhraseBackupFlowTests.swift
@@ -133,6 +133,57 @@ final class RecoveryPhraseBackupFlowTests: XCTestCase {
         }
     }
 
+    // MARK: - Lifetime / scrub (onym-ios #265 review)
+
+    /// `stop()` must SCRUB, not just cancel: the revealed phrase held
+    /// in `.reveal` and the cached identity are dropped, and the step
+    /// rewinds to `.intro` so any re-entry goes back through the
+    /// biometric gate.
+    func test_stop_scrubsRevealedPhraseBackToIntro() async {
+        authenticator.outcome = .success
+        await flow.authenticate()
+        flow.tappedReveal()
+        guard case .reveal(_, true) = flow.step else {
+            return XCTFail("expected revealed step, got \(flow.step)")
+        }
+
+        flow.stop()
+
+        XCTAssertEqual(flow.step, .intro,
+                       "stop() must rewind to intro, dropping the phrase")
+        // Re-arming after stop goes back through auth, not straight to
+        // the words.
+        flow.start()
+        await waitForReady()
+        XCTAssertEqual(flow.step, .intro)
+    }
+
+    /// The snapshot task strongly retains the flow over a
+    /// never-finishing stream — `stop()` is what breaks the cycle.
+    /// Without it, releasing the last external reference leaks an
+    /// immortal flow holding the plaintext phrase.
+    func test_stop_breaksSnapshotRetainCycle_flowDeallocates() async {
+        weak var leaked: RecoveryPhraseBackupFlow?
+        do {
+            var scoped: RecoveryPhraseBackupFlow? = RecoveryPhraseBackupFlow(
+                repository: repository,
+                authenticator: authenticator,
+                pasteboard: pasteboard
+            )
+            leaked = scoped
+            scoped?.start()
+            await waitForReady(scoped)
+            authenticator.outcome = .success
+            await scoped?.authenticate()
+            scoped?.stop()
+            scoped = nil
+        }
+        // One main-actor hop lets the cancelled task unwind.
+        await Task.yield()
+        XCTAssertNil(leaked,
+                     "stop() must break the snapshot task's self-retain so the flow deallocates")
+    }
+
     // DEBUG posture: the same unevaluable policy fails OPEN so the dev flow
     // proceeds to the reveal step.
     func test_unevaluablePolicy_failOpen_reachesReveal() async {


### PR DESCRIPTION
Ports three findings from onym-android #215's review that apply equally to the merged iOS flow:

1. **Recovery phrase lifetime / re-auth** — `OnboardingRecoveryContent` held one `RecoveryPhraseBackupFlow` for the step's whole life, so after a reveal the sheet could be dismissed and re-opened onto the revealed words with no biometric re-auth, and the plaintext phrase stayed resident. The flow is now created per presentation and released on dismiss (`flow = nil`): every entry starts at Intro behind the biometric gate; the flow-held `recoveryBackupState` keeps the status card truthful across navigation.
2. **Honest hub footnote** — "remove it from the lists above if you've changed your mind" was false (onboarding rows have no remove affordance). Now: "…you can remove it later in Settings → Services." (en + ru catalog entry swapped.)
3. **Cancellation guard** — `identityReady`'s `try?` swallows `CancellationError`, so a navigation-cancelled probe could paint the failure card. The identity task now bails on cancellation instead of reporting a false failure.

3/3 onboarding UI tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)