### PR TITLE
Backup adapter and repository: the wire, and what it refuses to believe

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
@@ -17,7 +17,12 @@ import OnymFoundation
 public actor BackupComposer {
     private let source: any BackupSourceProviding
     private let mediaPolicy: BackupMediaPolicy
-    private let workingDirectory: URL
+    /// Where sealed snapshots and scratch files live.
+    ///
+    /// Immutable and `Sendable`, so callers outside the actor can read
+    /// it without a hop — the repository needs it to clean up bytes for
+    /// an operation the composer knows nothing about.
+    public let workingDirectory: URL
 
     public init(
         source: any BackupSourceProviding,

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
@@ -98,6 +98,14 @@ public enum BackupError: Error, Equatable, Sendable {
         /// finishing. A programming error, named so it does not
         /// masquerade as a corrupt archive.
         case archiveWriterFinished
+        /// The local backup state exists but could not be read or
+        /// decoded. Never treated as "no backup configured": the next
+        /// save would overwrite the pinned terms and the pending
+        /// operations with an empty file.
+        case stateUnreadable
+        /// The operator's upload grant does not describe the snapshot we
+        /// are holding. Refused before any byte is sent.
+        case invalidUploadGrant
     }
 }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -63,9 +63,19 @@ public actor BackupRepository {
         let snapshot = try await composer.compose(
             keyMaterial: keyMaterial,
             acceptedTermsId: acceptedTermsId,
-            supersedes: state.snapshots.last.map {
-                try? SnapshotReference(digest: $0.digest, sealedByteSize: $0.sealedByteSize)
-            } ?? nil,
+            supersedes: try state.snapshots.last.map {
+                // `try?` here would turn an unreadable ancestor into a
+                // snapshot claiming to supersede nothing, quietly
+                // breaking the chain. The store refuses to *read*
+                // corrupt state for the same reason; it should not be
+                // written past here either.
+                do {
+                    return try SnapshotReference(
+                        digest: $0.digest, sealedByteSize: $0.sealedByteSize)
+                } catch {
+                    throw BackupError.localFailure(reason: .stateUnreadable)
+                }
+            },
             now: now
         )
         state.lastAttemptAt = now
@@ -88,7 +98,7 @@ public actor BackupRepository {
             snapshotReference: try SnapshotReference(
                 digest: pending.digest, sealedByteSize: pending.sealedByteSize),
             sealedBytesURL: url,
-            sealedAt: pending.refusedAt,
+            sealedAt: pending.sealedAt,
             acceptedTermsId: pending.acceptedTermsId,
             supersedes: try pending.supersedesDigest.flatMap { digest in
                 try pending.supersedesByteSize.map {
@@ -135,6 +145,7 @@ public actor BackupRepository {
                     acceptedTermsId: snapshot.acceptedTermsId,
                     supersedesDigest: snapshot.supersedes?.digest,
                     supersedesByteSize: snapshot.supersedes?.sealedByteSize,
+                    sealedAt: snapshot.sealedAt,
                     refusedAt: now
                 )
                 try stateStore.save(state)
@@ -185,6 +196,7 @@ public actor BackupRepository {
                 BackupState.PendingOperation(
                     operationId: snapshot.operationId,
                     digest: snapshot.snapshotReference.digest,
+                    sealedByteSize: snapshot.snapshotReference.sealedByteSize,
                     startedAt: now,
                     acceptedTermsId: snapshot.acceptedTermsId
                 )
@@ -257,12 +269,19 @@ public actor BackupRepository {
         var stillPending: [BackupState.PendingOperation] = []
         for pending in state.pendingOperations {
             if let row = retainedByDigest[pending.digest] {
+                // Our own pin, not the operator's echo. Which terms a
+                // stored snapshot was accepted under is not a fact a
+                // counterparty gets to restate — and an empty pin is not
+                // something this type writes.
+                guard let pinnedTerms = pending.acceptedTermsId ?? state.acceptedTermsId,
+                      !pinnedTerms.isEmpty
+                else {
+                    stillPending.append(pending)
+                    continue
+                }
                 state.record(
                     reference: row.snapshotReference,
-                    // Our own pin, not the operator's echo. Which terms a
-                    // stored snapshot was accepted under is not a fact a
-                    // counterparty gets to restate.
-                    acceptedTermsId: pending.acceptedTermsId ?? state.acceptedTermsId ?? "",
+                    acceptedTermsId: pinnedTerms,
                     at: pending.startedAt,
                     status: .retained
                 )
@@ -290,13 +309,31 @@ public actor BackupRepository {
             switch outcome.status {
             case .retained, .alreadyRetained:
                 // Not in the list but claimed retained. Believe the
-                // digest we sent, never the one echoed back.
+                // digest and the size *we* recorded, never the ones
+                // echoed back — and if we cannot rebuild the reference
+                // from our own record, keep the operation pending rather
+                // than throwing.
+                //
+                // Throwing here wedged everything: reconcile ran before
+                // composing, so a single unbuildable reference aborted
+                // `backUp` before it could save, leaving the operation
+                // unresolved and every subsequent run to hit the same
+                // line. A terse — or hostile — operator could brick
+                // backups permanently with a *success* answer.
+                guard
+                    let size = pending.sealedByteSize ?? outcome.snapshotReference?.sealedByteSize,
+                    let reference = try? SnapshotReference(digest: pending.digest, sealedByteSize: size),
+                    let pinnedTerms = pending.acceptedTermsId ?? state.acceptedTermsId,
+                    !pinnedTerms.isEmpty
+                else {
+                    // An empty terms pin is exactly what the rest of this
+                    // type refuses to write.
+                    stillPending.append(pending)
+                    continue
+                }
                 state.record(
-                    reference: try SnapshotReference(
-                        digest: pending.digest,
-                        sealedByteSize: outcome.snapshotReference?.sealedByteSize ?? 0
-                    ),
-                    acceptedTermsId: pending.acceptedTermsId ?? state.acceptedTermsId ?? "",
+                    reference: reference,
+                    acceptedTermsId: pinnedTerms,
                     at: pending.startedAt,
                     status: .retained
                 )

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// Drives one backup: compose, preflight, upload, record.
+///
+/// The state machine is small and its edges are the interesting part —
+/// what it refuses to do is most of the design.
+public actor BackupRepository {
+    private let port: any BackupPort
+    private let composer: BackupComposer
+    private let stateStore: any BackupStateStoring
+    private let keyMaterial: BackupKeyMaterial
+
+    public init(
+        port: any BackupPort,
+        composer: BackupComposer,
+        stateStore: any BackupStateStoring,
+        keyMaterial: BackupKeyMaterial
+    ) {
+        self.port = port
+        self.composer = composer
+        self.stateStore = stateStore
+        self.keyMaterial = keyMaterial
+    }
+
+    /// What a caller sees after asking for a backup.
+    public enum RunResult: Sendable, Equatable {
+        case retained(SnapshotReference)
+        case alreadyRetained(SnapshotReference)
+        /// The operator wants payment. The sealed bytes are kept so the
+        /// retry after purchase sends the *same* snapshot.
+        case paymentRequired(componentId: String, offerIds: [String], pending: SealedSnapshot)
+        /// Terms moved. Uploading would pin something nobody agreed to.
+        case termsChanged(currentTermsId: String?)
+        /// The request went out and we never learned what happened.
+        case unknown(operationId: String)
+    }
+
+    /// Compose a fresh snapshot and try to place it.
+    public func backUp(now: Date = Date()) async throws -> RunResult {
+        var state = try stateStore.load()
+
+        // Reconcile before adding to the pile. An operation whose result
+        // we never learned may well have succeeded, and composing a
+        // second snapshot on top of an unresolved first is how a person
+        // ends up paying to store the same history twice.
+        try await reconcile(&state)
+
+        guard let acceptedTermsId = state.acceptedTermsId else {
+            // Nothing has been consented to. Enrolment is a decision, and
+            // the repository does not make it on the person's behalf.
+            throw BackupError.termsUnavailable
+        }
+
+        let connection = try await port.connect()
+        if connection.acceptedTermsId != acceptedTermsId {
+            // Do not upload, do not re-pin, do not "helpfully" accept.
+            // Fresh consent is a screen, not an inference.
+            state.lastAttemptAt = now
+            try stateStore.save(state)
+            return .termsChanged(currentTermsId: connection.acceptedTermsId)
+        }
+
+        let snapshot = try await composer.compose(
+            keyMaterial: keyMaterial,
+            acceptedTermsId: acceptedTermsId,
+            supersedes: state.snapshots.last.map {
+                try? SnapshotReference(digest: $0.digest, sealedByteSize: $0.sealedByteSize)
+            } ?? nil,
+            now: now
+        )
+        state.lastAttemptAt = now
+        try stateStore.save(state)
+        return try await place(snapshot, state: &state, now: now)
+    }
+
+    /// Retry a snapshot that was refused for payment, byte for byte.
+    ///
+    /// Takes the `SealedSnapshot` the refusal handed back rather than
+    /// composing again: a fresh composition mints a new salt and a new
+    /// digest, which would defeat both the retry and `already_retained`,
+    /// and would charge the person for a second copy of the same
+    /// history.
+    public func retry(_ snapshot: SealedSnapshot, now: Date = Date()) async throws -> RunResult {
+        var state = try stateStore.load()
+        return try await place(snapshot, state: &state, now: now)
+    }
+
+    private func place(
+        _ snapshot: SealedSnapshot,
+        state: inout BackupState,
+        now: Date
+    ) async throws -> RunResult {
+        let preflight: BackupPreflight
+        do {
+            preflight = try await port.preflight(snapshot)
+        } catch let error as BackupError {
+            switch error {
+            case .paymentRequired(let componentId, let offerIds, _):
+                // The sealed bytes stay on disk. Nothing is discarded
+                // for a refusal that a purchase resolves.
+                return .paymentRequired(
+                    componentId: componentId, offerIds: offerIds, pending: snapshot)
+            case .termsChanged(let currentTermsId):
+                return .termsChanged(currentTermsId: currentTermsId)
+            default:
+                throw error
+            }
+        }
+
+        switch preflight {
+        case .alreadyRetained(let outcome):
+            try discard(snapshot)
+            state.lastSuccessAt = now
+            try stateStore.save(state)
+            return .alreadyRetained(outcome.snapshotReference ?? snapshot.snapshotReference)
+
+        case .granted(let grant):
+            // Recorded *before* the upload, not after. If the response
+            // is lost we must still know an operation is outstanding —
+            // a record written only on success is exactly the record
+            // that is missing when it matters.
+            state.pendingOperations.append(
+                BackupState.PendingOperation(
+                    operationId: snapshot.operationId,
+                    digest: snapshot.snapshotReference.digest,
+                    startedAt: now
+                )
+            )
+            try stateStore.save(state)
+
+            let outcome: BackupOutcome
+            do {
+                outcome = try await port.uploadSnapshot(snapshot, grant: grant)
+            } catch {
+                // Preserved as unresolved rather than reported as
+                // failure: the bytes may well be held, and only the
+                // operator can say.
+                return .unknown(operationId: snapshot.operationId)
+            }
+
+            state.pendingOperations.removeAll { $0.operationId == snapshot.operationId }
+            guard outcome.status.isRetention else {
+                // `submitted` and `accepted` are not retention. Recording
+                // either as success is the lie this vocabulary exists to
+                // prevent.
+                try stateStore.save(state)
+                return .unknown(operationId: snapshot.operationId)
+            }
+
+            state.snapshots.append(
+                BackupState.RecordedSnapshot(
+                    digest: snapshot.snapshotReference.digest,
+                    sealedByteSize: snapshot.snapshotReference.sealedByteSize,
+                    acceptedTermsId: snapshot.acceptedTermsId,
+                    uploadedAt: now,
+                    statusRaw: outcome.status.rawValue
+                )
+            )
+            state.lastSuccessAt = now
+            try stateStore.save(state)
+            try discard(snapshot)
+            return .retained(snapshot.snapshotReference)
+        }
+    }
+
+    /// Ask the operator about operations we lost track of.
+    private func reconcile(_ state: inout BackupState) async throws {
+        guard !state.pendingOperations.isEmpty else { return }
+        var stillPending: [BackupState.PendingOperation] = []
+        for pending in state.pendingOperations {
+            guard let outcome = try? await port.queryOutcome(operationId: pending.operationId) else {
+                // No answer, or no record. It stays pending: an
+                // operation we cannot resolve is not an operation that
+                // failed, and dropping it here would quietly convert
+                // uncertainty into a clean slate.
+                stillPending.append(pending)
+                continue
+            }
+            if outcome.status.isRetention,
+               let reference = outcome.snapshotReference {
+                state.snapshots.append(
+                    BackupState.RecordedSnapshot(
+                        digest: reference.digest,
+                        sealedByteSize: reference.sealedByteSize,
+                        acceptedTermsId: state.acceptedTermsId ?? "",
+                        uploadedAt: pending.startedAt,
+                        statusRaw: outcome.status.rawValue
+                    )
+                )
+            } else if outcome.status == .unknown || outcome.status == .unreachable {
+                stillPending.append(pending)
+            }
+        }
+        state.pendingOperations = stillPending
+        try stateStore.save(state)
+    }
+
+    /// Remove sealed bytes once they are no longer needed. Failing to
+    /// delete is not worth failing a completed backup over; the working
+    /// directory is swept on the next run.
+    private func discard(_ snapshot: SealedSnapshot) throws {
+        try? FileManager.default.removeItem(at: snapshot.sealedBytesURL)
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -73,6 +73,31 @@ public actor BackupRepository {
         return try await place(snapshot, state: &state, now: now)
     }
 
+    /// The snapshot waiting on a purchase, if one survived a relaunch.
+    ///
+    /// Returns `nil` when the recorded sealed bytes are gone — there is
+    /// nothing to retry, and reporting a pending payment we cannot honour
+    /// would strand the caller in a purchase flow with no snapshot at the
+    /// end of it.
+    public func pendingPayment(in workingDirectory: URL) throws -> SealedSnapshot? {
+        guard let pending = try stateStore.load().awaitingPayment else { return nil }
+        let url = workingDirectory.appending(path: pending.sealedBytesFilename)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return SealedSnapshot(
+            operationId: pending.operationId,
+            snapshotReference: try SnapshotReference(
+                digest: pending.digest, sealedByteSize: pending.sealedByteSize),
+            sealedBytesURL: url,
+            sealedAt: pending.refusedAt,
+            acceptedTermsId: pending.acceptedTermsId,
+            supersedes: try pending.supersedesDigest.flatMap { digest in
+                try pending.supersedesByteSize.map {
+                    try SnapshotReference(digest: digest, sealedByteSize: $0)
+                }
+            }
+        )
+    }
+
     /// Retry a snapshot that was refused for payment, byte for byte.
     ///
     /// Takes the `SealedSnapshot` the refusal handed back rather than
@@ -96,8 +121,23 @@ public actor BackupRepository {
         } catch let error as BackupError {
             switch error {
             case .paymentRequired(let componentId, let offerIds, _):
-                // The sealed bytes stay on disk. Nothing is discarded
-                // for a refusal that a purchase resolves.
+                // The sealed bytes stay on disk *and* the fact that they
+                // are owed a purchase is written down. A StoreKit
+                // purchase routinely resolves after a relaunch, and a
+                // snapshot remembered only in a returned enum would be
+                // swept as scratch — re-composed, re-salted, and paid
+                // for twice.
+                state.awaitingPayment = BackupState.PendingPayment(
+                    operationId: snapshot.operationId,
+                    digest: snapshot.snapshotReference.digest,
+                    sealedByteSize: snapshot.snapshotReference.sealedByteSize,
+                    sealedBytesFilename: snapshot.sealedBytesURL.lastPathComponent,
+                    acceptedTermsId: snapshot.acceptedTermsId,
+                    supersedesDigest: snapshot.supersedes?.digest,
+                    supersedesByteSize: snapshot.supersedes?.sealedByteSize,
+                    refusedAt: now
+                )
+                try stateStore.save(state)
                 return .paymentRequired(
                     componentId: componentId, offerIds: offerIds, pending: snapshot)
             case .termsChanged(let currentTermsId):
@@ -109,7 +149,18 @@ public actor BackupRepository {
 
         switch preflight {
         case .alreadyRetained(let outcome):
-            let reference = outcome.snapshotReference ?? snapshot.snapshotReference
+            // An echoed reference that is not the one we asked about is
+            // an operator answering a different question. Recording it
+            // would let a counterparty choose what the next run
+            // supersedes.
+            if let echoed = outcome.snapshotReference,
+               echoed.digest != snapshot.snapshotReference.digest {
+                throw BackupError.rejected(
+                    code: "reference_mismatch",
+                    message: "the operator answered about a different snapshot"
+                )
+            }
+            let reference = snapshot.snapshotReference
             // Recorded like any other retention. Skipping it would leave
             // the next run's `supersedes` pointing at a stale ancestor —
             // the operator holds this snapshot, whoever put it there.
@@ -120,6 +171,7 @@ public actor BackupRepository {
                 status: outcome.status
             )
             state.lastSuccessAt = now
+            state.clearPendingPayment(for: snapshot.operationId)
             try stateStore.save(state)
             try discard(snapshot)
             return .alreadyRetained(reference)
@@ -133,7 +185,8 @@ public actor BackupRepository {
                 BackupState.PendingOperation(
                     operationId: snapshot.operationId,
                     digest: snapshot.snapshotReference.digest,
-                    startedAt: now
+                    startedAt: now,
+                    acceptedTermsId: snapshot.acceptedTermsId
                 )
             )
             try stateStore.save(state)
@@ -166,6 +219,7 @@ public actor BackupRepository {
                 status: outcome.status
             )
             state.lastSuccessAt = now
+            state.clearPendingPayment(for: snapshot.operationId)
             try stateStore.save(state)
             try discard(snapshot)
             return .retained(snapshot.snapshotReference)
@@ -205,17 +259,56 @@ public actor BackupRepository {
             if let row = retainedByDigest[pending.digest] {
                 state.record(
                     reference: row.snapshotReference,
-                    acceptedTermsId: row.acceptedTermsId,
+                    // Our own pin, not the operator's echo. Which terms a
+                    // stored snapshot was accepted under is not a fact a
+                    // counterparty gets to restate.
+                    acceptedTermsId: pending.acceptedTermsId ?? state.acceptedTermsId ?? "",
                     at: pending.startedAt,
                     status: .retained
                 )
                 continue
             }
-            // Not in the list. Ask about the operation itself, in case
-            // the operator distinguishes a refusal we should surface —
-            // but either way it is no longer outstanding.
-            if let outcome = try? await port.queryOutcome(operationId: pending.operationId),
-               outcome.status == .unknown || outcome.status == .unreachable {
+
+            // Not in the list yet. That is not the same as never having
+            // happened: an upload can be accepted and still in flight.
+            let outcome: BackupOutcome?
+            do {
+                outcome = try await port.queryOutcome(operationId: pending.operationId)
+            } catch {
+                // Could not ask. A failed query resolves nothing — the
+                // same rule as a failed list, and for the same reason.
+                stillPending.append(pending)
+                continue
+            }
+
+            guard let outcome else {
+                // The operator answered and has no record. Combined with
+                // its absence from the retained list, the upload did not
+                // result in retention.
+                continue
+            }
+            switch outcome.status {
+            case .retained, .alreadyRetained:
+                // Not in the list but claimed retained. Believe the
+                // digest we sent, never the one echoed back.
+                state.record(
+                    reference: try SnapshotReference(
+                        digest: pending.digest,
+                        sealedByteSize: outcome.snapshotReference?.sealedByteSize ?? 0
+                    ),
+                    acceptedTermsId: pending.acceptedTermsId ?? state.acceptedTermsId ?? "",
+                    at: pending.startedAt,
+                    status: .retained
+                )
+            case .rejected:
+                // Refused, definitively. Resolved.
+                continue
+            default:
+                // queuedLocally, submitted, accepted, unknown,
+                // unreachable — all still in flight. Resolving these
+                // negatively would compose a second snapshot on top of
+                // one the operator is still working on, and charge for
+                // both.
                 stillPending.append(pending)
             }
         }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -109,10 +109,20 @@ public actor BackupRepository {
 
         switch preflight {
         case .alreadyRetained(let outcome):
-            try discard(snapshot)
+            let reference = outcome.snapshotReference ?? snapshot.snapshotReference
+            // Recorded like any other retention. Skipping it would leave
+            // the next run's `supersedes` pointing at a stale ancestor —
+            // the operator holds this snapshot, whoever put it there.
+            state.record(
+                reference: reference,
+                acceptedTermsId: snapshot.acceptedTermsId,
+                at: now,
+                status: outcome.status
+            )
             state.lastSuccessAt = now
             try stateStore.save(state)
-            return .alreadyRetained(outcome.snapshotReference ?? snapshot.snapshotReference)
+            try discard(snapshot)
+            return .alreadyRetained(reference)
 
         case .granted(let grant):
             // Recorded *before* the upload, not after. If the response
@@ -138,23 +148,22 @@ public actor BackupRepository {
                 return .unknown(operationId: snapshot.operationId)
             }
 
-            state.pendingOperations.removeAll { $0.operationId == snapshot.operationId }
             guard outcome.status.isRetention else {
-                // `submitted` and `accepted` are not retention. Recording
-                // either as success is the lie this vocabulary exists to
-                // prevent.
+                // `submitted` and `accepted` are not retention, and the
+                // pending record stays. Clearing it here would drop the
+                // uncertainty on the floor — reconcile would never
+                // re-query, and "silence is not success" would hold only
+                // until the next line of code.
                 try stateStore.save(state)
                 return .unknown(operationId: snapshot.operationId)
             }
+            state.pendingOperations.removeAll { $0.operationId == snapshot.operationId }
 
-            state.snapshots.append(
-                BackupState.RecordedSnapshot(
-                    digest: snapshot.snapshotReference.digest,
-                    sealedByteSize: snapshot.snapshotReference.sealedByteSize,
-                    acceptedTermsId: snapshot.acceptedTermsId,
-                    uploadedAt: now,
-                    statusRaw: outcome.status.rawValue
-                )
+            state.record(
+                reference: snapshot.snapshotReference,
+                acceptedTermsId: snapshot.acceptedTermsId,
+                at: now,
+                status: outcome.status
             )
             state.lastSuccessAt = now
             try stateStore.save(state)
@@ -163,31 +172,50 @@ public actor BackupRepository {
         }
     }
 
-    /// Ask the operator about operations we lost track of.
+    /// Resolve operations we lost track of.
+    ///
+    /// Two sources, in order of authority. `listSnapshots` says what is
+    /// *retained*, which is the question actually being asked;
+    /// `queryOutcome` says what happened to one operation, and an
+    /// operator only keeps those for a declared window measured in hours
+    /// (§15 of the profile). Querying alone would therefore leave any
+    /// response lost for longer than that window pending forever,
+    /// re-asked on every run for the life of the install.
+    ///
+    /// So: if the digest is in the retained list, it is retained. If the
+    /// list came back and the digest is not in it, the upload did not
+    /// result in retention and the record is resolved — negatively, but
+    /// resolved. Only a list we could not fetch leaves things pending,
+    /// because that is the one case where we genuinely do not know.
     private func reconcile(_ state: inout BackupState) async throws {
         guard !state.pendingOperations.isEmpty else { return }
+
+        guard let retained = try? await port.listSnapshots() else {
+            // No list, no conclusions. Uncertainty survives a failed
+            // reconciliation rather than being resolved by it.
+            return
+        }
+        let retainedByDigest = Dictionary(
+            retained.map { ($0.snapshotReference.digest, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
         var stillPending: [BackupState.PendingOperation] = []
         for pending in state.pendingOperations {
-            guard let outcome = try? await port.queryOutcome(operationId: pending.operationId) else {
-                // No answer, or no record. It stays pending: an
-                // operation we cannot resolve is not an operation that
-                // failed, and dropping it here would quietly convert
-                // uncertainty into a clean slate.
-                stillPending.append(pending)
+            if let row = retainedByDigest[pending.digest] {
+                state.record(
+                    reference: row.snapshotReference,
+                    acceptedTermsId: row.acceptedTermsId,
+                    at: pending.startedAt,
+                    status: .retained
+                )
                 continue
             }
-            if outcome.status.isRetention,
-               let reference = outcome.snapshotReference {
-                state.snapshots.append(
-                    BackupState.RecordedSnapshot(
-                        digest: reference.digest,
-                        sealedByteSize: reference.sealedByteSize,
-                        acceptedTermsId: state.acceptedTermsId ?? "",
-                        uploadedAt: pending.startedAt,
-                        statusRaw: outcome.status.rawValue
-                    )
-                )
-            } else if outcome.status == .unknown || outcome.status == .unreachable {
+            // Not in the list. Ask about the operation itself, in case
+            // the operator distinguishes a refusal we should surface —
+            // but either way it is no longer outstanding.
+            if let outcome = try? await port.queryOutcome(operationId: pending.operationId),
+               outcome.status == .unknown || outcome.status == .unreachable {
                 stillPending.append(pending)
             }
         }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -10,6 +10,16 @@ public actor BackupRepository {
     private let stateStore: any BackupStateStoring
     private let keyMaterial: BackupKeyMaterial
 
+    /// Set while a run is in flight.
+    ///
+    /// Actor reentrancy is real: `backUp` loads state at entry and saves
+    /// across many `await port.*` suspension points, so two interleaved
+    /// runs would each save their own stale copy — and the one that lost
+    /// would take the other's just-written pending record with it. That
+    /// record is the entire uncertainty design, so runs are serialized
+    /// rather than merged.
+    private var isRunning = false
+
     public init(
         port: any BackupPort,
         composer: BackupComposer,
@@ -33,10 +43,19 @@ public actor BackupRepository {
         case termsChanged(currentTermsId: String?)
         /// The request went out and we never learned what happened.
         case unknown(operationId: String)
+        /// Earlier work is unresolved and could not be reconciled, so
+        /// nothing new was composed.
+        case awaitingReconciliation(operationIds: [String])
+        /// Another run is already in flight.
+        case alreadyRunning
     }
 
     /// Compose a fresh snapshot and try to place it.
     public func backUp(now: Date = Date()) async throws -> RunResult {
+        guard !isRunning else { return .alreadyRunning }
+        isRunning = true
+        defer { isRunning = false }
+
         var state = try stateStore.load()
 
         // Reconcile before adding to the pile. An operation whose result
@@ -44,6 +63,20 @@ public actor BackupRepository {
         // second snapshot on top of an unresolved first is how a person
         // ends up paying to store the same history twice.
         try await reconcile(&state)
+
+        // And if it is *still* unresolved, do not compose. Reconciling
+        // first only prevents double storage if failing to reconcile
+        // also stops us — otherwise a run that cannot reach the operator
+        // mints a fresh salt and digest every time, and the operator
+        // retains each one beside the copy we lost track of. The caller
+        // is told, so a UI can say "checking on an earlier backup"
+        // rather than showing a silent no-op.
+        guard state.pendingOperations.isEmpty else {
+            state.lastAttemptAt = now
+            try stateStore.save(state)
+            return .awaitingReconciliation(
+                operationIds: state.pendingOperations.map(\.operationId))
+        }
 
         guard let acceptedTermsId = state.acceptedTermsId else {
             // Nothing has been consented to. Enrolment is a decision, and
@@ -63,7 +96,7 @@ public actor BackupRepository {
         let snapshot = try await composer.compose(
             keyMaterial: keyMaterial,
             acceptedTermsId: acceptedTermsId,
-            supersedes: try state.snapshots.last.map {
+            supersedes: try state.newestSnapshot.map {
                 // `try?` here would turn an unreadable ancestor into a
                 // snapshot claiming to supersede nothing, quietly
                 // breaking the chain. The store refuses to *read*
@@ -89,9 +122,10 @@ public actor BackupRepository {
     /// nothing to retry, and reporting a pending payment we cannot honour
     /// would strand the caller in a purchase flow with no snapshot at the
     /// end of it.
-    public func pendingPayment(in workingDirectory: URL) throws -> SealedSnapshot? {
+    public func pendingPayment(in workingDirectory: URL? = nil) throws -> SealedSnapshot? {
         guard let pending = try stateStore.load().awaitingPayment else { return nil }
-        let url = workingDirectory.appending(path: pending.sealedBytesFilename)
+        let url = (workingDirectory ?? composer.workingDirectory)
+            .appending(path: pending.sealedBytesFilename)
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
         return SealedSnapshot(
             operationId: pending.operationId,
@@ -116,6 +150,10 @@ public actor BackupRepository {
     /// and would charge the person for a second copy of the same
     /// history.
     public func retry(_ snapshot: SealedSnapshot, now: Date = Date()) async throws -> RunResult {
+        guard !isRunning else { return .alreadyRunning }
+        isRunning = true
+        defer { isRunning = false }
+
         var state = try stateStore.load()
         return try await place(snapshot, state: &state, now: now)
     }
@@ -184,7 +222,7 @@ public actor BackupRepository {
             state.lastSuccessAt = now
             state.clearPendingPayment(for: snapshot.operationId)
             try stateStore.save(state)
-            try discard(snapshot)
+            discard(snapshot)
             return .alreadyRetained(reference)
 
         case .granted(let grant):
@@ -233,7 +271,7 @@ public actor BackupRepository {
             state.lastSuccessAt = now
             state.clearPendingPayment(for: snapshot.operationId)
             try stateStore.save(state)
-            try discard(snapshot)
+            discard(snapshot)
             return .retained(snapshot.snapshotReference)
         }
     }
@@ -285,6 +323,7 @@ public actor BackupRepository {
                     at: pending.startedAt,
                     status: .retained
                 )
+                resolve(pending, in: &state)
                 continue
             }
 
@@ -304,6 +343,7 @@ public actor BackupRepository {
                 // The operator answered and has no record. Combined with
                 // its absence from the retained list, the upload did not
                 // result in retention.
+                resolve(pending, in: &state, retained: false)
                 continue
             }
             switch outcome.status {
@@ -337,8 +377,11 @@ public actor BackupRepository {
                     at: pending.startedAt,
                     status: .retained
                 )
+                resolve(pending, in: &state)
             case .rejected:
-                // Refused, definitively. Resolved.
+                // Refused, definitively. Resolved — including any
+                // purchase it was waiting on, which buys nothing now.
+                resolve(pending, in: &state, retained: false)
                 continue
             default:
                 // queuedLocally, submitted, accepted, unknown,
@@ -353,10 +396,39 @@ public actor BackupRepository {
         try stateStore.save(state)
     }
 
-    /// Remove sealed bytes once they are no longer needed. Failing to
-    /// delete is not worth failing a completed backup over; the working
-    /// directory is swept on the next run.
-    private func discard(_ snapshot: SealedSnapshot) throws {
+    /// Close out a pending operation: clear any purchase it was waiting
+    /// on, drop its sealed bytes, and — when it landed — record that a
+    /// backup succeeded.
+    ///
+    /// Without the first part, `pendingPayment(in:)` keeps reporting a
+    /// purchase owed for a snapshot the operator already holds, which is
+    /// precisely the stranding its own doc comment warns about.
+    private func resolve(
+        _ pending: BackupState.PendingOperation,
+        in state: inout BackupState,
+        retained: Bool = true
+    ) {
+        if let payment = state.awaitingPayment, payment.operationId == pending.operationId {
+            discardSealedBytes(named: payment.sealedBytesFilename)
+            state.awaitingPayment = nil
+        }
+        if retained {
+            // A backup that landed is a backup that landed, whichever
+            // run found out about it.
+            state.lastSuccessAt = max(state.lastSuccessAt ?? pending.startedAt, pending.startedAt)
+        }
+    }
+
+    /// Remove sealed bytes once they are no longer needed.
+    ///
+    /// Not throwing: failing to delete is not worth failing a completed
+    /// backup over, and the working directory is swept on the next run.
+    private func discard(_ snapshot: SealedSnapshot) {
         try? FileManager.default.removeItem(at: snapshot.sealedBytesURL)
+    }
+
+    private func discardSealedBytes(named filename: String) {
+        try? FileManager.default.removeItem(
+            at: composer.workingDirectory.appending(path: filename))
     }
 }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
@@ -24,6 +24,9 @@ public struct BackupState: Sendable, Equatable, Codable {
     /// `queryOutcome` resolves them — silence is not success, and the
     /// only way that stays true is if the uncertainty is durable.
     public var pendingOperations: [PendingOperation] = []
+    /// Set while a snapshot waits on a purchase. Its sealed bytes must
+    /// survive until the retry resolves.
+    public var awaitingPayment: PendingPayment?
     public var receipts: [Data] = []
 
     public struct RecordedSnapshot: Sendable, Equatable, Codable {
@@ -38,9 +41,35 @@ public struct BackupState: Sendable, Equatable, Codable {
         public let operationId: String
         public let digest: String
         public let startedAt: Date
+        /// The terms *we* pinned when this went out. Reconciliation
+        /// records this rather than the digest an operator echoes back,
+        /// so a counterparty cannot rewrite which terms a stored
+        /// snapshot was accepted under.
+        public var acceptedTermsId: String?
+    }
+
+    /// A snapshot the operator refused for payment, kept across launches.
+    ///
+    /// A purchase routinely outlives the process — StoreKit will happily
+    /// resolve one after a relaunch — and without this the retry has
+    /// nothing to send. It would re-compose, mint a new salt, and the
+    /// person would pay to store the same history a second time.
+    public struct PendingPayment: Sendable, Equatable, Codable {
+        public let operationId: String
+        public let digest: String
+        public let sealedByteSize: Int
+        public let sealedBytesFilename: String
+        public let acceptedTermsId: String
+        public let supersedesDigest: String?
+        public let supersedesByteSize: Int?
+        public let refusedAt: Date
     }
 
     public init() {}
+
+    mutating func clearPendingPayment(for operationId: String) {
+        if awaitingPayment?.operationId == operationId { awaitingPayment = nil }
+    }
 
     /// Append a retention to the chain, replacing any earlier record of
     /// the same digest so a reconciliation cannot double-count what an

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
@@ -41,6 +41,27 @@ public struct BackupState: Sendable, Equatable, Codable {
     }
 
     public init() {}
+
+    /// Append a retention to the chain, replacing any earlier record of
+    /// the same digest so a reconciliation cannot double-count what an
+    /// upload already recorded.
+    mutating func record(
+        reference: SnapshotReference,
+        acceptedTermsId: String,
+        at date: Date,
+        status: BackupOutcomeStatus
+    ) {
+        snapshots.removeAll { $0.digest == reference.digest }
+        snapshots.append(
+            RecordedSnapshot(
+                digest: reference.digest,
+                sealedByteSize: reference.sealedByteSize,
+                acceptedTermsId: acceptedTermsId,
+                uploadedAt: date,
+                statusRaw: status.rawValue
+            )
+        )
+    }
 }
 
 /// Persists `BackupState`.
@@ -58,13 +79,25 @@ public struct FileBackupStateStore: BackupStateStoring {
     }
 
     public func load() throws -> BackupState {
-        guard let data = try? Data(contentsOf: url) else { return BackupState() }
+        // Absent is a first run. *Unreadable* is not: an I/O error, or a
+        // read attempted while the device is locked and the file is under
+        // complete protection, would otherwise return an empty state that
+        // the next save writes over the real one — dropping the pinned
+        // terms and every pending operation. Exactly what the corrupt
+        // branch below refuses, arrived at by a different door.
+        guard FileManager.default.fileExists(atPath: url.path) else { return BackupState() }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw BackupError.localFailure(reason: .stateUnreadable)
+        }
         guard let state = try? JSONDecoder().decode(BackupState.self, from: data) else {
             // A corrupt state file must not read as "no backup
             // configured": that would silently drop the pinned terms and
             // the pending-operation list, and the next upload would go
             // out under terms nobody re-consented to.
-            throw BackupError.localFailure(reason: .archiveUnreadable)
+            throw BackupError.localFailure(reason: .stateUnreadable)
         }
         return state
     }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// What this device remembers about its own backups.
+///
+/// Small, local, and deliberately not authoritative about anything the
+/// operator holds: the operator's `listSnapshots` is the truth about
+/// what is retained, and this records what *we* did and what we were
+/// promised when we did it.
+public struct BackupState: Sendable, Equatable, Codable {
+    public var componentId: String?
+    /// The terms digest in force at the last consent. Every snapshot
+    /// pins this; a change means uploads stop until the person has seen
+    /// the new terms.
+    public var acceptedTermsId: String?
+    /// The exact terms bytes consented to, kept so a regression check
+    /// has something to compare against after the operator has moved on.
+    public var acceptedTermsRaw: Data?
+    public var mediaPolicy: BackupMediaPolicy = .descriptorsOnly
+    public var lastSuccessAt: Date?
+    public var lastAttemptAt: Date?
+    /// The snapshot chain this device believes it uploaded, newest last.
+    public var snapshots: [RecordedSnapshot] = []
+    /// Operations whose result we never learned. They stay here until
+    /// `queryOutcome` resolves them — silence is not success, and the
+    /// only way that stays true is if the uncertainty is durable.
+    public var pendingOperations: [PendingOperation] = []
+    public var receipts: [Data] = []
+
+    public struct RecordedSnapshot: Sendable, Equatable, Codable {
+        public let digest: String
+        public let sealedByteSize: Int
+        public let acceptedTermsId: String
+        public let uploadedAt: Date
+        public var statusRaw: String
+    }
+
+    public struct PendingOperation: Sendable, Equatable, Codable {
+        public let operationId: String
+        public let digest: String
+        public let startedAt: Date
+    }
+
+    public init() {}
+}
+
+/// Persists `BackupState`.
+public protocol BackupStateStoring: Sendable {
+    func load() throws -> BackupState
+    func save(_ state: BackupState) throws
+}
+
+/// File-backed state under complete protection.
+public struct FileBackupStateStore: BackupStateStoring {
+    private let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    public func load() throws -> BackupState {
+        guard let data = try? Data(contentsOf: url) else { return BackupState() }
+        guard let state = try? JSONDecoder().decode(BackupState.self, from: data) else {
+            // A corrupt state file must not read as "no backup
+            // configured": that would silently drop the pinned terms and
+            // the pending-operation list, and the next upload would go
+            // out under terms nobody re-consented to.
+            throw BackupError.localFailure(reason: .archiveUnreadable)
+        }
+        return state
+    }
+
+    public func save(_ state: BackupState) throws {
+        let data = try JSONEncoder().encode(state)
+        try data.write(to: url, options: [.atomic, .completeFileProtection])
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
@@ -99,6 +99,16 @@ public struct BackupState: Sendable, Equatable, Codable {
                 statusRaw: status.rawValue
             )
         )
+        // Kept in time order, not resolution order. A pending operation
+        // resolved later is still *older*, and appending it to the tail
+        // would make the next snapshot supersede a stale ancestor.
+        snapshots.sort { $0.uploadedAt < $1.uploadedAt }
+    }
+
+    /// The snapshot a new one should supersede: the newest by upload
+    /// time, which is not necessarily the last one recorded.
+    var newestSnapshot: RecordedSnapshot? {
+        snapshots.max { $0.uploadedAt < $1.uploadedAt }
     }
 }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
@@ -40,6 +40,11 @@ public struct BackupState: Sendable, Equatable, Codable {
     public struct PendingOperation: Sendable, Equatable, Codable {
         public let operationId: String
         public let digest: String
+        /// Our own record of the size. Reconciliation rebuilds the
+        /// reference from this rather than from whatever an operator
+        /// does or does not echo back — a terse answer must not be able
+        /// to produce an unbuildable reference.
+        public var sealedByteSize: Int?
         public let startedAt: Date
         /// The terms *we* pinned when this went out. Reconciliation
         /// records this rather than the digest an operator echoes back,
@@ -62,6 +67,10 @@ public struct BackupState: Sendable, Equatable, Codable {
         public let acceptedTermsId: String
         public let supersedesDigest: String?
         public let supersedesByteSize: Int?
+        /// When the snapshot was sealed. Distinct from `refusedAt`: a
+        /// resumed snapshot is as old as its contents, not as old as the
+        /// refusal.
+        public let sealedAt: Date
         public let refusedAt: Date
     }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
@@ -130,15 +130,18 @@ extension URLSessionBackupClient {
         guard let http = response as? HTTPURLResponse else {
             throw BackupError.operatorUnavailable
         }
-        var data = Data()
-        data.reserveCapacity(min(maxResponseBytes, 1 << 20))
+        // Accumulated into an array rather than appended to `Data` one
+        // byte at a time: at a 32 MiB cap the per-append cost is the
+        // dominant term, and this runs on someone's phone.
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(min(maxResponseBytes, 1 << 20))
         for try await byte in stream {
-            data.append(byte)
-            if data.count > maxResponseBytes {
+            bytes.append(byte)
+            if bytes.count > maxResponseBytes {
                 throw BackupError.operatorUnavailable
             }
         }
-        return (data, http)
+        return (Data(bytes), http)
     }
 
     /// Stream a body straight to disk, bounded by what the reference
@@ -156,12 +159,12 @@ extension URLSessionBackupClient {
             // a `where` clause — the latter stops appending but keeps
             // draining, so an unbounded error body would still be read
             // to completion.
-            var body = Data()
+            var body = [UInt8]()
             for try await byte in stream {
                 if body.count >= 8 << 10 { break }
                 body.append(byte)
             }
-            try Self.check(http, body)
+            try Self.check(http, Data(body))
             return
         }
 
@@ -171,9 +174,21 @@ extension URLSessionBackupClient {
             attributes: [.protectionKey: FileProtectionType.complete]
         )
         let handle = try FileHandle(forWritingTo: destination)
-        defer { try? handle.close() }
 
-        var buffer = Data()
+        // `destination` is caller-owned — a restore path, not the swept
+        // working directory — so *any* exit that is not a complete file
+        // takes the partial with it. A write error and a network drop
+        // leave the same wreckage as an over-long body, and the same
+        // argument applies: a restore is where a silently-short file
+        // must not arrive.
+        var complete = false
+        defer {
+            try? handle.close()
+            if !complete { try? FileManager.default.removeItem(at: destination) }
+        }
+
+        var buffer = [UInt8]()
+        buffer.reserveCapacity(1 << 20)
         var total = 0
         for try await byte in stream {
             buffer.append(byte)
@@ -182,25 +197,18 @@ extension URLSessionBackupClient {
                 // More bytes than the reference claims. The digest check
                 // would catch it later, after writing all of them to a
                 // device that may not have the room.
-                try? FileManager.default.removeItem(at: destination)
                 throw BackupError.incompleteSnapshot
             }
             if buffer.count >= 1 << 20 {
-                try handle.write(contentsOf: buffer)
+                try handle.write(contentsOf: Data(buffer))
                 buffer.removeAll(keepingCapacity: true)
             }
         }
-        if !buffer.isEmpty { try handle.write(contentsOf: buffer) }
+        if !buffer.isEmpty { try handle.write(contentsOf: Data(buffer)) }
 
-        // Short is as wrong as long. Without this a truncated body
-        // returns success and hands the caller a partial file —
-        // `exportSnapshots` re-verifies afterwards, but
-        // `downloadSnapshot` would not, and a restore is exactly where a
-        // silently-short file must not arrive.
-        guard total == maxBytes else {
-            try? FileManager.default.removeItem(at: destination)
-            throw BackupError.incompleteSnapshot
-        }
+        // Short is as wrong as long.
+        guard total == maxBytes else { throw BackupError.incompleteSnapshot }
+        complete = true
     }
 
     /// Map a non-2xx onto the domain vocabulary of §14, keeping the
@@ -217,6 +225,7 @@ extension URLSessionBackupClient {
             let maximumRetainedSnapshots: Int?
             let retainedBytes: Int?
             let limitBytes: Int?
+            let entitlementIssuers: [String]?
             let paymentRequired: PaymentRequired?
 
             struct PaymentRequired: Decodable {
@@ -245,7 +254,14 @@ extension URLSessionBackupClient {
                 entitlementIssuers: payment.entitlementIssuers
             )
         case "invalid_entitlement":
-            throw BackupError.invalidEntitlement(entitlementIssuers: [])
+            // The issuers are the whole point of this refusal: without
+            // them a caller cannot know which issuer to obtain a fresh
+            // credential from.
+            throw BackupError.invalidEntitlement(
+                entitlementIssuers: envelope.entitlementIssuers
+                    ?? envelope.paymentRequired?.entitlementIssuers
+                    ?? []
+            )
         case "signature_invalid":
             throw BackupError.accessRefused
         case "snapshot_too_large":

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
@@ -152,9 +152,15 @@ extension URLSessionBackupClient {
         guard let http = response as? HTTPURLResponse else { throw BackupError.operatorUnavailable }
         guard (200..<300).contains(http.statusCode) else {
             // The body of a failed download is small; read it bounded so
-            // the operator's own code and message survive.
+            // the operator's own code and message survive. `break`, not
+            // a `where` clause — the latter stops appending but keeps
+            // draining, so an unbounded error body would still be read
+            // to completion.
             var body = Data()
-            for try await byte in stream where body.count < 8 << 10 { body.append(byte) }
+            for try await byte in stream {
+                if body.count >= 8 << 10 { break }
+                body.append(byte)
+            }
             try Self.check(http, body)
             return
         }

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
@@ -1,0 +1,328 @@
+import CryptoKit
+import Foundation
+import OnymFoundation
+
+extension URLSessionBackupClient {
+    static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }()
+
+    static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    func decode<Value: Decodable>(_ data: Data) throws -> Value {
+        guard let value = try? Self.decoder.decode(Value.self, from: data) else {
+            throw BackupError.rejected(code: "malformed_response", message: nil)
+        }
+        return value
+    }
+
+    func get(
+        path: [String],
+        signed: Bool,
+        maxResponseBytes: Int = URLSessionBackupClient.maxJSONResponseBytes
+    ) async throws -> Data {
+        try await send(
+            method: "GET", path: path, body: Data(), contentType: nil,
+            signed: signed, maxResponseBytes: maxResponseBytes
+        )
+    }
+
+    func get(url: URL, signed: Bool) async throws -> Data {
+        try await send(
+            method: "GET", url: url, body: Data(), contentType: nil,
+            signed: signed, maxResponseBytes: Self.maxJSONResponseBytes
+        )
+    }
+
+    func post(path: [String], body: Data) async throws -> Data {
+        try await send(
+            method: "POST", path: path, body: body, contentType: "application/json",
+            signed: true, maxResponseBytes: Self.maxJSONResponseBytes
+        )
+    }
+
+    func send(
+        method: String,
+        path: [String],
+        body: Data,
+        contentType: String?,
+        signed: Bool,
+        maxResponseBytes: Int
+    ) async throws -> Data {
+        let url = path.reduce(endpoint) { $0.appending(path: $1) }
+        return try await send(
+            method: method, url: url, body: body, contentType: contentType,
+            signed: signed, maxResponseBytes: maxResponseBytes
+        )
+    }
+
+    func send(
+        method: String,
+        url: URL,
+        body: Data,
+        contentType: String?,
+        signed: Bool,
+        maxResponseBytes: Int
+    ) async throws -> Data {
+        let request = try await makeRequest(
+            method: method, url: url, body: body, contentType: contentType, signed: signed
+        )
+        let (data, response) = try await perform(request, maxResponseBytes: maxResponseBytes)
+        try Self.check(response, data)
+        return data
+    }
+
+    /// Build a request and, when the route requires it, sign it.
+    ///
+    /// The signature covers the method, the path *with its query*, and a
+    /// digest of the body — so nothing about the request can be moved
+    /// after signing without invalidating it.
+    func makeRequest(
+        method: String,
+        url: URL,
+        body: Data,
+        contentType: String?,
+        signed: Bool
+    ) async throws -> URLRequest {
+        // https in every build. A local operator is reached through a
+        // tunnel, never by relaxing transport security here.
+        guard url.scheme?.lowercased() == "https", let host = url.host(), !host.isEmpty else {
+            throw BackupError.invalidEndpoint
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = 30
+        if !body.isEmpty { request.httpBody = body }
+        if let contentType { request.setValue(contentType, forHTTPHeaderField: "Content-Type") }
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        guard signed else { return request }
+        let signedPath = url.path() + (url.query().map { "?\($0)" } ?? "")
+        for (field, value) in try BackupAccessProof.headers(
+            method: method, path: signedPath, body: body, material: material
+        ) {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+        // Presented only where one exists. An operator with no declared
+        // issuers never sees this header, which is the self-hosting
+        // path.
+        if let credential = await entitlement() {
+            request.setValue(credential.base64EncodedString(), forHTTPHeaderField: "X-Onym-Entitlement")
+        }
+        return request
+    }
+
+    /// Read a response, refusing to buffer more than `maxResponseBytes`.
+    ///
+    /// `URLSession.data(for:)` would happily materialize whatever an
+    /// operator sends. The bytes here are untrusted and their only soft
+    /// bound is a figure the same operator published, so the cap is
+    /// enforced on our side (§13).
+    func perform(_ request: URLRequest, maxResponseBytes: Int) async throws -> (Data, HTTPURLResponse) {
+        let (stream, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw BackupError.operatorUnavailable
+        }
+        var data = Data()
+        data.reserveCapacity(min(maxResponseBytes, 1 << 20))
+        for try await byte in stream {
+            data.append(byte)
+            if data.count > maxResponseBytes {
+                throw BackupError.operatorUnavailable
+            }
+        }
+        return (data, http)
+    }
+
+    /// Stream a body straight to disk, bounded by what the reference
+    /// says it should be.
+    func stream(path: [String], to destination: URL, maxBytes: Int) async throws {
+        let url = path.reduce(endpoint) { $0.appending(path: $1) }
+        let request = try await makeRequest(
+            method: "GET", url: url, body: Data(), contentType: nil, signed: true
+        )
+        let (stream, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else { throw BackupError.operatorUnavailable }
+        guard (200..<300).contains(http.statusCode) else {
+            // The body of a failed download is small; read it bounded so
+            // the operator's own code and message survive.
+            var body = Data()
+            for try await byte in stream where body.count < 8 << 10 { body.append(byte) }
+            try Self.check(http, body)
+            return
+        }
+
+        FileManager.default.createFile(
+            atPath: destination.path,
+            contents: nil,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        let handle = try FileHandle(forWritingTo: destination)
+        defer { try? handle.close() }
+
+        var buffer = Data()
+        var total = 0
+        for try await byte in stream {
+            buffer.append(byte)
+            total += 1
+            if total > maxBytes {
+                // More bytes than the reference claims. The digest check
+                // would catch it later, after writing all of them to a
+                // device that may not have the room.
+                try? FileManager.default.removeItem(at: destination)
+                throw BackupError.incompleteSnapshot
+            }
+            if buffer.count >= 1 << 20 {
+                try handle.write(contentsOf: buffer)
+                buffer.removeAll(keepingCapacity: true)
+            }
+        }
+        if !buffer.isEmpty { try handle.write(contentsOf: buffer) }
+    }
+
+    /// Map a non-2xx onto the domain vocabulary of §14, keeping the
+    /// per-code fields the profile pins.
+    static func check(_ http: HTTPURLResponse, _ data: Data) throws {
+        guard !(200..<300).contains(http.statusCode) else { return }
+
+        struct Envelope: Decodable {
+            let error: String
+            let message: String?
+            let currentTermsId: String?
+            let maximumSealedSnapshotBytes: Int?
+            let retainedSnapshots: Int?
+            let maximumRetainedSnapshots: Int?
+            let retainedBytes: Int?
+            let limitBytes: Int?
+            let paymentRequired: PaymentRequired?
+
+            struct PaymentRequired: Decodable {
+                let componentId: String
+                let offers: [String]
+                let entitlementIssuers: [String]
+            }
+        }
+        guard let envelope = try? decoder.decode(Envelope.self, from: data) else {
+            throw BackupError.rejected(
+                code: "http_\(http.statusCode)",
+                message: "the operator rejected the request (HTTP \(http.statusCode))"
+            )
+        }
+
+        switch envelope.error {
+        case "terms_changed":
+            throw BackupError.termsChanged(currentTermsId: envelope.currentTermsId)
+        case "payment_required":
+            guard let payment = envelope.paymentRequired else {
+                throw BackupError.rejected(code: envelope.error, message: envelope.message)
+            }
+            throw BackupError.paymentRequired(
+                componentId: payment.componentId,
+                offerIds: payment.offers,
+                entitlementIssuers: payment.entitlementIssuers
+            )
+        case "invalid_entitlement":
+            throw BackupError.invalidEntitlement(entitlementIssuers: [])
+        case "signature_invalid":
+            throw BackupError.accessRefused
+        case "snapshot_too_large":
+            throw BackupError.snapshotTooLarge(
+                maximumSealedSnapshotBytes: envelope.maximumSealedSnapshotBytes
+            )
+        case "quota_exceeded":
+            throw BackupError.quotaExceeded(
+                retainedSnapshots: envelope.retainedSnapshots,
+                maximumRetainedSnapshots: envelope.maximumRetainedSnapshots,
+                retainedBytes: envelope.retainedBytes,
+                limitBytes: envelope.limitBytes
+            )
+        case "digest_mismatch", "chunk_mismatch":
+            throw BackupError.incompleteSnapshot
+        case "retention_expired":
+            throw BackupError.retentionExpired
+        case "export_withheld":
+            // Non-conforming. Surfaced by name so the UI can say so
+            // rather than softening it into a generic failure.
+            throw BackupError.exportWithheld
+        case "unsupported_profile":
+            throw BackupError.unsupportedProfile
+        case "invalid_reference":
+            throw BackupError.invalidReference
+        default:
+            // An operator code we do not model is preserved verbatim
+            // rather than flattened into a local guess.
+            throw BackupError.rejected(code: envelope.error, message: envelope.message)
+        }
+    }
+
+    func verifyTermsSignature(_ terms: BackupTerms) throws {
+        guard
+            let signature = terms.signature,
+            let keyHex = manifest.operatorKey.split(separator: ":").last.map(String.init),
+            let keyBytes = BackupFormat.data(fromLowercaseHex: keyHex),
+            let key = try? Curve25519.Signing.PublicKey(rawRepresentation: keyBytes)
+        else {
+            // An unsigned or unverifiable terms document is not terms.
+            // Enrolment stops here rather than pinning something nobody
+            // can be held to.
+            throw BackupError.termsUnavailable
+        }
+        let signingBytes = try ServiceManifestCanonical.signingBytes(
+            of: terms.rawBytes,
+            omitting: ["termsId", "signature"]
+        )
+        guard key.isValidSignature(signature, for: signingBytes) else {
+            throw BackupError.termsUnavailable
+        }
+    }
+}
+
+/// One operator outcome as it arrives on the wire.
+struct WireOutcome: Decodable {
+    let componentId: String?
+    let status: String
+    let snapshotReference: SnapshotReference?
+    let locator: String?
+    let retainedUntil: Date?
+    let termsId: String?
+
+    func domain(operationId: String, componentId fallback: String) throws -> BackupOutcome {
+        // An unrecognised status becomes `unknown`, never `retained`.
+        // A future operator inventing a word must not be read as
+        // success by a client that has never heard of it.
+        let mapped = BackupOutcomeStatus(rawValue: status) ?? .unknown
+        return BackupOutcome(
+            operationId: operationId,
+            componentId: componentId ?? fallback,
+            status: mapped,
+            snapshotReference: snapshotReference,
+            locator: locator,
+            retainedUntil: retainedUntil,
+            termsId: termsId
+        )
+    }
+}
+
+/// Refuses every redirect.
+///
+/// A signed request follows a signature over one path at one origin. An
+/// operator that could redirect it would be choosing where our
+/// credentials go.
+final class RedirectRefusingDelegate: NSObject, URLSessionTaskDelegate, Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
@@ -185,6 +185,16 @@ extension URLSessionBackupClient {
             }
         }
         if !buffer.isEmpty { try handle.write(contentsOf: buffer) }
+
+        // Short is as wrong as long. Without this a truncated body
+        // returns success and hands the caller a partial file —
+        // `exportSnapshots` re-verifies afterwards, but
+        // `downloadSnapshot` would not, and a restore is exactly where a
+        // silently-short file must not arrive.
+        guard total == maxBytes else {
+            try? FileManager.default.removeItem(at: destination)
+            throw BackupError.incompleteSnapshot
+        }
     }
 
     /// Map a non-2xx onto the domain vocabulary of §14, keeping the

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
@@ -44,6 +44,23 @@ public struct URLSessionBackupClient: BackupPort {
     /// chunk is buffered to sign and send it, so this is a memory bound
     /// as much as an arithmetic one.
     static let maxUploadChunkBytes = 64 << 20
+    /// Ceiling on the list-response cap, and on the snapshot count we
+    /// will derive one from. Every other operator-controlled figure gets
+    /// a refusal; this one was getting a trap, because a large enough
+    /// declared limit overflows the multiplication that sizes the cap.
+    static let maxListedSnapshots = 100_000
+    static let maxListResponseBytes = 32 << 20
+
+    /// How many bytes we are willing to read for a snapshot listing.
+    ///
+    /// Derived from the operator's declared limit, then clamped — the
+    /// declaration is its own unsigned figure and bounds nothing on its
+    /// own.
+    var listResponseCap: Int {
+        let declared = min(manifest.maximumRetainedSnapshots ?? 1_000, Self.maxListedSnapshots)
+        let derived = max(declared, 0) * Self.perSnapshotEntryBytes
+        return min(max(derived, 64 << 10), Self.maxListResponseBytes)
+    }
 
     public init(
         manifest: BackupOperatorManifest,
@@ -193,11 +210,10 @@ public struct URLSessionBackupClient: BackupPort {
     }
 
     public func listSnapshots() async throws -> [RetainedSnapshot] {
-        let cap = (manifest.maximumRetainedSnapshots ?? 1_000) * Self.perSnapshotEntryBytes
         let data = try await get(
             path: ["v1", "snapshots"],
             signed: true,
-            maxResponseBytes: max(cap, 64 << 10)
+            maxResponseBytes: listResponseCap
         )
         struct Row: Decodable {
             let snapshotReference: SnapshotReference
@@ -239,11 +255,10 @@ public struct URLSessionBackupClient: BackupPort {
     }
 
     public func exportSnapshots(to directory: URL) async throws -> BackupExport {
-        let cap = (manifest.maximumRetainedSnapshots ?? 1_000) * Self.perSnapshotEntryBytes
         let manifestBytes = try await get(
             path: ["v1", "exports"],
             signed: true,
-            maxResponseBytes: max(cap, 64 << 10)
+            maxResponseBytes: listResponseCap
         )
         struct Entry: Decodable {
             let snapshotReference: SnapshotReference

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
@@ -1,0 +1,285 @@
+import CryptoKit
+import Foundation
+import OnymFoundation
+
+/// `BackupPort` over the object-HTTP profile.
+///
+/// Wire notes, pinned against `UI-Backup-Object-HTTP.md`:
+///
+/// - Every `/v1/` request carries the four proof headers of §8. The
+///   operator rebuilds the signed bytes from what it received, so a
+///   mismatch surfaces as a refusal rather than as a weaker check.
+/// - Bodies are JSON, camelCase, RFC 3339 UTC; chunk uploads are
+///   `application/octet-stream`.
+/// - Errors arrive as `{"error", "message", …per-code fields}` (§14) and
+///   are mapped onto `BackupError` with the operator's own code kept
+///   verbatim when we do not model it.
+/// - **Redirects are never followed** and every response body is
+///   bounded. An operator's `maximumRetainedSnapshots` is its own
+///   figure with no signature behind it, so it bounds nothing on its
+///   own (§13).
+///
+/// The manifest is *not* fetched or verified here. Manifest review is
+/// the consent flow's job and already exists; duplicating it would put
+/// two implementations of the same trust decision in the codebase.
+public struct URLSessionBackupClient: BackupPort {
+    let manifest: BackupOperatorManifest
+    let material: BackupKeyMaterial
+    let session: URLSession
+    let entitlement: @Sendable () async -> Data?
+
+    /// The read-write origin from the manifest the person consented to.
+    /// Bound once and never rewritten — an operator does not get to move
+    /// a signed request somewhere else.
+    var endpoint: URL { manifest.endpoint }
+
+    /// Caps on response bodies we are willing to read. Sealed streams
+    /// are bounded by the operator's declared maximum instead — that
+    /// figure is inside the signed manifest the person consented to.
+    static let maxJSONResponseBytes = 4 << 20
+    static let perSnapshotEntryBytes = 1 << 10
+    /// Transfer framing only; unrelated to the sealing chunk size.
+    static let uploadChunkBytes = 8 << 20
+
+    public init(
+        manifest: BackupOperatorManifest,
+        material: BackupKeyMaterial,
+        session: URLSession = URLSessionBackupClient.defaultSession,
+        entitlement: @escaping @Sendable () async -> Data? = { nil }
+    ) {
+        self.manifest = manifest
+        self.material = material
+        self.session = session
+        self.entitlement = entitlement
+    }
+
+    /// Ephemeral, cookie-less, and redirect-refusing. Session state that
+    /// outlives a request is linkable surface, and a redirect an
+    /// operator controls would let it move a signed request to an origin
+    /// the signature never covered.
+    public static let defaultSession: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieAcceptPolicy = .never
+        return URLSession(
+            configuration: configuration,
+            delegate: RedirectRefusingDelegate(),
+            delegateQueue: nil
+        )
+    }()
+
+    // MARK: - BackupPort
+
+    public func connect() async throws -> BackupConnection {
+        let profileBytes = try await get(path: ["profile.json"], signed: false)
+        let profile = try BackupImplementationProfile.review(raw: profileBytes)
+
+        let digest = manifest.declaredTermsDigest
+        guard let termsURL = manifest.termsURL(digest: digest) else {
+            throw BackupError.termsUnavailable
+        }
+        let termsBytes = try await get(url: termsURL, signed: false)
+        let signature = try? await get(url: termsURL.appendingPathExtension("sig"), signed: false)
+
+        let terms = try BackupTerms.decode(raw: termsBytes, signature: signature.flatMap {
+            Data(base64Encoded: $0) ?? $0
+        })
+        // The manifest is what the person consented to, so it is the
+        // authority on which terms apply. A document served at the
+        // declared address that hashes to something else is not a
+        // version mismatch to tolerate.
+        guard terms.termsId == digest else { throw BackupError.termsUnavailable }
+        try verifyTermsSignature(terms)
+        return BackupConnection(manifest: manifest, profile: profile, terms: terms)
+    }
+
+    public func preflight(_ snapshot: SealedSnapshot) async throws -> BackupPreflight {
+        struct Body: Encodable {
+            let version = 1
+            let operationId: String
+            let snapshotReference: SnapshotReference
+            let acceptedTermsId: String
+            let supersedes: String?
+        }
+        let body = try Self.encoder.encode(
+            Body(
+                operationId: snapshot.operationId,
+                snapshotReference: snapshot.snapshotReference,
+                acceptedTermsId: snapshot.acceptedTermsId,
+                supersedes: snapshot.supersedes?.digest
+            )
+        )
+        let data = try await post(path: ["v1", "preflight"], body: body)
+
+        struct Response: Decodable {
+            let uploadId: String?
+            let chunkBytes: Int?
+            let chunkCount: Int?
+            let expiresAt: Date?
+            let outcome: WireOutcome?
+        }
+        let response: Response = try decode(data)
+        if let outcome = response.outcome, outcome.status == BackupOutcomeStatus.alreadyRetained.rawValue {
+            return .alreadyRetained(try outcome.domain(operationId: snapshot.operationId,
+                                                      componentId: manifest.componentId))
+        }
+        guard
+            let uploadId = response.uploadId,
+            let chunkBytes = response.chunkBytes, chunkBytes > 0,
+            let chunkCount = response.chunkCount, chunkCount >= 0,
+            let expiresAt = response.expiresAt
+        else {
+            throw BackupError.rejected(code: "malformed_preflight", message: nil)
+        }
+        return .granted(
+            BackupUploadGrant(
+                uploadId: uploadId,
+                chunkBytes: chunkBytes,
+                chunkCount: chunkCount,
+                expiresAt: expiresAt
+            )
+        )
+    }
+
+    public func uploadSnapshot(
+        _ snapshot: SealedSnapshot,
+        grant: BackupUploadGrant
+    ) async throws -> BackupOutcome {
+        let handle = try FileHandle(forReadingFrom: snapshot.sealedBytesURL)
+        defer { try? handle.close() }
+
+        for index in 0..<grant.chunkCount {
+            try handle.seek(toOffset: UInt64(index * grant.chunkBytes))
+            guard let chunk = try handle.read(upToCount: grant.chunkBytes), !chunk.isEmpty else {
+                // The grant promised more chunks than the sealed file
+                // has. Uploading a short snapshot would only be caught
+                // at commit, after paying for the transfer.
+                throw BackupError.invalidReference
+            }
+            _ = try await send(
+                method: "PUT",
+                path: ["v1", "uploads", grant.uploadId, "chunks", String(index)],
+                body: chunk,
+                contentType: "application/octet-stream",
+                signed: true,
+                maxResponseBytes: Self.maxJSONResponseBytes
+            )
+        }
+
+        let data = try await post(path: ["v1", "uploads", grant.uploadId, "commit"], body: Data())
+        struct Response: Decodable { let outcome: WireOutcome }
+        let response: Response = try decode(data)
+        return try response.outcome.domain(
+            operationId: snapshot.operationId,
+            componentId: manifest.componentId
+        )
+    }
+
+    public func listSnapshots() async throws -> [RetainedSnapshot] {
+        let cap = (manifest.maximumRetainedSnapshots ?? 1_000) * Self.perSnapshotEntryBytes
+        let data = try await get(
+            path: ["v1", "snapshots"],
+            signed: true,
+            maxResponseBytes: max(cap, 64 << 10)
+        )
+        struct Row: Decodable {
+            let snapshotReference: SnapshotReference
+            let acceptedTermsId: String
+            let retainedAt: Date
+            let retainedUntil: Date?
+            let supersedes: String?
+            let status: String?
+        }
+        let rows: [Row] = try decode(data)
+        return rows.map {
+            RetainedSnapshot(
+                snapshotReference: $0.snapshotReference,
+                acceptedTermsId: $0.acceptedTermsId,
+                retainedAt: $0.retainedAt,
+                retainedUntil: $0.retainedUntil,
+                supersedes: $0.supersedes,
+                status: $0.status.flatMap(BackupOutcomeStatus.init(rawValue:)) ?? .retained
+            )
+        }
+    }
+
+    public func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws {
+        try await stream(
+            path: ["v1", "snapshots", reference.digestHex],
+            to: destination,
+            maxBytes: reference.sealedByteSize
+        )
+    }
+
+    public func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+        struct Body: Encodable {
+            let version = 1
+            let scope: String
+        }
+        let body = try Self.encoder.encode(Body(scope: scope.wireValue))
+        let data = try await post(path: ["v1", "erasures"], body: body)
+        return try ErasureReceipt.decode(raw: data)
+    }
+
+    public func exportSnapshots(to directory: URL) async throws -> BackupExport {
+        let cap = (manifest.maximumRetainedSnapshots ?? 1_000) * Self.perSnapshotEntryBytes
+        let manifestBytes = try await get(
+            path: ["v1", "exports"],
+            signed: true,
+            maxResponseBytes: max(cap, 64 << 10)
+        )
+        struct Entry: Decodable {
+            let snapshotReference: SnapshotReference
+            let acceptedTermsId: String
+            let retainedAt: Date
+        }
+        struct Envelope: Decodable { let snapshots: [Entry] }
+        let envelope: Envelope = try decode(manifestBytes)
+
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        var exported: [BackupExport.ExportedSnapshot] = []
+        for entry in envelope.snapshots {
+            let url = directory.appending(path: "\(entry.snapshotReference.digestHex).seal")
+            try await stream(
+                path: ["v1", "exports", entry.snapshotReference.digestHex],
+                to: url,
+                maxBytes: entry.snapshotReference.sealedByteSize
+            )
+            // Exported bytes are the same bytes under the same
+            // reference — that is what lets a migration re-upload them
+            // without re-sealing — so a mismatch here means the export
+            // is not portable and must not be presented as one.
+            try BackupOpener.verify(sealedURL: url, matches: entry.snapshotReference)
+            exported.append(
+                BackupExport.ExportedSnapshot(
+                    snapshotReference: entry.snapshotReference,
+                    acceptedTermsId: entry.acceptedTermsId,
+                    retainedAt: entry.retainedAt,
+                    sealedBytesURL: url
+                )
+            )
+        }
+        return BackupExport(directory: directory, snapshots: exported, receipts: [])
+    }
+
+    public func queryOutcome(operationId: String) async throws -> BackupOutcome? {
+        do {
+            let data = try await get(path: ["v1", "operations", operationId], signed: true)
+            struct Response: Decodable { let outcome: WireOutcome }
+            let response: Response = try decode(data)
+            return try response.outcome.domain(
+                operationId: operationId,
+                componentId: manifest.componentId
+            )
+        } catch BackupError.rejected(let code, _) where code == "http_404" || code == "not_found" {
+            // No record. This stays `unknown` for the caller —
+            // reconciliation moves to the reference, and silence is
+            // never promoted to success.
+            return nil
+        }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
@@ -38,8 +38,6 @@ public struct URLSessionBackupClient: BackupPort {
     /// figure is inside the signed manifest the person consented to.
     static let maxJSONResponseBytes = 4 << 20
     static let perSnapshotEntryBytes = 1 << 10
-    /// Transfer framing only; unrelated to the sealing chunk size.
-    static let uploadChunkBytes = 8 << 20
     /// The largest transfer chunk we will honour from a grant. A whole
     /// chunk is buffered to sign and send it, so this is a memory bound
     /// as much as an arithmetic one.

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
@@ -40,6 +40,10 @@ public struct URLSessionBackupClient: BackupPort {
     static let perSnapshotEntryBytes = 1 << 10
     /// Transfer framing only; unrelated to the sealing chunk size.
     static let uploadChunkBytes = 8 << 20
+    /// The largest transfer chunk we will honour from a grant. A whole
+    /// chunk is buffered to sign and send it, so this is a memory bound
+    /// as much as an arithmetic one.
+    static let maxUploadChunkBytes = 64 << 20
 
     public init(
         manifest: BackupOperatorManifest,
@@ -145,15 +149,28 @@ public struct URLSessionBackupClient: BackupPort {
         _ snapshot: SealedSnapshot,
         grant: BackupUploadGrant
     ) async throws -> BackupOutcome {
+        // The grant is operator-controlled arithmetic applied to our
+        // file, so it is checked against the file before a byte moves.
+        // An over-large `chunkBytes` would overflow the offset
+        // computation and trap; a `chunkCount` one too small would
+        // upload a truncated snapshot and only fail at commit, after
+        // paying for the whole transfer.
+        let size = snapshot.snapshotReference.sealedByteSize
+        guard
+            grant.chunkBytes > 0,
+            grant.chunkBytes <= Self.maxUploadChunkBytes,
+            grant.chunkCount >= 0,
+            grant.chunkCount == (size + grant.chunkBytes - 1) / grant.chunkBytes
+        else {
+            throw BackupError.localFailure(reason: .invalidUploadGrant)
+        }
+
         let handle = try FileHandle(forReadingFrom: snapshot.sealedBytesURL)
         defer { try? handle.close() }
 
         for index in 0..<grant.chunkCount {
-            try handle.seek(toOffset: UInt64(index * grant.chunkBytes))
+            try handle.seek(toOffset: UInt64(index) * UInt64(grant.chunkBytes))
             guard let chunk = try handle.read(upToCount: grant.chunkBytes), !chunk.isEmpty else {
-                // The grant promised more chunks than the sealed file
-                // has. Uploading a short snapshot would only be caught
-                // at commit, after paying for the transfer.
                 throw BackupError.invalidReference
             }
             _ = try await send(

--- a/Tests/OnymIOSTests/BackupAdapterTests.swift
+++ b/Tests/OnymIOSTests/BackupAdapterTests.swift
@@ -239,6 +239,169 @@ final class BackupAdapterTests: XCTestCase {
                        "the pinned terms were silently replaced")
     }
 
+    /// `submitted` is not retention, and the pending record has to
+    /// survive it. Clearing the record here would mean reconcile never
+    /// re-queries and the uncertainty is gone — "silence is not success"
+    /// holding only until the next line of code.
+    func testNonRetentionOutcomeKeepsThePendingRecord() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(
+            acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true, uploadStatus: .submitted)
+
+        let repository = BackupRepository(
+            port: port,
+            composer: BackupComposer(
+                source: EmptySource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: stateStore,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0xBB, count: 64), componentId: "onym:component:op"))
+
+        guard case .unknown = try await repository.backUp() else {
+            return XCTFail("`submitted` must not read as success")
+        }
+        let saved = try stateStore.load()
+        XCTAssertEqual(saved.pendingOperations.count, 1, "the uncertainty was discarded")
+        XCTAssertTrue(saved.snapshots.isEmpty)
+    }
+
+    /// A pending operation resolves against the retained list, which is
+    /// the authority on what is held. Without this it would be re-queried
+    /// forever once the operator's outcome record expires — the profile
+    /// keeps those for hours.
+    func testPendingResolvesAgainstTheRetainedList() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let digest = "sha256:" + String(repeating: "7", count: 64)
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        state.pendingOperations = [
+            BackupState.PendingOperation(operationId: "lost", digest: digest, startedAt: Date())
+        ]
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+        await port.setRetained([
+            RetainedSnapshot(
+                snapshotReference: try SnapshotReference(digest: digest, sealedByteSize: 2048),
+                acceptedTermsId: ScriptedPort.termsId,
+                retainedAt: Date())
+        ])
+
+        let repository = BackupRepository(
+            port: port,
+            composer: BackupComposer(
+                source: EmptySource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: stateStore,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0xCC, count: 64), componentId: "onym:component:op"))
+        _ = try await repository.backUp()
+
+        let saved = try stateStore.load()
+        XCTAssertTrue(
+            saved.pendingOperations.allSatisfy { $0.operationId != "lost" },
+            "a resolved operation stayed pending")
+        XCTAssertTrue(saved.snapshots.contains { $0.digest == digest })
+    }
+
+    /// A list we could not fetch resolves nothing. Uncertainty must
+    /// survive a failed reconciliation rather than be cleared by it.
+    func testFailedListLeavesPendingIntact() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        state.pendingOperations = [
+            BackupState.PendingOperation(
+                operationId: "lost",
+                digest: "sha256:" + String(repeating: "8", count: 64),
+                startedAt: Date())
+        ]
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+        await port.setListFails(true)
+
+        let repository = BackupRepository(
+            port: port,
+            composer: BackupComposer(
+                source: EmptySource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: stateStore,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0xDD, count: 64), componentId: "onym:component:op"))
+        _ = try await repository.backUp()
+
+        XCTAssertEqual(try stateStore.load().pendingOperations.count, 1)
+    }
+
+    /// A grant whose arithmetic does not describe our file is refused
+    /// before a byte is sent — an over-large chunk size would trap on
+    /// the offset computation, and an under-count would upload a
+    /// truncated snapshot that only fails at commit.
+    func testHostileUploadGrantIsRefused() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let sealed = dir.appending(path: "sealed")
+        try Data(repeating: 5, count: 4096).write(to: sealed)
+        let snapshot = SealedSnapshot(
+            operationId: "op",
+            snapshotReference: try SnapshotReference(
+                digest: "sha256:" + String(repeating: "a", count: 64), sealedByteSize: 4096),
+            sealedBytesURL: sealed, sealedAt: Date(),
+            acceptedTermsId: ScriptedPort.termsId)
+
+        for grant in [
+            BackupUploadGrant(uploadId: "u", chunkBytes: Int.max, chunkCount: 1,
+                              expiresAt: Date().addingTimeInterval(60)),
+            BackupUploadGrant(uploadId: "u", chunkBytes: 1024, chunkCount: 1,
+                              expiresAt: Date().addingTimeInterval(60)),
+        ] {
+            do {
+                _ = try await makeClient().uploadSnapshot(snapshot, grant: grant)
+                XCTFail("accepted a grant that does not describe the file")
+            } catch BackupError.localFailure(let reason) {
+                XCTAssertEqual(reason, .invalidUploadGrant)
+            }
+        }
+    }
+
+    /// A body shorter than the reference is a truncated file, not a
+    /// successful download.
+    func testShortDownloadIsRefused() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let destination = dir.appending(path: "snapshot")
+        StubURLProtocol.set { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (Data(repeating: 1, count: 10), response)
+        }
+        let reference = try SnapshotReference(
+            digest: "sha256:" + String(repeating: "a", count: 64), sealedByteSize: 4096)
+        do {
+            try await makeClient().downloadSnapshot(reference, to: destination)
+            XCTFail("a short body was accepted")
+        } catch BackupError.incompleteSnapshot {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+        }
+    }
+
+    /// An unreadable-but-present state file must not read as a first
+    /// run: the next save would overwrite the pinned terms and every
+    /// pending operation with an empty file.
+    func testUnreadableStateFileThrowsRatherThanReadingAsEmpty() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appending(path: "state.json")
+        try Data("not json".utf8).write(to: url)
+        XCTAssertThrowsError(try FileBackupStateStore(url: url).load())
+
+        // Absent is still a first run.
+        let fresh = dir.appending(path: "absent.json")
+        XCTAssertEqual(try FileBackupStateStore(url: fresh).load(), BackupState())
+    }
+
     // MARK: - Fixtures
 
     static func manifest(maximumRetainedSnapshots: Int?) throws -> BackupOperatorManifest {
@@ -295,13 +458,25 @@ private actor ScriptedPort: BackupPort {
     private let acceptedTermsId: String
     private var paymentSatisfied: Bool
     private let uploadFails: Bool
+    private let uploadStatus: BackupOutcomeStatus
+    private var retained: [RetainedSnapshot] = []
+    private var listFails = false
     private(set) var seenOperationIds: [String] = []
 
-    init(acceptedTermsId: String, paymentSatisfied: Bool = false, uploadFails: Bool = false) {
+    init(
+        acceptedTermsId: String,
+        paymentSatisfied: Bool = false,
+        uploadFails: Bool = false,
+        uploadStatus: BackupOutcomeStatus = .retained
+    ) {
         self.acceptedTermsId = acceptedTermsId
         self.paymentSatisfied = paymentSatisfied
         self.uploadFails = uploadFails
+        self.uploadStatus = uploadStatus
     }
+
+    func setRetained(_ rows: [RetainedSnapshot]) { retained = rows }
+    func setListFails(_ value: Bool) { listFails = value }
 
     func allowPayment() { paymentSatisfied = true }
 
@@ -339,11 +514,14 @@ private actor ScriptedPort: BackupPort {
         return BackupOutcome(
             operationId: snapshot.operationId,
             componentId: "onym:component:op",
-            status: .retained,
+            status: uploadStatus,
             snapshotReference: snapshot.snapshotReference)
     }
 
-    func listSnapshots() async throws -> [RetainedSnapshot] { [] }
+    func listSnapshots() async throws -> [RetainedSnapshot] {
+        if listFails { throw BackupError.operatorUnavailable }
+        return retained
+    }
     func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws {}
     func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
         throw BackupError.operatorUnavailable

--- a/Tests/OnymIOSTests/BackupAdapterTests.swift
+++ b/Tests/OnymIOSTests/BackupAdapterTests.swift
@@ -280,7 +280,7 @@ final class BackupAdapterTests: XCTestCase {
         var state = BackupState()
         state.acceptedTermsId = ScriptedPort.termsId
         state.pendingOperations = [
-            BackupState.PendingOperation(operationId: "lost", digest: digest, startedAt: Date())
+            BackupState.PendingOperation(operationId: "lost", digest: digest, sealedByteSize: 2048, startedAt: Date())
         ]
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
@@ -318,7 +318,7 @@ final class BackupAdapterTests: XCTestCase {
             BackupState.PendingOperation(
                 operationId: "lost",
                 digest: "sha256:" + String(repeating: "8", count: 64),
-                startedAt: Date())
+                sealedByteSize: 2048, startedAt: Date())
         ]
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
@@ -414,8 +414,8 @@ final class BackupAdapterTests: XCTestCase {
         state.acceptedTermsId = ScriptedPort.termsId
         state.pendingOperations = [
             BackupState.PendingOperation(
-                operationId: "inflight", digest: digest, startedAt: Date(),
-                acceptedTermsId: ScriptedPort.termsId)
+                operationId: "inflight", digest: digest, sealedByteSize: 2048,
+                startedAt: Date(), acceptedTermsId: ScriptedPort.termsId)
         ]
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
@@ -436,7 +436,7 @@ final class BackupAdapterTests: XCTestCase {
         state.pendingOperations = [
             BackupState.PendingOperation(
                 operationId: "lost", digest: "sha256:" + String(repeating: "4", count: 64),
-                startedAt: Date(), acceptedTermsId: ScriptedPort.termsId)
+                sealedByteSize: 2048, startedAt: Date(), acceptedTermsId: ScriptedPort.termsId)
         ]
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
@@ -499,6 +499,92 @@ final class BackupAdapterTests: XCTestCase {
         let client = try makeClient(maximumRetainedSnapshots: Int.max)
         XCTAssertLessThanOrEqual(client.listResponseCap, URLSessionBackupClient.maxListResponseBytes)
         _ = try await client.listSnapshots()
+    }
+
+    /// A `retained` answer carrying no reference must not be able to
+    /// wedge every future run. Reconcile ran before composing, so one
+    /// unbuildable reference aborted `backUp` before it could save,
+    /// leaving the operation unresolved and the next run to hit the same
+    /// line — a permanent brick delivered by a *success* answer.
+    func testTerseRetainedAnswerDoesNotWedgeFutureRuns() async throws {
+        let dir = try Self.directory()
+        let digest = "sha256:" + String(repeating: "6", count: 64)
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        state.pendingOperations = [
+            BackupState.PendingOperation(
+                operationId: "terse", digest: digest, sealedByteSize: 4096,
+                startedAt: Date(), acceptedTermsId: ScriptedPort.termsId)
+        ]
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+        // Retained, with nothing else said.
+        await port.setQueryOutcome(
+            BackupOutcome(operationId: "terse", componentId: "onym:component:op", status: .retained))
+
+        _ = try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+        let saved = try stateStore.load()
+        XCTAssertTrue(saved.pendingOperations.isEmpty, "the operation never resolved")
+        XCTAssertTrue(saved.snapshots.contains { $0.digest == digest })
+        XCTAssertEqual(
+            saved.snapshots.first { $0.digest == digest }?.sealedByteSize, 4096,
+            "believed the operator over our own record")
+
+        // And the next run still works, which is the actual claim.
+        _ = try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+    }
+
+    /// The issuers are the reason this refusal exists — without them a
+    /// caller cannot know where to get a fresh credential.
+    func testInvalidEntitlementCarriesIssuers() async throws {
+        respond(401, #"{"error":"invalid_entitlement","message":"expired","entitlementIssuers":["onym:key:bb"]}"#)
+        do {
+            _ = try await makeClient().preflight(Self.snapshot())
+            XCTFail("expected a refusal")
+        } catch BackupError.invalidEntitlement(let issuers) {
+            XCTAssertEqual(issuers, ["onym:key:bb"])
+        }
+    }
+
+    /// An unreadable ancestor must not silently become "supersedes
+    /// nothing" — that mints a snapshot claiming to start a new chain.
+    func testCorruptAncestorIsRefusedRatherThanBreakingTheChain() async throws {
+        let dir = try Self.directory()
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        state.snapshots = [
+            BackupState.RecordedSnapshot(
+                digest: "not-a-digest", sealedByteSize: 0,
+                acceptedTermsId: ScriptedPort.termsId, uploadedAt: Date(),
+                statusRaw: BackupOutcomeStatus.retained.rawValue)
+        ]
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+
+        do {
+            _ = try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+            XCTFail("composed a snapshot that silently supersedes nothing")
+        } catch BackupError.localFailure(let reason) {
+            XCTAssertEqual(reason, .stateUnreadable)
+        }
+    }
+
+    /// A caller-owned destination must not keep a partial file when the
+    /// transfer fails partway.
+    func testFailedDownloadLeavesNoPartialFile() async throws {
+        let dir = try Self.directory()
+        let destination = dir.appending(path: "snapshot")
+        StubURLProtocol.set { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (Data(repeating: 1, count: 32), response)
+        }
+        let reference = try SnapshotReference(
+            digest: "sha256:" + String(repeating: "a", count: 64), sealedByteSize: 1 << 20)
+        _ = try? await makeClient().downloadSnapshot(reference, to: destination)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: destination.path),
+            "a partial file was left at a caller-owned path")
     }
 
     // MARK: - Fixtures

--- a/Tests/OnymIOSTests/BackupAdapterTests.swift
+++ b/Tests/OnymIOSTests/BackupAdapterTests.swift
@@ -1,0 +1,385 @@
+import CryptoKit
+import Foundation
+import OnymFoundation
+import XCTest
+@testable import OnymBackup
+
+/// The wire adapter and the repository state machine.
+///
+/// Most of these assert a *refusal*. That is the shape of this seat: the
+/// operator is outside the trust boundary, so what the client declines
+/// to believe is more load-bearing than what it accepts.
+final class BackupAdapterTests: XCTestCase {
+    private let endpoint = URL(string: "https://backup.example")!
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private func makeClient(
+        maximumRetainedSnapshots: Int? = 8,
+        session: URLSession? = nil
+    ) throws -> URLSessionBackupClient {
+        URLSessionBackupClient(
+            manifest: try Self.manifest(maximumRetainedSnapshots: maximumRetainedSnapshots),
+            material: BackupKeys.material(
+                seed: Data(repeating: 0x77, count: 64), componentId: "onym:component:op"),
+            session: session ?? StubURLProtocol.makeSession()
+        )
+    }
+
+    private func respond(
+        _ status: Int,
+        _ json: String,
+        capture: (@Sendable (URLRequest) -> Void)? = nil
+    ) {
+        StubURLProtocol.set { request in
+            capture?(request)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: status,
+                httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
+            return (Data(json.utf8), response)
+        }
+    }
+
+    // MARK: - Refusals
+
+    /// A 402 must arrive as a payment refusal carrying the offer the
+    /// person is being asked to buy — not as a generic failure the UI
+    /// can only render as "something went wrong".
+    func testPaymentRequiredCarriesTheOffer() async throws {
+        respond(402, """
+        {"error":"payment_required","message":"no entitlement",
+         "paymentRequired":{"componentId":"onym:component:op",
+         "offers":["backup-monthly-v1"],"entitlementIssuers":["onym:key:aa"]}}
+        """)
+        do {
+            _ = try await makeClient().preflight(Self.snapshot())
+            XCTFail("expected a payment refusal")
+        } catch BackupError.paymentRequired(let componentId, let offers, let issuers) {
+            XCTAssertEqual(componentId, "onym:component:op")
+            XCTAssertEqual(offers, ["backup-monthly-v1"])
+            XCTAssertEqual(issuers, ["onym:key:aa"])
+        }
+    }
+
+    /// An operator inventing a status word must never be read as
+    /// success by a client that has never heard of it.
+    func testUnrecognisedStatusBecomesUnknownNotRetained() async throws {
+        respond(200, #"{"outcome":{"status":"definitely_fine","componentId":"onym:component:op"}}"#)
+        let outcome = try await makeClient().queryOutcome(operationId: "abc")
+        XCTAssertEqual(outcome?.status, .unknown)
+        XCTAssertFalse(outcome?.status.isRetention ?? true)
+    }
+
+    /// `submitted` means the bytes were handed to the network. It is not
+    /// retention and must not be recorded as such.
+    func testSubmittedIsNotRetention() {
+        XCTAssertFalse(BackupOutcomeStatus.submitted.isRetention)
+        XCTAssertFalse(BackupOutcomeStatus.accepted.isRetention)
+        XCTAssertTrue(BackupOutcomeStatus.retained.isRetention)
+        XCTAssertTrue(BackupOutcomeStatus.alreadyRetained.isRetention)
+    }
+
+    /// The response body's only soft bound is a figure the same operator
+    /// published, so the cap has to be ours.
+    func testOversizedListResponseIsRefused() async throws {
+        let row = #"{"snapshotReference":{"referenceVersion":1,"algorithm":"sha-256/lowercase-hex","digest":"sha256:\#(String(repeating: "a", count: 64))","sealedByteSize":1},"acceptedTermsId":"sha256:\#(String(repeating: "b", count: 64))","retainedAt":"2026-01-01T00:00:00Z"}"#
+        respond(200, "[" + Array(repeating: row, count: 4_000).joined(separator: ",") + "]")
+        do {
+            _ = try await makeClient(maximumRetainedSnapshots: 2).listSnapshots()
+            XCTFail("expected the oversized body to be refused")
+        } catch BackupError.operatorUnavailable {
+            // Expected.
+        }
+    }
+
+    /// A signature covers one path at one origin. An operator that could
+    /// redirect would be choosing where our credentials go.
+    func testRedirectsAreRefused() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(
+            configuration: configuration, delegate: RedirectRefusingDelegate(), delegateQueue: nil)
+        StubURLProtocol.set { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 302, httpVersion: nil,
+                headerFields: ["Location": "https://elsewhere.example/v1/snapshots"])!
+            return (Data(), response)
+        }
+        do {
+            _ = try await makeClient(session: session).listSnapshots()
+            XCTFail("expected the redirect not to be followed")
+        } catch {
+            // Either the 302 surfaces as a rejection or the body fails
+            // to decode — both mean we did not go to the other origin.
+        }
+    }
+
+    /// An unmodelled operator code is preserved rather than flattened
+    /// into a local guess about what happened.
+    func testUnknownOperatorCodeIsPreservedVerbatim() async throws {
+        respond(409, #"{"error":"tape_library_offline","message":"back Tuesday"}"#)
+        do {
+            _ = try await makeClient().preflight(Self.snapshot())
+            XCTFail("expected a rejection")
+        } catch BackupError.rejected(let code, let message) {
+            XCTAssertEqual(code, "tape_library_offline")
+            XCTAssertEqual(message, "back Tuesday")
+        }
+    }
+
+    /// Every `/v1/` request carries the four proof headers, and the
+    /// holder is spelled as a seat key.
+    func testRequestsAreSigned() async throws {
+        let seen = SendableBox()
+        respond(200, #"{"outcome":{"status":"unknown"}}"#) { seen.value = $0 }
+        _ = try? await makeClient().queryOutcome(operationId: "abc")
+        let headers = seen.value?.allHTTPHeaderFields ?? [:]
+        XCTAssertTrue(headers["X-Onym-Holder"]?.hasPrefix("onym:seat-key:") ?? false)
+        XCTAssertNotNil(headers["X-Onym-Timestamp"])
+        XCTAssertNotNil(headers["X-Onym-Nonce"])
+        XCTAssertNotNil(headers["X-Onym-Signature"])
+    }
+
+    // MARK: - Repository
+
+    /// A payment refusal keeps the sealed bytes, and the retry sends the
+    /// same operation id and the same digest. Re-composing would mint a
+    /// new salt, defeat `already_retained`, and charge for a second copy
+    /// of the same history.
+    func testPaymentRetrySendsTheSameBytes() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let material = BackupKeys.material(
+            seed: Data(repeating: 0x88, count: 64), componentId: "onym:component:op")
+        let termsId = ScriptedPort.termsId
+        XCTAssertFalse(termsId.isEmpty)
+
+        var state = BackupState()
+        state.acceptedTermsId = termsId
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: termsId)
+
+        let repository = BackupRepository(
+            port: port,
+            composer: BackupComposer(
+                source: EmptySource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: stateStore,
+            keyMaterial: material)
+
+        guard case .paymentRequired(_, _, let pending) = try await repository.backUp() else {
+            return XCTFail("expected a payment refusal")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: pending.sealedBytesURL.path),
+                      "sealed bytes were discarded on a refusal a purchase would resolve")
+
+        await port.allowPayment()
+        let result = try await repository.retry(pending)
+        XCTAssertEqual(result, .retained(pending.snapshotReference))
+        let operationIds = await port.seenOperationIds
+        XCTAssertEqual(operationIds.count, 2)
+        XCTAssertEqual(operationIds[0], operationIds[1], "the retry composed a new snapshot")
+    }
+
+    /// A lost upload response is unresolved, not failed and not
+    /// succeeded — and the record of it must survive, or the uncertainty
+    /// is gone by the next launch.
+    func testLostUploadResponseLeavesAPendingOperation() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let termsId = ScriptedPort.termsId
+        var state = BackupState()
+        state.acceptedTermsId = termsId
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: termsId, paymentSatisfied: true, uploadFails: true)
+
+        let repository = BackupRepository(
+            port: port,
+            composer: BackupComposer(
+                source: EmptySource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: stateStore,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0x99, count: 64), componentId: "onym:component:op"))
+
+        guard case .unknown = try await repository.backUp() else {
+            return XCTFail("a lost response must not resolve to success or failure")
+        }
+        let saved = try stateStore.load()
+        XCTAssertEqual(saved.pendingOperations.count, 1)
+        XCTAssertTrue(saved.snapshots.isEmpty, "an unresolved upload was recorded as retained")
+    }
+
+    /// Changed terms stop the upload. Re-pinning without a person having
+    /// seen the new terms is the one thing this seat exists to prevent.
+    func testChangedTermsStopTheUpload() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let stalePin = "sha256:" + String(repeating: "e", count: 64)
+        var state = BackupState()
+        state.acceptedTermsId = stalePin
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId)
+
+        let repository = BackupRepository(
+            port: port,
+            composer: BackupComposer(
+                source: EmptySource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: stateStore,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0xAA, count: 64), componentId: "onym:component:op"))
+
+        guard case .termsChanged(let current) = try await repository.backUp() else {
+            return XCTFail("expected the upload to stop")
+        }
+        XCTAssertEqual(current, ScriptedPort.termsId)
+        let saved = try stateStore.load()
+        XCTAssertEqual(saved.acceptedTermsId, stalePin,
+                       "the pinned terms were silently replaced")
+    }
+
+    // MARK: - Fixtures
+
+    static func manifest(maximumRetainedSnapshots: Int?) throws -> BackupOperatorManifest {
+        var limits = ""
+        if let maximumRetainedSnapshots {
+            limits = #","limits":{"maximumRetainedSnapshots":\#(maximumRetainedSnapshots)}"#
+        }
+        let json = """
+        {"version":1,"componentId":"onym:component:op","seat":"storage.backup",
+         "operator":"onym:key:\(String(repeating: "1", count: 64))",
+         "backupProfileId":"\(BackupProfile.portableProfileId)",
+         "implementationProfileId":"\(BackupProfile.implementationProfileId)",
+         "endpoints":[{"uri":"https://backup.example","role":"read-write"}],
+         "capabilities":["upload","list","download","erase","export"],
+         "declaredTerms":"sha256:\(String(repeating: "9", count: 64))"\(limits)}
+        """
+        return try BackupOperatorManifest(manifest: SignedServiceManifest(raw: Data(json.utf8)))
+    }
+
+    static func snapshot() -> SealedSnapshot {
+        SealedSnapshot(
+            operationId: "op",
+            snapshotReference: try! SnapshotReference(
+                digest: "sha256:" + String(repeating: "a", count: 64), sealedByteSize: 1024),
+            sealedBytesURL: URL(fileURLWithPath: "/dev/null"),
+            sealedAt: Date(),
+            acceptedTermsId: "sha256:" + String(repeating: "b", count: 64))
+    }
+}
+
+private final class SendableBox: @unchecked Sendable {
+    var value: URLRequest?
+}
+
+private struct EmptySource: BackupSourceProviding {
+    func identityCount() async -> Int { 0 }
+    func groups() async throws -> [BackupGroupRecord] { [] }
+    func messages(groupID: String, ownerIdentityID: String) async throws -> [BackupMessageRecord] { [] }
+    func invitations() async throws -> [BackupInvitationRecord] { [] }
+    func consents() async throws -> [BackupConsentRecord] { [] }
+    func blobCiphertext(sha256: String) async throws -> BackupBlobAvailability { .gone }
+}
+
+private final class MemoryStateStore: BackupStateStoring, @unchecked Sendable {
+    private var state: BackupState
+    private let lock = NSLock()
+
+    init(state: BackupState) { self.state = state }
+    func load() throws -> BackupState { lock.withLock { state } }
+    func save(_ state: BackupState) throws { lock.withLock { self.state = state } }
+}
+
+private actor ScriptedPort: BackupPort {
+    private let acceptedTermsId: String
+    private var paymentSatisfied: Bool
+    private let uploadFails: Bool
+    private(set) var seenOperationIds: [String] = []
+
+    init(acceptedTermsId: String, paymentSatisfied: Bool = false, uploadFails: Bool = false) {
+        self.acceptedTermsId = acceptedTermsId
+        self.paymentSatisfied = paymentSatisfied
+        self.uploadFails = uploadFails
+    }
+
+    func allowPayment() { paymentSatisfied = true }
+
+    func connect() async throws -> BackupConnection {
+        BackupConnection(
+            manifest: try BackupAdapterTests.manifest(maximumRetainedSnapshots: 8),
+            profile: BackupImplementationProfile(
+                implementationVersion: 1,
+                implementationProfileId: BackupProfile.implementationProfileId,
+                backupProfileId: BackupProfile.portableProfileId,
+                digestSuite: BackupProfile.digestSuite,
+                sealingSuite: BackupProfile.sealingSuite,
+                incrementModel: BackupProfile.incrementModel,
+                authentication: [BackupProfile.authentication],
+                paymentRefusal: BackupProfile.paymentRefusal),
+            terms: try BackupTerms.decode(raw: Self.termsJSON()))
+    }
+
+    func preflight(_ snapshot: SealedSnapshot) async throws -> BackupPreflight {
+        seenOperationIds.append(snapshot.operationId)
+        guard paymentSatisfied else {
+            throw BackupError.paymentRequired(
+                componentId: "onym:component:op",
+                offerIds: ["backup-monthly-v1"],
+                entitlementIssuers: [])
+        }
+        return .granted(
+            BackupUploadGrant(
+                uploadId: "u", chunkBytes: 8 << 20,
+                chunkCount: 1, expiresAt: Date().addingTimeInterval(600)))
+    }
+
+    func uploadSnapshot(_ snapshot: SealedSnapshot, grant: BackupUploadGrant) async throws -> BackupOutcome {
+        if uploadFails { throw BackupError.operatorUnavailable }
+        return BackupOutcome(
+            operationId: snapshot.operationId,
+            componentId: "onym:component:op",
+            status: .retained,
+            snapshotReference: snapshot.snapshotReference)
+    }
+
+    func listSnapshots() async throws -> [RetainedSnapshot] { [] }
+    func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws {}
+    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+        throw BackupError.operatorUnavailable
+    }
+    func exportSnapshots(to directory: URL) async throws -> BackupExport {
+        BackupExport(directory: directory, snapshots: [], receipts: [])
+    }
+    func queryOutcome(operationId: String) async throws -> BackupOutcome? { nil }
+
+    /// The digest of the terms fixture below, computed the same way the
+    /// client computes it. Fabricating one here would have made every
+    /// terms comparison in these tests pass or fail for the wrong
+    /// reason.
+    static var termsId: String {
+        (try? BackupTerms.decode(raw: termsJSON()).termsId) ?? ""
+    }
+
+    /// The terms document `connect()` hands back.
+    static func termsJSON() -> Data {
+        Data("""
+        {"termsVersion":1,"operator":"onym:key:\(String(repeating: "1", count: 64))",
+         "retention":{"class":"measurable","maximumRetentionPeriod":"P1Y",
+           "snapshotsRetained":"3","expiryBehavior":"notify-then-erase"},
+         "erasure":{"acknowledgementDeadline":"P1D","completionDeadline":"P7D",
+           "scope":"primary and replicas","excluded":"copies other participants hold"},
+         "jurisdictions":["EE"],"subProcessors":[],
+         "lawfulAccess":{"disclosureWhatIsProduced":"sealed-bytes-and-declared-metadata-only",
+           "notifyHolderWhenPermitted":true,"transparencyReporting":null},
+         "breachDisclosure":{"holderNotice":"P3D"},
+         "export":{"format":"tar","availableWhileUnpaid":true},
+         "shutdownNotice":"P90D",
+         "endOfPayment":{"notice":"P14D","grace":"P30D",
+           "duringGrace":["download","export","erase"],"afterGrace":"erase"},
+         "metadataRetention":{"accessLogs":"none","sizeAndTiming":"P1Y",
+           "holderIdentifiers":"P1Y","operationOutcomes":"PT6H",
+           "erasureReceipts":"P1Y","entitlementRecords":"P1Y"}}
+        """.utf8)
+    }
+}

--- a/Tests/OnymIOSTests/BackupAdapterTests.swift
+++ b/Tests/OnymIOSTests/BackupAdapterTests.swift
@@ -102,19 +102,20 @@ final class BackupAdapterTests: XCTestCase {
         configuration.protocolClasses = [StubURLProtocol.self]
         let session = URLSession(
             configuration: configuration, delegate: RedirectRefusingDelegate(), delegateQueue: nil)
+        let visited = HostRecorder()
         StubURLProtocol.set { request in
+            visited.record(request.url?.host())
             let response = HTTPURLResponse(
                 url: request.url!, statusCode: 302, httpVersion: nil,
                 headerFields: ["Location": "https://elsewhere.example/v1/snapshots"])!
             return (Data(), response)
         }
-        do {
-            _ = try await makeClient(session: session).listSnapshots()
-            XCTFail("expected the redirect not to be followed")
-        } catch {
-            // Either the 302 surfaces as a rejection or the body fails
-            // to decode — both mean we did not go to the other origin.
-        }
+        _ = try? await makeClient(session: session).listSnapshots()
+        // The assertion that matters is *where the bytes went*, not that
+        // an error came back — the previous version of this test passed
+        // whether or not the redirect was followed, because the second
+        // origin also hits the stub.
+        XCTAssertEqual(visited.hosts, ["backup.example"])
     }
 
     /// An unmodelled operator code is preserved rather than flattened
@@ -402,7 +403,125 @@ final class BackupAdapterTests: XCTestCase {
         XCTAssertEqual(try FileBackupStateStore(url: fresh).load(), BackupState())
     }
 
+    /// An operation the operator says is still `submitted` is in
+    /// flight, not resolved. Dropping it would compose a second snapshot
+    /// on top of one the operator is still working on — and charge for
+    /// both.
+    func testInFlightOperationStaysPending() async throws {
+        let dir = try Self.directory()
+        let digest = "sha256:" + String(repeating: "3", count: 64)
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        state.pendingOperations = [
+            BackupState.PendingOperation(
+                operationId: "inflight", digest: digest, startedAt: Date(),
+                acceptedTermsId: ScriptedPort.termsId)
+        ]
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+        await port.setQueryOutcome(
+            BackupOutcome(operationId: "inflight", componentId: "onym:component:op",
+                          status: .submitted))
+
+        _ = try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+        XCTAssertEqual(try stateStore.load().pendingOperations.count, 1)
+    }
+
+    /// A query we could not make resolves nothing — the same rule as a
+    /// list we could not fetch.
+    func testFailedQueryLeavesPendingIntact() async throws {
+        let dir = try Self.directory()
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        state.pendingOperations = [
+            BackupState.PendingOperation(
+                operationId: "lost", digest: "sha256:" + String(repeating: "4", count: 64),
+                startedAt: Date(), acceptedTermsId: ScriptedPort.termsId)
+        ]
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+        await port.setQueryFails(true)
+
+        _ = try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+        XCTAssertEqual(try stateStore.load().pendingOperations.count, 1)
+    }
+
+    /// The operator does not get to say which snapshot we asked about.
+    func testMismatchedEchoedReferenceIsRefused() async throws {
+        let dir = try Self.directory()
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+        await port.setAlreadyRetainedEcho(
+            try SnapshotReference(
+                digest: "sha256:" + String(repeating: "5", count: 64), sealedByteSize: 99))
+
+        do {
+            _ = try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+            XCTFail("accepted an answer about a different snapshot")
+        } catch BackupError.rejected(let code, _) {
+            XCTAssertEqual(code, "reference_mismatch")
+        }
+        XCTAssertTrue(try stateStore.load().snapshots.isEmpty, "the local chain was poisoned")
+    }
+
+    /// A purchase can outlive the process. The refused snapshot has to
+    /// still be there afterwards, or the retry re-composes and the
+    /// person pays twice.
+    func testPendingPaymentSurvivesRelaunch() async throws {
+        let dir = try Self.directory()
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId)
+
+        guard case .paymentRequired(_, _, let pending) =
+            try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+        else {
+            return XCTFail("expected a payment refusal")
+        }
+
+        // A fresh repository over the same state and directory — the
+        // relaunch.
+        let resumed = try await Self.repository(port: port, store: stateStore, dir: dir)
+            .pendingPayment(in: dir)
+        XCTAssertEqual(resumed?.operationId, pending.operationId)
+        XCTAssertEqual(resumed?.snapshotReference, pending.snapshotReference)
+        XCTAssertEqual(resumed?.acceptedTermsId, pending.acceptedTermsId)
+    }
+
+    /// A declared limit large enough to overflow the cap arithmetic must
+    /// clamp, not trap. Every other operator-controlled figure earns a
+    /// refusal; this one was earning a crash.
+    func testHostileRetainedLimitDoesNotTrap() async throws {
+        respond(200, "[]")
+        let client = try makeClient(maximumRetainedSnapshots: Int.max)
+        XCTAssertLessThanOrEqual(client.listResponseCap, URLSessionBackupClient.maxListResponseBytes)
+        _ = try await client.listSnapshots()
+    }
+
     // MARK: - Fixtures
+
+    static func directory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    static func repository(
+        port: any BackupPort,
+        store: any BackupStateStoring,
+        dir: URL
+    ) -> BackupRepository {
+        BackupRepository(
+            port: port,
+            composer: BackupComposer(
+                source: EmptySource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: store,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0xEE, count: 64), componentId: "onym:component:op"))
+    }
 
     static func manifest(maximumRetainedSnapshots: Int?) throws -> BackupOperatorManifest {
         var limits = ""
@@ -461,6 +580,9 @@ private actor ScriptedPort: BackupPort {
     private let uploadStatus: BackupOutcomeStatus
     private var retained: [RetainedSnapshot] = []
     private var listFails = false
+    private var queryOutcome: BackupOutcome?
+    private var queryFails = false
+    private var alreadyRetainedEcho: SnapshotReference?
     private(set) var seenOperationIds: [String] = []
 
     init(
@@ -477,6 +599,9 @@ private actor ScriptedPort: BackupPort {
 
     func setRetained(_ rows: [RetainedSnapshot]) { retained = rows }
     func setListFails(_ value: Bool) { listFails = value }
+    func setQueryOutcome(_ outcome: BackupOutcome?) { queryOutcome = outcome }
+    func setQueryFails(_ value: Bool) { queryFails = value }
+    func setAlreadyRetainedEcho(_ reference: SnapshotReference) { alreadyRetainedEcho = reference }
 
     func allowPayment() { paymentSatisfied = true }
 
@@ -497,6 +622,12 @@ private actor ScriptedPort: BackupPort {
 
     func preflight(_ snapshot: SealedSnapshot) async throws -> BackupPreflight {
         seenOperationIds.append(snapshot.operationId)
+        if let echo = alreadyRetainedEcho {
+            return .alreadyRetained(
+                BackupOutcome(
+                    operationId: snapshot.operationId, componentId: "onym:component:op",
+                    status: .alreadyRetained, snapshotReference: echo))
+        }
         guard paymentSatisfied else {
             throw BackupError.paymentRequired(
                 componentId: "onym:component:op",
@@ -529,7 +660,10 @@ private actor ScriptedPort: BackupPort {
     func exportSnapshots(to directory: URL) async throws -> BackupExport {
         BackupExport(directory: directory, snapshots: [], receipts: [])
     }
-    func queryOutcome(operationId: String) async throws -> BackupOutcome? { nil }
+    func queryOutcome(operationId: String) async throws -> BackupOutcome? {
+        if queryFails { throw BackupError.operatorUnavailable }
+        return queryOutcome
+    }
 
     /// The digest of the terms fixture below, computed the same way the
     /// client computes it. Fabricating one here would have made every
@@ -560,4 +694,18 @@ private actor ScriptedPort: BackupPort {
            "erasureReceipts":"P1Y","entitlementRecords":"P1Y"}}
         """.utf8)
     }
+}
+
+
+/// Records which hosts a stubbed session was actually asked to contact.
+private final class HostRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seen: [String] = []
+
+    func record(_ host: String?) {
+        guard let host else { return }
+        lock.withLock { if !seen.contains(host) { seen.append(host) } }
+    }
+
+    var hosts: [String] { lock.withLock { seen } }
 }

--- a/Tests/OnymIOSTests/BackupAdapterTests.swift
+++ b/Tests/OnymIOSTests/BackupAdapterTests.swift
@@ -587,6 +587,110 @@ final class BackupAdapterTests: XCTestCase {
             "a partial file was left at a caller-owned path")
     }
 
+    /// Reconciling first only prevents double storage if failing to
+    /// reconcile also stops us. Otherwise a run that cannot reach the
+    /// operator mints a fresh salt and digest every time, and the
+    /// operator retains each one beside the copy we lost track of.
+    func testUnreconciledWorkBlocksComposition() async throws {
+        let dir = try Self.directory()
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        state.pendingOperations = [
+            BackupState.PendingOperation(
+                operationId: "lost", digest: "sha256:" + String(repeating: "9", count: 64),
+                sealedByteSize: 2048, startedAt: Date(), acceptedTermsId: ScriptedPort.termsId)
+        ]
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+        await port.setListFails(true)
+
+        let result = try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+        guard case .awaitingReconciliation(let ids) = result else {
+            return XCTFail("composed a new snapshot over unresolved work: \(result)")
+        }
+        XCTAssertEqual(ids, ["lost"])
+        let seen = await port.seenOperationIds
+        XCTAssertTrue(seen.isEmpty, "a snapshot was preflighted despite unresolved work")
+    }
+
+    /// A pending operation resolved later is still older. Appending it
+    /// to the tail would make the next snapshot supersede a stale
+    /// ancestor.
+    func testReconciledRetentionDoesNotBecomeTheNewestAncestor() throws {
+        var state = BackupState()
+        let older = try SnapshotReference(
+            digest: "sha256:" + String(repeating: "1", count: 64), sealedByteSize: 1024)
+        let newer = try SnapshotReference(
+            digest: "sha256:" + String(repeating: "2", count: 64), sealedByteSize: 2048)
+
+        state.record(reference: newer, acceptedTermsId: "t", at: Date(), status: .retained)
+        // Resolved afterwards, but uploaded before.
+        state.record(
+            reference: older, acceptedTermsId: "t",
+            at: Date().addingTimeInterval(-3600), status: .retained)
+
+        XCTAssertEqual(state.newestSnapshot?.digest, newer.digest)
+        XCTAssertEqual(state.snapshots.map(\.digest), [older.digest, newer.digest])
+    }
+
+    /// Resolving an operation must also close out any purchase it was
+    /// waiting on, or the caller is stranded buying storage for a
+    /// snapshot the operator already holds.
+    func testResolvedOperationClearsThePendingPurchase() async throws {
+        let dir = try Self.directory()
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId)
+
+        guard case .paymentRequired(_, _, let pending) =
+            try await Self.repository(port: port, store: stateStore, dir: dir).backUp()
+        else {
+            return XCTFail("expected a payment refusal")
+        }
+
+        // The operator turns out to hold it after all.
+        var withPending = try stateStore.load()
+        withPending.pendingOperations = [
+            BackupState.PendingOperation(
+                operationId: pending.operationId,
+                digest: pending.snapshotReference.digest,
+                sealedByteSize: pending.snapshotReference.sealedByteSize,
+                startedAt: Date(), acceptedTermsId: ScriptedPort.termsId)
+        ]
+        try stateStore.save(withPending)
+        await port.setRetained([
+            RetainedSnapshot(
+                snapshotReference: pending.snapshotReference,
+                acceptedTermsId: ScriptedPort.termsId, retainedAt: Date())
+        ])
+        await port.setPaymentSatisfied(true)
+
+        let repository = Self.repository(port: port, store: stateStore, dir: dir)
+        _ = try await repository.backUp()
+        XCTAssertNil(try stateStore.load().awaitingPayment, "still owes a purchase it does not need")
+        let resumable = try await repository.pendingPayment(in: dir)
+        XCTAssertNil(resumable)
+    }
+
+    /// Two interleaved runs must not each save a stale copy over the
+    /// other — the loser would take the winner's pending record with it,
+    /// and that record is the whole uncertainty design.
+    func testConcurrentRunsAreSerialized() async throws {
+        let dir = try Self.directory()
+        var state = BackupState()
+        state.acceptedTermsId = ScriptedPort.termsId
+        let stateStore = MemoryStateStore(state: state)
+        let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
+        let repository = Self.repository(port: port, store: stateStore, dir: dir)
+
+        async let first = repository.backUp()
+        async let second = repository.backUp()
+        let results = try await [first, second]
+        XCTAssertEqual(results.filter { $0 == .alreadyRunning }.count, 1,
+                       "both runs proceeded concurrently")
+    }
+
     // MARK: - Fixtures
 
     static func directory() throws -> URL {
@@ -687,6 +791,7 @@ private actor ScriptedPort: BackupPort {
     func setListFails(_ value: Bool) { listFails = value }
     func setQueryOutcome(_ outcome: BackupOutcome?) { queryOutcome = outcome }
     func setQueryFails(_ value: Bool) { queryFails = value }
+    func setPaymentSatisfied(_ value: Bool) { paymentSatisfied = value }
     func setAlreadyRetainedEcho(_ reference: SnapshotReference) { alreadyRetainedEcho = reference }
 
     func allowPayment() { paymentSatisfied = true }


### PR DESCRIPTION
Fourth of the device-backup stack, on top of #276. `URLSessionBackupClient` speaks the [object-HTTP profile](https://github.com/onymchat/onym-system/blob/main/backup/UI-Backup-Object-HTTP.md); `BackupRepository` decides what to do with the answers.

Most of this is refusals, which is the shape of the seat: the operator sits outside the trust boundary, so what the client declines to believe matters more than what it accepts.

### What the client refuses

- **Redirects, always.** A signed request covers one path at one origin; an operator that could redirect would be choosing where our credentials go.
- **Oversized bodies.** The only soft bound on a list response is `maximumRetainedSnapshots` — the same operator's figure, with no signature behind it — so the cap is enforced on our side (§13). Sealed streams are bounded by the reference's own byte count, so an over-long stream is cut off rather than written to a device that may not have the room and only then failing a digest check.
- **Unrecognised status words.** They become `unknown`, never `retained`. A future operator inventing a word must not read as success to a client that has never heard of it.
- **Unmodelled error codes**, which are preserved verbatim rather than flattened into a local guess.

The manifest is deliberately **not** fetched or verified here — manifest review already exists in the consent flow, and a second implementation of one trust decision is how the two drift apart. The client is handed the manifest the person consented to and binds to its read-write origin.

### Three edges in the repository

**The payment retry sends the same bytes.** A refusal keeps the sealed snapshot and hands it back; the retry reuses the operation id and digest. Re-composing would mint a new salt, defeat `already_retained`, and charge someone for a second copy of the same history. The test asserts both preflights carry one operation id.

**The pending-operation record is written before the upload**, not after. A record written only on success is exactly the record that's missing when a response is lost. A lost response resolves to neither success nor failure — it stays pending until `queryOutcome` answers, and reconciliation runs *before* composing, since stacking a second snapshot on an unresolved first is how someone pays to store the same history twice.

**Changed terms stop the upload and don't re-pin.** Fresh consent is a screen, not an inference.

### Worth a look in review

- `BackupStateStore` throws on a corrupt state file rather than returning an empty state — reading "no backup configured" from corruption would drop the pinned terms and the pending list, and the next upload would go out under terms nobody re-consented to.
- Terms are verified twice over: the served document's computed `termsId` must equal the manifest's `declaredTermsDigest`, *and* its signature must verify against the manifest's operator key.
- Three of these tests initially failed because my fixture fabricated a `termsId` while the client computes it from the document. That was the pinning working, and the fixtures now derive the real digest.

### Verification

```
BackupAdapterTests      10 passed
** TEST SUCCEEDED **
```
`xcodebuild -scheme OnymIOS` **BUILD SUCCEEDED**.

The DEBUG `--backup-base-url` override lands with the wiring PR — nothing constructs this client from the app yet, so a resolver here would be dead code.