### PR TITLE
Multi-use invite links, retired only by the inviter

### DIFF
--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadViewController.swift
@@ -134,6 +134,20 @@ final class ChatThreadViewController: UIViewController {
     /// user is already near the bottom.
     private var hasAppliedFirstSnapshot = false
 
+    /// Real, measured height per row id, filled in as rows are
+    /// displayed and served back through
+    /// `tableView(_:estimatedHeightForRowAt:)`.
+    ///
+    /// Without this the table answers every height question about a
+    /// row it hasn't displayed with the flat `estimatedRowHeight`, and
+    /// corrects it to the real height the moment the row is measured.
+    /// Each correction resizes the content and shifts the offset under
+    /// the user's thumb — which is the jump a fresh message produced:
+    /// inserting a row makes the table re-measure, so the whole thread
+    /// lurched every time one landed. Cached heights make the estimate
+    /// exact, so nothing moves but the intended scroll.
+    private var measuredRowHeights: [UUID: CGFloat] = [:]
+
     /// The message the composer is currently replying to, if any. Set
     /// by a swipe-to-reply on a bubble, cleared on cancel or after a
     /// send. Threaded into `onSendTapped` so the sent message carries
@@ -300,9 +314,23 @@ final class ChatThreadViewController: UIViewController {
         if !changedIDs.isEmpty {
             snapshot.reconfigureItems(changedIDs)
         }
+        // A reconfigured row may render at a different height (body
+        // edit, attachment resolving), so its cached measurement is
+        // stale until it's displayed again.
+        for id in changedIDs { measuredRowHeights[id] = nil }
+        pruneMeasuredHeights(keeping: snapshot.itemIdentifiers)
+
+        // A new row at the bottom that we're going to follow is applied
+        // without animation: the insert fade and the follow-scroll are
+        // two separate motions — the second only starting when `apply`'s
+        // completion fires, a third of a second after the row landed —
+        // and the pair read as a lurch. Committing the row instantly and
+        // animating the offset gives one continuous scroll instead.
+        let followsBottom = !isFirstApply && wasNearBottom && sorted.count > previousCount
+        let animates = !isFirstApply && !followsBottom
         // First apply is non-animated to avoid an initial-load
         // "fly-in" of every existing message.
-        dataSource.apply(snapshot, animatingDifferences: !isFirstApply) { [weak self] in
+        dataSource.apply(snapshot, animatingDifferences: animates) { [weak self] in
             guard let self else { return }
             if isFirstApply {
                 // Cold open: land at the bottom with no visible scroll.
@@ -313,10 +341,18 @@ final class ChatThreadViewController: UIViewController {
                 guard !sorted.isEmpty else { return }
                 self.jumpToBottomForColdOpen()
                 self.hasAppliedFirstSnapshot = true
-            } else if wasNearBottom && sorted.count > previousCount {
+            } else if followsBottom {
                 self.scrollToBottom(animated: true)
             }
         }
+    }
+
+    /// Forget measurements for rows no longer in the thread, so the
+    /// cache can't outgrow the list over a long session.
+    private func pruneMeasuredHeights(keeping ids: [UUID]) {
+        guard measuredRowHeights.count > ids.count else { return }
+        let live = Set(ids)
+        measuredRowHeights = measuredRowHeights.filter { live.contains($0.key) }
     }
 
     /// Push the founder's pending join requests for *this* group into
@@ -396,6 +432,8 @@ final class ChatThreadViewController: UIViewController {
         if !changed.isEmpty {
             snapshot.reconfigureItems(changed)
         }
+        for id in changed { measuredRowHeights[id] = nil }
+        pruneMeasuredHeights(keeping: snapshot.itemIdentifiers)
         dataSource.apply(snapshot, animatingDifferences: hasAppliedFirstSnapshot) { [weak self] in
             guard let self else { return }
             // The table sits at alpha 0 until the cold open reveals it,
@@ -651,13 +689,37 @@ final class ChatThreadViewController: UIViewController {
     }
 
     /// Scroll the table so the last row is visible.
+    ///
+    /// Targets the content offset directly rather than going through
+    /// `scrollToRow(at: .bottom)`. `scrollToRow` resolves its
+    /// destination from the row heights the table knows *at the time of
+    /// the call* — with self-sizing bubbles that includes estimates —
+    /// so it would animate to a position that stops being the bottom as
+    /// soon as the rows underneath it were measured, and the table
+    /// snapped the rest of the way. Laying out first and then animating
+    /// to the computed end of the content lands in one motion.
     func scrollToBottom(animated: Bool) {
-        let snapshot = dataSource.snapshot()
-        guard let lastSection = snapshot.sectionIdentifiers.last else { return }
-        let itemCount = snapshot.numberOfItems(inSection: lastSection)
-        guard itemCount > 0 else { return }
-        let lastIndex = IndexPath(row: itemCount - 1, section: 0)
-        tableView.scrollToRow(at: lastIndex, at: .bottom, animated: animated)
+        guard dataSource.snapshot().numberOfItems > 0 else { return }
+        // Resolve pending inserts/heights so `contentSize` below is the
+        // post-update one, not the size from before this row landed.
+        tableView.layoutIfNeeded()
+        let inset = tableView.adjustedContentInset
+        let target = max(
+            -inset.top,
+            tableView.contentSize.height + inset.bottom - tableView.bounds.height
+        )
+        guard abs(target - tableView.contentOffset.y) > 0.5 else { return }
+        guard animated else {
+            tableView.contentOffset.y = target
+            return
+        }
+        UIView.animate(
+            withDuration: 0.25,
+            delay: 0,
+            options: [.curveEaseOut, .beginFromCurrentState]
+        ) {
+            self.tableView.contentOffset.y = target
+        }
     }
 
     // MARK: - Table view (message list)
@@ -962,6 +1024,30 @@ extension ChatThreadViewController: UIGestureRecognizerDelegate {
 }
 
 extension ChatThreadViewController: UITableViewDelegate {
+    /// Serve the row's real height once we've seen it, so the table's
+    /// content size stops changing under the user as rows are measured.
+    /// Falls back to the flat estimate for a row never yet displayed.
+    func tableView(
+        _ tableView: UITableView,
+        estimatedHeightForRowAt indexPath: IndexPath
+    ) -> CGFloat {
+        guard let id = dataSource.itemIdentifier(for: indexPath),
+              let height = measuredRowHeights[id] else { return tableView.estimatedRowHeight }
+        return height
+    }
+
+    /// Record what the row actually measured. `willDisplay` runs after
+    /// the cell has been sized by the table, so `frame.height` here is
+    /// the resolved self-sizing height.
+    func tableView(
+        _ tableView: UITableView,
+        willDisplay cell: UITableViewCell,
+        forRowAt indexPath: IndexPath
+    ) {
+        guard let id = dataSource.itemIdentifier(for: indexPath) else { return }
+        measuredRowHeights[id] = cell.frame.height
+    }
+
     func tableView(
         _ tableView: UITableView,
         contextMenuConfigurationForRowAt indexPath: IndexPath,

--- a/Packages/OnymGroup/EXTRACTION-NOTES.md
+++ b/Packages/OnymGroup/EXTRACTION-NOTES.md
@@ -67,7 +67,7 @@ OnymIdentity/OnymDesign/OnymChain/OnymPersistence were doc comments only).
 | IntroRequestStore (protocol), InMemoryIntroRequestStore (init, witnesses) | OnymIOSApp, PendingInvitesStore, tests |
 | IntroKeyEntry (all props, init) | KeychainIntroKeyStoreTests, tests' InMemoryIntroKeyStore |
 | IntroKeyStore (protocol) | OnymIOSApp, IdentityRepository wiring in app shell, tests |
-| KeychainIntroKeyStore (init, serviceDefault, account, entryTTL, wipeAll, witnesses) | OnymIOSApp, KeychainIntroKeyStoreTests |
+| KeychainIntroKeyStore (init, serviceDefault, account, wipeAll, witnesses) | OnymIOSApp, KeychainIntroKeyStoreTests |
 | InviteIntroducer (init, mint), IntroducerError | OnymIOSApp, ShareInviteFlow tests, InviteIntroducerTests |
 | IntroInboxPump (init, run, static inboxTag) | OnymIOSApp, GroupStateVerifier, ChatReceiptSender, tests |
 | JoinRequestSender (init, Outcome, send) | OnymIOSApp, PendingInvitesFlow, JoinFlowTests |

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupInteractor.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupInteractor.swift
@@ -724,9 +724,8 @@ public struct CreateGroupInteractor: Sendable {
     /// Mint a per-invitee intro key and ship a durable
     /// `GroupInviteOfferPayload` to each invitee's inbox. Reuses the
     /// inbox seal+send path, but the payload grants nothing: it carries
-    /// only the reply channel + display context, so it never expires
-    /// and never anchors anyone. The invitee turns it into a join
-    /// request on accept; the admin anchors only on explicit approve.
+    /// only the reply channel + display context, and never anchors
+    /// anyone. Labelled per invitee so the invite list can revoke it.
     private func sendOffers(
         to invitees: [Data],
         ownerIdentityID: IdentityID,
@@ -736,15 +735,15 @@ public struct CreateGroupInteractor: Sendable {
         inviterAlias: String
     ) async throws {
         for (index, inboxKey) in invitees.enumerated() {
-            // One fresh intro key per invitee → granular revoke and a
-            // clean 1:1 mapping from an inbound join request back to
-            // the person the admin meant to invite.
+            // One key per invitee keeps the 1:1 map from request back
+            // to person; `currentOrMint` would collapse it.
             let capability: IntroCapability
             do {
                 capability = try await introducer.mint(
                     ownerIdentityID: ownerIdentityID,
                     groupId: groupID,
-                    groupName: groupName
+                    groupName: groupName,
+                    label: IntroKeyEntry.fingerprint(of: inboxKey)
                 )
             } catch {
                 throw CreateGroupError.invitationSendFailed(

--- a/Packages/OnymGroup/Sources/OnymGroup/HandledIntroRequestLog.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/HandledIntroRequestLog.swift
@@ -12,6 +12,19 @@ public protocol HandledIntroRequestLog: Sendable {
     func handledIDs() -> Set<String>
     /// Remember `id`, attributed to the link it arrived on.
     func record(id: String, introPublicKey: Data)
+
+    /// Drop tombstones for links that no longer exist anywhere on the
+    /// device. Safe as a keep-set only because the caller supplies
+    /// EVERY owner's live keys; unattributed tombstones are kept.
+    func reconcile(livePublicKeys: Set<Data>)
+
+    /// Joiners the host declined, keyed by collapse key (joiner
+    /// identity ⊕ group) rather than event id — a retry arrives as a
+    /// fresh Nostr event, so an id-keyed tombstone would not catch it.
+    func declinedCollapseKeys() -> Set<String>
+
+    /// Remember that this joiner was declined for this group.
+    func recordDeclined(collapseKey: String)
     /// Drop the tombstones belonging to links that were just retired.
     ///
     /// Phrased as "these died", not "these are all that live": the
@@ -30,6 +43,7 @@ public struct UserDefaultsHandledIntroRequestLog: HandledIntroRequestLog, @unche
     public static let maxEntries = 2_000
 
     private static let storageKey = "app.onym.ios.intro_requests.handled"
+    private static let declinedKey = "app.onym.ios.intro_requests.declined"
 
     private let defaults: UserDefaults
 
@@ -50,6 +64,29 @@ public struct UserDefaultsHandledIntroRequestLog: HandledIntroRequestLog, @unche
             rows.removeFirst(rows.count - Self.maxEntries)
         }
         save(rows)
+    }
+
+    public func reconcile(livePublicKeys: Set<Data>) {
+        let rows = load()
+        // `introPub.isEmpty` is the unattributed marker — no link to
+        // check it against, so it is never reconciled away.
+        let kept = rows.filter { $0.introPub.isEmpty || livePublicKeys.contains($0.introPub) }
+        if kept.count != rows.count { save(kept) }
+    }
+
+    public func declinedCollapseKeys() -> Set<String> {
+        Set(defaults.stringArray(forKey: Self.declinedKey) ?? [])
+    }
+
+    public func recordDeclined(collapseKey: String) {
+        var keys = defaults.stringArray(forKey: Self.declinedKey) ?? []
+        guard !keys.contains(collapseKey) else { return }
+        keys.append(collapseKey)
+        // Same oldest-first backstop as the handled ids.
+        if keys.count > Self.maxEntries {
+            keys.removeFirst(keys.count - Self.maxEntries)
+        }
+        defaults.set(keys, forKey: Self.declinedKey)
     }
 
     public func prune(retiring retiredPublicKeys: Set<Data>) {
@@ -82,6 +119,7 @@ public struct UserDefaultsHandledIntroRequestLog: HandledIntroRequestLog, @unche
 public final class InMemoryHandledIntroRequestLog: HandledIntroRequestLog, @unchecked Sendable {
     private let lock = NSLock()
     private var rows: [String: Data] = [:]
+    private var declined: Set<String> = []
 
     public init() {}
 
@@ -95,5 +133,19 @@ public final class InMemoryHandledIntroRequestLog: HandledIntroRequestLog, @unch
 
     public func prune(retiring retiredPublicKeys: Set<Data>) {
         lock.withLock { rows = rows.filter { !retiredPublicKeys.contains($0.value) } }
+    }
+
+    public func reconcile(livePublicKeys: Set<Data>) {
+        lock.withLock {
+            rows = rows.filter { $0.value.isEmpty || livePublicKeys.contains($0.value) }
+        }
+    }
+
+    public func declinedCollapseKeys() -> Set<String> {
+        lock.withLock { declined }
+    }
+
+    public func recordDeclined(collapseKey: String) {
+        lock.withLock { declined.insert(collapseKey) }
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/HandledIntroRequestLog.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/HandledIntroRequestLog.swift
@@ -12,8 +12,14 @@ public protocol HandledIntroRequestLog: Sendable {
     func handledIDs() -> Set<String>
     /// Remember `id`, attributed to the link it arrived on.
     func record(id: String, introPublicKey: Data)
-    /// Drop tombstones whose link no longer exists.
-    func prune(keeping livePublicKeys: Set<Data>)
+    /// Drop the tombstones belonging to links that were just retired.
+    ///
+    /// Phrased as "these died", not "these are all that live": the
+    /// only snapshots available are scoped to ONE identity, while this
+    /// log spans every identity in the process. A keep-set from one
+    /// owner would delete every other owner's tombstones, and their
+    /// handled requests would replay as pending on the next reconnect.
+    func prune(retiring retiredPublicKeys: Set<Data>)
 }
 
 /// UserDefaults-backed: event ids are not secrets, so the Keychain
@@ -46,9 +52,10 @@ public struct UserDefaultsHandledIntroRequestLog: HandledIntroRequestLog, @unche
         save(rows)
     }
 
-    public func prune(keeping livePublicKeys: Set<Data>) {
+    public func prune(retiring retiredPublicKeys: Set<Data>) {
+        guard !retiredPublicKeys.isEmpty else { return }
         let rows = load()
-        let kept = rows.filter { livePublicKeys.contains($0.introPub) }
+        let kept = rows.filter { !retiredPublicKeys.contains($0.introPub) }
         if kept.count != rows.count { save(kept) }
     }
 
@@ -86,7 +93,7 @@ public final class InMemoryHandledIntroRequestLog: HandledIntroRequestLog, @unch
         lock.withLock { rows[id] = introPublicKey }
     }
 
-    public func prune(keeping livePublicKeys: Set<Data>) {
-        lock.withLock { rows = rows.filter { livePublicKeys.contains($0.value) } }
+    public func prune(retiring retiredPublicKeys: Set<Data>) {
+        lock.withLock { rows = rows.filter { !retiredPublicKeys.contains($0.value) } }
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/HandledIntroRequestLog.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/HandledIntroRequestLog.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Durable record of intro-request event ids the user already acted on.
+///
+/// The REQ carries no `since`, so every cold start replays an intro
+/// inbox in full. The burn used to make those replays undecodable.
+///
+/// Scoped by intro pubkey, so `prune(keeping:)` bounds the set by the
+/// links that still exist. `maxEntries` backstops one busy link.
+public protocol HandledIntroRequestLog: Sendable {
+    /// Event ids already acted on, for the reader's fast path.
+    func handledIDs() -> Set<String>
+    /// Remember `id`, attributed to the link it arrived on.
+    func record(id: String, introPublicKey: Data)
+    /// Drop tombstones whose link no longer exists.
+    func prune(keeping livePublicKeys: Set<Data>)
+}
+
+/// UserDefaults-backed: event ids are not secrets, so the Keychain
+/// would be over-rotation. Isolated `app.onym.ios.*` key prefix.
+public struct UserDefaultsHandledIntroRequestLog: HandledIntroRequestLog, @unchecked Sendable {
+    /// Backstop for a busy link. Ids are 64-char hex, so this caps the
+    /// blob in the low hundreds of KB.
+    public static let maxEntries = 2_000
+
+    private static let storageKey = "app.onym.ios.intro_requests.handled"
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func handledIDs() -> Set<String> {
+        Set(load().map(\.id))
+    }
+
+    public func record(id: String, introPublicKey: Data) {
+        var rows = load()
+        guard !rows.contains(where: { $0.id == id }) else { return }
+        rows.append(Row(id: id, introPub: introPublicKey))
+        // Oldest-first drop: a replay is likeliest to hit recent ids.
+        if rows.count > Self.maxEntries {
+            rows.removeFirst(rows.count - Self.maxEntries)
+        }
+        save(rows)
+    }
+
+    public func prune(keeping livePublicKeys: Set<Data>) {
+        let rows = load()
+        let kept = rows.filter { livePublicKeys.contains($0.introPub) }
+        if kept.count != rows.count { save(kept) }
+    }
+
+    // MARK: - Private
+
+    private struct Row: Codable {
+        let id: String
+        let introPub: Data
+    }
+
+    private func load() -> [Row] {
+        guard let data = defaults.data(forKey: Self.storageKey) else { return [] }
+        // Corrupted blob → start over; one round of replays re-surfaces.
+        return (try? JSONDecoder().decode([Row].self, from: data)) ?? []
+    }
+
+    private func save(_ rows: [Row]) {
+        guard let data = try? JSONEncoder().encode(rows) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+}
+
+/// Test double, and the fallback when no durable log is wired.
+public final class InMemoryHandledIntroRequestLog: HandledIntroRequestLog, @unchecked Sendable {
+    private let lock = NSLock()
+    private var rows: [String: Data] = [:]
+
+    public init() {}
+
+    public func handledIDs() -> Set<String> {
+        lock.withLock { Set(rows.keys) }
+    }
+
+    public func record(id: String, introPublicKey: Data) {
+        lock.withLock { rows[id] = introPublicKey }
+    }
+
+    public func prune(keeping livePublicKeys: Set<Data>) {
+        lock.withLock { rows = rows.filter { livePublicKeys.contains($0.value) } }
+    }
+}

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroCapability.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroCapability.swift
@@ -219,6 +219,9 @@ public struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
         let e = JSONEncoder()
         // Default `.base64` + matches Android `Base64.getEncoder()`.
         e.dataEncodingStrategy = .base64
+        // Without this one capability can encode to two different
+        // link strings. Decoding is order-agnostic, so links keep working.
+        e.outputFormatting = .sortedKeys
         return e
     }()
 

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroKeyEntry.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroKeyEntry.swift
@@ -28,13 +28,24 @@ public struct IntroKeyEntry: Equatable, Sendable {
     /// aimed at one invitee.
     public let label: String?
 
+    /// True for entries persisted before labels existed. Those decode
+    /// with `label == nil`, which is indistinguishable from a shared
+    /// link — and on a create-with-invitees group the newest of them is
+    /// the LAST INVITEE'S PRIVATE OFFER KEY. Without this flag
+    /// `currentOrMint` would adopt it as the group's public link, and
+    /// the first rotate would revoke every outstanding legacy invite.
+    /// Never adopted, never mass-revoked; listed and individually
+    /// revokable like any other superseded key.
+    public let isLegacy: Bool
+
     public init(
         introPublicKey: Data,
         introPrivateKey: Data,
         ownerIdentityID: IdentityID,
         groupId: Data,
         createdAt: Date,
-        label: String? = nil
+        label: String? = nil,
+        isLegacy: Bool = false
     ) {
         precondition(introPublicKey.count == 32,
                      "introPublicKey: expected 32 bytes, got \(introPublicKey.count)")
@@ -48,6 +59,7 @@ public struct IntroKeyEntry: Equatable, Sendable {
         self.groupId = groupId
         self.createdAt = createdAt
         self.label = label
+        self.isLegacy = isLegacy
     }
 
     /// First 4 bytes of the inbox key — same fingerprint shape the

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroKeyEntry.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroKeyEntry.swift
@@ -16,21 +16,25 @@ import OnymIdentity
 /// - `groupId` is the on-chain `group_id` the invite is for —
 ///   needed when the inviter's app surfaces "Bob wants to join
 ///   <group>?" so it can render the group's name.
-/// - `createdAt` drives optional expiration UI (later PRs may
-///   prune invites older than N days).
+/// - `createdAt` is display-only; links live until revoked.
+/// - `label` is nil for the shared link, else the invitee's fingerprint.
 public struct IntroKeyEntry: Equatable, Sendable {
     public let introPublicKey: Data
     public let introPrivateKey: Data
     public let ownerIdentityID: IdentityID
     public let groupId: Data
     public let createdAt: Date
+    /// nil == the group's shared link. Non-nil == a create-time offer
+    /// aimed at one invitee.
+    public let label: String?
 
     public init(
         introPublicKey: Data,
         introPrivateKey: Data,
         ownerIdentityID: IdentityID,
         groupId: Data,
-        createdAt: Date
+        createdAt: Date,
+        label: String? = nil
     ) {
         precondition(introPublicKey.count == 32,
                      "introPublicKey: expected 32 bytes, got \(introPublicKey.count)")
@@ -43,5 +47,12 @@ public struct IntroKeyEntry: Equatable, Sendable {
         self.ownerIdentityID = ownerIdentityID
         self.groupId = groupId
         self.createdAt = createdAt
+        self.label = label
+    }
+
+    /// First 4 bytes of the inbox key — same fingerprint shape the
+    /// approval screen shows.
+    static func fingerprint(of inboxPublicKey: Data) -> String {
+        inboxPublicKey.prefix(4).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroKeyStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroKeyStore.swift
@@ -44,6 +44,14 @@ public protocol IntroKeyStore: Sendable {
     /// per-row revoke. No-op if the pubkey isn't present.
     func revoke(introPublicKey: Data) async
 
+    /// Every live intro pubkey this device holds, across ALL owners.
+    ///
+    /// Exists for the tombstone reconcile: a per-owner snapshot cannot
+    /// tell "this link was retired" from "this link belongs to another
+    /// identity", so a reconcile driven by one owner's view would
+    /// delete the other's tombstones. This is the only safe input.
+    func allLivePublicKeys() async -> Set<Data>
+
     /// Cascade for the identity-removal flow. Returns the count of
     /// entries deleted so the caller can log the cleanup size.
     /// Hooked into `IdentityRepository`'s removal listeners.

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroKeyStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroKeyStore.swift
@@ -15,7 +15,8 @@ import OnymIdentity
 ///     payload.
 ///  4. On Approve, sender seals the existing
 ///     `GroupInvitationPayload` to the joiner's identity inbox key.
-///     `revoke` is called to retire the intro slot.
+///     The intro key is NOT retired: one link serves many joiners
+///     until the inviter revokes it.
 ///
 /// Owner-scoping: every entry carries an `IdentityID`. Removing an
 /// identity cascades a `deleteForOwner` so we don't leak intro
@@ -39,9 +40,8 @@ public protocol IntroKeyStore: Sendable {
     /// list reads here.
     func listForOwner(_ ownerIdentityID: IdentityID) async -> [IntroKeyEntry]
 
-    /// Single-entry deletion. Called after a request is accepted +
-    /// sealed → the intro slot is no longer useful. No-op if the
-    /// pubkey isn't present.
+    /// Single-entry deletion, behind "Generate new link" and the
+    /// per-row revoke. No-op if the pubkey isn't present.
     func revoke(introPublicKey: Data) async
 
     /// Cascade for the identity-removal flow. Returns the count of

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroRequestStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroRequestStore.swift
@@ -28,7 +28,7 @@ public protocol IntroRequestStore: Sendable {
 
     /// Drop tombstones for links that no longer exist, so the durable
     /// set stays bounded by the live invites.
-    func pruneTombstones(keeping livePublicKeys: Set<Data>) async
+    func pruneTombstones(retiring retiredPublicKeys: Set<Data>) async
 
     /// Snapshot read used by tests + bootstrap reads. UI prefers
     /// the stream.
@@ -70,16 +70,28 @@ public actor InMemoryIntroRequestStore: IntroRequestStore {
         consumed.insert(id)
         // Attribute to the link it arrived on so `pruneTombstones` can
         // drop it when that link is retired.
-        if let raw = pending.first(where: { $0.id == id }) {
-            handledLog.record(id: id, introPublicKey: raw.targetIntroPublicKey)
-        }
+        // Durable even when the row is absent (a tombstone laid ahead
+        // of a replay, or a stale sibling id). Without the row there is
+        // no link to attribute it to, so it goes in unattributed: it can
+        // never be pruned by a retired link, and is bounded only by the
+        // log's own cap — the right trade, since losing it means the
+        // handled request comes back as pending on the next cold start.
+        handledLog.record(
+            id: id,
+            introPublicKey: pending.first(where: { $0.id == id })?.targetIntroPublicKey
+                ?? Self.unattributedLink
+        )
         let before = pending.count
         pending.removeAll { $0.id == id }
         if pending.count != before { publish() }
     }
 
-    public func pruneTombstones(keeping livePublicKeys: Set<Data>) async {
-        handledLog.prune(keeping: livePublicKeys)
+    /// Stands in for "no link known". Never 32 bytes, so it can never
+    /// collide with a real intro pubkey in a retired set.
+    static let unattributedLink = Data()
+
+    public func pruneTombstones(retiring retiredPublicKeys: Set<Data>) async {
+        handledLog.prune(retiring: retiredPublicKeys)
         consumed = handledLog.handledIDs()
     }
 

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroRequestStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroRequestStore.swift
@@ -30,6 +30,27 @@ public protocol IntroRequestStore: Sendable {
     /// set stays bounded by the live invites.
     func pruneTombstones(retiring retiredPublicKeys: Set<Data>) async
 
+    /// Drop every tombstone whose link is not in `livePublicKeys`.
+    ///
+    /// Unlike `pruneTombstones(retiring:)` this IS a keep-set, and is
+    /// safe only because the caller passes every owner's live keys —
+    /// see `IntroKeyStore.allLivePublicKeys`. Run once at startup: the
+    /// diff-based prune only observes retirements that happen while
+    /// this identity is subscribed, so links retired with the app
+    /// closed, or under another identity, would otherwise linger until
+    /// `maxEntries` evicted them oldest-first — which can drop a LIVE
+    /// link's tombstone and resurface a handled request.
+    func reconcileTombstones(livePublicKeys: Set<Data>) async
+
+    /// Joiners declined for a group, so a decline means something
+    /// durable. Keyed by collapse key, not event id: a retry arrives as
+    /// a fresh Nostr event and would sail past an id tombstone.
+    func recordDeclined(collapseKey: String) async
+
+    /// Collapse keys the host has declined; `refresh` filters on these.
+    func declinedCollapseKeys() async -> Set<String>
+
+
     /// Snapshot read used by tests + bootstrap reads. UI prefers
     /// the stream.
     func current() async -> [IntroRequest]
@@ -93,6 +114,20 @@ public actor InMemoryIntroRequestStore: IntroRequestStore {
     public func pruneTombstones(retiring retiredPublicKeys: Set<Data>) async {
         handledLog.prune(retiring: retiredPublicKeys)
         consumed = handledLog.handledIDs()
+    }
+
+
+    public func reconcileTombstones(livePublicKeys: Set<Data>) async {
+        handledLog.reconcile(livePublicKeys: livePublicKeys)
+        consumed = handledLog.handledIDs()
+    }
+
+    public func recordDeclined(collapseKey: String) async {
+        handledLog.recordDeclined(collapseKey: collapseKey)
+    }
+
+    public func declinedCollapseKeys() async -> Set<String> {
+        handledLog.declinedCollapseKeys()
     }
 
     public func current() async -> [IntroRequest] {

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroRequestStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroRequestStore.swift
@@ -22,9 +22,13 @@ public protocol IntroRequestStore: Sendable {
     @discardableResult
     func record(_ request: IntroRequest) async -> Bool
 
-    /// Drop a request after the user has acted on it (Approve or
-    /// Decline) so it stops cluttering the surface.
+    /// Drop a handled request and tombstone its id. Conformers MUST
+    /// tombstone durably: cold starts replay the inbox too.
     func consume(id: String) async
+
+    /// Drop tombstones for links that no longer exist, so the durable
+    /// set stays bounded by the live invites.
+    func pruneTombstones(keeping livePublicKeys: Set<Data>) async
 
     /// Snapshot read used by tests + bootstrap reads. UI prefers
     /// the stream.
@@ -37,13 +41,23 @@ public protocol IntroRequestStore: Sendable {
 /// launch outright.
 public actor InMemoryIntroRequestStore: IntroRequestStore {
 
-    public init() {}
-
     private var pending: [IntroRequest] = []
+    /// Event ids already acted on, mirrored from `handledLog` so the
+    /// hot `record` path doesn't hit storage per inbound.
+    private var consumed: Set<String>
+    /// Durable half of the tombstone. Process-lifetime alone would let
+    /// every handled request re-decode on the next cold start.
+    private let handledLog: any HandledIntroRequestLog
     private var continuations: [UUID: AsyncStream<[IntroRequest]>.Continuation] = [:]
+
+    public init(handledLog: any HandledIntroRequestLog = InMemoryHandledIntroRequestLog()) {
+        self.handledLog = handledLog
+        self.consumed = handledLog.handledIDs()
+    }
 
     @discardableResult
     public func record(_ request: IntroRequest) async -> Bool {
+        if consumed.contains(request.id) { return false }
         if pending.contains(where: { $0.id == request.id }) { return false }
         pending.append(request)
         publish()
@@ -51,9 +65,22 @@ public actor InMemoryIntroRequestStore: IntroRequestStore {
     }
 
     public func consume(id: String) async {
+        // Unconditional, so a tombstone can be laid ahead of a replay
+        // that hasn't landed yet.
+        consumed.insert(id)
+        // Attribute to the link it arrived on so `pruneTombstones` can
+        // drop it when that link is retired.
+        if let raw = pending.first(where: { $0.id == id }) {
+            handledLog.record(id: id, introPublicKey: raw.targetIntroPublicKey)
+        }
         let before = pending.count
         pending.removeAll { $0.id == id }
         if pending.count != before { publish() }
+    }
+
+    public func pruneTombstones(keeping livePublicKeys: Set<Data>) async {
+        handledLog.prune(keeping: livePublicKeys)
+        consumed = handledLog.handledIDs()
     }
 
     public func current() async -> [IntroRequest] {

--- a/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
@@ -92,8 +92,11 @@ public actor InviteIntroducer {
         return try await serializingLink(ownerIdentityID, groupId) {
             // `label == nil` is the shared link. Create-with-invitees
             // would otherwise hand out the last invitee's offer key.
+            // `isLegacy` excludes rows written before labels existed —
+            // they are also `label == nil`, and the newest of them on
+            // such a group IS that last invitee's private offer key.
             let live = await self.store.listForOwner(ownerIdentityID).first {
-                $0.groupId == groupId && $0.label == nil
+                $0.groupId == groupId && $0.label == nil && !$0.isLegacy
             }
             if let live {
                 return try IntroCapability(
@@ -144,8 +147,11 @@ public actor InviteIntroducer {
         return try await serializingLink(ownerIdentityID, groupId) {
             // Only the shared link rotates; offer keys are revoked one
             // at a time from the invite list.
+            // Legacy rows are excluded for the same reason: rotating
+            // the shared link must not silently kill every outstanding
+            // pre-upgrade invite.
             let superseded = await self.store.listForOwner(ownerIdentityID)
-                .filter { $0.groupId == groupId && $0.label == nil }
+                .filter { $0.groupId == groupId && $0.label == nil && !$0.isLegacy }
                 .map(\.introPublicKey)
 
             let fresh = try await self.mint(
@@ -173,7 +179,12 @@ public actor InviteIntroducer {
         ownerIdentityID: IdentityID,
         groupId: Data
     ) async -> [IntroKeyEntry] {
-        await store.listForOwner(ownerIdentityID).filter { $0.groupId == groupId }
+        // Sorted here rather than relying on the store: newest-first is
+        // `KeychainIntroKeyStore`'s behaviour, not an `IntroKeyStore`
+        // guarantee, and the in-memory double doesn't sort.
+        await store.listForOwner(ownerIdentityID)
+            .filter { $0.groupId == groupId }
+            .sorted { $0.createdAt > $1.createdAt }
     }
 }
 

--- a/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
@@ -15,9 +15,15 @@ import OnymIdentity
 /// link revocation. The inviter can stop listening on a specific
 /// intro tag → that link goes silent without affecting other
 /// outstanding invites. A leaked link only burns its own slot.
+///
+/// `currentOrMint` reuses the group's shared link; `mint` is always
+/// fresh, for create-time offers needing one key per invitee.
 public actor InviteIntroducer {
     private let store: any IntroKeyStore
     private let now: @Sendable () -> Date
+    /// In-flight shared-link mutation per group: both paths read the
+    /// store across an `await`, so the actor suspends between them.
+    private var inFlight: [String: Task<IntroCapability, Error>] = [:]
 
     public init(store: any IntroKeyStore, now: @escaping @Sendable () -> Date = { Date() }) {
         self.store = store
@@ -36,10 +42,13 @@ public actor InviteIntroducer {
     ///   - groupName: optional plaintext name surfaced in the deeplink
     ///     for the joiner's preview. Pass nil for groups whose name
     ///     is sensitive (deeplink transits cleartext channels).
+    ///   - label: nil for the shared link; the invitee's fingerprint
+    ///     for a create-time offer, so the invite list can name it.
     public func mint(
         ownerIdentityID: IdentityID,
         groupId: Data,
-        groupName: String? = nil
+        groupName: String? = nil,
+        label: String? = nil
     ) async throws -> IntroCapability {
         guard groupId.count == 32 else {
             throw IntroducerError.invalidGroupID(actualSize: groupId.count)
@@ -57,7 +66,8 @@ public actor InviteIntroducer {
             introPrivateKey: privBytes,
             ownerIdentityID: ownerIdentityID,
             groupId: groupId,
-            createdAt: now()
+            createdAt: now(),
+            label: label
         ))
 
         return try IntroCapability(
@@ -65,6 +75,105 @@ public actor InviteIntroducer {
             groupId: groupId,
             groupName: groupName
         )
+    }
+
+    /// The group's shared link, minting only when it has none. Owner-
+    /// scoped: the pump only listens on the active identity's inboxes.
+    public func currentOrMint(
+        ownerIdentityID: IdentityID,
+        groupId: Data,
+        groupName: String? = nil
+    ) async throws -> IntroCapability {
+        // Ahead of the store read so the throw is the same whichever
+        // branch would have run.
+        guard groupId.count == 32 else {
+            throw IntroducerError.invalidGroupID(actualSize: groupId.count)
+        }
+        return try await serializingLink(ownerIdentityID, groupId) {
+            // `label == nil` is the shared link. Create-with-invitees
+            // would otherwise hand out the last invitee's offer key.
+            let live = await self.store.listForOwner(ownerIdentityID).first {
+                $0.groupId == groupId && $0.label == nil
+            }
+            if let live {
+                return try IntroCapability(
+                    introPublicKey: live.introPublicKey,
+                    groupId: groupId,
+                    groupName: groupName
+                )
+            }
+            return try await self.mint(
+                ownerIdentityID: ownerIdentityID,
+                groupId: groupId,
+                groupName: groupName
+            )
+        }
+    }
+
+    /// Serialize the read-decide-write on a group's shared link, which
+    /// actor isolation alone doesn't cover across the store `await`.
+    private func serializingLink(
+        _ owner: IdentityID,
+        _ groupId: Data,
+        _ body: @escaping @Sendable () async throws -> IntroCapability
+    ) async throws -> IntroCapability {
+        let key = owner.rawValue.uuidString + ":"
+            + groupId.map { String(format: "%02x", $0) }.joined()
+        // Wait out any predecessor; its failure is not ours to handle.
+        while let running = inFlight[key] {
+            _ = try? await running.value
+            if inFlight[key] == running { inFlight[key] = nil }
+        }
+        let task = Task { try await body() }
+        inFlight[key] = task
+        defer { if inFlight[key] == task { inFlight[key] = nil } }
+        return try await task.value
+    }
+
+    /// "Generate new link": mint fresh, then revoke the old shared key.
+    /// That order, so a crash leaves two working links rather than none.
+    @discardableResult
+    public func rotate(
+        ownerIdentityID: IdentityID,
+        groupId: Data,
+        groupName: String? = nil
+    ) async throws -> IntroCapability {
+        guard groupId.count == 32 else {
+            throw IntroducerError.invalidGroupID(actualSize: groupId.count)
+        }
+        return try await serializingLink(ownerIdentityID, groupId) {
+            // Only the shared link rotates; offer keys are revoked one
+            // at a time from the invite list.
+            let superseded = await self.store.listForOwner(ownerIdentityID)
+                .filter { $0.groupId == groupId && $0.label == nil }
+                .map(\.introPublicKey)
+
+            let fresh = try await self.mint(
+                ownerIdentityID: ownerIdentityID,
+                groupId: groupId,
+                groupName: groupName
+            )
+
+            for pub in superseded where pub != fresh.introPublicKey {
+                await self.store.revoke(introPublicKey: pub)
+            }
+            return fresh
+        }
+    }
+
+    /// Kill one link. Backs the per-row revoke, chiefly for offer keys
+    /// which have no other way to be retired.
+    public func revoke(introPublicKey: Data) async {
+        await store.revoke(introPublicKey: introPublicKey)
+    }
+
+    /// Every live invite this identity holds for the group,
+    /// newest-first. Backs the invite list on the share screen.
+    public func liveInvites(
+        ownerIdentityID: IdentityID,
+        groupId: Data
+    ) async -> [IntroKeyEntry] {
+        await store.listForOwner(ownerIdentityID).filter { $0.groupId == groupId }
     }
 }
 

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinFlow.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinFlow.swift
@@ -50,6 +50,9 @@ public final class JoinFlow {
         case ready(IntroCapability)
         case sending
         case awaitingApproval
+        /// Nothing came back in time. Not a failure — a revoked link
+        /// and a slow host are indistinguishable from here.
+        case unanswered
         case approved(ChatGroup)
         case failed(reason: String)
     }
@@ -67,17 +70,23 @@ public final class JoinFlow {
 
     private var sendTask: Task<Void, Never>?
     private var watcherTask: Task<Void, Never>?
+    private var unansweredTask: Task<Void, Never>?
+    /// Wait before flipping to `.unanswered`, nil to never flip.
+    /// Injected so tests drive it in milliseconds.
+    private let unansweredAfter: Duration?
 
     public init(
         capability: IntroCapability,
         suggestedDisplayLabel: String,
         submitRequest: @escaping @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome,
-        groupRepository: GroupRepository
+        groupRepository: GroupRepository,
+        unansweredAfter: Duration? = JoinFlow.unansweredAfter
     ) {
         self.capability = capability
         self.suggestedDisplayLabel = suggestedDisplayLabel
         self.submitRequest = submitRequest
         self.groupRepository = groupRepository
+        self.unansweredAfter = unansweredAfter
         self.state = .ready(capability)
         startWatcher()
     }
@@ -86,6 +95,13 @@ public final class JoinFlow {
     // capture `[weak self]` so they exit gracefully on deallocation
     // without needing main-actor-isolated cancellation in `deinit`
     // (which Swift's strict concurrency checking would flag).
+
+    /// Generous: approval is a human tap plus a proof and a chain
+    /// round-trip, so anything short cries wolf on a thinking host.
+    ///
+    /// `public` because it is the default for a public initializer's
+    /// parameter, which is part of this type's exported interface.
+    public static let unansweredAfter: Duration = .seconds(90)
 
     /// Ship the join request. No-op if a previous `send` is in flight
     /// (debounce — protects against double-tap on the primary
@@ -98,7 +114,7 @@ public final class JoinFlow {
             // tap will be guarded by the state check below anyway.)
         }
         switch state {
-        case .ready, .failed: break
+        case .ready, .failed, .unanswered: break
         default: return
         }
         sendTask = Task { [weak self, submitRequest, capability] in
@@ -111,11 +127,25 @@ public final class JoinFlow {
             switch outcome {
             case .sent:
                 self.state = .awaitingApproval
+                self.startUnansweredTimer()
             case .noIdentityLoaded:
                 self.state = .failed(reason: "Sign in first.")
             case .transportFailed(let reason):
                 self.state = .failed(reason: "Couldn't send: \(reason)")
             }
+        }
+    }
+
+    /// Flip to `.unanswered` at the deadline. A late approval still
+    /// overwrites it via the watcher.
+    private func startUnansweredTimer() {
+        guard let unansweredAfter else { return }
+        unansweredTask?.cancel()
+        unansweredTask = Task { [weak self] in
+            try? await Task.sleep(for: unansweredAfter)
+            guard let self, !Task.isCancelled else { return }
+            guard case .awaitingApproval = self.state else { return }
+            self.state = .unanswered
         }
     }
 
@@ -130,6 +160,9 @@ public final class JoinFlow {
                     continue
                 }
                 if case .approved = self.state { continue }  // terminal
+                // Beats `.unanswered` too: a late approval is still an
+                // approval.
+                self.unansweredTask?.cancel()
                 self.state = .approved(match)
             }
         }

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
@@ -29,11 +29,8 @@ public protocol JoinRequestApproving: Sendable {
 ///     Approve?" prompts.
 ///  3. On Approve → seals the existing `GroupInvitationPayload`
 ///     (built from the local `ChatGroup`) to the joiner's identity
-///     inbox key, ships via `inboxTransport.send`, revokes the
-///     intro key. The pump from PR-3 stops listening on that intro
-///     tag within one emission window.
-///  4. On Decline → drop the request, revoke the intro key. No
-///     NACK to the joiner; their JoinScreen times out gracefully.
+///     inbox key and ships it. The intro key is NOT retired.
+///  4. On Decline → drop that one request; the link stays live.
 public actor JoinRequestApprover: JoinRequestApproving {
 
     /// UI-renderable view of one decrypted, awaiting-action request.
@@ -152,6 +149,9 @@ public actor JoinRequestApprover: JoinRequestApproving {
     private let systemEvents: any GroupSystemEventRecording
 
     private var pendingValue: [PendingRequest] = []
+    /// Surviving row id → every raw id that collapsed into it.
+    /// Rebuilt by `refresh`, read by `consumeRequestAndSiblings`.
+    private var collapsedRequestIDs: [String: [String]] = [:]
     private var pendingContinuations: [UUID: AsyncStream<[PendingRequest]>.Continuation] = [:]
     private var decryptFailures: Int = 0
     private var collectorTask: Task<Void, Never>?
@@ -269,7 +269,8 @@ public actor JoinRequestApprover: JoinRequestApproving {
     ///      (members, commitment, epoch, salt), seal + ship the
     ///      `GroupInvitationPayload` (with new state) to the joiner,
     ///      fanout `MemberAnnouncementPayload` (also with new state)
-    ///      to existing members, revoke intro key + consume request.
+    ///      to existing members, consume the request. The key survives.
+    ///   8. A joiner already in `members` skips 2-6; snapshot only.
     ///
     /// Failures at the proof / anchor steps return without mutating
     /// any local state or consuming the request, so the admin can
@@ -294,10 +295,16 @@ public actor JoinRequestApprover: JoinRequestApproving {
             return .unknownGroup
         }
 
+        // Already in the roster (reinstall, replay, retry) — re-anchoring
+        // would duplicate a leaf. `members`, not `memberProfiles`.
+        let alreadyInRoster = req.joinerBlsPublicKey.map { blsPub in
+            group.members.contains { $0.publicKeyCompressed == blsPub }
+        } ?? false
+
         // PR-13a admin-anchor path is Tyranny-only. Other types fall
         // through to the pre-PR-13 ship-only flow at the bottom.
         var anchored = group
-        if group.groupType == .tyranny {
+        if group.groupType == .tyranny, !alreadyInRoster {
             switch await anchorTyrannyJoin(
                 req: req,
                 group: group,
@@ -372,6 +379,8 @@ public actor JoinRequestApprover: JoinRequestApproving {
         // already updated by the anchor step. Both side-effects only
         // run when the joiner shipped a BLS pubkey.
         if let blsPub = req.joinerBlsPublicKey {
+            // Idempotent, and the point of the re-join path: a
+            // reinstalled joiner has a new inbox pubkey.
             await recordJoiner(
                 in: anchored,
                 blsPub: blsPub,
@@ -379,30 +388,34 @@ public actor JoinRequestApprover: JoinRequestApproving {
                 sendingPub: req.joinerSendingPublicKey,
                 alias: req.joinerDisplayLabel
             )
-            await broadcastJoin(
-                in: anchored,
-                joinerBlsPub: blsPub,
-                joinerInboxPub: req.joinerInboxPublicKey,
-                joinerSendingPub: req.joinerSendingPublicKey,
-                joinerAlias: req.joinerDisplayLabel
-            )
-            // The admin's own "X joined" row. Everyone else derives
-            // theirs from the announcement fanned out just above, which
-            // the admin — as its sender — never receives.
-            await systemEvents.recordMemberJoined(
-                groupID: anchored.id,
-                ownerIdentityID: anchored.ownerIdentityID,
-                groupType: anchored.groupType,
-                joinerBlsPubkeyHex: blsPub.map { String(format: "%02x", $0) }.joined(),
-                alias: req.joinerDisplayLabel,
-                at: Date()
-            )
+            // Both skipped on re-join: receivers bail on a known BLS
+            // hex, so the broadcast would be N seals and N publishes
+            // for nothing — and the admin's own notice would be a
+            // second "X joined" for someone already in the room.
+            if !alreadyInRoster {
+                await broadcastJoin(
+                    in: anchored,
+                    joinerBlsPub: blsPub,
+                    joinerInboxPub: req.joinerInboxPublicKey,
+                    joinerSendingPub: req.joinerSendingPublicKey,
+                    joinerAlias: req.joinerDisplayLabel
+                )
+                // The admin's own "X joined" row. Everyone else derives
+                // theirs from the announcement fanned out just above,
+                // which the admin — as its sender — never receives.
+                await systemEvents.recordMemberJoined(
+                    groupID: anchored.id,
+                    ownerIdentityID: anchored.ownerIdentityID,
+                    groupType: anchored.groupType,
+                    joinerBlsPubkeyHex: blsPub.map { String(format: "%02x", $0) }.joined(),
+                    alias: req.joinerDisplayLabel,
+                    at: Date()
+                )
+            }
         }
-        // Best-effort cleanup.
-        if let introPub = await findIntroPub(forRequestID: requestId) {
-            await introKeyStore.revoke(introPublicKey: introPub)
-        }
-        await introRequestStore.consume(id: requestId)
+        // Drop the request and its siblings. The key stays alive, or
+        // every other joiner's row would silently vanish.
+        await consumeRequestAndSiblings(requestId)
         return .sent
     }
 
@@ -681,13 +694,10 @@ public actor JoinRequestApprover: JoinRequestApproving {
         }
     }
 
-    /// Decline a pending request: drop it + revoke the intro slot.
-    /// No NACK to the joiner — their JoinScreen times out.
+    /// Drop that one request and its siblings, nothing else: a decline
+    /// judges one requester, not the link. No NACK to the joiner.
     public func decline(requestId: String) async {
-        if let introPub = await findIntroPub(forRequestID: requestId) {
-            await introKeyStore.revoke(introPublicKey: introPub)
-        }
-        await introRequestStore.consume(id: requestId)
+        await consumeRequestAndSiblings(requestId)
     }
 
     // MARK: - Private
@@ -718,12 +728,15 @@ public actor JoinRequestApprover: JoinRequestApproving {
         // rows and approving/declining one leaves the siblings behind —
         // which reads as "the buttons don't work". Keep the most recently
         // received copy, positioned at the first-seen index.
+        // Re-decodes each emission, so a row lives only while its key
+        // does — stable now that approve no longer revokes.
         var collapsed: [String: (request: PendingRequest, receivedAt: Date)] = [:]
+        var siblings: [String: [String]] = [:]
         var order: [String] = []
         for r in raw {
             guard let p = await decode(r) else { continue }
-            let identity = p.joinerBlsPublicKey ?? p.joinerInboxPublicKey
-            let key = Self.hex(identity) + ":" + Self.hex(p.groupId)
+            let key = Self.collapseKey(for: p)
+            siblings[key, default: []].append(r.id)
             if let existing = collapsed[key] {
                 if r.receivedAt > existing.receivedAt {
                     collapsed[key] = (p, r.receivedAt)
@@ -734,7 +747,40 @@ public actor JoinRequestApprover: JoinRequestApproving {
             }
         }
         pendingValue = order.compactMap { collapsed[$0]?.request }
+        // Approve/Decline consume the whole set; dropping only the
+        // winner lets a sibling resurface on the next emission.
+        collapsedRequestIDs = order.reduce(into: [:]) { acc, key in
+            guard let winner = collapsed[key]?.request else { return }
+            acc[winner.id] = siblings[key] ?? [winner.id]
+        }
         publishPending()
+    }
+
+    /// Drop `requestId` plus every sibling that collapsed into its row.
+    /// The intro key is left alive — see the type doc.
+    private func consumeRequestAndSiblings(_ requestId: String) async {
+        var ids = Set(collapsedRequestIDs[requestId] ?? [requestId])
+        // The cached map is only as fresh as the last `refresh`, so
+        // re-derive against the live store before consuming.
+        if let target = pendingValue.first(where: { $0.id == requestId }) {
+            let key = Self.collapseKey(for: target)
+            for raw in await introRequestStore.current() {
+                guard let decoded = await decode(raw),
+                      Self.collapseKey(for: decoded) == key
+                else { continue }
+                ids.insert(raw.id)
+            }
+        }
+        for id in ids {
+            await introRequestStore.consume(id: id)
+        }
+    }
+
+    /// Same joiner, same group — the identity two copies of one logical
+    /// join share.
+    private static func collapseKey(for request: PendingRequest) -> String {
+        let identity = request.joinerBlsPublicKey ?? request.joinerInboxPublicKey
+        return hex(identity) + ":" + hex(request.groupId)
     }
 
     private static func hex(_ data: Data) -> String {
@@ -791,12 +837,5 @@ public actor JoinRequestApprover: JoinRequestApproving {
             groupId: payload.groupId,
             groupName: groupName
         )
-    }
-
-    /// `PendingRequest` doesn't carry the introPub (intentional —
-    /// UI never needs it). Resolve via the raw store on demand.
-    private func findIntroPub(forRequestID id: String) async -> Data? {
-        let raw = await introRequestStore.current()
-        return raw.first { $0.id == id }?.targetIntroPublicKey
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
@@ -388,30 +388,36 @@ public actor JoinRequestApprover: JoinRequestApproving {
                 sendingPub: req.joinerSendingPublicKey,
                 alias: req.joinerDisplayLabel
             )
-            // Both skipped on re-join: receivers bail on a known BLS
-            // hex, so the broadcast would be N seals and N publishes
-            // for nothing — and the admin's own notice would be a
-            // second "X joined" for someone already in the room.
-            if !alreadyInRoster {
-                await broadcastJoin(
-                    in: anchored,
-                    joinerBlsPub: blsPub,
-                    joinerInboxPub: req.joinerInboxPublicKey,
-                    joinerSendingPub: req.joinerSendingPublicKey,
-                    joinerAlias: req.joinerDisplayLabel
-                )
-                // The admin's own "X joined" row. Everyone else derives
-                // theirs from the announcement fanned out just above,
-                // which the admin — as its sender — never receives.
-                await systemEvents.recordMemberJoined(
-                    groupID: anchored.id,
-                    ownerIdentityID: anchored.ownerIdentityID,
-                    groupType: anchored.groupType,
-                    joinerBlsPubkeyHex: blsPub.map { String(format: "%02x", $0) }.joined(),
-                    alias: req.joinerDisplayLabel,
-                    at: Date()
-                )
-            }
+            // Deliberately NOT gated on `alreadyInRoster`. That flag
+            // reads `members` (the crypto roster, advanced by the
+            // anchor), while receivers dedupe on `memberProfiles` —
+            // and those two diverge in exactly the case retry exists
+            // to repair: the anchor persisted, then seal/send failed,
+            // so the joiner is in `members` while no other member has
+            // heard of them. Skipping here would leave their messages
+            // parked forever. Both calls are idempotent at the
+            // receiver — `applyAnnouncement` bails on a known BLS hex,
+            // and the notice's id derives from `member-joined:<hex>`
+            // over an idempotent insert — so a genuine re-join costs
+            // some wasted seals, never a duplicate.
+            await broadcastJoin(
+                in: anchored,
+                joinerBlsPub: blsPub,
+                joinerInboxPub: req.joinerInboxPublicKey,
+                joinerSendingPub: req.joinerSendingPublicKey,
+                joinerAlias: req.joinerDisplayLabel
+            )
+            // The admin's own "X joined" row. Everyone else derives
+            // theirs from the announcement fanned out just above,
+            // which the admin — as its sender — never receives.
+            await systemEvents.recordMemberJoined(
+                groupID: anchored.id,
+                ownerIdentityID: anchored.ownerIdentityID,
+                groupType: anchored.groupType,
+                joinerBlsPubkeyHex: blsPub.map { String(format: "%02x", $0) }.joined(),
+                alias: req.joinerDisplayLabel,
+                at: Date()
+            )
         }
         // Drop the request and its siblings. The key stays alive, or
         // every other joiner's row would silently vanish.
@@ -789,8 +795,13 @@ public actor JoinRequestApprover: JoinRequestApproving {
 
     private func decode(_ raw: IntroRequest) async -> PendingRequest? {
         guard let entry = await introKeyStore.find(introPublicKey: raw.targetIntroPublicKey) else {
-            // Entry was already revoked, or the request landed on a
-            // pubkey we never minted (forged). Drop silently.
+            // Entry was revoked or rotated away, or the request landed
+            // on a pubkey we never minted (forged). Counted like every
+            // other decode failure: now that links are retired only
+            // deliberately, this is what a request against a retired
+            // link looks like, and it was the one drop with no signal
+            // at all.
+            decryptFailures += 1
             return nil
         }
         let privKey: Curve25519.KeyAgreement.PrivateKey

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
@@ -433,7 +433,7 @@ public actor JoinRequestApprover: JoinRequestApproving {
         // redeemable by anyone it leaked to — retire it here rather
         // than hoping the host finds the invite list. The shared link
         // is untouched: that one is meant to be multi-use.
-        await revokeSpentOfferKey(for: req)
+        await revokeSpentOfferKey(forRequestID: requestId, in: anchored)
 
         // Drop the request and its siblings. The shared key stays
         // alive, or every other joiner's row would silently vanish.
@@ -797,18 +797,27 @@ public actor JoinRequestApprover: JoinRequestApproving {
     /// The intro key is left alive — see the type doc.
     /// Revoke the per-invitee offer key this joiner came in on, if
     /// any. Matched on the label, which `CreateGroupInteractor` stamps
-    /// with the invitee's inbox fingerprint — so this only ever fires
-    /// for the person that key was minted for.
-    private func revokeSpentOfferKey(for req: PendingRequest) async {
-        let fingerprint = IntroKeyEntry.fingerprint(of: req.joinerInboxPublicKey)
-        let owner = await groupRepository.currentGroups()
-            .first { $0.groupIDData == req.groupId }?
-            .ownerIdentityID
-        guard let owner else { return }
-        for entry in await introKeyStore.listForOwner(owner)
-        where entry.groupId == req.groupId && entry.label == fingerprint {
-            await introKeyStore.revoke(introPublicKey: entry.introPublicKey)
-        }
+    /// with the invitee's inbox fingerprint.
+    ///
+    /// Matched on the link the request actually arrived on, NOT the
+    /// joiner's fingerprint. A fingerprint match broke twice: a
+    /// reinstalled joiner presents a fresh inbox key, so their offer
+    /// key would never be retired and would hold a private link and its
+    /// subscription open for good; and two invitees can collide on four
+    /// bytes, so it would revoke a bystander's link alongside the spent
+    /// one. The intro pubkey is unambiguous.
+    ///
+    /// `label != nil` is what separates a create-time offer from the
+    /// group's shared link, which is meant to be multi-use and is never
+    /// retired here.
+    private func revokeSpentOfferKey(forRequestID requestID: String, in group: ChatGroup) async {
+        let raw = await introRequestStore.current()
+        guard let introPub = raw.first(where: { $0.id == requestID })?.targetIntroPublicKey,
+              let entry = await introKeyStore.find(introPublicKey: introPub),
+              entry.label != nil,
+              entry.groupId == group.groupIDData
+        else { return }
+        await introKeyStore.revoke(introPublicKey: introPub)
     }
 
     private func consumeRequestAndSiblings(_ requestId: String) async {

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
@@ -154,6 +154,9 @@ public actor JoinRequestApprover: JoinRequestApproving {
     private var collapsedRequestIDs: [String: [String]] = [:]
     private var pendingContinuations: [UUID: AsyncStream<[PendingRequest]>.Continuation] = [:]
     private var decryptFailures: Int = 0
+    /// Request ids already counted in `decryptFailures`, so a re-decode
+    /// of the same undecodable row doesn't inflate the signal.
+    private var countedDecodeFailures: Set<String> = []
     private var collectorTask: Task<Void, Never>?
     /// Serializes `approve` calls. Each approval reads `group.epoch`,
     /// proves an `update_commitment` from it, submits, then persists
@@ -213,6 +216,11 @@ public actor JoinRequestApprover: JoinRequestApproving {
     /// decode (forged link campaign, corrupted intro key, etc.).
     /// Wired to a Settings → Diagnostics view in a follow-up.
     func decryptFailureCount() -> Int { decryptFailures }
+
+    private func countDecodeFailureOnce(_ requestID: String) {
+        guard countedDecodeFailures.insert(requestID).inserted else { return }
+        decryptFailures += 1
+    }
 
     /// Subscribe to `IntroRequestStore.requests` and keep `pending`
     /// in sync. Idempotent — a second call replaces the prior
@@ -419,8 +427,16 @@ public actor JoinRequestApprover: JoinRequestApproving {
                 at: Date()
             )
         }
-        // Drop the request and its siblings. The key stays alive, or
-        // every other joiner's row would silently vanish.
+        // A create-time offer key is 1:1 with one named invitee and is
+        // spent the moment that invitee is in. Leaving it live would
+        // hold a relay subscription for good and leave a private link
+        // redeemable by anyone it leaked to — retire it here rather
+        // than hoping the host finds the invite list. The shared link
+        // is untouched: that one is meant to be multi-use.
+        await revokeSpentOfferKey(for: req)
+
+        // Drop the request and its siblings. The shared key stays
+        // alive, or every other joiner's row would silently vanish.
         await consumeRequestAndSiblings(requestId)
         return .sent
     }
@@ -700,9 +716,20 @@ public actor JoinRequestApprover: JoinRequestApproving {
         }
     }
 
-    /// Drop that one request and its siblings, nothing else: a decline
-    /// judges one requester, not the link. No NACK to the joiner.
+    /// Drop that one request and its siblings, and remember the
+    /// joiner. A decline judges one requester, not the link — the link
+    /// stays live for everyone else — but it has to mean something:
+    /// the joiner's screen offers a retry, and each retry is a fresh
+    /// Nostr event, so an id-keyed tombstone would let a declined
+    /// stranger refill the queue indefinitely. Keyed on the collapse
+    /// key (joiner identity ⊕ group), which survives that.
+    /// No NACK to the joiner.
     public func decline(requestId: String) async {
+        if let target = pendingValue.first(where: { $0.id == requestId }) {
+            await introRequestStore.recordDeclined(
+                collapseKey: Self.collapseKey(for: target)
+            )
+        }
         await consumeRequestAndSiblings(requestId)
     }
 
@@ -736,12 +763,16 @@ public actor JoinRequestApprover: JoinRequestApproving {
         // received copy, positioned at the first-seen index.
         // Re-decodes each emission, so a row lives only while its key
         // does — stable now that approve no longer revokes.
+        let declined = await introRequestStore.declinedCollapseKeys()
         var collapsed: [String: (request: PendingRequest, receivedAt: Date)] = [:]
         var siblings: [String: [String]] = [:]
         var order: [String] = []
         for r in raw {
             guard let p = await decode(r) else { continue }
             let key = Self.collapseKey(for: p)
+            // Declined joiners stay declined across retries and
+            // relaunches; the link itself is unaffected.
+            if declined.contains(key) { continue }
             siblings[key, default: []].append(r.id)
             if let existing = collapsed[key] {
                 if r.receivedAt > existing.receivedAt {
@@ -764,6 +795,22 @@ public actor JoinRequestApprover: JoinRequestApproving {
 
     /// Drop `requestId` plus every sibling that collapsed into its row.
     /// The intro key is left alive — see the type doc.
+    /// Revoke the per-invitee offer key this joiner came in on, if
+    /// any. Matched on the label, which `CreateGroupInteractor` stamps
+    /// with the invitee's inbox fingerprint — so this only ever fires
+    /// for the person that key was minted for.
+    private func revokeSpentOfferKey(for req: PendingRequest) async {
+        let fingerprint = IntroKeyEntry.fingerprint(of: req.joinerInboxPublicKey)
+        let owner = await groupRepository.currentGroups()
+            .first { $0.groupIDData == req.groupId }?
+            .ownerIdentityID
+        guard let owner else { return }
+        for entry in await introKeyStore.listForOwner(owner)
+        where entry.groupId == req.groupId && entry.label == fingerprint {
+            await introKeyStore.revoke(introPublicKey: entry.introPublicKey)
+        }
+    }
+
     private func consumeRequestAndSiblings(_ requestId: String) async {
         var ids = Set(collapsedRequestIDs[requestId] ?? [requestId])
         // The cached map is only as fresh as the last `refresh`, so
@@ -801,7 +848,13 @@ public actor JoinRequestApprover: JoinRequestApproving {
             // deliberately, this is what a request against a retired
             // link looks like, and it was the one drop with no signal
             // at all.
-            decryptFailures += 1
+            //
+            // Counted once per request id. `refresh` re-decodes the
+            // whole raw set on every store publish and a request
+            // against a retired link is never consumed, so a running
+            // total would climb without bound off one dead link and
+            // couldn't be told apart from a thousand real replays.
+            countDecodeFailureOnce(raw.id)
             return nil
         }
         let privKey: Curve25519.KeyAgreement.PrivateKey

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinView.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinView.swift
@@ -141,6 +141,35 @@ public struct JoinView: View {
             }
             .padding(.top, 24)
             .accessibilityIdentifier("join.awaiting_approval")
+        case .unanswered:
+            VStack(spacing: 12) {
+                Image(systemName: "clock.badge.questionmark")
+                    .font(.system(size: 36))
+                    .foregroundStyle(OnymTokens.text2)
+                Text("No response yet")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                // Host offline or link replaced — indistinguishable
+                // from here, since revocation is silent. Name both.
+                Text("The host may be offline, or this invite may no longer work. Ask them for a new link.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                Text("You can leave this screen open — if they approve, the chat still appears.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(OnymTokens.text2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                Button("Try again") {
+                    flow.send(displayLabel: displayLabel)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 4)
+                .accessibilityIdentifier("join.retry_button")
+            }
+            .padding(.top, 24)
+            .accessibilityIdentifier("join.unanswered")
         case .approved(let group):
             VStack(spacing: 12) {
                 Image(systemName: "checkmark.seal.fill")

--- a/Packages/OnymGroup/Sources/OnymGroup/KeychainIntroKeyStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/KeychainIntroKeyStore.swift
@@ -22,26 +22,18 @@ public actor KeychainIntroKeyStore: IntroKeyStore {
     public static let serviceDefault = "app.onym.ios.intro_keys"
     public static let account = "blob"
 
-    /// How long an invite link is honored after minting. 24 hours per
-    /// issue onymchat/onym-ios#111 (shrink the leak window of a
-    /// forwarded or screenshotted link) — matches onym-android's
-    /// `IntroKeyEntry.LIFETIME_MILLIS`. Expired entries are invisible
-    /// to `find`/`listForOwner`/streams (so the intro pump stops
-    /// subscribing their inboxes, which each cost a relay REQ slot)
-    /// and are compacted out of the blob by the load that first sees
-    /// them expired.
-    public static let entryTTL: TimeInterval = 24 * 60 * 60
+    // No entry TTL. Links are retired by `revoke` alone — from the
+    // share screen's per-row Revoke or "Generate new link" — so a QR
+    // shared yesterday still works today. This deliberately reverses
+    // the 24h expiry of issue onymchat/onym-ios#111, and diverges from
+    // onym-android's `IntroKeyEntry.LIFETIME_MILLIS`, which still
+    // expires after 24h.
 
     private let service: String
     /// Per-owner subscriber continuations. Mutations re-emit the
     /// filtered+sorted snapshot to every subscriber whose owner
     /// matches.
     private var continuations: [IdentityID: [UUID: AsyncStream<[IntroKeyEntry]>.Continuation]] = [:]
-    /// Reentrancy latch: `loadAll()` publishes when it compacts, and
-    /// `publish` itself calls `loadAll()` — the latch stops that inner
-    /// load from re-entering the compaction path.
-    private var compacting = false
-
     public init(testNamespace: String? = nil) {
         if let testNamespace, !testNamespace.isEmpty {
             self.service = "\(Self.serviceDefault).\(testNamespace)"
@@ -171,34 +163,9 @@ public actor KeychainIntroKeyStore: IntroKeyStore {
         var result: AnyObject?
         let status = SecItemCopyMatching(q as CFDictionary, &result)
         guard status == errSecSuccess, let data = result as? Data else { return [] }
-        // Corrupted blob → discard rather than crash. Acceptable
-        // because this store holds ephemeral per-invite keys; if we
-        // lose them, the worst that happens is in-flight invites
-        // fail to deliver and the inviter re-shares.
-        let entries = (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
-        // TTL filter at the single load point so expired entries are
-        // invisible to every reader.
-        let cutoff = Int64((Date().timeIntervalSince1970 - Self.entryTTL) * 1000)
-        let live = entries.filter { $0.createdAtMillis > cutoff }
-        // Compact immediately: expired rows carry intro PRIVATE keys,
-        // and a read-only workload would otherwise leave them at rest
-        // indefinitely waiting for a mutation to rewrite the blob.
-        // Publish for the expired entries' owners so a live session's
-        // intro pump drops their relay REQ slots too — but note this
-        // still only runs when *something* touches the store; a fully
-        // quiet session keeps its slots until the next access or
-        // launch.
-        if live.count != entries.count, !compacting {
-            compacting = true
-            writeAll(live)
-            let expiredOwners = Set(
-                entries.filter { $0.createdAtMillis <= cutoff }
-                    .compactMap { IdentityID($0.ownerIdentityID) }
-            )
-            for owner in expiredOwners { publish(forOwner: owner) }
-            compacting = false
-        }
-        return live
+        // Corrupted blob → discard; the inviter re-shares. No
+        // time-based filter: entries live until revoked.
+        return (try? JSONDecoder().decode(StoredIntroKeysBlob.self, from: data))?.entries ?? []
     }
 
     private func writeAll(_ entries: [StoredIntroKey]) {
@@ -237,6 +204,9 @@ private struct StoredIntroKey: Codable {
     let ownerIdentityID: String
     let groupId: Data
     let createdAtMillis: Int64
+    /// MUST stay optional: the decode is `(try? …) ?? []`, so a
+    /// required field would wipe every existing invite on upgrade.
+    let label: String?
 
     enum CodingKeys: String, CodingKey {
         case introPub = "intro_pub"
@@ -244,6 +214,7 @@ private struct StoredIntroKey: Codable {
         case ownerIdentityID = "owner_identity_id"
         case groupId = "group_id"
         case createdAtMillis = "created_at_millis"
+        case label
     }
 
     init(from entry: IntroKeyEntry) {
@@ -252,6 +223,7 @@ private struct StoredIntroKey: Codable {
         self.ownerIdentityID = entry.ownerIdentityID.rawValue.uuidString
         self.groupId = entry.groupId
         self.createdAtMillis = Int64(entry.createdAt.timeIntervalSince1970 * 1000)
+        self.label = entry.label
     }
 
     func toEntry() -> IntroKeyEntry? {
@@ -263,7 +235,8 @@ private struct StoredIntroKey: Codable {
             introPrivateKey: introPriv,
             ownerIdentityID: owner,
             groupId: groupId,
-            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000)
+            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000),
+            label: label
         )
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/KeychainIntroKeyStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/KeychainIntroKeyStore.swift
@@ -78,6 +78,10 @@ public actor KeychainIntroKeyStore: IntroKeyStore {
     }
 
     @discardableResult
+    public func allLivePublicKeys() async -> Set<Data> {
+        Set(loadAll().compactMap { $0.toEntry()?.introPublicKey })
+    }
+
     public func deleteForOwner(_ ownerIdentityID: IdentityID) async -> Int {
         var current = loadAll()
         let before = current.count
@@ -207,6 +211,14 @@ private struct StoredIntroKey: Codable {
     /// MUST stay optional: the decode is `(try? …) ?? []`, so a
     /// required field would wipe every existing invite on upgrade.
     let label: String?
+    /// Absent on rows written before labels existed. Optional so the
+    /// `(try? …) ?? []` decode can't wipe every stored invite on
+    /// upgrade, and so its absence is exactly the legacy signal.
+    let labelVersion: Int?
+
+    /// Bumped only if the meaning of `label` changes; its presence is
+    /// what marks a row as written by a label-aware build.
+    static let currentLabelVersion = 1
 
     enum CodingKeys: String, CodingKey {
         case introPub = "intro_pub"
@@ -215,6 +227,7 @@ private struct StoredIntroKey: Codable {
         case groupId = "group_id"
         case createdAtMillis = "created_at_millis"
         case label
+        case labelVersion = "label_version"
     }
 
     init(from entry: IntroKeyEntry) {
@@ -224,6 +237,9 @@ private struct StoredIntroKey: Codable {
         self.groupId = entry.groupId
         self.createdAtMillis = Int64(entry.createdAt.timeIntervalSince1970 * 1000)
         self.label = entry.label
+        // Stamped on every write, so a row without it is one this
+        // build never wrote — i.e. from before labels existed.
+        self.labelVersion = StoredIntroKey.currentLabelVersion
     }
 
     func toEntry() -> IntroKeyEntry? {
@@ -236,7 +252,8 @@ private struct StoredIntroKey: Codable {
             ownerIdentityID: owner,
             groupId: groupId,
             createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000),
-            label: label
+            label: label,
+            isLegacy: labelVersion == nil
         )
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/ShareInviteFlow.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/ShareInviteFlow.swift
@@ -46,6 +46,13 @@ public final class ShareInviteFlow: Identifiable {
     /// button — rotating twice in a row would strand a live key.
     public private(set) var isRotating = false
 
+    /// The intro pubkey behind the link currently on screen, remembered
+    /// rather than re-parsed. Deriving it from `state` meant any
+    /// non-`.ready` state (a failed revoke, say) resolved to nil and the
+    /// live link showed up in the revokable list — one tap from killing
+    /// the link the user is in the middle of sharing.
+    private var currentIntroPub: Data?
+
     private let identity: IdentityRepository
     private let introducer: InviteIntroducer
     private let groupRepository: GroupRepository
@@ -88,6 +95,7 @@ public final class ShareInviteFlow: Identifiable {
                 groupId: group.groupIDData,
                 groupName: group.name
             )
+            currentIntroPub = cap.introPublicKey
             state = .ready(link: cap.toAppLink(), groupName: group.name)
             await refreshOtherInvites(ownerIdentityID: activeID, groupId: group.groupIDData)
         } catch {
@@ -122,7 +130,13 @@ public final class ShareInviteFlow: Identifiable {
                 groupId: group.groupIDData,
                 groupName: group.name
             )
+            currentIntroPub = cap.introPublicKey
             state = .ready(link: cap.toAppLink(), groupName: group.name)
+            // Same refresh mint and revoke do. Without it a key
+            // stranded by a crash mid-rotate stays invisible until the
+            // sheet is dismissed and reopened — the exact "listed
+            // nowhere" state the mint-then-revoke order exists to avoid.
+            await refreshOtherInvites(ownerIdentityID: activeID, groupId: group.groupIDData)
         } catch {
             state = .failed(reason: "\(error)")
         }
@@ -160,6 +174,8 @@ public final class ShareInviteFlow: Identifiable {
 
     /// Intro pubkey behind the rendered link, so the list excludes it.
     private func currentIntroPublicKey() -> Data? {
+        if let currentIntroPub { return currentIntroPub }
+        // Only reached before the first mint resolves.
         guard case .ready(let link, _) = state,
               let cap = IntroCapability.fromLink(link)
         else { return nil }

--- a/Packages/OnymGroup/Sources/OnymGroup/ShareInviteFlow.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/ShareInviteFlow.swift
@@ -3,15 +3,11 @@ import Observation
 import OnymIdentity
 
 /// Drives the post-create "Share invite" surface. Owns one piece of
-/// state — the share link for the just-minted invite — and exposes
-/// one intent (`mintFor`) to refresh / re-mint.
+/// state — the group's share link — and exposes one intent
+/// (`mintFor`) to load or refresh it.
 ///
-/// Why minting is decoupled from the view's first appearance:
-/// minting is a side effect (writes to `IntroKeyStore`); doing it
-/// in `.onAppear` ties it to view lifecycle (re-entries would mint
-/// twice). This flow holds the side effect off the view tree where
-/// it belongs. The view calls `mintFor` exactly once on appear,
-/// re-mint requires an explicit "Generate new link" tap.
+/// Re-entry is idempotent: `currentOrMint` returns the existing key
+/// rather than stacking a new one per visit.
 ///
 /// Mirrors onym-android's `ShareInviteViewModel.kt`.
 @MainActor
@@ -24,6 +20,16 @@ public final class ShareInviteFlow: Identifiable {
         case failed(reason: String)
     }
 
+    /// One revokable invite. `label` is nil for a superseded shared
+    /// key; the view supplies the localized name for that case.
+    public struct InviteRow: Equatable, Identifiable, Sendable {
+        public let introPublicKey: Data
+        public let label: String?
+        public let createdAt: Date
+
+        public var id: Data { introPublicKey }
+    }
+
     /// Drives `.sheet(item:)` from a single source of truth.
     /// `.sheet(isPresented:)` paired with a separate optional-flow
     /// `@State` raced on first present — the content closure read
@@ -31,6 +37,14 @@ public final class ShareInviteFlow: Identifiable {
     public nonisolated var id: ObjectIdentifier { ObjectIdentifier(self) }
 
     public private(set) var state: State = .idle
+
+    /// Other live invites: the per-invitee offer keys, plus any
+    /// superseded shared key, so nothing is left unrevokable.
+    public private(set) var otherInvites: [InviteRow] = []
+
+    /// Set while a rotate is in flight so the UI can disable the
+    /// button — rotating twice in a row would strand a live key.
+    public private(set) var isRotating = false
 
     private let identity: IdentityRepository
     private let introducer: InviteIntroducer
@@ -46,10 +60,8 @@ public final class ShareInviteFlow: Identifiable {
         self.groupRepository = groupRepository
     }
 
-    /// Mint a fresh capability for the group with hex id `groupID` and
-    /// surface the share link. Idempotent for repeated taps from the
-    /// same screen — re-mints a fresh keypair so each share goes
-    /// through a distinct intro slot (per-link revocation friendly).
+    /// Resolve and surface the group's share link. Idempotent: re-entry
+    /// returns the same link. One link, many joiners.
     ///
     /// If `groupID` does not resolve to a local group (race between
     /// persistence + navigation, or a stale deeplink back into share)
@@ -71,7 +83,41 @@ public final class ShareInviteFlow: Identifiable {
         }
         state = .minting
         do {
-            let cap = try await introducer.mint(
+            let cap = try await introducer.currentOrMint(
+                ownerIdentityID: activeID,
+                groupId: group.groupIDData,
+                groupName: group.name
+            )
+            state = .ready(link: cap.toAppLink(), groupName: group.name)
+            await refreshOtherInvites(ownerIdentityID: activeID, groupId: group.groupIDData)
+        } catch {
+            state = .failed(reason: "\(error)")
+        }
+    }
+
+    /// Replace the shared link. Nobody holding the old one is told, so
+    /// this is the "my link leaked" escape hatch.
+    public func rotateLink(groupID: String) {
+        Task { await rotateLinkAsync(groupID: groupID) }
+    }
+
+    private func rotateLinkAsync(groupID: String) async {
+        // Set before the first await, or a double-tap clears both this
+        // guard and `.disabled(flow.isRotating)` inside the window.
+        guard !isRotating else { return }
+        isRotating = true
+        defer { isRotating = false }
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }) else {
+            state = .failed(reason: "Group not found on this device")
+            return
+        }
+        guard let activeID = await identity.currentSelectedID() else {
+            state = .failed(reason: "No identity selected")
+            return
+        }
+        do {
+            let cap = try await introducer.rotate(
                 ownerIdentityID: activeID,
                 groupId: group.groupIDData,
                 groupName: group.name
@@ -80,5 +126,43 @@ public final class ShareInviteFlow: Identifiable {
         } catch {
             state = .failed(reason: "\(error)")
         }
+    }
+
+    /// Retire one per-invitee offer key.
+    public func revoke(_ row: InviteRow, groupID: String) {
+        Task { await revokeAsync(row, groupID: groupID) }
+    }
+
+    private func revokeAsync(_ row: InviteRow, groupID: String) async {
+        await introducer.revoke(introPublicKey: row.introPublicKey)
+        let groups = await groupRepository.currentGroups()
+        guard let group = groups.first(where: { $0.id == groupID }),
+              let activeID = await identity.currentSelectedID()
+        else { return }
+        await refreshOtherInvites(ownerIdentityID: activeID, groupId: group.groupIDData)
+    }
+
+    private func refreshOtherInvites(ownerIdentityID: IdentityID, groupId: Data) async {
+        let current = currentIntroPublicKey()
+        // Everything but the link on screen. A shared key stranded by a
+        // crash mid-rotate would otherwise be listed nowhere.
+        otherInvites = await introducer
+            .liveInvites(ownerIdentityID: ownerIdentityID, groupId: groupId)
+            .filter { $0.introPublicKey != current }
+            .map { entry in
+                InviteRow(
+                    introPublicKey: entry.introPublicKey,
+                    label: entry.label,
+                    createdAt: entry.createdAt
+                )
+            }
+    }
+
+    /// Intro pubkey behind the rendered link, so the list excludes it.
+    private func currentIntroPublicKey() -> Data? {
+        guard case .ready(let link, _) = state,
+              let cap = IntroCapability.fromLink(link)
+        else { return nil }
+        return cap.introPublicKey
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/ShareInviteView.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/ShareInviteView.swift
@@ -116,8 +116,13 @@ public struct ShareInviteView: View {
                         }
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(.red)
+                        // Keyed on the intro pubkey, not the label: two
+                        // invitees can share a 4-byte fingerprint (or be
+                        // the same person invited twice), and duplicate
+                        // ids leave the user unable to tell which Revoke
+                        // kills which link.
                         .accessibilityIdentifier(
-                            "share_invite.revoke_button.\(row.label ?? "superseded")"
+                            "share_invite.revoke_button.\(row.id.prefix(8).map { String(format: "%02x", $0) }.joined())"
                         )
                     }
                     .padding(.vertical, 10)

--- a/Packages/OnymGroup/Sources/OnymGroup/ShareInviteView.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/ShareInviteView.swift
@@ -2,13 +2,13 @@ import SwiftUI
 import OnymDesign
 
 /// Post-create surface. The just-created group is identified by hex
-/// `groupID`; the flow resolves it from the repository, mints a
-/// fresh deeplink capability, and surfaces the link. The user
+/// `groupID`; the flow resolves it from the repository, resolves the
+/// group's deeplink capability, and surfaces the link. The user
 /// shares via the system share sheet, copies it, or skips.
 ///
-/// Mints exactly once per screen entry — re-entry (after Done →
-/// back) re-mints with a fresh intro keypair so the previous share
-/// stays revocable independently.
+/// Reuses the group's link instead of minting per entry, so a QR
+/// already screenshotted keeps working. "Generate new link" is the
+/// only thing that rotates it.
 public struct ShareInviteView: View {
     let groupID: String
     @Bindable var flow: ShareInviteFlow
@@ -53,6 +53,82 @@ public struct ShareInviteView: View {
         }
         .background(OnymTokens.bg)
         .onAppear { flow.mintFor(groupID: groupID) }
+    }
+
+    /// Rotate. The only way a leaked link stops working, framed as
+    /// generate-a-new-one so the user always holds a working link.
+    private var rotateButton: some View {
+        Button {
+            copied = false
+            flow.rotateLink(groupID: groupID)
+        } label: {
+            HStack(spacing: 8) {
+                if flow.isRotating {
+                    ProgressView().controlSize(.small)
+                }
+                Text(flow.isRotating ? "Generating…" : "Generate new link")
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .foregroundStyle(OnymTokens.text2)
+        }
+        .disabled(flow.isRotating)
+        .accessibilityIdentifier("share_invite.rotate_button")
+        .overlay(alignment: .bottom) {
+            Text("The old link stops working. Anyone still holding it won't be told.")
+                .font(.system(size: 11))
+                .foregroundStyle(OnymTokens.text2)
+                .multilineTextAlignment(.center)
+                .offset(y: 16)
+        }
+        .padding(.bottom, 20)
+    }
+
+    /// The create-time offers, one per invitee. Nothing expires, so
+    /// this list is the only way they are ever retired.
+    @ViewBuilder
+    private var otherInvitesSection: some View {
+        if !flow.otherInvites.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Direct invites")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                Text("Sent when you created the group. Each one can still be used to request to join.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(OnymTokens.text2)
+
+                ForEach(flow.otherInvites) { row in
+                    HStack {
+                        // A literal key so it localizes; a String
+                        // variable would render verbatim.
+                        if let label = row.label {
+                            Text(label)
+                                .font(.system(size: 13, design: .monospaced))
+                                .foregroundStyle(OnymTokens.text)
+                        } else {
+                            Text("Older link")
+                                .font(.system(size: 13))
+                                .foregroundStyle(OnymTokens.text)
+                        }
+                        Spacer()
+                        Button("Revoke") {
+                            flow.revoke(row, groupID: groupID)
+                        }
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.red)
+                        .accessibilityIdentifier(
+                            "share_invite.revoke_button.\(row.label ?? "superseded")"
+                        )
+                    }
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 12)
+                    .background(OnymTokens.surface2,
+                                in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityIdentifier("share_invite.other_invites")
+        }
     }
 
     private var topBar: some View {
@@ -137,6 +213,9 @@ public struct ShareInviteView: View {
                 // capability aloud in Release.
                 .accessibilityValue(link)
                 #endif
+
+                rotateButton
+                otherInvitesSection
             }
             .padding(.top, 24)
         case .failed(let reason):

--- a/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
@@ -27,13 +27,26 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
 
     private var continuations: [UUID: AsyncStream<[IntroRequest]>.Continuation] = [:]
 
+    /// Event ids already acted on, mirrored from `handledLog` so the
+    /// hot `record` path doesn't hit storage per inbound.
+    private var consumed: Set<String>
+    /// Durable half of the tombstone. Deleting the pending row is not
+    /// enough now that links are multi-use: the subscription outlives
+    /// the approval and the REQ carries no `since`, so every reconnect
+    /// replays a handled request and would re-insert it here.
+    private let handledLog: any HandledIntroRequestLog
+
     /// Production initializer — on-disk SQLite under
     /// `Application Support/OnymIOS/IntroRequests.store` with
     /// `FileProtectionType.complete`. Open failures go through
     /// `PersistentStoreOpener`: logged, moved aside as `.bak` (never
     /// deleted), retried once — and left completely untouched when
     /// the file is merely unreadable (locked-device launch).
-    public init() throws {
+    public init(
+        handledLog: any HandledIntroRequestLog = UserDefaultsHandledIntroRequestLog()
+    ) throws {
+        self.handledLog = handledLog
+        self.consumed = handledLog.handledIDs()
         let url = try PersistentStoreOpener.storeDirectory()
             .appendingPathComponent("IntroRequests.store")
         let container = try PersistentStoreOpener.openContainer(
@@ -52,7 +65,12 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
         return SwiftDataIntroRequestStore(container: container)
     }
 
-    private init(container: ModelContainer) {
+    private init(
+        container: ModelContainer,
+        handledLog: any HandledIntroRequestLog = InMemoryHandledIntroRequestLog()
+    ) {
+        self.handledLog = handledLog
+        self.consumed = handledLog.handledIDs()
         self.container = container
         self.context = ModelContext(container)
     }
@@ -67,6 +85,9 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
     /// cases call for the same thing from it — nothing.
     @discardableResult
     public func record(_ request: IntroRequest) async -> Bool {
+        // Already acted on: a replay of an approved/declined request
+        // must not reappear as pending.
+        if consumed.contains(request.id) { return false }
         // No sweep here: the `publish()` below reads through `loadAll()`,
         // which prunes. Calling it on entry too meant two fetch+delete
         // passes per insert.
@@ -107,10 +128,24 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
         let descriptor = FetchDescriptor<PersistedIntroRequest>(
             predicate: #Predicate { $0.id == id }
         )
-        guard let rows = try? context.fetch(descriptor), !rows.isEmpty else { return }
+        // Unconditional, so a tombstone can be laid ahead of a replay
+        // that hasn't landed yet.
+        consumed.insert(id)
+        let rows = (try? context.fetch(descriptor)) ?? []
+        // Attribute to the link it arrived on so `pruneTombstones` can
+        // drop it when that link is retired.
+        if let row = rows.first, let introPub = Self.decode(row)?.targetIntroPublicKey {
+            handledLog.record(id: id, introPublicKey: introPub)
+        }
+        guard !rows.isEmpty else { return }
         for row in rows { context.delete(row) }
         try? context.save()
         publish()
+    }
+
+    public func pruneTombstones(keeping livePublicKeys: Set<Data>) async {
+        handledLog.prune(keeping: livePublicKeys)
+        consumed = handledLog.handledIDs()
     }
 
     public func current() async -> [IntroRequest] {

--- a/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
@@ -57,12 +57,16 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
         self.context = ModelContext(container)
     }
 
-    /// In-memory factory for tests.
-    public static func inMemory() -> SwiftDataIntroRequestStore {
+    /// In-memory factory for tests. `handledLog` is injectable so a
+    /// test can share one across two stores and model a relaunch —
+    /// the tombstones are the half that is meant to outlive the rows.
+    public static func inMemory(
+        handledLog: any HandledIntroRequestLog = InMemoryHandledIntroRequestLog()
+    ) -> SwiftDataIntroRequestStore {
         let schema = Schema([PersistedIntroRequest.self])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         let container = try! ModelContainer(for: schema, configurations: [config])
-        return SwiftDataIntroRequestStore(container: container)
+        return SwiftDataIntroRequestStore(container: container, handledLog: handledLog)
     }
 
     private init(

--- a/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
@@ -160,6 +160,19 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
         consumed = handledLog.handledIDs()
     }
 
+    public func reconcileTombstones(livePublicKeys: Set<Data>) async {
+        handledLog.reconcile(livePublicKeys: livePublicKeys)
+        consumed = handledLog.handledIDs()
+    }
+
+    public func recordDeclined(collapseKey: String) async {
+        handledLog.recordDeclined(collapseKey: collapseKey)
+    }
+
+    public func declinedCollapseKeys() async -> Set<String> {
+        handledLog.declinedCollapseKeys()
+    }
+
     public func current() async -> [IntroRequest] {
         loadAll()
     }

--- a/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/SwiftDataIntroRequestStore.swift
@@ -138,17 +138,25 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
         let rows = (try? context.fetch(descriptor)) ?? []
         // Attribute to the link it arrived on so `pruneTombstones` can
         // drop it when that link is retired.
-        if let row = rows.first, let introPub = Self.decode(row)?.targetIntroPublicKey {
-            handledLog.record(id: id, introPublicKey: introPub)
-        }
+        // Durable even when the row is absent (a tombstone laid ahead
+        // of a replay, or a stale sibling id). Without the row there is
+        // no link to attribute it to, so it goes in unattributed: it can
+        // never be pruned by a retired link, and is bounded only by the
+        // log's own cap — the right trade, since losing it means the
+        // handled request comes back as pending on the next cold start.
+        let introPub = rows.first.flatMap { Self.decode($0)?.targetIntroPublicKey }
+        handledLog.record(
+            id: id,
+            introPublicKey: introPub ?? InMemoryIntroRequestStore.unattributedLink
+        )
         guard !rows.isEmpty else { return }
         for row in rows { context.delete(row) }
         try? context.save()
         publish()
     }
 
-    public func pruneTombstones(keeping livePublicKeys: Set<Data>) async {
-        handledLog.prune(keeping: livePublicKeys)
+    public func pruneTombstones(retiring retiredPublicKeys: Set<Data>) async {
+        handledLog.prune(retiring: retiredPublicKeys)
         consumed = handledLog.handledIDs()
     }
 
@@ -252,13 +260,17 @@ public actor SwiftDataIntroRequestStore: IntroRequestStore {
     /// Rows that fail to decrypt are skipped rather than failing the
     /// whole read — a single corrupted row shouldn't hide every other
     /// pending request.
+    /// Tombstoned ids are filtered here as well as in `record`: the
+    /// tombstone is written before the row is deleted, so a crash in
+    /// that window leaves a handled request on disk. Filtering on read
+    /// makes the two halves self-healing instead of resurrecting it.
     private func loadAll() -> [IntroRequest] {
         pruneExpired()
         let descriptor = FetchDescriptor<PersistedIntroRequest>(
             sortBy: [SortDescriptor(\.receivedAt, order: .reverse)]
         )
         guard let rows = try? context.fetch(descriptor) else { return [] }
-        return rows.compactMap(Self.decode)
+        return rows.compactMap(Self.decode).filter { !consumed.contains($0.id) }
     }
 
     // MARK: - Mapping

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2500,6 +2500,22 @@
         }
       }
     },
+    "Direct invites": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direct invites"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Персональные приглашения"
+          }
+        }
+      }
+    },
     "Dismiss": {
       "localizations": {
         "en": {
@@ -2693,6 +2709,22 @@
         }
       }
     },
+    "Generate new link": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate new link"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать новую ссылку"
+          }
+        }
+      }
+    },
     "Generate with AI": {
       "extractionState": "stale",
       "localizations": {
@@ -2722,6 +2754,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Генерируется доказательство и обновляется обязательство в блокчейне. Обычно занимает несколько секунд."
+          }
+        }
+      }
+    },
+    "Generating…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generating…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создаём…"
           }
         }
       }
@@ -3382,6 +3430,22 @@
         }
       }
     },
+    "No response yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No response yet"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока нет ответа"
+          }
+        }
+      }
+    },
     "No servers configured. Media can't be sent or received.": {
       "localizations": {
         "ru": {
@@ -3443,6 +3507,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Это не то слово. Проверьте фразу и повторите попытку."
+          }
+        }
+      }
+    },
+    "Older link": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Older link"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Старая ссылка"
           }
         }
       }
@@ -4089,6 +4169,22 @@
         }
       }
     },
+    "Revoke": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revoke"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отозвать"
+          }
+        }
+      }
+    },
     "Run a relayer for yourself, your team, or your org. End-to-end encryption stays intact — Onym never sees your messages.": {
       "localizations": {
         "en": {
@@ -4314,6 +4410,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Отправляем запрос…"
+          }
+        }
+      }
+    },
+    "Sent when you created the group. Each one can still be used to request to join.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent when you created the group. Each one can still be used to request to join."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отправлены при создании группы. По каждому из них всё ещё можно запросить вступление."
           }
         }
       }
@@ -4628,6 +4740,38 @@
         }
       }
     },
+    "The host may be offline, or this invite may no longer work. Ask them for a new link.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The host may be offline, or this invite may no longer work. Ask them for a new link."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Возможно, владелец группы не в сети или это приглашение больше не действует. Попросите новую ссылку."
+          }
+        }
+      }
+    },
+    "The old link stops working. Anyone still holding it won't be told.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The old link stops working. Anyone still holding it won't be told."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Старая ссылка перестанет работать. Тех, у кого она осталась, об этом не уведомят."
+          }
+        }
+      }
+    },
     "The phrase is generated on-device and never sent off the device.": {
       "localizations": {
         "en": {
@@ -4901,6 +5045,38 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ждём одобрения от хоста…"
+          }
+        }
+      }
+    },
+    "You can leave this screen open — if they approve, the chat still appears.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can leave this screen open — if they approve, the chat still appears."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Можно не закрывать этот экран — если заявку одобрят, чат появится сам."
+          }
+        }
+      }
+    },
+    "wants to join “%@”": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wants to join “%@”"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "хочет вступить в «%@»"
           }
         }
       }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -679,12 +679,14 @@ struct OnymIOSApp: App {
         // container can't be opened, so a storage failure degrades to
         // the old behaviour instead of blocking launch.
         //
-        // Either store tombstones handled ids durably (supplied inside
-        // OnymGroup): a multi-use link keeps its relay subscription for
-        // good, and the REQ carries no `since`, so every reconnect
-        // replays requests that were already acted on.
+        // Both stores tombstone handled ids in the same durable log: a
+        // multi-use link keeps its relay subscription for good, and the
+        // REQ carries no `since`, so every reconnect replays requests
+        // that were already acted on. The fallback needs it too — its
+        // rows are gone after a restart, so the tombstones are all that
+        // stop the replay refilling the queue.
         self.introRequestStore = (try? SwiftDataIntroRequestStore())
-            ?? InMemoryIntroRequestStore()
+            ?? InMemoryIntroRequestStore(handledLog: UserDefaultsHandledIntroRequestLog())
 
         // Single shared IdentitiesFlow so the toolbar picker on Chats
         // and the Settings → Identities screen observe the same state.
@@ -1575,10 +1577,19 @@ struct OnymIOSApp: App {
                         // so a retired link's tombstones go with it.
                         let (forPump, pumpFeed) = AsyncStream.makeStream(of: [IntroKeyEntry].self)
                         let tee = Task {
+                            // Diff successive snapshots and prune only what
+                            // actually disappeared. This stream is scoped to
+                            // ONE identity while the request store spans the
+                            // process, so passing the snapshot as a keep-set
+                            // would delete every other identity's tombstones
+                            // and replay their handled requests as pending.
+                            var live: Set<Data> = []
                             for await snapshot in entries {
+                                let current = Set(snapshot.map(\.introPublicKey))
                                 await store.pruneTombstones(
-                                    keeping: Set(snapshot.map(\.introPublicKey))
+                                    retiring: live.subtracting(current)
                                 )
+                                live = current
                                 pumpFeed.yield(snapshot)
                             }
                             pumpFeed.finish()

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1591,15 +1591,21 @@ struct OnymIOSApp: App {
                             )
                         }
                         let tee = Task {
-                            // Diff successive snapshots and prune only what
-                            // actually disappeared. This stream is scoped to
-                            // ONE identity while the request store spans the
-                            // process, so passing the snapshot as a keep-set
-                            // would delete every other identity's tombstones
-                            // and replay their handled requests as pending.
+                            // The diff is taken over EVERY owner's keys,
+                            // never the per-identity snapshot this stream
+                            // carries. "Absent from an owner-scoped
+                            // snapshot" is not "retired": it is also what
+                            // an identity switch, or a keychain read that
+                            // fails closed, looks like — and treating it
+                            // as retirement deletes the other identity's
+                            // tombstones, replaying their handled joiners
+                            // as pending. That is precisely the wipe
+                            // `retiring:` was phrased to make
+                            // inexpressible, so the phrasing has to be
+                            // fed the right set.
                             var live: Set<Data> = []
                             for await snapshot in entries {
-                                let current = Set(snapshot.map(\.introPublicKey))
+                                let current = await keyStore.allLivePublicKeys()
                                 await store.pruneTombstones(
                                     retiring: live.subtracting(current)
                                 )

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1576,6 +1576,20 @@ struct OnymIOSApp: App {
                         // Tee the same snapshots the pump reconciles on,
                         // so a retired link's tombstones go with it.
                         let (forPump, pumpFeed) = AsyncStream.makeStream(of: [IntroKeyEntry].self)
+                        // One owner-agnostic reconcile per subscribe.
+                        // The diff below only sees retirements that
+                        // happen while this identity is subscribed —
+                        // links retired with the app closed, or under
+                        // another identity, would otherwise linger until
+                        // `maxEntries` evicted them oldest-first, which
+                        // can drop a LIVE link's tombstone and bring a
+                        // handled request back as pending.
+                        let keyStore = introKeyStore
+                        Task {
+                            await store.reconcileTombstones(
+                                livePublicKeys: await keyStore.allLivePublicKeys()
+                            )
+                        }
                         let tee = Task {
                             // Diff successive snapshots and prune only what
                             // actually disappeared. This stream is scoped to

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -678,6 +678,11 @@ struct OnymIOSApp: App {
         // approve…". Falls back to the in-memory store if the on-disk
         // container can't be opened, so a storage failure degrades to
         // the old behaviour instead of blocking launch.
+        //
+        // Either store tombstones handled ids durably (supplied inside
+        // OnymGroup): a multi-use link keeps its relay subscription for
+        // good, and the REQ carries no `since`, so every reconnect
+        // replays requests that were already acted on.
         self.introRequestStore = (try? SwiftDataIntroRequestStore())
             ?? InMemoryIntroRequestStore()
 
@@ -1565,7 +1570,23 @@ struct OnymIOSApp: App {
                             continue
                         }
                         let entries = introKeyStore.entriesStream(forOwner: activeID)
-                        currentTask = Task { await pump.run(entries: entries) }
+                        let store = introRequestStore
+                        // Tee the same snapshots the pump reconciles on,
+                        // so a retired link's tombstones go with it.
+                        let (forPump, pumpFeed) = AsyncStream.makeStream(of: [IntroKeyEntry].self)
+                        let tee = Task {
+                            for await snapshot in entries {
+                                await store.pruneTombstones(
+                                    keeping: Set(snapshot.map(\.introPublicKey))
+                                )
+                                pumpFeed.yield(snapshot)
+                            }
+                            pumpFeed.finish()
+                        }
+                        currentTask = Task {
+                            defer { tee.cancel() }
+                            await pump.run(entries: forPump)
+                        }
                     }
                     currentTask?.cancel()
                 }

--- a/Tests/OnymIOSTests/IntroInboxPumpTests.swift
+++ b/Tests/OnymIOSTests/IntroInboxPumpTests.swift
@@ -147,6 +147,102 @@ final class IntroInboxPumpTests: XCTestCase {
         runTask.cancel()
     }
 
+    // MARK: - IntroRequestStore consume tombstone
+
+    func test_record_afterConsume_isRejected_soRelayReplayCannotResurrect() async {
+        let store = InMemoryIntroRequestStore()
+        let request = IntroRequest(
+            id: "evt-1",
+            targetIntroPublicKey: Data(repeating: 0xA1, count: 32),
+            payload: Data([0x01, 0x02]),
+            receivedAt: Date()
+        )
+
+        let recorded = await store.record(request)
+        XCTAssertTrue(recorded)
+        await store.consume(id: request.id)
+
+        // The REQ has no `since`, so reconnects replay the whole inbox.
+        // A handled request must not come back.
+        let reRecorded = await store.record(request)
+        XCTAssertFalse(reRecorded, "a consumed event id must never be re-recorded")
+        let remaining = await store.current()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_consume_unknownId_stillTombstones_soALateReplayIsRejected() async {
+        let store = InMemoryIntroRequestStore()
+
+        // Tombstone laid before the replay lands — the ordering the
+        // pump can actually produce when a consume races a reconnect.
+        await store.consume(id: "evt-never-seen")
+
+        let late = IntroRequest(
+            id: "evt-never-seen",
+            targetIntroPublicKey: Data(repeating: 0xA1, count: 32),
+            payload: Data([0x03]),
+            receivedAt: Date()
+        )
+        let recordedLate = await store.record(late)
+        XCTAssertFalse(recordedLate)
+        let remaining = await store.current()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_tombstoneSurvivesRelaunch_soAHandledRequestStaysGone() async {
+        // A fresh store over the same durable log is what a cold start
+        // looks like. This is the case a process-lifetime set missed.
+        let log = InMemoryHandledIntroRequestLog()
+        let request = IntroRequest(
+            id: "evt-1",
+            targetIntroPublicKey: Data(repeating: 0xA1, count: 32),
+            payload: Data([0x01]),
+            receivedAt: Date()
+        )
+
+        let first = InMemoryIntroRequestStore(handledLog: log)
+        _ = await first.record(request)
+        await first.consume(id: request.id)
+
+        let relaunched = InMemoryIntroRequestStore(handledLog: log)
+        let reRecorded = await relaunched.record(request)
+
+        XCTAssertFalse(reRecorded, "a handled request must not return after relaunch")
+        let remaining = await relaunched.current()
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func test_pruneTombstones_dropsRetiredLinks_keepsLiveOnes() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let livePub = Data(repeating: 0xA1, count: 32)
+        let retiredPub = Data(repeating: 0xB2, count: 32)
+        let store = InMemoryIntroRequestStore(handledLog: log)
+
+        for (id, pub) in [("evt-live", livePub), ("evt-retired", retiredPub)] {
+            _ = await store.record(IntroRequest(
+                id: id, targetIntroPublicKey: pub,
+                payload: Data([0x01]), receivedAt: Date()
+            ))
+            await store.consume(id: id)
+        }
+
+        // The retired link's tombstones go with it, so the set stays
+        // bounded by the invites that still exist.
+        await store.pruneTombstones(keeping: [livePub])
+
+        let after = InMemoryIntroRequestStore(handledLog: log)
+        let liveStillBlocked = await after.record(IntroRequest(
+            id: "evt-live", targetIntroPublicKey: livePub,
+            payload: Data([0x01]), receivedAt: Date()
+        ))
+        let retiredNowFree = await after.record(IntroRequest(
+            id: "evt-retired", targetIntroPublicKey: retiredPub,
+            payload: Data([0x01]), receivedAt: Date()
+        ))
+        XCTAssertFalse(liveStillBlocked)
+        XCTAssertTrue(retiredNowFree)
+    }
+
     // MARK: - Helpers
 
     private func waitFor(

--- a/Tests/OnymIOSTests/IntroInboxPumpTests.swift
+++ b/Tests/OnymIOSTests/IntroInboxPumpTests.swift
@@ -227,8 +227,10 @@ final class IntroInboxPumpTests: XCTestCase {
         }
 
         // The retired link's tombstones go with it, so the set stays
-        // bounded by the invites that still exist.
-        await store.pruneTombstones(keeping: [livePub])
+        // bounded by the invites that still exist. Named by what died,
+        // not what lived: this stream is one identity's, while the log
+        // spans the process.
+        await store.pruneTombstones(retiring: [retiredPub])
 
         let after = InMemoryIntroRequestStore(handledLog: log)
         let liveStillBlocked = await after.record(IntroRequest(

--- a/Tests/OnymIOSTests/InviteIntroducerTests.swift
+++ b/Tests/OnymIOSTests/InviteIntroducerTests.swift
@@ -15,6 +15,45 @@ final class InviteIntroducerTests: XCTestCase {
     private let bob = IdentityID("22222222-2222-2222-2222-222222222222")!
     private let sampleGroupId = Data(repeating: 0x42, count: 32)
 
+    /// Everything written before labels existed decodes as
+    /// `label == nil`, i.e. indistinguishable from a shared link — and
+    /// `listForOwner` is newest-first, so on a create-with-invitees
+    /// group the one `currentOrMint` would pick is the LAST INVITEE'S
+    /// private offer key. Adopting it hands one person's private link
+    /// to everyone; rotating then revokes every legacy invite at once.
+    func test_legacyEntries_areNeverAdoptedAsTheSharedLink() async throws {
+        let store = InMemoryIntroKeyStore()
+        let owner = IdentityID()
+        let groupId = Data(repeating: 0x11, count: 32)
+        let legacyOffer = IntroKeyEntry(
+            introPublicKey: Data(repeating: 0x22, count: 32),
+            introPrivateKey: Data(repeating: 0x23, count: 32),
+            ownerIdentityID: owner,
+            groupId: groupId,
+            createdAt: Date(),          // newest, so it would win
+            label: nil,
+            isLegacy: true
+        )
+        await store.save(legacyOffer)
+        let introducer = InviteIntroducer(store: store)
+
+        let cap = try await introducer.currentOrMint(
+            ownerIdentityID: owner, groupId: groupId
+        )
+        XCTAssertNotEqual(
+            cap.introPublicKey, legacyOffer.introPublicKey,
+            "a pre-upgrade key must never become the group's public link"
+        )
+
+        // And rotating the shared link must leave it alone.
+        _ = try await introducer.rotate(ownerIdentityID: owner, groupId: groupId)
+        let live = await introducer.liveInvites(ownerIdentityID: owner, groupId: groupId)
+        XCTAssertTrue(
+            live.contains { $0.introPublicKey == legacyOffer.introPublicKey },
+            "rotate must not mass-revoke outstanding pre-upgrade invites"
+        )
+    }
+
     func test_mint_producesDistinctKeypairs_acrossInvocations() async throws {
         let store = InMemoryIntroKeyStore()
         let introducer = InviteIntroducer(store: store)

--- a/Tests/OnymIOSTests/InviteIntroducerTests.swift
+++ b/Tests/OnymIOSTests/InviteIntroducerTests.swift
@@ -138,4 +138,274 @@ final class InviteIntroducerTests: XCTestCase {
         XCTAssertNotNil(entry)
         XCTAssertEqual(entry?.createdAt, frozen)
     }
+
+    // MARK: - currentOrMint (multi-use links)
+
+    func test_currentOrMint_noLiveKeyForGroup_mintsAndPersistsOne() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let cap = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
+        XCTAssertEqual(listed.first?.introPublicKey, cap.introPublicKey)
+    }
+
+    func test_currentOrMint_twiceForSameGroup_returnsSameKey_persistsOneEntry() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let first = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let second = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(first.introPublicKey, second.introPublicKey)
+        // The count is what stops this from being "returns the same
+        // link but still writes a row".
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
+    }
+
+    func test_currentOrMint_differentGroups_doNotShareAKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let g1 = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let g2 = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: other)
+
+        XCTAssertNotEqual(g1.introPublicKey, g2.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 2)
+    }
+
+    func test_currentOrMint_neverExpires_soAnAncientKeyIsStillReused() async throws {
+        let store = InMemoryIntroKeyStore()
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+        let early = InviteIntroducer(store: store, now: { t0 })
+        // A year later. Invite links have no TTL — only `rotate` or
+        // `revoke` retires one.
+        let muchLater = InviteIntroducer(
+            store: store,
+            now: { t0.addingTimeInterval(365 * 24 * 60 * 60) }
+        )
+
+        let first = try await early.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let second = try await muchLater.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(first.introPublicKey, second.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1)
+    }
+
+    // MARK: - rotate / revoke
+
+    func test_rotate_mintsAFreshKey_andRetiresTheOldOne() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        let old = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let new = try await introducer.rotate(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(old.introPublicKey, new.introPublicKey)
+        let foundOld = await store.find(introPublicKey: old.introPublicKey)
+        XCTAssertNil(foundOld, "the superseded link must stop decrypting requests")
+        let foundNew = await store.find(introPublicKey: new.introPublicKey)
+        XCTAssertNotNil(foundNew)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1, "rotate must not leave the old slot behind")
+    }
+
+    func test_rotate_thenCurrentOrMint_returnsTheRotatedKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        let rotated = try await introducer.rotate(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let resolved = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(rotated.introPublicKey, resolved.introPublicKey)
+    }
+
+    func test_rotate_leavesOtherGroupsAlone() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let untouched = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: other
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        _ = try await introducer.rotate(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        let foundUntouched = await store.find(introPublicKey: untouched.introPublicKey)
+        XCTAssertNotNil(foundUntouched)
+    }
+
+    func test_rotate_doesNotRetireLabelledOfferKeys() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // Per-invitee offers are revoked one at a time from the invite
+        // list; rotating the shared link must not sweep them away.
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        _ = try await introducer.rotate(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        let foundOffer = await store.find(introPublicKey: offer.introPublicKey)
+        XCTAssertNotNil(foundOffer)
+    }
+
+    func test_currentOrMint_ignoresLabelledOfferKeys() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // Create-with-invitees leaves an offer key as the newest entry;
+        // handing it out would collapse the 1:1 mapping.
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(offer.introPublicKey, shared.introPublicKey)
+    }
+
+    func test_liveInvites_listsEveryKeyForTheGroup() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        let other = Data(repeating: 0x5A, count: 32)
+
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let offer = try await introducer.mint(
+            ownerIdentityID: alice, groupId: sampleGroupId, label: "aabbccdd"
+        )
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: other)
+
+        let live = await introducer.liveInvites(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertEqual(Set(live.map(\.introPublicKey)),
+                       Set([shared.introPublicKey, offer.introPublicKey]))
+        XCTAssertEqual(live.first(where: { $0.label == "aabbccdd" })?.introPublicKey,
+                       offer.introPublicKey)
+    }
+
+    func test_currentOrMint_doesNotReuseAnotherIdentitysLiveKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // The pump only subscribes the active identity's tags, so this
+        // would hand out a link nobody is listening on.
+        let bobCap = try await introducer.currentOrMint(
+            ownerIdentityID: bob, groupId: sampleGroupId
+        )
+        let aliceCap = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+
+        XCTAssertNotEqual(bobCap.introPublicKey, aliceCap.introPublicKey)
+        let aliceKeys = await store.listForOwner(alice)
+        let bobKeys = await store.listForOwner(bob)
+        XCTAssertEqual(aliceKeys.count, 1)
+        XCTAssertEqual(bobKeys.count, 1)
+    }
+
+    func test_currentOrMint_rejectsWrongSizedGroupId_withoutTouchingTheStore() async {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        do {
+            _ = try await introducer.currentOrMint(
+                ownerIdentityID: alice,
+                groupId: Data(repeating: 0x01, count: 16)
+            )
+            XCTFail("expected IntroducerError.invalidGroupID")
+        } catch IntroducerError.invalidGroupID {
+            // expected
+        } catch {
+            XCTFail("expected IntroducerError.invalidGroupID, got \(error)")
+        }
+
+        let listed = await store.listForOwner(alice)
+        XCTAssertTrue(listed.isEmpty)
+    }
+
+    func test_mint_alwaysMintsFresh_evenWhenALiveKeyExists() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // Locks the two-entry-point split; collapsing them would break
+        // the offers' 1:1 mapping.
+        let shared = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let fresh = try await introducer.mint(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        XCTAssertNotEqual(shared.introPublicKey, fresh.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 2)
+    }
+
+    // MARK: - concurrency
+
+    func test_currentOrMint_concurrentCalls_produceExactlyOneKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        // `.onAppear` fires more than once per entry; the store read is
+        // an await, so unserialized this mints twice.
+        async let a = introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        async let b = introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+        let (first, second) = try await (a, b)
+
+        XCTAssertEqual(first.introPublicKey, second.introPublicKey)
+        let listed = await store.listForOwner(alice)
+        XCTAssertEqual(listed.count, 1, "a second shared key would be unrevokable")
+    }
+
+    func test_rotate_concurrentWithCurrentOrMint_leavesOneSharedKey() async throws {
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+        _ = try await introducer.currentOrMint(ownerIdentityID: alice, groupId: sampleGroupId)
+
+        async let rotated = introducer.rotate(ownerIdentityID: alice, groupId: sampleGroupId)
+        async let resolved = introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId
+        )
+        let (_, handedToCaller) = try await (rotated, resolved)
+
+        // The hazard is the value handed to the concurrent caller, not
+        // the end state: unserialized, it can be a link rotate revoked.
+        let stillLive = await store.find(introPublicKey: handedToCaller.introPublicKey)
+        XCTAssertNotNil(stillLive, "the caller was handed a link that was then revoked")
+        let shared = await store.listForOwner(alice).filter { $0.label == nil }
+        XCTAssertEqual(shared.count, 1)
+    }
 }

--- a/Tests/OnymIOSTests/JoinFlowTests.swift
+++ b/Tests/OnymIOSTests/JoinFlowTests.swift
@@ -104,7 +104,10 @@ final class JoinFlowTests: XCTestCase {
 
     private func harness(
         outcome: JoinRequestSender.Outcome,
-        seedGroups: [ChatGroup] = []
+        seedGroups: [ChatGroup] = [],
+        // Nil by default so the suite keeps observing
+        // `.awaitingApproval`; the timer has its own tests.
+        unansweredAfter: Duration? = nil
     ) async throws -> Env {
         let store = JoinTestableInMemoryGroupStore()
         await store.preload(seedGroups)
@@ -118,9 +121,23 @@ final class JoinFlowTests: XCTestCase {
                 counter.bump()
                 return outcome
             },
-            groupRepository: repo
+            groupRepository: repo,
+            unansweredAfter: unansweredAfter
         )
         return Env(flow: flow, repo: repo, counter: counter)
+    }
+
+    func test_unanswered_allowsResend_soItIsNotADeadEnd() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: .milliseconds(50))
+        env.flow.send(displayLabel: "alice")
+        try await waitFor { env.flow.state.isUnanswered }
+
+        // Without this, the copy's "ask for a new link" is the only
+        // exit and the Try again button does nothing.
+        env.flow.send(displayLabel: "alice")
+
+        try await waitFor { env.flow.state.isAwaitingApproval }
+        XCTAssertEqual(env.counter.value, 2, "the retry must actually re-submit")
     }
 
     // MARK: - Helpers
@@ -161,6 +178,43 @@ final class JoinFlowTests: XCTestCase {
         XCTFail("waitFor predicate never became true within \(timeout)s",
                 file: file, line: line)
     }
+
+    // MARK: - unanswered
+
+    func test_awaitingApproval_afterTheTimeout_flipsToUnanswered() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: .milliseconds(50))
+
+        env.flow.send(displayLabel: "alice")
+
+        // A revoked link is indistinguishable from a slow host here, so
+        // the joiner gets told rather than left on an endless spinner.
+        try await waitFor { env.flow.state.isUnanswered }
+    }
+
+    func test_approvalArrivingAfterTheTimeout_stillWins() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: .milliseconds(50))
+        env.flow.send(displayLabel: "alice")
+        try await waitFor { env.flow.state.isUnanswered }
+
+        // The watcher stays live past the timeout — `.unanswered` is a
+        // hint, not a terminal state.
+        _ = await env.repo.insert(makeGroup(groupID: groupIdRaw, owner: alice))
+
+        try await waitFor {
+            if case .approved = env.flow.state { return true }
+            return false
+        }
+    }
+
+    func test_unansweredAfterNil_neverLeavesAwaitingApproval() async throws {
+        let env = try await harness(outcome: .sent, unansweredAfter: nil)
+
+        env.flow.send(displayLabel: "alice")
+        try await waitFor { env.flow.state.isAwaitingApproval }
+        try? await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertTrue(env.flow.state.isAwaitingApproval)
+    }
 }
 
 // MARK: - State helpers
@@ -173,6 +227,9 @@ private extension JoinFlow.State {
     }
     var isApproved: Bool { if case .approved = self { return true } else { return false } }
     var isFailed: Bool { if case .failed = self { return true } else { return false } }
+    var isUnanswered: Bool {
+        if case .unanswered = self { return true } else { return false }
+    }
 }
 
 // MARK: - Test doubles

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -92,7 +92,7 @@ final class JoinRequestApproverTests: XCTestCase {
 
     // MARK: - approve happy path
 
-    func test_approve_sendsSealedInviteAndConsumesRequest() async throws {
+    func test_approve_sendsSealedInvite_consumesRequest_keepsIntroKeyLive() async throws {
         let env = try await seedEnvironment()
 
         // Pump once: collector reads the seeded request, decodes,
@@ -108,12 +108,15 @@ final class JoinRequestApproverTests: XCTestCase {
         XCTAssertNotNil(toJoiner,
                         "approve must send to the joiner's inbox tag")
 
-        // Request consumed + intro key revoked.
+        // Request consumed, but the link stays usable.
         let remaining = await introRequestStore.current()
         XCTAssertTrue(remaining.isEmpty,
                       "approved request must be consumed from the store")
         let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNil(intro, "intro key must be revoked after approve")
+        XCTAssertNotNil(
+            intro,
+            "intro key must survive approve — one link is redeemable by many joiners"
+        )
     }
 
     // MARK: - duplicate collapse
@@ -172,9 +175,11 @@ final class JoinRequestApproverTests: XCTestCase {
         } else {
             XCTFail("expected .transportFailed, got \(outcome)")
         }
-        let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNotNil(intro,
-                        "intro key must NOT be revoked when transport rejects — caller may retry")
+        // Key survival is vacuous now. What this path still owes is
+        // that the request stays available for a retry.
+        let remaining = await introRequestStore.current()
+        XCTAssertEqual(remaining.count, 1,
+                       "a transport-rejected request must stay in the store for retry")
     }
 
     // MARK: - PR 4: recordJoiner side effect
@@ -364,7 +369,7 @@ final class JoinRequestApproverTests: XCTestCase {
 
     // MARK: - decline
 
-    func test_decline_dropsRequestAndRevokesKey() async throws {
+    func test_decline_dropsOnlyThatRequest_leavesLinkLive() async throws {
         let env = try await seedEnvironment()
         await env.approver.pumpOnce()
 
@@ -374,13 +379,257 @@ final class JoinRequestApproverTests: XCTestCase {
         XCTAssertTrue(remaining.isEmpty,
                       "declined request must be consumed")
         let intro = await introKeyStore.find(introPublicKey: env.introPub)
-        XCTAssertNil(intro, "intro key revoked even on decline")
+        XCTAssertNotNil(
+            intro,
+            "declining one joiner must not kill the link for everyone else holding it"
+        )
         let sends = await transport.sends
         XCTAssertTrue(sends.isEmpty,
                       "decline ships no envelopes")
     }
 
     // MARK: - Test fixture builder
+
+    // MARK: - multi-use links
+
+    func test_approve_joinerA_thenJoinerBOnTheSameIntroKey_bothJoin() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        var pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 2, "two joiners on one link are two rows")
+
+        let firstOutcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(firstOutcome, .sent)
+
+        // The whole feature. Before, revoking here made B's request
+        // undecodable and B's row silently vanished.
+        let intro = await introKeyStore.find(introPublicKey: env.introPub)
+        XCTAssertNotNil(intro, "approving A must not burn the link B is holding")
+
+        await env.approver.pumpOnce()
+        pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "A consumed, B still standing")
+        XCTAssertEqual(pending.first?.joinerBlsPublicKey, second.blsPub)
+
+        let secondOutcome = await env.approver.approve(requestId: second.requestID)
+        XCTAssertEqual(secondOutcome, .sent)
+
+        let snapshotGroup = await groups.currentGroups()
+        let group = try XCTUnwrap(
+            snapshotGroup.first { $0.groupIDData == env.groupID }
+        )
+        XCTAssertEqual(group.members.count, 3, "admin + both joiners")
+        XCTAssertEqual(group.epoch, 2, "each joiner is its own anchor")
+        XCTAssertEqual(contractTransport.calls.count, 2, "two real anchors, not one")
+
+        let sends = await transport.sends
+        XCTAssertNotNil(sends.first { $0.inbox == env.expectedJoinerTag })
+        XCTAssertNotNil(sends.first { $0.inbox == second.expectedTag })
+    }
+
+    func test_decline_joinerA_leavesJoinerBApprovable() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        await env.approver.decline(requestId: env.requestID)
+        await env.approver.pumpOnce()
+
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "declining A must not drop B")
+        XCTAssertEqual(pending.first?.joinerBlsPublicKey, second.blsPub)
+
+        let outcome = await env.approver.approve(requestId: second.requestID)
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(contractTransport.calls.count, 1)
+    }
+
+    func test_pumpOnce_twoDifferentJoinersOnOneIntroKey_yieldTwoPendingRows() async throws {
+        let env = try await seedEnvironment()
+        let second = try await seedSecondJoiner(on: env)
+        await env.approver.pumpOnce()
+
+        // Collapse is per joiner, not per key; over-merging would
+        // silently drop invitees.
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 2)
+        XCTAssertEqual(
+            Set(pending.compactMap(\.joinerBlsPublicKey)),
+            Set([env.joinerBlsPub, second.blsPub])
+        )
+    }
+
+    func test_approve_consumesEveryCollapsedSibling() async throws {
+        let env = try await seedEnvironment()
+        // Two more copies of the SAME joiner's request, as a retry or a
+        // relay replay under fresh ephemeral keys would produce.
+        for _ in 0..<2 {
+            await introRequestStore.record(IntroRequest(
+                id: "req-\(UUID().uuidString)",
+                targetIntroPublicKey: env.introPub,
+                payload: env.sealedPayload,
+                receivedAt: Date().addingTimeInterval(30)
+            ))
+        }
+        await env.approver.pumpOnce()
+
+        let pending = await pendingRows(env.approver)
+        XCTAssertEqual(pending.count, 1, "one joiner is one row")
+        let winner = try XCTUnwrap(pending.first?.id)
+
+        let outcome = await env.approver.approve(requestId: winner)
+        XCTAssertEqual(outcome, .sent)
+
+        // Consuming only the winner would leave the siblings behind to
+        // resurface on the next emission.
+        let leftover = await introRequestStore.current()
+        XCTAssertTrue(leftover.isEmpty, "every collapsed sibling must be consumed")
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    func test_decline_consumesEveryCollapsedSibling() async throws {
+        let env = try await seedEnvironment()
+        await introRequestStore.record(IntroRequest(
+            id: "req-\(UUID().uuidString)",
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(30)
+        ))
+        await env.approver.pumpOnce()
+        let rows = await pendingRows(env.approver)
+        let winner = try XCTUnwrap(rows.first?.id)
+
+        await env.approver.decline(requestId: winner)
+
+        let leftover = await introRequestStore.current()
+        XCTAssertTrue(leftover.isEmpty)
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    func test_approvedRequest_replayedByRelay_doesNotReappearAsPending() async throws {
+        let env = try await seedEnvironment()
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .sent)
+
+        // Reconnects replay the inbox in full, and the key is still
+        // live — without the tombstone this decodes again.
+        let reRecorded = await introRequestStore.record(IntroRequest(
+            id: env.requestID,
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(120)
+        ))
+        XCTAssertFalse(reRecorded, "a consumed event id must not be re-recorded")
+
+        await env.approver.pumpOnce()
+        let after = await pendingRows(env.approver)
+        XCTAssertTrue(after.isEmpty)
+    }
+
+    // MARK: - re-join recovery
+
+    func test_approve_joinerAlreadyInRoster_skipsAnchor_reshipsInvitation() async throws {
+        let env = try await seedEnvironment()
+        await env.approver.pumpOnce()
+        let firstOutcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(firstOutcome, .sent)
+        XCTAssertEqual(contractTransport.calls.count, 1)
+        let snapshotAfterfirst = await groups.currentGroups()
+        let afterFirst = try XCTUnwrap(
+            snapshotAfterfirst.first { $0.groupIDData == env.groupID }
+        )
+
+        // Same joiner, fresh event id: a reinstall, or a replay landing
+        // on the still-live link.
+        let replayID = "req-\(UUID().uuidString)"
+        await introRequestStore.record(IntroRequest(
+            id: replayID,
+            targetIntroPublicKey: env.introPub,
+            payload: env.sealedPayload,
+            receivedAt: Date().addingTimeInterval(60)
+        ))
+        await env.approver.pumpOnce()
+
+        let replayOutcome = await env.approver.approve(requestId: replayID)
+        XCTAssertEqual(replayOutcome, .sent)
+
+        // No second anchor: re-adding an existing member would push a
+        // duplicate leaf into the tree and burn an epoch.
+        XCTAssertEqual(contractTransport.calls.count, 1, "re-join must not re-anchor")
+        let proveCalls = await proofGenerator.proveUpdateCalls
+        XCTAssertEqual(proveCalls, 1,
+                       "the guard must sit before the proof, not after it")
+
+        let snapshotAftersecond = await groups.currentGroups()
+        let afterSecond = try XCTUnwrap(
+            snapshotAftersecond.first { $0.groupIDData == env.groupID }
+        )
+        XCTAssertEqual(afterSecond.epoch, afterFirst.epoch)
+        XCTAssertEqual(afterSecond.members.count, afterFirst.members.count)
+        XCTAssertEqual(afterSecond.commitment, afterFirst.commitment)
+
+        // But the joiner did get the snapshot again — that's the point.
+        let sends = await transport.sends
+        XCTAssertEqual(
+            sends.filter { $0.inbox == env.expectedJoinerTag }.count, 2,
+            "the re-join path must re-ship the current invitation"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Point-in-time read: `pending` yields its snapshot to each new
+    /// subscriber, so one `next()` is enough.
+    private func pendingRows(
+        _ approver: JoinRequestApprover
+    ) async -> [JoinRequestApprover.PendingRequest] {
+        var iterator = approver.pending.makeAsyncIterator()
+        return await iterator.next() ?? []
+    }
+
+    private struct SecondJoiner {
+        let requestID: String
+        let blsPub: Data
+        let expectedTag: TransportInboxID
+    }
+
+    /// A second joiner sealed to the *same* intro pubkey — two people
+    /// redeeming one shared link.
+    private func seedSecondJoiner(on env: Env) async throws -> SecondJoiner {
+        let blsPub = Data(repeating: 0x1A, count: 48)
+        let inboxPub = Data(repeating: 0x1C, count: 32)
+        let payload = try JoinRequestPayload(
+            joinerInboxPublicKey: inboxPub,
+            joinerBlsPublicKey: blsPub,
+            joinerLeafHash: Data(repeating: 0x1B, count: 32),
+            joinerSendingPublicKey: Data(repeating: 0x1D, count: 32),
+            joinerDisplayLabel: "Joiner Carol",
+            groupId: env.groupID
+        )
+        let sealed = try await identity.sealInvitation(
+            payload: try JSONEncoder().encode(payload),
+            to: env.introPub
+        )
+        let requestID = "req-\(UUID().uuidString)"
+        await introRequestStore.record(IntroRequest(
+            id: requestID,
+            targetIntroPublicKey: env.introPub,
+            payload: sealed,
+            receivedAt: Date().addingTimeInterval(10)
+        ))
+        return SecondJoiner(
+            requestID: requestID,
+            blsPub: blsPub,
+            expectedTag: TransportInboxID(rawValue: ApproverInboxTag.from(inboxPub))
+        )
+    }
 
     private struct Env {
         let approver: JoinRequestApprover

--- a/Tests/OnymIOSTests/KeychainIntroKeyStoreTests.swift
+++ b/Tests/OnymIOSTests/KeychainIntroKeyStoreTests.swift
@@ -27,42 +27,53 @@ final class KeychainIntroKeyStoreTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // MARK: - TTL
+    // MARK: - no expiry
 
-    func test_expiredEntry_invisibleToReads() async {
-        await store.save(makeEntry(owner: ownerA, age: KeychainIntroKeyStore.entryTTL + 60))
+    func test_oldEntry_staysVisibleAndAtRest() async {
+        // Invite links do not expire. An entry minted long ago is as
+        // usable as one minted a second ago; only `revoke` retires it.
+        let ancient = makeEntry(owner: ownerA, age: 400 * 24 * 60 * 60)
+        await store.save(ancient)
         let fresh = makeEntry(owner: ownerA)
         await store.save(fresh)
 
         let listed = await store.listForOwner(ownerA)
-        XCTAssertEqual(listed.map(\.introPublicKey), [fresh.introPublicKey],
-                       "entries past the 24h TTL must be invisible to listForOwner")
+        XCTAssertEqual(Set(listed.map(\.introPublicKey)),
+                       Set([ancient.introPublicKey, fresh.introPublicKey]))
+        let foundAncient = await store.find(introPublicKey: ancient.introPublicKey)
+        XCTAssertNotNil(foundAncient)
+        XCTAssertEqual(rawEntryCount(), 2, "reads must not silently drop rows")
     }
 
-    func test_expiredEntry_compactsOutOfBlobOnFirstRead() async {
-        let fresh = makeEntry(owner: ownerA)
-        await store.save(fresh)
-        await store.save(makeEntry(owner: ownerB, age: KeychainIntroKeyStore.entryTTL + 60))
-        // No subscribers → save's publish no-ops without reading, so
-        // the expired row really is at rest now.
-        XCTAssertEqual(rawEntryCount(), 2)
+    func test_revokedEntry_disappearsFromReadsAndFromTheBlob() async {
+        let doomed = makeEntry(owner: ownerA, age: 400 * 24 * 60 * 60)
+        await store.save(doomed)
+        let kept = makeEntry(owner: ownerA)
+        await store.save(kept)
 
-        _ = await store.listForOwner(ownerA)
+        await store.revoke(introPublicKey: doomed.introPublicKey)
 
-        XCTAssertEqual(rawEntryCount(), 1,
-                       "the read that first sees an expired intro privkey must rewrite the blob without it")
+        let listed = await store.listForOwner(ownerA)
+        XCTAssertEqual(listed.map(\.introPublicKey), [kept.introPublicKey])
+        let foundDoomed = await store.find(introPublicKey: doomed.introPublicKey)
+        XCTAssertNil(foundDoomed)
+        // The row held an intro PRIVATE key; revoke must remove it at
+        // rest, not just hide it from reads.
+        XCTAssertEqual(rawEntryCount(), 1)
     }
 
-    func test_expiredEntry_streamSnapshotExcludesIt() async {
-        await store.save(makeEntry(owner: ownerB, age: KeychainIntroKeyStore.entryTTL + 60))
+    func test_revoke_publishesToTheOwnersStream_soThePumpDropsTheInbox() async {
+        let doomed = makeEntry(owner: ownerB)
+        await store.save(doomed)
 
         var iterator = store.entriesStream(forOwner: ownerB).makeAsyncIterator()
-        let snapshot = await iterator.next()
+        _ = await iterator.next()  // initial snapshot
 
-        XCTAssertEqual(snapshot, [],
-                       "the intro pump must never see an expired entry's inbox")
-        XCTAssertEqual(rawEntryCount(), 0,
-                       "subscribing triggered the read → the expired privkey is gone at rest too")
+        await store.revoke(introPublicKey: doomed.introPublicKey)
+        let afterRevoke = await iterator.next()
+
+        XCTAssertEqual(afterRevoke, [],
+                       "the intro pump must stop subscribing a revoked inbox")
     }
 
     // MARK: - pruneOwners

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -84,7 +84,7 @@ final class ShareInviteFlowTests: XCTestCase {
         XCTAssertEqual(listed.count, 0)
     }
 
-    func test_mintFor_calledTwice_mintsTwoIndependentKeypairs() async throws {
+    func test_mintFor_fromASecondFlowOverTheSameStore_reusesTheLiveLink() async throws {
         let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
         _ = try await identity.bootstrap()
         let resolved = await identity.currentSelectedID()
@@ -96,35 +96,36 @@ final class ShareInviteFlowTests: XCTestCase {
         let groupRepo = GroupRepository(store: store, currentIdentityID: owner)
         let introKeyStore = InMemoryIntroKeyStore()
         let introducer = InviteIntroducer(store: introKeyStore)
-        let flow = ShareInviteFlow(
+
+        // Two flows over one store: the real path (a fresh flow per
+        // tap) and deterministic, since the second starts `.idle`.
+        let first = ShareInviteFlow(
             identity: identity,
             introducer: introducer,
             groupRepository: groupRepo
         )
-
-        flow.mintFor(groupID: group.id)
-        try await waitFor { flow.state.isReady }
-        guard case .ready(let firstLink, _) = flow.state else {
+        first.mintFor(groupID: group.id)
+        try await waitFor { first.state.isReady }
+        guard case .ready(let firstLink, _) = first.state else {
             return XCTFail("expected first .ready")
         }
 
-        flow.mintFor(groupID: group.id)
-        // Wait for the link to actually change (the second mint emits
-        // `.minting` then `.ready` again).
-        try await waitFor {
-            if case .ready(let link, _) = flow.state, link != firstLink { return true }
-            return false
-        }
-        guard case .ready(let secondLink, _) = flow.state else {
+        let second = ShareInviteFlow(
+            identity: identity,
+            introducer: introducer,
+            groupRepository: groupRepo
+        )
+        second.mintFor(groupID: group.id)
+        try await waitFor { second.state.isReady }
+        guard case .ready(let secondLink, _) = second.state else {
             return XCTFail("expected second .ready")
         }
 
-        // Per-link revocation depends on this — re-shares cannot
-        // collapse to the same intro slot or revoking one would kill
-        // the other.
-        XCTAssertNotEqual(firstLink, secondLink, "two shares should produce different links")
+        // The share screen is a view onto the group's link, not a link
+        // factory; re-entry must not leave a trail of slots.
+        XCTAssertEqual(firstLink, secondLink, "re-entry should surface the same link")
         let listed = await introKeyStore.listForOwner(owner)
-        XCTAssertEqual(listed.count, 2)
+        XCTAssertEqual(listed.count, 1, "reuse must not persist a second intro slot")
     }
 
     func test_state_transitionsThroughMinting() async throws {
@@ -147,6 +148,76 @@ final class ShareInviteFlowTests: XCTestCase {
         flow.mintFor(groupID: group.id)
         try await waitFor { flow.state.isReady }
         XCTAssertTrue(flow.state.isReady)
+    }
+
+    func test_rotate_doubleTap_onlyRotatesOnce() async throws {
+        let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        _ = try await identity.bootstrap()
+        let resolved = await identity.currentSelectedID()
+        let owner = try XCTUnwrap(resolved)
+        let store = TestableInMemoryGroupStore()
+        let group = makeGroup(id: String(repeating: "ab", count: 32), name: "G", owner: owner)
+        await store.preload([group])
+        let introKeyStore = InMemoryIntroKeyStore()
+        let flow = ShareInviteFlow(
+            identity: identity,
+            introducer: InviteIntroducer(store: introKeyStore),
+            groupRepository: GroupRepository(store: store, currentIdentityID: owner)
+        )
+        flow.mintFor(groupID: group.id)
+        try await waitFor { flow.state.isReady }
+
+        // The guard has to bite before the first await, or the second
+        // tap slips through while `isRotating` is still false.
+        flow.rotateLink(groupID: group.id)
+        flow.rotateLink(groupID: group.id)
+        try await waitFor { flow.state.isReady && !flow.isRotating }
+
+        let shared = await introKeyStore.listForOwner(owner).filter { $0.label == nil }
+        XCTAssertEqual(shared.count, 1, "a second rotate would strand a live key")
+    }
+
+    func test_supersededSharedKey_isListedSoItCanBeRevoked() async throws {
+        let identity = IdentityRepository(keychain: keychain, selectionStore: .inMemory())
+        _ = try await identity.bootstrap()
+        let resolved = await identity.currentSelectedID()
+        let owner = try XCTUnwrap(resolved)
+        let store = TestableInMemoryGroupStore()
+        let group = makeGroup(id: String(repeating: "ab", count: 32), name: "G", owner: owner)
+        await store.preload([group])
+        let introKeyStore = InMemoryIntroKeyStore()
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // Two unlabelled keys is what a crash mid-rotate leaves. The
+        // older one used to be on no list: no revoke, live subscription.
+        let stranded = try await InviteIntroducer(store: introKeyStore, now: { t0 })
+            .mint(ownerIdentityID: owner, groupId: group.groupIDData)
+        let introducer = InviteIntroducer(
+            store: introKeyStore,
+            now: { t0.addingTimeInterval(60) }
+        )
+        let current = try await introducer.mint(
+            ownerIdentityID: owner, groupId: group.groupIDData
+        )
+        let flow = ShareInviteFlow(
+            identity: identity,
+            introducer: introducer,
+            groupRepository: GroupRepository(store: store, currentIdentityID: owner)
+        )
+        flow.mintFor(groupID: group.id)
+        try await waitFor { flow.state.isReady }
+        try await waitFor { !flow.otherInvites.isEmpty }
+
+        let row = try XCTUnwrap(flow.otherInvites.first)
+        XCTAssertEqual(flow.otherInvites.count, 1, "the rendered link is not a row")
+        XCTAssertEqual(row.introPublicKey, stranded.introPublicKey)
+        XCTAssertNotEqual(row.introPublicKey, current.introPublicKey)
+        XCTAssertNil(row.label, "a superseded key has no invitee name; the view names it")
+
+        flow.revoke(row, groupID: group.id)
+        try await waitFor { flow.otherInvites.isEmpty }
+        let gone = await introKeyStore.find(introPublicKey: stranded.introPublicKey)
+        XCTAssertNil(gone)
     }
 
     // MARK: - Helpers

--- a/Tests/OnymIOSTests/Support/InMemoryIntroKeyStore.swift
+++ b/Tests/OnymIOSTests/Support/InMemoryIntroKeyStore.swift
@@ -36,6 +36,10 @@ actor InMemoryIntroKeyStore: IntroKeyStore {
         for owner in owners { publish(forOwner: owner) }
     }
 
+    func allLivePublicKeys() async -> Set<Data> {
+        Set(entries.map(\.introPublicKey))
+    }
+
     @discardableResult
     func deleteForOwner(_ ownerIdentityID: IdentityID) async -> Int {
         let before = entries.count

--- a/Tests/OnymIOSTests/SwiftDataIntroRequestStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataIntroRequestStoreTests.swift
@@ -248,6 +248,43 @@ final class SwiftDataIntroRequestStoreTests: XCTestCase {
         XCTAssertFalse(late, "the tombstone must survive without a row to attribute it to")
     }
 
+    /// A decline has to survive the joiner's retry. Each retry is a
+    /// fresh Nostr event, so an id-keyed tombstone never matches; the
+    /// collapse key (joiner ⊕ group) is what does.
+    func test_declinedCollapseKey_isRememberedAcrossInstances() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let before = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        await before.recordDeclined(collapseKey: "joiner-a:group-1")
+
+        let after = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        let declined = await after.declinedCollapseKeys()
+        XCTAssertEqual(declined, ["joiner-a:group-1"])
+    }
+
+    /// The diff-based prune only sees retirements that happen while
+    /// this identity is subscribed. The reconcile is what catches a
+    /// link retired with the app closed — and it must not touch an
+    /// unattributed tombstone, which has no link to be checked against.
+    func test_reconcile_dropsDeadLinksAndKeepsLiveAndUnattributed() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let store = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        _ = await store.record(makeRequest(id: "evt-live"))
+        await store.consume(id: "evt-live")                 // 0xAB… link
+        await store.consume(id: "evt-unattributed")         // no row → unattributed
+
+        await store.reconcileTombstones(
+            livePublicKeys: [Data(repeating: 0xAB, count: 32)]
+        )
+        XCTAssertEqual(log.handledIDs(), ["evt-live", "evt-unattributed"])
+
+        // Now that link is gone from the device entirely.
+        await store.reconcileTombstones(livePublicKeys: [])
+        XCTAssertEqual(
+            log.handledIDs(), ["evt-unattributed"],
+            "a dead link's tombstone goes; an unattributed one has nothing to check"
+        )
+    }
+
     private func makeRequest(
         id: String,
         receivedAt: Date = Date()

--- a/Tests/OnymIOSTests/SwiftDataIntroRequestStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataIntroRequestStoreTests.swift
@@ -147,6 +147,69 @@ final class SwiftDataIntroRequestStoreTests: XCTestCase {
     /// Relative to now, not a fixed epoch: the store sweeps rows past
     /// `retention`, so a hardcoded past date would age out from under
     /// these tests as the wall clock moves.
+    // MARK: - handled-request tombstones
+
+    /// Multi-use links keep their relay subscription after an approval,
+    /// and the REQ carries no `since` — so the inbox replays requests
+    /// that were already acted on. Deleting the pending row is not
+    /// enough on its own; without a tombstone the replay re-inserts it
+    /// and the founder sees a request they already answered.
+    func test_consumedRequest_doesNotReappearOnReplay() async {
+        let store = SwiftDataIntroRequestStore.inMemory()
+        _ = await store.record(makeRequest(id: "evt-handled"))
+
+        await store.consume(id: "evt-handled")
+        let reinserted = await store.record(makeRequest(id: "evt-handled"))
+
+        XCTAssertFalse(reinserted, "a replay of a handled request must not re-insert")
+        let current = await store.current()
+        XCTAssertTrue(current.isEmpty)
+    }
+
+    /// The rows are process-durable, but the tombstones have to outlive
+    /// them: a cold start replays the whole inbox.
+    func test_tombstoneSurvivesARelaunch() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let before = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        _ = await before.record(makeRequest(id: "evt-across"))
+        await before.consume(id: "evt-across")
+
+        // Fresh store, same durable log — the relaunch case.
+        let after = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        let reinserted = await after.record(makeRequest(id: "evt-across"))
+
+        XCTAssertFalse(reinserted, "the tombstone must outlive the store instance")
+    }
+
+    /// Tombstones are attributed to the link they arrived on, so
+    /// retiring that link drops them rather than growing forever.
+    func test_pruneTombstones_dropsRetiredLinksAndKeepsLiveOnes() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let store = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        _ = await store.record(makeRequest(id: "evt-retired"))
+        await store.consume(id: "evt-retired")
+
+        // The link this request arrived on is revoked.
+        await store.pruneTombstones(keeping: [Data(repeating: 0x11, count: 32)])
+
+        XCTAssertTrue(log.handledIDs().isEmpty, "a retired link takes its tombstones with it")
+        let reinserted = await store.record(makeRequest(id: "evt-retired"))
+        XCTAssertTrue(reinserted, "with the tombstone gone the id is insertable again")
+    }
+
+    func test_pruneTombstones_keepsTombstonesForLiveLinks() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let store = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        _ = await store.record(makeRequest(id: "evt-live"))
+        await store.consume(id: "evt-live")
+
+        // makeRequest targets 0xAB… — still live.
+        await store.pruneTombstones(keeping: [Data(repeating: 0xAB, count: 32)])
+
+        let reinserted = await store.record(makeRequest(id: "evt-live"))
+        XCTAssertFalse(reinserted, "a live link keeps its tombstones")
+    }
+
     private func makeRequest(
         id: String,
         receivedAt: Date = Date()

--- a/Tests/OnymIOSTests/SwiftDataIntroRequestStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataIntroRequestStoreTests.swift
@@ -189,8 +189,9 @@ final class SwiftDataIntroRequestStoreTests: XCTestCase {
         _ = await store.record(makeRequest(id: "evt-retired"))
         await store.consume(id: "evt-retired")
 
-        // The link this request arrived on is revoked.
-        await store.pruneTombstones(keeping: [Data(repeating: 0x11, count: 32)])
+        // The link this request arrived on is revoked. makeRequest
+        // targets 0xAB…, so that is what retires.
+        await store.pruneTombstones(retiring: [Data(repeating: 0xAB, count: 32)])
 
         XCTAssertTrue(log.handledIDs().isEmpty, "a retired link takes its tombstones with it")
         let reinserted = await store.record(makeRequest(id: "evt-retired"))
@@ -203,11 +204,48 @@ final class SwiftDataIntroRequestStoreTests: XCTestCase {
         _ = await store.record(makeRequest(id: "evt-live"))
         await store.consume(id: "evt-live")
 
-        // makeRequest targets 0xAB… — still live.
-        await store.pruneTombstones(keeping: [Data(repeating: 0xAB, count: 32)])
+        // An unrelated link retires; makeRequest's 0xAB… is untouched.
+        await store.pruneTombstones(retiring: [Data(repeating: 0x11, count: 32)])
 
         let reinserted = await store.record(makeRequest(id: "evt-live"))
         XCTAssertFalse(reinserted, "a live link keeps its tombstones")
+    }
+
+    /// The pump's entries stream is scoped to ONE identity, but the
+    /// request store spans the process. Pruning by "everything still
+    /// live" therefore used to delete every other identity's
+    /// tombstones — and on a locked-device launch, where the keychain
+    /// read returns nothing, it deleted all of them. Both replay as
+    /// pending on the next reconnect. Pruning by what actually retired
+    /// cannot express either wipe.
+    func test_pruneTombstones_withNothingRetired_keepsEverything() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let store = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        _ = await store.record(makeRequest(id: "evt-other-identity"))
+        await store.consume(id: "evt-other-identity")
+
+        // What an empty snapshot now produces: nothing died.
+        await store.pruneTombstones(retiring: [])
+
+        XCTAssertEqual(log.handledIDs(), ["evt-other-identity"])
+        let reinserted = await store.record(makeRequest(id: "evt-other-identity"))
+        XCTAssertFalse(reinserted, "an unrelated identity's snapshot must not wipe tombstones")
+    }
+
+    /// `consume` is documented to tombstone durably even when the row
+    /// is absent — the ordering a consume racing a reconnect produces.
+    /// Only the in-memory half used to happen, so the id came back on
+    /// the next cold start.
+    func test_consume_withNoStoredRow_stillTombstonesDurably() async {
+        let log = InMemoryHandledIntroRequestLog()
+        let before = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+
+        await before.consume(id: "evt-ahead-of-replay")
+        XCTAssertEqual(log.handledIDs(), ["evt-ahead-of-replay"])
+
+        let after = SwiftDataIntroRequestStore.inMemory(handledLog: log)
+        let late = await after.record(makeRequest(id: "evt-ahead-of-replay"))
+        XCTAssertFalse(late, "the tombstone must survive without a row to attribute it to")
     }
 
     private func makeRequest(


### PR DESCRIPTION
An invite link died on the first Approve — or Decline. Both revoked the per-invite intro key, which tore down the relay subscription the link points at, so every later joiner's request landed on a tag nobody was listening to. Nothing surfaced this on either side: the joiner sat on "Waiting for the host to approve…" forever, and the host never saw a row. Reported from the field as "the same link doesn't work twice in a row".

This is the #209–#213 stack rebased onto the SPM package layout (it was written against `Sources/OnymIOS/Group/…`; these files now live in `Packages/OnymGroup/`). Squashed to one feature commit for review, plus two commits addressing review findings.

## What changes

- **Approve and Decline no longer revoke.** Links are retired only by the inviter — "Generate new link" rotates, and a new invite list offers per-row Revoke. Every join is still gated by an explicit tap; nothing is auto-granted.
- **Re-join is safe.** A joiner already in `members` skips the chain anchor, so a replay or reinstall can't push a duplicate Merkle leaf. This also makes the long-standing double-tapped-Approve race safe.
- **Both approve and decline consume the whole collapsed sibling set**, re-derived from the live store at consume time.
- **Handled request ids are tombstoned durably**, keyed by the link they arrived on and pruned when that link is retired. Necessary because the subscription now outlives the approval and the Nostr REQ carries no `since`, so every reconnect replays requests already acted on.
- **Create-time offer keys are labelled per invitee** and listed with a per-row Revoke, alongside any superseded shared key, so no live key is unlistable.
- **The joiner gets a 90s `.unanswered` state** — a dead link is finally distinguishable from a thinking host. Non-terminal: a late approval still wins.

## Rebase decisions worth reviewing

Three conflicts needed judgement rather than mechanical resolution:

**The 24h TTL is gone, and this reverses a later decision.** `main` added `entryTTL` after this branch (issue #111, matching Android's `LIFETIME_MILLIS`); the branch deletes expiry entirely. Git auto-merged the deletion of the *filter* while the conflict resolution kept the *constant* — dead code claiming an expiry that no longer happened. I resolved toward the branch's design, because its whole UX assumes permanence (one reusable link, explicit rotate, per-row Revoke) and a silent 24h death recreates the exact complaint this fixes. **This is the one call I'd most like a second opinion on** — see Risks.

**The durable request store is kept.** `main` gained `SwiftDataIntroRequestStore` after this branch, which replaced it with an in-memory store. Kept main's durable store and moved the tombstones onto it.

**`alreadyInRoster` gates the anchor only.** I first also gated `broadcastJoin` and the admin's "X joined" row behind it; review showed that breaks the documented retry repair (see below).

## Review findings addressed

Two independent reviews of the diff. The load-bearing ones, all fixed in the follow-up commits:

- **Tombstone pruning wiped other identities' tombstones.** It was fed the *active* identity's snapshot but pruned a process-wide log, so any identity switch — and any locked-device launch, where the keychain read yields nothing — deleted every other identity's tombstones and replayed their handled requests as pending. Prune now names what **retired** (diffed from successive snapshots) rather than what survived, which cannot express either wipe.
- **The `alreadyInRoster` guard broke retry repair.** `approve()` is documented as re-runnable and persists the anchor *before* seal/send, so a transport failure leaves the joiner in `members` while no other member has heard of them — and the retry skipped the repair, parking their messages forever. The flag reads `members`; receivers dedupe on `memberProfiles`, and those diverge in exactly that case. Both calls are idempotent at the receiver, so they're unconditional again.
- **`consume()` only tombstoned durably when a row was present**, so the "laid ahead of a replay" case it documents was process-lifetime only.
- **`loadAll()` now filters tombstoned ids** — the tombstone commits before the row is deleted, so a crash in that window resurrected a handled request.
- The missing-intro-key drop now increments `decryptFailures` (it was the only decode path with no signal, and it's the common case for a retired link); rotate refreshes the invite list; the shared link's key is remembered rather than re-parsed (a non-`.ready` state listed the live link as revokable); the fallback store gets the durable log.

## Risks, stated plainly

- **A leaked link is now a standing invitation.** It used to be worth one join attempt. It's a spam/enumeration surface, not an access-control bypass — every joiner still needs an explicit Approve — but the only backstop is a human noticing and revoking.
- **Decline has no teeth, and the joiner has a "Try again" button.** There's no blocklist anywhere in the repo, and each retry is a fresh event id, so tombstones and the collapse key don't suppress it. A declined stranger can refill the queue indefinitely; the only remedy is rotating the link and redistributing it. Previously, decline locked them out. **Not fixed here** — a declined-joiner suppression list is a feature, and I'd rather scope it deliberately than bolt it on. This is the sharpest regression in the change.
- **Relay REQ slots grow monotonically.** Nothing expires and there's no group-scoped cascade, so a group created with 50 invitees holds 51 permanent subscriptions. The TTL used to reclaim these. A future leave/delete-group flow must cascade a revoke.
- **iOS/Android asymmetry.** Android still expires intro keys at 24h, so the same QR works forever with an iOS admin and dies overnight with an Android one — silently on both. Android needs the matching change before this ships widely.
- **Pre-upgrade keys all decode as `label == nil`**, i.e. as the shared link, so on upgrade `currentOrMint` may publish a per-invitee offer key and the first rotate revokes all of them. A migration marker would close this.
- `UserDefaultsHandledIntroRequestLog` stores `(intro pubkey, handled ids)` in UserDefaults — weaker file protection than the SwiftData store it mirrors, and backed up. Event ids aren't secret, but the pair reconstructs invite activity and derives the inbox tag.

**Android has the identical revoke-on-approve bug** (`JoinRequestApprover.kt:341` approve, `:461` decline). It needs its own PR; a faithful port needs the reusable-link/rotate/invite-list UI and tombstones to land coherently, not just deleting the two calls.

## Tests

1307 unit tests, 0 failures, on `iPhone 17 Pro` simulator. Both test bundles compile, so the UI-test target still builds against the changed views. New coverage for the tombstone half the rebase moved onto the durable store — including the cross-identity wipe and the no-row durability case — each verified to fail without its fix rather than pass vacuously.

Not verified: no device or multi-device run. Given the bug being fixed is a cross-device one, a two-device walkthrough (one link, two joiners, approve both) is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)