### PR TITLE
Store-open failures: log, back up aside, never delete

### DIFF
--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SwiftDataMessageStore.swift
@@ -21,34 +21,17 @@ public actor SwiftDataMessageStore: MessageStore {
     /// `Application Support/OnymIOS/Messages.store`, with
     /// `FileProtectionType.complete` on the directory.
     ///
-    /// Schema-mismatch at `ModelContainer(...)` init wipes the
-    /// on-disk store and retries once. Pre-1.0 install base, no real
-    /// users to preserve — matches the policy on `SwiftDataGroupStore`.
+    /// Open failures go through `PersistentStoreOpener`: logged,
+    /// moved aside as `.bak` (never deleted), retried once — and left
+    /// completely untouched when the file is merely unreadable
+    /// (locked-device launch).
     public init() throws {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        )[0]
-        let storeDir = appSupport.appendingPathComponent("OnymIOS", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: storeDir,
-            withIntermediateDirectories: true,
-            attributes: [.protectionKey: FileProtectionType.complete]
+        let url = try PersistentStoreOpener.storeDirectory()
+            .appendingPathComponent("Messages.store")
+        let container = try PersistentStoreOpener.openContainer(
+            schema: Schema([PersistedMessage.self]),
+            url: url
         )
-        let url = storeDir.appendingPathComponent("Messages.store")
-        let schema = Schema([PersistedMessage.self])
-        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
-        let container: ModelContainer
-        do {
-            container = try ModelContainer(for: schema, configurations: [config])
-        } catch {
-            for suffix in ["", "-shm", "-wal"] {
-                try? FileManager.default.removeItem(
-                    at: url.deletingPathExtension().appendingPathExtension("store\(suffix)")
-                )
-            }
-            try? FileManager.default.removeItem(at: url)
-            container = try ModelContainer(for: schema, configurations: [config])
-        }
         self.container = container
         self.context = ModelContext(container)
     }

--- a/Packages/OnymFoundation/Sources/OnymFoundation/PersistentStoreOpener.swift
+++ b/Packages/OnymFoundation/Sources/OnymFoundation/PersistentStoreOpener.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SwiftData
+import os
+
+/// Shared open-with-recovery policy for the app's SwiftData stores
+/// (`Groups.store`, `Messages.store`, `Invitations.store`,
+/// `IntroRequests.store`).
+///
+/// History: each store used to answer ANY `ModelContainer` open error
+/// by deleting the SQLite trio and retrying — silently. On 2026-08-16
+/// that policy destroyed a device's chat history twice in one day
+/// (once at a TestFlight-over-debug install, once at the
+/// debug-over-TestFlight reinstall), with nothing in the logs to say
+/// why the open failed. Two properties of that incident drive the
+/// policy here:
+///
+/// - The open error was never recorded, so the root cause is
+///   unknowable after the fact. Every failure is now logged as a
+///   fault with the store name and the thrown error.
+/// - Deletion is unrecoverable, and "failed to open" does not imply
+///   "worth destroying": a transiently unreadable file (Complete file
+///   protection while the device is locked — e.g. a prewarmed or
+///   background launch) throws the same way a genuine schema mismatch
+///   does. The trio is now moved aside as a `.bak`, never deleted,
+///   and only when the store file is actually readable — an
+///   unreadable file means the data is fine and the *launch context*
+///   is wrong, so the error is rethrown and the caller's in-memory
+///   fallback covers the session.
+public enum PersistentStoreOpener {
+    private static let log = Logger(subsystem: "app.onym.ios", category: "PersistentStoreOpener")
+
+    /// The directory every store shares:
+    /// `Application Support/OnymIOS/`, Complete file protection.
+    public static func storeDirectory() throws -> URL {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        )[0]
+        let dir = appSupport.appendingPathComponent("OnymIOS", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        return dir
+    }
+
+    /// Open the on-disk container at `url`; on failure, move the
+    /// store trio aside (recoverable) and retry once with a fresh
+    /// store. Throws when the store exists but can't be read at all
+    /// (locked-device launch) — the data on disk is untouched then.
+    public static func openContainer(schema: Schema, url: URL) throws -> ModelContainer {
+        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        do {
+            return try ModelContainer(for: schema, configurations: [config])
+        } catch {
+            let name = url.lastPathComponent
+            log.fault("open failed for \(name, privacy: .public): \(String(describing: error), privacy: .public)")
+            guard isReadable(url) else {
+                // Complete file protection while locked (prewarm /
+                // background launch) reads exactly like corruption to
+                // ModelContainer. The data is intact; destroying or
+                // moving it here is the bug this type exists to stop.
+                log.fault("\(name, privacy: .public) is unreadable (file protection?) — leaving the store untouched")
+                throw error
+            }
+            moveAsideTrio(at: url)
+            return try ModelContainer(for: schema, configurations: [config])
+        }
+    }
+
+    /// A store that exists but yields no bytes is protected-locked,
+    /// not broken. A store that doesn't exist can't lose data either
+    /// way — treat it as "readable" so the retry can create it.
+    private static func isReadable(_ url: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path) else { return true }
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        return (try? handle.read(upToCount: 1)) != nil
+    }
+
+    /// Rename the SQLite trio to `<name>.bak` siblings, replacing any
+    /// previous backup — one generation deep keeps disk use bounded
+    /// while making the newest incompatible store recoverable.
+    private static func moveAsideTrio(at url: URL) {
+        for suffix in ["", "-shm", "-wal"] {
+            let source = url.deletingPathExtension()
+                .appendingPathExtension("store\(suffix)")
+            guard FileManager.default.fileExists(atPath: source.path) else { continue }
+            let backup = source.appendingPathExtension("bak")
+            try? FileManager.default.removeItem(at: backup)
+            do {
+                try FileManager.default.moveItem(at: source, to: backup)
+            } catch {
+                // A move that fails must not leave the incompatible
+                // file in place — the retry would fail identically
+                // and the caller would run in-memory forever.
+                log.fault("backup move failed for \(source.lastPathComponent, privacy: .public): \(String(describing: error), privacy: .public)")
+                try? FileManager.default.removeItem(at: source)
+            }
+        }
+    }
+}

