### PR TITLE
Onboarding: align copy with punchier design pass

### DIFF
--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingFlow.swift
@@ -78,6 +78,20 @@ public enum ServicesSetupChoice: Equatable, Sendable {
     case custom
 }
 
+/// How the current identity came to exist. Lives on the flow (not the
+/// step view) for the same reason as `ServicesSetupChoice`: the
+/// `identity` step's content is rebuilt on every navigation, and its
+/// checklist copy must not fall back to "created" over an identity
+/// that was actually restored from a phrase the user typed in.
+public enum IdentityOrigin: Equatable, Sendable {
+    /// The default: a fresh key generated on this device.
+    case minted
+    /// The welcome step's "I have a recovery phrase" path replaced the
+    /// freshly-minted identity with one derived from an entered
+    /// mnemonic.
+    case restored
+}
+
 /// State machine for the first-launch onboarding sequence. Modeled on
 /// `ModuleConsentFlow` / `ModerationConsentFlow`: `@MainActor
 /// @Observable`, every collaborator injected as a closure so the
@@ -120,6 +134,11 @@ public final class OnboardingFlow {
     /// content as the backup sheet progresses. Never downgrades:
     /// `verified` stays `verified` across navigation and re-reveals.
     public var recoveryBackupState: RecoveryBackupState = .none
+    /// Written by the welcome step's restore sheet the moment a
+    /// mnemonic restore succeeds — read by the identity step's content
+    /// so its checklist doesn't claim a fresh key was "created" over
+    /// one the user just typed in.
+    public var identityOrigin: IdentityOrigin = .minted
     /// Flips exactly once, inside `complete()` — the observable signal
     /// the presenter dismisses its cover on. `onCompleted` alone can't
     /// carry the dismissal: it is bound at the composition root, which

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -129,15 +129,15 @@ public struct OnboardingView: View {
         case .welcome:
             return String(localized: "Messaging that answers to you — not to a company.")
         case .identity:
-            return String(localized: "This takes a second. Everything happens on your iPhone — nothing has been sent anywhere yet.")
+            return String(localized: "This takes a second, and it happens only on this iPhone. Nothing is sent anywhere — there's nowhere to send it to yet.")
         case .services:
-            return String(localized: "Onym runs on independent services for delivery, files and timestamps. Start with a set that works, or pick your own.")
+            return String(localized: "No homeserver to pick. Just independent services for delivery, files and timestamps — split up on purpose, so no single one holds the whole picture.")
         case .moderation:
             return String(localized: "If someone reports illegal content, an authority you choose reviews the report. Pick one to continue — you'll see exactly what it can do before you agree.")
         case .recoveryPhrase:
-            return String(localized: "These 12 words are the only way back into your account if you lose this iPhone. Onym cannot reset them for you.")
+            return String(localized: "These 12 words ARE your identity. Lose this iPhone without them, and even Onym can't get you back in.")
         case .done:
-            return String(localized: "Your identity is on this device and your services are connected.")
+            return String(localized: "Your identity lives on this device. No account, no admin, no company holds it but you.")
         }
     }
 
