### PR TITLE
Chat bubbles: tappable links and a Copy action on the long-press menu

### DIFF
--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatBubbleCell.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatBubbleCell.swift
@@ -103,7 +103,7 @@ final class ChatBubbleCell: UITableViewCell {
     private let maxWidthFraction: CGFloat = 0.75
 
     private let bubble = UIView()
-    private let bodyLabel = UILabel()
+    private let bodyView = LinkTextView()
     /// Image attachment view (shown when `message.imageAttachment != nil`).
     /// Sits above the caption; the blurhash placeholder renders first,
     /// then the decrypted image swaps in from `ChatImageLoader`.
@@ -333,14 +333,17 @@ final class ChatBubbleCell: UITableViewCell {
         // Reuse safety: a cell recycled mid-drag must start at rest.
         resetSwipeState()
         self.onSwipeToReply = onSwipeToReply
-        bodyLabel.text = message.body
         switch message.direction {
         case .outgoing:
             // Own messages: solid fill in the user's own accent (so
             // "your color" is consistent with the members list and
             // every group). Right-aligned, status glyph below.
             bubble.backgroundColor = UIColor(sender.accent.color)
-            bodyLabel.textColor = UIColor(OnymTokens.onAccent)
+            bodyView.setBody(
+                message.body,
+                font: .preferredFont(forTextStyle: .body),
+                color: UIColor(OnymTokens.onAccent)
+            )
             NSLayoutConstraint.deactivate(incomingConstraints)
             NSLayoutConstraint.activate(outgoingConstraints)
             bubbleBottomConstraint.isActive = false
@@ -350,7 +353,11 @@ final class ChatBubbleCell: UITableViewCell {
             // — distinguishable per person while keeping body text on
             // the regular text token readable.
             bubble.backgroundColor = UIColor(sender.accent.color.opacity(incomingTintAlpha))
-            bodyLabel.textColor = UIColor(OnymTokens.text)
+            bodyView.setBody(
+                message.body,
+                font: .preferredFont(forTextStyle: .body),
+                color: UIColor(OnymTokens.text)
+            )
             NSLayoutConstraint.deactivate(outgoingConstraints)
             NSLayoutConstraint.activate(incomingConstraints)
             statusBottomConstraint.isActive = false
@@ -883,20 +890,17 @@ final class ChatBubbleCell: UITableViewCell {
         bubble.layer.cornerCurve = .continuous
         contentView.addSubview(bubble)
 
-        bodyLabel.translatesAutoresizingMaskIntoConstraints = false
-        bodyLabel.numberOfLines = 0
-        bodyLabel.font = .preferredFont(forTextStyle: .body)
-        bodyLabel.adjustsFontForContentSizeCategory = true
+        bodyView.translatesAutoresizingMaskIntoConstraints = false
         // Hug the text horizontally with a decisive priority so a text
-        // bubble shrinks to fit its content. Without this the label sits at
-        // the default hugging (251), tying with the hidden media siblings
+        // bubble shrinks to fit its content. Without this the body view
+        // sits at its default hugging, tying with the hidden media siblings
         // (image/album/voice) that are also pinned edge-to-edge on the
         // bubble — autolayout resolves the tie inconsistently, so *some*
         // short text bubbles stretch toward the 75% cap. `.defaultHigh`
         // (750) beats those siblings while still yielding to the fixed
         // 75%-width constraint (1000) a real media message installs.
-        bodyLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        bubble.addSubview(bodyLabel)
+        bodyView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        bubble.addSubview(bodyView)
 
         attachmentImageView.translatesAutoresizingMaskIntoConstraints = false
         attachmentImageView.contentMode = .scaleAspectFill
@@ -1136,10 +1140,10 @@ final class ChatBubbleCell: UITableViewCell {
 
         // Body-top toggle — `configure` activates exactly one depending
         // on whether a reply quote is shown.
-        bodyTopToBubbleConstraint = bodyLabel.topAnchor.constraint(
+        bodyTopToBubbleConstraint = bodyView.topAnchor.constraint(
             equalTo: bubble.topAnchor, constant: 8
         )
-        bodyTopToQuoteConstraint = bodyLabel.topAnchor.constraint(
+        bodyTopToQuoteConstraint = bodyView.topAnchor.constraint(
             equalTo: quoteContainer.bottomAnchor, constant: 6
         )
 
@@ -1147,7 +1151,7 @@ final class ChatBubbleCell: UITableViewCell {
         imageTopToBubbleConstraint = attachmentImageView.topAnchor.constraint(
             equalTo: bubble.topAnchor, constant: 4
         )
-        bodyTopToImageConstraint = bodyLabel.topAnchor.constraint(
+        bodyTopToImageConstraint = bodyView.topAnchor.constraint(
             equalTo: attachmentImageView.bottomAnchor, constant: 6
         )
         // Fixed bubble width for attachment messages (toggled in
@@ -1161,7 +1165,7 @@ final class ChatBubbleCell: UITableViewCell {
         albumTopToBubbleConstraint = albumGridView.topAnchor.constraint(
             equalTo: bubble.topAnchor, constant: 4
         )
-        bodyTopToAlbumConstraint = bodyLabel.topAnchor.constraint(
+        bodyTopToAlbumConstraint = bodyView.topAnchor.constraint(
             equalTo: albumGridView.bottomAnchor, constant: 6
         )
 
@@ -1169,7 +1173,7 @@ final class ChatBubbleCell: UITableViewCell {
         voiceTopToBubbleConstraint = voiceView.topAnchor.constraint(
             equalTo: bubble.topAnchor, constant: 6
         )
-        bodyTopToVoiceConstraint = bodyLabel.topAnchor.constraint(
+        bodyTopToVoiceConstraint = bodyView.topAnchor.constraint(
             equalTo: voiceView.bottomAnchor, constant: 2
         )
 
@@ -1184,9 +1188,9 @@ final class ChatBubbleCell: UITableViewCell {
                 lessThanOrEqualTo: contentView.widthAnchor,
                 multiplier: maxWidthFraction
             ),
-            bodyLabel.leadingAnchor.constraint(equalTo: bubble.leadingAnchor, constant: 12),
-            bodyLabel.trailingAnchor.constraint(equalTo: bubble.trailingAnchor, constant: -12),
-            bodyLabel.bottomAnchor.constraint(equalTo: bubble.bottomAnchor, constant: -8),
+            bodyView.leadingAnchor.constraint(equalTo: bubble.leadingAnchor, constant: 12),
+            bodyView.trailingAnchor.constraint(equalTo: bubble.trailingAnchor, constant: -12),
+            bodyView.bottomAnchor.constraint(equalTo: bubble.bottomAnchor, constant: -8),
 
             // Reply quote — pinned across the top of the bubble. Only
             // drives the body's top when `bodyTopToQuoteConstraint` is

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatBubbleCell.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatBubbleCell.swift
@@ -333,17 +333,14 @@ final class ChatBubbleCell: UITableViewCell {
         // Reuse safety: a cell recycled mid-drag must start at rest.
         resetSwipeState()
         self.onSwipeToReply = onSwipeToReply
+        let bodyColor: UIColor
         switch message.direction {
         case .outgoing:
             // Own messages: solid fill in the user's own accent (so
             // "your color" is consistent with the members list and
             // every group). Right-aligned, status glyph below.
             bubble.backgroundColor = UIColor(sender.accent.color)
-            bodyView.setBody(
-                message.body,
-                font: .preferredFont(forTextStyle: .body),
-                color: UIColor(OnymTokens.onAccent)
-            )
+            bodyColor = UIColor(OnymTokens.onAccent)
             NSLayoutConstraint.deactivate(incomingConstraints)
             NSLayoutConstraint.activate(outgoingConstraints)
             bubbleBottomConstraint.isActive = false
@@ -353,11 +350,7 @@ final class ChatBubbleCell: UITableViewCell {
             // — distinguishable per person while keeping body text on
             // the regular text token readable.
             bubble.backgroundColor = UIColor(sender.accent.color.opacity(incomingTintAlpha))
-            bodyView.setBody(
-                message.body,
-                font: .preferredFont(forTextStyle: .body),
-                color: UIColor(OnymTokens.text)
-            )
+            bodyColor = UIColor(OnymTokens.text)
             NSLayoutConstraint.deactivate(outgoingConstraints)
             NSLayoutConstraint.activate(incomingConstraints)
             statusBottomConstraint.isActive = false
@@ -368,6 +361,11 @@ final class ChatBubbleCell: UITableViewCell {
             failureLabel.isHidden = true
             failureLabel.text = nil
         }
+        bodyView.setBody(
+            message.body,
+            font: .preferredFont(forTextStyle: .body),
+            color: bodyColor
+        )
         applyNameHeader(sender)
         applyReplyQuote(reply, direction: message.direction, onTap: onQuoteTapped)
         let media = message.media

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 import OnymDesign
 import OnymGroup
 import OnymChatsCore
@@ -992,8 +993,14 @@ extension ChatThreadViewController: UITableViewDelegate {
                 ) { _ in
                     // The untrimmed body: trimming was only the "is
                     // there anything to copy" test, the user gets the
-                    // message text as written.
-                    UIPasteboard.general.string = message.body
+                    // message text as written. `localOnly` keeps an
+                    // E2E-encrypted message from crossing Universal
+                    // Clipboard to the user's other Apple devices —
+                    // same posture as the recovery-phrase copy.
+                    UIPasteboard.general.setItems(
+                        [[UTType.utf8PlainText.identifier: message.body]],
+                        options: [.localOnly: true]
+                    )
                 })
             }
             if canReport {

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
@@ -971,25 +971,41 @@ extension ChatThreadViewController: UITableViewDelegate {
         // `apply` commits, so during an in-flight insert the committed
         // rows and the array can disagree and a positional index would
         // attach Report to the wrong message.
-        // A system notice has no author to report and isn't evidence of
-        // anything — no menu on it, regardless of what the host's
-        // reportability predicate says.
+        // A system notice has no author to report and no user-authored
+        // text worth copying — no menu on it, regardless of what the
+        // host's reportability predicate says.
         guard let id = dataSource.itemIdentifier(for: indexPath),
               let message = messagesByID[id],
-              !message.isSystem,
-              canReportMessage?(message) == true else { return nil }
+              !message.isSystem else { return nil }
+        let canReport = canReportMessage?(message) == true
+        let copyableBody = message.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard canReport || !copyableBody.isEmpty else { return nil }
         return UIContextMenuConfiguration(
             identifier: message.id as NSUUID,
             previewProvider: nil
         ) { [weak self] _ in
-            let report = UIAction(
-                title: String(localized: "Report"),
-                image: UIImage(systemName: "exclamationmark.bubble"),
-                attributes: .destructive
-            ) { [weak self] _ in
-                self?.onReportRequested?(message)
+            var actions: [UIAction] = []
+            if !copyableBody.isEmpty {
+                actions.append(UIAction(
+                    title: String(localized: "Copy"),
+                    image: UIImage(systemName: "doc.on.doc")
+                ) { _ in
+                    // The untrimmed body: trimming was only the "is
+                    // there anything to copy" test, the user gets the
+                    // message text as written.
+                    UIPasteboard.general.string = message.body
+                })
             }
-            return UIMenu(children: [report])
+            if canReport {
+                actions.append(UIAction(
+                    title: String(localized: "Report"),
+                    image: UIImage(systemName: "exclamationmark.bubble"),
+                    attributes: .destructive
+                ) { [weak self] _ in
+                    self?.onReportRequested?(message)
+                })
+            }
+            return UIMenu(children: actions)
         }
     }
 }

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/LinkTextView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/LinkTextView.swift
@@ -1,0 +1,85 @@
+import UIKit
+
+/// The message bubble's body: renders like the `UILabel` it replaced,
+/// but URLs in the text are tappable.
+///
+/// A plain `UITextView` would claim *every* touch, which breaks the
+/// bubble's surroundings — the table's scroll, the row context menu
+/// (Copy/Report), and the swipe-to-reply pan all start on the text.
+/// This subclass only accepts touches that land on a link character;
+/// everything else falls through to the cell as if the text were a
+/// label. Long-pressing a link gets the system link menu, which is
+/// wanted; long-pressing anywhere else reaches the row's own menu.
+final class LinkTextView: UITextView {
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+        // Label-like metrics: no inner padding, no scrolling (so the
+        // view self-sizes through Auto Layout like a label does).
+        isEditable = false
+        isScrollEnabled = false
+        // Required for link taps; non-link touches never reach the
+        // view (see `point(inside:)`), so selection can't start on
+        // body text and fight the row's long-press menu.
+        isSelectable = true
+        backgroundColor = .clear
+        textContainerInset = .zero
+        self.textContainer.lineFragmentPadding = 0
+        adjustsFontForContentSizeCategory = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    /// A `UILabel` with no text measures zero; an empty `UITextView`
+    /// measures one caret line. Media-only bubbles (image, voice) set
+    /// an empty body and rely on it contributing no height — keep the
+    /// label's behaviour.
+    override var intrinsicContentSize: CGSize {
+        guard let text, !text.isEmpty else { return .zero }
+        return super.intrinsicContentSize
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        guard let attributed = attributedText, attributed.length > 0 else { return false }
+        // Character index under the touch; `closestPosition` snaps to
+        // the nearest glyph, so also reject touches past the line end
+        // that would otherwise "hit" a trailing link from whitespace.
+        guard let position = closestPosition(to: point),
+              let range = tokenizer.rangeEnclosingPosition(
+                position, with: .character, inDirection: .layout(.left)
+              )
+        else { return false }
+        let index = offset(from: beginningOfDocument, to: range.start)
+        guard index < attributed.length else { return false }
+        return attributed.attribute(.link, at: index, effectiveRange: nil) != nil
+    }
+
+    /// One shared detector — `NSDataDetector` construction is costly
+    /// and cell reuse calls this per configure.
+    private static let linkDetector = try? NSDataDetector(
+        types: NSTextCheckingResult.CheckingType.link.rawValue
+    )
+
+    /// Set the bubble body: plain text plus `.link` runs for every
+    /// URL the detector finds. Links keep the body's color and gain
+    /// an underline — readable on both the accent-filled outgoing
+    /// bubble and the tinted incoming one, with no extra color token.
+    func setBody(_ body: String, font: UIFont, color: UIColor) {
+        let attributed = NSMutableAttributedString(
+            string: body,
+            attributes: [.font: font, .foregroundColor: color]
+        )
+        if let detector = Self.linkDetector {
+            let full = NSRange(body.startIndex..., in: body)
+            for match in detector.matches(in: body, options: [], range: full) {
+                guard let url = match.url else { continue }
+                attributed.addAttribute(.link, value: url, range: match.range)
+            }
+        }
+        linkTextAttributes = [
+            .foregroundColor: color,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+        attributedText = attributed
+    }
+}

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/LinkTextView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/LinkTextView.swift
@@ -40,18 +40,36 @@ final class LinkTextView: UITextView {
     }
 
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        // `hitTest` probes subviews with out-of-bounds points too (the
+        // "enlarged tap area" mechanism) — without this guard, a tap
+        // in the bubble's padding beside a body that ends in a link
+        // would count as a hit on the link below.
+        guard bounds.contains(point) else { return false }
         guard let attributed = attributedText, attributed.length > 0 else { return false }
-        // Character index under the touch; `closestPosition` snaps to
-        // the nearest glyph, so also reject touches past the line end
-        // that would otherwise "hit" a trailing link from whitespace.
-        guard let position = closestPosition(to: point),
-              let range = tokenizer.rangeEnclosingPosition(
-                position, with: .character, inDirection: .layout(.left)
-              )
-        else { return false }
-        let index = offset(from: beginningOfDocument, to: range.start)
-        guard index < attributed.length else { return false }
-        return attributed.attribute(.link, at: index, effectiveRange: nil) != nil
+        // Hit-test the links' rendered rects directly. Position-based
+        // probing (`closestPosition` + tokenizer) is unreliable here:
+        // it clamps empty-space touches onto the nearest glyph, and
+        // inside a link TextKit 2 snaps positions to the link's
+        // boundary — both produce wrong answers at the edges. The
+        // per-line `selectionRects(for:)` of each link range are the
+        // exact area where a tap visually lands on the link.
+        var hit = false
+        attributed.enumerateAttribute(
+            .link, in: NSRange(location: 0, length: attributed.length)
+        ) { value, range, stop in
+            guard value != nil,
+                  let start = position(from: beginningOfDocument, offset: range.location),
+                  let end = position(from: start, offset: range.length),
+                  let textRange = textRange(from: start, to: end)
+            else { return }
+            for selection in selectionRects(for: textRange)
+            where !selection.rect.isNull && selection.rect.contains(point) {
+                hit = true
+                stop.pointee = true
+                return
+            }
+        }
+        return hit
     }
 
     /// One shared detector — `NSDataDetector` construction is costly

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -65,6 +65,30 @@ final class ChatBubbleCellTests: XCTestCase {
         XCTAssertNil(attributed.attribute(.link, at: attributed.length - 1, effectiveRange: nil))
     }
 
+    func test_multilineBody_measuresTallerThanSingleLine() {
+        // UITextView self-sizing is not UILabel self-sizing: the
+        // intrinsic height depends on the container width resolved in
+        // a prior layout pass. A wrapping body must measure several
+        // lines taller than a one-liner at the same fitting width, or
+        // the label→text-view swap silently truncated the thread.
+        let single = measuredHeight(body: "hi")
+        let multi = measuredHeight(
+            body: String(repeating: "wrap this message body ", count: 12)
+        )
+        XCTAssertGreaterThan(multi, single * 2,
+                             "a long body must wrap and grow the cell")
+    }
+
+    private func measuredHeight(body: String) -> CGFloat {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(direction: .incoming, body: body))
+        return cell.contentView.systemLayoutSizeFitting(
+            CGSize(width: 320, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+    }
+
     private func findTextView(in view: UIView) -> UITextView? {
         if let textView = view as? UITextView { return textView }
         for sub in view.subviews {

--- a/Tests/OnymIOSTests/ChatBubbleCellTests.swift
+++ b/Tests/OnymIOSTests/ChatBubbleCellTests.swift
@@ -41,11 +41,36 @@ final class ChatBubbleCellTests: XCTestCase {
         XCTAssertFalse(activeTrailingAlignment(in: cell))
     }
 
-    func test_body_writesThroughToLabel() {
+    func test_body_writesThroughToBodyView() {
         let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
         cell.configure(message: makeMessage(direction: .incoming, body: "hello, world"))
-        let label = findLabel(in: cell.contentView)
-        XCTAssertEqual(label?.text, "hello, world")
+        let body = findTextView(in: cell.contentView)
+        XCTAssertEqual(body?.text, "hello, world")
+    }
+
+    func test_body_urlGetsLinkAttribute_plainTextDoesNot() throws {
+        let cell = ChatBubbleCell(style: .default, reuseIdentifier: ChatBubbleCell.reuseID)
+        cell.configure(message: makeMessage(
+            direction: .incoming,
+            body: "docs at https://onym.foundation ok"
+        ))
+        let attributed = try XCTUnwrap(findTextView(in: cell.contentView)?.attributedText)
+
+        // The URL run carries `.link` with the parsed URL…
+        let urlStart = ("docs at " as NSString).length
+        let link = attributed.attribute(.link, at: urlStart, effectiveRange: nil) as? URL
+        XCTAssertEqual(link?.host, "onym.foundation")
+        // …and the surrounding prose does not.
+        XCTAssertNil(attributed.attribute(.link, at: 0, effectiveRange: nil))
+        XCTAssertNil(attributed.attribute(.link, at: attributed.length - 1, effectiveRange: nil))
+    }
+
+    private func findTextView(in view: UIView) -> UITextView? {
+        if let textView = view as? UITextView { return textView }
+        for sub in view.subviews {
+            if let found = findTextView(in: sub) { return found }
+        }
+        return nil
     }
 
     // MARK: - Sender name header
@@ -540,14 +565,6 @@ final class ChatBubbleCellTests: XCTestCase {
             found.append(contentsOf: collectActiveConstraints(in: sub))
         }
         return found
-    }
-
-    private func findLabel(in view: UIView) -> UILabel? {
-        if let label = view as? UILabel { return label }
-        for sub in view.subviews {
-            if let found = findLabel(in: sub) { return found }
-        }
-        return nil
     }
 
     private func makeMessage(

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -153,11 +153,31 @@ final class ChatThreadViewControllerTests: XCTestCase {
         XCTAssertNotNil(configuration)
     }
 
-    func test_longPress_unreportableMessageHasNoContextMenu() {
+    func test_longPress_unreportableMessageStillOffersCopyMenu() {
+        // Not reportable (own message), but it has text — the menu
+        // must still appear for Copy.
         let vc = ChatThreadViewController()
         vc.loadViewIfNeeded()
         vc.canReportMessage = { $0.direction == .incoming }
         vc.update(messages: [makeMessage(body: "mine", direction: .outgoing)])
+        let table = tableView(in: vc)!
+
+        let configuration = vc.tableView(
+            table,
+            contextMenuConfigurationForRowAt: IndexPath(row: 0, section: 0),
+            point: .zero
+        )
+
+        XCTAssertNotNil(configuration,
+                        "a message with a body is copyable even when it isn't reportable")
+    }
+
+    func test_longPress_unreportableEmptyBodyHasNoContextMenu() {
+        // Nothing to copy AND nothing to report → no menu at all.
+        let vc = ChatThreadViewController()
+        vc.loadViewIfNeeded()
+        vc.canReportMessage = { _ in false }
+        vc.update(messages: [makeMessage(body: "  ", direction: .outgoing)])
         let table = tableView(in: vc)!
 
         let configuration = vc.tableView(
@@ -1025,7 +1045,15 @@ final class ChatThreadViewControllerTests: XCTestCase {
     }
 
     private func findLabelText(in view: UIView) -> String? {
-        if let label = view as? UILabel { return label.text }
+        // The body moved from a UILabel to the link-aware UITextView;
+        // labels remain for headers/status, so prefer the text view
+        // and only fall back to a label with actual content.
+        if let textView = view as? UITextView, let text = textView.text, !text.isEmpty {
+            return text
+        }
+        if let label = view as? UILabel, let text = label.text, !text.isEmpty {
+            return text
+        }
         for sub in view.subviews {
             if let text = findLabelText(in: sub) { return text }
         }

--- a/Tests/OnymIOSTests/LinkTextViewTests.swift
+++ b/Tests/OnymIOSTests/LinkTextViewTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import OnymChatsUI
+
+/// `LinkTextView.point(inside:)` — the bubble body only claims
+/// touches that land on a link glyph; everything else must fall
+/// through to the cell (scroll, context menu, swipe-to-reply). A
+/// false positive here opens a sender-controlled URL from a touch
+/// the user aimed at something else, so every miss case is pinned.
+@MainActor
+final class LinkTextViewTests: XCTestCase {
+
+    private func makeView(_ body: String, width: CGFloat = 300) -> LinkTextView {
+        let view = LinkTextView()
+        view.setBody(body, font: .systemFont(ofSize: 17), color: .black)
+        let size = view.systemLayoutSizeFitting(
+            CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        view.frame = CGRect(origin: .zero, size: CGSize(width: width, height: size.height))
+        view.layoutIfNeeded()
+        return view
+    }
+
+    /// Center of the rendered rect for the character at `index`.
+    private func centerOfChar(_ index: Int, in view: LinkTextView) throws -> CGPoint {
+        let start = try XCTUnwrap(view.position(from: view.beginningOfDocument, offset: index))
+        let end = try XCTUnwrap(view.position(from: start, offset: 1))
+        let rect = view.firstRect(for: try XCTUnwrap(view.textRange(from: start, to: end)))
+        return CGPoint(x: rect.midX, y: rect.midY)
+    }
+
+    func test_pointOnLinkGlyph_hits() throws {
+        let view = makeView("see https://onym.foundation now")
+        // Inside the URL run ("see " is 4 chars).
+        let point = try centerOfChar(10, in: view)
+        XCTAssertTrue(view.point(inside: point, with: nil))
+    }
+
+    func test_pointOnProse_misses() throws {
+        let view = makeView("see https://onym.foundation now")
+        let point = try centerOfChar(0, in: view)
+        XCTAssertFalse(view.point(inside: point, with: nil),
+                       "prose must fall through to the cell")
+    }
+
+    func test_pointOutsideBounds_misses() throws {
+        // `hitTest` probes with out-of-bounds points (enlarged tap
+        // areas); a bubble-padding tap beside a trailing link must
+        // not clamp onto it.
+        let view = makeView("tap https://onym.foundation")
+        let onLink = try centerOfChar(10, in: view)
+        XCTAssertFalse(view.point(inside: CGPoint(x: -6, y: onLink.y), with: nil))
+        XCTAssertFalse(view.point(inside: CGPoint(x: view.bounds.maxX + 6, y: onLink.y), with: nil))
+        XCTAssertFalse(view.point(inside: CGPoint(x: onLink.x, y: view.bounds.maxY + 6), with: nil))
+    }
+
+    func test_bodyStartingWithURL_firstGlyphHits() throws {
+        // `.layout(.left)` is nil at the document start — the fallback
+        // keeps a leading URL tappable on its very first character.
+        let view = makeView("https://onym.foundation first")
+        let point = try centerOfChar(0, in: view)
+        XCTAssertTrue(view.point(inside: point, with: nil))
+    }
+
+    func test_emptySpaceRightOfLinkLine_misses() throws {
+        // The URL ends its line; the empty area right of the last
+        // glyph is inside bounds, and `closestPosition` clamps to
+        // that glyph — the rendered-rect check must reject it.
+        let view = makeView("https://a.example\nsecond line is much longer text")
+        let lastLinkChar = try centerOfChar(16, in: view)
+        let rightOfLine = CGPoint(x: view.bounds.maxX - 2, y: lastLinkChar.y)
+        XCTAssertFalse(view.point(inside: rightOfLine, with: nil))
+    }
+
+    func test_emptyBody_misses() {
+        let view = makeView("")
+        XCTAssertFalse(view.point(inside: CGPoint(x: 1, y: 1), with: nil))
+    }
+}

--- a/Tests/OnymIOSUITests/MultiIdentityChatUITests.swift
+++ b/Tests/OnymIOSUITests/MultiIdentityChatUITests.swift
@@ -229,7 +229,7 @@ final class MultiIdentityChatUITests: XCTestCase {
         // matched message rendered — proving search → open-at-message.
         XCTAssertTrue(app.textViews["chat.input.textview"].waitForExistence(timeout: 15),
                       "tapping a search result never opened the chat thread")
-        XCTAssertTrue(app.staticTexts["Hello from Bob"].waitForExistence(timeout: 15),
+        XCTAssertTrue(ChatThreadScreen(app: app).waitForMessage("Hello from Bob", timeout: 15),
                       "the searched message wasn't shown in the opened thread")
     }
 

--- a/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
+++ b/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
@@ -250,12 +250,11 @@ struct ChatThreadScreen {
             NSPredicate(format: "value == %@", text)
         ).firstMatch
         let label = app.staticTexts[text]
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if bubble.exists || label.exists { return true }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
-        } while Date() < deadline
-        return false
+        let either = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in bubble.exists || label.exists },
+            object: nil
+        )
+        return XCTWaiter().wait(for: [either], timeout: timeout) == .completed
     }
 
     /// The delivery-status glyph exposes its state via accessibilityLabel

--- a/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
+++ b/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
@@ -242,7 +242,20 @@ struct ChatThreadScreen {
 
     @discardableResult
     func waitForMessage(_ text: String, timeout: TimeInterval = 25) -> Bool {
-        app.staticTexts[text].waitForExistence(timeout: timeout)
+        // Bubble bodies render in a link-aware UITextView, which
+        // XCUITest exposes as a text view whose `value` is the text —
+        // not as a static text. Other message renderings (system
+        // notices, quotes) remain labels, so accept either.
+        let bubble = app.textViews.matching(
+            NSPredicate(format: "value == %@", text)
+        ).firstMatch
+        let label = app.staticTexts[text]
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if bubble.exists || label.exists { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        } while Date() < deadline
+        return false
     }
 
     /// The delivery-status glyph exposes its state via accessibilityLabel

--- a/Tests/OnymIOSUITests/SearchUITests.swift
+++ b/Tests/OnymIOSUITests/SearchUITests.swift
@@ -62,7 +62,7 @@ final class SearchUITests: XCTestCase {
         hit.tap()
         XCTAssertTrue(app.textViews["chat.input.textview"].waitForExistence(timeout: 15),
                       "tapping a search result never opened the chat thread")
-        XCTAssertTrue(app.staticTexts["lunch plans today"].waitForExistence(timeout: 15),
+        XCTAssertTrue(ChatThreadScreen(app: app).waitForMessage("lunch plans today", timeout: 15),
                       "the searched message wasn't shown in the opened thread")
     }
 


### PR DESCRIPTION
## What

Two bubble affordances in one PR, as requested:

1. **Links in message text are tappable.** The body moves from `UILabel` to `LinkTextView`, a `UITextView` subclass that mimics the label everywhere except links: zero inner padding, Auto Layout self-sizing, zero intrinsic height when the body is empty (media-only bubbles), and — the load-bearing part — `point(inside:)` accepts only touches that land on a `.link` character. Everything else falls through to the cell, so table scrolling, the row's long-press menu, and swipe-to-reply behave exactly as before on body text. URLs are found by a shared `NSDataDetector` and rendered as an underline in the body's own color, readable on both the accent-filled outgoing bubble and the tinted incoming one. Long-pressing a link itself gets the system link preview/menu, which is the wanted behavior there.

2. **Copy on the long-press menu.** The existing context menu (previously Report-only, and only for reportable rows) now offers Copy for any non-system message with a non-blank body; Report keeps its gate unchanged. Copy puts the untrimmed body on the pasteboard.

## Tests

- `test_body_writesThroughToBodyView`, `test_body_urlGetsLinkAttribute_plainTextDoesNot` — the URL run carries `.link` with the parsed URL, the surrounding prose doesn't.
- Menu contract split: `test_longPress_unreportableMessageStillOffersCopyMenu` (has text → menu even when unreportable) and `test_longPress_unreportableEmptyBodyHasNoContextMenu` (nothing to copy or report → no menu).
- Full `ChatBubbleCellTests` + `ChatThreadViewControllerTests`: 90 tests, 0 failures — including the constraint-conflict and reuse suites, which cover the UILabel→UITextView layout swap.
- XCUITest exposure changed (bubble bodies are `textViews` now, not `staticTexts`): `ChatThreadScreen.waitForMessage` matches either, and the two direct `staticTexts` bubble assertions route through it.

## Related

`SearchUITests.test_search_findsMessage_andOpensChatAtIt` was failing on main — initially misattributed here to the onboarding redesign, actually a regression from #267 (the stub moderation seat's seeded mandate names a key no identity owns, so the identity-addressed gate signer throws and the app blocks on the verification screen). Fixed in #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)