### PR TITLE
Park out-of-order chat messages; drain when their group catches up

### DIFF
--- a/Packages/OnymInbox/Sources/OnymInbox/ChatMessageParkingLot.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/ChatMessageParkingLot.swift
@@ -1,0 +1,57 @@
+import Foundation
+import OnymChatsCore
+import OnymIdentity
+
+/// Holding pen for chat messages that arrived before the local state
+/// they depend on.
+///
+/// Relays replay the stored inbox newest-first, so after a store loss
+/// (or on any fresh device) chat messages routinely land *before* the
+/// `GroupInvitationPayload` that materializes their group or the
+/// `MemberAnnouncementPayload` that adds their sender to the roster.
+/// The dispatcher used to drop such messages silently, which turned
+/// the relay's full-history replay into a one-shot lottery: only
+/// messages that happened to arrive after their group materialized
+/// survived. Parking them here and re-driving them when the group or
+/// roster catches up turns that replay into a real backfill.
+///
+/// Session-scoped by design: the replay that delivers an orphaned
+/// message delivers its group in the same subscription, and a launch
+/// that dies mid-replay gets the full replay again on the next
+/// connect (the inbox REQ is unbounded).
+public actor ChatMessageParkingLot {
+    struct Entry: Sendable {
+        let groupIDHex: String
+        let payload: ChatMessagePayload
+        let ownerIdentityID: IdentityID
+        let senderEd25519PublicKey: Data
+    }
+
+    /// Oldest entries are evicted first past this cap — a bound on
+    /// replay-burst memory, not a correctness knob. At the default
+    /// cap a full drop-and-repark cycle stays far below the size of
+    /// any realistic single-group backlog.
+    private let capacity: Int
+    private var entries: [Entry] = []
+
+    public init(capacity: Int = 2048) {
+        self.capacity = capacity
+    }
+
+    func park(_ entry: Entry) {
+        entries.append(entry)
+        if entries.count > capacity {
+            entries.removeFirst(entries.count - capacity)
+        }
+    }
+
+    /// Remove and return every parked message for `groupIDHex`, in
+    /// arrival order. The caller re-drives them through the normal
+    /// persist path; any that are still blocked re-park themselves.
+    func takeMatching(groupIDHex: String) -> [Entry] {
+        let matching = entries.filter { $0.groupIDHex == groupIDHex }
+        guard !matching.isEmpty else { return [] }
+        entries.removeAll { $0.groupIDHex == groupIDHex }
+        return matching
+    }
+}