--- a/Packages/OnymGroup/Sources/OnymGroup/SwiftDataGroupStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/SwiftDataGroupStore.swift
@@ -16,37 +16,17 @@ public actor SwiftDataGroupStore: GroupStore {
     /// `Application Support/OnymIOS/Groups.store`, with
     /// `FileProtectionType.complete` on the directory.
     ///
-    /// Per the multi-identity no-backcompat licence, schema-mismatch
-    /// errors at `ModelContainer(...)` init wipe the on-disk store and
-    /// retry once. Pre-1.0 install base, no real users to preserve.
+    /// Open failures go through `PersistentStoreOpener`: logged,
+    /// moved aside as `.bak` (never deleted), retried once — and left
+    /// completely untouched when the file is merely unreadable
+    /// (locked-device launch).
     public init() throws {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        )[0]
-        let storeDir = appSupport.appendingPathComponent("OnymIOS", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: storeDir,
-            withIntermediateDirectories: true,
-            attributes: [.protectionKey: FileProtectionType.complete]
+        let url = try PersistentStoreOpener.storeDirectory()
+            .appendingPathComponent("Groups.store")
+        let container = try PersistentStoreOpener.openContainer(
+            schema: Schema([PersistedGroup.self]),
+            url: url
         )
-        let url = storeDir.appendingPathComponent("Groups.store")
-        let schema = Schema([PersistedGroup.self])
-        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
-        let container: ModelContainer
-        do {
-            container = try ModelContainer(for: schema, configurations: [config])
-        } catch {
-            // Schema migration failure — wipe + retry. SwiftData's
-            // SQLite trio (`.store`, `.store-shm`, `.store-wal`) all
-            // need to go.
-            for suffix in ["", "-shm", "-wal"] {
-                try? FileManager.default.removeItem(
-                    at: url.deletingPathExtension().appendingPathExtension("store\(suffix)")
-                )
-            }
-            try? FileManager.default.removeItem(at: url)
-            container = try ModelContainer(for: schema, configurations: [config])
-        }
         self.container = container
         self.context = ModelContext(container)
     }

--- a/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
@@ -29,35 +29,17 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
 
     /// Production initializer — on-disk SQLite under
     /// `Application Support/OnymIOS/IntroRequests.store` with
-    /// `FileProtectionType.complete`. Schema mismatch wipes and retries
-    /// once, matching the policy on the message + group stores (pre-1.0
-    /// install base; a dropped pending request is recoverable by the
-    /// joiner re-sharing).
+    /// `FileProtectionType.complete`. Open failures go through
+    /// `PersistentStoreOpener`: logged, moved aside as `.bak` (never
+    /// deleted), retried once — and left completely untouched when
+    /// the file is merely unreadable (locked-device launch).
     public init() throws {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        )[0]
-        let storeDir = appSupport.appendingPathComponent("OnymIOS", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: storeDir,
-            withIntermediateDirectories: true,
-            attributes: [.protectionKey: FileProtectionType.complete]
+        let url = try PersistentStoreOpener.storeDirectory()
+            .appendingPathComponent("IntroRequests.store")
+        let container = try PersistentStoreOpener.openContainer(
+            schema: Schema([PersistedIntroRequest.self]),
+            url: url
         )
-        let url = storeDir.appendingPathComponent("IntroRequests.store")
-        let schema = Schema([PersistedIntroRequest.self])
-        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
-        let container: ModelContainer
-        do {
-            container = try ModelContainer(for: schema, configurations: [config])
-        } catch {
-            for suffix in ["", "-shm", "-wal"] {
-                try? FileManager.default.removeItem(
-                    at: url.deletingPathExtension().appendingPathExtension("store\(suffix)")
-                )
-            }
-            try? FileManager.default.removeItem(at: url)
-            container = try ModelContainer(for: schema, configurations: [config])
-        }
         self.container = container
         self.context = ModelContext(container)
     }

--- a/Packages/OnymPersistence/Sources/OnymPersistence/SwiftDataInvitationStore.swift
+++ b/Packages/OnymPersistence/Sources/OnymPersistence/SwiftDataInvitationStore.swift
@@ -45,37 +45,17 @@ public actor SwiftDataInvitationStore: InvitationStore {
     /// `Application Support/OnymIOS/Invitations.store`, with
     /// `FileProtectionType.complete` on the directory.
     ///
-    /// Per the multi-identity no-backcompat licence, schema-mismatch
-    /// errors at `ModelContainer(...)` init wipe the on-disk store and
-    /// retry once. Same pattern as `SwiftDataGroupStore`.
+    /// Open failures go through `PersistentStoreOpener`: logged,
+    /// moved aside as `.bak` (never deleted), retried once — and left
+    /// completely untouched when the file is merely unreadable
+    /// (locked-device launch).
     public init() throws {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        )[0]
-        let storeDir = appSupport.appendingPathComponent("OnymIOS", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: storeDir,
-            withIntermediateDirectories: true,
-            attributes: [.protectionKey: FileProtectionType.complete]
+        let url = try PersistentStoreOpener.storeDirectory()
+            .appendingPathComponent("Invitations.store")
+        let container = try PersistentStoreOpener.openContainer(
+            schema: Schema([PersistedInvitation.self]),
+            url: url
         )
-        let url = storeDir.appendingPathComponent("Invitations.store")
-        let schema = Schema([PersistedInvitation.self])
-        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
-        let container: ModelContainer
-        do {
-            container = try ModelContainer(for: schema, configurations: [config])
-        } catch {
-            // Schema migration failure — wipe + retry. SwiftData's
-            // SQLite trio (`.store`, `.store-shm`, `.store-wal`) all
-            // need to go.
-            for suffix in ["", "-shm", "-wal"] {
-                try? FileManager.default.removeItem(
-                    at: url.deletingPathExtension().appendingPathExtension("store\(suffix)")
-                )
-            }
-            try? FileManager.default.removeItem(at: url)
-            container = try ModelContainer(for: schema, configurations: [config])
-        }
         self.container = container
         self.context = ModelContext(container)
     }

--- a/Tests/OnymIOSTests/PersistentStoreOpenerTests.swift
+++ b/Tests/OnymIOSTests/PersistentStoreOpenerTests.swift
@@ -1,0 +1,94 @@
+import SwiftData
+import XCTest
+import OnymFoundation
+
+/// The store-open recovery policy: a store that can't be opened is
+/// moved aside as `.bak` — never deleted — and a healthy store is
+/// reopened untouched. Born from the 2026-08-16 incident where the
+/// old wipe-on-any-error policy destroyed a device's chat history
+/// with no log line to explain why.
+@Model
+private final class Row {
+    var value: String
+    init(value: String) { self.value = value }
+}
+
+final class PersistentStoreOpenerTests: XCTestCase {
+    private var dir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opener-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: dir)
+        dir = nil
+        try super.tearDownWithError()
+    }
+
+    private var url: URL { dir.appendingPathComponent("Rows.store") }
+
+    func testHealthyStoreReopensWithDataIntactAndNoBackup() throws {
+        autoreleasepool {
+            let container = try! PersistentStoreOpener.openContainer(
+                schema: Schema([Row.self]), url: url
+            )
+            let context = ModelContext(container)
+            context.insert(Row(value: "survives"))
+            try! context.save()
+        }
+
+        let reopened = try PersistentStoreOpener.openContainer(
+            schema: Schema([Row.self]), url: url
+        )
+        let rows = try ModelContext(reopened).fetch(FetchDescriptor<Row>())
+        XCTAssertEqual(rows.map(\.value), ["survives"])
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: url.appendingPathExtension("bak").path),
+            "a clean reopen must not manufacture a backup"
+        )
+    }
+
+    func testUnopenableStoreIsMovedAsideNotDeleted() throws {
+        let garbage = Data("not a sqlite database, definitely".utf8)
+        try garbage.write(to: url)
+
+        let container = try PersistentStoreOpener.openContainer(
+            schema: Schema([Row.self]), url: url
+        )
+
+        // Fresh, usable store at the original path…
+        let context = ModelContext(container)
+        context.insert(Row(value: "fresh"))
+        try context.save()
+
+        // …and the unopenable original preserved byte-for-byte.
+        let backup = url.appendingPathExtension("bak")
+        XCTAssertEqual(try Data(contentsOf: backup), garbage)
+    }
+
+    func testSecondIncidentReplacesTheBackup() throws {
+        let first = Data("first broken store".utf8)
+        try first.write(to: url)
+        _ = try PersistentStoreOpener.openContainer(schema: Schema([Row.self]), url: url)
+
+        try FileManager.default.removeItem(at: url)
+        for suffix in ["-shm", "-wal"] {
+            try? FileManager.default.removeItem(
+                at: dir.appendingPathComponent("Rows.store\(suffix)")
+            )
+        }
+        let second = Data("second broken store".utf8)
+        try second.write(to: url)
+        _ = try PersistentStoreOpener.openContainer(schema: Schema([Row.self]), url: url)
+
+        XCTAssertEqual(
+            try Data(contentsOf: url.appendingPathExtension("bak")),
+            second,
+            "one generation of backup, newest incident wins"
+        )
+    }
+}


