### PR TITLE
Onboarding: TOFU-pin the seeded discovery source on recommended-setup accept

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7130,6 +7130,23 @@
           }
         }
       }
+    },
+    "Not confirmed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not confirmed"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не подтверждён"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -44,6 +44,12 @@ struct OnboardingStepContentBuilder {
     /// exists — the identity step's checklist binds to this instead of
     /// asserting success it can't know about.
     let identityReady: @MainActor () async -> Bool
+    /// TOFU-pins the SEEDED default discovery source when the user
+    /// leaves the services step on the recommended path — accepting
+    /// the recommended setup is the explicit confirm (see
+    /// `SeededDiscoveryConfirmation`). Idempotent; a no-op when
+    /// discovery is absent or the source is already pinned.
+    let confirmSeededDiscovery: @MainActor () async -> Void
     let loadSummary: @MainActor () async -> [OnboardingSummaryRow]
 
     func content(for step: OnboardingStep, flow: OnboardingFlow) -> AnyView? {
@@ -420,6 +426,23 @@ struct OnboardingServicesContent: View {
                 onboarding.recordOutcome(.consented(componentId: nil))
             }
         }
+        // Accepting the recommended setup IS the seeded directory's
+        // TOFU confirm. `onDisappear` fires once the walk moved on
+        // (flow.step is already the destination), so this catches
+        // exactly the forward-leave with the recommended card
+        // selected — the moment the acceptance becomes final — and
+        // runs the same fetch → verify → pin path the hub's manual
+        // "Verify & Confirm" uses. Back-navigation doesn't trigger it
+        // (the user may still switch to custom), a possible double
+        // fire is harmless (the confirm is idempotent), and failure
+        // never blocks the walk — an offline first run leaves the
+        // source unpinned and the Done summary says "Not confirmed".
+        .onDisappear {
+            guard onboarding.servicesChoice == .recommended,
+                  stepIsAfterServices(onboarding.step)
+            else { return }
+            Task { await builder.confirmSeededDiscovery() }
+        }
         .sheet(isPresented: $showHub) {
             OnboardingServicesHub(
                 onboarding: onboarding,
@@ -453,6 +476,16 @@ struct OnboardingServicesContent: View {
                 }
             )
         }
