### PR TITLE
Stub moderation seat signs with a stub signer (fixes simulator runs + SearchUITests)

### DIFF
--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -335,6 +335,11 @@ struct OnymIOSApp: App {
             let backend = StubEnforcementBackendClient(
                 scenario: Self.resolveModerationScenario(args: args)
             )
+            // The stub seat signs with a stub: the seeded mandate's
+            // `onym:key:uitest-user` belongs to no real identity, so
+            // the real signer's identity-addressed `sign(_:as:)`
+            // cannot answer for it (see `UITestModerationSigner`).
+            let stubSigner = UITestModerationSigner()
             moderationManifestFetcher = UITestAuthorityManifestFetcher()
             moderationRepository = ModerationRepository(
                 authoritiesFetcher: UITestKnownAuthoritiesFetcher(),
@@ -345,13 +350,13 @@ struct OnymIOSApp: App {
                 backend: backend,
                 authorityClients: StubModerationAuthorityClientFactory(),
                 attestation: UITestDeviceAttestationProvider(),
-                signer: moderationSigner
+                signer: stubSigner
             )
             gateCheckRepository = GateCheckRepository(
                 attestation: UITestDeviceAttestationProvider(),
                 backend: backend,
                 moderation: moderationRepository,
-                signer: moderationSigner,
+                signer: stubSigner,
                 store: UITestGateStateStore(),
                 // Scenario fixtures are stage props (sentinel
                 // signatures, fixed refs), not authenticated

--- a/Sources/OnymIOS/UITestFakes.swift
+++ b/Sources/OnymIOS/UITestFakes.swift
@@ -375,6 +375,23 @@ struct UITestAuthorityManifestFetcher: AuthorityManifestFetcher {
 /// by default so the consent gate doesn't block every unrelated UI
 /// test; `--moderation-needs-consent` starts it empty to exercise the
 /// consent flow itself.
+/// Signer for the stubbed moderation seat. The seeded mandate names
+/// `onym:key:uitest-user` — a key no real identity owns — so the real
+/// `IdentityModerationSigner`'s identity-addressed `sign(_:as:)`
+/// throws `noIdentityForKey` for it and every gate check degrades to
+/// "unreachable", blocking the whole app behind the verification
+/// screen. Nothing in the stub seat verifies signatures, so a
+/// constant answers both methods.
+struct UITestModerationSigner: ModerationSigner {
+    func userKeyID() async throws -> String { "onym:key:uitest-user" }
+    func sign(_ message: Data) async throws -> Data {
+        Data("uitest-signature".utf8)
+    }
+    func sign(_ message: Data, as userKey: String) async throws -> Data {
+        Data("uitest-signature".utf8)
+    }
+}
+
 final class UITestMandateStore: MandateStore, @unchecked Sendable {
     private let lock = NSLock()
     private var records: [MandateRecord]


### PR DESCRIPTION
Since #267 the gate session is signed **as** the mandate's identity. The stubbed moderation seat (`--ui-testing`, and every plain simulator run) seeds a mandate for `onym:key:uitest-user` — a key no real identity owns — so `IdentityModerationSigner.sign(_:as:)` threw `noIdentityForKey`, every gate check degraded to `.unreachable`, grace had never been earned, and the app hard-blocked on "Verification required" before the Chats tab ever rendered. Verified by launching with the UI-test args and screenshotting: the gate screen, not the Chats empty state.

The stub seat never verifies signatures, so it now uses a constant `UITestModerationSigner` for both `ModerationRepository` and `GateCheckRepository`. The real branches keep the real signer.

Result: `SearchUITests` (both tests) passes again on a clean simulator — it was failing with "no create-group entry point on the Chats tab", which PR #270 initially misattributed to the onboarding redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)