### PR TITLE
Gate sessions sign as the mandate's identity, not the selected one

### DIFF
--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityError.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityError.swift
@@ -7,6 +7,9 @@ public enum IdentityError: Error, Equatable {
     case storedSnapshotInvalid(reason: String)
     case invalidMnemonic
     case identityNotLoaded
+    /// No stored identity's Stellar public key matches the requested
+    /// hex — it was removed, or quarantined by a fresh-install verdict.
+    case noIdentityForKey(String)
     case sdkFailure(String)
 }
 
@@ -25,6 +28,8 @@ extension IdentityError: LocalizedError {
             return "Invalid recovery phrase"
         case .identityNotLoaded:
             return "No identity is loaded — bootstrap or restore first"
+        case let .noIdentityForKey(hex):
+            return "No stored identity has the public key \(hex)"
         case let .sdkFailure(message):
             return "OnymSDK call failed: \(message)"
         }

--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
@@ -271,6 +271,35 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
         return try privateKey.signature(for: message)
     }
 
+    /// Ed25519 detached signature over `message` with the signing key
+    /// of whichever stored identity's derived Stellar public key is
+    /// `publicKeyHex` — NOT the currently-selected identity. The
+    /// moderation layer uses this for mandate-scoped sessions: the
+    /// mandate names the identity that consented, and that identity
+    /// must sign even while another one is selected in the picker.
+    /// Throws `.noIdentityForKey` when no stored identity matches
+    /// (removed, or quarantined by a fresh-install verdict).
+    public func signWithStellarKey(
+        _ message: Data,
+        matchingPublicKeyHex publicKeyHex: String
+    ) async throws -> Data {
+        try await ensureLoaded()
+        let target = publicKeyHex.lowercased()
+        for id in orderedIDs {
+            guard let identity = cache[id] else { continue }
+            let hex = identity.stellarPublicKey
+                .map { String(format: "%02x", $0) }
+                .joined()
+            guard hex == target else { continue }
+            guard let snapshot = try keychain.read(id) else { continue }
+            let privateKey = try Self.stellarSigningPrivateKey(
+                fromNostrSecret: snapshot.nostrSecretKey
+            )
+            return try privateKey.signature(for: message)
+        }
+        throw IdentityError.noIdentityForKey(publicKeyHex)
+    }
+
     // MARK: - Streams
 
     public nonisolated var snapshots: AsyncStream<Identity?> {

--- a/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/GateCheckRepository.swift
@@ -260,13 +260,18 @@ public actor GateCheckRepository {
             let timestamp = max(clock(), lastSessionTimestamp.addingTimeInterval(1))
             lastSessionTimestamp = timestamp
             let mandateRef = try? record.mandate.mandateHash()
+            // Signed AS the mandate's identity, not the selected one:
+            // with several identities on the device, the selected key
+            // and `mandate.user` diverge, and a session naming one but
+            // signed by the other is refused as `signature_invalid`.
             let signature = try await signer.sign(
                 GateCheckRequest.signedPayload(
                     deviceToken: token,
                     userKey: record.mandate.user,
                     mandateRef: mandateRef,
                     timestamp: timestamp
-                )
+                ),
+                as: record.mandate.user
             )
             let request = GateCheckRequest(
                 deviceToken: token,

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationRepository.swift
@@ -1180,7 +1180,10 @@ public actor ModerationRepository {
             statement: statement,
             evidence: []
         )
-        response.signature = try await signer.sign(response.signingBytes())
+        // Signed as the mandate's identity — the case is bound to
+        // `mandate.user`, which may not be the selected identity.
+        response.signature = try await signer
+            .sign(response.signingBytes(), as: record.mandate.user)
             .base64EncodedString()
         let submission = CaseSubmissionRecord(
             caseId: caseId,
@@ -1223,7 +1226,8 @@ public actor ModerationRepository {
         // A new-holder claim is signed too — the reference ignores the
         // signature by design, but signing costs nothing and keeps the
         // artifact self-describing if the endpoint ever authenticates.
-        appeal.signature = try await signer.sign(appeal.signingBytes())
+        appeal.signature = try await signer
+            .sign(appeal.signingBytes(), as: submittingUser)
             .base64EncodedString()
         let submission = CaseSubmissionRecord(
             caseId: caseId,
@@ -1516,7 +1520,9 @@ public actor ModerationRepository {
             )],
             filedAt: clock()
         )
-        report.signature = try await signer.sign(report.signingBytes()).base64EncodedString()
+        report.signature = try await signer
+            .sign(report.signingBytes(), as: reporter)
+            .base64EncodedString()
         let record = ReportFilingRecord(
             sourceMessageId: message.id,
             report: report,

--- a/Packages/OnymModeration/Sources/OnymModeration/ModerationSigner.swift
+++ b/Packages/OnymModeration/Sources/OnymModeration/ModerationSigner.swift
@@ -6,8 +6,18 @@ import Foundation
 /// the boundary, only detached signatures do.
 public protocol ModerationSigner: Sendable {
     /// The user's identity key reference as mandates carry it:
-    /// `onym:key:<hex>`.
+    /// `onym:key:<hex>`. Follows the currently-selected identity.
     func userKeyID() async throws -> String
-    /// Ed25519 detached signature over `message`.
+    /// Ed25519 detached signature over `message` with the
+    /// currently-selected identity's key. Only for payloads whose
+    /// `userKey` field came from `userKeyID()` in the same flow.
     func sign(_ message: Data) async throws -> Data
+    /// Ed25519 detached signature over `message` with the key that
+    /// `userKey` names (`onym:key:<hex>`), regardless of which
+    /// identity is currently selected. Payloads that name
+    /// `mandate.user` MUST be signed through this: the device can
+    /// hold several identities, and a session that presents the
+    /// mandate's identity but carries another identity's signature is
+    /// refused by the backend as `signature_invalid`.
+    func sign(_ message: Data, as userKey: String) async throws -> Data
 }

--- a/Sources/OnymIOS/IdentityModerationSigner.swift
+++ b/Sources/OnymIOS/IdentityModerationSigner.swift
@@ -20,4 +20,14 @@ struct IdentityModerationSigner: ModerationSigner {
     func sign(_ message: Data) async throws -> Data {
         try await repository.signWithStellarKey(message)
     }
+
+    func sign(_ message: Data, as userKey: String) async throws -> Data {
+        let hex = userKey.hasPrefix("onym:key:")
+            ? String(userKey.dropFirst("onym:key:".count))
+            : userKey
+        return try await repository.signWithStellarKey(
+            message,
+            matchingPublicKeyHex: hex
+        )
+    }
 }

--- a/Tests/OnymIOSTests/DeviceRecoveryTests.swift
+++ b/Tests/OnymIOSTests/DeviceRecoveryTests.swift
@@ -665,6 +665,10 @@ final class DeviceRecoveryTests: XCTestCase {
             lock.withLock { _lastMessage = message }
             return Data("sig".utf8)
         }
+        func sign(_ message: Data, as userKey: String) async throws -> Data {
+            lock.withLock { _lastMessage = message }
+            return Data("sig".utf8)
+        }
     }
 
     private struct TokenAttestation: DeviceAttestationProvider {

--- a/Tests/OnymIOSTests/GateHardeningTests.swift
+++ b/Tests/OnymIOSTests/GateHardeningTests.swift
@@ -223,6 +223,58 @@ final class GateHardeningTests: XCTestCase {
         return await gate.currentStatus()
     }
 
+    func testGateSessionIsSignedAsTheMandateIdentity() async {
+        // With several identities on one device, the selected identity
+        // and the mandate's identity can diverge. The gate session
+        // names `mandate.user`, so it must be signed AS that key —
+        // signing with whichever identity is selected produced
+        // sessions the backend refused as `signature_invalid`, and the
+        // blocking screen with it.
+        let signer = KeyCapturingSigner()
+        let backend = ThrowingBackend(error: AuthorityClientError.rejected(
+            AuthorityRejection(statusCode: 500, rawCode: "internal_error", message: "boom")
+        ))
+        let moderation = ModerationRepository(
+            authoritiesFetcher: EmptyAuthoritiesFetcher(),
+            manifestFetcher: UnusedManifestFetcher(),
+            mandateStore: SeededMandateStore(records: [seededActiveRecord()]),
+            backend: backend,
+            authorityClients: StubModerationAuthorityClientFactory(),
+            attestation: FixedAttestation(),
+            signer: signer,
+            clock: { [now] in now }
+        )
+        let gate = GateCheckRepository(
+            attestation: FixedAttestation(),
+            backend: backend,
+            moderation: moderation,
+            signer: signer,
+            store: InMemoryGateStateStore(),
+            clock: { [now] in now }
+        )
+        await gate.checkNow()
+        XCTAssertEqual(signer.signedAs, ["onym:key:user"])
+    }
+
+    /// Records which identity every signature was requested as.
+    /// Plain `sign(_:)` records the sentinel `<selected>` so a gate
+    /// session regressing to selected-identity signing fails the
+    /// assertion above.
+    private final class KeyCapturingSigner: ModerationSigner, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _signedAs: [String] = []
+        var signedAs: [String] { lock.withLock { _signedAs } }
+        func userKeyID() async throws -> String { "onym:key:selected" }
+        func sign(_ message: Data) async throws -> Data {
+            lock.withLock { _signedAs.append("<selected>") }
+            return Data("sig".utf8)
+        }
+        func sign(_ message: Data, as userKey: String) async throws -> Data {
+            lock.withLock { _signedAs.append(userKey) }
+            return Data("sig".utf8)
+        }
+    }
+
     func testReplayedSignature401BlocksAsBackendRefused() async {
         let status = await gateStatus(afterBackendError: AuthorityClientError.rejected(
             AuthorityRejection(statusCode: 401, rawCode: "signature_invalid", message: "replayed")
@@ -392,6 +444,9 @@ final class GateHardeningTests: XCTestCase {
     private struct FixedSigner: ModerationSigner {
         func userKeyID() async throws -> String { "onym:key:user" }
         func sign(_ message: Data) async throws -> Data { Data("sig".utf8) }
+        func sign(_ message: Data, as userKey: String) async throws -> Data {
+            Data("sig".utf8)
+        }
     }
 
     private final class InMemoryGateStateStore: GateStateStore, @unchecked Sendable {

--- a/Tests/OnymIOSTests/IdentityRepositorySignAsTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositorySignAsTests.swift
@@ -1,0 +1,73 @@
+import CryptoKit
+import XCTest
+@testable import OnymIOS
+import OnymIdentity
+
+/// `signWithStellarKey(matchingPublicKeyHex:)` — identity-addressed
+/// signing for mandate-scoped moderation sessions. The mandate names
+/// the identity that consented; with several identities on the device
+/// the *selected* identity can be a different one, and the signature
+/// must still come from the named key or the enforcement backend
+/// refuses the session as `signature_invalid`.
+final class IdentityRepositorySignAsTests: XCTestCase {
+    private var keychain: IdentityKeychainStore!
+    private var repository: IdentityRepository!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        keychain = IdentityKeychainStore(
+            testNamespace: "sign-as-\(UUID().uuidString)"
+        )
+        repository = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory()
+        )
+    }
+
+    override func tearDown() async throws {
+        try? keychain.wipeAll()
+        keychain = nil
+        repository = nil
+        try await super.tearDown()
+    }
+
+    func test_signsWithTheNamedIdentity_notTheSelectedOne() async throws {
+        // First add becomes current — capture its key as "the identity
+        // that consented", then switch to a second one.
+        _ = try await repository.add(
+            mnemonic: "legal winner thank year wave sausage worth useful legal winner thank yellow"
+        )
+        let current = await repository.currentIdentity()
+        let enrolledKey = try XCTUnwrap(current).stellarPublicKey
+        let otherID = try await repository.add(
+            mnemonic: "letter advice cage absurd amount doctor acoustic avoid letter advice cage above"
+        )
+        try await repository.select(otherID)
+
+        let message = Data("gate-session".utf8)
+        let signature = try await repository.signWithStellarKey(
+            message,
+            matchingPublicKeyHex: enrolledKey.map { String(format: "%02x", $0) }.joined()
+        )
+
+        let verifier = try Curve25519.Signing.PublicKey(rawRepresentation: enrolledKey)
+        XCTAssertTrue(verifier.isValidSignature(signature, for: message))
+
+        // The selected identity's plain signature is a different key's.
+        let selectedSignature = try await repository.signWithStellarKey(message)
+        XCTAssertFalse(verifier.isValidSignature(selectedSignature, for: message))
+    }
+
+    func test_unknownKeyThrowsNoIdentityForKey() async throws {
+        try await repository.add()
+        do {
+            _ = try await repository.signWithStellarKey(
+                Data("msg".utf8),
+                matchingPublicKeyHex: String(repeating: "ab", count: 32)
+            )
+            XCTFail("expected noIdentityForKey")
+        } catch let IdentityError.noIdentityForKey(hex) {
+            XCTAssertEqual(hex, String(repeating: "ab", count: 32))
+        }
+    }
+}

--- a/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
+++ b/Tests/OnymIOSTests/ModerationAuthorityClientTests.swift
@@ -15,6 +15,9 @@ final class ModerationAuthorityClientTests: XCTestCase {
             )
             return Data("status-signature".utf8)
         }
+        func sign(_ message: Data, as userKey: String) async throws -> Data {
+            Data("status-signature".utf8)
+        }
     }
 
     private final class RecordedBodies: @unchecked Sendable {

--- a/Tests/OnymIOSTests/ModerationRepositoryTests.swift
+++ b/Tests/OnymIOSTests/ModerationRepositoryTests.swift
@@ -113,6 +113,9 @@ final class ModerationRepositoryTests: XCTestCase {
     private struct FakeSigner: ModerationSigner {
         func userKeyID() async throws -> String { "onym:key:test-user" }
         func sign(_ message: Data) async throws -> Data { Data("fake-signature".utf8) }
+        func sign(_ message: Data, as userKey: String) async throws -> Data {
+            Data("fake-signature".utf8)
+        }
     }
 
     private enum RegistrationFailure: Error {


### PR DESCRIPTION
## The bug

With 2+ identities on one device, switching identities broke the moderation gate: `GateCheckRepository.performAttempt` presented `userKey: record.mandate.user` (the identity that consented) but signed via `IdentityRepository.signWithStellarKey`, which uses the **currently-selected** identity. The enforcement service verifies strictly and refused every such session — `signature invalid: identity signature did not verify` in the deployed interface's logs — so the app hard-blocked on "Verification required". Retry rebuilds the same mismatched pair and can never succeed; re-consent successfully minted fresh mandates server-side without unblocking the gate. Foregrounding triggers the cadence re-check, so the repro was simply: switch identity, background, reopen.

(The "disappeared chats" from the same incident were the flip side of the identity switch — chats are owner-scoped by `ownerIdentityIDString` — not data loss.)

## The fix

- `ModerationSigner` gains `sign(_ message:, as userKey:)` — signature by the key the payload names, regardless of selection.
- `IdentityRepository.signWithStellarKey(_:matchingPublicKeyHex:)` resolves the named Stellar key across all stored identities; throws the new `IdentityError.noIdentityForKey` when it's absent (removed or quarantined).
- Signed **as** the identity their payload names: gate session, case response, appeal, report.
- Kept on plain `sign(_:)` because they present `userKeyID()` in the same flow (self-consistent): enrollment, mandate countersign, recovery redemption, authority-client credentials.

## Tests

- `testGateSessionIsSignedAsTheMandateIdentity` — the gate session must request the mandate's key; a regression to selected-identity signing records the `<selected>` sentinel and fails.
- `IdentityRepositorySignAsTests` — two-identity repository: signature verifies against the *named* identity's Ed25519 key while another is selected; unknown key throws `noIdentityForKey`.
- Full moderation suites (GateHardening, ModerationRepository, DeviceRecovery, ModerationAuthorityClient): 102 tests, 0 failures.

## Follow-up worth its own issue

`sessionRefusalReason` maps any 401/403 onto `backendRefused`, whose copy says "check the date and time" — this incident produced that misleading screen for an identity mismatch. The server could distinguish `signature_invalid` from timestamp staleness so the client can suggest switching to the enrolled identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)