+    }
+
+    /// Whether `step` comes after `.services` in presentation order —
+    /// the forward-leave test for the trigger above.
+    private func stepIsAfterServices(_ step: OnboardingStep) -> Bool {
+        let all = OnboardingStep.allCases
+        guard let services = all.firstIndex(of: .services),
+              let current = all.firstIndex(of: step)
+        else { return false }
+        return current > services
     }
 
     private var recommendedCard: some View {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -997,6 +997,16 @@ struct OnymIOSApp: App {
                 identityReady: { @MainActor in
                     (try? await repository.bootstrap()) != nil
                 },
+                // Recommended-path accept = the seeded source's TOFU
+                // confirm (trust rationale on the helper). Nil
+                // discovery (UI-test harness without --ui-discovery)
+                // makes it a no-op.
+                confirmSeededDiscovery: { @MainActor in
+                    guard let discoveryRepository else { return }
+                    await SeededDiscoveryConfirmation.confirmIfUnpinned(
+                        repository: discoveryRepository
+                    )
+                },
                 loadSummary: { @MainActor in
                     // The Done step's summary is read from the
                     // repositories, not the walk's outcomes — what the
@@ -1044,13 +1054,21 @@ struct OnymIOSApp: App {
                     if let discoveryRepository {
                         let state = await discoveryRepository.currentState()
                         if let source = state.sources.first {
+                            // An unpinned source must read visibly
+                            // different from an active one: no
+                            // fingerprint detail (there is no pinned
+                            // key to show) and "Not confirmed" where
+                            // the count would imply working sources.
+                            let pinned = source.source.pinnedOperatorKeyHex != nil
                             rows.append(OnboardingSummaryRow(
                                 id: "discovery",
                                 title: String(localized: "Directory"),
                                 value: source.source.userLabel,
                                 detail: source.source.operatorKeyFingerprint,
                                 symbol: "magnifyingglass",
-                                trailing: String(localized: "\(state.sources.count) sources")
+                                trailing: pinned
+                                    ? String(localized: "\(state.sources.count) sources")
+                                    : String(localized: "Not confirmed")
                             ))
                         }
                     }

--- a/Sources/OnymIOS/SeededDiscoveryConfirmation.swift
+++ b/Sources/OnymIOS/SeededDiscoveryConfirmation.swift
@@ -1,0 +1,62 @@
+import Foundation
+import OnymDiscovery
+
+/// Programmatic TOFU confirm of the SEEDED default discovery source,
+/// run when the user leaves the onboarding services step having
+/// accepted the "Recommended setup".
+///
+/// Why this is a legitimate TOFU site: the recommended card names
+/// "Onym Discovery" as part of the setup being accepted, so tapping
+/// Continue over it IS the user's explicit trust-on-first-use act for
+/// the seeded source — the same decision the hub's Directory seat
+/// captures with its "Verify & Confirm" walk, minus the on-screen
+/// fingerprint. Nothing is weakened downstream: the manifest is
+/// fetched and signature-verified before anything is pinned
+/// (`DiscoveryRepository.addSource`), every later refresh verifies
+/// against the pinned key, and the pin is refused if the URL serves a
+/// different provider than the seeded identity. Out-of-band
+/// fingerprint verification remains what the custom path ("Choose
+/// services myself" → Directory) is for — this helper never touches a
+/// user-added URL, only the source seeded from
+/// `DiscoverySource.onymDefault`.
+///
+/// Without this, the recommended path left the seed unpinned:
+/// `DiscoveryRepository` skips unpinned sources on refresh, so the
+/// catalog aggregate stayed empty ("SUGGESTED BY YOUR DIRECTORIES"
+/// never populated) while the walk presented the directory as active.
+enum SeededDiscoveryConfirmation {
+
+    /// Fetch → verify → pin the seeded default source, then refresh it
+    /// so its catalogs land in the aggregate.
+    ///
+    /// Idempotent: a no-op when the source is already pinned (the user
+    /// confirmed it through the hub, or a previous fire won), absent
+    /// (removed), or the repository runs without it. Failure must not
+    /// block the onboarding walk — an offline first run simply leaves
+    /// the source unpinned, the Done summary reports "Not confirmed",
+    /// and the Settings "Confirm…" affordance stays available.
+    static func confirmIfUnpinned(repository: DiscoveryRepository) async {
+        let seeded = DiscoverySource.onymDefault
+        let state = await repository.currentState()
+        guard let status = state.sources.first(where: { $0.id == seeded.providerId }),
+              status.source.pinnedOperatorKeyHex == nil
+        else { return }
+        do {
+            // The SEEDED manifest URL only — never a user-typed one.
+            let preview = try await repository.addSource(manifestURL: seeded.manifestURL)
+            // The URL must still serve the seeded provider identity;
+            // anything else is not what the recommended card promised,
+            // so it gets no programmatic pin.
+            guard preview.providerId == seeded.providerId else { return }
+            await repository.confirmAddSource(preview)
+            // Targeted refresh (same as the manual confirm path): a
+            // full pass already in flight captured its source list
+            // before this pin and would silently skip it.
+            await repository.refreshSource(providerId: seeded.providerId)
+        } catch {
+            // Offline or misbehaving endpoint: the source stays
+            // unpinned and the summary says so honestly. No retry
+            // here — the walk must not block on the network.
+        }
+    }
+}

--- a/Tests/OnymIOSTests/SeededDiscoveryConfirmationTests.swift
+++ b/Tests/OnymIOSTests/SeededDiscoveryConfirmationTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import XCTest
+@testable import OnymIOS
+import OnymDiscovery
+
+/// Tests for `SeededDiscoveryConfirmation.confirmIfUnpinned` — the
+/// programmatic TOFU confirm the onboarding recommended path runs when
+/// the services step is left with the recommended setup accepted.
+///
+/// Runs the REAL trust pipeline against the byte-pinned fixtures the
+/// `--ui-discovery` harness serves (`UITestDiscoveryFixtures`): real
+/// signatures, fixture-era clock, in-memory store — offline and
+/// deterministic, same recipe as the UI tests' repository wiring.
+final class SeededDiscoveryConfirmationTests: XCTestCase {
+
+    private func makeRepository(
+        fetcher: any DiscoveryFetching = UITestDiscoveryFetcher()
+    ) -> DiscoveryRepository {
+        DiscoveryRepository(
+            fetcher: fetcher,
+            store: InMemoryDiscoveryStore(),
+            now: { UITestDiscoveryFixtures.now }
+        )
+    }
+
+    /// The recommended-path accept pins the seeded default and its
+    /// catalogs land in the aggregate — the exact gap this seam fixes:
+    /// before, the seed stayed unpinned and the aggregate stayed empty.
+    func test_confirm_pinsSeededSource_andPopulatesAggregate() async throws {
+        let repository = makeRepository()
+        // start() seeds the unconfirmed default; its background
+        // refresh SKIPS the unpinned source by design.
+        await repository.start()
+        var state = await repository.currentState()
+        let seeded = try XCTUnwrap(
+            state.sources.first { $0.id == DiscoverySource.onymDefault.providerId }
+        )
+        XCTAssertNil(seeded.source.pinnedOperatorKeyHex,
+                     "the seeded default must start unpinned (TOFU by design)")
+
+        await SeededDiscoveryConfirmation.confirmIfUnpinned(repository: repository)
+
+        state = await repository.currentState()
+        let confirmed = try XCTUnwrap(
+            state.sources.first { $0.id == DiscoverySource.onymDefault.providerId }
+        )
+        XCTAssertNotNil(confirmed.source.pinnedOperatorKeyHex,
+                        "accepting the recommended setup must pin the seeded source")
+        XCTAssertEqual(confirmed.source.operatorKeyFingerprint,
+                       UITestDiscoveryFixtures.operatorKeyFingerprint,
+                       "the pinned key must be the one the manifest is signed with")
+        XCTAssertFalse(state.aggregate.isEmpty,
+                       "the targeted refresh after the pin must populate the catalog aggregate")
+    }
+
+    /// Already pinned → the confirm is a no-op: same pinned key, no
+    /// re-pin churn (idempotence makes the trigger's possible double
+    /// fire harmless).
+    func test_confirm_isIdempotent_whenAlreadyPinned() async throws {
+        let repository = makeRepository()
+        await repository.start()
+        await SeededDiscoveryConfirmation.confirmIfUnpinned(repository: repository)
+        let first = await repository.currentState()
+        let firstKey = first.sources.first?.source.pinnedOperatorKeyHex
+        XCTAssertNotNil(firstKey)
+
+        await SeededDiscoveryConfirmation.confirmIfUnpinned(repository: repository)
+
+        let second = await repository.currentState()
+        XCTAssertEqual(second.sources.first?.source.pinnedOperatorKeyHex, firstKey)
+        XCTAssertEqual(second.sources.count, first.sources.count)
+        XCTAssertFalse(second.aggregate.isEmpty)
+    }
+
+    /// Offline first run: the fetch fails, the source stays unpinned
+    /// (the summary then reports "Not confirmed"), and nothing throws
+    /// out of the walk.
+    func test_confirm_failureLeavesSourceUnpinned() async throws {
+        struct OfflineFetcher: DiscoveryFetching {
+            func fetchProviderManifest(url: URL) async throws -> Data {
+                throw DiscoveryFetchError.badStatus(503)
+            }
+            func fetchSnapshot(url: URL) async throws -> Data {
+                throw DiscoveryFetchError.badStatus(503)
+            }
+        }
+        let repository = makeRepository(fetcher: OfflineFetcher())
+        await repository.start()
+
+        await SeededDiscoveryConfirmation.confirmIfUnpinned(repository: repository)
+
+        let state = await repository.currentState()
+        let seeded = try XCTUnwrap(
+            state.sources.first { $0.id == DiscoverySource.onymDefault.providerId }
+        )
+        XCTAssertNil(seeded.source.pinnedOperatorKeyHex,
+                     "a failed fetch must leave the seed unpinned, not block or crash")
+        XCTAssertTrue(state.aggregate.isEmpty)
+    }
+}

--- a/Tests/OnymIOSUITests/OnboardingUITests.swift
+++ b/Tests/OnymIOSUITests/OnboardingUITests.swift
@@ -302,7 +302,19 @@ final class OnboardingUITests: XCTestCase {
         XCTAssertTrue(onboarding.skip("recoveryPhrase").waitForExistence(timeout: 5))
         onboarding.skip("recoveryPhrase").tap()
 
-        // Done → Start messaging → tab bar.
+        // Done. Leaving the services step on the recommended path
+        // auto-ran the seeded directory's TOFU confirm (fetch →
+        // verify → pin against the fixture manifest), so the summary
+        // must show the pinned operator-key fingerprint — not the
+        // "Not confirmed" state an unpinned seed would report.
+        XCTAssertTrue(onboarding.title("done").waitForExistence(timeout: 5))
+        XCTAssertTrue(onboarding.doneSummary.waitForExistence(timeout: 5),
+                      "done summary card never appeared")
+        XCTAssertTrue(app.staticTexts[fingerprint].waitForExistence(timeout: 10),
+                      "recommended-path accept should have pinned the seeded directory; "
+                      + "its fingerprint never appeared in the summary. Hierarchy:\n\(app.debugDescription)")
+
+        // Start messaging → tab bar.
         onboarding.continueFrom("done")
         let chats = ChatsScreen(app: app)
         XCTAssertTrue(chats.chatsTab.waitForExistence(timeout: 10),


### PR DESCRIPTION
## The gap

The merged onboarding redesign (#259–#261) never pins the seeded default discovery source on the "Recommended setup" path. The seed ships unpinned **by design** (pinning is the user's own TOFU act), and only the manual hub walk ("Choose services myself" → Directory → Verify & Confirm) ever pinned it. `DiscoveryRepository` hard-skips unpinned sources on refresh, so for every user who took the recommended path:

- the catalog aggregate stayed empty — "SUGGESTED BY YOUR DIRECTORIES" never populated in the hub or Settings;
- the recommended card and the Done summary still presented "Onym Discovery" as part of the active setup, with a source count implying it worked.

Same gap dev-onym flagged on the Android port (onym-android #215, round 4); this is the iOS mirror of that fix.

## Pin on accept

**Accepting the recommended setup IS the explicit TOFU confirm.** The recommended card names "Onym Discovery" as part of what's being accepted, so leaving the services step forward with the recommended choice now programmatically runs the same fetch → verify → pin path the manual "Verify & Confirm" drives, then a targeted `refreshSource` so catalogs populate.

Trust rationale (documented at the implementation site, `SeededDiscoveryConfirmation`):
- only the SEEDED source's manifest URL is ever fetched — never a user-typed one;
- the manifest is signature-verified before anything is pinned, and the pin is refused if the URL serves a different providerId than the seeded identity;
- every later refresh still verifies against the pinned key;
- out-of-band fingerprint verification remains what the custom path is for.

Mechanics: new `confirmSeededDiscovery` closure on `OnboardingStepContentBuilder`, implemented in `OnymIOSApp` against the real repository (no-op when discovery is absent). Triggered from the services step's `onDisappear` — it fires after `flow.step` has already moved, so a forward-leave check (`step > .services`) catches exactly the moment the acceptance becomes final, and Back-navigation (where the user may still switch to custom) doesn't fire it. Idempotent, so a double fire is harmless; failure never blocks the walk (offline first run: the seed just stays unpinned).

## Honest "Not confirmed" summary

The Done summary's directory row previously showed `operatorKeyFingerprint` as detail (silently nil when unpinned) with a trailing "N sources" either way. An unpinned source is now visibly distinct: trailing **"Not confirmed"** (ru: «Не подтверждён») instead of the count, and no detail line; pinned keeps fingerprint + count. Strings appended to `Localizable.xcstrings` (en + ru).

Also checked OnymDiscovery's security-load-bearing comments for references to the deleted `discoveryConfirm` onboarding step as the TOFU site — none found; no package change needed (or made).

## Tests

- `SeededDiscoveryConfirmationTests` (new, OnymIOSTests): real trust pipeline over the byte-pinned `--ui-discovery` fixtures — pin + aggregate population, idempotence when already pinned, offline failure leaves the seed unpinned.
- `test_onboardingSmoke_defaultPathCompletes_thenNeverAgain` now asserts the pinned fixture fingerprint appears on the Done summary — the end-to-end proof the recommended path auto-pinned.
- Full `OnymIOSTests` suite and all three `OnboardingUITests` pass locally (iPhone 17e simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)