### PR DESCRIPTION
## The incident (2026-08-16)

A device lost its chat history twice in one day: once at the TestFlight-over-debug install, once at the debug-over-TestFlight reinstall. Forensics on the container showed the four `.store` files recreated while month-old cache files survived — the wipe-and-retry in the store inits fired, silently. Two facts rule out the "schema mismatch" story the old comments assumed:

- Release-over-Debug from **identical sources** on a simulator clone with months-old stores opens cleanly — no wipe.
- `Groups.store` was wiped again **14 minutes into the same debug binary's session** — same build, same schema.

So the trigger is environmental: a transiently unreadable store (Complete file protection during a locked or prewarmed launch is the prime suspect) throws from `ModelContainer(...)` exactly like corruption does, and the old policy answered *any* throw with `removeItem`. Silent, permanent data loss. The catch blocks logged nothing, so the true error was never recorded anywhere.

## The policy, now shared

`PersistentStoreOpener` (OnymFoundation, all three store packages already depend on it):

- **Log first**: every open failure becomes an os_log fault with the store name and the real error — the next incident is diagnosable from Console.app.
- **Unreadable ≠ broken**: if the store file exists but yields no bytes (file-protection lock), the error is rethrown with the disk untouched; the app-level in-memory fallback covers the session and the data is intact next launch.
- **Back up, never delete**: an openable-but-incompatible store trio is renamed to `.bak` siblings (one generation, newest incident wins) before the fresh-store retry.

`SwiftDataGroupStore`, `SwiftDataMessageStore`, `SwiftDataInvitationStore`, and `SwiftDataIntroRequestStore` all route through it, replacing four copies of the wipe boilerplate.

## Tests

`PersistentStoreOpenerTests`: healthy store reopens with data intact and no backup manufactured; garbage store is moved aside byte-for-byte (not deleted) with a usable fresh store in its place; a second incident replaces the backup. Existing store-consumer suite (GroupStateRefreshTests) still green.

## Not in this PR

The recovered `.bak` currently has no re-import path — it makes loss recoverable by hand, not automatic. And the root-cause hunt for the launch context that makes the open fail (prewarming vs. locked background launch) needs the fault log this PR adds; today there is nothing to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)