### PR TITLE
Backup composition and restore, over a source/sink port

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupArchive.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupArchive.swift
@@ -40,6 +40,14 @@ public struct BackupArchiveHeader: Sendable, Equatable, Codable {
     /// The archive's true length before padding. The padding is inside
     /// the seal, so this is the only place the real size is recorded.
     public let contentByteSize: Int
+    /// What this snapshot set out to carry for media.
+    ///
+    /// Recorded because a restore cannot otherwise tell "this archive
+    /// deliberately carries descriptors only" from "this archive should
+    /// have carried blobs and some are missing" — and reporting every
+    /// attachment of a descriptors-only snapshot as unresolved would be
+    /// alarming and wrong.
+    public let mediaPolicy: BackupMediaPolicy
     public let entries: [BackupArchiveEntry]
 }
 
@@ -68,6 +76,7 @@ public final class BackupArchiveWriter {
     private let handle: FileHandle
     private var entries: [BackupArchiveEntry] = []
     private var identityCount = 0
+    private var mediaPolicy: BackupMediaPolicy = .descriptorsOnly
     private var finished = false
 
     public init(scratchURL: URL) throws {
@@ -82,6 +91,10 @@ public final class BackupArchiveWriter {
 
     public func setIdentityCount(_ count: Int) {
         identityCount = count
+    }
+
+    public func setMediaPolicy(_ policy: BackupMediaPolicy) {
+        mediaPolicy = policy
     }
 
     /// Append one record. `bytes` is whatever the composer serialized
@@ -123,6 +136,7 @@ public final class BackupArchiveWriter {
             createdAt: createdAt,
             identityCount: identityCount,
             contentByteSize: recordBytes,
+            mediaPolicy: mediaPolicy,
             entries: entries
         )
         let encoder = JSONEncoder()
@@ -205,7 +219,16 @@ public struct BackupArchiveReader {
         defer { try? handle.close() }
         try handle.seek(toOffset: UInt64(recordsOffset))
 
+        var seenKinds: Set<UInt8> = []
         for entry in header.entries {
+            // Two records of one kind would be decoded in order and the
+            // later would win silently, so an archive that names groups
+            // twice could quietly discard half of them. Nothing writes
+            // that shape, which is exactly why it should be refused
+            // rather than tolerated.
+            guard seenKinds.insert(entry.kind).inserted else {
+                throw BackupError.incompleteSnapshot
+            }
             guard
                 let framing = try handle.read(upToCount: 5), framing.count == 5,
                 let kind = BackupArchiveEntryKind(rawValue: framing[framing.startIndex]),

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupArchive.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupArchive.swift
@@ -72,10 +72,10 @@ public final class BackupArchiveWriter {
 
     public init(scratchURL: URL) throws {
         self.scratchURL = scratchURL
-        FileManager.default.createFile(atPath: scratchURL.path, contents: nil)
-        try (scratchURL as NSURL).setResourceValue(
-            URLFileProtection.complete,
-            forKey: .fileProtectionKey
+        FileManager.default.createFile(
+            atPath: scratchURL.path,
+            contents: nil,
+            attributes: [.protectionKey: FileProtectionType.complete]
         )
         self.handle = try FileHandle(forWritingTo: scratchURL)
     }
@@ -130,8 +130,11 @@ public final class BackupArchiveWriter {
         encoder.dateEncodingStrategy = .iso8601
         let headerJSON = try encoder.encode(header)
 
-        FileManager.default.createFile(atPath: url.path, contents: nil)
-        try (url as NSURL).setResourceValue(URLFileProtection.complete, forKey: .fileProtectionKey)
+        FileManager.default.createFile(
+            atPath: url.path,
+            contents: nil,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
         let output = try FileHandle(forWritingTo: url)
         defer { try? output.close() }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupArchiveRecords.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupArchiveRecords.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+/// The archive's wire schema.
+///
+/// These are **not** the app's domain models, and that separation is
+/// load-bearing: an archive written today must still decode years later
+/// on a device running a client whose `ChatGroup` has been renamed,
+/// split, or re-typed twice over. Conforming the domain models to
+/// `Codable` would tie the on-disk schema to whatever refactor lands
+/// next; an explicit mirror makes a schema change a deliberate act with
+/// a version bump attached.
+///
+/// Everything here is plaintext *inside the seal*. It carries group
+/// secrets and per-blob content keys, because that is what makes a
+/// restore a restore rather than a transcript — the rule is that none of
+/// it is ever legible to an operator, not that it is absent
+/// (`UI-Backup.md` §14.1).
+
+/// One chat group.
+public struct BackupGroupRecord: Sendable, Equatable, Codable {
+    public let id: String
+    public let ownerIdentityID: String
+    public let name: String
+    public let groupSecret: Data
+    public let createdAt: Date
+    public let membersJSON: Data
+    public let memberProfilesJSON: Data
+    public let epoch: UInt64
+    public let salt: Data
+    public let commitment: Data?
+    public let tierRaw: Int
+    public let groupTypeRaw: String
+    public let adminPubkeyHex: String?
+    public let adminEd25519PubkeyHex: String?
+    public let isPublishedOnChain: Bool
+    public let avatarJPEG: Data?
+    public let lastReadAt: Date?
+    public let invitationMessage: String?
+
+    public init(
+        id: String,
+        ownerIdentityID: String,
+        name: String,
+        groupSecret: Data,
+        createdAt: Date,
+        membersJSON: Data,
+        memberProfilesJSON: Data,
+        epoch: UInt64,
+        salt: Data,
+        commitment: Data?,
+        tierRaw: Int,
+        groupTypeRaw: String,
+        adminPubkeyHex: String?,
+        adminEd25519PubkeyHex: String?,
+        isPublishedOnChain: Bool,
+        avatarJPEG: Data?,
+        lastReadAt: Date?,
+        invitationMessage: String?
+    ) {
+        self.id = id
+        self.ownerIdentityID = ownerIdentityID
+        self.name = name
+        self.groupSecret = groupSecret
+        self.createdAt = createdAt
+        self.membersJSON = membersJSON
+        self.memberProfilesJSON = memberProfilesJSON
+        self.epoch = epoch
+        self.salt = salt
+        self.commitment = commitment
+        self.tierRaw = tierRaw
+        self.groupTypeRaw = groupTypeRaw
+        self.adminPubkeyHex = adminPubkeyHex
+        self.adminEd25519PubkeyHex = adminEd25519PubkeyHex
+        self.isPublishedOnChain = isPublishedOnChain
+        self.avatarJPEG = avatarJPEG
+        self.lastReadAt = lastReadAt
+        self.invitationMessage = invitationMessage
+    }
+}
+
+/// One chat message.
+///
+/// Attachment descriptors ride as re-encoded JSON rather than typed
+/// fields: their shapes belong to the chat layer and change with it, and
+/// this schema should not have to move every time a new media kind
+/// lands. Each descriptor carries its own content key, which is why a
+/// snapshot restores media rather than just referring to it.
+public struct BackupMessageRecord: Sendable, Equatable, Codable {
+    public let id: String
+    public let groupID: String
+    public let ownerIdentityID: String
+    public let senderBlsPubkeyHex: String
+    public let body: String
+    public let sentAt: Date
+    public let directionRaw: String
+    public let statusRaw: String
+    public let groupTypeRaw: String
+    public let replyToMessageID: String?
+    public let failureReasonRaw: String?
+    public let moderationAuthenticityProof: String?
+    public let imageAttachmentJSON: Data?
+    public let videoAttachmentJSON: Data?
+    public let albumAttachmentsJSON: Data?
+    public let voiceAttachmentJSON: Data?
+    public let systemEventJSON: Data?
+
+    public init(
+        id: String,
+        groupID: String,
+        ownerIdentityID: String,
+        senderBlsPubkeyHex: String,
+        body: String,
+        sentAt: Date,
+        directionRaw: String,
+        statusRaw: String,
+        groupTypeRaw: String,
+        replyToMessageID: String?,
+        failureReasonRaw: String?,
+        moderationAuthenticityProof: String?,
+        imageAttachmentJSON: Data?,
+        videoAttachmentJSON: Data?,
+        albumAttachmentsJSON: Data?,
+        voiceAttachmentJSON: Data?,
+        systemEventJSON: Data?
+    ) {
+        self.id = id
+        self.groupID = groupID
+        self.ownerIdentityID = ownerIdentityID
+        self.senderBlsPubkeyHex = senderBlsPubkeyHex
+        self.body = body
+        self.sentAt = sentAt
+        self.directionRaw = directionRaw
+        self.statusRaw = statusRaw
+        self.groupTypeRaw = groupTypeRaw
+        self.replyToMessageID = replyToMessageID
+        self.failureReasonRaw = failureReasonRaw
+        self.moderationAuthenticityProof = moderationAuthenticityProof
+        self.imageAttachmentJSON = imageAttachmentJSON
+        self.videoAttachmentJSON = videoAttachmentJSON
+        self.albumAttachmentsJSON = albumAttachmentsJSON
+        self.voiceAttachmentJSON = voiceAttachmentJSON
+        self.systemEventJSON = systemEventJSON
+    }
+}
+
+/// A received invitation, still sealed to the recipient's inbox key.
+public struct BackupInvitationRecord: Sendable, Equatable, Codable {
+    public let id: String
+    public let ownerIdentityID: String
+    public let payload: Data
+    public let receivedAt: Date
+    public let statusRaw: String
+
+    public init(id: String, ownerIdentityID: String, payload: Data, receivedAt: Date, statusRaw: String) {
+        self.id = id
+        self.ownerIdentityID = ownerIdentityID
+        self.payload = payload
+        self.receivedAt = receivedAt
+        self.statusRaw = statusRaw
+    }
+}
+
+/// A pinned service consent.
+///
+/// Included because a device restored without them is stranded: it has
+/// history but no record of which operators the person chose, and the
+/// first action would re-ask consents already given.
+public struct BackupConsentRecord: Sendable, Equatable, Codable {
+    public let componentId: String
+    public let raw: Data
+
+    public init(componentId: String, raw: Data) {
+        self.componentId = componentId
+        self.raw = raw
+    }
+}
+
+/// One attachment blob, exactly as the blob store holds it.
+///
+/// **Ciphertext, never plaintext.** The device's media caches hold
+/// decrypted bytes under filenames that are public content addresses;
+/// copying those into a snapshot would put plaintext media in an
+/// operator's hands keyed by an identifier anyone can look up. The bytes
+/// here are what Blossom serves, and they are verified against the
+/// descriptor's address before they go in.
+public struct BackupBlobRecord: Sendable, Equatable, Codable {
+    /// Lowercase hex SHA-256 of these exact bytes — the content address
+    /// the attachment descriptor points at.
+    public let sha256: String
+    public let ciphertext: Data
+
+    public init(sha256: String, ciphertext: Data) {
+        self.sha256 = sha256
+        self.ciphertext = ciphertext
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
@@ -60,6 +60,7 @@ public actor BackupComposer {
 
         let writer = try BackupArchiveWriter(scratchURL: scratchURL)
         writer.setIdentityCount(await source.identityCount())
+        writer.setMediaPolicy(mediaPolicy)
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
@@ -90,11 +91,21 @@ public actor BackupComposer {
         try writer.finish(writingTo: plaintextURL, createdAt: now)
 
         let sealedURL = workingDirectory.appending(path: "pending-\(operationId)")
-        let reference = try BackupSealer.seal(
-            plaintextURL: plaintextURL,
-            to: sealedURL,
-            archiveRoot: keyMaterial.archiveRoot
-        )
+        let reference: SnapshotReference
+        do {
+            reference = try BackupSealer.seal(
+                plaintextURL: plaintextURL,
+                to: sealedURL,
+                archiveRoot: keyMaterial.archiveRoot
+            )
+        } catch {
+            // A half-written seal is ciphertext, so it is not a
+            // disclosure — but it is a file nobody will ever claim, and
+            // repeated failures would accumulate them under a directory
+            // the person never sees.
+            try? FileManager.default.removeItem(at: sealedURL)
+            throw error
+        }
         return SealedSnapshot(
             operationId: operationId,
             snapshotReference: reference,
@@ -131,11 +142,15 @@ public actor BackupComposer {
 
         var blobs: [BackupBlobRecord] = []
         for address in addresses.sorted() {
-            // A blob the store no longer serves is not a failure: blob
-            // retention is its own contract, shorter than a backup's by
-            // design. The descriptor still travels, and the restore says
-            // what it could not resolve.
-            guard let ciphertext = try await source.blobCiphertext(sha256: address) else { continue }
+            // `.gone` is expected and skipped: blob retention is its
+            // own contract, shorter than a backup's by design. A
+            // transport failure is *not* folded in here — the source
+            // throws for that, so a flaky network fails the snapshot and
+            // it is retried, rather than silently producing one with
+            // half the media in it.
+            guard case .available(let ciphertext) = try await source.blobCiphertext(sha256: address) else {
+                continue
+            }
             let actual = SHA256.hash(data: ciphertext).map { String(format: "%02x", $0) }.joined()
             guard actual == address else { continue }
             blobs.append(BackupBlobRecord(sha256: address, ciphertext: ciphertext))

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
@@ -1,0 +1,173 @@
+import CryptoKit
+import Foundation
+import OnymFoundation
+
+/// Builds one sealed snapshot from local state.
+///
+/// The order is fixed and the reason is the whole seat: read through the
+/// source, write an archive, pad it, seal it under a seed-derived key,
+/// and address it by a digest over the sealed bytes. Nothing before the
+/// seal ever leaves the device, and nothing after it is legible to
+/// anyone who does not hold the recovery phrase.
+///
+/// Whole-snapshot only. The profile names verifiable incrementals as
+/// unsolved design work and this does not pretend otherwise: a large
+/// history re-uploads in full, which is a real cost the consent surface
+/// has to state rather than let someone discover on their data plan.
+public actor BackupComposer {
+    private let source: any BackupSourceProviding
+    private let mediaPolicy: BackupMediaPolicy
+    private let workingDirectory: URL
+
+    public init(
+        source: any BackupSourceProviding,
+        mediaPolicy: BackupMediaPolicy,
+        workingDirectory: URL
+    ) {
+        self.source = source
+        self.mediaPolicy = mediaPolicy
+        self.workingDirectory = workingDirectory
+    }
+
+    /// Compose, seal, and return the snapshot ready for the adapter.
+    ///
+    /// `acceptedTermsId` is pinned into the result, not looked up later:
+    /// what the person consented to is a property of this snapshot, and
+    /// re-reading current terms at upload time would silently re-point
+    /// it at terms nobody agreed to.
+    public func compose(
+        keyMaterial: BackupKeyMaterial,
+        acceptedTermsId: String,
+        supersedes: SnapshotReference? = nil,
+        now: Date = Date()
+    ) async throws -> SealedSnapshot {
+        try FileManager.default.createDirectory(
+            at: workingDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        let operationId = try SecureRandom.data(16).map { String(format: "%02x", $0) }.joined()
+        let plaintextURL = workingDirectory.appending(path: "archive-\(operationId)")
+        let scratchURL = workingDirectory.appending(path: "scratch-\(operationId)")
+
+        // The plaintext archive is the one artefact on disk that is
+        // readable without the seed, so it is removed the moment the
+        // seal exists — including on the throwing path.
+        defer {
+            try? FileManager.default.removeItem(at: plaintextURL)
+            try? FileManager.default.removeItem(at: scratchURL)
+        }
+
+        let writer = try BackupArchiveWriter(scratchURL: scratchURL)
+        writer.setIdentityCount(await source.identityCount())
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+
+        let groups = try await source.groups()
+        try writer.append(kind: .groups, bytes: try encoder.encode(groups))
+
+        var messages: [BackupMessageRecord] = []
+        for group in groups {
+            messages += try await source.messages(
+                groupID: group.id,
+                ownerIdentityID: group.ownerIdentityID
+            )
+        }
+        try writer.append(kind: .messages, bytes: try encoder.encode(messages))
+
+        try writer.append(kind: .invitations, bytes: try encoder.encode(try await source.invitations()))
+        try writer.append(kind: .consents, bytes: try encoder.encode(try await source.consents()))
+
+        if mediaPolicy == .includeCiphertext {
+            let blobs = try await collectBlobs(from: messages)
+            if !blobs.isEmpty {
+                try writer.append(kind: .blobCiphertext, bytes: try encoder.encode(blobs))
+            }
+        }
+
+        try writer.finish(writingTo: plaintextURL, createdAt: now)
+
+        let sealedURL = workingDirectory.appending(path: "pending-\(operationId)")
+        let reference = try BackupSealer.seal(
+            plaintextURL: plaintextURL,
+            to: sealedURL,
+            archiveRoot: keyMaterial.archiveRoot
+        )
+        return SealedSnapshot(
+            operationId: operationId,
+            snapshotReference: reference,
+            sealedBytesURL: sealedURL,
+            sealedAt: now,
+            acceptedTermsId: acceptedTermsId,
+            supersedes: supersedes
+        )
+    }
+
+    /// Fetch the ciphertext behind every attachment the messages
+    /// reference.
+    ///
+    /// Two rules, both non-negotiable. The bytes come from the blob
+    /// store, never from the device's media caches — those hold
+    /// *decrypted* media under filenames that are public content
+    /// addresses, and putting them in a snapshot would hand an operator
+    /// plaintext keyed by an identifier anyone can look up. And every
+    /// blob is verified against the address it claims before it is
+    /// included, because a snapshot is the last place to discover that a
+    /// blob store served something else.
+    private func collectBlobs(from messages: [BackupMessageRecord]) async throws -> [BackupBlobRecord] {
+        var addresses: Set<String> = []
+        for message in messages {
+            for json in [
+                message.imageAttachmentJSON,
+                message.videoAttachmentJSON,
+                message.albumAttachmentsJSON,
+                message.voiceAttachmentJSON,
+            ].compactMap({ $0 }) {
+                addresses.formUnion(BackupComposer.contentAddresses(inAttachmentJSON: json))
+            }
+        }
+
+        var blobs: [BackupBlobRecord] = []
+        for address in addresses.sorted() {
+            // A blob the store no longer serves is not a failure: blob
+            // retention is its own contract, shorter than a backup's by
+            // design. The descriptor still travels, and the restore says
+            // what it could not resolve.
+            guard let ciphertext = try await source.blobCiphertext(sha256: address) else { continue }
+            let actual = SHA256.hash(data: ciphertext).map { String(format: "%02x", $0) }.joined()
+            guard actual == address else { continue }
+            blobs.append(BackupBlobRecord(sha256: address, ciphertext: ciphertext))
+        }
+        return blobs
+    }
+
+    /// Pull `sha256` values out of an attachment descriptor without
+    /// decoding it into a typed shape.
+    ///
+    /// Deliberately structural rather than typed: the descriptor schemas
+    /// belong to the chat layer and gain fields with every new media
+    /// kind, and this package should not need a release to keep finding
+    /// their addresses.
+    static func contentAddresses(inAttachmentJSON json: Data) -> [String] {
+        guard let any = try? JSONSerialization.jsonObject(with: json) else { return [] }
+        var found: [String] = []
+        func walk(_ value: Any) {
+            if let object = value as? [String: Any] {
+                for (key, child) in object {
+                    if key == "sha256", let hex = child as? String, BackupFormat.isLowercaseHex(hex),
+                       hex.count == 64 {
+                        found.append(hex)
+                    } else {
+                        walk(child)
+                    }
+                }
+            } else if let array = value as? [Any] {
+                array.forEach(walk)
+            }
+        }
+        walk(any)
+        return found
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupOpener.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupOpener.swift
@@ -77,10 +77,10 @@ public enum BackupOpener {
 
         let key = BackupKeys.snapshotKey(archiveRoot: archiveRoot, snapshotSalt: Data(salt))
 
-        FileManager.default.createFile(atPath: plaintextURL.path, contents: nil)
-        try (plaintextURL as NSURL).setResourceValue(
-            URLFileProtection.complete,
-            forKey: .fileProtectionKey
+        FileManager.default.createFile(
+            atPath: plaintextURL.path,
+            contents: nil,
+            attributes: [.protectionKey: FileProtectionType.complete]
         )
         let output = try FileHandle(forWritingTo: plaintextURL)
         defer { try? output.close() }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRestorer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRestorer.swift
@@ -1,0 +1,132 @@
+import CryptoKit
+import Foundation
+
+/// Turns a downloaded snapshot back into local state.
+///
+/// Three gates, in this order, and none of them may move:
+///
+/// 1. **Verify the whole reference.** Bytes that do not compose their
+///    digest never reach a decoder.
+/// 2. **Decode the entire archive.** Every record is parsed and its
+///    per-entry digest checked before anything is written.
+/// 3. **Only then write.**
+///
+/// The cost of that ordering is holding a decoded archive in memory; the
+/// alternative is a half-restored device, which `UI-Backup.md` §7.11
+/// forbids and which is worse in every way a person would notice — a
+/// chat list with some groups and none of their messages looks like data
+/// loss, because it is.
+public actor BackupRestorer {
+    private let sink: any BackupSinkProviding
+
+    public init(sink: any BackupSinkProviding) {
+        self.sink = sink
+    }
+
+    public func restore(
+        sealedURL: URL,
+        reference: SnapshotReference,
+        keyMaterial: BackupKeyMaterial,
+        workingDirectory: URL
+    ) async throws -> BackupRestoreSummary {
+        try FileManager.default.createDirectory(
+            at: workingDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        let plaintextURL = workingDirectory.appending(path: "restore-\(reference.digestHex)")
+        defer { try? FileManager.default.removeItem(at: plaintextURL) }
+
+        // Gate 1 and the decryption it guards.
+        try BackupOpener.open(
+            sealedURL: sealedURL,
+            to: plaintextURL,
+            reference: reference,
+            archiveRoot: keyMaterial.archiveRoot
+        )
+
+        // Gate 2: read and validate everything first.
+        let reader = try BackupArchiveReader(url: plaintextURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        var groups: [BackupGroupRecord] = []
+        var messages: [BackupMessageRecord] = []
+        var invitations: [BackupInvitationRecord] = []
+        var consents: [BackupConsentRecord] = []
+        var blobs: [BackupBlobRecord] = []
+
+        try reader.forEachRecord { kind, bytes in
+            // A record that will not decode is `incompleteSnapshot`, not
+            // a record to skip. Skipping would produce a restore that
+            // reports success while silently dropping a person's groups.
+            switch kind {
+            case .groups:
+                groups = try Self.decode([BackupGroupRecord].self, from: bytes, using: decoder)
+            case .messages:
+                messages = try Self.decode([BackupMessageRecord].self, from: bytes, using: decoder)
+            case .invitations:
+                invitations = try Self.decode([BackupInvitationRecord].self, from: bytes, using: decoder)
+            case .consents:
+                consents = try Self.decode([BackupConsentRecord].self, from: bytes, using: decoder)
+            case .blobCiphertext:
+                blobs = try Self.decode([BackupBlobRecord].self, from: bytes, using: decoder)
+            }
+        }
+
+        // Every blob is re-checked against the address it claims. The
+        // archive was authenticated, so this is not about tampering — it
+        // catches a snapshot written by a buggy composer before its
+        // contents become this device's media.
+        for blob in blobs {
+            let actual = SHA256.hash(data: blob.ciphertext).map { String(format: "%02x", $0) }.joined()
+            guard actual == blob.sha256 else { throw BackupError.incompleteSnapshot }
+        }
+
+        // Gate 3: write. Groups before messages, because a message whose
+        // group does not exist yet is an orphan in every surface that
+        // renders it.
+        try await sink.restore(groups: groups)
+        try await sink.restore(messages: messages)
+        try await sink.restore(invitations: invitations)
+        try await sink.restore(consents: consents)
+        for blob in blobs {
+            try await sink.restore(blob: blob)
+        }
+
+        let carried = Set(blobs.map(\.sha256))
+        let referenced = Set(messages.flatMap(Self.contentAddresses(in:)))
+        return BackupRestoreSummary(
+            groups: groups.count,
+            messages: messages.count,
+            invitations: invitations.count,
+            consents: consents.count,
+            blobs: blobs.count,
+            // What the snapshot pointed at but did not carry. The person
+            // is told rather than left to find the gaps themselves.
+            unresolvedBlobs: referenced.subtracting(carried).sorted()
+        )
+    }
+
+    private static func decode<T: Decodable>(
+        _ type: T.Type,
+        from bytes: Data,
+        using decoder: JSONDecoder
+    ) throws -> T {
+        guard let value = try? decoder.decode(type, from: bytes) else {
+            throw BackupError.incompleteSnapshot
+        }
+        return value
+    }
+
+    private static func contentAddresses(in message: BackupMessageRecord) -> [String] {
+        [
+            message.imageAttachmentJSON,
+            message.videoAttachmentJSON,
+            message.albumAttachmentsJSON,
+            message.voiceAttachmentJSON,
+        ]
+        .compactMap { $0 }
+        .flatMap(BackupComposer.contentAddresses(inAttachmentJSON:))
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRestorer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRestorer.swift
@@ -86,25 +86,50 @@ public actor BackupRestorer {
         // Gate 3: write. Groups before messages, because a message whose
         // group does not exist yet is an orphan in every surface that
         // renders it.
-        try await sink.restore(groups: groups)
-        try await sink.restore(messages: messages)
-        try await sink.restore(invitations: invitations)
-        try await sink.restore(consents: consents)
+        // Counts come from the sink, not from the archive. A row the
+        // sink could not reconstruct is skipped, and reporting the
+        // archive's totals would claim to have restored things that are
+        // not there — the same overstatement this seat refuses
+        // everywhere else.
+        let wroteGroups = try await sink.restore(groups: groups)
+        let wroteMessages = try await sink.restore(messages: messages)
+        let wroteInvitations = try await sink.restore(invitations: invitations)
+        let wroteConsents = try await sink.restore(consents: consents)
         for blob in blobs {
             try await sink.restore(blob: blob)
         }
 
-        let carried = Set(blobs.map(\.sha256))
-        let referenced = Set(messages.flatMap(Self.contentAddresses(in:)))
+        var skipped: [String: Int] = [:]
+        for (name, held, written) in [
+            ("groups", groups.count, wroteGroups),
+            ("messages", messages.count, wroteMessages),
+            ("invitations", invitations.count, wroteInvitations),
+            ("consents", consents.count, wroteConsents),
+        ] where held > written {
+            skipped[name] = held - written
+        }
+
+        // Only a snapshot that meant to carry blobs can be missing any.
+        // A descriptors-only archive carries none by design and its
+        // attachments still resolve from the blob store, so reporting
+        // every one of them as unresolved would be alarming and false.
+        let unresolved: [String]
+        if reader.header.mediaPolicy == .includeCiphertext {
+            let carried = Set(blobs.map(\.sha256))
+            let referenced = Set(messages.flatMap(Self.contentAddresses(in:)))
+            unresolved = referenced.subtracting(carried).sorted()
+        } else {
+            unresolved = []
+        }
+
         return BackupRestoreSummary(
-            groups: groups.count,
-            messages: messages.count,
-            invitations: invitations.count,
-            consents: consents.count,
+            groups: wroteGroups,
+            messages: wroteMessages,
+            invitations: wroteInvitations,
+            consents: wroteConsents,
             blobs: blobs.count,
-            // What the snapshot pointed at but did not carry. The person
-            // is told rather than left to find the gaps themselves.
-            unresolvedBlobs: referenced.subtracting(carried).sorted()
+            skipped: skipped,
+            unresolvedBlobs: unresolved
         )
     }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupSealer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupSealer.swift
@@ -64,10 +64,16 @@ public enum BackupSealer {
 
         let key = BackupKeys.snapshotKey(archiveRoot: archiveRoot, snapshotSalt: salt)
 
-        FileManager.default.createFile(atPath: sealedURL.path, contents: nil)
-        try (sealedURL as NSURL).setResourceValue(
-            URLFileProtection.complete,
-            forKey: .fileProtectionKey
+        // Protection is set at creation rather than with a follow-up
+        // setResourceValue: the latter throws where data protection is
+        // unavailable (notably the simulator), and failing to seal a
+        // backup because a test host cannot encrypt at rest is the wrong
+        // trade. Passed as an attribute, it is honoured on device and
+        // ignored where it cannot apply.
+        FileManager.default.createFile(
+            atPath: sealedURL.path,
+            contents: nil,
+            attributes: [.protectionKey: FileProtectionType.complete]
         )
         let input = try FileHandle(forReadingFrom: plaintextURL)
         let output = try FileHandle(forWritingTo: sealedURL)

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupSource.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupSource.swift
@@ -41,27 +41,41 @@ public protocol BackupSourceProviding: Sendable {
 
     func consents() async throws -> [BackupConsentRecord]
 
-    /// The blob store's bytes for one content address, or `nil` if it no
-    /// longer serves them.
+    /// The blob store's answer for one content address.
     ///
-    /// A missing blob is not a failure: retention at the blob operator
-    /// is its own contract and shorter than a backup's by design. The
-    /// snapshot records what it could get and the restore reports what
-    /// it could not.
-    func blobCiphertext(sha256: String) async throws -> Data?
+    /// The two failure modes must be told apart. A blob the store no
+    /// longer holds is `.gone`: blob retention is its own contract,
+    /// shorter than a backup's by design, and a snapshot should record
+    /// what it could get rather than abort. A blob the store could not
+    /// be *asked* about — a dropped connection, a 5xx — is an error, and
+    /// folding it into `.gone` would quietly produce a media-thin
+    /// snapshot on a flaky network and call it complete.
+    func blobCiphertext(sha256: String) async throws -> BackupBlobAvailability
 }
 
-/// Where a restored snapshot's contents go.
-///
 /// Writes go through the app's stores rather than into the database
 /// files, so the restoring device re-encrypts everything under *its*
 /// at-rest key. That is the whole reason a snapshot is a logical export:
 /// the bytes that arrive are not the bytes that get stored.
+/// What a blob store had to say.
+public enum BackupBlobAvailability: Sendable, Equatable {
+    case available(Data)
+    /// The store answered, and does not hold it.
+    case gone
+}
+
+/// Where a restored snapshot's contents go.
+///
+/// Every method returns **how many rows it actually wrote**, not how
+/// many it was handed. An implementation that cannot reconstruct a row —
+/// an enum case from a newer schema, an unparseable id — skips it, and a
+/// summary built from the archive's counts would then report restoring
+/// things that are not there. The count has to come from the writer.
 public protocol BackupSinkProviding: Sendable {
-    func restore(groups: [BackupGroupRecord]) async throws
-    func restore(messages: [BackupMessageRecord]) async throws
-    func restore(invitations: [BackupInvitationRecord]) async throws
-    func restore(consents: [BackupConsentRecord]) async throws
+    @discardableResult func restore(groups: [BackupGroupRecord]) async throws -> Int
+    @discardableResult func restore(messages: [BackupMessageRecord]) async throws -> Int
+    @discardableResult func restore(invitations: [BackupInvitationRecord]) async throws -> Int
+    @discardableResult func restore(consents: [BackupConsentRecord]) async throws -> Int
     /// Hand back one attachment blob. The implementation is responsible
     /// for putting it somewhere the media loaders will find it.
     func restore(blob: BackupBlobRecord) async throws
@@ -74,10 +88,15 @@ public struct BackupRestoreSummary: Sendable, Equatable {
     public let invitations: Int
     public let consents: Int
     public let blobs: Int
-    /// Content addresses the snapshot referenced but did not carry, and
-    /// which the blob store no longer serves. Surfaced rather than
-    /// swallowed: the person's media is partly gone, and a restore that
-    /// reported plain success would be lying about it.
+    /// Rows the archive held that the sink could not reconstruct, by
+    /// kind. Non-empty means this build does not understand part of the
+    /// snapshot — worth telling someone about rather than absorbing.
+    public let skipped: [String: Int]
+    /// Content addresses this snapshot *meant* to carry and did not.
+    ///
+    /// Empty for a descriptors-only snapshot, which carries no blobs by
+    /// design and whose attachments still resolve from the blob store —
+    /// reporting all of them as unresolved would be alarming and wrong.
     public let unresolvedBlobs: [String]
 
     public init(
@@ -86,8 +105,10 @@ public struct BackupRestoreSummary: Sendable, Equatable {
         invitations: Int,
         consents: Int,
         blobs: Int,
+        skipped: [String: Int] = [:],
         unresolvedBlobs: [String]
     ) {
+        self.skipped = skipped
         self.groups = groups
         self.messages = messages
         self.invitations = invitations

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupSource.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupSource.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// What may go into a snapshot, and what the person chose about media.
+public enum BackupMediaPolicy: String, Sendable, Equatable, Codable, CaseIterable {
+    /// Attachments ride as descriptors only; media re-resolves from the
+    /// blob store on restore. Cheap and honest — and the honesty costs
+    /// something the consent surface must say out loud: media whose blob
+    /// retention has lapsed is gone, and no snapshot will bring it back.
+    case descriptorsOnly
+    /// Attachment ciphertext travels in the archive. Larger snapshots,
+    /// and media that survives the blob operator.
+    case includeCiphertext
+}
+
+/// Where a snapshot's contents come from.
+///
+/// The composer talks to this and to nothing else. That is the
+/// structural half of the eligibility rule: `BackupComposer` holds no
+/// reference to identity, to the keychain, or to any store that could
+/// hand it seed material, so "seed material is never eligible"
+/// (`UI-Backup.md` §16.1) is a property of the type graph rather than a
+/// discipline someone has to keep remembering.
+///
+/// Implementations read through the app's own store protocols. They must
+/// never read the SwiftData files directly: local rows are encrypted
+/// under a device-bound key, so a file-level copy is unopenable on the
+/// device that would need it.
+public protocol BackupSourceProviding: Sendable {
+    /// How many identities this snapshot covers. Recorded in the archive
+    /// header for the restore surface, not used for anything else.
+    func identityCount() async -> Int
+
+    func groups() async throws -> [BackupGroupRecord]
+
+    /// Messages for one group, scoped to the identity that owns it —
+    /// the same scoping the chat list uses, so a group two local
+    /// identities are both in yields each one's own rows.
+    func messages(groupID: String, ownerIdentityID: String) async throws -> [BackupMessageRecord]
+
+    func invitations() async throws -> [BackupInvitationRecord]
+
+    func consents() async throws -> [BackupConsentRecord]
+
+    /// The blob store's bytes for one content address, or `nil` if it no
+    /// longer serves them.
+    ///
+    /// A missing blob is not a failure: retention at the blob operator
+    /// is its own contract and shorter than a backup's by design. The
+    /// snapshot records what it could get and the restore reports what
+    /// it could not.
+    func blobCiphertext(sha256: String) async throws -> Data?
+}
+
+/// Where a restored snapshot's contents go.
+///
+/// Writes go through the app's stores rather than into the database
+/// files, so the restoring device re-encrypts everything under *its*
+/// at-rest key. That is the whole reason a snapshot is a logical export:
+/// the bytes that arrive are not the bytes that get stored.
+public protocol BackupSinkProviding: Sendable {
+    func restore(groups: [BackupGroupRecord]) async throws
+    func restore(messages: [BackupMessageRecord]) async throws
+    func restore(invitations: [BackupInvitationRecord]) async throws
+    func restore(consents: [BackupConsentRecord]) async throws
+    /// Hand back one attachment blob. The implementation is responsible
+    /// for putting it somewhere the media loaders will find it.
+    func restore(blob: BackupBlobRecord) async throws
+}
+
+/// What a restore actually did.
+public struct BackupRestoreSummary: Sendable, Equatable {
+    public let groups: Int
+    public let messages: Int
+    public let invitations: Int
+    public let consents: Int
+    public let blobs: Int
+    /// Content addresses the snapshot referenced but did not carry, and
+    /// which the blob store no longer serves. Surfaced rather than
+    /// swallowed: the person's media is partly gone, and a restore that
+    /// reported plain success would be lying about it.
+    public let unresolvedBlobs: [String]
+
+    public init(
+        groups: Int,
+        messages: Int,
+        invitations: Int,
+        consents: Int,
+        blobs: Int,
+        unresolvedBlobs: [String]
+    ) {
+        self.groups = groups
+        self.messages = messages
+        self.invitations = invitations
+        self.consents = consents
+        self.blobs = blobs
+        self.unresolvedBlobs = unresolvedBlobs
+    }
+}

--- a/Sources/OnymIOS/BackupSinks.swift
+++ b/Sources/OnymIOS/BackupSinks.swift
@@ -1,0 +1,176 @@
+import Foundation
+import OnymBackup
+import OnymChain
+import OnymChatsCore
+import OnymFoundation
+import OnymGroup
+import OnymIdentity
+import OnymPersistence
+
+/// Writes a restored snapshot back into local state.
+///
+/// Everything goes through the app's stores, never into their database
+/// files. That is what makes a snapshot restorable at all: the rows
+/// arrive as domain values and each store re-encrypts them under *this*
+/// device's at-rest key, which is the key the previous device could not
+/// have shared even if it wanted to.
+///
+/// Writes are `insertOrUpdate`, so restoring twice — or restoring onto a
+/// device that has since received some of the same messages — converges
+/// instead of duplicating.
+struct AppBackupSink: BackupSinkProviding {
+    let groupStore: any GroupStore
+    let messageStore: any MessageStore
+    let invitationStore: any InvitationStore
+    let consentStore: any PinnedConsentStore
+    /// Where restored attachment ciphertext is written so the media
+    /// loaders find it without a round trip to the blob store.
+    let blobDirectory: URL
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    func restore(groups: [BackupGroupRecord]) async throws {
+        for record in groups {
+            // A record we cannot reconstruct is skipped rather than
+            // fatal, and the reason is asymmetric: the whole archive was
+            // already verified and decoded before any of this ran, so a
+            // failure here means one row's *shape* is from a schema this
+            // build does not know. Refusing the entire restore over one
+            // unknown group would cost the person everything else.
+            guard
+                let ownerID = IdentityID(record.ownerIdentityID),
+                let tier = SEPTier(rawValue: record.tierRaw),
+                let groupType = SEPGroupType(rawValue: record.groupTypeRaw),
+                let members = try? Self.decoder.decode([GovernanceMember].self, from: record.membersJSON),
+                let profiles = try? Self.decoder.decode(
+                    [String: MemberProfile].self, from: record.memberProfilesJSON)
+            else {
+                continue
+            }
+            await groupStore.insertOrUpdate(
+                ChatGroup(
+                    id: record.id,
+                    ownerIdentityID: ownerID,
+                    name: record.name,
+                    groupSecret: record.groupSecret,
+                    createdAt: record.createdAt,
+                    members: members,
+                    memberProfiles: profiles,
+                    epoch: record.epoch,
+                    salt: record.salt,
+                    commitment: record.commitment,
+                    tier: tier,
+                    groupType: groupType,
+                    adminPubkeyHex: record.adminPubkeyHex,
+                    adminEd25519PubkeyHex: record.adminEd25519PubkeyHex,
+                    isPublishedOnChain: record.isPublishedOnChain,
+                    avatarJPEG: record.avatarJPEG,
+                    lastReadAt: record.lastReadAt,
+                    invitationMessage: record.invitationMessage
+                )
+            )
+        }
+    }
+
+    func restore(messages: [BackupMessageRecord]) async throws {
+        for record in messages {
+            guard
+                let id = UUID(uuidString: record.id),
+                let ownerID = IdentityID(record.ownerIdentityID),
+                let direction = MessageDirection(rawValue: record.directionRaw),
+                let status = MessageStatus(rawValue: record.statusRaw),
+                let groupType = SEPGroupType(rawValue: record.groupTypeRaw)
+            else {
+                continue
+            }
+            await messageStore.insertOrUpdate(
+                ChatMessage(
+                    id: id,
+                    groupID: record.groupID,
+                    ownerIdentityID: ownerID,
+                    senderBlsPubkeyHex: record.senderBlsPubkeyHex,
+                    body: record.body,
+                    sentAt: record.sentAt,
+                    direction: direction,
+                    status: status,
+                    replyToMessageID: record.replyToMessageID.flatMap(UUID.init(uuidString:)),
+                    groupType: groupType,
+                    failureReason: record.failureReasonRaw.flatMap(SendFailureReason.init(rawValue:)),
+                    moderationAuthenticityProof: record.moderationAuthenticityProof,
+                    imageAttachment: Self.decode(ChatImageAttachment.self, record.imageAttachmentJSON),
+                    videoAttachment: Self.decode(ChatVideoAttachment.self, record.videoAttachmentJSON),
+                    albumAttachments: Self.decode([ChatMediaAttachment].self, record.albumAttachmentsJSON),
+                    voiceAttachment: Self.decode(ChatVoiceAttachment.self, record.voiceAttachmentJSON),
+                    systemEvent: Self.decode(ChatSystemEvent.self, record.systemEventJSON)
+                )
+            )
+        }
+    }
+
+    func restore(invitations: [BackupInvitationRecord]) async throws {
+        for record in invitations {
+            guard
+                let ownerID = IdentityID(record.ownerIdentityID),
+                let status = IncomingInvitationStatus(rawValue: record.statusRaw)
+            else {
+                continue
+            }
+            await invitationStore.save(
+                IncomingInvitationRecord(
+                    id: record.id,
+                    ownerIdentityID: ownerID,
+                    payload: record.payload,
+                    receivedAt: record.receivedAt,
+                    status: status
+                )
+            )
+        }
+    }
+
+    func restore(consents: [BackupConsentRecord]) async throws {
+        let restored = consents.compactMap {
+            try? Self.decoder.decode(PinnedConsentRecord.self, from: $0.raw)
+        }
+        guard !restored.isEmpty else { return }
+        // Merged, not replaced: a device may already have consented to
+        // something since the snapshot was taken, and a restore that
+        // overwrote it would silently revoke a choice the person made
+        // more recently than the backup.
+        let existing = (try? consentStore.load()) ?? []
+        let known = Set(existing.map { "\($0.componentId)|\($0.manifestHash)" })
+        let additions = restored.filter { !known.contains("\($0.componentId)|\($0.manifestHash)") }
+        guard !additions.isEmpty else { return }
+        try consentStore.save(existing + additions.map {
+            // Restored consents land inactive. Re-activating one would
+            // silently re-select an operator the person has not seen
+            // since; the consent surface asks.
+            var record = $0
+            record.isActive = false
+            return record
+        })
+    }
+
+    func restore(blob: BackupBlobRecord) async throws {
+        try FileManager.default.createDirectory(
+            at: blobDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        // Ciphertext, addressed by its own digest — the same shape the
+        // blob store serves, so the media loaders treat a restored blob
+        // exactly like a downloaded one.
+        try blob.ciphertext.write(
+            to: blobDirectory.appending(path: blob.sha256),
+            options: [.atomic, .completeFileProtection]
+        )
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, _ json: Data?) -> T? {
+        guard let json else { return nil }
+        return try? decoder.decode(type, from: json)
+    }
+}

--- a/Sources/OnymIOS/BackupSinks.swift
+++ b/Sources/OnymIOS/BackupSinks.swift
@@ -33,7 +33,9 @@ struct AppBackupSink: BackupSinkProviding {
         return decoder
     }()
 
-    func restore(groups: [BackupGroupRecord]) async throws {
+    @discardableResult
+    func restore(groups: [BackupGroupRecord]) async throws -> Int {
+        var written = 0
         for record in groups {
             // A record we cannot reconstruct is skipped rather than
             // fatal, and the reason is asymmetric: the whole archive was
@@ -73,10 +75,14 @@ struct AppBackupSink: BackupSinkProviding {
                     invitationMessage: record.invitationMessage
                 )
             )
+            written += 1
         }
+        return written
     }
 
-    func restore(messages: [BackupMessageRecord]) async throws {
+    @discardableResult
+    func restore(messages: [BackupMessageRecord]) async throws -> Int {
+        var written = 0
         for record in messages {
             guard
                 let id = UUID(uuidString: record.id),
@@ -108,10 +114,14 @@ struct AppBackupSink: BackupSinkProviding {
                     systemEvent: Self.decode(ChatSystemEvent.self, record.systemEventJSON)
                 )
             )
+            written += 1
         }
+        return written
     }
 
-    func restore(invitations: [BackupInvitationRecord]) async throws {
+    @discardableResult
+    func restore(invitations: [BackupInvitationRecord]) async throws -> Int {
+        var written = 0
         for record in invitations {
             guard
                 let ownerID = IdentityID(record.ownerIdentityID),
@@ -128,22 +138,33 @@ struct AppBackupSink: BackupSinkProviding {
                     status: status
                 )
             )
+            written += 1
         }
+        return written
     }
 
-    func restore(consents: [BackupConsentRecord]) async throws {
+    @discardableResult
+    func restore(consents: [BackupConsentRecord]) async throws -> Int {
         let restored = consents.compactMap {
             try? Self.decoder.decode(PinnedConsentRecord.self, from: $0.raw)
         }
-        guard !restored.isEmpty else { return }
+        guard !restored.isEmpty else { return 0 }
         // Merged, not replaced: a device may already have consented to
         // something since the snapshot was taken, and a restore that
         // overwrote it would silently revoke a choice the person made
         // more recently than the backup.
-        let existing = (try? consentStore.load()) ?? []
+        //
+        // A *failed* load must therefore abort rather than read as "no
+        // existing consents". Treating a corrupt or transient read as an
+        // empty store and then saving would replace every live consent
+        // with the restored, inactive ones — the exact revocation this
+        // merge exists to prevent, executed by the code meant to prevent
+        // it. Losing the restored consents is recoverable; the person is
+        // re-asked. Losing the live ones is not.
+        let existing = try consentStore.load()
         let known = Set(existing.map { "\($0.componentId)|\($0.manifestHash)" })
         let additions = restored.filter { !known.contains("\($0.componentId)|\($0.manifestHash)") }
-        guard !additions.isEmpty else { return }
+        guard !additions.isEmpty else { return 0 }
         try consentStore.save(existing + additions.map {
             // Restored consents land inactive. Re-activating one would
             // silently re-select an operator the person has not seen
@@ -152,6 +173,7 @@ struct AppBackupSink: BackupSinkProviding {
             record.isActive = false
             return record
         })
+        return additions.count
     }
 
     func restore(blob: BackupBlobRecord) async throws {

--- a/Sources/OnymIOS/BackupSources.swift
+++ b/Sources/OnymIOS/BackupSources.swift
@@ -113,12 +113,19 @@ struct AppBackupSource: BackupSourceProviding {
         }
     }
 
-    func blobCiphertext(sha256: String) async throws -> Data? {
-        guard let blobClient else { return nil }
-        // Nil rather than throwing: blob retention is the blob
-        // operator's own contract and shorter than a backup's by
-        // design, so an expired attachment is an expected outcome and
-        // must not abort a snapshot of everything else.
-        return try? await blobClient.download(sha256: sha256)
+    func blobCiphertext(sha256: String) async throws -> BackupBlobAvailability {
+        guard let blobClient else { return .gone }
+        do {
+            return .available(try await blobClient.download(sha256: sha256))
+        } catch BlossomError.badStatus(404), BlossomError.badStatus(410) {
+            // The store answered and does not hold it. Expected: blob
+            // retention is its own contract, shorter than a backup's.
+            return .gone
+        }
+        // Everything else — a dropped connection, a 5xx, a malformed
+        // response — propagates. Folding it into "gone" would turn a
+        // flaky network into a snapshot that is quietly missing half its
+        // media and reports itself complete; failing means the snapshot
+        // is retried, which is cheap and correct.
     }
 }

--- a/Sources/OnymIOS/BackupSources.swift
+++ b/Sources/OnymIOS/BackupSources.swift
@@ -1,0 +1,124 @@
+import Foundation
+import OnymBackup
+import OnymChain
+import OnymChatsCore
+import OnymFoundation
+import OnymGroup
+import OnymIdentity
+import OnymPersistence
+import OnymTransportBlossom
+
+/// Reads local state for a snapshot, through the app's own store
+/// protocols.
+///
+/// It lives in the composition root because it is the only place that
+/// knows both the domain models and the archive schema — `OnymBackup`
+/// deliberately knows nothing about `ChatGroup`, so a rename there can
+/// never silently change what an archive means.
+///
+/// What it can reach is the point. There is no `IdentityRepository`
+/// here, no keychain, no `StorageEncryption`: the eligibility rule of
+/// `UI-Backup.md` §16.1 holds because this type has no way to obtain
+/// seed material, not because someone remembered not to ask for it.
+struct AppBackupSource: BackupSourceProviding {
+    let groupStore: any GroupStore
+    let messageStore: any MessageStore
+    let invitationStore: any InvitationStore
+    let consentStore: any PinnedConsentStore
+    /// Only ever asked for *ciphertext*, and only under
+    /// `.includeCiphertext`. The device's own media caches are never
+    /// read: they hold decrypted bytes under filenames that are public
+    /// content addresses.
+    let blobClient: (any BlossomClient)?
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    func identityCount() async -> Int {
+        Set(await groupStore.list().map(\.ownerIdentityID)).count
+    }
+
+    func groups() async throws -> [BackupGroupRecord] {
+        try await groupStore.list().map { group in
+            BackupGroupRecord(
+                id: group.id,
+                ownerIdentityID: group.ownerIdentityID.description,
+                name: group.name,
+                groupSecret: group.groupSecret,
+                createdAt: group.createdAt,
+                membersJSON: try Self.encoder.encode(group.members),
+                memberProfilesJSON: try Self.encoder.encode(group.memberProfiles),
+                epoch: group.epoch,
+                salt: group.salt,
+                commitment: group.commitment,
+                tierRaw: group.tier.rawValue,
+                groupTypeRaw: group.groupType.rawValue,
+                adminPubkeyHex: group.adminPubkeyHex,
+                adminEd25519PubkeyHex: group.adminEd25519PubkeyHex,
+                isPublishedOnChain: group.isPublishedOnChain,
+                avatarJPEG: group.avatarJPEG,
+                lastReadAt: group.lastReadAt,
+                invitationMessage: group.invitationMessage
+            )
+        }
+    }
+
+    func messages(groupID: String, ownerIdentityID: String) async throws -> [BackupMessageRecord] {
+        try await messageStore.list(groupID: groupID, ownerIDString: ownerIdentityID).map { message in
+            BackupMessageRecord(
+                id: message.id.uuidString,
+                groupID: message.groupID,
+                ownerIdentityID: message.ownerIdentityID.description,
+                senderBlsPubkeyHex: message.senderBlsPubkeyHex,
+                body: message.body,
+                sentAt: message.sentAt,
+                directionRaw: message.direction.rawValue,
+                statusRaw: message.status.rawValue,
+                groupTypeRaw: message.groupType.rawValue,
+                replyToMessageID: message.replyToMessageID?.uuidString,
+                failureReasonRaw: message.failureReason?.rawValue,
+                moderationAuthenticityProof: message.moderationAuthenticityProof,
+                imageAttachmentJSON: try message.imageAttachment.map(Self.encoder.encode),
+                videoAttachmentJSON: try message.videoAttachment.map(Self.encoder.encode),
+                albumAttachmentsJSON: try message.albumAttachments.map(Self.encoder.encode),
+                voiceAttachmentJSON: try message.voiceAttachment.map(Self.encoder.encode),
+                systemEventJSON: try message.systemEvent.map(Self.encoder.encode)
+            )
+        }
+    }
+
+    func invitations() async throws -> [BackupInvitationRecord] {
+        await invitationStore.list().map { record in
+            BackupInvitationRecord(
+                id: record.id,
+                ownerIdentityID: record.ownerIdentityID.description,
+                payload: record.payload,
+                receivedAt: record.receivedAt,
+                statusRaw: record.status.rawValue
+            )
+        }
+    }
+
+    func consents() async throws -> [BackupConsentRecord] {
+        // A corrupt consent store is not a reason to abandon a snapshot
+        // of someone's messages. The restore re-asks for consent, which
+        // is a nuisance; losing the history would not be.
+        let records = (try? consentStore.load()) ?? []
+        return try records.map {
+            BackupConsentRecord(componentId: $0.componentId, raw: try Self.encoder.encode($0))
+        }
+    }
+
+    func blobCiphertext(sha256: String) async throws -> Data? {
+        guard let blobClient else { return nil }
+        // Nil rather than throwing: blob retention is the blob
+        // operator's own contract and shorter than a backup's by
+        // design, so an expired attachment is an expected outcome and
+        // must not abort a snapshot of everything else.
+        return try? await blobClient.download(sha256: sha256)
+    }
+}

--- a/Tests/OnymIOSTests/BackupCompositionTests.swift
+++ b/Tests/OnymIOSTests/BackupCompositionTests.swift
@@ -1,0 +1,182 @@
+import CryptoKit
+import XCTest
+@testable import OnymBackup
+
+/// Composition and restore, with one test that matters more than the
+/// rest: nothing derived from the recovery phrase may appear in a
+/// plaintext archive.
+final class BackupCompositionTests: XCTestCase {
+    private func makeDirectory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// The §16.1 guard. A snapshot that leaked seed material would hand
+    /// an operator the ability to open every snapshot it ever stores,
+    /// and the failure would be invisible from the outside.
+    func testArchiveContainsNoSeedMaterial() async throws {
+        let dir = try makeDirectory()
+        let mnemonic = "legal winner thank year wave sausage worth useful legal winner thank yellow"
+        let source = StubSource(
+            groups: [Self.group(name: "Weekend plans")],
+            messages: [Self.message(body: "see you at six")]
+        )
+        let composer = BackupComposer(
+            source: source, mediaPolicy: .descriptorsOnly, workingDirectory: dir)
+
+        let seed = Data(repeating: 0x11, count: 64)
+        let material = BackupKeys.material(seed: seed, componentId: "onym:component:op")
+        let snapshot = try await composer.compose(
+            keyMaterial: material, acceptedTermsId: "sha256:" + String(repeating: "a", count: 64))
+
+        // Open it back to plaintext and scan the actual archive bytes.
+        let plain = dir.appending(path: "plain")
+        try BackupOpener.open(
+            sealedURL: snapshot.sealedBytesURL, to: plain,
+            reference: snapshot.snapshotReference, archiveRoot: material.archiveRoot)
+        let bytes = try Data(contentsOf: plain)
+
+        XCTAssertFalse(bytes.contains(seed), "raw seed bytes are in the archive")
+        for word in mnemonic.split(separator: " ") {
+            XCTAssertFalse(
+                bytes.range(of: Data(word.utf8)) != nil && word.count > 5,
+                "mnemonic word \"\(word)\" appears in the archive")
+        }
+        XCTAssertNil(
+            bytes.range(of: material.accessSigningKey.rawRepresentation),
+            "the access signing key is in the archive")
+        XCTAssertNil(
+            bytes.range(of: material.archiveRoot.withUnsafeBytes { Data($0) }),
+            "the archive root key is in the archive")
+
+        // Sanity: the archive really does contain the payload, so the
+        // assertions above are not passing on an empty file.
+        XCTAssertNotNil(bytes.range(of: Data("Weekend plans".utf8)))
+    }
+
+    func testComposeRestoreRoundTrip() async throws {
+        let dir = try makeDirectory()
+        let source = StubSource(
+            groups: [Self.group(name: "Book club")],
+            messages: [Self.message(body: "chapter four")])
+        let composer = BackupComposer(
+            source: source, mediaPolicy: .descriptorsOnly, workingDirectory: dir)
+        let material = BackupKeys.material(
+            seed: Data(repeating: 0x22, count: 64), componentId: "onym:component:op")
+        let snapshot = try await composer.compose(
+            keyMaterial: material, acceptedTermsId: "sha256:" + String(repeating: "b", count: 64))
+
+        let sink = StubSink()
+        let summary = try await BackupRestorer(sink: sink).restore(
+            sealedURL: snapshot.sealedBytesURL,
+            reference: snapshot.snapshotReference,
+            keyMaterial: material,
+            workingDirectory: dir)
+
+        XCTAssertEqual(summary.groups, 1)
+        XCTAssertEqual(summary.messages, 1)
+        let restored = await sink.groups
+        XCTAssertEqual(restored.first?.name, "Book club")
+    }
+
+    /// The plaintext archive is the one artefact on disk readable
+    /// without the seed. It must not survive composition.
+    func testPlaintextArchiveIsRemovedAfterSealing() async throws {
+        let dir = try makeDirectory()
+        let composer = BackupComposer(
+            source: StubSource(groups: [Self.group(name: "x")], messages: []),
+            mediaPolicy: .descriptorsOnly, workingDirectory: dir)
+        let material = BackupKeys.material(
+            seed: Data(repeating: 0x33, count: 64), componentId: "onym:component:op")
+        let snapshot = try await composer.compose(
+            keyMaterial: material, acceptedTermsId: "sha256:" + String(repeating: "c", count: 64))
+
+        let leftover = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+        XCTAssertEqual(leftover, [snapshot.sealedBytesURL.lastPathComponent],
+                       "composition left plaintext behind: \(leftover)")
+    }
+
+    func testBlobsAreVerifiedAgainstTheirAddress() async throws {
+        let dir = try makeDirectory()
+        let real = Data("real bytes".utf8)
+        let address = SHA256.hash(data: real).map { String(format: "%02x", $0) }.joined()
+        let attachment = Data(#"{"sha256":"\#(address)","encKey":"k"}"#.utf8)
+
+        // The store answers with something that is not what it claims.
+        let source = StubSource(
+            groups: [Self.group(name: "g")],
+            messages: [Self.message(body: "with media", imageJSON: attachment)],
+            blobs: [address: Data("different bytes".utf8)])
+        let composer = BackupComposer(
+            source: source, mediaPolicy: .includeCiphertext, workingDirectory: dir)
+        let material = BackupKeys.material(
+            seed: Data(repeating: 0x44, count: 64), componentId: "onym:component:op")
+        let snapshot = try await composer.compose(
+            keyMaterial: material, acceptedTermsId: "sha256:" + String(repeating: "d", count: 64))
+
+        let sink = StubSink()
+        let summary = try await BackupRestorer(sink: sink).restore(
+            sealedURL: snapshot.sealedBytesURL, reference: snapshot.snapshotReference,
+            keyMaterial: material, workingDirectory: dir)
+        XCTAssertEqual(summary.blobs, 0, "a mis-addressed blob was included")
+        XCTAssertEqual(summary.unresolvedBlobs, [address], "the gap was not reported")
+    }
+
+    // MARK: - Fixtures
+
+    private static func group(name: String) -> BackupGroupRecord {
+        BackupGroupRecord(
+            id: String(repeating: "a", count: 64), ownerIdentityID: UUID().uuidString,
+            name: name, groupSecret: Data(repeating: 0xEE, count: 32), createdAt: Date(),
+            membersJSON: Data("[]".utf8), memberProfilesJSON: Data("{}".utf8),
+            epoch: 0, salt: Data(repeating: 1, count: 32), commitment: nil,
+            tierRaw: 0, groupTypeRaw: "tyranny", adminPubkeyHex: nil,
+            adminEd25519PubkeyHex: nil, isPublishedOnChain: false,
+            avatarJPEG: nil, lastReadAt: nil, invitationMessage: nil)
+    }
+
+    private static func message(body: String, imageJSON: Data? = nil) -> BackupMessageRecord {
+        BackupMessageRecord(
+            id: UUID().uuidString, groupID: String(repeating: "a", count: 64),
+            ownerIdentityID: UUID().uuidString, senderBlsPubkeyHex: "ab",
+            body: body, sentAt: Date(), directionRaw: "outgoing", statusRaw: "sent",
+            groupTypeRaw: "tyranny", replyToMessageID: nil, failureReasonRaw: nil,
+            moderationAuthenticityProof: nil, imageAttachmentJSON: imageJSON,
+            videoAttachmentJSON: nil, albumAttachmentsJSON: nil,
+            voiceAttachmentJSON: nil, systemEventJSON: nil)
+    }
+}
+
+private struct StubSource: BackupSourceProviding {
+    var groupRecords: [BackupGroupRecord] = []
+    var messageRecords: [BackupMessageRecord] = []
+    var blobs: [String: Data] = [:]
+
+    init(groups: [BackupGroupRecord], messages: [BackupMessageRecord], blobs: [String: Data] = [:]) {
+        self.groupRecords = groups
+        self.messageRecords = messages
+        self.blobs = blobs
+    }
+
+    func identityCount() async -> Int { 1 }
+    func groups() async throws -> [BackupGroupRecord] { groupRecords }
+    func messages(groupID: String, ownerIdentityID: String) async throws -> [BackupMessageRecord] {
+        messageRecords
+    }
+    func invitations() async throws -> [BackupInvitationRecord] { [] }
+    func consents() async throws -> [BackupConsentRecord] { [] }
+    func blobCiphertext(sha256: String) async throws -> Data? { blobs[sha256] }
+}
+
+private actor StubSink: BackupSinkProviding {
+    var groups: [BackupGroupRecord] = []
+    var messages: [BackupMessageRecord] = []
+    var blobs: [BackupBlobRecord] = []
+
+    func restore(groups: [BackupGroupRecord]) async throws { self.groups = groups }
+    func restore(messages: [BackupMessageRecord]) async throws { self.messages = messages }
+    func restore(invitations: [BackupInvitationRecord]) async throws {}
+    func restore(consents: [BackupConsentRecord]) async throws {}
+    func restore(blob: BackupBlobRecord) async throws { blobs.append(blob) }
+}

--- a/Tests/OnymIOSTests/BackupCompositionTests.swift
+++ b/Tests/OnymIOSTests/BackupCompositionTests.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import OnymFoundation
 import XCTest
 @testable import OnymBackup
 
@@ -17,7 +18,12 @@ final class BackupCompositionTests: XCTestCase {
     /// and the failure would be invisible from the outside.
     func testArchiveContainsNoSeedMaterial() async throws {
         let dir = try makeDirectory()
+        // The seed is derived from *this* mnemonic, so the word
+        // assertions below are actually reachable. Previously the seed
+        // was unrelated constant bytes, which made the whole word loop
+        // vacuous — it could not have failed.
         let mnemonic = "legal winner thank year wave sausage worth useful legal winner thank yellow"
+        let seed = Bip39.seedFromMnemonic(mnemonic)
         let source = StubSource(
             groups: [Self.group(name: "Weekend plans")],
             messages: [Self.message(body: "see you at six")]
@@ -25,7 +31,6 @@ final class BackupCompositionTests: XCTestCase {
         let composer = BackupComposer(
             source: source, mediaPolicy: .descriptorsOnly, workingDirectory: dir)
 
-        let seed = Data(repeating: 0x11, count: 64)
         let material = BackupKeys.material(seed: seed, componentId: "onym:component:op")
         let snapshot = try await composer.compose(
             keyMaterial: material, acceptedTermsId: "sha256:" + String(repeating: "a", count: 64))
@@ -37,10 +42,13 @@ final class BackupCompositionTests: XCTestCase {
             reference: snapshot.snapshotReference, archiveRoot: material.archiveRoot)
         let bytes = try Data(contentsOf: plain)
 
-        XCTAssertFalse(bytes.contains(seed), "raw seed bytes are in the archive")
-        for word in mnemonic.split(separator: " ") {
-            XCTAssertFalse(
-                bytes.range(of: Data(word.utf8)) != nil && word.count > 5,
+        XCTAssertNil(bytes.range(of: seed), "raw seed bytes are in the archive")
+        // Every word, unconditionally. The earlier form ANDed on
+        // `word.count > 5`, which let six of the twelve pass no matter
+        // what the archive contained.
+        for word in Set(mnemonic.split(separator: " ")) {
+            XCTAssertNil(
+                bytes.range(of: Data(word.utf8)),
                 "mnemonic word \"\(word)\" appears in the archive")
         }
         XCTAssertNil(
@@ -123,6 +131,51 @@ final class BackupCompositionTests: XCTestCase {
         XCTAssertEqual(summary.unresolvedBlobs, [address], "the gap was not reported")
     }
 
+    /// A descriptors-only snapshot carries no blobs *by design*, and its
+    /// attachments still resolve from the blob store. Reporting them all
+    /// as unresolved would tell someone their media is gone when it is
+    /// not.
+    func testDescriptorsOnlySnapshotReportsNoUnresolvedBlobs() async throws {
+        let dir = try makeDirectory()
+        let attachment = Data(#"{"sha256":"\#(String(repeating: "f", count: 64))","encKey":"k"}"#.utf8)
+        let composer = BackupComposer(
+            source: StubSource(
+                groups: [Self.group(name: "g")],
+                messages: [Self.message(body: "with media", imageJSON: attachment)]),
+            mediaPolicy: .descriptorsOnly, workingDirectory: dir)
+        let material = BackupKeys.material(
+            seed: Data(repeating: 0x55, count: 64), componentId: "onym:component:op")
+        let snapshot = try await composer.compose(
+            keyMaterial: material, acceptedTermsId: "sha256:" + String(repeating: "e", count: 64))
+
+        let summary = try await BackupRestorer(sink: StubSink()).restore(
+            sealedURL: snapshot.sealedBytesURL, reference: snapshot.snapshotReference,
+            keyMaterial: material, workingDirectory: dir)
+        XCTAssertTrue(summary.unresolvedBlobs.isEmpty)
+    }
+
+    /// A summary must count what the sink wrote, not what the archive
+    /// held — "5 groups restored" when three landed is the same
+    /// overstatement this seat refuses everywhere else.
+    func testSummaryCountsWhatTheSinkWrote() async throws {
+        let dir = try makeDirectory()
+        let composer = BackupComposer(
+            source: StubSource(
+                groups: [Self.group(name: "a"), Self.group(name: "b")], messages: []),
+            mediaPolicy: .descriptorsOnly, workingDirectory: dir)
+        let material = BackupKeys.material(
+            seed: Data(repeating: 0x66, count: 64), componentId: "onym:component:op")
+        let snapshot = try await composer.compose(
+            keyMaterial: material, acceptedTermsId: "sha256:" + String(repeating: "f", count: 64))
+
+        let sink = RefusingSink()
+        let summary = try await BackupRestorer(sink: sink).restore(
+            sealedURL: snapshot.sealedBytesURL, reference: snapshot.snapshotReference,
+            keyMaterial: material, workingDirectory: dir)
+        XCTAssertEqual(summary.groups, 1, "reported more groups than the sink wrote")
+        XCTAssertEqual(summary.skipped["groups"], 1)
+    }
+
     // MARK: - Fixtures
 
     private static func group(name: String) -> BackupGroupRecord {
@@ -166,7 +219,9 @@ private struct StubSource: BackupSourceProviding {
     }
     func invitations() async throws -> [BackupInvitationRecord] { [] }
     func consents() async throws -> [BackupConsentRecord] { [] }
-    func blobCiphertext(sha256: String) async throws -> Data? { blobs[sha256] }
+    func blobCiphertext(sha256: String) async throws -> BackupBlobAvailability {
+        blobs[sha256].map { .available($0) } ?? .gone
+    }
 }
 
 private actor StubSink: BackupSinkProviding {
@@ -174,9 +229,26 @@ private actor StubSink: BackupSinkProviding {
     var messages: [BackupMessageRecord] = []
     var blobs: [BackupBlobRecord] = []
 
-    func restore(groups: [BackupGroupRecord]) async throws { self.groups = groups }
-    func restore(messages: [BackupMessageRecord]) async throws { self.messages = messages }
-    func restore(invitations: [BackupInvitationRecord]) async throws {}
-    func restore(consents: [BackupConsentRecord]) async throws {}
+    func restore(groups: [BackupGroupRecord]) async throws -> Int {
+        self.groups = groups
+        return groups.count
+    }
+    func restore(messages: [BackupMessageRecord]) async throws -> Int {
+        self.messages = messages
+        return messages.count
+    }
+    func restore(invitations: [BackupInvitationRecord]) async throws -> Int { 0 }
+    func restore(consents: [BackupConsentRecord]) async throws -> Int { 0 }
     func restore(blob: BackupBlobRecord) async throws { blobs.append(blob) }
+}
+
+
+/// Writes only the first group it is handed, standing in for a sink that
+/// meets a row from a schema it does not understand.
+private actor RefusingSink: BackupSinkProviding {
+    func restore(groups: [BackupGroupRecord]) async throws -> Int { min(groups.count, 1) }
+    func restore(messages: [BackupMessageRecord]) async throws -> Int { messages.count }
+    func restore(invitations: [BackupInvitationRecord]) async throws -> Int { 0 }
+    func restore(consents: [BackupConsentRecord]) async throws -> Int { 0 }
+    func restore(blob: BackupBlobRecord) async throws {}
 }


### PR DESCRIPTION
Third of the device-backup stack, on top of #275. Reads local state through a port, writes a versioned archive, seals it — and on the way back, verifies, decodes, then writes through the app's stores so the restoring device re-encrypts everything under *its* at-rest key.

### Eligibility is structural, not remembered

`BackupComposer` holds a `BackupSourceProviding` and nothing else — no `IdentityRepository`, no keychain, no `StorageEncryption`. "Seed material is never eligible" ([UI-Backup.md §16.1](https://github.com/onymchat/onym-system/blob/main/backup/UI-Backup.md)) is therefore a property of the type graph rather than a discipline someone has to keep.

The test that matters most here opens a composed snapshot back to plaintext and asserts the seed, its mnemonic words, the access signing key and the archive root are all absent — with a positive assertion alongside, so it can't pass on an empty file.

### Media never comes from the device's caches

`ChatImageLoader` and friends write **decrypted** bytes into `Caches/Onym*` under filenames that are public Blossom content addresses. Copying those into a snapshot would hand an operator plaintext media keyed by an identifier anyone can look up — the single worst thing that could go in. Under `.includeCiphertext` the bytes come from the blob store and are verified against the address they claim before inclusion, and again on restore.

### Restore has three gates, in this order

1. Verify the whole reference — bytes that don't compose their digest never reach a decoder.
2. Decode and validate the *entire* archive.
3. Only then write, groups before messages.

Holding a decoded archive in memory is the cost. A half-restored device is the alternative, and a chat list with some groups and none of their messages looks like data loss because it is.

### Two judgement calls worth review

- **A missing blob is not a failure.** Blob retention is the blob operator's own contract and shorter than a backup's by design, so the descriptor still travels and `BackupRestoreSummary.unresolvedBlobs` reports what couldn't be resolved — rather than reporting plain success while the person's media is partly gone.
- **Restored consents land inactive.** Re-activating one would silently re-select an operator the person hasn't seen since the snapshot. They're also merged rather than replacing existing consents, so a choice made *after* the backup isn't revoked by restoring it.

### A bug the tests caught

Setting file protection via `setResourceValue` after creation throws where data protection is unavailable — every one of these tests failed with a misleading "couldn't be removed". It's now passed as a creation attribute, honoured on device and ignored where it can't apply. This would have failed on the simulator and on device-less CI only, so it was worth finding here.

### Verification

```
BackupCompositionTests   4 passed  (seed-absence, round trip, plaintext cleanup, blob address check)
BackupSealingTests       8 passed
** TEST SUCCEEDED **
```

`xcodebuild -scheme OnymIOS` **BUILD SUCCEEDED**.

### Still to come in the stack

The adapter and repository (`URLSessionBackupClient`, the payment-retry loop), then `OnymBilling`, then the UI. Nothing here is reachable from the app yet.