### PR TITLE
Add OnymBackup: the device-backup domain, with no I/O and no crypto

### DIFF
--- a/Packages/OnymBackup/Package.swift
+++ b/Packages/OnymBackup/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OnymBackup",
+    platforms: [.iOS("18.0")],
+    products: [
+        .library(name: "OnymBackup", targets: ["OnymBackup"]),
+    ],
+    dependencies: [
+        .package(path: "../OnymFoundation"),
+    ],
+    targets: [
+        .target(
+            name: "OnymBackup",
+            dependencies: [
+                "OnymFoundation",
+            ]
+        ),
+    ]
+)

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
@@ -36,13 +36,23 @@ public enum BackupError: Error, Equatable, Sendable {
     /// The operator requires a valid entitlement for this operation.
     case paymentRequired(componentId: String, offerIds: [String], entitlementIssuers: [String])
     /// An entitlement was presented and refused. Refresh without leaking
-    /// another credential to this operator.
-    case invalidEntitlement
+    /// another credential to this operator — the issuers it names are the
+    /// ones *this* operator accepts, and they go nowhere else.
+    case invalidEntitlement(entitlementIssuers: [String])
     /// Exceeds the operator's declared maximum sealed snapshot size.
     case snapshotTooLarge(maximumSealedSnapshotBytes: Int?)
     /// Retained count or byte limit reached. The operator reports it and
     /// must not silently drop an older snapshot to make room.
-    case quotaExceeded(retainedSnapshots: Int?, maximumRetainedSnapshots: Int?)
+    ///
+    /// All four figures are the operator's own claims about its own state,
+    /// carried so a person can be shown what is full rather than only that
+    /// something is.
+    case quotaExceeded(
+        retainedSnapshots: Int?,
+        maximumRetainedSnapshots: Int?,
+        retainedBytes: Int?,
+        limitBytes: Int?
+    )
     /// Bytes received do not compose the reference claimed. Never merged,
     /// never partially restored.
     case incompleteSnapshot

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
@@ -49,6 +49,13 @@ public enum BackupError: Error, Equatable, Sendable {
     /// Held once; no longer held.
     case retentionExpired
     /// Erasure acknowledged, completion pending. Not destruction.
+    ///
+    /// Never an operator response: erase always returns a receipt, and a
+    /// receipt is always an acknowledgment. This is *derived* locally by
+    /// comparing the receipt's `completionCommittedBy` against the clock,
+    /// so an operator that misses its own committed deadline is caught
+    /// from the receipt we already hold rather than from a status code it
+    /// would have to volunteer against its own interest.
     case erasureUnconfirmed(receipt: ErasureReceipt?)
     /// The operator withheld export. **Non-conforming** — see the note above.
     case exportWithheld

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
@@ -126,9 +126,18 @@ extension BackupError {
     /// same operation id (`UI-Backup-Object-HTTP.md` §10.2). `termsChanged`
     /// is not, because a retry would upload under terms nobody consented
     /// to.
+    ///
+    /// `accessRefused` is deliberately absent. A refused proof is usually
+    /// a wrong key or a wrong signed byte string, and those fail
+    /// identically forever — an automatic retry would loop against an
+    /// operator that has already said no. The recoverable slice is
+    /// narrow (a clock far enough out that every timestamp reads as
+    /// stale) and does not belong behind a blanket property: it needs a
+    /// bounded, deliberate re-attempt with a freshly minted proof, which
+    /// is a decision for the repository driving the queue.
     public var isRetriable: Bool {
         switch self {
-        case .operatorUnavailable, .paymentRequired, .accessRefused:
+        case .operatorUnavailable, .paymentRequired:
             true
         default:
             false

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// The error vocabulary of `UI-Backup.md` §13, mapped in
+/// `UI-Backup-Object-HTTP.md` §14.
+///
+/// Two rules shape this enum:
+///
+/// - **An unknown operator code is preserved, not flattened.** `.rejected`
+///   carries the operator's own code and message so a person sees what the
+///   counterparty actually said rather than our guess at it
+///   (`UI-Backup.md` §8.9).
+/// - **`exportWithheld` exists so a client can name a violation.** It is
+///   not a state an operator may put us in: export is unconditional
+///   (§14.15). A client that receives it records the operator's
+///   non-conformance and must not soften the wording it shows.
+public enum BackupError: Error, Equatable, Sendable {
+    /// The operator's profile is not one this build implements.
+    case unsupportedProfile
+    /// Endpoint syntax, scheme, or origin is unusable. Never rewritten
+    /// silently into something that works.
+    case invalidEndpoint
+    /// Reference syntax, algorithm, or byte count is malformed.
+    case invalidReference
+    /// Terms could not be fetched or verified. Enrolment cannot proceed:
+    /// terms are a precondition, not a nicety.
+    case termsUnavailable
+    /// The operator's current terms differ from the ones we pinned. Stop,
+    /// re-present, obtain fresh consent.
+    case termsChanged(currentTermsId: String?)
+    /// Terms on offer are weaker than those a retained snapshot pinned.
+    /// Refused outright — terms bind forward only (`UI-Backup.md` §10.2).
+    case termsRegression(field: String)
+    /// Proof of possession was refused: bad signature, stale timestamp, or
+    /// a replayed nonce.
+    case accessRefused
+    /// The operator requires a valid entitlement for this operation.
+    case paymentRequired(componentId: String, offerIds: [String], entitlementIssuers: [String])
+    /// An entitlement was presented and refused. Refresh without leaking
+    /// another credential to this operator.
+    case invalidEntitlement
+    /// Exceeds the operator's declared maximum sealed snapshot size.
+    case snapshotTooLarge(maximumSealedSnapshotBytes: Int?)
+    /// Retained count or byte limit reached. The operator reports it and
+    /// must not silently drop an older snapshot to make room.
+    case quotaExceeded(retainedSnapshots: Int?, maximumRetainedSnapshots: Int?)
+    /// Bytes received do not compose the reference claimed. Never merged,
+    /// never partially restored.
+    case incompleteSnapshot
+    /// Held once; no longer held.
+    case retentionExpired
+    /// Erasure acknowledged, completion pending. Not destruction.
+    case erasureUnconfirmed(receipt: ErasureReceipt?)
+    /// The operator withheld export. **Non-conforming** — see the note above.
+    case exportWithheld
+    /// Nothing was decided. Distinct from a refusal, and from `unknown`.
+    case operatorUnavailable
+    /// The operator refused with a code we do not model. Preserved verbatim.
+    case rejected(code: String, message: String?)
+    /// A local precondition failed before anything left the device.
+    case localFailure(reason: LocalFailureReason)
+
+    public enum LocalFailureReason: String, Sendable, Equatable {
+        /// This identity has no recovery phrase (imported from raw key
+        /// material), so no restorable archive can be sealed for it.
+        case noRecoveryPhrase
+        /// The sealed bytes we were asked to upload are gone from the
+        /// pending directory.
+        case sealedBytesUnavailable
+        /// The archive did not decode, or its schema is from a newer
+        /// client.
+        case archiveUnreadable
+        /// The composed archive would contain material the eligible set
+        /// forbids. Should be unreachable by construction; if it ever
+        /// fires, it is a bug worth failing loudly for.
+        case ineligibleContent
+    }
+}
+
+extension BackupError {
+    /// The wire code this error corresponds to, for logging and for
+    /// mapping an operator response back onto the enum.
+    public var code: String {
+        switch self {
+        case .unsupportedProfile: "unsupported_profile"
+        case .invalidEndpoint: "invalid_endpoint"
+        case .invalidReference: "invalid_reference"
+        case .termsUnavailable: "terms_unavailable"
+        case .termsChanged: "terms_changed"
+        case .termsRegression: "terms_regression"
+        case .accessRefused: "signature_invalid"
+        case .paymentRequired: "payment_required"
+        case .invalidEntitlement: "invalid_entitlement"
+        case .snapshotTooLarge: "snapshot_too_large"
+        case .quotaExceeded: "quota_exceeded"
+        case .incompleteSnapshot: "digest_mismatch"
+        case .retentionExpired: "retention_expired"
+        case .erasureUnconfirmed: "erasure_unconfirmed"
+        case .exportWithheld: "export_withheld"
+        case .operatorUnavailable: "operator_unavailable"
+        case .rejected(let code, _): code
+        case .localFailure(let reason): "local_\(reason.rawValue)"
+        }
+    }
+
+    /// True when retrying the *same* operation, unchanged, could succeed.
+    ///
+    /// `paymentRequired` is retriable because that is exactly the shape of
+    /// the payment loop: refuse, purchase, retry the same bytes under the
+    /// same operation id (`UI-Backup-Object-HTTP.md` §10.2). `termsChanged`
+    /// is not, because a retry would upload under terms nobody consented
+    /// to.
+    public var isRetriable: Bool {
+        switch self {
+        case .operatorUnavailable, .paymentRequired, .accessRefused:
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupFormat.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupFormat.swift
@@ -1,0 +1,67 @@
+import CryptoKit
+import Foundation
+
+/// Small syntax helpers for the shapes this seat shares with the rest of
+/// the system: `sha256:<64 lowercase hex>` digests and RFC 3339 UTC
+/// timestamps.
+///
+/// `OnymFoundation` has the same helpers behind `ServiceManifestFormat`,
+/// but they are internal to that module. Rather than widen a shared
+/// package's API for one consumer, this seat carries its own copy — the
+/// same posture the profile takes for canonical bytes, where the point is
+/// that two sides agree on *bytes*, not that they share code.
+enum BackupFormat {
+    static let digestPrefix = "sha256:"
+
+    static func isLowercaseHex(_ value: String) -> Bool {
+        !value.isEmpty && value.allSatisfy { $0.isNumber || ("a"..."f").contains($0) }
+    }
+
+    /// `sha256:<64 lowercase hex>` over `data`, matching
+    /// `ServiceManifestFormat.sha256Digest` so one digest syntax covers
+    /// manifests, terms, and snapshots.
+    static func sha256Digest(of data: Data) -> String {
+        digestPrefix + SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// True for a well-formed digest string. Deliberately strict: an
+    /// operator-supplied digest that merely *looks* plausible must not
+    /// reach a comparison.
+    static func isDigest(_ value: String) -> Bool {
+        guard value.hasPrefix(digestPrefix) else { return false }
+        let hex = String(value.dropFirst(digestPrefix.count))
+        return hex.count == 64 && isLowercaseHex(hex)
+    }
+
+    static func data(fromLowercaseHex hex: String) -> Data? {
+        guard hex.count.isMultiple(of: 2), isLowercaseHex(hex) else { return nil }
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(hex.count / 2)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        return Data(bytes)
+    }
+
+    /// RFC 3339 with no fractional seconds — the same pinned form the
+    /// moderation seat signs over, so a timestamp inside signed bytes
+    /// cannot drift between encoder configurations.
+    static let timestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
+    static func date(fromRFC3339 value: String) -> Date? {
+        timestampFormatter.date(from: value)
+    }
+
+    static func string(fromDate date: Date) -> String {
+        timestampFormatter.string(from: date)
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupFormat.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupFormat.swift
@@ -13,8 +13,14 @@ import Foundation
 enum BackupFormat {
     static let digestPrefix = "sha256:"
 
+    /// ASCII `0-9a-f` only.
+    ///
+    /// `Character.isNumber` is true for Arabic-Indic digits, fullwidth
+    /// digits, and vulgar fractions, so the obvious spelling of this
+    /// accepts a 64-character "digest" made of `٣` — precisely the value
+    /// that merely looks plausible and must never reach a comparison.
     static func isLowercaseHex(_ value: String) -> Bool {
-        !value.isEmpty && value.allSatisfy { $0.isNumber || ("a"..."f").contains($0) }
+        !value.isEmpty && value.allSatisfy { $0.isASCII && $0.isHexDigit && !$0.isUppercase }
     }
 
     /// `sha256:<64 lowercase hex>` over `data`, matching

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupOperatorManifest.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupOperatorManifest.swift
@@ -16,8 +16,12 @@ public struct BackupOperatorManifest: Sendable, Equatable {
     public let backupProfileId: String
     public let implementationProfileId: String
     /// Read-write HTTPS origin. Exactly one is supported today; a manifest
-    /// offering several is not an error, but we bind to the first
-    /// read-write entry and stay bound to it for the whole operation.
+    /// offering several is not an error. We bind to the first read-write
+    /// entry that is *usable* — https, with a host — skipping malformed
+    /// ones rather than failing the manifest, and stay bound to it for
+    /// the whole operation. A manifest whose read-write entries are all
+    /// malformed is `invalidEndpoint`; we never rewrite one into
+    /// something that works.
     public let endpoint: URL
     public let capabilities: Set<String>
     public let maximumSealedSnapshotBytes: Int?
@@ -96,11 +100,17 @@ public struct BackupOperatorManifest: Sendable, Equatable {
     public var requiresEntitlement: Bool { !entitlementIssuers.isEmpty }
 
     /// Where this operator's content-addressed terms live.
+    ///
+    /// Requires a full `sha256:<64 hex>` digest rather than any hex
+    /// string: this builds a URL we then fetch, and a short or
+    /// over-long component would send a request for something that is
+    /// not a terms document at all.
     public func termsURL(digest: String) -> URL? {
-        let hex = digest.hasPrefix(BackupFormat.digestPrefix)
-            ? String(digest.dropFirst(BackupFormat.digestPrefix.count))
-            : digest
-        guard BackupFormat.isLowercaseHex(hex) else { return nil }
+        let prefixed = digest.hasPrefix(BackupFormat.digestPrefix)
+            ? digest
+            : BackupFormat.digestPrefix + digest
+        guard BackupFormat.isDigest(prefixed) else { return nil }
+        let hex = String(prefixed.dropFirst(BackupFormat.digestPrefix.count))
         return endpoint.appending(path: "terms").appending(path: "\(hex).json")
     }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupOperatorManifest.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupOperatorManifest.swift
@@ -1,0 +1,121 @@
+import Foundation
+import OnymFoundation
+
+/// The backup-seat fields of an operator's signed service manifest.
+///
+/// `SignedServiceManifest` already carries and verifies the spine every
+/// seat shares — component id, seat, operator key, offers, validity,
+/// canonical signing bytes. This reads the `storage.backup` fields out of
+/// the same verified `rawBytes` rather than re-fetching or re-deriving
+/// them, so there is exactly one document under exactly one signature.
+///
+/// Spec: `UI-Backup.md` §5.3.
+public struct BackupOperatorManifest: Sendable, Equatable {
+    public let componentId: String
+    public let operatorKey: String
+    public let backupProfileId: String
+    public let implementationProfileId: String
+    /// Read-write HTTPS origin. Exactly one is supported today; a manifest
+    /// offering several is not an error, but we bind to the first
+    /// read-write entry and stay bound to it for the whole operation.
+    public let endpoint: URL
+    public let capabilities: Set<String>
+    public let maximumSealedSnapshotBytes: Int?
+    public let maximumRetainedSnapshots: Int?
+    /// `sha256:<hex>` of the `BackupTerms` this manifest declares.
+    public let declaredTermsDigest: String
+    public let privacyProfile: String?
+    /// Keys whose signature over a `SeatEntitlement` this operator will
+    /// accept. Pinned from here — never from an entitlement response.
+    public let entitlementIssuers: [String]
+    public let offerIds: [String]
+    public let manifestHash: String
+    public let validUntil: Date?
+
+    /// The seat value a backup operator must declare.
+    public static let seat = "storage.backup"
+
+    /// Read the backup fields from an already-verified manifest.
+    ///
+    /// Refusals are deliberately coarse. A manifest that is not a backup
+    /// seat, that names a profile we do not implement, or that is missing
+    /// a field this seat needs, all end the same way: this operator cannot
+    /// be used, and no partially-populated value escapes to be checked
+    /// later against a snapshot.
+    public init(manifest: SignedServiceManifest) throws {
+        guard manifest.seat == Self.seat else { throw BackupError.unsupportedProfile }
+        guard let object = try? JSONSerialization.jsonObject(with: manifest.rawBytes) as? [String: Any] else {
+            throw BackupError.unsupportedProfile
+        }
+        guard
+            let backupProfileId = object["backupProfileId"] as? String,
+            let implementationProfileId = object["implementationProfileId"] as? String,
+            BackupProfile.supports(portableProfileId: backupProfileId),
+            BackupProfile.supports(implementationProfileId: implementationProfileId)
+        else {
+            throw BackupError.unsupportedProfile
+        }
+        guard
+            let declaredTermsDigest = object["declaredTerms"] as? String,
+            BackupFormat.isDigest(declaredTermsDigest)
+        else {
+            throw BackupError.termsUnavailable
+        }
+
+        let endpoints = (object["endpoints"] as? [[String: Any]]) ?? []
+        guard let endpoint = Self.readWriteEndpoint(from: endpoints) else {
+            throw BackupError.invalidEndpoint
+        }
+
+        let capabilities = Set((object["capabilities"] as? [String]) ?? [])
+        guard BackupProfile.requiredOperations.isSubset(of: capabilities) else {
+            throw BackupError.unsupportedProfile
+        }
+
+        let limits = (object["limits"] as? [String: Any]) ?? [:]
+
+        self.componentId = manifest.componentId
+        self.operatorKey = manifest.operatorKey
+        self.backupProfileId = backupProfileId
+        self.implementationProfileId = implementationProfileId
+        self.endpoint = endpoint
+        self.capabilities = capabilities
+        self.maximumSealedSnapshotBytes = limits["maximumSealedSnapshotBytes"] as? Int
+        self.maximumRetainedSnapshots = limits["maximumRetainedSnapshots"] as? Int
+        self.declaredTermsDigest = declaredTermsDigest
+        self.privacyProfile = object["privacyProfile"] as? String
+        self.entitlementIssuers = (object["entitlementIssuers"] as? [String]) ?? []
+        self.offerIds = manifest.offers.map(\.offerId)
+        self.manifestHash = manifest.manifestHash
+        self.validUntil = manifest.validUntil
+    }
+
+    /// An operator with no declared entitlement issuer never charges. That
+    /// is the self-hosting path, and it is the same implementation — not a
+    /// different build (`UI-Backup-Object-HTTP.md` §4.2).
+    public var requiresEntitlement: Bool { !entitlementIssuers.isEmpty }
+
+    /// Where this operator's content-addressed terms live.
+    public func termsURL(digest: String) -> URL? {
+        let hex = digest.hasPrefix(BackupFormat.digestPrefix)
+            ? String(digest.dropFirst(BackupFormat.digestPrefix.count))
+            : digest
+        guard BackupFormat.isLowercaseHex(hex) else { return nil }
+        return endpoint.appending(path: "terms").appending(path: "\(hex).json")
+    }
+
+    private static func readWriteEndpoint(from endpoints: [[String: Any]]) -> URL? {
+        for entry in endpoints where (entry["role"] as? String) == "read-write" {
+            guard
+                let uri = entry["uri"] as? String,
+                let url = URL(string: uri),
+                url.scheme?.lowercased() == "https",
+                let host = url.host(), !host.isEmpty
+            else {
+                continue
+            }
+            return url
+        }
+        return nil
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupOutcome.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupOutcome.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// What an operator did, as far as we can honestly tell.
+///
+/// The distinctions here are the point of the type. `retained` is not a
+/// restorability proof, a durability guarantee, or a statement about any
+/// copy the operator does not control; `erased` is bounded by the receipt's
+/// declared scope; and `unknown` is a real, terminal state that must never
+/// be rendered as success (`UI-Backup.md` §5.7, §14.9).
+public enum BackupOutcomeStatus: String, Sendable, Equatable, Codable, CaseIterable {
+    /// Accepted into the local upload queue. Nothing has left the device.
+    case queuedLocally = "queued_locally"
+    /// The request body was handed to the network. Says nothing about receipt.
+    case submitted
+    /// The operator explicitly accepted the operation.
+    case accepted
+    /// The operator confirmed a matching stored snapshot under pinned terms.
+    case retained
+    /// The same reference was already held for this holder.
+    case alreadyRetained = "already_retained"
+    /// The operator explicitly refused, with a reason.
+    case rejected
+    /// The operator confirmed erasure within its declared scope.
+    case erased
+    /// No meaningful operator response was obtained.
+    case unreachable
+    /// The request may have succeeded; the result is inconclusive.
+    /// Reconciled by reference through `queryOutcome`, never relabelled.
+    case unknown
+
+    /// True only for the states a person may honestly be shown as "your
+    /// backup is on the operator". Deliberately excludes `submitted` and
+    /// `accepted`: neither means the bytes are held.
+    public var isRetention: Bool {
+        self == .retained || self == .alreadyRetained
+    }
+}
+
+/// One operator's answer to one operation.
+///
+/// Every field except `status` is an *observation* — the operator's own
+/// claim, not a verified fact. `retainedUntil` in particular is a
+/// statement, not a promise (`UI-Backup.md` §10.1).
+public struct BackupOutcome: Sendable, Equatable {
+    public let operationId: String
+    public let componentId: String
+    public let status: BackupOutcomeStatus
+    public let snapshotReference: SnapshotReference?
+    /// Profile-specific location hint. Untrusted: never used to drive
+    /// navigation, execution, or a follow-up request to a new origin.
+    public let locator: String?
+    public let retainedUntil: Date?
+    /// The terms digest the operator says it accepted this under. A
+    /// mismatch against what we pinned is `termsChanged`, not a detail.
+    public let termsId: String?
+    public let evidence: Data?
+
+    public init(
+        operationId: String,
+        componentId: String,
+        status: BackupOutcomeStatus,
+        snapshotReference: SnapshotReference? = nil,
+        locator: String? = nil,
+        retainedUntil: Date? = nil,
+        termsId: String? = nil,
+        evidence: Data? = nil
+    ) {
+        self.operationId = operationId
+        self.componentId = componentId
+        self.status = status
+        self.snapshotReference = snapshotReference
+        self.locator = locator
+        self.retainedUntil = retainedUntil
+        self.termsId = termsId
+        self.evidence = evidence
+    }
+}
+
+/// One row of `listSnapshots`.
+public struct RetainedSnapshot: Sendable, Equatable {
+    public let snapshotReference: SnapshotReference
+    public let acceptedTermsId: String
+    public let retainedAt: Date
+    public let retainedUntil: Date?
+    public let supersedes: String?
+    public let status: BackupOutcomeStatus
+
+    public init(
+        snapshotReference: SnapshotReference,
+        acceptedTermsId: String,
+        retainedAt: Date,
+        retainedUntil: Date? = nil,
+        supersedes: String? = nil,
+        status: BackupOutcomeStatus = .retained
+    ) {
+        self.snapshotReference = snapshotReference
+        self.acceptedTermsId = acceptedTermsId
+        self.retainedAt = retainedAt
+        self.retainedUntil = retainedUntil
+        self.supersedes = supersedes
+        self.status = status
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupPort.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupPort.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// The seven operations of `UI-Backup.md` §6, as this client needs them.
+///
+/// The port carries sealed bytes, references, pinned-terms digests, and
+/// typed outcomes — and nothing else. No wire object, no locator format,
+/// no HTTP status, no authorization header crosses it
+/// (`UI-Backup.md` §8.1). An adapter for a different retention technology
+/// implements this same protocol without any caller changing.
+///
+/// What it deliberately cannot do: compose a snapshot, seal or open one,
+/// hold a key, decide what is eligible, or restore an identity.
+public protocol BackupPort: Sendable {
+    /// Verify the operator's manifest, profile, and terms, and report what
+    /// we would be enrolling under. Purely local plus fetches — nothing is
+    /// uploaded, and no consent is implied.
+    func connect() async throws -> BackupConnection
+
+    /// The cheap refusal point. Called before a large upload so a
+    /// `paymentRequired` costs one small request rather than the whole
+    /// snapshot (`UI-Backup-Object-HTTP.md` §9.2).
+    func preflight(_ snapshot: SealedSnapshot) async throws -> BackupPreflight
+
+    /// Upload the sealed bytes and commit them. Idempotent by
+    /// `operationId` and reference: a retry re-sends the same bytes and
+    /// never re-seals.
+    func uploadSnapshot(_ snapshot: SealedSnapshot, grant: BackupUploadGrant) async throws -> BackupOutcome
+
+    /// Everything this holder's access key can enumerate at this operator.
+    func listSnapshots() async throws -> [RetainedSnapshot]
+
+    /// Fetch sealed bytes to `destination`. The caller verifies the full
+    /// reference before treating any byte as restorable; a short or
+    /// mismatching download is `incompleteSnapshot`, never a partial
+    /// restore.
+    func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws
+
+    /// Request erasure and return the operator's signed receipt.
+    /// An acknowledged-but-incomplete erasure is `erasureUnconfirmed`,
+    /// carrying the receipt — it is not success.
+    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt
+
+    /// The portable container for migration to another operator or to the
+    /// person's own storage. Never gated on payment
+    /// (`UI-Backup.md` §14.15).
+    func exportSnapshots(to directory: URL) async throws -> BackupExport
+
+    /// Reconcile an operation whose response was lost. Returns `nil` when
+    /// the operator has no record, which stays `unknown` — it is never
+    /// promoted to `retained` or `erased` (`UI-Backup.md` §7.13).
+    func queryOutcome(operationId: String) async throws -> BackupOutcome?
+}
+
+/// What `connect` established, before anything was uploaded.
+public struct BackupConnection: Sendable, Equatable {
+    public let manifest: BackupOperatorManifest
+    public let profile: BackupImplementationProfile
+    public let terms: BackupTerms
+    /// The digest the caller must pin into every snapshot it uploads under
+    /// this connection.
+    public var acceptedTermsId: String { terms.termsId }
+
+    public init(
+        manifest: BackupOperatorManifest,
+        profile: BackupImplementationProfile,
+        terms: BackupTerms
+    ) {
+        self.manifest = manifest
+        self.profile = profile
+        self.terms = terms
+    }
+}
+
+/// The operator's answer to a preflight.
+public enum BackupPreflight: Sendable, Equatable {
+    /// Proceed; the grant describes how to send the bytes.
+    case granted(BackupUploadGrant)
+    /// This exact reference is already held for this holder. Nothing to do.
+    case alreadyRetained(BackupOutcome)
+}
+
+/// Permission to upload one snapshot, in transfer chunks.
+///
+/// `chunkBytes` is transfer framing only. It has nothing to do with the
+/// sealing chunk size, which is a property of the sealed container and is
+/// invisible to the operator.
+public struct BackupUploadGrant: Sendable, Equatable {
+    public let uploadId: String
+    public let chunkBytes: Int
+    public let chunkCount: Int
+    public let expiresAt: Date
+
+    public init(uploadId: String, chunkBytes: Int, chunkCount: Int, expiresAt: Date) {
+        self.uploadId = uploadId
+        self.chunkBytes = chunkBytes
+        self.chunkCount = chunkCount
+        self.expiresAt = expiresAt
+    }
+}
+
+/// The result of an export: sealed bytes verbatim, plus the evidence that
+/// makes them meaningful somewhere else.
+public struct BackupExport: Sendable, Equatable {
+    public let directory: URL
+    public let snapshots: [ExportedSnapshot]
+    public let receipts: [ErasureReceipt]
+
+    public init(directory: URL, snapshots: [ExportedSnapshot], receipts: [ErasureReceipt]) {
+        self.directory = directory
+        self.snapshots = snapshots
+        self.receipts = receipts
+    }
+
+    public struct ExportedSnapshot: Sendable, Equatable {
+        public let snapshotReference: SnapshotReference
+        public let acceptedTermsId: String
+        public let retainedAt: Date
+        /// The sealed bytes, byte-identical to what was uploaded — so
+        /// migration is an upload of the same bytes under the same
+        /// reference, with no re-sealing.
+        public let sealedBytesURL: URL
+
+        public init(
+            snapshotReference: SnapshotReference,
+            acceptedTermsId: String,
+            retainedAt: Date,
+            sealedBytesURL: URL
+        ) {
+            self.snapshotReference = snapshotReference
+            self.acceptedTermsId = acceptedTermsId
+            self.retainedAt = retainedAt
+            self.sealedBytesURL = sealedBytesURL
+        }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupProfile.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupProfile.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// The profile identifiers this client implements.
+///
+/// A backup operator publishes both a portable `backupProfileId` (what the
+/// operations *mean*) and an `implementationProfileId` (how they are
+/// carried on a wire). We refuse anything we do not recognise rather than
+/// attempting a best-effort mapping: the whole seat is built on the idea
+/// that a snapshot's terms and semantics are checkable, and guessing at an
+/// unknown profile discards exactly that.
+///
+/// Spec: `onym-system/backup/UI-Backup.md` §5.1–5.2 and
+/// `onym-system/backup/UI-Backup-Object-HTTP.md` §1.
+public enum BackupProfile {
+    /// The portable semantics: sealed device archives, holder-keyed,
+    /// restore by possession only.
+    public static let portableProfileId = "onym:backup-profile:sealed-device-archive-v1"
+
+    /// The wire mapping: HTTPS object operations, SHA-256 hex references,
+    /// AES-256-GCM sealing, Ed25519 request-bound proof of possession.
+    public static let implementationProfileId = "onym:backup-implementation:object-http-v1"
+
+    /// Pinned suite identifiers, echoed by the operator's `/profile.json`.
+    /// A mismatch on any of these means the operator is speaking a
+    /// different protocol under the same name.
+    public static let digestSuite = "sha-256/lowercase-hex"
+    public static let sealingSuite = "aes-256-gcm/hkdf-sha256-from-bip39-seed"
+    public static let incrementModel = "whole-snapshot-transfer-chunked-v1"
+    public static let authentication = "holder-scoped-capability/ed25519-request-bound-v1"
+    public static let paymentRefusal = "onym-payment-required-v1"
+
+    /// The operations this profile requires an operator to implement.
+    /// `connect` is client-side (manifest and terms verification), so it
+    /// is not in the wire set.
+    public static let requiredOperations: Set<String> = [
+        "upload", "list", "download", "erase", "export",
+    ]
+
+    public static func supports(portableProfileId id: String) -> Bool {
+        id == portableProfileId
+    }
+
+    public static func supports(implementationProfileId id: String) -> Bool {
+        id == implementationProfileId
+    }
+}
+
+/// An operator's `/profile.json`, checked against what we implement.
+///
+/// Kept as a plain decoded value with no behaviour beyond `review`: it is
+/// untrusted input describing a counterparty's claims, and the only useful
+/// question about it is whether we can proceed.
+public struct BackupImplementationProfile: Sendable, Equatable {
+    public let implementationVersion: Int
+    public let implementationProfileId: String
+    public let backupProfileId: String
+    public let digestSuite: String
+    public let sealingSuite: String
+    public let incrementModel: String
+    public let authentication: [String]
+    public let paymentRefusal: String
+
+    public init(
+        implementationVersion: Int,
+        implementationProfileId: String,
+        backupProfileId: String,
+        digestSuite: String,
+        sealingSuite: String,
+        incrementModel: String,
+        authentication: [String],
+        paymentRefusal: String
+    ) {
+        self.implementationVersion = implementationVersion
+        self.implementationProfileId = implementationProfileId
+        self.backupProfileId = backupProfileId
+        self.digestSuite = digestSuite
+        self.sealingSuite = sealingSuite
+        self.incrementModel = incrementModel
+        self.authentication = authentication
+        self.paymentRefusal = paymentRefusal
+    }
+
+    /// Decode and check in one step. Every failure is
+    /// `.unsupportedProfile`, because from the caller's side they are the
+    /// same event: this operator cannot be used by this build, and the
+    /// remedy is a client that implements the profile — not a retry.
+    public static func review(raw: Data) throws -> BackupImplementationProfile {
+        guard let object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any] else {
+            throw BackupError.unsupportedProfile
+        }
+        guard
+            let implementationVersion = object["implementationVersion"] as? Int,
+            let implementationProfileId = object["implementationProfileId"] as? String,
+            let backupProfileId = object["backupProfileId"] as? String,
+            let digestSuite = object["digestSuite"] as? String,
+            let sealingSuite = object["sealingSuite"] as? String,
+            let incrementModel = object["incrementModel"] as? String,
+            let paymentRefusal = object["paymentRefusal"] as? String
+        else {
+            throw BackupError.unsupportedProfile
+        }
+        let authentication = (object["authentication"] as? [String]) ?? []
+
+        let profile = BackupImplementationProfile(
+            implementationVersion: implementationVersion,
+            implementationProfileId: implementationProfileId,
+            backupProfileId: backupProfileId,
+            digestSuite: digestSuite,
+            sealingSuite: sealingSuite,
+            incrementModel: incrementModel,
+            authentication: authentication,
+            paymentRefusal: paymentRefusal
+        )
+        guard profile.isSupported else { throw BackupError.unsupportedProfile }
+        return profile
+    }
+
+    /// Every pinned value must match. A profile that agrees on the
+    /// identifier but differs on, say, the sealing suite is the more
+    /// dangerous case of the two — it would upload bytes the operator
+    /// believes are shaped differently than they are.
+    public var isSupported: Bool {
+        implementationVersion == 1
+            && BackupProfile.supports(implementationProfileId: implementationProfileId)
+            && BackupProfile.supports(portableProfileId: backupProfileId)
+            && digestSuite == BackupProfile.digestSuite
+            && sealingSuite == BackupProfile.sealingSuite
+            && incrementModel == BackupProfile.incrementModel
+            && paymentRefusal == BackupProfile.paymentRefusal
+            && authentication.contains(BackupProfile.authentication)
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupTerms.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupTerms.swift
@@ -1,0 +1,343 @@
+import Foundation
+
+/// The declared policy this seat exists to make legible: how long a
+/// snapshot is kept, where, under whose law, erased how, exported how, and
+/// what happens when payment stops.
+///
+/// Terms are content-addressed and pinned into every snapshot. They bind
+/// **forward only** (`UI-Backup.md` §10.2): a retained snapshot keeps the
+/// terms it was accepted under, and an operator may publish new terms at
+/// any time but cannot restate the ones a stored snapshot already pins.
+/// `regresses(against:)` is how that stops being a promise and starts
+/// being a check.
+///
+/// `rawBytes` is preserved because the signature is over the operator's
+/// exact bytes; nothing here re-serialises for verification.
+public struct BackupTerms: Sendable, Equatable {
+    public let termsVersion: Int
+    /// `sha256:<hex>` over the canonical bytes with `termsId` and
+    /// `signature` omitted. Computed locally, never taken from the
+    /// document's own claim about itself.
+    public let termsId: String
+    public let operatorKey: String
+
+    public let retention: Retention
+    public let erasure: Erasure
+    public let jurisdictions: [String]
+    public let subProcessors: [SubProcessor]
+    public let lawfulAccess: LawfulAccess
+    public let breachHolderNotice: String
+    public let export: Export
+    /// Declared window during which export keeps working after the
+    /// operator announces shutdown. Optional only because terms written
+    /// before this field existed will lack it; its absence is a gap a
+    /// consent surface should say out loud.
+    public let shutdownNotice: String?
+    public let endOfPayment: EndOfPayment
+    public let metadataRetention: MetadataRetention
+
+    public let rawBytes: Data
+    public let signature: Data?
+
+    public struct Retention: Sendable, Equatable {
+        /// `measurable` or `best-effort`, verbatim.
+        public let retentionClass: String
+        /// An ISO 8601 duration, or `until-erased`.
+        public let maximumRetentionPeriod: String
+        public let snapshotsRetained: String
+        /// `erase` or `notify-then-erase`.
+        public let expiryBehavior: String
+    }
+
+    public struct Erasure: Sendable, Equatable {
+        public let acknowledgementDeadline: String
+        public let completionDeadline: String
+        /// Free text. Compared for *equality*, never interpreted — see
+        /// `regresses(against:)`.
+        public let scope: String
+        /// What erasure provably does not cover. Mandatory and never
+        /// empty; an operator that cannot name this has not understood
+        /// what it is signing.
+        public let excluded: String
+    }
+
+    public struct SubProcessor: Sendable, Equatable, Hashable {
+        public let role: String
+        public let jurisdiction: String
+    }
+
+    public struct LawfulAccess: Sendable, Equatable {
+        public let disclosureWhatIsProduced: String
+        public let notifyHolderWhenPermitted: Bool
+        public let transparencyReporting: String?
+    }
+
+    public struct Export: Sendable, Equatable {
+        public let format: String
+        public let availableWhileUnpaid: Bool
+    }
+
+    public struct EndOfPayment: Sendable, Equatable {
+        public let notice: String
+        public let grace: String
+        /// Operations that keep working during grace. `download`,
+        /// `export`, and `erase` are the conforming minimum.
+        public let duringGrace: [String]
+        public let afterGrace: String
+    }
+
+    public struct MetadataRetention: Sendable, Equatable {
+        public let accessLogs: String
+        public let sizeAndTiming: String
+    }
+}
+
+// MARK: - Decoding
+
+extension BackupTerms {
+    /// Decode an operator's terms document from its exact served bytes.
+    ///
+    /// Every missing or malformed field is `termsUnavailable` rather than
+    /// a partial value: terms are a precondition for enrolment
+    /// (`UI-Backup.md` §13), and half-read terms are worse than none —
+    /// they would be pinned and later compared against.
+    public static func decode(raw: Data, signature: Data? = nil) throws -> BackupTerms {
+        guard let object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any] else {
+            throw BackupError.termsUnavailable
+        }
+        func string(_ container: [String: Any], _ key: String) throws -> String {
+            guard let value = container[key] as? String, !value.isEmpty else {
+                throw BackupError.termsUnavailable
+            }
+            return value
+        }
+        func nested(_ key: String) throws -> [String: Any] {
+            guard let value = object[key] as? [String: Any] else { throw BackupError.termsUnavailable }
+            return value
+        }
+
+        guard let termsVersion = object["termsVersion"] as? Int, termsVersion == 1 else {
+            throw BackupError.termsUnavailable
+        }
+
+        let retentionObject = try nested("retention")
+        let erasureObject = try nested("erasure")
+        let lawfulObject = try nested("lawfulAccess")
+        let breachObject = try nested("breachDisclosure")
+        let exportObject = try nested("export")
+        let paymentObject = try nested("endOfPayment")
+        let metadataObject = try nested("metadataRetention")
+
+        let jurisdictions = (object["jurisdictions"] as? [String]) ?? []
+        guard !jurisdictions.isEmpty else { throw BackupError.termsUnavailable }
+
+        let subProcessors = ((object["subProcessors"] as? [[String: Any]]) ?? []).map {
+            SubProcessor(
+                role: ($0["role"] as? String) ?? "",
+                jurisdiction: ($0["jurisdiction"] as? String) ?? ""
+            )
+        }
+
+        let excluded = try string(erasureObject, "excluded")
+
+        let terms = BackupTerms(
+            termsVersion: termsVersion,
+            termsId: try canonicalTermsId(raw: raw),
+            operatorKey: try string(object, "operator"),
+            retention: Retention(
+                retentionClass: try string(retentionObject, "class"),
+                maximumRetentionPeriod: try string(retentionObject, "maximumRetentionPeriod"),
+                snapshotsRetained: try string(retentionObject, "snapshotsRetained"),
+                expiryBehavior: try string(retentionObject, "expiryBehavior")
+            ),
+            erasure: Erasure(
+                acknowledgementDeadline: try string(erasureObject, "acknowledgementDeadline"),
+                completionDeadline: try string(erasureObject, "completionDeadline"),
+                scope: try string(erasureObject, "scope"),
+                excluded: excluded
+            ),
+            jurisdictions: jurisdictions,
+            subProcessors: subProcessors,
+            lawfulAccess: LawfulAccess(
+                disclosureWhatIsProduced: try string(lawfulObject, "disclosureWhatIsProduced"),
+                notifyHolderWhenPermitted: (lawfulObject["notifyHolderWhenPermitted"] as? Bool) ?? false,
+                transparencyReporting: lawfulObject["transparencyReporting"] as? String
+            ),
+            breachHolderNotice: try string(breachObject, "holderNotice"),
+            export: Export(
+                format: try string(exportObject, "format"),
+                availableWhileUnpaid: (exportObject["availableWhileUnpaid"] as? Bool) ?? false
+            ),
+            shutdownNotice: object["shutdownNotice"] as? String,
+            endOfPayment: EndOfPayment(
+                notice: try string(paymentObject, "notice"),
+                grace: try string(paymentObject, "grace"),
+                duringGrace: (paymentObject["duringGrace"] as? [String]) ?? [],
+                afterGrace: try string(paymentObject, "afterGrace")
+            ),
+            metadataRetention: MetadataRetention(
+                accessLogs: try string(metadataObject, "accessLogs"),
+                sizeAndTiming: try string(metadataObject, "sizeAndTiming")
+            ),
+            rawBytes: raw,
+            signature: signature
+        )
+        return terms
+    }
+
+    /// `sha256:<hex>` over the document with `termsId` and `signature`
+    /// removed **structurally** — never by string editing, which would
+    /// depend on the operator's whitespace.
+    static func canonicalTermsId(raw: Data) throws -> String {
+        guard var object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any] else {
+            throw BackupError.termsUnavailable
+        }
+        object.removeValue(forKey: "termsId")
+        object.removeValue(forKey: "signature")
+        guard let canonical = try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        ) else {
+            throw BackupError.termsUnavailable
+        }
+        return BackupFormat.sha256Digest(of: canonical)
+    }
+}
+
+// MARK: - Forward-only binding
+
+extension BackupTerms {
+    /// The name of the first field on which `self` is **weaker** than
+    /// `pinned`, or `nil` when `self` may be applied to a snapshot that
+    /// pinned `pinned`.
+    ///
+    /// Fails closed everywhere. An unparseable duration counts as a
+    /// regression; free-text scope fields count as a regression on *any*
+    /// change, because nothing here can prove a reworded scope is a
+    /// widening rather than a narrowing. The consequence is that an
+    /// operator improving its own wording must obtain fresh consent, which
+    /// is the correct direction to be wrong in.
+    public func regresses(against pinned: BackupTerms) -> String? {
+        // Retention may not be extended over a snapshot already accepted.
+        if longer(retention.maximumRetentionPeriod, than: pinned.retention.maximumRetentionPeriod) {
+            return "retention.maximumRetentionPeriod"
+        }
+        if retention.expiryBehavior != pinned.retention.expiryBehavior {
+            return "retention.expiryBehavior"
+        }
+        // Erasure may not become slower or narrower.
+        if longer(erasure.acknowledgementDeadline, than: pinned.erasure.acknowledgementDeadline) {
+            return "erasure.acknowledgementDeadline"
+        }
+        if longer(erasure.completionDeadline, than: pinned.erasure.completionDeadline) {
+            return "erasure.completionDeadline"
+        }
+        if erasure.scope != pinned.erasure.scope { return "erasure.scope" }
+        if erasure.excluded != pinned.erasure.excluded { return "erasure.excluded" }
+        // Jurisdictions and sub-processors may be removed, never added.
+        if !Set(jurisdictions).subtracting(pinned.jurisdictions).isEmpty {
+            return "jurisdictions"
+        }
+        if !Set(subProcessors).subtracting(pinned.subProcessors).isEmpty {
+            return "subProcessors"
+        }
+        // Lawful-access practice may not become less protective.
+        if lawfulAccess.disclosureWhatIsProduced != pinned.lawfulAccess.disclosureWhatIsProduced {
+            return "lawfulAccess.disclosureWhatIsProduced"
+        }
+        if pinned.lawfulAccess.notifyHolderWhenPermitted && !lawfulAccess.notifyHolderWhenPermitted {
+            return "lawfulAccess.notifyHolderWhenPermitted"
+        }
+        if longer(breachHolderNotice, than: pinned.breachHolderNotice) {
+            return "breachDisclosure.holderNotice"
+        }
+        // The export path may not be removed or narrowed.
+        if export.format != pinned.export.format { return "export.format" }
+        if pinned.export.availableWhileUnpaid && !export.availableWhileUnpaid {
+            return "export.availableWhileUnpaid"
+        }
+        if shorter(shutdownNotice, than: pinned.shutdownNotice) { return "shutdownNotice" }
+        // Notice and grace may not shrink; grace may not lose an operation.
+        if shorter(endOfPayment.notice, than: pinned.endOfPayment.notice) {
+            return "endOfPayment.notice"
+        }
+        if shorter(endOfPayment.grace, than: pinned.endOfPayment.grace) {
+            return "endOfPayment.grace"
+        }
+        if !Set(pinned.endOfPayment.duringGrace).subtracting(endOfPayment.duringGrace).isEmpty {
+            return "endOfPayment.duringGrace"
+        }
+        if endOfPayment.afterGrace != pinned.endOfPayment.afterGrace {
+            return "endOfPayment.afterGrace"
+        }
+        // Metadata may not be kept longer.
+        if longer(metadataRetention.accessLogs, than: pinned.metadataRetention.accessLogs) {
+            return "metadataRetention.accessLogs"
+        }
+        if longer(metadataRetention.sizeAndTiming, than: pinned.metadataRetention.sizeAndTiming) {
+            return "metadataRetention.sizeAndTiming"
+        }
+        return nil
+    }
+
+    private func longer(_ candidate: String, than pinned: String) -> Bool {
+        if candidate == pinned { return false }
+        // "until-erased" is unbounded: it is longer than everything, and
+        // nothing is longer than it.
+        if candidate == BackupDuration.untilErased { return true }
+        if pinned == BackupDuration.untilErased { return false }
+        guard let a = BackupDuration.seconds(candidate), let b = BackupDuration.seconds(pinned) else {
+            return true  // unparseable: fail closed
+        }
+        return a > b
+    }
+
+    private func shorter(_ candidate: String?, than pinned: String?) -> Bool {
+        guard let pinned else { return false }
+        guard let candidate else { return true }  // a declared window was dropped
+        if candidate == pinned { return false }
+        if pinned == BackupDuration.untilErased { return candidate != BackupDuration.untilErased }
+        if candidate == BackupDuration.untilErased { return false }
+        guard let a = BackupDuration.seconds(candidate), let b = BackupDuration.seconds(pinned) else {
+            return true
+        }
+        return a < b
+    }
+}
+
+/// Minimal ISO 8601 duration reader, for *comparison only*.
+///
+/// Years and months are approximated (365 and 30 days). That is unfit for
+/// calendar arithmetic and perfectly fit for the one question asked here —
+/// is this declared window longer than that one — where the alternative is
+/// refusing to compare `P1M` against `P30D` at all.
+enum BackupDuration {
+    static let untilErased = "until-erased"
+
+    static func seconds(_ value: String) -> TimeInterval? {
+        guard value.hasPrefix("P") else { return nil }
+        var total: TimeInterval = 0
+        var number = ""
+        var inTime = false
+        var sawUnit = false
+        for character in value.dropFirst() {
+            if character == "T" { inTime = true; continue }
+            if character.isNumber { number.append(character); continue }
+            guard let magnitude = Double(number) else { return nil }
+            number = ""
+            sawUnit = true
+            switch (character, inTime) {
+            case ("Y", false): total += magnitude * 365 * 86_400
+            case ("M", false): total += magnitude * 30 * 86_400
+            case ("W", false): total += magnitude * 7 * 86_400
+            case ("D", false): total += magnitude * 86_400
+            case ("H", true): total += magnitude * 3_600
+            case ("M", true): total += magnitude * 60
+            case ("S", true): total += magnitude
+            default: return nil
+            }
+        }
+        guard number.isEmpty, sawUnit else { return nil }
+        return total
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupTerms.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupTerms.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OnymFoundation
 
 /// The declared policy this seat exists to make legible: how long a
 /// snapshot is kept, where, under whose law, erased how, exported how, and
@@ -86,9 +87,21 @@ public struct BackupTerms: Sendable, Equatable {
         public let afterGrace: String
     }
 
+    /// What the operator declares it keeps, and for how long.
+    ///
+    /// Six fields for five record classes: `accessLogs` declares an
+    /// *absence* under this profile — its only conforming value is
+    /// `none` — and the other five name the records the profile's own
+    /// operations require an operator to hold. A declaration that omits
+    /// one is understating, which is the failure the field exists to
+    /// prevent.
     public struct MetadataRetention: Sendable, Equatable {
         public let accessLogs: String
         public let sizeAndTiming: String
+        public let holderIdentifiers: String
+        public let operationOutcomes: String
+        public let erasureReceipts: String
+        public let entitlementRecords: String
     }
 }
 
@@ -131,10 +144,15 @@ extension BackupTerms {
         let jurisdictions = (object["jurisdictions"] as? [String]) ?? []
         guard !jurisdictions.isEmpty else { throw BackupError.termsUnavailable }
 
-        let subProcessors = ((object["subProcessors"] as? [[String: Any]]) ?? []).map {
+        // Fail closed like every other field: a sub-processor whose role
+        // or jurisdiction is missing or not a string is a malformed
+        // disclosure, and coercing it to "" would pin a snapshot against
+        // terms naming a processor in the empty jurisdiction — a
+        // comparison that then passes forever.
+        let subProcessors = try ((object["subProcessors"] as? [[String: Any]]) ?? []).map {
             SubProcessor(
-                role: ($0["role"] as? String) ?? "",
-                jurisdiction: ($0["jurisdiction"] as? String) ?? ""
+                role: try string($0, "role"),
+                jurisdiction: try string($0, "jurisdiction")
             )
         }
 
@@ -177,7 +195,11 @@ extension BackupTerms {
             ),
             metadataRetention: MetadataRetention(
                 accessLogs: try string(metadataObject, "accessLogs"),
-                sizeAndTiming: try string(metadataObject, "sizeAndTiming")
+                sizeAndTiming: try string(metadataObject, "sizeAndTiming"),
+                holderIdentifiers: try string(metadataObject, "holderIdentifiers"),
+                operationOutcomes: try string(metadataObject, "operationOutcomes"),
+                erasureReceipts: try string(metadataObject, "erasureReceipts"),
+                entitlementRecords: try string(metadataObject, "entitlementRecords")
             ),
             rawBytes: raw,
             signature: signature
@@ -186,17 +208,26 @@ extension BackupTerms {
     }
 
     /// `sha256:<hex>` over the document with `termsId` and `signature`
-    /// removed **structurally** — never by string editing, which would
-    /// depend on the operator's whitespace.
+    /// removed, in the canonical form the profile pins.
+    ///
+    /// This must be the *same* canonicalization the operator used, or an
+    /// honest operator's `declaredTermsDigest` will not match what we
+    /// compute and enrolment fails for no reason either side can see. So
+    /// it goes through `ServiceManifestCanonical`, the one serializer in
+    /// this codebase that implements the pinned rules: keys sorted by
+    /// **UTF-8 byte order** (not Foundation's `.sortedKeys`, which is a
+    /// different order and the exact trap the profile's §6.3 warns
+    /// about), floats refused rather than rendered, and one fixed
+    /// escaping set.
+    ///
+    /// Re-serializing with `JSONSerialization` instead would be
+    /// plausible and wrong: a round trip normalizes number formatting
+    /// and escaping in ways that are stable for us and need not match a
+    /// conforming operator computing the digest properly.
     static func canonicalTermsId(raw: Data) throws -> String {
-        guard var object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any] else {
-            throw BackupError.termsUnavailable
-        }
-        object.removeValue(forKey: "termsId")
-        object.removeValue(forKey: "signature")
-        guard let canonical = try? JSONSerialization.data(
-            withJSONObject: object,
-            options: [.sortedKeys, .withoutEscapingSlashes]
+        guard let canonical = try? ServiceManifestCanonical.signingBytes(
+            of: raw,
+            omitting: ["termsId", "signature"]
         ) else {
             throw BackupError.termsUnavailable
         }
@@ -225,6 +256,19 @@ extension BackupTerms {
         if retention.expiryBehavior != pinned.retention.expiryBehavior {
             return "retention.expiryBehavior"
         }
+        // `measurable` -> `best-effort` is a downgrade of what the
+        // operator claims it can be held to, and the class values are a
+        // small vocabulary this layer should not rank: any change is a
+        // regression, same as the free-text fields below.
+        if retention.retentionClass != pinned.retention.retentionClass {
+            return "retention.retentionClass"
+        }
+        // A cut in how many snapshots are kept destroys history the
+        // person is already relying on. Free text ("3", "latest only",
+        // "all"), so any change requires fresh consent.
+        if retention.snapshotsRetained != pinned.retention.snapshotsRetained {
+            return "retention.snapshotsRetained"
+        }
         // Erasure may not become slower or narrower.
         if longer(erasure.acknowledgementDeadline, than: pinned.erasure.acknowledgementDeadline) {
             return "erasure.acknowledgementDeadline"
@@ -248,6 +292,12 @@ extension BackupTerms {
         if pinned.lawfulAccess.notifyHolderWhenPermitted && !lawfulAccess.notifyHolderWhenPermitted {
             return "lawfulAccess.notifyHolderWhenPermitted"
         }
+        // Dropping a declared transparency cadence, or changing it at
+        // all, removes a commitment the person weighed at enrolment.
+        // Optional, so nil-to-nil is fine and anything else is not.
+        if lawfulAccess.transparencyReporting != pinned.lawfulAccess.transparencyReporting {
+            return "lawfulAccess.transparencyReporting"
+        }
         if longer(breachHolderNotice, than: pinned.breachHolderNotice) {
             return "breachDisclosure.holderNotice"
         }
@@ -270,12 +320,18 @@ extension BackupTerms {
         if endOfPayment.afterGrace != pinned.endOfPayment.afterGrace {
             return "endOfPayment.afterGrace"
         }
-        // Metadata may not be kept longer.
-        if longer(metadataRetention.accessLogs, than: pinned.metadataRetention.accessLogs) {
-            return "metadataRetention.accessLogs"
-        }
-        if longer(metadataRetention.sizeAndTiming, than: pinned.metadataRetention.sizeAndTiming) {
-            return "metadataRetention.sizeAndTiming"
+        // Metadata may not be kept longer — every declared class, or the
+        // check only covers the two the schema happened to start with.
+        let metadataAxes: [(String, String, String)] = [
+            ("accessLogs", metadataRetention.accessLogs, pinned.metadataRetention.accessLogs),
+            ("sizeAndTiming", metadataRetention.sizeAndTiming, pinned.metadataRetention.sizeAndTiming),
+            ("holderIdentifiers", metadataRetention.holderIdentifiers, pinned.metadataRetention.holderIdentifiers),
+            ("operationOutcomes", metadataRetention.operationOutcomes, pinned.metadataRetention.operationOutcomes),
+            ("erasureReceipts", metadataRetention.erasureReceipts, pinned.metadataRetention.erasureReceipts),
+            ("entitlementRecords", metadataRetention.entitlementRecords, pinned.metadataRetention.entitlementRecords),
+        ]
+        for (name, candidate, pinnedValue) in metadataAxes where longer(candidate, than: pinnedValue) {
+            return "metadataRetention.\(name)"
         }
         return nil
     }
@@ -313,8 +369,15 @@ extension BackupTerms {
 /// refusing to compare `P1M` against `P30D` at all.
 enum BackupDuration {
     static let untilErased = "until-erased"
+    /// Declared absence. The object-HTTP profile requires `accessLogs:
+    /// "none"`, and a declaration of nothing is a real, comparable
+    /// window of length zero — without this, moving from a 30-day log to
+    /// no log at all would read as an unparseable value and be refused
+    /// as a regression, which is backwards.
+    static let none = "none"
 
     static func seconds(_ value: String) -> TimeInterval? {
+        if value == none { return 0 }
         guard value.hasPrefix("P") else { return nil }
         var total: TimeInterval = 0
         var number = ""

--- a/Packages/OnymBackup/Sources/OnymBackup/ErasureReceipt.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/ErasureReceipt.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// An operator's signed commitment about an erasure, measured against the
+/// terms the erased snapshot pinned.
+///
+/// It is **not** proof of destruction, and a client must never render it
+/// as one (`UI-Backup.md` §10.3). What it is: a statement, attributable and
+/// timestamped, that an operator will be held to.
+///
+/// `excludedScope` is mandatory and non-empty by construction. There is
+/// always something excluded — at minimum the copies held by the other
+/// participants in every conversation the snapshot contained, and any copy
+/// the holder exported. A receipt that names nothing is malformed rather
+/// than generous, so decoding rejects it.
+public struct ErasureReceipt: Sendable, Equatable {
+    public let receiptVersion: Int
+    public let receiptId: String
+    public let operatorKey: String
+    public let scope: String
+    public let acknowledgedAt: Date
+    public let completionCommittedBy: Date
+    public let coveredScope: String
+    public let excludedScope: String
+    /// The terms this erasure was measured against — the *pinned* terms of
+    /// the erased snapshot, not the operator's current ones.
+    public let termsId: String
+    public let rawBytes: Data
+    public let signature: Data?
+
+    public init(
+        receiptId: String,
+        operatorKey: String,
+        scope: String,
+        acknowledgedAt: Date,
+        completionCommittedBy: Date,
+        coveredScope: String,
+        excludedScope: String,
+        termsId: String,
+        rawBytes: Data,
+        signature: Data?
+    ) {
+        self.receiptVersion = 1
+        self.receiptId = receiptId
+        self.operatorKey = operatorKey
+        self.scope = scope
+        self.acknowledgedAt = acknowledgedAt
+        self.completionCommittedBy = completionCommittedBy
+        self.coveredScope = coveredScope
+        self.excludedScope = excludedScope
+        self.termsId = termsId
+        self.rawBytes = rawBytes
+        self.signature = signature
+    }
+
+    /// True while the operator's own committed deadline has not passed.
+    /// A client shows "acknowledged, not proven destroyed" in this window
+    /// rather than "erased".
+    public func isCompletionPending(now: Date = Date()) -> Bool {
+        now < completionCommittedBy
+    }
+
+    public static func decode(raw: Data, signature: Data? = nil) throws -> ErasureReceipt {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any],
+            let version = object["receiptVersion"] as? Int, version == 1,
+            let receiptId = object["receiptId"] as? String, !receiptId.isEmpty,
+            let operatorKey = object["operator"] as? String, !operatorKey.isEmpty,
+            let scope = object["scope"] as? String, !scope.isEmpty,
+            let acknowledgedAtString = object["acknowledgedAt"] as? String,
+            let acknowledgedAt = BackupFormat.date(fromRFC3339: acknowledgedAtString),
+            let committedByString = object["completionCommittedBy"] as? String,
+            let completionCommittedBy = BackupFormat.date(fromRFC3339: committedByString),
+            let coveredScope = object["coveredScope"] as? String, !coveredScope.isEmpty,
+            let termsId = object["termsId"] as? String, BackupFormat.isDigest(termsId)
+        else {
+            throw BackupError.rejected(code: "malformed_receipt", message: nil)
+        }
+        // The one field worth its own guard: an empty excluded scope is a
+        // claim no honest operator can make.
+        guard
+            let excludedScope = object["excludedScope"] as? String,
+            !excludedScope.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw BackupError.rejected(
+                code: "malformed_receipt",
+                message: "excludedScope is mandatory and must not be empty"
+            )
+        }
+        return ErasureReceipt(
+            receiptId: receiptId,
+            operatorKey: operatorKey,
+            scope: scope,
+            acknowledgedAt: acknowledgedAt,
+            completionCommittedBy: completionCommittedBy,
+            coveredScope: coveredScope,
+            excludedScope: excludedScope,
+            termsId: termsId,
+            rawBytes: raw,
+            signature: signature
+        )
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/SealedSnapshot.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/SealedSnapshot.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// One sealed archive, ready to hand to the adapter.
+///
+/// The bytes are referenced by URL rather than held in memory: a snapshot
+/// is routinely hundreds of megabytes, and the payment-refusal loop keeps
+/// the same file on disk across a purchase (`UI-Backup-Object-HTTP.md`
+/// §10.2). Re-sealing to retry would mint a new snapshot salt and
+/// therefore a new digest, defeating both the retry and `already_retained`.
+public struct SealedSnapshot: Sendable, Equatable {
+    public let snapshotVersion: Int
+    /// Stable across every retry of this logical operation. The operator
+    /// reconciles on it when a response is lost.
+    public let operationId: String
+    public let snapshotReference: SnapshotReference
+    /// Location of the sealed bytes on this device, under file protection.
+    public let sealedBytesURL: URL
+    public let sealedAt: Date
+    /// The terms digest in force when the person consented. Pinned into
+    /// the snapshot and checked against the operator's answer.
+    public let acceptedTermsId: String
+    /// The previous snapshot this one replaces, if any. An ordering hint
+    /// for the client's own chain — never an instruction to the operator,
+    /// which must not drop anything on its own initiative.
+    public let supersedes: SnapshotReference?
+
+    public init(
+        operationId: String,
+        snapshotReference: SnapshotReference,
+        sealedBytesURL: URL,
+        sealedAt: Date,
+        acceptedTermsId: String,
+        supersedes: SnapshotReference? = nil
+    ) {
+        self.snapshotVersion = 1
+        self.operationId = operationId
+        self.snapshotReference = snapshotReference
+        self.sealedBytesURL = sealedBytesURL
+        self.sealedAt = sealedAt
+        self.acceptedTermsId = acceptedTermsId
+        self.supersedes = supersedes
+    }
+}
+
+/// What an erasure covers.
+public enum ErasureScope: Sendable, Equatable {
+    case snapshot(SnapshotReference)
+    /// Every snapshot under this holder's access key.
+    case all
+
+    public var wireValue: String {
+        switch self {
+        case .snapshot(let reference): reference.digest
+        case .all: "all"
+        }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/SnapshotReference.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/SnapshotReference.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// The identity of one snapshot: a digest over the exact sealed byte
+/// sequence, plus that sequence's length.
+///
+/// It covers the sealed bytes and nothing else — not the local state
+/// before sealing, not the decoded archive, not a locator, not any
+/// mutable operator metadata. That is what lets the same reference survive
+/// export from one operator and upload to another with no re-sealing
+/// (`UI-Backup-Object-HTTP.md` §12).
+///
+/// `sealedByteSize` is a padding bucket, not a measurement of a person's
+/// history: the archive is padded before sealing (§7 of the profile), so
+/// two very different histories land on the same size.
+public struct SnapshotReference: Sendable, Equatable, Hashable, Codable {
+    public let referenceVersion: Int
+    public let algorithm: String
+    /// `sha256:<64 lowercase hex>`.
+    public let digest: String
+    public let sealedByteSize: Int
+
+    public init(digest: String, sealedByteSize: Int) throws {
+        guard BackupFormat.isDigest(digest) else { throw BackupError.invalidReference }
+        guard sealedByteSize > 0 else { throw BackupError.invalidReference }
+        self.referenceVersion = 1
+        self.algorithm = BackupProfile.digestSuite
+        self.digest = digest
+        self.sealedByteSize = sealedByteSize
+    }
+
+    /// Decoding is where operator-supplied references arrive, so it
+    /// validates rather than trusting the wire. An unparseable or
+    /// wrong-suite reference is `invalidReference`, never a value we go on
+    /// to compare against real bytes.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(Int.self, forKey: .referenceVersion)
+        let algorithm = try container.decode(String.self, forKey: .algorithm)
+        let digest = try container.decode(String.self, forKey: .digest)
+        let sealedByteSize = try container.decode(Int.self, forKey: .sealedByteSize)
+        guard
+            version == 1,
+            algorithm == BackupProfile.digestSuite,
+            BackupFormat.isDigest(digest),
+            sealedByteSize > 0
+        else {
+            throw BackupError.invalidReference
+        }
+        self.referenceVersion = version
+        self.algorithm = algorithm
+        self.digest = digest
+        self.sealedByteSize = sealedByteSize
+    }
+
+    /// The hex body without the `sha256:` prefix — for path components and
+    /// filenames, where the colon is unwelcome.
+    public var digestHex: String {
+        String(digest.dropFirst(BackupFormat.digestPrefix.count))
+    }
+
+    /// First and last four hex characters, for display. Never used for
+    /// comparison: a truncated digest is a label, not an identity.
+    public var shortDigest: String {
+        let hex = digestHex
+        return "\(hex.prefix(4))…\(hex.suffix(4))"
+    }
+}

--- a/Packages/OnymFoundation/Sources/OnymFoundation/ServiceManifest.swift
+++ b/Packages/OnymFoundation/Sources/OnymFoundation/ServiceManifest.swift
@@ -161,6 +161,24 @@ public struct SignedServiceManifest: Sendable, Equatable {
 public enum ServiceManifestCanonical {
     /// The bytes a manifest's embedded Ed25519 signature is made over.
     public static func signingBytes(of raw: Data) throws -> Data {
+        try signingBytes(of: raw, omitting: ["signature"])
+    }
+
+    /// The same canonical form over a document that carries more than
+    /// one self-referential field.
+    ///
+    /// A service manifest omits only `signature`. Other signed documents
+    /// in this system also carry their own content address — a backup
+    /// terms document has both `termsId` and `signature` — and neither
+    /// can be inside the bytes it addresses. The canonical form is
+    /// otherwise identical, and it has to be: two documents signed under
+    /// two different serializers cannot be checked against each other,
+    /// which is the entire property this type exists to provide.
+    ///
+    /// Fields are removed **structurally**, after parsing — never by
+    /// editing the raw text, which would depend on the publisher's
+    /// whitespace.
+    public static func signingBytes(of raw: Data, omitting fields: Set<String>) throws -> Data {
         let parsed: Any
         do {
             parsed = try JSONSerialization.jsonObject(with: raw)
@@ -170,7 +188,9 @@ public enum ServiceManifestCanonical {
         guard var object = parsed as? [String: Any] else {
             throw ServiceManifestError.manifestInvalid(reason: "top level is not a JSON object")
         }
-        object.removeValue(forKey: "signature")
+        for field in fields {
+            object.removeValue(forKey: field)
+        }
         var out = ""
         try serialize(object, at: "", into: &out)
         return Data(out.utf8)

--- a/project.yml
+++ b/project.yml
@@ -32,6 +32,7 @@ packages:
   OnymIdentityUI: {path: Packages/OnymIdentityUI}
   OnymChatsUI: {path: Packages/OnymChatsUI}
   OnymSettings: {path: Packages/OnymSettings}
+  OnymBackup: {path: Packages/OnymBackup}
   OnymModeration: {path: Packages/OnymModeration}
   OnymModerationUI: {path: Packages/OnymModerationUI}
   OnymDiscovery: {path: Packages/OnymDiscovery}
@@ -62,6 +63,7 @@ targets:
       - package: OnymIdentityUI
       - package: OnymChatsUI
       - package: OnymSettings
+      - package: OnymBackup
       - package: OnymModeration
       - package: OnymModerationUI
       - package: OnymDiscovery
@@ -226,6 +228,7 @@ targets:
       - package: OnymIdentityUI
       - package: OnymChatsUI
       - package: OnymSettings
+      - package: OnymBackup
       - package: OnymModeration
       - package: OnymModerationUI
       - package: OnymDiscovery


### PR DESCRIPTION
First of the device-backup stack, and the smallest useful slice: the boundary objects of [`UI-Backup.md`](https://github.com/onymchat/onym-system/blob/main/backup/UI-Backup.md) plus the wire semantics its first implementation profile pins (onymchat/onym-system#37). Nothing here touches the network, the keychain, or a byte of user state, and nothing is reachable from the app yet — the sealing, adapter, and UI PRs that follow need a vocabulary to be written against, and this is it.

### Why this seat exists at all

Shipping the SwiftData stores to a server would leak the social graph: `PersistedGroup.id`, `PersistedMessage.groupID`, `sentAt`, `directionRaw` and `PersistedIntroRequest.id` (a raw Nostr event id) are plaintext columns, so a server holding many users' backups joins on group ID and rebuilds membership. The remedy is one opaque sealed archive rather than column scrubbing — which is what the types in this PR describe.

### The three that carry the weight

**`BackupTerms.regresses(against:)`** turns "terms bind forward only" from a promise into a check. It fails closed on every axis: an unparseable duration counts as a regression, and free-text scope fields count as a regression on *any* change, because nothing here can prove a reworded erasure scope is a widening rather than a narrowing. An operator improving its own wording therefore has to obtain fresh consent — the correct direction to be wrong in.

**`BackupOutcomeStatus`** keeps `submitted`, `accepted`, `retained` and `unknown` as distinct words, and `isRetention` deliberately excludes the first two: neither means the bytes are held. `unknown` is a real terminal state, reconciled by reference rather than promoted to success.

**`BackupError`** passes the operator's own code and message through `.rejected` instead of flattening an unrecognised refusal into a local guess. `exportWithheld` is in the enum so a client can *name* a violation, not because an operator may put us in that state.

`ErasureReceipt.decode` rejects an empty `excludedScope` as malformed — there is always something excluded, at minimum the copies held by everyone else in the conversations a snapshot contained.

### Worth a look in review

- `BackupFormat` duplicates four helpers `OnymFoundation` keeps internal behind `ServiceManifestFormat`. Widening a shared package's API for one consumer seemed worse than thirty lines of hex and digest handling — especially for a seat whose whole discipline is that two sides agree on *bytes* rather than share code. Say if you'd rather promote them.
- `BackupDuration` approximates years and months (365/30 days). Unfit for calendar arithmetic, fit for the one question asked: is this declared window longer than that one. The alternative was refusing to compare `P1M` against `P30D` at all.
- `BackupOperatorManifest` binds to the first `read-write` endpoint and stays bound. Multi-endpoint manifests are not an error but are not exercised.

### Verification

`swift build` clean for the package; `xcodebuild -scheme OnymIOS` **BUILD SUCCEEDED** with it linked into both targets. Tests land in the final PR of the stack, per convention.