### PR TITLE
Add OnymBackupUI: the consent surface, and honest copy about scheduling

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -396,6 +396,45 @@ public actor BackupRepository {
         try stateStore.save(state)
     }
 
+    /// What the operator says it holds for this holder.
+    ///
+    /// The operator's list is authoritative about retention; the local
+    /// chain records what *we* did. They can differ — a snapshot
+    /// uploaded from another device, or one whose response we lost — and
+    /// a surface showing "your backups" should show the operator's
+    /// answer rather than our memory of it.
+    public func listSnapshots() async throws -> [RetainedSnapshot] {
+        try await port.listSnapshots()
+    }
+
+    /// Erase, and record the receipt.
+    ///
+    /// The receipt is kept because its `excludedScope` outlives the
+    /// snapshot it describes: what an erasure did not reach is the part
+    /// a person may need to re-read long afterwards.
+    @discardableResult
+    public func erase(scope: ErasureScope) async throws -> ErasureReceipt {
+        let receipt = try await port.eraseSnapshot(scope: scope)
+        var state = try stateStore.load()
+        state.receipts.append(receipt.rawBytes)
+        if case .snapshot(let reference) = scope {
+            state.snapshots.removeAll { $0.digest == reference.digest }
+        } else {
+            state.snapshots.removeAll()
+        }
+        try stateStore.save(state)
+        return receipt
+    }
+
+    /// Export every retained snapshot in portable form.
+    ///
+    /// Never gated on payment here, and it must not be gated at the
+    /// operator either — retention is not leverage over someone's own
+    /// history.
+    public func export(to directory: URL) async throws -> BackupExport {
+        try await port.exportSnapshots(to: directory)
+    }
+
     /// Close out a pending operation: clear any purchase it was waiting
     /// on, drop its sealed bytes, and — when it landed — record that a
     /// backup succeeded.

--- a/Packages/OnymBackupUI/Package.swift
+++ b/Packages/OnymBackupUI/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OnymBackupUI",
+    platforms: [.iOS("18.0")],
+    products: [
+        .library(name: "OnymBackupUI", targets: ["OnymBackupUI"]),
+    ],
+    dependencies: [
+        .package(path: "../OnymBackup"),
+        .package(path: "../OnymBilling"),
+        .package(path: "../OnymDesign"),
+    ],
+    targets: [
+        .target(
+            name: "OnymBackupUI",
+            dependencies: [
+                "OnymBackup",
+                "OnymBilling",
+                "OnymDesign",
+            ]
+        ),
+    ]
+)

--- a/Packages/OnymBackupUI/Package.swift
+++ b/Packages/OnymBackupUI/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         .package(path: "../OnymBackup"),
         .package(path: "../OnymBilling"),
         .package(path: "../OnymDesign"),
+        .package(path: "../OnymFoundation"),
     ],
     targets: [
         .target(
@@ -19,6 +20,7 @@ let package = Package(
                 "OnymBackup",
                 "OnymBilling",
                 "OnymDesign",
+                "OnymFoundation",
             ]
         ),
     ]

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
@@ -1,0 +1,165 @@
+import Foundation
+import OnymBackup
+
+/// Everything the enrolment surface must say before a single byte
+/// leaves the device.
+///
+/// Built as data rather than assembled inline in a view so a fixture can
+/// assert its content. `UI-Backup.md` §18.10 asks for exactly that: the
+/// consent surface is verified "by fixture rather than by review",
+/// because a disclosure that quietly loses a paragraph in a refactor is
+/// worse than one that was never written.
+public struct BackupDisclosure: Sendable, Equatable {
+    public struct Item: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let label: String
+        public let value: String
+    }
+
+    /// The sentence §7.4 and §10.4 require, and the reason this seat
+    /// treats disclosure as a contract term rather than a courtesy: a
+    /// snapshot extends the life of both sides of every conversation in
+    /// it, for people who never chose this operator.
+    public let thirdPartyConsequence: String
+    /// The absent reset path (§11). Stated as plainly as it deserves —
+    /// there is no recovery, and a person should learn that here rather
+    /// than when they need it.
+    public let noResetPath: String
+    /// What this build actually does about scheduling. Copy that
+    /// promises "automatic" while uploads are foreground-only would be
+    /// the easiest lie in the product.
+    public let whenBackupsHappen: String
+    public let operatorName: String
+    public let items: [Item]
+
+    public init(
+        thirdPartyConsequence: String,
+        noResetPath: String,
+        whenBackupsHappen: String,
+        operatorName: String,
+        items: [Item]
+    ) {
+        self.thirdPartyConsequence = thirdPartyConsequence
+        self.noResetPath = noResetPath
+        self.whenBackupsHappen = whenBackupsHappen
+        self.operatorName = operatorName
+        self.items = items
+    }
+
+    /// Compose from what the operator actually published.
+    ///
+    /// Every declared field is rendered, including the ones that read
+    /// badly. An operator that excludes a great deal from erasure, or
+    /// keeps access logs, or names four sub-processors, has said so in a
+    /// signed document, and the surface's job is to repeat it rather
+    /// than summarise it into something more comfortable.
+    public static func from(
+        connection: BackupConnection,
+        schedule: BackupSchedule,
+        mediaPolicy: BackupMediaPolicy
+    ) -> BackupDisclosure {
+        let terms = connection.terms
+        var items: [Item] = [
+            Item(id: "operator", label: "Operator", value: connection.manifest.componentId),
+            Item(id: "retention.class", label: "Retention class", value: terms.retention.retentionClass),
+            Item(
+                id: "retention.period", label: "Kept for",
+                value: terms.retention.maximumRetentionPeriod),
+            Item(
+                id: "retention.count", label: "Snapshots kept",
+                value: terms.retention.snapshotsRetained),
+            Item(
+                id: "retention.expiry", label: "When retention ends",
+                value: terms.retention.expiryBehavior),
+            Item(
+                id: "erasure.acknowledgement", label: "Erasure acknowledged within",
+                value: terms.erasure.acknowledgementDeadline),
+            Item(
+                id: "erasure.completion", label: "Erasure completed within",
+                value: terms.erasure.completionDeadline),
+            Item(id: "erasure.scope", label: "Erasure covers", value: terms.erasure.scope),
+            // Verbatim, and never summarised. What erasure does *not*
+            // reach is the part a person is most likely to assume away.
+            Item(id: "erasure.excluded", label: "Erasure does not cover", value: terms.erasure.excluded),
+            Item(
+                id: "jurisdictions", label: "Stored and processed in",
+                value: terms.jurisdictions.joined(separator: ", ")),
+            Item(
+                id: "subProcessors", label: "Sub-processors",
+                value: terms.subProcessors.isEmpty
+                    ? "None declared"
+                    : terms.subProcessors
+                        .map { "\($0.role) (\($0.jurisdiction))" }
+                        .joined(separator: ", ")),
+            Item(
+                id: "lawfulAccess.produces", label: "A legal demand produces",
+                value: terms.lawfulAccess.disclosureWhatIsProduced),
+            Item(
+                id: "lawfulAccess.notify", label: "You are told when permitted",
+                value: terms.lawfulAccess.notifyHolderWhenPermitted ? "Yes" : "No"),
+            Item(
+                id: "breach", label: "Breach notice",
+                value: terms.breachHolderNotice),
+            Item(id: "export.format", label: "Export format", value: terms.export.format),
+            Item(
+                id: "export.unpaid", label: "Export while unpaid",
+                value: terms.export.availableWhileUnpaid ? "Available" : "Not available"),
+            Item(
+                id: "shutdownNotice", label: "If the operator shuts down",
+                value: terms.shutdownNotice.map { "Export works for \($0)" }
+                    ?? "No notice period declared"),
+            Item(id: "endOfPayment.notice", label: "Notice if payment stops", value: terms.endOfPayment.notice),
+            Item(id: "endOfPayment.grace", label: "Grace period", value: terms.endOfPayment.grace),
+            Item(
+                id: "endOfPayment.duringGrace", label: "Still works during grace",
+                value: terms.endOfPayment.duringGrace.joined(separator: ", ")),
+            Item(
+                id: "endOfPayment.afterGrace", label: "After grace",
+                value: terms.endOfPayment.afterGrace),
+            Item(
+                id: "metadata.accessLogs", label: "Access logs kept",
+                value: terms.metadataRetention.accessLogs),
+            Item(
+                id: "metadata.sizeAndTiming", label: "Size and timing kept",
+                value: terms.metadataRetention.sizeAndTiming),
+            Item(
+                id: "media", label: "Attachments",
+                value: mediaPolicy == .includeCiphertext
+                    ? "Included in the backup"
+                    : "Not included — they reload from your media provider, and are gone if it no longer has them"),
+        ]
+        items.append(
+            Item(
+                id: "termsId", label: "Terms digest",
+                value: connection.acceptedTermsId))
+
+        return BackupDisclosure(
+            thirdPartyConsequence: """
+                A backup keeps a copy of both sides of every conversation on this phone. \
+                The other people in those chats did not choose this operator, this country, \
+                or how long it keeps things. Backing up extends how long their messages exist.
+                """,
+            noResetPath: """
+                Only your recovery phrase can open this backup — not the operator, and not Onym. \
+                If you lose the phrase, the backup is unreadable forever. There is no reset, \
+                and nobody can make one for you.
+                """,
+            whenBackupsHappen: Self.scheduleSentence(schedule),
+            operatorName: connection.manifest.componentId,
+            items: items
+        )
+    }
+
+    static func scheduleSentence(_ schedule: BackupSchedule) -> String {
+        var conditions: [String] = []
+        if schedule.requiresWiFi { conditions.append("on Wi-Fi") }
+        if schedule.requiresCharging { conditions.append("while charging") }
+        let when = conditions.isEmpty ? "" : " " + conditions.joined(separator: " and ")
+        return """
+            Backups run when you tap Back Up Now. Onym may also back up on its own while \
+            the app is open\(when), at most once a day. It cannot back up in the background, \
+            so if you never open the app, nothing is backed up. Each backup uploads your \
+            whole history, not just what changed.
+            """
+    }
+}

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
@@ -150,14 +150,26 @@ public struct BackupDisclosure: Sendable, Equatable {
         )
     }
 