--- a/Packages/OnymInbox/Sources/OnymInbox/IncomingMessageDispatcher.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/IncomingMessageDispatcher.swift
@@ -79,6 +79,13 @@ public struct IncomingMessageDispatcher: Sendable {
     /// raises a message to `.read` when this device also sends read
     /// receipts. Defaulted to `true` (the shipping default).
     let readReceiptsEnabled: @Sendable () -> Bool
+    /// Chat messages that arrived before their group (or their
+    /// sender's roster entry) wait here instead of being dropped, and
+    /// are re-driven when `materializeGroup` / `applyAnnouncement`
+    /// catches the local state up — see `ChatMessageParkingLot`.
+    /// Defaulted so existing constructions get the behaviour without
+    /// a new parameter.
+    let parkedMessages: ChatMessageParkingLot
 
     /// Mints the membership notices this device is entitled to render:
     /// "X joined" off a verified announcement, "You joined X" off a
@@ -100,7 +107,8 @@ public struct IncomingMessageDispatcher: Sendable {
         pendingInvites: any PendingInvitesRecording = PendingInvitesStore(),
         groupStateRefresher: any GroupStateRefreshing = NoopGroupStateRefresher(),
         receiptSender: any ChatReceiptSending = NoopChatReceiptSender(),
-        readReceiptsEnabled: @escaping @Sendable () -> Bool = { true }
+        readReceiptsEnabled: @escaping @Sendable () -> Bool = { true },
+        parkedMessages: ChatMessageParkingLot = ChatMessageParkingLot()
     ) {
         self.envelopeDecrypter = envelopeDecrypter
         self.identities = identities
@@ -112,6 +120,7 @@ public struct IncomingMessageDispatcher: Sendable {
         self.groupStateRefresher = groupStateRefresher
         self.receiptSender = receiptSender
         self.readReceiptsEnabled = readReceiptsEnabled
+        self.parkedMessages = parkedMessages
     }
 
     public func dispatch(
@@ -461,6 +470,10 @@ public struct IncomingMessageDispatcher: Sendable {
         }
 
         await groupRepository.insert(group)
+
+        // The group exists now — re-drive any chat messages that
+        // arrived ahead of this invitation in the replay stream.
+        await drainParkedMessages(groupIDHex: groupIDHex)
 
         // Open the joiner's brand-new thread with a line explaining
         // what it is, instead of a blank screen, once the invitation has
@@ -836,6 +849,10 @@ public struct IncomingMessageDispatcher: Sendable {
         )
         await groupRepository.insert(updated)
 
+        // The roster caught up — re-drive any of this member's chat
+        // messages that arrived ahead of their announcement.
+        await drainParkedMessages(groupIDHex: updated.id)
+
         // "X joined", for every existing member. Reached only past the
         // dedup guard above (`memberProfiles[key] != nil`), the admin
         // signature check, and the on-chain commitment check — so a
@@ -907,6 +924,22 @@ public struct IncomingMessageDispatcher: Sendable {
         await groupRepository.insert(updated)
     }
 
+    /// Re-drive every parked message for `groupIDHex` through the
+    /// normal persist path now that the group or its roster caught
+    /// up. Entries that are still blocked (e.g. their sender's
+    /// announcement hasn't landed yet) re-park themselves; each
+    /// drain removes the batch first, so a still-blocked entry is
+    /// processed once per drain, never in a loop.
+    private func drainParkedMessages(groupIDHex: String) async {
+        for entry in await parkedMessages.takeMatching(groupIDHex: groupIDHex) {
+            await persistChatMessage(
+                entry.payload,
+                ownerIdentityID: entry.ownerIdentityID,
+                senderEd25519PublicKey: entry.senderEd25519PublicKey
+            )
+        }
+    }
+
     /// Persist an incoming chat message after authenticating the
     /// sender. The trust chain:
     ///
@@ -931,23 +964,41 @@ public struct IncomingMessageDispatcher: Sendable {
         // are not part of the v1 trust model.
         guard let senderEd25519PublicKey else { return }
 
-        // Look up the local group. Drop if we don't know it (stale
-        // delivery for a group we left, or routing mistake) or if it
-        // belongs to a different identity than the receiving inbox.
+        // Look up the local group. An unknown group is NOT dropped:
+        // relays replay the inbox newest-first, so on a fresh (or
+        // store-lost) device the thread's messages routinely arrive
+        // before the invitation that materializes the group. Park them;
+        // `materializeGroup` drains the lot once the group exists. A
+        // genuinely stale delivery (group we left for good) just ages
+        // out of the session-scoped lot.
         let groupIDHex = payload.groupID
             .map { String(format: "%02x", $0) }.joined()
         let groups = await groupRepository.currentGroups()
         guard let group = groups.first(where: {
             $0.id == groupIDHex && $0.ownerIdentityID == ownerIdentityID
         }) else {
+            await parkedMessages.park(.init(
+                groupIDHex: groupIDHex,
+                payload: payload,
+                ownerIdentityID: ownerIdentityID,
+                senderEd25519PublicKey: senderEd25519PublicKey
+            ))
             return
         }
 
         // Sender must be a known member. `memberProfiles` is keyed by
         // lowercase BLS pubkey hex; normalize the payload's claim
-        // before lookup.
+        // before lookup. Unknown senders park too — during a replay
+        // the member's announcement may simply not have been applied
+        // yet; `applyAnnouncement` drains the lot when it lands.
         let senderKey = payload.senderBlsPubkeyHex.lowercased()
         guard let senderProfile = group.memberProfiles[senderKey] else {
+            await parkedMessages.park(.init(
+                groupIDHex: groupIDHex,
+                payload: payload,
+                ownerIdentityID: ownerIdentityID,
+                senderEd25519PublicKey: senderEd25519PublicKey
+            ))
             return
         }
 

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherChatMessageTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import OnymIOS
+import OnymChain
 import OnymIdentity
 import OnymGroup
 import OnymPersistence
@@ -357,6 +358,151 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
                        "second delivery of the same message id must be a no-op")
     }
 
+    // MARK: - Replay backfill (parking)
+
+    /// The relay replays the stored inbox newest-first, so after a
+    /// store loss the thread's messages arrive before the invitation
+    /// that materializes their group. They must park and then persist
+    /// when the invitation lands — not silently drop.
+    func test_chatMessage_beforeInvitation_parksThenPersistsOnMaterialize() async throws {
+        let lot = ChatMessageParkingLot()
+        let newGroupBytes = Data(repeating: 0x99, count: 32)
+        let newGroupHex = newGroupBytes.map { String(format: "%02x", $0) }.joined()
+
+        // 1. Chat message for a group this device doesn't know yet.
+        let payload = makePayload(body: "from before the wipe", groupIDBytes: newGroupBytes)
+        let msgDispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: senderEd25519,
+            parkedMessages: lot
+        )
+        await msgDispatcher.dispatch(
+            messageID: "msg-early",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let before = await messages.currentMessages(groupID: newGroupHex, owner: owner)
+        XCTAssertTrue(before.isEmpty, "no group yet — the message parks, it does not persist")
+
+        // 2. The invitation materializes the group with the sender in
+        // the roster; the parked message must drain into the store.
+        let invitation = makeTyrannyInvitation(
+            groupID: newGroupBytes,
+            memberProfiles: [
+                senderBlsHex: MemberProfile(
+                    alias: "Alice",
+                    inboxPublicKey: senderInbox,
+                    sendingPubkey: senderEd25519
+                )
+            ]
+        )
+        let inviteDispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(invitation),
+            envelopeSigner: Data(repeating: 0xAD, count: 32),
+            parkedMessages: lot
+        )
+        await inviteDispatcher.dispatch(
+            messageID: "msg-invite",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await messages.currentMessages(groupID: newGroupHex, owner: owner)
+        XCTAssertEqual(after.map(\.body), ["from before the wipe"],
+                       "materializing the group must drain the parked message")
+    }
+
+    /// Known group, unknown sender: the message waits for the roster
+    /// to catch up (here via a re-delivered invitation carrying the
+    /// fuller roster) instead of being dropped.
+    func test_chatMessage_unknownSender_parksThenPersistsWhenRosterCatchesUp() async throws {
+        let lot = ChatMessageParkingLot()
+        let lateBlsHex = "22".repeated(48)
+        let lateEd25519 = Data(repeating: 0xE2, count: 32)
+
+        // 1. Message from a member whose roster entry hasn't arrived.
+        let payload = makePayload(body: "hello from the latecomer", senderBlsHex: lateBlsHex)
+        let msgDispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(payload),
+            envelopeSigner: lateEd25519,
+            parkedMessages: lot
+        )
+        await msgDispatcher.dispatch(
+            messageID: "msg-unknown-sender",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+        let before = await messages.currentMessages(groupID: groupIDHex, owner: owner)
+        XCTAssertTrue(before.isEmpty, "unknown sender — the message parks")
+
+        // 2. A re-delivered invitation for the SAME group now carries
+        // the sender; re-materializing drains the parked message.
+        let invitation = makeTyrannyInvitation(
+            groupID: groupIDBytes,
+            memberProfiles: [
+                senderBlsHex: MemberProfile(
+                    alias: "Alice",
+                    inboxPublicKey: senderInbox,
+                    sendingPubkey: senderEd25519
+                ),
+                lateBlsHex: MemberProfile(
+                    alias: "Bob",
+                    inboxPublicKey: Data(repeating: 0x22, count: 32),
+                    sendingPubkey: lateEd25519
+                )
+            ]
+        )
+        let inviteDispatcher = makeDispatcher(
+            plaintext: try JSONEncoder().encode(invitation),
+            envelopeSigner: Data(repeating: 0xAD, count: 32),
+            parkedMessages: lot
+        )
+        await inviteDispatcher.dispatch(
+            messageID: "msg-reinvite",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await messages.currentMessages(groupID: groupIDHex, owner: owner)
+        XCTAssertEqual(after.map(\.body), ["hello from the latecomer"],
+                       "the roster catching up must drain the parked message")
+    }
+
+    /// A verified Tyranny invitation: commitment recomputed from the
+    /// (empty) member set and mirrored on the stub chain, so
+    /// `materializeGroup` actually runs instead of rejecting.
+    private func makeTyrannyInvitation(
+        groupID: Data,
+        memberProfiles: [String: MemberProfile]
+    ) -> GroupInvitationPayload {
+        let salt = Data(repeating: 0x66, count: 32)
+        let commitment = try! GroupCommitmentBuilder.computePoseidonCommitment(
+            poseidonRoot: GroupCommitmentBuilder.computeMerkleRoot(members: [], tier: .small),
+            epoch: 0,
+            salt: salt
+        )
+        chainState.setNext(commitment: commitment, epoch: 0)
+        return GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),
+            name: "Recovered",
+            members: [],
+            epoch: 0,
+            salt: salt,
+            commitment: commitment,
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.tyranny.rawValue,
+            adminPubkeyHex: nil,
+            peerBlsSecret: nil,
+            memberProfiles: memberProfiles
+        )
+    }
+
     // MARK: - Helpers
 
     private func makePayload(
@@ -383,7 +529,8 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
         plaintext: Data,
         envelopeSigner: Data?,
         receiptSender: any ChatReceiptSending = NoopChatReceiptSender(),
-        readReceiptsEnabled: @escaping @Sendable () -> Bool = { true }
+        readReceiptsEnabled: @escaping @Sendable () -> Bool = { true },
+        parkedMessages: ChatMessageParkingLot = ChatMessageParkingLot()
     ) -> IncomingMessageDispatcher {
         let decrypter = FakeInvitationEnvelopeDecrypter(
             mode: .fixed(plaintext),
@@ -397,7 +544,8 @@ final class IncomingMessageDispatcherChatMessageTests: XCTestCase {
             chainState: chainState,
             messageRepository: messages,
             receiptSender: receiptSender,
-            readReceiptsEnabled: readReceiptsEnabled
+            readReceiptsEnabled: readReceiptsEnabled,
+            parkedMessages: parkedMessages
         )
     }
 


### PR DESCRIPTION
## Why 11 messages came back instead of the whole history

After the 2026-08-16 store wipes, the device's relaunch did replay the full inbox — the REQ has no `since`, no `limit`, and no persisted watermark, and the relay still holds ~35k events. But relays deliver stored events newest-first, so most chat messages arrived *before* the `GroupInvitationPayload` that re-materializes their group (or the `MemberAnnouncementPayload` that re-adds their sender), hit the unknown-group / unknown-sender guards in `persistChatMessage`, and were silently discarded mid-replay. Only the slice that happened to follow its group's materialization survived.

## The change

- `ChatMessageParkingLot` — a session-scoped, capacity-bounded actor in OnymInbox. Messages that hit either guard park (keyed by group id) instead of dropping.
- `materializeGroup` and `applyAnnouncement` drain the lot for their group after updating the repository, re-driving each parked message through the **normal** persist path — every trust check (roster membership, insider-spoof Ed25519 match, variant/group-type gate) runs unchanged at drain time. Parking defers verification; it never bypasses it. Still-blocked entries re-park; each drain removes its batch first, so there is no loop.
- Session-scoped on purpose: the replay that delivers an orphaned message delivers its group in the same subscription, and a launch that dies mid-replay just gets the full unbounded replay again on the next connect.

Net effect: any app relaunch is now a genuine backfill of whatever history the relay retains — which is also the recovery path for the wiped device.

## Tests

- `test_chatMessage_beforeInvitation_parksThenPersistsOnMaterialize` — message for an unknown group parks, then persists when the (chain-verified Tyranny) invitation lands.
- `test_chatMessage_unknownSender_parksThenPersistsWhenRosterCatchesUp` — known group, unknown sender parks, then persists when a re-delivered invitation carries the fuller roster.
- All existing dispatcher/fanout suites pass unchanged — including `unknownGroup_drops`/`senderNotInRoster_drops`, which assert nothing is *persisted* (parking keeps that true).

## Notes for review

- Delivered-receipt latching (`deliveredAckSent`) applies to drained messages exactly as to normal arrivals, so a large backfill acks each recovered message once — same volume as if they'd arrived in order.
- The `applyAnnouncement` group lookup matches on group id without an owner filter (pre-existing); the drain re-checks owner inside `persistChatMessage`, so a drain can only persist rows for owners whose group row actually exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)