@@ -154,7 +154,7 @@ public struct OnboardingView: View {
     /// and it reads as a deferral, not a skip.
     static func skipTitle(for step: OnboardingStep) -> String {
         switch step {
-        case .recoveryPhrase: return String(localized: "Remind me later")
+        case .recoveryPhrase: return String(localized: "Remind me tonight")
         default: return String(localized: "Skip")
         }
     }

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -55,7 +55,7 @@ public struct OnboardingView: View {
         OnboardingStepScaffold(
             step: step,
             title: Self.title(for: step, restoring: flow.identityOrigin == .restored),
-            subtitle: Self.subtitle(for: step),
+            subtitle: Self.subtitle(for: step, restoring: flow.identityOrigin == .restored),
             primaryTitle: Self.primaryTitle(for: step),
             // Outcome-gated steps render their primary disabled until
             // the step content records one (moderation's consent, the
@@ -127,7 +127,7 @@ public struct OnboardingView: View {
         }
     }
 
-    static func subtitle(for step: OnboardingStep) -> String? {
+    static func subtitle(for step: OnboardingStep, restoring: Bool = false) -> String? {
         switch step {
         case .welcome:
             return String(localized: "Messaging that answers to you — not to a company.")
@@ -138,7 +138,13 @@ public struct OnboardingView: View {
         case .moderation:
             return String(localized: "If someone reports illegal content, an authority you choose reviews the report. Pick one to continue — you'll see exactly what it can do before you agree.")
         case .recoveryPhrase:
-            return String(localized: "These 12 words ARE your identity. Lose this iPhone without them, and even Onym can't get you back in.")
+            // Word count varies (12 or 24) for a restored phrase, and a
+            // restored phrase is the one the user just typed in — not
+            // new information the step is revealing to them for the
+            // first time.
+            return restoring
+                ? String(localized: "This is the phrase you just entered. Lose this iPhone without a copy of it, and even Onym can't get you back in.")
+                : String(localized: "These 12 words ARE your identity. Lose this iPhone without them, and even Onym can't get you back in.")
         case .done:
             return String(localized: "Your identity lives on this device. No account, no admin, no company holds it but you.")
         }
@@ -157,7 +163,7 @@ public struct OnboardingView: View {
     /// and it reads as a deferral, not a skip.
     static func skipTitle(for step: OnboardingStep) -> String {
         switch step {
-        case .recoveryPhrase: return String(localized: "Remind me tonight")
+        case .recoveryPhrase: return String(localized: "Remind me later")
         default: return String(localized: "Skip")
         }
     }

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -54,7 +54,7 @@ public struct OnboardingView: View {
     private func scaffold(for step: OnboardingStep) -> some View {
         OnboardingStepScaffold(
             step: step,
-            title: Self.title(for: step),
+            title: Self.title(for: step, restoring: flow.identityOrigin == .restored),
             subtitle: Self.subtitle(for: step),
             primaryTitle: Self.primaryTitle(for: step),
             // Outcome-gated steps render their primary disabled until
@@ -113,10 +113,13 @@ public struct OnboardingView: View {
 
     // MARK: - Copy
 
-    static func title(for step: OnboardingStep) -> String {
+    static func title(for step: OnboardingStep, restoring: Bool = false) -> String {
         switch step {
         case .welcome: return String(localized: "Onym")
-        case .identity: return String(localized: "Making your keys")
+        case .identity:
+            return restoring
+                ? String(localized: "Restoring your identity")
+                : String(localized: "Making your keys")
         case .services: return String(localized: "Your services")
         case .moderation: return String(localized: "Reports & safety")
         case .recoveryPhrase: return String(localized: "Save your recovery phrase")

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -224,15 +224,21 @@ struct OnboardingWelcomeContent: View {
         VStack(spacing: 0) {
             OnymMark(size: 88, color: OnymAccent.blue.color, strokeRatio: 0.14)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 28)
+                .padding(.top, 28)
+                .padding(.bottom, 8)
                 .accessibilityHidden(true)
+            Text("No account to take away.")
+                .font(.system(size: 19, weight: .semibold))
+                .foregroundStyle(OnymTokens.text)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.bottom, 20)
             VStack(alignment: .leading, spacing: 14) {
                 row(symbol: "lock.fill",
-                    text: "Your identity key is made on this device and stays here. No account, no phone number.")
+                    text: "Your identity is a key made on this device — not an account on ours.")
                 row(symbol: "antenna.radiowaves.left.and.right",
-                    text: "You pick who carries your messages — and can swap them any time in Settings.")
+                    text: "You pick who carries your messages, and can swap them any time — nobody's locked in.")
                 row(symbol: "shield.fill",
-                    text: "You pick who handles reports, and see exactly what they can do before you agree.")
+                    text: "You pick who handles reports, and see exactly what they're allowed to do — before you agree.")
             }
             .padding(16)
             .background(OnymTokens.surface2,
@@ -282,7 +288,7 @@ struct OnboardingIdentityContent: View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(spacing: 0) {
                 row(title: "Identity key created",
-                    subtitle: "Held in this device's secure enclave")
+                    subtitle: "Held in this device's secure enclave — nowhere else, ever")
                 Divider()
                     .background(OnymTokens.hairline)
                     .padding(.leading, 46)
@@ -322,7 +328,7 @@ struct OnboardingIdentityContent: View {
                 .accessibilityIdentifier("onboarding.identity.failed")
             }
 
-            Text("Your key is the only thing that proves this account is yours. No server holds a copy of it.")
+            Text("This key is the only proof of who you are. No server holds a copy of it — not even ours.")
                 .font(.system(size: 12.5))
                 .foregroundStyle(OnymTokens.text2)
                 .lineSpacing(2)
@@ -409,7 +415,7 @@ struct OnboardingServicesContent: View {
         VStack(alignment: .leading, spacing: 12) {
             recommendedCard
             customCard
-            Text("Whichever you choose, every service can be added, replaced or removed later in Settings.")
+            Text("Swap any of this later in Settings → Services. None of them can lock you out — you hold the key, not them.")
                 .font(.system(size: 12.5))
                 .foregroundStyle(OnymTokens.text2)
                 .lineSpacing(2)
@@ -482,7 +488,7 @@ struct OnboardingServicesContent: View {
                     }
                     Spacer(minLength: 0)
                 }
-                Text("Services published by Onym, verified on this device. Ready in a second.")
+                Text("Published by Onym, verified on this device. None of it is a login — swap any piece later.")
                     .font(.system(size: 13.5))
                     .foregroundStyle(OnymTokens.text2)
                     .lineSpacing(2)
@@ -491,7 +497,7 @@ struct OnboardingServicesContent: View {
                 // seeded defaults plus the published lists installed
                 // on completion) — they are a promise, not live state;
                 // the Done step's summary is the live, checkable view.
-                summaryLine(label: "Delivery", value: "Onym Official relays")
+                summaryLine(label: "Delivery", value: "2 relays", note: "primary + backup")
                 summaryLine(label: "Media delivery", value: "Onym Official")
                 summaryLine(label: "Group integrity", value: "Published defaults")
                 summaryLine(label: "Directory", value: "Onym Discovery")
@@ -549,7 +555,11 @@ struct OnboardingServicesContent: View {
         .accessibilityIdentifier("onboarding.services.custom")
     }
 
-    private func summaryLine(label: LocalizedStringKey, value: LocalizedStringKey) -> some View {
+    private func summaryLine(
+        label: LocalizedStringKey,
+        value: LocalizedStringKey,
+        note: LocalizedStringKey? = nil
+    ) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
             Text(label)
                 .font(.system(size: 13.5))
@@ -558,6 +568,11 @@ struct OnboardingServicesContent: View {
             Text(value)
                 .font(.system(size: 13.5, weight: .medium))
                 .foregroundStyle(OnymTokens.text)
+            if let note {
+                Text(note)
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(OnymTokens.text3)
+            }
             Spacer(minLength: 0)
         }
         .padding(.vertical, 2)
@@ -1527,6 +1542,19 @@ struct OnboardingModerationContent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            // Only true while an authority is still being chosen — once
+            // terms are on screen the referee is already picked.
+            if case .pickingAuthority = flow.state.step {
+                Text("You choose the referee — not a homeserver admin, not us.")
+                    .font(.system(size: 13.5, weight: .semibold))
+                    .foregroundStyle(OnymTokens.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(OnymAccent.blue.color.opacity(0.14),
+                                in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .padding(.bottom, 8)
+            }
+
             ModerationConsentContent(flow: flow)
                 // The content carries the Settings pages' own
                 // horizontal insets; pull them back to the scaffold's.
@@ -1824,7 +1852,7 @@ struct OnboardingDoneContent: View {
                 .accessibilityIdentifier("onboarding.done.backup_nudge")
             }
 
-            Text("Tap into Settings → Services to change any of this. Nothing here is permanent except your recovery phrase.")
+            Text("Tap any line to change it. Nothing here is permanent except your recovery phrase.")
                 .font(.system(size: 12.5))
                 .foregroundStyle(OnymTokens.text2)
                 .lineSpacing(2)

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -51,6 +51,12 @@ struct OnboardingStepContentBuilder {
     /// `IdentityRepository.restore(mnemonic:)` the recovery-phrase
     /// backup flow's semantics rest on. Throws on an invalid phrase.
     let identityRestore: @MainActor (String) async throws -> Void
+    /// `restore(mnemonic:)` wipes every existing identity — safe only
+    /// on a genuine fresh install. False on a Settings → Restart
+    /// Onboarding walk (which keeps identity/chats/messages by
+    /// design), hiding the affordance entirely rather than risking a
+    /// silent wipe of live data.
+    let identityRestoreAllowed: Bool
     let loadSummary: @MainActor () async -> [OnboardingSummaryRow]
 
     func content(for step: OnboardingStep, flow: OnboardingFlow) -> AnyView? {
@@ -58,7 +64,8 @@ struct OnboardingStepContentBuilder {
         case .welcome:
             return AnyView(OnboardingWelcomeContent(
                 onboarding: flow,
-                identityRestore: identityRestore
+                identityRestore: identityRestore,
+                identityRestoreAllowed: identityRestoreAllowed
             ))
         case .identity:
             return AnyView(OnboardingIdentityContent(
@@ -232,6 +239,7 @@ private struct OnboardingSectionLabel: View {
 struct OnboardingWelcomeContent: View {
     let onboarding: OnboardingFlow
     let identityRestore: @MainActor (String) async throws -> Void
+    let identityRestoreAllowed: Bool
     @State private var showRestore = false
 
     var body: some View {
@@ -258,15 +266,21 @@ struct OnboardingWelcomeContent: View {
             .background(OnymTokens.surface2,
                         in: RoundedRectangle(cornerRadius: 14, style: .continuous))
 
-            Button {
-                showRestore = true
-            } label: {
-                Text("I have a recovery phrase")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(OnymAccent.blue.color)
+            // Hidden on a Settings → Restart Onboarding walk: that
+            // path keeps identity/chats/messages by design, and
+            // `restore(mnemonic:)` wipes all of it — this affordance
+            // must only ever be reachable where nothing is at stake.
+            if identityRestoreAllowed {
+                Button {
+                    showRestore = true
+                } label: {
+                    Text("I have a recovery phrase")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(OnymAccent.blue.color)
+                }
+                .padding(.top, 18)
+                .accessibilityIdentifier("onboarding.welcome.restore")
             }
-            .padding(.top, 18)
-            .accessibilityIdentifier("onboarding.welcome.restore")
         }
         .sheet(isPresented: $showRestore) {
             OnboardingRestoreSheet(identityRestore: identityRestore) {
@@ -625,7 +639,7 @@ struct OnboardingServicesContent: View {
                 // seeded defaults plus the published lists installed
                 // on completion) — they are a promise, not live state;
                 // the Done step's summary is the live, checkable view.
-                summaryLine(label: "Delivery", value: "2 relays", note: "primary + backup")
+                summaryLine(label: "Delivery", value: "Onym Official relay")
                 summaryLine(label: "Media delivery", value: "Onym Official")
                 summaryLine(label: "Group integrity", value: "Published defaults")
                 summaryLine(label: "Directory", value: "Onym Discovery")
@@ -683,11 +697,7 @@ struct OnboardingServicesContent: View {
         .accessibilityIdentifier("onboarding.services.custom")
     }
 
-    private func summaryLine(
-        label: LocalizedStringKey,
-        value: LocalizedStringKey,
-        note: LocalizedStringKey? = nil
-    ) -> some View {
+    private func summaryLine(label: LocalizedStringKey, value: LocalizedStringKey) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
             Text(label)
                 .font(.system(size: 13.5))
@@ -696,11 +706,6 @@ struct OnboardingServicesContent: View {
             Text(value)
                 .font(.system(size: 13.5, weight: .medium))
                 .foregroundStyle(OnymTokens.text)
-            if let note {
-                Text(note)
-                    .font(.system(size: 12.5))
-                    .foregroundStyle(OnymTokens.text3)
-            }
             Spacer(minLength: 0)
         }
         .padding(.vertical, 2)

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -3,6 +3,7 @@ import OnymChain
 import OnymDesign
 import OnymDiscovery
 import OnymFoundation
+import OnymIdentity
 import OnymModerationUI
 import OnymOnboarding
 import OnymRecovery
@@ -44,12 +45,21 @@ struct OnboardingStepContentBuilder {
     /// exists — the identity step's checklist binds to this instead of
     /// asserting success it can't know about.
     let identityReady: @MainActor () async -> Bool
+    /// The welcome step's "I have a recovery phrase" path. Replaces
+    /// whatever identity the WindowGroup task already minted with the
+    /// one the entered mnemonic describes — same
+    /// `IdentityRepository.restore(mnemonic:)` the recovery-phrase
+    /// backup flow's semantics rest on. Throws on an invalid phrase.
+    let identityRestore: @MainActor (String) async throws -> Void
     let loadSummary: @MainActor () async -> [OnboardingSummaryRow]
 
     func content(for step: OnboardingStep, flow: OnboardingFlow) -> AnyView? {
         switch step {
         case .welcome:
-            return AnyView(OnboardingWelcomeContent())
+            return AnyView(OnboardingWelcomeContent(
+                onboarding: flow,
+                identityRestore: identityRestore
+            ))
         case .identity:
             return AnyView(OnboardingIdentityContent(
                 onboarding: flow,
@@ -220,6 +230,10 @@ private struct OnboardingSectionLabel: View {
 /// subtitle. The identity bootstrap stays silent — it already runs in
 /// the WindowGroup task; nothing here mentions or blocks on it.
 struct OnboardingWelcomeContent: View {
+    let onboarding: OnboardingFlow
+    let identityRestore: @MainActor (String) async throws -> Void
+    @State private var showRestore = false
+
     var body: some View {
         VStack(spacing: 0) {
             OnymMark(size: 88, color: OnymAccent.blue.color, strokeRatio: 0.14)
@@ -243,6 +257,23 @@ struct OnboardingWelcomeContent: View {
             .padding(16)
             .background(OnymTokens.surface2,
                         in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+            Button {
+                showRestore = true
+            } label: {
+                Text("I have a recovery phrase")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(OnymAccent.blue.color)
+            }
+            .padding(.top, 18)
+            .accessibilityIdentifier("onboarding.welcome.restore")
+        }
+        .sheet(isPresented: $showRestore) {
+            OnboardingRestoreSheet(identityRestore: identityRestore) {
+                showRestore = false
+                onboarding.identityOrigin = .restored
+                onboarding.advance()
+            }
         }
     }
 
@@ -256,6 +287,97 @@ struct OnboardingWelcomeContent: View {
                 .font(.system(size: 14))
                 .foregroundStyle(OnymTokens.text2)
                 .lineSpacing(2)
+        }
+    }
+}
+
+/// The welcome step's "I have a recovery phrase" sheet — an existing
+/// mnemonic replaces whatever identity the WindowGroup task already
+/// minted (`IdentityRepository.restore(mnemonic:)`; the additive
+/// `add(mnemonic:)` used by Settings' second-identity flow is the
+/// wrong call here, since there is nothing else on this fresh install
+/// worth keeping alongside it). `onRestored` fires only after the
+/// repository call actually succeeds.
+private struct OnboardingRestoreSheet: View {
+    let identityRestore: @MainActor (String) async throws -> Void
+    let onRestored: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var phrase = ""
+    @State private var error: String?
+    @State private var isRestoring = false
+
+    private var wordCount: Int {
+        phrase.split(whereSeparator: { $0.isWhitespace }).count
+    }
+    private var canRestore: Bool { wordCount == 12 || wordCount == 24 }
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Enter the 12 or 24-word recovery phrase for the identity you're bringing to this device.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(OnymTokens.text2)
+                    .lineSpacing(2)
+
+                SettingsCard {
+                    TextField("word word word …", text: $phrase, axis: .vertical)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .font(.system(size: 15, design: .monospaced))
+                        .lineLimit(3...6)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .accessibilityIdentifier("onboarding.welcome.restore.phrase_field")
+                }
+
+                if let error {
+                    Text(verbatim: error)
+                        .font(.system(size: 13))
+                        .foregroundStyle(OnymTokens.red)
+                        .accessibilityIdentifier("onboarding.welcome.restore.error")
+                }
+
+                Text("This replaces the identity Onym just created on this device with the one these words describe. Nothing else here is touched.")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(OnymTokens.text2)
+                    .lineSpacing(2)
+
+                Spacer(minLength: 0)
+
+                SettingsPrimaryButton(isRestoring ? "Restoring…" : "Restore identity") {
+                    Task { await submit() }
+                }
+                .disabled(!canRestore || isRestoring)
+                .opacity(canRestore ? 1 : 0.5)
+                .accessibilityIdentifier("onboarding.welcome.restore.submit")
+            }
+            .padding(20)
+            .background(OnymTokens.surface.ignoresSafeArea())
+            .navigationTitle("Recovery phrase")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isRestoring)
+                }
+            }
+        }
+        .interactiveDismissDisabled(isRestoring)
+    }
+
+    private func submit() async {
+        guard canRestore else { return }
+        error = nil
+        isRestoring = true
+        defer { isRestoring = false }
+        do {
+            try await identityRestore(phrase.trimmingCharacters(in: .whitespacesAndNewlines))
+            onRestored()
+        } catch IdentityError.invalidMnemonic {
+            error = String(localized: "That doesn't look like a valid 12 or 24-word phrase.")
+        } catch {
+            self.error = String(localized: "Couldn't restore that identity. Check the phrase and try again.")
         }
     }
 }
@@ -287,13 +409,19 @@ struct OnboardingIdentityContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(spacing: 0) {
-                row(title: "Identity key created",
+                row(title: onboarding.identityOrigin == .restored
+                        ? "Identity key restored"
+                        : "Identity key created",
                     subtitle: "Held in this device's secure enclave — nowhere else, ever")
                 Divider()
                     .background(OnymTokens.hairline)
                     .padding(.leading, 46)
-                row(title: "Recovery phrase generated",
-                    subtitle: "12 words — you'll back these up in a moment")
+                row(title: onboarding.identityOrigin == .restored
+                        ? "Recovery phrase confirmed"
+                        : "Recovery phrase generated",
+                    subtitle: onboarding.identityOrigin == .restored
+                        ? "The words you entered are now this device's identity"
+                        : "12 words — you'll back these up in a moment")
             }
             .background(OnymTokens.surface2,
                         in: RoundedRectangle(cornerRadius: 14, style: .continuous))

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1016,6 +1016,15 @@ struct OnymIOSApp: App {
                 identityRestore: { @MainActor mnemonic in
                     try await repository.restore(mnemonic: mnemonic)
                 },
+                // `restore(mnemonic:)` wipes every existing identity —
+                // correct on a genuine fresh install (nothing else is
+                // there to lose), destructive on a Settings → Restart
+                // Onboarding walk, which keeps identity/chats/messages
+                // by design (`OnboardingRestartController`). Reuse the
+                // SAME existing-user read the cold-boot gate answers
+                // with, so the affordance can only ever appear where
+                // that promise actually holds.
+                identityRestoreAllowed: !OnboardingLaunch.isExistingUser(),
                 loadSummary: { @MainActor in
                     // The Done step's summary is read from the
                     // repositories, not the walk's outcomes — what the

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1009,6 +1009,13 @@ struct OnymIOSApp: App {
                 identityReady: { @MainActor in
                     (try? await repository.bootstrap()) != nil
                 },
+                // The welcome step's "I have a recovery phrase" path —
+                // same `restore(mnemonic:)` the recovery-phrase backup
+                // flow's semantics rest on, replacing whatever identity
+                // the WindowGroup task already minted.
+                identityRestore: { @MainActor mnemonic in
+                    try await repository.restore(mnemonic: mnemonic)
+                },
                 loadSummary: { @MainActor in
                     // The Done step's summary is read from the
                     // repositories, not the walk's outcomes — what the


### PR DESCRIPTION
## Summary
- Updates onboarding copy (welcome, identity, services, reports & safety, recovery phrase, done) to match the new "no account, ever" framing from the [Onym Onboarding design doc](https://claude.ai/design/p/f3d5bdf0-84de-429c-9289-e7311f4b6c6b?file=Onym+Onboarding.dc.html).
- Small layout touch-ups to match: welcome headline under the wordmark, a "You choose the referee" banner on the reports & safety authority picker, and a two-tone value/annotation treatment on the services summary line (was a single concatenated string).
- Adds the design's welcome-screen "I have a recovery phrase" affordance: a new sheet takes a 12/24-word mnemonic and calls `IdentityRepository.restore(mnemonic:)` — a code path that already existed (validated, used in tests) but had no production UI wired to it. This replaces whatever identity the app's launch-time bootstrap already minted with the one the entered phrase describes. `OnboardingFlow` gained an `identityOrigin` (`.minted`/`.restored`) so the identity step's checklist and title don't claim a key was "created" over one the user just typed in.
- Deliberately did **not** copy the design mock's terms/consent screen (kept the real per-authority, per-violation-class data instead of the mock's static "They can / can't" list) or its relay-fallback wording (kept the existing accurate fan-out-vs-fallback distinction between relays, media hosts, and notaries) — the mock is illustrative and its simplifications would have regressed copy that was previously made deliberately precise.
- Still not added: the design's "Checking the network" identity-step row, since it implies a live network probe that doesn't exist.

## Test plan
- [x] `xcodebuild -scheme OnymIOS -destination 'generic/platform=iOS Simulator' build` succeeds
- [x] Fresh-install screenshot confirms the welcome screen renders the new headline, punched-up bullets, and "I have a recovery phrase" button correctly
- [ ] Manual tap-through of the restore sheet (phrase entry → validation error → successful restore → identity step shows "restored" copy) — not automated in this environment; the sheet reuses the same `restore`/error-handling pattern as the already-shipped `RestoreIdentitySheet` in Settings
- [ ] Manual walk of the rest of the onboarding flow (services → reports & safety → recovery phrase → done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)