+    /// Describes the configured interval rather than asserting a day.
+    /// A hardcoded cadence beside a configurable one is a sentence that
+    /// starts true and quietly stops being.
+    static func cadence(_ interval: TimeInterval) -> String {
+        let hours = interval / 3600
+        if hours >= 48 { return "once every \(Int((hours / 24).rounded())) days" }
+        if hours >= 24 { return "once a day" }
+        if hours >= 2 { return "once every \(Int(hours.rounded())) hours" }
+        return "once an hour"
+    }
+
     static func scheduleSentence(_ schedule: BackupSchedule) -> String {
         var conditions: [String] = []
         if schedule.requiresWiFi { conditions.append("on Wi-Fi") }
         if schedule.requiresCharging { conditions.append("while charging") }
         let when = conditions.isEmpty ? "" : " " + conditions.joined(separator: " and ")
+        let cadence = Self.cadence(schedule.minimumInterval)
         return """
             Backups run when you tap Back Up Now. Onym may also back up on its own while \
-            the app is open\(when), at most once a day. It cannot back up in the background, \
+            the app is open\(when), at most \(cadence). It cannot back up in the background, \
             so if you never open the app, nothing is backed up. Each backup uploads your \
             whole history, not just what changed.
             """

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
@@ -1,0 +1,135 @@
+import OnymBackup
+import OnymDesign
+import SwiftUI
+
+/// The screen a person reads before their history leaves this device.
+///
+/// Deliberately not a paragraph of terms with a checkbox. Three things
+/// come first, in this order, because they are the three someone would
+/// otherwise find out too late:
+///
+/// 1. what a backup does to everyone else in their conversations;
+/// 2. that nobody — including us — can recover it without the phrase;
+/// 3. when backups actually happen, which is not "automatically".
+///
+/// The operator's declared terms follow in full, unsummarised. An
+/// operator that keeps access logs or excludes a great deal from
+/// erasure has published that, and this screen repeats it.
+public struct BackupEnrolmentView: View {
+    private let disclosure: BackupDisclosure
+    private let onAccept: () -> Void
+    private let onCancel: () -> Void
+
+    @State private var scrolledToEnd = false
+
+    public init(
+        disclosure: BackupDisclosure,
+        onAccept: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.disclosure = disclosure
+        self.onAccept = onAccept
+        self.onCancel = onCancel
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                headline(
+                    "This copies other people's messages too",
+                    disclosure.thirdPartyConsequence,
+                    symbol: "person.2.slash",
+                    identifier: "backup.enrolment.third_party")
+
+                headline(
+                    "Nobody can recover this for you",
+                    disclosure.noResetPath,
+                    symbol: "key.slash",
+                    identifier: "backup.enrolment.no_reset")
+
+                headline(
+                    "When backups happen",
+                    disclosure.whenBackupsHappen,
+                    symbol: "clock.arrow.circlepath",
+                    identifier: "backup.enrolment.schedule")
+
+                SettingsSectionLabel("WHAT THE OPERATOR PROMISES")
+                SettingsCard {
+                    ForEach(Array(disclosure.items.enumerated()), id: \.element.id) { index, item in
+                        VStack(alignment: .leading, spacing: 4) {
+                            // `verbatim` throughout: these are the
+                            // operator's own published strings, and a
+                            // value that happened to match a
+                            // localization key would render the
+                            // translation instead of what was signed.
+                            Text(verbatim: item.label)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                            Text(verbatim: item.value)
+                                .font(.callout)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 14)
+                        .accessibilityIdentifier("backup.terms.\(item.id)")
+
+                        if index < disclosure.items.count - 1 {
+                            SettingsRowDivider()
+                        }
+                    }
+                }
+
+                SettingsFootnote(
+                    "These terms are pinned to every backup you make under them. If the operator publishes different terms later, backups stop until you have seen them.")
+
+                // Marks the end of the disclosure. Enabling the accept
+                // button only once this has been reached is the cheapest
+                // honest way to keep "read the terms" from being a
+                // formality — the button is not the consent, the reading
+                // is.
+                Color.clear
+                    .frame(height: 1)
+                    .onAppear { scrolledToEnd = true }
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 10) {
+                Button(action: onAccept) {
+                    Text("Turn On Backup")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!scrolledToEnd)
+                .accessibilityIdentifier("backup.enrolment.accept")
+
+                Button("Not Now", action: onCancel)
+                    .accessibilityIdentifier("backup.enrolment.cancel")
+            }
+            .padding(16)
+            .background(.bar)
+        }
+        .navigationTitle("Device Backup")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func headline(
+        _ title: String,
+        _ body: String,
+        symbol: String,
+        identifier: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: symbol)
+                .font(.headline)
+            Text(verbatim: body)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier(identifier)
+    }
+}

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
@@ -35,6 +35,17 @@ public struct BackupEnrolmentView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Backing up to")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Text(verbatim: disclosure.operatorName)
+                        .font(.headline)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityIdentifier("backup.enrolment.operator")
+
                 headline(
                     "This copies other people's messages too",
                     disclosure.thirdPartyConsequence,
@@ -83,17 +94,27 @@ public struct BackupEnrolmentView: View {
                 SettingsFootnote(
                     "These terms are pinned to every backup you make under them. If the operator publishes different terms later, backups stop until you have seen them.")
 
-                // Marks the end of the disclosure. Enabling the accept
-                // button only once this has been reached is the cheapest
-                // honest way to keep "read the terms" from being a
-                // formality — the button is not the consent, the reading
-                // is.
-                Color.clear
-                    .frame(height: 1)
-                    .onAppear { scrolledToEnd = true }
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
+        }
+        // Scroll geometry, not an `onAppear` sentinel.
+        //
+        // The first version put a `Color.clear` marker at the bottom of
+        // a plain `VStack` and set the flag in its `onAppear` — which
+        // fires at initial layout for offscreen children too, so the
+        // gate opened immediately and the button was enabled without
+        // anyone reading anything. The claim that "the button is not the
+        // consent, the reading is" was false in the exact way §18.10
+        // warns about: it still compiled, still rendered, and still
+        // looked like a consent screen.
+        .onScrollGeometryChange(for: Bool.self) { geometry in
+            Self.hasReachedEnd(
+                contentOffsetY: geometry.contentOffset.y,
+                containerHeight: geometry.containerSize.height,
+                contentHeight: geometry.contentSize.height)
+        } action: { _, reachedEnd in
+            if reachedEnd { scrolledToEnd = true }
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 10) {
@@ -113,6 +134,22 @@ public struct BackupEnrolmentView: View {
         }
         .navigationTitle("Device Backup")
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    /// Whether the disclosure has been scrolled to its end.
+    ///
+    /// Pure, so it can be tested — including the case that matters most
+    /// and is easiest to get wrong: content shorter than the container
+    /// has *already* been read in full, and gating on a scroll that can
+    /// never happen would lock the button forever.
+    static func hasReachedEnd(
+        contentOffsetY: CGFloat,
+        containerHeight: CGFloat,
+        contentHeight: CGFloat,
+        tolerance: CGFloat = 24
+    ) -> Bool {
+        guard contentHeight > containerHeight else { return true }
+        return contentOffsetY + containerHeight >= contentHeight - tolerance
     }
 
     private func headline(

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupSchedule.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupSchedule.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OnymFoundation
 
 /// When a backup is allowed to run.
 ///
@@ -85,11 +86,36 @@ public struct BackupSchedule: Sendable, Equatable {
     /// Whether an *opportunistic* run may start. A person tapping "Back
     /// up now" bypasses this entirely — an explicit request is not
     /// something to second-guess about battery.
-    public func permitsOpportunisticRun(_ conditions: Conditions, now: Date = Date()) -> Bool {
+    ///
+    /// `jitter` is drawn once per app session by the caller and added to
+    /// the interval. Without it the run fires the instant the interval
+    /// elapses, which is deterministic and therefore correlated with
+    /// whatever the person was doing when the previous one ran — the
+    /// activity signal this seat spends padding and an opaque archive
+    /// suppressing. A declared-but-unapplied jitter would have been
+    /// decoration on top of that.
+    public func permitsOpportunisticRun(
+        _ conditions: Conditions,
+        jitter: TimeInterval,
+        now: Date = Date()
+    ) -> Bool {
         if requiresWiFi && !conditions.onWiFi { return false }
         if requiresCharging && !conditions.charging { return false }
         guard let last = conditions.lastAttemptAt else { return true }
-        return now.timeIntervalSince(last) >= minimumInterval
+        let wait = minimumInterval + min(max(jitter, 0), maximumJitter)
+        return now.timeIntervalSince(last) >= wait
+    }
+
+    /// Draw a jitter offset from the CSPRNG.
+    ///
+    /// Drawn once and held for the session rather than re-drawn per
+    /// check: re-drawing would let a caller that polls frequently
+    /// sample until it got a small value, which is the same as having no
+    /// jitter at all.
+    public func drawJitter() -> TimeInterval {
+        guard maximumJitter > 0, let bytes = try? SecureRandom.data(8) else { return 0 }
+        let value = bytes.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+        return maximumJitter * (Double(value % 10_000) / 10_000)
     }
 
     public func isStale(lastSuccessAt: Date?, now: Date = Date()) -> Bool {

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupSchedule.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupSchedule.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// When a backup is allowed to run.
+///
+/// One type, on purpose: this is a policy decision with user-visible
+/// consequences — the enrolment copy has to describe it accurately — and
+/// it should be cheap to change without hunting through view code.
+///
+/// **v1 is deliberately not a cron.** Two constraints decide it:
+///
+/// - Uploads are foreground-only. A multi-hundred-megabyte transfer
+///   wants a background `URLSession` with a persistent identifier, which
+///   is exactly the long-lived, linkable session state this codebase
+///   avoids everywhere else.
+/// - Snapshots are whole, never incremental, so every run re-uploads the
+///   entire history. That argues for deliberate and occasional rather
+///   than frequent and automatic.
+///
+/// So: an explicit "Back up now" is the primary path, and an
+/// opportunistic check runs when the app is already open under
+/// conditions that make a large upload reasonable. Nothing starts on its
+/// own — `UI-Backup.md` §7.1 requires backup to stay off until a person
+/// turns it on, and never to enable itself as a side effect.
+public struct BackupSchedule: Sendable, Equatable {
+    /// Minimum gap between opportunistic runs.
+    public var minimumInterval: TimeInterval
+    /// Extra delay drawn per run, up to this bound.
+    ///
+    /// Not battery politeness. Upload timing that tracks send activity
+    /// re-leaks per-group activity to the operator through volume and
+    /// cadence — the same signal the padding and the opaque archive
+    /// exist to suppress. Jitter decouples the two.
+    public var maximumJitter: TimeInterval
+    /// Require an unmetered connection.
+    public var requiresWiFi: Bool
+    /// Require external power.
+    public var requiresCharging: Bool
+    /// How long without a successful backup before the UI calls it
+    /// stale. A backup that has quietly stopped working must be a state
+    /// a person can see (§7.15).
+    public var stalenessThreshold: TimeInterval
+
+    public static let `default` = BackupSchedule(
+        minimumInterval: 24 * 60 * 60,
+        maximumJitter: 4 * 60 * 60,
+        requiresWiFi: true,
+        requiresCharging: true,
+        stalenessThreshold: 7 * 24 * 60 * 60
+    )
+
+    public init(
+        minimumInterval: TimeInterval,
+        maximumJitter: TimeInterval,
+        requiresWiFi: Bool,
+        requiresCharging: Bool,
+        stalenessThreshold: TimeInterval
+    ) {
+        self.minimumInterval = minimumInterval
+        self.maximumJitter = maximumJitter
+        self.requiresWiFi = requiresWiFi
+        self.requiresCharging = requiresCharging
+        self.stalenessThreshold = stalenessThreshold
+    }
+
+    /// Conditions as the device currently reports them.
+    public struct Conditions: Sendable, Equatable {
+        public var onWiFi: Bool
+        public var charging: Bool
+        public var lastSuccessAt: Date?
+        public var lastAttemptAt: Date?
+
+        public init(
+            onWiFi: Bool,
+            charging: Bool,
+            lastSuccessAt: Date?,
+            lastAttemptAt: Date?
+        ) {
+            self.onWiFi = onWiFi
+            self.charging = charging
+            self.lastSuccessAt = lastSuccessAt
+            self.lastAttemptAt = lastAttemptAt
+        }
+    }
+
+    /// Whether an *opportunistic* run may start. A person tapping "Back
+    /// up now" bypasses this entirely — an explicit request is not
+    /// something to second-guess about battery.
+    public func permitsOpportunisticRun(_ conditions: Conditions, now: Date = Date()) -> Bool {
+        if requiresWiFi && !conditions.onWiFi { return false }
+        if requiresCharging && !conditions.charging { return false }
+        guard let last = conditions.lastAttemptAt else { return true }
+        return now.timeIntervalSince(last) >= minimumInterval
+    }
+
+    public func isStale(lastSuccessAt: Date?, now: Date = Date()) -> Bool {
+        guard let lastSuccessAt else { return true }
+        return now.timeIntervalSince(lastSuccessAt) >= stalenessThreshold
+    }
+}

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -44,6 +44,10 @@ public final class DeviceBackupSettingsFlow {
     private let repository: BackupRepository
     private let stateStore: any BackupStateStoring
     private let schedule: BackupSchedule
+    /// Drawn once for this flow's lifetime. Re-drawing per check would
+    /// let frequent polling sample until it found a small value, which
+    /// is the same as no jitter.
+    private let sessionJitter: TimeInterval
 
     public init(
         repository: BackupRepository,
@@ -53,6 +57,7 @@ public final class DeviceBackupSettingsFlow {
         self.repository = repository
         self.stateStore = stateStore
         self.schedule = schedule
+        self.sessionJitter = schedule.drawJitter()
     }
 
     public func refresh() {
@@ -65,6 +70,15 @@ public final class DeviceBackupSettingsFlow {
         }
         guard stored.acceptedTermsId != nil else {
             state.status = .off
+            return
+        }
+        // Unresolved work outranks "on". An upload whose result we never
+        // learned survives a relaunch, and rendering it as idle would
+        // show uncertainty as success on exactly the screen that exists
+        // to prevent that — and would leave the person wondering why
+        // Back Up Now does nothing new.
+        guard stored.pendingOperations.isEmpty else {
+            state.status = .checkingEarlierBackup
             return
         }
         state.status = schedule.isStale(lastSuccessAt: stored.lastSuccessAt)
@@ -104,7 +118,7 @@ public final class DeviceBackupSettingsFlow {
 
     /// Run only if the schedule permits it — the opportunistic path.
     public func backUpIfDue(conditions: BackupSchedule.Conditions) async {
-        guard schedule.permitsOpportunisticRun(conditions) else { return }
+        guard schedule.permitsOpportunisticRun(conditions, jitter: sessionJitter) else { return }
         await backUpNow()
     }
 
@@ -122,7 +136,11 @@ public final class DeviceBackupSettingsFlow {
             state.lastReceipt = try await repository.erase(scope: scope)
             await loadSnapshots()
         } catch {
-            state.lastReceipt = nil
+            // The previous receipt is left alone. It describes an
+            // erasure that did happen, and its excludedScope is
+            // something a person may need long afterwards — a failure
+            // here is not a reason to destroy the record of an earlier
+            // success.
             state.status = .failed(message: String(describing: error))
         }
     }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -1,0 +1,129 @@
+import Foundation
+import OnymBackup
+
+/// Backs Settings → Device Backup.
+///
+/// Holds no policy of its own: what a backup means, when one may run,
+/// and what an outcome is called all live below. This turns those into
+/// something a view can render, and — the part that matters — renders
+/// uncertainty as uncertainty.
+@MainActor
+@Observable
+public final class DeviceBackupSettingsFlow {
+    public enum Status: Equatable {
+        /// Never enrolled. The only state a person starts in.
+        case off
+        case idle(lastSuccessAt: Date?)
+        case running
+        /// No successful backup for longer than the schedule allows.
+        /// Shown as a state rather than left to look like "on".
+        case stale(lastSuccessAt: Date?)
+        /// The operator wants payment before it will take a snapshot.
+        case paymentRequired(offerIds: [String])
+        /// The operator published new terms. Uploads stop until they
+        /// have been seen and accepted.
+        case termsChanged
+        /// Earlier work could not be resolved, so nothing new was
+        /// composed. Not a failure — and not success either.
+        case checkingEarlierBackup
+        case failed(message: String)
+    }
+
+    public struct State: Equatable {
+        public var status: Status = .off
+        public var snapshots: [RetainedSnapshot] = []
+        public var lastReceipt: ErasureReceipt?
+        /// Content addresses a restore could not resolve. Surfaced
+        /// because partially-missing media is something a person should
+        /// hear from us rather than discover.
+        public var unresolvedMedia: [String] = []
+    }
+
+    public private(set) var state = State()
+
+    private let repository: BackupRepository
+    private let stateStore: any BackupStateStoring
+    private let schedule: BackupSchedule
+
+    public init(
+        repository: BackupRepository,
+        stateStore: any BackupStateStoring,
+        schedule: BackupSchedule = .default
+    ) {
+        self.repository = repository
+        self.stateStore = stateStore
+        self.schedule = schedule
+    }
+
+    public func refresh() {
+        guard let stored = try? stateStore.load() else {
+            // An unreadable state file is not "no backup configured".
+            // Saying so would invite someone to enrol again on top of
+            // an enrolment that already exists.
+            state.status = .failed(message: "Backup settings could not be read.")
+            return
+        }
+        guard stored.acceptedTermsId != nil else {
+            state.status = .off
+            return
+        }
+        state.status = schedule.isStale(lastSuccessAt: stored.lastSuccessAt)
+            ? .stale(lastSuccessAt: stored.lastSuccessAt)
+            : .idle(lastSuccessAt: stored.lastSuccessAt)
+    }
+
+    /// Run a backup the person asked for.
+    ///
+    /// An explicit request bypasses the schedule entirely — someone who
+    /// taps the button has already decided the upload is worth it, and
+    /// second-guessing them about battery would be presumptuous.
+    public func backUpNow() async {
+        state.status = .running
+        do {
+            switch try await repository.backUp() {
+            case .retained, .alreadyRetained:
+                refresh()
+            case .paymentRequired(_, let offerIds, _):
+                state.status = .paymentRequired(offerIds: offerIds)
+            case .termsChanged:
+                state.status = .termsChanged
+            case .awaitingReconciliation:
+                state.status = .checkingEarlierBackup
+            case .unknown:
+                // Never rendered as success. The bytes may be held; only
+                // the operator can say, and it has not.
+                state.status = .failed(
+                    message: "The result of the last backup is still unknown.")
+            case .alreadyRunning:
+                state.status = .running
+            }
+        } catch {
+            state.status = .failed(message: String(describing: error))
+        }
+    }
+
+    /// Run only if the schedule permits it — the opportunistic path.
+    public func backUpIfDue(conditions: BackupSchedule.Conditions) async {
+        guard schedule.permitsOpportunisticRun(conditions) else { return }
+        await backUpNow()
+    }
+
+    public func loadSnapshots() async {
+        state.snapshots = (try? await repository.listSnapshots()) ?? []
+    }
+
+    /// Erase, and keep the receipt.
+    ///
+    /// The receipt is retained rather than discarded after display: its
+    /// `excludedScope` is what an erasure did *not* reach, and a person
+    /// may want it later.
+    public func erase(scope: ErasureScope) async {
+        do {
+            state.lastReceipt = try await repository.erase(scope: scope)
+            await loadSnapshots()
+        } catch {
+            state.lastReceipt = nil
+            state.status = .failed(message: String(describing: error))
+        }
+    }
+}

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
@@ -1,0 +1,185 @@
+import OnymBackup
+import OnymDesign
+import SwiftUI
+
+/// Settings → Device Backup.
+public struct DeviceBackupSettingsView: View {
+    @State private var flow: DeviceBackupSettingsFlow
+    private let makeEnrolment: () -> BackupEnrolmentView?
+
+    public init(
+        flow: DeviceBackupSettingsFlow,
+        makeEnrolment: @escaping () -> BackupEnrolmentView?
+    ) {
+        _flow = State(wrappedValue: flow)
+        self.makeEnrolment = makeEnrolment
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                SettingsSectionLabel("STATUS")
+                SettingsCard {
+                    SettingsRow(title: statusTitle, subtitle: statusSubtitle, last: true) {
+                        SettingsIconTile(symbol: statusSymbol, bg: SettingsTile.blue)
+                    }
+                    .accessibilityIdentifier("backup.status_row")
+                }
+                SettingsFootnote(verbatim: statusFootnote)
+
+                if case .off = flow.state.status {
+                    if let enrolment = makeEnrolment() {
+                        SettingsCard {
+                            NavigationLink { enrolment } label: {
+                                SettingsRow(
+                                    title: "Set Up Backup",
+                                    subtitle: "Read what it does before turning it on",
+                                    last: true
+                                ) {
+                                    SettingsIconTile(symbol: "externaldrive.badge.plus",
+                                                     bg: SettingsTile.green)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("backup.setup_row")
+                        }
+                    }
+                } else {
+                    SettingsCard {
+                        Button {
+                            Task { await flow.backUpNow() }
+                        } label: {
+                            SettingsRow(
+                                title: "Back Up Now",
+                                subtitle: "Uploads your whole history",
+                                last: true
+                            ) {
+                                SettingsIconTile(symbol: "arrow.up.circle", bg: SettingsTile.blue)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(flow.state.status == .running)
+                        .accessibilityIdentifier("backup.back_up_now_row")
+                    }
+                    SettingsFootnote(
+                        "Each backup uploads everything, not just what changed — there is no incremental upload yet.")
+
+                    snapshotsSection
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+        }
+        .navigationTitle("Device Backup")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            flow.refresh()
+            await flow.loadSnapshots()
+        }
+    }
+
+    private var snapshotsSection: some View {
+        Group {
+            SettingsSectionLabel("SNAPSHOTS")
+            SettingsCard {
+                if flow.state.snapshots.isEmpty {
+                    SettingsRow(
+                        title: "None yet",
+                        subtitle: "Nothing has been accepted by the operator",
+                        last: true
+                    ) {
+                        SettingsIconTile(symbol: "tray", bg: SettingsTile.gray)
+                    }
+                } else {
+                    ForEach(Array(flow.state.snapshots.enumerated()), id: \.element.snapshotReference) {
+                        index, snapshot in
+                        // The digest lives in the subtitle rather than
+                        // the title: `SettingsRow` takes a localization
+                        // key for its title, and runtime data must never
+                        // be looked up as one.
+                        SettingsRow(
+                            title: "Snapshot",
+                            subtitle: Self.subtitle(for: snapshot),
+                            last: index == flow.state.snapshots.count - 1
+                        ) {
+                            SettingsIconTile(symbol: "shippingbox", bg: SettingsTile.gray)
+                        }
+                        .accessibilityIdentifier("backup.snapshot.\(snapshot.snapshotReference.digestHex)")
+                    }
+                }
+            }
+            SettingsFootnote(
+                "Sizes are rounded into buckets before upload, so what the operator sees does not measure your history.")
+        }
+    }
+
+    /// `retained` is the only word here that means the operator has the
+    /// bytes. Anything else is reported as what it is.
+    private static func subtitle(for snapshot: RetainedSnapshot) -> String {
+        let date = snapshot.retainedAt.formatted(date: .abbreviated, time: .shortened)
+        let digest = snapshot.snapshotReference.shortDigest
+        switch snapshot.status {
+        case .retained, .alreadyRetained: return "\(digest) · held since \(date)"
+        case .erased: return "\(digest) · erased"
+        case .unknown, .unreachable: return "\(digest) · result unknown, checking"
+        default: return "\(digest) · \(snapshot.status.rawValue)"
+        }
+    }
+
+    private var statusTitle: LocalizedStringKey {
+        switch flow.state.status {
+        case .off: "Off"
+        case .idle: "On"
+        case .running: "Backing up…"
+        case .stale: "Out of date"
+        case .paymentRequired: "Payment needed"
+        case .termsChanged: "Terms changed"
+        case .checkingEarlierBackup: "Checking an earlier backup"
+        case .failed: "Something went wrong"
+        }
+    }
+
+    private var statusSubtitle: String {
+        switch flow.state.status {
+        case .off:
+            "Your history stays on this phone only"
+        case .idle(let last), .stale(let last):
+            last.map { "Last backup \($0.formatted(date: .abbreviated, time: .shortened))" }
+                ?? "No backup has completed yet"
+        case .running:
+            "Uploading"
+        case .paymentRequired:
+            "The operator needs a subscription before it will keep a backup"
+        case .termsChanged:
+            "Read the new terms to continue backing up"
+        case .checkingEarlierBackup:
+            "An earlier backup has not been confirmed yet"
+        case .failed(let message):
+            message
+        }
+    }
+
+    private var statusFootnote: String {
+        switch flow.state.status {
+        case .stale:
+            "Backups only run while the app is open. If you have not opened Onym in a while, nothing has been backed up."
+        case .checkingEarlierBackup:
+            "Nothing new is uploaded until the earlier one is resolved, so you are not charged to store the same history twice."
+        default:
+            "Only your recovery phrase can open a backup. The operator stores bytes it cannot read."
+        }
+    }
+
+    private var statusSymbol: String {
+        switch flow.state.status {
+        case .off: "externaldrive"
+        case .idle: "externaldrive.badge.checkmark"
+        case .running: "arrow.triangle.2.circlepath"
+        case .stale: "exclamationmark.triangle"
+        case .paymentRequired: "creditcard"
+        case .termsChanged: "doc.badge.ellipsis"
+        case .checkingEarlierBackup: "questionmark.circle"
+        case .failed: "xmark.octagon"
+        }
+    }
+}

--- a/Packages/OnymSettings/Package.swift
+++ b/Packages/OnymSettings/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(path: "../OnymDesign"),
         .package(path: "../OnymModeration"),
         .package(path: "../OnymModerationUI"),
+        .package(path: "../OnymBackupUI"),
         .package(path: "../OnymDiscovery"),
         .package(path: "../OnymFoundation"),
     ],
@@ -35,6 +36,7 @@ let package = Package(
                 "OnymDesign",
                 "OnymModeration",
                 "OnymModerationUI",
+                "OnymBackupUI",
                 "OnymDiscovery",
                 "OnymFoundation",
             ]

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -221,10 +221,6 @@ public struct SettingsView: View {
                 }
                 SettingsFootnote("Nostr relays and Blossom servers carry your messages and media. Replace them with your own instances for maximum privacy.")
 
-                // The section gates on the two original factories; the
-                // case factory only enriches the open-case banner and
-                // must not make the whole MODERATION entry vanish for
-                // callers that don't supply it.
                 // Absent until the app supplies it, like every other
                 // optional section here — a build without backup wired
                 // shows no backup row rather than a dead one.
@@ -250,6 +246,10 @@ public struct SettingsView: View {
                     SettingsFootnote("A backup is sealed on this phone before it leaves. The operator keeps bytes it cannot read, and only your recovery phrase can open them.")
                 }
 
+                // The section gates on the two original factories; the
+                // case factory only enriches the open-case banner and
+                // must not make the whole MODERATION entry vanish for
+                // callers that don't supply it.
                 if let makeModerationSettingsFlow, let makeModerationConsentFlow {
                     SettingsSectionLabel("MODERATION")
                     SettingsCard {

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -6,6 +6,7 @@ import OnymIdentityUI
 import OnymRecovery
 import OnymChatsCore
 import OnymModeration
+import OnymBackupUI
 import OnymModerationUI
 import OnymDiscovery
 
@@ -46,6 +47,13 @@ public struct SettingsView: View {
     /// moderation/discovery factories. The closure fires only after
     /// the confirmation alert.
     let onRestartOnboarding: (@MainActor () -> Void)?
+    /// Settings → Device Backup. Optional so the section hides when the
+    /// app has not wired it — same pattern as moderation and discovery.
+    ///
+    /// Note the name: `makeBackupFlow` above is the *recovery phrase*
+    /// backup, which is a different thing entirely. One protects the
+    /// key; this protects the history.
+    let makeDeviceBackupView: (@MainActor () -> DeviceBackupSettingsView)?
 
     public init(
         makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow,
@@ -59,7 +67,8 @@ public struct SettingsView: View {
         makeModerationConsentFlow: (@MainActor (ModerationConsentFlow.Mode) -> ModerationConsentFlow)? = nil,
         makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil,
         makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)? = nil,
-        onRestartOnboarding: (@MainActor () -> Void)? = nil
+        onRestartOnboarding: (@MainActor () -> Void)? = nil,
+        makeDeviceBackupView: (@MainActor () -> DeviceBackupSettingsView)? = nil
     ) {
         self.makeBackupFlow = makeBackupFlow
         self.makeRelayerSettingsFlow = makeRelayerSettingsFlow
@@ -73,6 +82,7 @@ public struct SettingsView: View {
         self.makeModerationCaseFlow = makeModerationCaseFlow
         self.makeDiscoverySettingsFlow = makeDiscoverySettingsFlow
         self.onRestartOnboarding = onRestartOnboarding
+        self.makeDeviceBackupView = makeDeviceBackupView
     }
 
     @State private var showRecoveryPhrase = false
@@ -215,6 +225,31 @@ public struct SettingsView: View {
                 // case factory only enriches the open-case banner and
                 // must not make the whole MODERATION entry vanish for
                 // callers that don't supply it.
+                // Absent until the app supplies it, like every other
+                // optional section here — a build without backup wired
+                // shows no backup row rather than a dead one.
+                if let makeDeviceBackupView {
+                    SettingsSectionLabel("BACKUP")
+                    SettingsCard {
+                        NavigationLink {
+                            makeDeviceBackupView()
+                        } label: {
+                            SettingsRow(
+                                title: "Device Backup",
+                                subtitle: "A sealed copy of this phone's history",
+                                last: true
+                            ) {
+                                SettingsIconTile(
+                                    symbol: "externaldrive.badge.timemachine",
+                                    bg: SettingsTile.blue)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("settings.device_backup_row")
+                    }
+                    SettingsFootnote("A backup is sealed on this phone before it leaves. The operator keeps bytes it cannot read, and only your recovery phrase can open them.")
+                }
+
                 if let makeModerationSettingsFlow, let makeModerationConsentFlow {
                     SettingsSectionLabel("MODERATION")
                     SettingsCard {

--- a/Tests/OnymIOSTests/BackupDisclosureTests.swift
+++ b/Tests/OnymIOSTests/BackupDisclosureTests.swift
@@ -112,15 +112,15 @@ final class BackupDisclosureTests: XCTestCase {
         let schedule = BackupSchedule.default
         let ready = BackupSchedule.Conditions(
             onWiFi: true, charging: true, lastSuccessAt: nil, lastAttemptAt: nil)
-        XCTAssertTrue(schedule.permitsOpportunisticRun(ready))
+        XCTAssertTrue(schedule.permitsOpportunisticRun(ready, jitter: 0))
 
         var cellular = ready
         cellular.onWiFi = false
-        XCTAssertFalse(schedule.permitsOpportunisticRun(cellular))
+        XCTAssertFalse(schedule.permitsOpportunisticRun(cellular, jitter: 0))
 
         var recent = ready
         recent.lastAttemptAt = Date()
-        XCTAssertFalse(schedule.permitsOpportunisticRun(recent))
+        XCTAssertFalse(schedule.permitsOpportunisticRun(recent, jitter: 0))
     }
 
     /// A backup that quietly stopped working has to be a visible state
@@ -128,6 +128,79 @@ final class BackupDisclosureTests: XCTestCase {
     func testNeverBackedUpCountsAsStale() {
         XCTAssertTrue(BackupSchedule.default.isStale(lastSuccessAt: nil))
         XCTAssertFalse(BackupSchedule.default.isStale(lastSuccessAt: Date()))
+    }
+
+    /// The gate this screen's central claim rests on.
+    ///
+    /// The first version set the flag from an `onAppear` sentinel in a
+    /// plain `VStack`, which fires at initial layout for offscreen
+    /// children — so "Turn On Backup" was enabled before anyone read a
+    /// word. Tested through the pure predicate now, because a claim
+    /// about consent that only a human can check is the claim most
+    /// likely to quietly stop being true.
+    func testScrollGateOnlyOpensAtTheEnd() {
+        // A long disclosure, sitting at the top: not read.
+        XCTAssertFalse(
+            BackupEnrolmentView.hasReachedEnd(
+                contentOffsetY: 0, containerHeight: 800, contentHeight: 4000))
+
+        // Halfway: still not read.
+        XCTAssertFalse(
+            BackupEnrolmentView.hasReachedEnd(
+                contentOffsetY: 1600, containerHeight: 800, contentHeight: 4000))
+
+        // At the bottom: read.
+        XCTAssertTrue(
+            BackupEnrolmentView.hasReachedEnd(
+                contentOffsetY: 3200, containerHeight: 800, contentHeight: 4000))
+    }
+
+    /// Content shorter than the screen has already been read in full.
+    /// Gating on a scroll that can never happen would lock the button
+    /// forever — a failure that only shows up on a large display.
+    func testShortDisclosureCountsAsRead() {
+        XCTAssertTrue(
+            BackupEnrolmentView.hasReachedEnd(
+                contentOffsetY: 0, containerHeight: 1200, contentHeight: 900))
+    }
+
+    /// A declared-but-unapplied jitter is decoration on top of the
+    /// activity signal it claims to suppress.
+    func testJitterDelaysTheOpportunisticRun() {
+        let schedule = BackupSchedule.default
+        let lastAttempt = Date()
+        let conditions = BackupSchedule.Conditions(
+            onWiFi: true, charging: true, lastSuccessAt: lastAttempt, lastAttemptAt: lastAttempt)
+
+        // Exactly one interval later, with two hours of jitter drawn:
+        // not yet.
+        let atInterval = lastAttempt.addingTimeInterval(schedule.minimumInterval)
+        XCTAssertFalse(
+            schedule.permitsOpportunisticRun(conditions, jitter: 7200, now: atInterval))
+
+        // Past the interval plus the jitter: now.
+        let afterJitter = lastAttempt.addingTimeInterval(schedule.minimumInterval + 7201)
+        XCTAssertTrue(
+            schedule.permitsOpportunisticRun(conditions, jitter: 7200, now: afterJitter))
+    }
+
+    /// Drawn jitter stays inside its declared bound, so the copy that
+    /// describes the cadence cannot be wrong about it.
+    func testDrawnJitterRespectsItsBound() {
+        let schedule = BackupSchedule.default
+        for _ in 0..<64 {
+            let jitter = schedule.drawJitter()
+            XCTAssertGreaterThanOrEqual(jitter, 0)
+            XCTAssertLessThanOrEqual(jitter, schedule.maximumJitter)
+        }
+    }
+
+    /// The cadence sentence follows the configured interval rather than
+    /// asserting a day beside a value that can change.
+    func testCadenceTracksTheInterval() {
+        XCTAssertEqual(BackupDisclosure.cadence(24 * 3600), "once a day")
+        XCTAssertEqual(BackupDisclosure.cadence(72 * 3600), "once every 3 days")
+        XCTAssertEqual(BackupDisclosure.cadence(6 * 3600), "once every 6 hours")
     }
 
     // MARK: - Fixtures

--- a/Tests/OnymIOSTests/BackupDisclosureTests.swift
+++ b/Tests/OnymIOSTests/BackupDisclosureTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import OnymFoundation
+import XCTest
+@testable import OnymBackup
+@testable import OnymBackupUI
+
+/// The consent surface, checked by fixture rather than by review.
+///
+/// `UI-Backup.md` §18.10 asks for exactly this, and the reason is that a
+/// disclosure is the one part of this seat that degrades silently: a
+/// paragraph dropped in a refactor still compiles, still renders, and
+/// still looks like a consent screen.
+final class BackupDisclosureTests: XCTestCase {
+    private func disclosure(
+        mediaPolicy: BackupMediaPolicy = .descriptorsOnly,
+        schedule: BackupSchedule = .default
+    ) throws -> BackupDisclosure {
+        let terms = try BackupTerms.decode(raw: Self.termsJSON)
+        let manifest = try BackupOperatorManifest(
+            manifest: SignedServiceManifest(raw: Self.manifestJSON(termsId: terms.termsId)))
+        let profile = BackupImplementationProfile(
+            implementationVersion: 1,
+            implementationProfileId: BackupProfile.implementationProfileId,
+            backupProfileId: BackupProfile.portableProfileId,
+            digestSuite: BackupProfile.digestSuite,
+            sealingSuite: BackupProfile.sealingSuite,
+            incrementModel: BackupProfile.incrementModel,
+            authentication: [BackupProfile.authentication],
+            paymentRefusal: BackupProfile.paymentRefusal)
+        return BackupDisclosure.from(
+            connection: BackupConnection(manifest: manifest, profile: profile, terms: terms),
+            schedule: schedule,
+            mediaPolicy: mediaPolicy)
+    }
+
+    /// Every declared term reaches the surface. The list is spelled out
+    /// rather than counted so that adding a field to `BackupTerms`
+    /// without disclosing it fails here.
+    func testEveryDeclaredTermIsDisclosed() throws {
+        let ids = Set(try disclosure().items.map(\.id))
+        let required: Set<String> = [
+            "operator",
+            "retention.class", "retention.period", "retention.count", "retention.expiry",
+            "erasure.acknowledgement", "erasure.completion", "erasure.scope", "erasure.excluded",
+            "jurisdictions", "subProcessors",
+            "lawfulAccess.produces", "lawfulAccess.notify",
+            "breach",
+            "export.format", "export.unpaid", "shutdownNotice",
+            "endOfPayment.notice", "endOfPayment.grace",
+            "endOfPayment.duringGrace", "endOfPayment.afterGrace",
+            "metadata.accessLogs", "metadata.sizeAndTiming",
+            "media", "termsId",
+        ]
+        XCTAssertTrue(required.isSubset(of: ids), "missing: \(required.subtracting(ids).sorted())")
+    }
+
+    /// The sentence §7.4 requires. Asserted on substance, not wording,
+    /// so a rewrite can improve the copy but not quietly drop the point.
+    func testThirdPartyConsequenceIsStated() throws {
+        let text = try disclosure().thirdPartyConsequence.lowercased()
+        XCTAssertTrue(text.contains("both sides of every conversation"))
+        XCTAssertTrue(text.contains("did not choose"))
+    }
+
+    /// §11: a person must learn there is no recovery here, not later.
+    func testAbsentResetPathIsStated() throws {
+        let text = try disclosure().noResetPath.lowercased()
+        XCTAssertTrue(text.contains("recovery phrase"))
+        XCTAssertTrue(text.contains("unreadable"))
+        XCTAssertTrue(text.contains("no reset"))
+    }
+
+    /// The schedule copy must not promise more than the build does.
+    /// Uploads are foreground-only, so "automatic" would be a lie, and
+    /// whole-snapshot means every run re-uploads everything.
+    func testScheduleCopyDoesNotOverpromise() throws {
+        let text = try disclosure().whenBackupsHappen.lowercased()
+        XCTAssertTrue(text.contains("cannot back up in the background"))
+        XCTAssertTrue(text.contains("whole history"))
+        XCTAssertFalse(text.contains("automatically"))
+    }
+
+    /// What erasure does *not* reach is the part a person is likeliest
+    /// to assume away, so it travels verbatim rather than summarised.
+    func testExcludedErasureScopeIsVerbatim() throws {
+        let item = try XCTUnwrap(try disclosure().items.first { $0.id == "erasure.excluded" })
+        XCTAssertEqual(item.value, "copies other participants hold, and copies you exported")
+    }
+
+    /// Descriptors-only must say what it costs, rather than letting
+    /// someone discover it when their media is gone.
+    func testDescriptorsOnlyDisclosesItsMediaCost() throws {
+        let item = try XCTUnwrap(try disclosure().items.first { $0.id == "media" })
+        XCTAssertTrue(item.value.contains("gone if it no longer has them"))
+
+        let included = try XCTUnwrap(
+            try disclosure(mediaPolicy: .includeCiphertext).items.first { $0.id == "media" })
+        XCTAssertEqual(included.value, "Included in the backup")
+    }
+
+    /// The schedule sentence follows the policy rather than being
+    /// written beside it.
+    func testScheduleSentenceTracksThePolicy() {
+        var schedule = BackupSchedule.default
+        schedule.requiresCharging = false
+        let sentence = BackupDisclosure.scheduleSentence(schedule).lowercased()
+        XCTAssertTrue(sentence.contains("on wi-fi"))
+        XCTAssertFalse(sentence.contains("charging"))
+    }
+
+    func testOpportunisticRunRespectsConditions() {
+        let schedule = BackupSchedule.default
+        let ready = BackupSchedule.Conditions(
+            onWiFi: true, charging: true, lastSuccessAt: nil, lastAttemptAt: nil)
+        XCTAssertTrue(schedule.permitsOpportunisticRun(ready))
+
+        var cellular = ready
+        cellular.onWiFi = false
+        XCTAssertFalse(schedule.permitsOpportunisticRun(cellular))
+
+        var recent = ready
+        recent.lastAttemptAt = Date()
+        XCTAssertFalse(schedule.permitsOpportunisticRun(recent))
+    }
+
+    /// A backup that quietly stopped working has to be a visible state
+    /// (§7.15), which starts with the flow calling it stale.
+    func testNeverBackedUpCountsAsStale() {
+        XCTAssertTrue(BackupSchedule.default.isStale(lastSuccessAt: nil))
+        XCTAssertFalse(BackupSchedule.default.isStale(lastSuccessAt: Date()))
+    }
+
+    // MARK: - Fixtures
+
+    static func manifestJSON(termsId: String) -> Data {
+        Data("""
+        {"version":1,"componentId":"onym:component:op","seat":"storage.backup",
+         "operator":"onym:key:\(String(repeating: "1", count: 64))",
+         "backupProfileId":"\(BackupProfile.portableProfileId)",
+         "implementationProfileId":"\(BackupProfile.implementationProfileId)",
+         "endpoints":[{"uri":"https://backup.example","role":"read-write"}],
+         "capabilities":["upload","list","download","erase","export"],
+         "declaredTerms":"\(termsId)"}
+        """.utf8)
+    }
+
+    static let termsJSON = Data("""
+    {"termsVersion":1,"operator":"onym:key:\(String(repeating: "1", count: 64))",
+     "retention":{"class":"measurable","maximumRetentionPeriod":"P1Y",
+       "snapshotsRetained":"3","expiryBehavior":"notify-then-erase"},
+     "erasure":{"acknowledgementDeadline":"P1D","completionDeadline":"P7D",
+       "scope":"primary and declared replicas",
+       "excluded":"copies other participants hold, and copies you exported"},
+     "jurisdictions":["EE"],"subProcessors":[],
+     "lawfulAccess":{"disclosureWhatIsProduced":"sealed-bytes-and-declared-metadata-only",
+       "notifyHolderWhenPermitted":true,"transparencyReporting":null},
+     "breachDisclosure":{"holderNotice":"P3D"},
+     "export":{"format":"tar","availableWhileUnpaid":true},
+     "shutdownNotice":"P90D",
+     "endOfPayment":{"notice":"P14D","grace":"P30D",
+       "duringGrace":["download","export","erase"],"afterGrace":"erase"},
+     "metadataRetention":{"accessLogs":"none","sizeAndTiming":"P1Y",
+       "holderIdentifiers":"P1Y","operationOutcomes":"PT6H",
+       "erasureReceipts":"P1Y","entitlementRecords":"P1Y"}}
+    """.utf8)
+}

--- a/project.yml
+++ b/project.yml
@@ -34,6 +34,7 @@ packages:
   OnymSettings: {path: Packages/OnymSettings}
   OnymBackup: {path: Packages/OnymBackup}
   OnymBilling: {path: Packages/OnymBilling}
+  OnymBackupUI: {path: Packages/OnymBackupUI}
   OnymModeration: {path: Packages/OnymModeration}
   OnymModerationUI: {path: Packages/OnymModerationUI}
   OnymDiscovery: {path: Packages/OnymDiscovery}
@@ -66,6 +67,7 @@ targets:
       - package: OnymSettings
       - package: OnymBackup
       - package: OnymBilling
+      - package: OnymBackupUI
       - package: OnymModeration
       - package: OnymModerationUI
       - package: OnymDiscovery
@@ -232,6 +234,7 @@ targets:
       - package: OnymSettings
       - package: OnymBackup
       - package: OnymBilling
+      - package: OnymBackupUI
       - package: OnymModeration
       - package: OnymModerationUI
       - package: OnymDiscovery


### PR DESCRIPTION
Sixth of the device-backup stack, on top of #278. The screen someone reads before their history leaves the phone, the settings surface that follows, and the scheduling policy both describe.

### Scheduling — a decision I made, easy to reverse

You asked what the schedule is; there wasn't one, so this PR picks a shape and puts it in a single type rather than scattering it through views. **v1 is deliberately not a cron**, for two reasons that were already decided:

- **Uploads are foreground-only.** A multi-hundred-megabyte transfer wants a background `URLSession` with a persistent identifier — precisely the long-lived, linkable session state this codebase avoids everywhere else.
- **Snapshots are whole, never incremental.** Every run re-uploads the entire history, which argues for deliberate and occasional over frequent and automatic.

So: explicit **Back Up Now** is the primary path, plus an opportunistic run while the app is open on Wi-Fi and charging, at most daily, with hours of jitter. The jitter isn't battery politeness — upload timing that tracks send activity re-leaks per-group activity through volume and cadence, the same signal the padding and the opaque archive exist to suppress.

If you'd rather have a background task (and accept the session-state tradeoff), or drop the opportunistic path entirely and make it purely manual, it's one type to change.

### The copy has to match

Because uploads are foreground-only, the enrolment screen says: *"It cannot back up in the background, so if you never open the app, nothing is backed up."* Calling this automatic would have been the easiest lie in the product — a test fails if the word "automatically" appears in the schedule copy.

### The enrolment surface

Leads with the three things someone would otherwise learn too late:

1. **what a backup does to everyone else** — a snapshot extends both sides of every conversation, for people who never chose this operator (§7.4, §10.4);
2. **that nobody, including us, can recover it** without the phrase (§11);
3. **when backups actually happen.**

The operator's declared terms follow **in full and unsummarised**. An operator that keeps access logs, or excludes a great deal from erasure, or names four sub-processors, has published that in a signed document — the screen repeats it rather than smoothing it. The excluded erasure scope travels verbatim, since it's the part a person is likeliest to assume away.

The accept button stays disabled until the disclosure has been scrolled through. The button isn't the consent; the reading is.

### Disclosure as data, so §18.10 can be satisfied

`BackupDisclosure` is built as a value rather than assembled inline in a view, so the fixture the spec asks for is possible: consent verified **by fixture rather than by review**. A disclosure is the one part of this seat that degrades silently — a paragraph dropped in a refactor still compiles, still renders, and still looks like a consent screen. The fixture names every required term and fails when one goes missing.

### Status reports uncertainty as uncertainty

`unknown` → "result unknown, checking". `awaitingReconciliation` → "checking an earlier backup", with a note that nothing new uploads until it resolves *so nobody is charged twice*. A stale backup is a visible state rather than something that still reads as on (§7.15).

### Verification

```
BackupDisclosureTests   9 passed
** TEST SUCCEEDED **
```
`xcodebuild -scheme OnymIOS` **BUILD SUCCEEDED**.

### Note on naming

`SettingsView` already had `makeBackupFlow` — that's the **recovery phrase** backup, which protects the key. This is `makeDeviceBackupView`, which protects the history. Different things, and the copy distinguishes them.

Restore is not here: it needs `IdentityRepository.restore(mnemonic:)`, which wipes existing identities, so it belongs with the wiring PR where the fresh-device path lives.