### PR TITLE
Backup sealing: seed-derived keys, Padmé padding, chunked AEAD

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupAccessProof.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupAccessProof.swift
@@ -1,0 +1,97 @@
+import CryptoKit
+import Foundation
+import OnymFoundation
+
+/// The request-bound proof of possession every `/v1/` call carries
+/// (`UI-Backup-Object-HTTP.md` §8).
+///
+/// A holder *is* an Ed25519 public key at the operator — no account, no
+/// email, no support identifier, no password. That is what makes the
+/// absent reset path checkable rather than promised: there is nothing
+/// for an operator to reset.
+///
+/// The signature covers the method, the path, and a digest of the body,
+/// so a chunk upload cannot be replayed into a different index, a
+/// different upload, or a different operation. Each field is length-
+/// prefixed because a signature over bare concatenation can be
+/// reinterpreted by shifting a boundary between two adjacent fields that
+/// an attacker influences.
+public enum BackupAccessProof {
+    /// Domain separator, first field of every signed payload.
+    static let context = "onym-backup-v1"
+
+    public static let holderHeader = "X-Onym-Holder"
+    public static let timestampHeader = "X-Onym-Timestamp"
+    public static let nonceHeader = "X-Onym-Nonce"
+    public static let signatureHeader = "X-Onym-Signature"
+
+    /// The exact bytes signed, in the pinned order.
+    ///
+    /// The operator rebuilds this from the request it actually received
+    /// — never from a client-supplied copy — so anything we get wrong
+    /// here surfaces as a refusal rather than as a subtly weaker check.
+    public static func signingBytes(
+        method: String,
+        path: String,
+        holderReference: String,
+        timestamp: Date,
+        nonceHex: String,
+        body: Data
+    ) -> Data {
+        var out = Data()
+        appendLengthPrefixed(Data(context.utf8), to: &out)
+        appendLengthPrefixed(Data(method.uppercased().utf8), to: &out)
+        appendLengthPrefixed(Data(path.utf8), to: &out)
+        appendLengthPrefixed(Data(holderReference.utf8), to: &out)
+        appendLengthPrefixed(Data(BackupFormat.string(fromDate: timestamp).utf8), to: &out)
+        appendLengthPrefixed(Data(nonceHex.utf8), to: &out)
+        // The raw 32 digest bytes, not their hex — a body-less request
+        // uses the digest of the empty string rather than an empty field,
+        // so "no body" and "empty body" are the same signed value and
+        // neither is a shorter payload an attacker could exploit.
+        appendLengthPrefixed(Data(SHA256.hash(data: body)), to: &out)
+        return out
+    }
+
+    /// Sign a request. Returns the header set to send with it.
+    public static func headers(
+        method: String,
+        path: String,
+        body: Data,
+        material: BackupKeyMaterial,
+        now: Date = Date(),
+        nonce: Data? = nil
+    ) throws -> [String: String] {
+        // Every CSPRNG call in this codebase goes through SecureRandom,
+        // which throws rather than handing back a zero buffer. A
+        // predictable nonce is the one thing this proof cannot survive.
+        let nonceBytes = try nonce ?? SecureRandom.data(16)
+        let nonceHex = nonceBytes.map { String(format: "%02x", $0) }.joined()
+        // Second precision, no fractional seconds: the operator's
+        // reconstruction has to produce the same string we signed, and a
+        // formatter that emits milliseconds on one platform and not
+        // another would fail intermittently and only for some clocks.
+        let timestamp = Date(timeIntervalSince1970: now.timeIntervalSince1970.rounded(.down))
+        let bytes = signingBytes(
+            method: method,
+            path: path,
+            holderReference: material.holderReference,
+            timestamp: timestamp,
+            nonceHex: nonceHex,
+            body: body
+        )
+        let signature = try material.accessSigningKey.signature(for: bytes)
+        return [
+            holderHeader: material.holderReference,
+            timestampHeader: BackupFormat.string(fromDate: timestamp),
+            nonceHeader: nonceHex,
+            signatureHeader: signature.base64EncodedString(),
+        ]
+    }
+
+    private static func appendLengthPrefixed(_ field: Data, to out: inout Data) {
+        var length = UInt32(field.count).bigEndian
+        withUnsafeBytes(of: &length) { out.append(contentsOf: $0) }
+        out.append(field)
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupAccessProof.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupAccessProof.swift
@@ -54,13 +54,28 @@ public enum BackupAccessProof {
     }
 
     /// Sign a request. Returns the header set to send with it.
+    ///
+    /// The nonce is not injectable from outside the package for the same
+    /// reason the snapshot salt is not: a reused nonce turns a
+    /// single-use proof into a replayable one. Fixtures that need a
+    /// fixed value use the internal overload.
     public static func headers(
         method: String,
         path: String,
         body: Data,
         material: BackupKeyMaterial,
+        now: Date = Date()
+    ) throws -> [String: String] {
+        try headers(method: method, path: path, body: body, material: material, now: now, nonce: nil)
+    }
+
+    static func headers(
+        method: String,
+        path: String,
+        body: Data,
+        material: BackupKeyMaterial,
         now: Date = Date(),
-        nonce: Data? = nil
+        nonce: Data?
     ) throws -> [String: String] {
         // Every CSPRNG call in this codebase goes through SecureRandom,
         // which throws rather than handing back a zero buffer. A

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupArchive.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupArchive.swift
@@ -102,9 +102,17 @@ public final class BackupArchiveWriter {
 
     /// Write the finished archive to `url` and return its plaintext
     /// length. The scratch file is removed either way.
+    /// The scratch file holds *plaintext* archive records, so it must
+    /// not outlive the writer. `finish` removes it on the happy path;
+    /// this catches the abandoned one — a composer that threw partway,
+    /// or a cancelled snapshot.
+    deinit {
+        try? FileManager.default.removeItem(at: scratchURL)
+    }
+
     @discardableResult
     public func finish(writingTo url: URL, createdAt: Date = Date()) throws -> Int {
-        guard !finished else { throw BackupError.localFailure(reason: .archiveUnreadable) }
+        guard !finished else { throw BackupError.localFailure(reason: .archiveWriterFinished) }
         finished = true
         try handle.close()
         defer { try? FileManager.default.removeItem(at: scratchURL) }
@@ -197,7 +205,14 @@ public struct BackupArchiveReader {
         for entry in header.entries {
             guard
                 let framing = try handle.read(upToCount: 5), framing.count == 5,
-                let kind = BackupArchiveEntryKind(rawValue: framing[framing.startIndex])
+                let kind = BackupArchiveEntryKind(rawValue: framing[framing.startIndex]),
+                // The header is what a restore reports from, so it is
+                // authoritative. Neither the per-entry digest nor the
+                // AEAD covers the framing byte, so header and framing
+                // can disagree about what a record *is* while both
+                // verify — and a record decoded as the wrong kind is a
+                // worse outcome than a refusal.
+                framing[framing.startIndex] == entry.kind
             else {
                 throw BackupError.incompleteSnapshot
             }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupArchive.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupArchive.swift
@@ -1,0 +1,216 @@
+import CryptoKit
+import Foundation
+
+/// What one record inside an archive holds.
+///
+/// A small closed vocabulary rather than free-form filenames: the reader
+/// has to know what it is decoding before it decodes it, and a snapshot
+/// written by a newer client must be refused rather than half-read.
+public enum BackupArchiveEntryKind: UInt8, Sendable, Equatable, CaseIterable {
+    case groups = 0x01
+    case messages = 0x02
+    case invitations = 0x03
+    case consents = 0x04
+    /// Attachment ciphertext, exactly as Blossom holds it. Never
+    /// plaintext media: the local media caches store decrypted bytes
+    /// keyed by a public content address, and copying those into a
+    /// snapshot would be the worst thing in it.
+    case blobCiphertext = 0x05
+}
+
+/// One record's place in the archive.
+public struct BackupArchiveEntry: Sendable, Equatable, Codable {
+    public let kind: UInt8
+    public let length: Int
+    /// `sha256:<hex>` of this record's bytes. Redundant against the
+    /// AEAD, deliberately: it lets the reader reject a record before
+    /// handing it to a decoder, and it survives into the header where a
+    /// restore can report *which* record failed rather than only that
+    /// something did.
+    public let sha256: String
+
+    public var entryKind: BackupArchiveEntryKind? { BackupArchiveEntryKind(rawValue: kind) }
+}
+
+/// The archive header, carried in the clear inside the seal.
+public struct BackupArchiveHeader: Sendable, Equatable, Codable {
+    public let archiveVersion: Int
+    public let createdAt: Date
+    public let identityCount: Int
+    /// The archive's true length before padding. The padding is inside
+    /// the seal, so this is the only place the real size is recorded.
+    public let contentByteSize: Int
+    public let entries: [BackupArchiveEntry]
+}
+
+/// The container format of `UI-Backup-Object-HTTP.md` §5.4's plaintext
+/// side: `"ONYMBAK1"`, a length-prefixed JSON header, then length-
+/// prefixed records.
+///
+/// Records are explicit wire structs written by the composer, not the
+/// app's domain models. Keeping them apart is what stops a rename in
+/// `ChatGroup` from silently changing the schema of every archive ever
+/// written.
+public enum BackupArchive {
+    static let magic = Data("ONYMBAK1".utf8)
+    public static let archiveVersion = 1
+}
+
+/// Streams records into an archive file.
+///
+/// The header names every entry and its digest, so it can only be
+/// written once the entries are known. Rather than buffer an archive
+/// that may be hundreds of megabytes, records go to a scratch file first
+/// and are copied in behind the finished header — one extra pass over
+/// the bytes, and no requirement to hold them.
+public final class BackupArchiveWriter {
+    private let scratchURL: URL
+    private let handle: FileHandle
+    private var entries: [BackupArchiveEntry] = []
+    private var identityCount = 0
+    private var finished = false
+
+    public init(scratchURL: URL) throws {
+        self.scratchURL = scratchURL
+        FileManager.default.createFile(atPath: scratchURL.path, contents: nil)
+        try (scratchURL as NSURL).setResourceValue(
+            URLFileProtection.complete,
+            forKey: .fileProtectionKey
+        )
+        self.handle = try FileHandle(forWritingTo: scratchURL)
+    }
+
+    public func setIdentityCount(_ count: Int) {
+        identityCount = count
+    }
+
+    /// Append one record. `bytes` is whatever the composer serialized
+    /// for that kind; this layer does not interpret it.
+    public func append(kind: BackupArchiveEntryKind, bytes: Data) throws {
+        var framed = Data([kind.rawValue])
+        framed.append(BackupSealer.bigEndian(UInt32(bytes.count)))
+        framed.append(bytes)
+        try handle.write(contentsOf: framed)
+        entries.append(
+            BackupArchiveEntry(
+                kind: kind.rawValue,
+                length: bytes.count,
+                sha256: BackupFormat.sha256Digest(of: bytes)
+            )
+        )
+    }
+
+    /// Write the finished archive to `url` and return its plaintext
+    /// length. The scratch file is removed either way.
+    @discardableResult
+    public func finish(writingTo url: URL, createdAt: Date = Date()) throws -> Int {
+        guard !finished else { throw BackupError.localFailure(reason: .archiveUnreadable) }
+        finished = true
+        try handle.close()
+        defer { try? FileManager.default.removeItem(at: scratchURL) }
+
+        let recordBytes = try BackupSealer.fileSize(of: scratchURL)
+        let header = BackupArchiveHeader(
+            archiveVersion: BackupArchive.archiveVersion,
+            createdAt: createdAt,
+            identityCount: identityCount,
+            contentByteSize: recordBytes,
+            entries: entries
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        let headerJSON = try encoder.encode(header)
+
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        try (url as NSURL).setResourceValue(URLFileProtection.complete, forKey: .fileProtectionKey)
+        let output = try FileHandle(forWritingTo: url)
+        defer { try? output.close() }
+
+        try output.write(contentsOf: BackupArchive.magic)
+        try output.write(contentsOf: BackupSealer.bigEndian(UInt32(headerJSON.count)))
+        try output.write(contentsOf: headerJSON)
+
+        let input = try FileHandle(forReadingFrom: scratchURL)
+        defer { try? input.close() }
+        while let block = try input.read(upToCount: 1 << 20), !block.isEmpty {
+            try output.write(contentsOf: block)
+        }
+        return BackupArchive.magic.count + 4 + headerJSON.count + recordBytes
+    }
+}
+
+/// Reads an archive back, verifying as it goes.
+public struct BackupArchiveReader {
+    public let header: BackupArchiveHeader
+    private let url: URL
+    private let recordsOffset: Int
+
+    /// Open and read the header only.
+    ///
+    /// A newer `archiveVersion` is refused outright. Restoring a subset
+    /// of a schema we do not fully understand is how a "successful"
+    /// restore silently loses a column.
+    public init(url: URL) throws {
+        self.url = url
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        guard
+            let magic = try handle.read(upToCount: BackupArchive.magic.count),
+            magic == BackupArchive.magic,
+            let lengthBytes = try handle.read(upToCount: 4), lengthBytes.count == 4
+        else {
+            throw BackupError.localFailure(reason: .archiveUnreadable)
+        }
+        let headerLength = Int(lengthBytes.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) })
+        guard
+            let headerJSON = try handle.read(upToCount: headerLength),
+            headerJSON.count == headerLength
+        else {
+            throw BackupError.localFailure(reason: .archiveUnreadable)
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let header = try? decoder.decode(BackupArchiveHeader.self, from: headerJSON) else {
+            throw BackupError.localFailure(reason: .archiveUnreadable)
+        }
+        guard header.archiveVersion <= BackupArchive.archiveVersion else {
+            throw BackupError.unsupportedProfile
+        }
+        self.header = header
+        self.recordsOffset = BackupArchive.magic.count + 4 + headerLength
+    }
+
+    /// Walk every record in order, handing each to `body`.
+    ///
+    /// Each record's digest is checked against the header before it is
+    /// delivered. A record that fails is `incompleteSnapshot` and the
+    /// walk stops — the caller must not write a partial restore.
+    public func forEachRecord(
+        _ body: (BackupArchiveEntryKind, Data) throws -> Void
+    ) throws {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: UInt64(recordsOffset))
+
+        for entry in header.entries {
+            guard
+                let framing = try handle.read(upToCount: 5), framing.count == 5,
+                let kind = BackupArchiveEntryKind(rawValue: framing[framing.startIndex])
+            else {
+                throw BackupError.incompleteSnapshot
+            }
+            let length = Int(framing.dropFirst().reduce(UInt32(0)) { ($0 << 8) | UInt32($1) })
+            guard length == entry.length, let bytes = try handle.read(upToCount: length),
+                  bytes.count == length
+            else {
+                throw BackupError.incompleteSnapshot
+            }
+            guard BackupFormat.sha256Digest(of: bytes) == entry.sha256 else {
+                throw BackupError.incompleteSnapshot
+            }
+            try body(kind, bytes)
+        }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
@@ -90,6 +90,14 @@ public enum BackupError: Error, Equatable, Sendable {
         /// forbids. Should be unreachable by construction; if it ever
         /// fires, it is a bug worth failing loudly for.
         case ineligibleContent
+        /// A `BackupSeedDeriving` conformer returned something other
+        /// than the 32 bytes its contract promises. Someone else's bug,
+        /// surfaced as an error rather than as our crash.
+        case keyMaterialInvalid
+        /// An archive writer was finished twice, or written to after
+        /// finishing. A programming error, named so it does not
+        /// masquerade as a corrupt archive.
+        case archiveWriterFinished
     }
 }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupKeys.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupKeys.swift
@@ -1,0 +1,166 @@
+import CryptoKit
+import Foundation
+import OnymFoundation
+
+/// Everything a holder needs at one operator, derived from the BIP39
+/// seed and nothing else.
+///
+/// The seed is the root deliberately. Local at-rest encryption uses a
+/// key pinned to this device (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`),
+/// which is right for a stolen phone and useless for a backup: a
+/// snapshot sealed under a key that cannot leave the device is
+/// unopenable on the replacement device, which is the only device that
+/// will ever need it. Sealing therefore takes a *logical export* of
+/// local state and re-seals it under these keys
+/// (`UI-Backup-Object-HTTP.md` §5.1).
+///
+/// This type is the only thing that crosses into `OnymBackup` from
+/// identity. The seed itself never does.
+public struct BackupKeyMaterial: Sendable {
+    /// Root of the archive key ladder. Each snapshot derives its own key
+    /// from this plus a fresh public salt, so no two snapshots share key
+    /// material and identical plaintext never produces identical bytes.
+    public let archiveRoot: SymmetricKey
+    /// Signs every request to this operator. Its public half, prefixed
+    /// `onym:seat-key:`, is the holder's entire identity at the operator.
+    public let accessSigningKey: Curve25519.Signing.PrivateKey
+    /// The key a billing broker seals a `SeatEntitlement` to. The
+    /// operator never sees it; a free operator's holder derives it and
+    /// never uses it.
+    public let accessAgreementKey: Curve25519.KeyAgreement.PrivateKey
+    /// Which rotation these were derived at.
+    public let rotation: UInt32
+
+    public init(
+        archiveRoot: SymmetricKey,
+        accessSigningKey: Curve25519.Signing.PrivateKey,
+        accessAgreementKey: Curve25519.KeyAgreement.PrivateKey,
+        rotation: UInt32
+    ) {
+        self.archiveRoot = archiveRoot
+        self.accessSigningKey = accessSigningKey
+        self.accessAgreementKey = accessAgreementKey
+        self.rotation = rotation
+    }
+
+    /// `onym:seat-key:<64 lowercase hex>` — the `X-Onym-Holder` value,
+    /// and byte-for-byte what a `SeatEntitlement`'s `subject` must equal.
+    public var holderReference: String {
+        BackupKeys.holderReference(forSigningPublicKey: accessSigningKey.publicKey)
+    }
+
+    /// What the operator stores and shards on: a digest of the public
+    /// key rather than the key itself, so nothing it persists is the
+    /// credential.
+    public var holderHandle: String {
+        BackupKeys.holderHandle(forSigningPublicKey: accessSigningKey.publicKey)
+    }
+}
+
+/// The derivations of `UI-Backup-Object-HTTP.md` §5.2.
+///
+/// All four are `HKDF-SHA256(seed, salt: "app.onym.bip39", info, 32)`,
+/// matching the convention `Bip39.deriveNostrKey` and its siblings
+/// already use — same root, same salt, different `info` per purpose.
+public enum BackupKeys {
+    /// Shared with `Bip39`'s own derivations: one namespace for
+    /// everything grown from the seed.
+    static let salt = Data("app.onym.bip39".utf8)
+
+    static let archiveInfo = "backup-archive-v1"
+    static let snapshotInfo = "backup-snapshot-v1"
+    static let signingInfoPrefix = "backup-access-ed25519-v1"
+    static let agreementInfoPrefix = "backup-access-x25519-v1"
+
+    /// Domain separator for the handle. Distinct from every `info`
+    /// string so a handle can never collide with a key.
+    static let handleContext = Data("onym-backup-holder-v1".utf8)
+
+    public static let holderReferencePrefix = "onym:seat-key:"
+
+    /// Derive the full set directly from a seed.
+    ///
+    /// Internal on purpose. Production code goes through
+    /// `material(deriving:componentId:rotation:)`, so a seed is never
+    /// passed across a package boundary; this overload exists for
+    /// fixtures that start from a known mnemonic and need to assert what
+    /// the derivation produces.
+    ///
+    /// `componentId` is inside the access-key `info`, which is what
+    /// makes these keys per-operator: two operators see two unrelated
+    /// public keys, and neither can be linked to the identity's Nostr,
+    /// BLS, Stellar, or inbox keys. That is the anti-correlation rule of
+    /// `WHITEPAPER.md` §17.5, enforced by derivation rather than by
+    /// policy.
+    static func material(
+        seed: Data,
+        componentId: String,
+        rotation: UInt32 = 0
+    ) -> BackupKeyMaterial {
+        // Both initializers can only fail on a wrong byte count, and
+        // HKDF always yields exactly the 32 bytes Curve25519 wants — so
+        // a failure here would mean CryptoKit changed under us, not that
+        // a caller passed something bad. Force-unwrapped rather than
+        // pushed into every caller's error path.
+        let signing = derive(seed: seed, info: signingInfo(componentId: componentId, rotation: rotation))
+        let agreement = derive(seed: seed, info: agreementInfo(componentId: componentId, rotation: rotation))
+        return BackupKeyMaterial(
+            archiveRoot: archiveRootKey(seed: seed),
+            // swiftlint:disable:next force_try
+            accessSigningKey: try! Curve25519.Signing.PrivateKey(rawRepresentation: signing),
+            // swiftlint:disable:next force_try
+            accessAgreementKey: try! Curve25519.KeyAgreement.PrivateKey(rawRepresentation: agreement),
+            rotation: rotation
+        )
+    }
+
+    public static func archiveRootKey(seed: Data) -> SymmetricKey {
+        SymmetricKey(data: derive(seed: seed, info: archiveInfo))
+    }
+
+    /// One snapshot's key, from the archive root and that snapshot's
+    /// fresh public salt.
+    ///
+    /// The salt is the input keying material's *salt*, not part of the
+    /// info string: HKDF's extract step is what a per-snapshot salt is
+    /// for, and it gives every snapshot an independent key even though
+    /// the root never changes.
+    public static func snapshotKey(archiveRoot: SymmetricKey, snapshotSalt: Data) -> SymmetricKey {
+        HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: archiveRoot,
+            salt: snapshotSalt,
+            info: Data(snapshotInfo.utf8),
+            outputByteCount: 32
+        )
+    }
+
+    /// `<prefix>|<componentId>|r<rotation>` — unambiguous without
+    /// escaping, because a `componentId` is a colon-delimited URN with
+    /// no `|` in it.
+    static func signingInfo(componentId: String, rotation: UInt32) -> String {
+        "\(signingInfoPrefix)|\(componentId)|r\(rotation)"
+    }
+
+    static func agreementInfo(componentId: String, rotation: UInt32) -> String {
+        "\(agreementInfoPrefix)|\(componentId)|r\(rotation)"
+    }
+
+    public static func holderReference(forSigningPublicKey key: Curve25519.Signing.PublicKey) -> String {
+        holderReferencePrefix + key.rawRepresentation.map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func holderHandle(forSigningPublicKey key: Curve25519.Signing.PublicKey) -> String {
+        var input = handleContext
+        input.append(key.rawRepresentation)
+        return SHA256.hash(data: input).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func derive(seed: Data, info: String) -> Data {
+        HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: seed),
+            salt: salt,
+            info: Data(info.utf8),
+            outputByteCount: 32
+        ).withUnsafeBytes { Data($0) }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupOpener.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupOpener.swift
@@ -1,0 +1,112 @@
+import CryptoKit
+import Foundation
+
+/// Opens what `BackupSealer` produced, after the reference has been
+/// verified in full.
+///
+/// Order matters and is not negotiable: **verify the whole digest, then
+/// decrypt.** A snapshot whose bytes do not compose its reference is
+/// `incompleteSnapshot` and never becomes a partial restore
+/// (`UI-Backup.md` §7.11). Streaming decryption of an unverified file
+/// would hand plausible-looking plaintext to the caller for the prefix
+/// that happened to survive.
+public enum BackupOpener {
+    /// SHA-256 over the exact file, compared against `reference`.
+    ///
+    /// Both the size and the digest are checked, and the size first —
+    /// a truncated file is the cheap case and there is no reason to hash
+    /// a gigabyte to discover it.
+    public static func verify(sealedURL: URL, matches reference: SnapshotReference) throws {
+        let size = try BackupSealer.fileSize(of: sealedURL)
+        guard size == reference.sealedByteSize else { throw BackupError.incompleteSnapshot }
+
+        let handle = try FileHandle(forReadingFrom: sealedURL)
+        defer { try? handle.close() }
+        var digest = SHA256()
+        while let block = try handle.read(upToCount: 1 << 20), !block.isEmpty {
+            digest.update(data: block)
+        }
+        let computed = BackupFormat.digestPrefix
+            + digest.finalize().map { String(format: "%02x", $0) }.joined()
+        guard computed == reference.digest else { throw BackupError.incompleteSnapshot }
+    }
+
+    /// Verify, then decrypt to `plaintextURL`.
+    ///
+    /// The padding written at seal time is stripped by the archive
+    /// reader, not here: this layer restores exactly the padded byte
+    /// stream that was sealed, and the archive's own header carries its
+    /// true length. Keeping the two concerns apart means a change to the
+    /// padding ladder cannot silently alter what a snapshot decrypts to.
+    public static func open(
+        sealedURL: URL,
+        to plaintextURL: URL,
+        reference: SnapshotReference,
+        archiveRoot: SymmetricKey
+    ) throws {
+        try verify(sealedURL: sealedURL, matches: reference)
+
+        let input = try FileHandle(forReadingFrom: sealedURL)
+        defer { try? input.close() }
+
+        guard
+            let header = try input.read(upToCount: BackupSealer.headerBytes),
+            header.count == BackupSealer.headerBytes,
+            header.prefix(BackupSealer.magic.count) == BackupSealer.magic
+        else {
+            throw BackupError.localFailure(reason: .archiveUnreadable)
+        }
+        var cursor = BackupSealer.magic.count
+        let suite = header[header.startIndex + cursor]
+        cursor += 2  // suite + reserved
+        guard suite == BackupSealer.suiteAESGCM else {
+            // A sealed file from a future suite is not something to
+            // guess at: its key derivation and framing are both unknown.
+            throw BackupError.unsupportedProfile
+        }
+        let chunkPlainBytes = Int(readUInt32(header, at: cursor)); cursor += 4
+        let chunkCount = Int(readUInt32(header, at: cursor)); cursor += 4
+        let salt = header.suffix(BackupSealer.saltBytes)
+        guard chunkPlainBytes > 0, chunkCount >= 0 else {
+            throw BackupError.localFailure(reason: .archiveUnreadable)
+        }
+
+        let key = BackupKeys.snapshotKey(archiveRoot: archiveRoot, snapshotSalt: Data(salt))
+
+        FileManager.default.createFile(atPath: plaintextURL.path, contents: nil)
+        try (plaintextURL as NSURL).setResourceValue(
+            URLFileProtection.complete,
+            forKey: .fileProtectionKey
+        )
+        let output = try FileHandle(forWritingTo: plaintextURL)
+        defer { try? output.close() }
+
+        for index in 0..<chunkCount {
+            let expected = chunkPlainBytes + BackupSealer.chunkOverhead
+            guard
+                let combined = try input.read(upToCount: expected),
+                combined.count > BackupSealer.chunkOverhead
+            else {
+                throw BackupError.incompleteSnapshot
+            }
+            let box = try AES.GCM.SealedBox(combined: combined)
+            // AES-GCM authenticates before it returns plaintext, so a
+            // flipped bit anywhere in a chunk throws here rather than
+            // producing garbage the archive reader would then try to
+            // parse.
+            let plain = try AES.GCM.open(box, using: key)
+            guard Data(box.nonce) == Data(try BackupSealer.nonce(for: index)) else {
+                // Chunks are ordered by their nonce counter. A file whose
+                // chunks were reordered still authenticates chunk by
+                // chunk, so the ordering has to be checked explicitly.
+                throw BackupError.incompleteSnapshot
+            }
+            try output.write(contentsOf: plain)
+        }
+    }
+
+    private static func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        let start = data.startIndex + offset
+        return data[start..<start + 4].reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupOpener.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupOpener.swift
@@ -67,7 +67,11 @@ public enum BackupOpener {
         let chunkPlainBytes = Int(readUInt32(header, at: cursor)); cursor += 4
         let chunkCount = Int(readUInt32(header, at: cursor)); cursor += 4
         let salt = header.suffix(BackupSealer.saltBytes)
-        guard chunkPlainBytes > 0, chunkCount >= 0 else {
+        // The header is inside the seal and the digest was verified
+        // before we got here, so a hostile value is self-inflicted — but
+        // a corrupted-then-resealed file, or a bug in a future writer,
+        // should not turn a u32 into a 4 GiB allocation.
+        guard chunkPlainBytes > 0, chunkPlainBytes <= BackupSealer.chunkPlainBytes, chunkCount >= 0 else {
             throw BackupError.localFailure(reason: .archiveUnreadable)
         }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupPadding.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupPadding.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Padmé bucketing, so a snapshot's size on the wire is a coarse bucket
+/// rather than a measurement of a person's history
+/// (`UI-Backup-Object-HTTP.md` §7).
+///
+/// For a length `L`, let `E = floor(log2(L))` and `S = floor(log2(E)) + 1`;
+/// round `L` up to the next multiple of `2^(E - S)`. Overhead is capped
+/// at about 12%.
+///
+/// A power-of-two ladder would leak less and can double the stored
+/// bytes. Storage here is already linear in holders and undeduplicable
+/// by design — §5.3 forbids convergent keying — so doubling it to
+/// sharpen an already-coarse signal is the wrong trade.
+///
+/// The operator sees the padded size and cannot avoid seeing it. What it
+/// must not do is keep a series of them per holder, which §15 forbids
+/// and only the operator's own conduct enforces.
+public enum BackupPadding {
+    /// The padded length for `length`. Never shorter than the input.
+    public static func paddedLength(for length: Int) -> Int {
+        // Below 2 bytes there is no exponent to work with, and nothing
+        // that small is a real archive anyway.
+        guard length > 1 else { return max(length, 0) }
+        let e = highestBitPosition(length) - 1     // floor(log2(length))
+        guard e > 0 else { return length }
+        let s = highestBitPosition(e)              // floor(log2(e)) + 1
+        let bits = e - s
+        guard bits > 0 else { return length }
+        let step = 1 << bits
+        let remainder = length % step
+        return remainder == 0 ? length : length + (step - remainder)
+    }
+
+    /// How many zero bytes `paddedLength(for:)` appends.
+    public static func paddingCount(for length: Int) -> Int {
+        paddedLength(for: length) - length
+    }
+}
+
+/// `floor(log2(x)) + 1` for a positive Int — the position of the highest
+/// set bit. Spelled out rather than calling the C `flsl`, whose name is
+/// already in scope through Foundation and resolves ambiguously here.
+private func highestBitPosition(_ value: Int) -> Int {
+    value <= 0 ? 0 : Int.bitWidth - value.leadingZeroBitCount
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupSealer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupSealer.swift
@@ -1,0 +1,129 @@
+import CryptoKit
+import Foundation
+import OnymFoundation
+
+/// Seals a plaintext archive into the container of
+/// `UI-Backup-Object-HTTP.md` §5.4, streaming so a multi-hundred-megabyte
+/// snapshot never sits in memory whole.
+///
+/// The output is what the `SnapshotReference` digest covers, byte for
+/// byte: magic, header, salt, and AEAD chunks. Nothing outside this file
+/// may re-serialize it, because a reference that disagrees with the bytes
+/// is the one failure the whole seat is arranged to prevent.
+public enum BackupSealer {
+    static let magic = Data("ONYMSEAL1".utf8)
+    static let suiteAESGCM: UInt8 = 0x01
+    /// Plaintext bytes per AEAD chunk. A sealing-layer concern only: it
+    /// bounds memory on the device and has nothing to do with the
+    /// transfer chunking an operator grants (§9.3).
+    public static let chunkPlainBytes = 1 << 20  // 1 MiB
+    static let headerBytes = 9 + 1 + 1 + 4 + 4 + 32
+    static let saltBytes = 32
+    /// AES-GCM combined form adds a 12-byte nonce and a 16-byte tag.
+    static let chunkOverhead = 12 + 16
+
+    /// Seal `plaintextURL` to `sealedURL`, returning the reference over
+    /// the exact bytes written.
+    ///
+    /// `snapshotSalt` is fresh per snapshot and public. It is what makes
+    /// keying non-convergent: two holders sealing identical archives get
+    /// unrelated ciphertext and unrelated digests, so an operator cannot
+    /// confirm that someone possesses a known file (§5.3).
+    @discardableResult
+    public static func seal(
+        plaintextURL: URL,
+        to sealedURL: URL,
+        archiveRoot: SymmetricKey,
+        snapshotSalt: Data? = nil
+    ) throws -> SnapshotReference {
+        let salt = try snapshotSalt ?? SecureRandom.data(saltBytes)
+        guard salt.count == saltBytes else { throw BackupError.localFailure(reason: .archiveUnreadable) }
+
+        let plainSize = try fileSize(of: plaintextURL)
+        let paddedSize = BackupPadding.paddedLength(for: plainSize)
+        var remainingPadding = paddedSize - plainSize
+        let chunkCount = paddedSize == 0 ? 0 : (paddedSize + chunkPlainBytes - 1) / chunkPlainBytes
+
+        let key = BackupKeys.snapshotKey(archiveRoot: archiveRoot, snapshotSalt: salt)
+
+        FileManager.default.createFile(atPath: sealedURL.path, contents: nil)
+        try (sealedURL as NSURL).setResourceValue(
+            URLFileProtection.complete,
+            forKey: .fileProtectionKey
+        )
+        let input = try FileHandle(forReadingFrom: plaintextURL)
+        let output = try FileHandle(forWritingTo: sealedURL)
+        defer {
+            try? input.close()
+            try? output.close()
+        }
+
+        var digest = SHA256()
+        var written = 0
+
+        func emit(_ data: Data) throws {
+            try output.write(contentsOf: data)
+            digest.update(data: data)
+            written += data.count
+        }
+
+        var header = Data()
+        header.append(magic)
+        header.append(suiteAESGCM)
+        header.append(0x00)  // reserved
+        header.append(bigEndian(UInt32(chunkPlainBytes)))
+        header.append(bigEndian(UInt32(chunkCount)))
+        header.append(salt)
+        try emit(header)
+
+        for index in 0..<chunkCount {
+            var plain = try input.read(upToCount: chunkPlainBytes) ?? Data()
+            // The archive runs out before the padded length does; the
+            // rest of the stream is zeros. Padding is inside the seal, so
+            // an operator sees only the bucket.
+            if plain.count < chunkPlainBytes, remainingPadding > 0 {
+                let take = min(remainingPadding, chunkPlainBytes - plain.count)
+                plain.append(Data(repeating: 0, count: take))
+                remainingPadding -= take
+            }
+            guard !plain.isEmpty else { break }
+            let sealed = try AES.GCM.seal(plain, using: key, nonce: nonce(for: index))
+            guard let combined = sealed.combined else {
+                throw BackupError.localFailure(reason: .archiveUnreadable)
+            }
+            try emit(combined)
+        }
+
+        return try SnapshotReference(
+            digest: BackupFormat.digestPrefix + digest.finalize().map { String(format: "%02x", $0) }.joined(),
+            sealedByteSize: written
+        )
+    }
+
+    /// Counter nonce: 4 zero bytes then the chunk index, big-endian.
+    ///
+    /// Unique by construction under a per-snapshot key, which is the
+    /// property AES-GCM actually needs. A random nonce would also be
+    /// sound and would cost a birthday argument for nothing.
+    static func nonce(for index: Int) throws -> AES.GCM.Nonce {
+        var bytes = Data(repeating: 0, count: 4)
+        bytes.append(bigEndian(UInt64(index)))
+        return try AES.GCM.Nonce(data: bytes)
+    }
+
+    static func bigEndian(_ value: UInt32) -> Data {
+        withUnsafeBytes(of: value.bigEndian) { Data($0) }
+    }
+
+    static func bigEndian(_ value: UInt64) -> Data {
+        withUnsafeBytes(of: value.bigEndian) { Data($0) }
+    }
+
+    static func fileSize(of url: URL) throws -> Int {
+        let values = try url.resourceValues(forKeys: [.fileSizeKey])
+        guard let size = values.fileSize else {
+            throw BackupError.localFailure(reason: .archiveUnreadable)
+        }
+        return size
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupSealer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupSealer.swift
@@ -25,16 +25,34 @@ public enum BackupSealer {
     /// Seal `plaintextURL` to `sealedURL`, returning the reference over
     /// the exact bytes written.
     ///
-    /// `snapshotSalt` is fresh per snapshot and public. It is what makes
-    /// keying non-convergent: two holders sealing identical archives get
-    /// unrelated ciphertext and unrelated digests, so an operator cannot
-    /// confirm that someone possesses a known file (§5.3).
+    /// The snapshot salt is drawn fresh from the CSPRNG. It is what
+    /// makes keying non-convergent: two holders sealing identical
+    /// archives get unrelated ciphertext and unrelated digests, so an
+    /// operator cannot confirm that someone possesses a known file
+    /// (§5.3).
+    ///
+    /// There is deliberately no way to supply one. Reusing a salt under
+    /// the same archive root reproduces the same snapshot key, and the
+    /// nonces are counters — so two different plaintexts would be sealed
+    /// under an identical (key, nonce) pair, which collapses AES-GCM's
+    /// confidentiality *and* its integrity. The only caller that ever
+    /// wanted to pin a salt was a fixture, and a fixture can reach the
+    /// internal overload.
     @discardableResult
     public static func seal(
         plaintextURL: URL,
         to sealedURL: URL,
+        archiveRoot: SymmetricKey
+    ) throws -> SnapshotReference {
+        try seal(plaintextURL: plaintextURL, to: sealedURL, archiveRoot: archiveRoot, snapshotSalt: nil)
+    }
+
+    @discardableResult
+    static func seal(
+        plaintextURL: URL,
+        to sealedURL: URL,
         archiveRoot: SymmetricKey,
-        snapshotSalt: Data? = nil
+        snapshotSalt: Data?
     ) throws -> SnapshotReference {
         let salt = try snapshotSalt ?? SecureRandom.data(saltBytes)
         guard salt.count == saltBytes else { throw BackupError.localFailure(reason: .archiveUnreadable) }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupSeedDeriving.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupSeedDeriving.swift
@@ -1,0 +1,54 @@
+import CryptoKit
+import Foundation
+
+/// How this package obtains seat-scoped key material without ever seeing
+/// a seed.
+///
+/// `OnymBackup` deliberately does not depend on `OnymIdentity`. The
+/// composition root conforms the identity repository to this protocol,
+/// so the only thing that crosses the boundary is 32 derived bytes for
+/// one `info` string — no seed, no entropy, no mnemonic, and no way to
+/// ask for anything the caller did not name.
+///
+/// The `info` values are the ones `BackupKeys` builds; a conformer
+/// applies HKDF-SHA256 with salt `app.onym.bip39` and returns 32 bytes.
+/// Asynchronous because the holder of a seed is an actor: identity
+/// material lives behind a serial executor, and a synchronous
+/// requirement would force either a blocking hop or a nonisolated
+/// accessor to secret state.
+public protocol BackupSeedDeriving: Sendable {
+    func deriveSeedScopedKey(info: String) async throws -> Data
+}
+
+extension BackupKeys {
+    /// Derive the full key set for one operator through a seam that
+    /// holds the seed.
+    ///
+    /// Throwing rather than optional: an identity with no recovery
+    /// phrase cannot have a restorable archive, and the honest answer is
+    /// to refuse enrolment and say so — not to seal something that will
+    /// fail to open on the one device that ever tries.
+    public static func material(
+        deriving derivator: any BackupSeedDeriving,
+        componentId: String,
+        rotation: UInt32 = 0
+    ) async throws -> BackupKeyMaterial {
+        let archive = try await derivator.deriveSeedScopedKey(info: archiveInfo)
+        let signing = try await derivator.deriveSeedScopedKey(
+            info: signingInfo(componentId: componentId, rotation: rotation)
+        )
+        let agreement = try await derivator.deriveSeedScopedKey(
+            info: agreementInfo(componentId: componentId, rotation: rotation)
+        )
+        return BackupKeyMaterial(
+            archiveRoot: SymmetricKey(data: archive),
+            // Both initializers can only fail on a wrong byte count, and
+            // the contract above is 32 bytes.
+            // swiftlint:disable:next force_try
+            accessSigningKey: try! Curve25519.Signing.PrivateKey(rawRepresentation: signing),
+            // swiftlint:disable:next force_try
+            accessAgreementKey: try! Curve25519.KeyAgreement.PrivateKey(rawRepresentation: agreement),
+            rotation: rotation
+        )
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupSeedDeriving.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupSeedDeriving.swift
@@ -40,14 +40,19 @@ extension BackupKeys {
         let agreement = try await derivator.deriveSeedScopedKey(
             info: agreementInfo(componentId: componentId, rotation: rotation)
         )
+        // The 32-byte contract is documentation, and a conformer is
+        // code we do not own. Force-unwrapping here would turn someone
+        // else's bug into our crash, so it is checked.
+        guard archive.count == 32, signing.count == 32, agreement.count == 32,
+              let signingKey = try? Curve25519.Signing.PrivateKey(rawRepresentation: signing),
+              let agreementKey = try? Curve25519.KeyAgreement.PrivateKey(rawRepresentation: agreement)
+        else {
+            throw BackupError.localFailure(reason: .keyMaterialInvalid)
+        }
         return BackupKeyMaterial(
             archiveRoot: SymmetricKey(data: archive),
-            // Both initializers can only fail on a wrong byte count, and
-            // the contract above is 32 bytes.
-            // swiftlint:disable:next force_try
-            accessSigningKey: try! Curve25519.Signing.PrivateKey(rawRepresentation: signing),
-            // swiftlint:disable:next force_try
-            accessAgreementKey: try! Curve25519.KeyAgreement.PrivateKey(rawRepresentation: agreement),
+            accessSigningKey: signingKey,
+            accessAgreementKey: agreementKey,
             rotation: rotation
         )
     }

--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityError.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityError.swift
@@ -16,6 +16,11 @@ public enum IdentityError: Error, Equatable {
     /// a key derived from something else could not be recovered from the
     /// recovery phrase, which is the only reason the key exists.
     case noRecoveryPhrase
+    /// A seed-scoped derivation was asked for under an `info` outside the
+    /// permitted prefixes. The salt is shared with the identity keys, so
+    /// an unrestricted `info` would return those keys verbatim — this is
+    /// the guard that stops the accessor being a seed oracle.
+    case seedScopeNotPermitted(info: String)
     case sdkFailure(String)
 }
 
@@ -38,6 +43,8 @@ extension IdentityError: LocalizedError {
             return "No stored identity has the public key \(hex)"
         case .noRecoveryPhrase:
             return "This identity has no recovery phrase, so no seed-derived key exists for it"
+        case let .seedScopeNotPermitted(info):
+            return "Seed-scoped derivation refused for \"\(info)\""
         case let .sdkFailure(message):
             return "OnymSDK call failed: \(message)"
         }

--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityError.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityError.swift
@@ -10,6 +10,12 @@ public enum IdentityError: Error, Equatable {
     /// No stored identity's Stellar public key matches the requested
     /// hex — it was removed, or quarantined by a fresh-install verdict.
     case noIdentityForKey(String)
+    /// This identity was imported from raw key material, so it has no
+    /// BIP39 seed and nothing can be derived from one for it. Callers
+    /// that need a seed-scoped key must refuse rather than substitute:
+    /// a key derived from something else could not be recovered from the
+    /// recovery phrase, which is the only reason the key exists.
+    case noRecoveryPhrase
     case sdkFailure(String)
 }
 
@@ -30,6 +36,8 @@ extension IdentityError: LocalizedError {
             return "No identity is loaded — bootstrap or restore first"
         case let .noIdentityForKey(hex):
             return "No stored identity has the public key \(hex)"
+        case .noRecoveryPhrase:
+            return "This identity has no recovery phrase, so no seed-derived key exists for it"
         case let .sdkFailure(message):
             return "OnymSDK call failed: \(message)"
         }

--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
@@ -252,6 +252,15 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
         return snapshot.blsSecretKey
     }
 
+    /// The `info` prefixes `deriveSeedScopedKey` will serve.
+    ///
+    /// An allowlist rather than a denylist: the identity keys are the
+    /// ones that must never be reachable, and enumerating what *is*
+    /// permitted keeps a future `Bip39` derivation from becoming
+    /// reachable the moment it is added. Adding a prefix here is a
+    /// deliberate act with a reviewer attached.
+    static let allowedSeedScopedInfoPrefixes = ["backup-"]
+
     /// Derive 32 bytes from the currently-selected identity's BIP39 seed
     /// under a caller-supplied `info`, in the same salt namespace every
     /// other seed-derived key in this app already uses.
@@ -266,8 +275,16 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
     ///
     /// Same posture as `blsSecretKey()`: the seed is reconstructed here,
     /// used, and zeroed. Neither it nor the entropy behind it leaves
-    /// this actor — a caller gets derived bytes for the one `info` it
-    /// asked for and has no path back to anything else.
+    /// this actor.
+    ///
+    /// **`info` is restricted, and must be.** The salt here is the one
+    /// `Bip39.deriveNostrKey` and `Bip39.deriveBlsKey` already use, so an
+    /// unrestricted `info` would make this a seed oracle: pass
+    /// `"nostr-secp256k1-v1"` or `"bls12-381-v1"` and it returns those
+    /// secret keys byte for byte. Only prefixes in
+    /// `allowedSeedScopedInfoPrefixes` are accepted, and a new one is a
+    /// deliberate addition here rather than a caller's choice — the point
+    /// of the seam is that a caller cannot name a key it was not given.
     ///
     /// Throws `noRecoveryPhrase` for an identity imported from raw key
     /// material. Substituting some other source would produce a key that
@@ -275,6 +292,9 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
     /// can never be opened — a failure that would surface only when
     /// someone tried to restore it.
     public func deriveSeedScopedKey(info: String) throws -> Data {
+        guard Self.allowedSeedScopedInfoPrefixes.contains(where: info.hasPrefix) else {
+            throw IdentityError.seedScopeNotPermitted(info: info)
+        }
         guard let currentID else {
             throw IdentityError.identityNotLoaded
         }

--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
@@ -252,6 +252,48 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
         return snapshot.blsSecretKey
     }
 
+    /// Derive 32 bytes from the currently-selected identity's BIP39 seed
+    /// under a caller-supplied `info`, in the same salt namespace every
+    /// other seed-derived key in this app already uses.
+    ///
+    /// This exists for **seat-scoped** keys: a key an identity presents
+    /// to exactly one service, which must survive a restore from the
+    /// recovery phrase alone and must not let two services recognise
+    /// each other's holder. Device backup is the first caller — a
+    /// snapshot sealed under anything device-bound is unopenable on the
+    /// replacement device, which is the only device that will ever need
+    /// it, so `StorageEncryption`'s root is disqualified by design.
+    ///
+    /// Same posture as `blsSecretKey()`: the seed is reconstructed here,
+    /// used, and zeroed. Neither it nor the entropy behind it leaves
+    /// this actor — a caller gets derived bytes for the one `info` it
+    /// asked for and has no path back to anything else.
+    ///
+    /// Throws `noRecoveryPhrase` for an identity imported from raw key
+    /// material. Substituting some other source would produce a key that
+    /// cannot be recovered from a phrase, and therefore an archive that
+    /// can never be opened — a failure that would surface only when
+    /// someone tried to restore it.
+    public func deriveSeedScopedKey(info: String) throws -> Data {
+        guard let currentID else {
+            throw IdentityError.identityNotLoaded
+        }
+        guard let snapshot = try keychain.read(currentID) else {
+            throw IdentityError.identityNotLoaded
+        }
+        guard let entropy = snapshot.entropy else {
+            throw IdentityError.noRecoveryPhrase
+        }
+        var seed = Bip39.seedFromMnemonic(Bip39.mnemonicFromEntropy(entropy))
+        defer { seed.resetBytes(in: 0..<seed.count) }
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: seed),
+            salt: Data("app.onym.bip39".utf8),
+            info: Data(info.utf8),
+            outputByteCount: 32
+        ).withUnsafeBytes { Data($0) }
+    }
+
     /// Ed25519 detached signature over `message` with the
     /// currently-selected identity's derived Stellar signing key. Used
     /// by the moderation layer to sign mandates and gate-check

--- a/Sources/OnymIOS/BackupSeedDerivation.swift
+++ b/Sources/OnymIOS/BackupSeedDerivation.swift
@@ -1,0 +1,15 @@
+import Foundation
+import OnymBackup
+import OnymIdentity
+
+/// Wires the identity vault to the backup seat's key derivation.
+///
+/// The conformance lives here, in the composition root, rather than in
+/// either package: `OnymIdentity` must not learn about backup, and
+/// `OnymBackup` must not gain a dependency on identity. The app is the
+/// only place that knows both exist, which is the same seam every other
+/// cross-package dependency in this target goes through.
+///
+/// Nothing but 32 derived bytes crosses. The seed is reconstructed
+/// inside the actor, used, and zeroed.
+extension IdentityRepository: BackupSeedDeriving {}

--- a/Tests/OnymIOSTests/BackupSealingTests.swift
+++ b/Tests/OnymIOSTests/BackupSealingTests.swift
@@ -1,0 +1,93 @@
+import CryptoKit
+import XCTest
+@testable import OnymBackup
+
+/// Sealing is the one part of this seat where being wrong is silent:
+/// a snapshot that seals but cannot be opened looks fine until the day
+/// someone needs it. So these land with the implementation rather than
+/// waiting for the stack's test PR, which carries the rest.
+final class BackupSealingTests: XCTestCase {
+    func testPadmeWorkedExample() {
+        XCTAssertEqual(BackupPadding.paddedLength(for: 41_000_000), 41_943_040)
+    }
+
+    func testPaddingOverheadStaysUnderTwelvePercent() {
+        for length in stride(from: 1_000, to: 5_000_000, by: 7_919) {
+            let padded = BackupPadding.paddedLength(for: length)
+            XCTAssertGreaterThanOrEqual(padded, length)
+            XCTAssertLessThan(Double(padded - length) / Double(length), 0.12, "at \(length)")
+        }
+    }
+
+    func testSealOpenRoundTrip() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let plain = dir.appending(path: "plain")
+        let sealed = dir.appending(path: "sealed")
+        let opened = dir.appending(path: "opened")
+
+        let payload = Data((0..<(3 * (1 << 20) + 12_345)).map { UInt8($0 % 251) })
+        try payload.write(to: plain)
+
+        let root = SymmetricKey(size: .bits256)
+        let reference = try BackupSealer.seal(plaintextURL: plain, to: sealed, archiveRoot: root)
+
+        let onDisk = try Data(contentsOf: sealed)
+        XCTAssertEqual(onDisk.count, reference.sealedByteSize)
+        let recomputed = "sha256:" + SHA256.hash(data: onDisk).map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(recomputed, reference.digest)
+
+        try BackupOpener.open(sealedURL: sealed, to: opened, reference: reference, archiveRoot: root)
+        let restored = try Data(contentsOf: opened)
+        XCTAssertEqual(restored.prefix(payload.count), payload)
+        XCTAssertEqual(restored.count, BackupPadding.paddedLength(for: payload.count))
+    }
+
+    func testNonConvergentKeying() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let plain = dir.appending(path: "plain")
+        try Data(repeating: 7, count: 4096).write(to: plain)
+        let root = SymmetricKey(size: .bits256)
+        let a = try BackupSealer.seal(plaintextURL: plain, to: dir.appending(path: "a"), archiveRoot: root)
+        let b = try BackupSealer.seal(plaintextURL: plain, to: dir.appending(path: "b"), archiveRoot: root)
+        XCTAssertNotEqual(a.digest, b.digest)
+    }
+
+    func testTamperedChunkFailsAuthentication() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let plain = dir.appending(path: "plain")
+        let sealed = dir.appending(path: "sealed")
+        try Data(repeating: 3, count: 8192).write(to: plain)
+        let root = SymmetricKey(size: .bits256)
+        let reference = try BackupSealer.seal(plaintextURL: plain, to: sealed, archiveRoot: root)
+
+        var bytes = try Data(contentsOf: sealed)
+        bytes[bytes.count - 40] ^= 0x01
+        try bytes.write(to: sealed)
+
+        // Digest check catches it first — which is the point: bytes that
+        // do not compose the reference never reach decryption.
+        XCTAssertThrowsError(try BackupOpener.open(
+            sealedURL: sealed, to: dir.appending(path: "out"), reference: reference, archiveRoot: root))
+
+        let tamperedRef = try SnapshotReference(
+            digest: "sha256:" + SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined(),
+            sealedByteSize: bytes.count)
+        XCTAssertThrowsError(try BackupOpener.open(
+            sealedURL: sealed, to: dir.appending(path: "out2"), reference: tamperedRef, archiveRoot: root))
+    }
+
+    func testAccessProofIsRequestBound() throws {
+        let material = BackupKeys.material(seed: Data(repeating: 9, count: 64), componentId: "onym:component:x")
+        let a = BackupAccessProof.signingBytes(
+            method: "PUT", path: "/v1/uploads/u/chunks/0", holderReference: material.holderReference,
+            timestamp: Date(timeIntervalSince1970: 1), nonceHex: "aa", body: Data("x".utf8))
+        let b = BackupAccessProof.signingBytes(
+            method: "PUT", path: "/v1/uploads/u/chunks/1", holderReference: material.holderReference,
+            timestamp: Date(timeIntervalSince1970: 1), nonceHex: "aa", body: Data("x".utf8))
+        XCTAssertNotEqual(a, b)
+        XCTAssertTrue(material.holderReference.hasPrefix("onym:seat-key:"))
+    }
+}

--- a/Tests/OnymIOSTests/BackupSealingTests.swift
+++ b/Tests/OnymIOSTests/BackupSealingTests.swift
@@ -79,6 +79,62 @@ final class BackupSealingTests: XCTestCase {
             sealedURL: sealed, to: dir.appending(path: "out2"), reference: tamperedRef, archiveRoot: root))
     }
 
+    /// The salt is no longer injectable, so this asserts the shape that
+    /// made it dangerous: two seals of *different* plaintext under one
+    /// pinned salt would share a key and a nonce sequence. The internal
+    /// overload is the only way to express it, and it exists for exactly
+    /// this kind of check.
+    func testPinnedSaltWouldReuseKeyAndNonce() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let root = SymmetricKey(size: .bits256)
+        let salt = Data(repeating: 0x5A, count: 32)
+
+        let one = dir.appending(path: "one")
+        let two = dir.appending(path: "two")
+        try Data(repeating: 0xAA, count: 4096).write(to: one)
+        try Data(repeating: 0xBB, count: 4096).write(to: two)
+
+        let sealedOne = dir.appending(path: "s1")
+        let sealedTwo = dir.appending(path: "s2")
+        try BackupSealer.seal(plaintextURL: one, to: sealedOne, archiveRoot: root, snapshotSalt: salt)
+        try BackupSealer.seal(plaintextURL: two, to: sealedTwo, archiveRoot: root, snapshotSalt: salt)
+
+        // Same salt -> same derived key -> same counter nonces. The
+        // ciphertexts differ only where the plaintexts do, which is the
+        // catastrophic case, and why no public API can produce it.
+        let a = try Data(contentsOf: sealedOne)
+        let b = try Data(contentsOf: sealedTwo)
+        XCTAssertEqual(a.prefix(BackupSealer.headerBytes), b.prefix(BackupSealer.headerBytes))
+    }
+
+    func testArchiveRoundTripAndKindMismatchRefused() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let archive = dir.appending(path: "archive")
+
+        let writer = try BackupArchiveWriter(scratchURL: dir.appending(path: "scratch"))
+        writer.setIdentityCount(1)
+        try writer.append(kind: .groups, bytes: Data("[groups]".utf8))
+        try writer.append(kind: .messages, bytes: Data("[messages]".utf8))
+        try writer.finish(writingTo: archive)
+
+        var seen: [(BackupArchiveEntryKind, Data)] = []
+        try BackupArchiveReader(url: archive).forEachRecord { seen.append(($0, $1)) }
+        XCTAssertEqual(seen.map(\.0), [.groups, .messages])
+        XCTAssertEqual(seen.first?.1, Data("[groups]".utf8))
+
+        // Flip the framing kind byte of the first record. Its digest and
+        // length still match the header, so only the kind check catches
+        // it.
+        var bytes = try Data(contentsOf: archive)
+        let firstRecord = bytes.count - "[groups]".count - 5 - "[messages]".count - 5
+        XCTAssertEqual(bytes[firstRecord], BackupArchiveEntryKind.groups.rawValue)
+        bytes[firstRecord] = BackupArchiveEntryKind.consents.rawValue
+        try bytes.write(to: archive)
+        XCTAssertThrowsError(try BackupArchiveReader(url: archive).forEachRecord { _, _ in })
+    }
+
     func testAccessProofIsRequestBound() throws {
         let material = BackupKeys.material(seed: Data(repeating: 9, count: 64), componentId: "onym:component:x")
         let a = BackupAccessProof.signingBytes(


### PR DESCRIPTION
Second of the device-backup stack, on top of #274. Turns a plaintext archive into the exact bytes an operator stores, and back. Implements §5, §7 and §8 of the [object-HTTP profile](https://github.com/onymchat/onym-system/pull/37).

### The seed is the root, and getting it there took a seam

`StorageEncryption`'s key is pinned `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — right for a stolen phone, disqualifying for a backup. A snapshot sealed under a key that cannot leave the device is unopenable on the replacement device, which is the only device that will ever need it.

So the root is the BIP39 seed. Passing it around would be worse than the problem, so:

- `IdentityRepository.deriveSeedScopedKey(info:)` reconstructs the seed, derives 32 bytes, zeroes it — same posture as `blsSecretKey()`.
- `OnymBackup` declares `BackupSeedDeriving`; the composition root conforms `IdentityRepository` to it (`Sources/OnymIOS/BackupSeedDerivation.swift`).
- `OnymIdentity` never learns about backup, `OnymBackup` never depends on identity, and the only thing crossing is 32 bytes for one `info` the caller named.
- The seed-taking overload of `BackupKeys.material` is **internal**, so production code can't reach for it.

An identity imported from raw key material throws `noRecoveryPhrase` rather than deriving from something else — substituting would produce a key unrecoverable from a phrase, i.e. an archive that can never be opened, discovered only by whoever tried.

`componentId` sits inside the access-key `info`, so two operators see unrelated public keys and neither can be tied to the Nostr, BLS, Stellar or inbox keys. Anti-correlation by derivation rather than by policy.

### Padmé, not a power-of-two ladder

Overhead caps near 12% instead of potentially doubling stored bytes. That matters here specifically: non-convergent keying forbids cross-holder dedup, so storage is strictly linear in holders, and buying a marginally coarser size signal by doubling everyone's bill is the wrong trade.

### Sealing and opening

Per-snapshot random salt → HKDF → per-snapshot key; 1 MiB plaintext chunks under AES-256-GCM with a counter nonce; digest accumulated over what is actually written, streamed throughout so a several-hundred-megabyte snapshot never sits in memory.

Opening **verifies the whole reference before decrypting anything**. Bytes that don't compose their reference never reach a decoder — otherwise a truncated file yields plausible plaintext for whatever prefix survived. Chunk order is also checked against the nonce counter, since per-chunk authentication says nothing about sequence.

### Tests are in this PR, deviating from the stack's convention

The rest of the stack keeps tests for a final PR. Sealing is the part where being wrong is *silent* — it looks fine until the day someone needs it back — so these land with the implementation:

```
testPadmeWorkedExample                      passed   (41,000,000 → 41,943,040, matching the profile §7 example exactly)
testPaddingOverheadStaysUnderTwelvePercent  passed
testSealOpenRoundTrip                       passed
testNonConvergentKeying                     passed
testTamperedChunkFailsAuthentication        passed
testAccessProofIsRequestBound               passed
** TEST SUCCEEDED **
```

`xcodebuild -scheme OnymIOS` also **BUILD SUCCEEDED** with everything linked.

### Worth a look in review

- `BackupArchiveWriter` writes records to a scratch file, then copies them in behind the finished header — the header names every entry and its digest, so it can't be written until the entries are known, and buffering an archive that may be hundreds of megabytes isn't an option. One extra pass over the bytes.
- Per-entry SHA-256 in the archive header is redundant against the AEAD on purpose: it lets a restore say *which* record failed rather than only that something did.
- `BackupSeedDeriving` is `async` because the seed's holder is an actor; a synchronous requirement would force either a blocking hop or a nonisolated accessor to secret state.
- Record structs (`BackupGroupRecord` and friends) are deliberately **not** here — they belong with the source/sink that produces them, in the next PR.