### PR TITLE
Wire device backup and seat purchases into the app

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -78,21 +78,14 @@ public actor BackupRepository {
         // A's operations — the cross-operator leak the rebind on
         // enrolment exists to prevent, arrived at through a different
         // door.
-        let connection = try await port.connect()
-        if let previous = state.componentId, previous != connection.manifest.componentId {
+        // Do not upload, do not re-pin, do not "helpfully" accept.
+        // Fresh consent is a screen, not an inference.
+        if let mismatch = try await operatorOrTermsMismatch(state: state, now: now) {
             state.lastAttemptAt = now
             try stateStore.save(state)
-            return .operatorChanged(
-                previousComponentId: previous,
-                currentComponentId: connection.manifest.componentId)
+            return mismatch
         }
-        if connection.acceptedTermsId != acceptedTermsId {
-            // Do not upload, do not re-pin, do not "helpfully" accept.
-            // Fresh consent is a screen, not an inference.
-            state.lastAttemptAt = now
-            try stateStore.save(state)
-            return .termsChanged(currentTermsId: connection.acceptedTermsId)
-        }
+        _ = acceptedTermsId
 
         // Only now: an operation whose result we never learned may well
         // have succeeded, and composing a second snapshot on top of an
@@ -144,10 +137,20 @@ public actor BackupRepository {
     /// would strand the caller in a purchase flow with no snapshot at the
     /// end of it.
     public func pendingPayment(in workingDirectory: URL? = nil) throws -> SealedSnapshot? {
-        guard let pending = try stateStore.load().awaitingPayment else { return nil }
+        var state = try stateStore.load()
+        guard let pending = state.awaitingPayment else { return nil }
         let url = (workingDirectory ?? composer.workingDirectory)
             .appending(path: pending.sealedBytesFilename)
-        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            // The bytes are gone, so there is nothing to retry — and the
+            // record has to go with them. Leaving it would strand the
+            // settings screen on "Payment needed" forever, including
+            // after later backups succeed, for a purchase that can no
+            // longer buy anything.
+            state.awaitingPayment = nil
+            try stateStore.save(state)
+            return nil
+        }
         return SealedSnapshot(
             operationId: pending.operationId,
             snapshotReference: try SnapshotReference(
@@ -176,7 +179,75 @@ public actor BackupRepository {
         defer { isRunning = false }
 
         var state = try stateStore.load()
+        // The same preconditions `backUp` checks, for the same reason —
+        // more so here. This snapshot was sealed under one operator's
+        // terms and pinned to its digest; sending it to a different
+        // operator is the leak this whole seam exists to close, and the
+        // retry path is the shortest route to it.
+        if let mismatch = try await operatorOrTermsMismatch(state: state, now: now) {
+            return mismatch
+        }
+        // And the snapshot's own pin must match what we are enrolled
+        // under. A snapshot left over from earlier terms is not one to
+        // send now.
+        guard snapshot.acceptedTermsId == state.acceptedTermsId else {
+            return .termsChanged(currentTermsId: state.acceptedTermsId)
+        }
         return try await place(snapshot, state: &state, now: now)
+    }
+
+    /// Save, unless someone re-enrolled underneath us.
+    ///
+    /// Enrolment runs on the main actor and rewrites this file; a run
+    /// here loads at the start and saves across several network hops.
+    /// An upload finishing after a re-enrolment would otherwise write
+    /// back its stale copy — resurrecting the previous operator's
+    /// `componentId` and pending operations, and silently undoing the
+    /// rebind that was the whole point.
+    ///
+    /// So the write is conditional on the enrolment not having moved.
+    /// Losing our own bookkeeping is the right side to fail on: the
+    /// snapshot itself is either retained or not regardless, and the
+    /// next run reconciles against the operator rather than trusting
+    /// this file.
+    @discardableResult
+    private func commit(_ state: BackupState, expecting enrolled: String?) throws -> Bool {
+        let current = try stateStore.load()
+        guard current.componentId == enrolled, current.acceptedTermsId == state.acceptedTermsId
+        else {
+            return false
+        }
+        try stateStore.save(state)
+        return true
+    }
+
+    /// Shared precondition: are we still talking to the operator this
+    /// state was enrolled with, under the terms it pinned?
+    ///
+    /// Returns the result to hand back, or `nil` to proceed.
+    private func operatorOrTermsMismatch(
+        state: BackupState,
+        now: Date
+    ) async throws -> RunResult? {
+        let connection = try await port.connect()
+        // `componentId` is nil for state written before it was recorded.
+        // That is not "matches" — we cannot tell, and guessing in favour
+        // of proceeding is how a snapshot reaches the wrong operator. It
+        // is treated as a switch, which routes to enrolment.
+        guard let enrolled = state.componentId else {
+            return .operatorChanged(
+                previousComponentId: "",
+                currentComponentId: connection.manifest.componentId)
+        }
+        if enrolled != connection.manifest.componentId {
+            return .operatorChanged(
+                previousComponentId: enrolled,
+                currentComponentId: connection.manifest.componentId)
+        }
+        if connection.acceptedTermsId != state.acceptedTermsId {
+            return .termsChanged(currentTermsId: connection.acceptedTermsId)
+        }
+        return nil
     }
 
     private func place(
@@ -184,6 +255,9 @@ public actor BackupRepository {
         state: inout BackupState,
         now: Date
     ) async throws -> RunResult {
+        // What we were enrolled with when this run began. Every write
+        // below is conditional on it still being true.
+        let enrolled = state.componentId
         let preflight: BackupPreflight
         do {
             preflight = try await port.preflight(snapshot)
@@ -207,7 +281,7 @@ public actor BackupRepository {
                     sealedAt: snapshot.sealedAt,
                     refusedAt: now
                 )
-                try stateStore.save(state)
+                try commit(state, expecting: enrolled)
                 return .paymentRequired(
                     componentId: componentId, offerIds: offerIds, pending: snapshot)
             case .termsChanged(let currentTermsId):
@@ -242,7 +316,7 @@ public actor BackupRepository {
             )
             state.lastSuccessAt = now
             state.clearPendingPayment(for: snapshot.operationId)
-            try stateStore.save(state)
+            try commit(state, expecting: enrolled)
             discard(snapshot)
             return .alreadyRetained(reference)
 
@@ -260,7 +334,7 @@ public actor BackupRepository {
                     acceptedTermsId: snapshot.acceptedTermsId
                 )
             )
-            try stateStore.save(state)
+            try commit(state, expecting: enrolled)
 
             let outcome: BackupOutcome
             do {
@@ -278,7 +352,7 @@ public actor BackupRepository {
                 // uncertainty on the floor — reconcile would never
                 // re-query, and "silence is not success" would hold only
                 // until the next line of code.
-                try stateStore.save(state)
+                try commit(state, expecting: enrolled)
                 return .unknown(operationId: snapshot.operationId)
             }
             state.pendingOperations.removeAll { $0.operationId == snapshot.operationId }
@@ -291,7 +365,7 @@ public actor BackupRepository {
             )
             state.lastSuccessAt = now
             state.clearPendingPayment(for: snapshot.operationId)
-            try stateStore.save(state)
+            try commit(state, expecting: enrolled)
             discard(snapshot)
             return .retained(snapshot.snapshotReference)
         }
@@ -314,6 +388,7 @@ public actor BackupRepository {
     /// because that is the one case where we genuinely do not know.
     private func reconcile(_ state: inout BackupState) async throws {
         guard !state.pendingOperations.isEmpty else { return }
+        let enrolled = state.componentId
 
         guard let retained = try? await port.listSnapshots() else {
             // No list, no conclusions. Uncertainty survives a failed
@@ -414,7 +489,7 @@ public actor BackupRepository {
             }
         }
         state.pendingOperations = stillPending
-        try stateStore.save(state)
+        try commit(state, expecting: enrolled)
     }
 
     /// What the operator says it holds for this holder.
@@ -437,13 +512,14 @@ public actor BackupRepository {
     public func erase(scope: ErasureScope) async throws -> ErasureReceipt {
         let receipt = try await port.eraseSnapshot(scope: scope)
         var state = try stateStore.load()
+        let enrolled = state.componentId
         state.receipts.append(receipt.rawBytes)
         if case .snapshot(let reference) = scope {
             state.snapshots.removeAll { $0.digest == reference.digest }
         } else {
             state.snapshots.removeAll()
         }
-        try stateStore.save(state)
+        try commit(state, expecting: enrolled)
         return receipt
     }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -62,6 +62,11 @@ public actor BackupRepository {
         defer { isRunning = false }
 
         var state = try stateStore.load()
+        // Captured before the first suspension. Every write below is
+        // conditional on the enrolment still being this one — `backUp`
+        // awaits `connect`, `reconcile` and `compose`, and a
+        // re-enrolment can land during any of them.
+        let enrolled = state.componentId
 
         guard let acceptedTermsId = state.acceptedTermsId else {
             // Nothing has been consented to. Enrolment is a decision, and
@@ -82,7 +87,7 @@ public actor BackupRepository {
         // Fresh consent is a screen, not an inference.
         if let mismatch = try await operatorOrTermsMismatch(state: state, now: now) {
             state.lastAttemptAt = now
-            try stateStore.save(state)
+            try commit(state, expecting: enrolled)
             return mismatch
         }
         _ = acceptedTermsId
@@ -102,7 +107,7 @@ public actor BackupRepository {
         // rather than showing a silent no-op.
         guard state.pendingOperations.isEmpty else {
             state.lastAttemptAt = now
-            try stateStore.save(state)
+            try commit(state, expecting: enrolled)
             return .awaitingReconciliation(
                 operationIds: state.pendingOperations.map(\.operationId))
         }
@@ -126,7 +131,7 @@ public actor BackupRepository {
             now: now
         )
         state.lastAttemptAt = now
-        try stateStore.save(state)
+        try commit(state, expecting: enrolled)
         return try await place(snapshot, state: &state, now: now)
     }
 
@@ -141,14 +146,26 @@ public actor BackupRepository {
         guard let pending = state.awaitingPayment else { return nil }
         let url = (workingDirectory ?? composer.workingDirectory)
             .appending(path: pending.sealedBytesFilename)
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            // The bytes are gone, so there is nothing to retry — and the
-            // record has to go with them. Leaving it would strand the
-            // settings screen on "Payment needed" forever, including
-            // after later backups succeed, for a purchase that can no
-            // longer buy anything.
+        // Two ways a pending payment stops being retriable, and both
+        // have to clear the record — otherwise Settings sits on
+        // "Payment needed" forever, with no offers to show and no route
+        // to enrolment, for a purchase that can no longer buy anything.
+        let bytesGone = !FileManager.default.fileExists(atPath: url.path)
+        // The second door, which the missing-bytes fix did not cover:
+        // terms re-accepted under the same operator. `retry` correctly
+        // refuses a snapshot pinned to superseded terms, and refusing
+        // forever without clearing is the same stranding by a different
+        // route.
+        let termsSuperseded = pending.acceptedTermsId != state.acceptedTermsId
+        guard !bytesGone, !termsSuperseded else {
             state.awaitingPayment = nil
             try stateStore.save(state)
+            if !bytesGone {
+                // Sealed under terms nobody is enrolled under now. It
+                // will never be sent, and it is ciphertext nobody will
+                // claim.
+                try? FileManager.default.removeItem(at: url)
+            }
             return nil
         }
         return SealedSnapshot(

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -41,6 +41,11 @@ public actor BackupRepository {
         case paymentRequired(componentId: String, offerIds: [String], pending: SealedSnapshot)
         /// Terms moved. Uploading would pin something nobody agreed to.
         case termsChanged(currentTermsId: String?)
+        /// A different operator is now consented to than the one this
+        /// state was enrolled with. Nothing may be uploaded, reconciled
+        /// or retried until the person has enrolled with the new one —
+        /// none of the recorded work means anything to it.
+        case operatorChanged(previousComponentId: String, currentComponentId: String)
         /// The request went out and we never learned what happened.
         case unknown(operationId: String)
         /// Earlier work is unresolved and could not be reconciled, so
@@ -58,10 +63,41 @@ public actor BackupRepository {
 
         var state = try stateStore.load()
 
-        // Reconcile before adding to the pile. An operation whose result
-        // we never learned may well have succeeded, and composing a
-        // second snapshot on top of an unresolved first is how a person
-        // ends up paying to store the same history twice.
+        guard let acceptedTermsId = state.acceptedTermsId else {
+            // Nothing has been consented to. Enrolment is a decision, and
+            // the repository does not make it on the person's behalf.
+            throw BackupError.termsUnavailable
+        }
+
+        // Terms and operator are checked *before* reconciling, not after.
+        //
+        // Reconciliation talks to whichever operator this repository was
+        // built for, using operation ids recorded against whoever was
+        // consented to when they were written. If those are not the same
+        // operator, reconciling first hands operator B a list of operator
+        // A's operations — the cross-operator leak the rebind on
+        // enrolment exists to prevent, arrived at through a different
+        // door.
+        let connection = try await port.connect()
+        if let previous = state.componentId, previous != connection.manifest.componentId {
+            state.lastAttemptAt = now
+            try stateStore.save(state)
+            return .operatorChanged(
+                previousComponentId: previous,
+                currentComponentId: connection.manifest.componentId)
+        }
+        if connection.acceptedTermsId != acceptedTermsId {
+            // Do not upload, do not re-pin, do not "helpfully" accept.
+            // Fresh consent is a screen, not an inference.
+            state.lastAttemptAt = now
+            try stateStore.save(state)
+            return .termsChanged(currentTermsId: connection.acceptedTermsId)
+        }
+
+        // Only now: an operation whose result we never learned may well
+        // have succeeded, and composing a second snapshot on top of an
+        // unresolved first is how a person ends up paying to store the
+        // same history twice.
         try await reconcile(&state)
 
         // And if it is *still* unresolved, do not compose. Reconciling
@@ -76,21 +112,6 @@ public actor BackupRepository {
             try stateStore.save(state)
             return .awaitingReconciliation(
                 operationIds: state.pendingOperations.map(\.operationId))
-        }
-
-        guard let acceptedTermsId = state.acceptedTermsId else {
-            // Nothing has been consented to. Enrolment is a decision, and
-            // the repository does not make it on the person's behalf.
-            throw BackupError.termsUnavailable
-        }
-
-        let connection = try await port.connect()
-        if connection.acceptedTermsId != acceptedTermsId {
-            // Do not upload, do not re-pin, do not "helpfully" accept.
-            // Fresh consent is a screen, not an inference.
-            state.lastAttemptAt = now
-            try stateStore.save(state)
-            return .termsChanged(currentTermsId: connection.acceptedTermsId)
         }
 
         let snapshot = try await composer.compose(

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
@@ -76,6 +76,39 @@ public struct BackupState: Sendable, Equatable, Codable {
 
     public init() {}
 
+    /// Point this state at a different operator, discarding everything
+    /// that only meant something to the previous one.
+    ///
+    /// Without this, switching operators left the new one holding the
+    /// old one's operational state: reconciliation would query operator
+    /// B with operator A's operation ids, `refresh()` would report
+    /// checking-an-earlier-backup for work B never saw, and — worst — a
+    /// snapshot awaiting payment, sealed under A's terms and pinned to
+    /// A's digest, could be retried against B. That last one is a
+    /// person paying B to store a snapshot that pins terms B never
+    /// published.
+    ///
+    /// Erasure receipts are kept. They are evidence of something that
+    /// happened, they are never acted on, and destroying them because
+    /// the person changed operator would discard the only durable record
+    /// of what an erasure did and did not reach.
+    ///
+    /// Returns the sealed-bytes filename of a dropped pending payment,
+    /// if there was one, so the caller can remove the file rather than
+    /// orphan it.
+    @discardableResult
+    public mutating func rebind(to newComponentId: String) -> String? {
+        guard componentId != newComponentId else { return nil }
+        let orphan = awaitingPayment?.sealedBytesFilename
+        componentId = newComponentId
+        snapshots.removeAll()
+        pendingOperations.removeAll()
+        awaitingPayment = nil
+        lastSuccessAt = nil
+        lastAttemptAt = nil
+        return orphan
+    }
+
     mutating func clearPendingPayment(for operationId: String) {
         if awaitingPayment?.operationId == operationId { awaitingPayment = nil }
     }

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
@@ -28,10 +28,20 @@ public struct URLSessionBackupClient: BackupPort {
     let session: URLSession
     let entitlement: @Sendable () async -> Data?
 
-    /// The read-write origin from the manifest the person consented to.
-    /// Bound once and never rewritten — an operator does not get to move
-    /// a signed request somewhere else.
-    var endpoint: URL { manifest.endpoint }
+    /// A development override for the operator's endpoint.
+    ///
+    /// Deliberately a construction parameter rather than something an
+    /// operator response can set: the point of binding to the manifest
+    /// is that a *counterparty* cannot move a signed request, and a
+    /// local-testing flag chosen by whoever built the app is a different
+    /// thing entirely. Nil in Release, where the caller does not offer
+    /// one.
+    let endpointOverride: URL?
+
+    /// The read-write origin from the manifest the person consented to,
+    /// unless a build-time override replaces it. Bound once and never
+    /// rewritten by anything the operator says.
+    var endpoint: URL { endpointOverride ?? manifest.endpoint }
 
     /// Caps on response bodies we are willing to read. Sealed streams
     /// are bounded by the operator's declared maximum instead — that
@@ -64,11 +74,13 @@ public struct URLSessionBackupClient: BackupPort {
         manifest: BackupOperatorManifest,
         material: BackupKeyMaterial,
         session: URLSession = URLSessionBackupClient.defaultSession,
+        endpointOverride: URL? = nil,
         entitlement: @escaping @Sendable () async -> Data? = { nil }
     ) {
         self.manifest = manifest
         self.material = material
         self.session = session
+        self.endpointOverride = endpointOverride
         self.entitlement = entitlement
     }
 
@@ -87,6 +99,18 @@ public struct URLSessionBackupClient: BackupPort {
         )
     }()
 
+    /// Terms live under whichever origin we are actually talking to,
+    /// so an endpoint override has to move them too — otherwise a local
+    /// operator would be checked against the production one's terms.
+    static func termsURL(base: URL, digest: String) -> URL? {
+        let prefixed = digest.hasPrefix(BackupFormat.digestPrefix)
+            ? digest
+            : BackupFormat.digestPrefix + digest
+        guard BackupFormat.isDigest(prefixed) else { return nil }
+        let hex = String(prefixed.dropFirst(BackupFormat.digestPrefix.count))
+        return base.appending(path: "terms").appending(path: "\(hex).json")
+    }
+
     // MARK: - BackupPort
 
     public func connect() async throws -> BackupConnection {
@@ -94,7 +118,7 @@ public struct URLSessionBackupClient: BackupPort {
         let profile = try BackupImplementationProfile.review(raw: profileBytes)
 
         let digest = manifest.declaredTermsDigest
-        guard let termsURL = manifest.termsURL(digest: digest) else {
+        guard let termsURL = Self.termsURL(base: endpoint, digest: digest) else {
             throw BackupError.termsUnavailable
         }
         let termsBytes = try await get(url: termsURL, signed: false)

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
@@ -1,0 +1,86 @@
+import Foundation
+import OnymBackup
+
+/// Turning backup on.
+///
+/// Two steps, and the order is the whole point: fetch and verify what
+/// the operator published, then — only if a person accepts it — write
+/// the pin that every future snapshot will carry. Nothing is uploaded
+/// here, and nothing is enabled by arriving at the screen.
+@MainActor
+@Observable
+public final class BackupEnrolmentFlow {
+    public enum State: Equatable {
+        case loading
+        /// Terms fetched and verified; waiting on a decision.
+        case ready(BackupDisclosure)
+        /// The operator's terms could not be fetched or did not verify.
+        /// Enrolment stops: terms are a precondition, not a nicety, and
+        /// enrolling without them would pin nothing.
+        case unavailable(message: String)
+        case enrolled
+    }
+
+    public private(set) var state: State = .loading
+
+    private let port: any BackupPort
+    private let stateStore: any BackupStateStoring
+    private let schedule: BackupSchedule
+    private let mediaPolicy: BackupMediaPolicy
+    private var connection: BackupConnection?
+
+    public init(
+        port: any BackupPort,
+        stateStore: any BackupStateStoring,
+        schedule: BackupSchedule = .default,
+        mediaPolicy: BackupMediaPolicy = .descriptorsOnly
+    ) {
+        self.port = port
+        self.stateStore = stateStore
+        self.schedule = schedule
+        self.mediaPolicy = mediaPolicy
+    }
+
+    public func load() async {
+        state = .loading
+        do {
+            let connection = try await port.connect()
+            self.connection = connection
+            state = .ready(
+                BackupDisclosure.from(
+                    connection: connection,
+                    schedule: schedule,
+                    mediaPolicy: mediaPolicy))
+        } catch {
+            self.connection = nil
+            state = .unavailable(message: String(describing: error))
+        }
+    }
+
+    /// Record the consent.
+    ///
+    /// Writes the terms digest the person just read, so every snapshot
+    /// pins it and a later change stops uploads until they have seen the
+    /// new one. Refuses if the connection is gone — accepting terms we
+    /// no longer hold would pin a digest nobody was shown.
+    public func accept() {
+        guard let connection else {
+            state = .unavailable(message: "The operator's terms are no longer available.")
+            return
+        }
+        do {
+            var stored = try stateStore.load()
+            stored.componentId = connection.manifest.componentId
+            stored.acceptedTermsId = connection.acceptedTermsId
+            stored.acceptedTermsRaw = connection.terms.rawBytes
+            stored.mediaPolicy = mediaPolicy
+            try stateStore.save(stored)
+            state = .enrolled
+        } catch {
+            // Not enrolled. Reporting success over a failed write would
+            // leave someone believing their history is being backed up
+            // when nothing is pinned.
+            state = .unavailable(message: String(describing: error))
+        }
+    }
+}

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
@@ -27,16 +27,19 @@ public final class BackupEnrolmentFlow {
     private let stateStore: any BackupStateStoring
     private let schedule: BackupSchedule
     private let mediaPolicy: BackupMediaPolicy
+    private let workingDirectory: URL
     private var connection: BackupConnection?
 
     public init(
         port: any BackupPort,
         stateStore: any BackupStateStoring,
+        workingDirectory: URL,
         schedule: BackupSchedule = .default,
         mediaPolicy: BackupMediaPolicy = .descriptorsOnly
     ) {
         self.port = port
         self.stateStore = stateStore
+        self.workingDirectory = workingDirectory
         self.schedule = schedule
         self.mediaPolicy = mediaPolicy
     }
@@ -70,11 +73,24 @@ public final class BackupEnrolmentFlow {
         }
         do {
             var stored = try stateStore.load()
-            stored.componentId = connection.manifest.componentId
+            // Enrolling with a *different* operator discards the
+            // previous one's operational state. Keeping it would let
+            // reconciliation ask the new operator about the old one's
+            // operations, and would let a snapshot awaiting payment —
+            // sealed under terms the new operator never published — be
+            // retried against it.
+            let orphaned = stored.rebind(to: connection.manifest.componentId)
             stored.acceptedTermsId = connection.acceptedTermsId
             stored.acceptedTermsRaw = connection.terms.rawBytes
             stored.mediaPolicy = mediaPolicy
             try stateStore.save(stored)
+            if let orphaned {
+                // Sealed bytes nobody will claim now. Ciphertext, so not
+                // a disclosure — but a file the person never sees and
+                // would otherwise keep paying for in storage.
+                try? FileManager.default.removeItem(
+                    at: workingDirectory.appending(path: orphaned))
+            }
             state = .enrolled
         } catch {
             // Not enrolled. Reporting success over a failed write would

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
@@ -16,23 +16,62 @@ import SwiftUI
 /// operator that keeps access logs or excludes a great deal from
 /// erasure has published that, and this screen repeats it.
 public struct BackupEnrolmentView: View {
-    private let disclosure: BackupDisclosure
-    private let onAccept: () -> Void
-    private let onCancel: () -> Void
+    @State private var flow: BackupEnrolmentFlow
+    private let onEnrolled: () -> Void
+    @Environment(\.dismiss) private var dismiss
 
     @State private var scrolledToEnd = false
 
-    public init(
-        disclosure: BackupDisclosure,
-        onAccept: @escaping () -> Void,
-        onCancel: @escaping () -> Void
-    ) {
-        self.disclosure = disclosure
-        self.onAccept = onAccept
-        self.onCancel = onCancel
+    public init(flow: BackupEnrolmentFlow, onEnrolled: @escaping () -> Void = {}) {
+        _flow = State(wrappedValue: flow)
+        self.onEnrolled = onEnrolled
     }
 
     public var body: some View {
+        Group {
+            switch flow.state {
+            case .loading:
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .unavailable(let message):
+                unavailable(message)
+            case .ready(let disclosure):
+                disclosureBody(disclosure)
+            case .enrolled:
+                // Nothing is uploaded by enrolling. The screen closes
+                // and the settings surface takes over.
+                Color.clear.onAppear {
+                    onEnrolled()
+                    dismiss()
+                }
+            }
+        }
+        .navigationTitle("Device Backup")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await flow.load() }
+    }
+
+    /// Terms are a precondition for enrolment, so a failure to fetch or
+    /// verify them ends here rather than offering to continue without.
+    private func unavailable(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+            Text("The operator's terms could not be verified")
+                .font(.headline)
+            Text(verbatim: message)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Text("Backup cannot be turned on without them.")
+                .font(.callout)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("backup.enrolment.unavailable")
+    }
+
+    private func disclosureBody(_ disclosure: BackupDisclosure) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 VStack(alignment: .leading, spacing: 4) {
@@ -118,7 +157,7 @@ public struct BackupEnrolmentView: View {
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 10) {
-                Button(action: onAccept) {
+                Button { flow.accept() } label: {
                     Text("Turn On Backup")
                         .frame(maxWidth: .infinity)
                 }
@@ -126,14 +165,12 @@ public struct BackupEnrolmentView: View {
                 .disabled(!scrolledToEnd)
                 .accessibilityIdentifier("backup.enrolment.accept")
 
-                Button("Not Now", action: onCancel)
+                Button("Not Now") { dismiss() }
                     .accessibilityIdentifier("backup.enrolment.cancel")
             }
             .padding(16)
             .background(.bar)
         }
-        .navigationTitle("Device Backup")
-        .navigationBarTitleDisplayMode(.inline)
     }
 
     /// Whether the disclosure has been scrolled to its end.

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -104,9 +104,11 @@ public final class DeviceBackupSettingsFlow {
         // The consented operator moved out from under this state. Nothing
         // recorded here means anything to the new one, so the only honest
         // next step is enrolment.
-        if let current = currentComponentId(),
-           let enrolled = stored.componentId,
-           current != enrolled {
+        // Includes state written before the operator was recorded at
+        // all: nil is not "matches", it is "cannot tell", and guessing
+        // in favour of proceeding is how a snapshot reaches the wrong
+        // operator. Re-enrolment is the cost, and it is one screen.
+        if currentComponentId() != stored.componentId {
             state.status = .operatorChanged
             return
         }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -23,10 +23,34 @@ public final class DeviceBackupSettingsFlow {
         /// The operator published new terms. Uploads stop until they
         /// have been seen and accepted.
         case termsChanged
+        /// A different operator is consented to than the one this state
+        /// was enrolled with.
+        case operatorChanged
         /// Earlier work could not be resolved, so nothing new was
         /// composed. Not a failure — and not success either.
         case checkingEarlierBackup
         case failed(message: String)
+    }
+
+    /// Whether the person needs to go through enrolment.
+    ///
+    /// `.off` alone was not enough, and the gap was the whole point of
+    /// the enrolment route: after consenting to a new operator, the
+    /// stored terms id from the *old* one is still there, so the status
+    /// read as enrolled, the "Set Up Backup" row never appeared, and
+    /// every Back Up Now returned `termsChanged` with nowhere to go. A
+    /// protection that only runs on first enrolment is not a protection
+    /// against switching.
+    public var needsEnrolment: Bool { Self.needsEnrolment(for: state.status) }
+
+    /// Pure, so the routing can be checked without a repository — the
+    /// previous version of this rule was wrong in a way only a human
+    /// clicking through Settings would have found.
+    nonisolated public static func needsEnrolment(for status: Status) -> Bool {
+        switch status {
+        case .off, .termsChanged, .operatorChanged: true
+        default: false
+        }
     }
 
     public struct State: Equatable {
@@ -43,6 +67,9 @@ public final class DeviceBackupSettingsFlow {
 
     private let repository: BackupRepository
     private let stateStore: any BackupStateStoring
+    /// The operator consented to *now*, which is not necessarily the one
+    /// this state was enrolled with.
+    private let currentComponentId: @Sendable () -> String?
     private let schedule: BackupSchedule
     /// Drawn once for this flow's lifetime. Re-drawing per check would
     /// let frequent polling sample until it found a small value, which
@@ -52,10 +79,12 @@ public final class DeviceBackupSettingsFlow {
     public init(
         repository: BackupRepository,
         stateStore: any BackupStateStoring,
+        currentComponentId: @escaping @Sendable () -> String? = { nil },
         schedule: BackupSchedule = .default
     ) {
         self.repository = repository
         self.stateStore = stateStore
+        self.currentComponentId = currentComponentId
         self.schedule = schedule
         self.sessionJitter = schedule.drawJitter()
     }
@@ -70,6 +99,22 @@ public final class DeviceBackupSettingsFlow {
         }
         guard stored.acceptedTermsId != nil else {
             state.status = .off
+            return
+        }
+        // The consented operator moved out from under this state. Nothing
+        // recorded here means anything to the new one, so the only honest
+        // next step is enrolment.
+        if let current = currentComponentId(),
+           let enrolled = stored.componentId,
+           current != enrolled {
+            state.status = .operatorChanged
+            return
+        }
+        // A snapshot already sealed and refused for payment outranks
+        // idle: it is owed a retry, and showing "On" would leave a person
+        // who has since paid wondering why nothing happens.
+        if stored.awaitingPayment != nil {
+            state.status = .paymentRequired(offerIds: [])
             return
         }
         // Unresolved work outranks "on". An upload whose result we never
@@ -94,6 +139,23 @@ public final class DeviceBackupSettingsFlow {
     public func backUpNow() async {
         state.status = .running
         do {
+            // A snapshot refused for payment is retried byte for byte
+            // before anything new is composed. Composing instead would
+            // mint a fresh salt and digest, so the person would have
+            // bought storage for a snapshot that is then never sent —
+            // and would be asked to buy again for its replacement.
+            if let pending = try await repository.pendingPayment() {
+                switch try await repository.retry(pending) {
+                case .retained, .alreadyRetained:
+                    refresh()
+                    return
+                case .paymentRequired(_, let offerIds, _):
+                    state.status = .paymentRequired(offerIds: offerIds)
+                    return
+                default:
+                    break
+                }
+            }
             switch try await repository.backUp() {
             case .retained, .alreadyRetained:
                 refresh()
@@ -101,6 +163,8 @@ public final class DeviceBackupSettingsFlow {
                 state.status = .paymentRequired(offerIds: offerIds)
             case .termsChanged:
                 state.status = .termsChanged
+            case .operatorChanged:
+                state.status = .operatorChanged
             case .awaitingReconciliation:
                 state.status = .checkingEarlierBackup
             case .unknown:

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -155,6 +155,11 @@ public final class DeviceBackupSettingsFlow {
                     state.status = .paymentRequired(offerIds: offerIds)
                     return
                 default:
+                    // Anything else — terms moved under it, operator
+                    // changed — means this snapshot is not sendable.
+                    // `pendingPayment()` has already cleared the record
+                    // in those cases, so falling through to compose is
+                    // safe rather than leaving a stale one behind.
                     break
                 }
             }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
@@ -27,12 +27,12 @@ public struct DeviceBackupSettingsView: View {
                 }
                 SettingsFootnote(verbatim: statusFootnote)
 
-                if case .off = flow.state.status {
+                if flow.needsEnrolment {
                     if let enrolment = makeEnrolment() {
                         SettingsCard {
                             NavigationLink { enrolment } label: {
                                 SettingsRow(
-                                    title: "Set Up Backup",
+                                    title: enrolmentRowTitle,
                                     subtitle: "Read what it does before turning it on",
                                     last: true
                                 ) {
@@ -44,7 +44,8 @@ public struct DeviceBackupSettingsView: View {
                             .accessibilityIdentifier("backup.setup_row")
                         }
                     }
-                } else {
+                }
+                if !flow.needsEnrolment {
                     SettingsCard {
                         Button {
                             Task { await flow.backUpNow() }
@@ -75,6 +76,17 @@ public struct DeviceBackupSettingsView: View {
         .task {
             flow.refresh()
             await flow.loadSnapshots()
+        }
+    }
+
+    /// The same screen either way, but not the same sentence: someone
+    /// who has backed up before is being asked to re-read terms, not
+    /// to discover the feature.
+    private var enrolmentRowTitle: LocalizedStringKey {
+        switch flow.state.status {
+        case .termsChanged: "Review New Terms"
+        case .operatorChanged: "Set Up With New Operator"
+        default: "Set Up Backup"
         }
     }
 
@@ -134,6 +146,7 @@ public struct DeviceBackupSettingsView: View {
         case .stale: "Out of date"
         case .paymentRequired: "Payment needed"
         case .termsChanged: "Terms changed"
+        case .operatorChanged: "Backup operator changed"
         case .checkingEarlierBackup: "Checking an earlier backup"
         case .failed: "Something went wrong"
         }
@@ -152,6 +165,8 @@ public struct DeviceBackupSettingsView: View {
             "The operator needs a subscription before it will keep a backup"
         case .termsChanged:
             "Read the new terms to continue backing up"
+        case .operatorChanged:
+            "Set up backup again with the operator you chose"
         case .checkingEarlierBackup:
             "An earlier backup has not been confirmed yet"
         case .failed(let message):
@@ -178,6 +193,7 @@ public struct DeviceBackupSettingsView: View {
         case .stale: "exclamationmark.triangle"
         case .paymentRequired: "creditcard"
         case .termsChanged: "doc.badge.ellipsis"
+        case .operatorChanged: "arrow.triangle.swap"
         case .checkingEarlierBackup: "questionmark.circle"
         case .failed: "xmark.octagon"
         }

--- a/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
@@ -30,9 +30,27 @@ public struct ChannelOffer: Sendable, Equatable, Codable {
 public struct ChannelOfferCatalog: Sendable {
     private let offers: [ChannelOffer]
 
+    /// Duplicated product identifiers are **dropped at construction**,
+    /// not asserted at lookup.
+    ///
+    /// An assert crashes a debug build in the middle of a replay, which
+    /// is the opposite of the refuse-and-retry the lookup promises, and
+    /// does nothing at all in Release. Dropping both sides of a clash
+    /// means the catalog is well-formed by construction: the affected
+    /// offer becomes unsellable, which is visible and safe, rather than
+    /// crediting a purchase to whichever operator sorted first.
     public init(offers: [ChannelOffer]) {
-        self.offers = offers
+        let duplicated = Set(
+            Dictionary(grouping: offers, by: \.productId)
+                .filter { $0.value.count > 1 }
+                .keys)
+        self.offers = offers.filter { !duplicated.contains($0.productId) }
+        self.rejectedProductIds = duplicated.sorted()
     }
+
+    /// Product identifiers dropped as ambiguous. Empty in a well-formed
+    /// catalog; surfaced so a build or a diagnostic can notice.
+    public let rejectedProductIds: [String]
 
     /// Load from a bundled JSON resource.
     ///
@@ -55,15 +73,7 @@ public struct ChannelOfferCatalog: Sendable {
         return ChannelOfferCatalog(offers: offers)
     }
 
-    /// Product identifiers listed more than once. Empty in a
-    /// well-formed catalog; surfaced so a build can fail on it rather
-    /// than discovering it during a replay.
-    public var duplicateProductIds: [String] {
-        Dictionary(grouping: offers, by: \.productId)
-            .filter { $0.value.count > 1 }
-            .keys
-            .sorted()
-    }
+
 
     public func offer(forOfferId offerId: String, componentId: String) -> ChannelOffer? {
         offers.first { $0.offerId == offerId && $0.componentId == componentId }
@@ -79,15 +89,11 @@ public struct ChannelOfferCatalog: Sendable {
     /// crediting one operator for a purchase made from another. Checked
     /// at load rather than left as a convention.
     public func offer(forProductId productId: String) -> ChannelOffer? {
-        let matches = offers.filter { $0.productId == productId }
-        guard matches.count == 1 else {
-            // Ambiguous or absent. Refusing is right for both: a replay
-            // we cannot attribute is left unfinished and retried, which
-            // is recoverable, where crediting the wrong operator is not.
-            assert(matches.count < 2, "channel offers share productId \(productId)")
-            return nil
-        }
-        return matches[0]
+        // Unambiguous by construction — a clash was dropped at load — so
+        // a miss here means the product is not ours to redeem, and the
+        // replay is left unfinished and retried rather than attributed
+        // to a guess.
+        offers.first { $0.productId == productId }
     }
 
     public var productIds: Set<String> { Set(offers.map(\.productId)) }

--- a/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
@@ -73,8 +73,6 @@ public struct ChannelOfferCatalog: Sendable {
         return ChannelOfferCatalog(offers: offers)
     }
 
-
-
     public func offer(forOfferId offerId: String, componentId: String) -> ChannelOffer? {
         offers.first { $0.offerId == offerId && $0.componentId == componentId }
     }

--- a/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
@@ -55,6 +55,16 @@ public struct ChannelOfferCatalog: Sendable {
         return ChannelOfferCatalog(offers: offers)
     }
 
+    /// Product identifiers listed more than once. Empty in a
+    /// well-formed catalog; surfaced so a build can fail on it rather
+    /// than discovering it during a replay.
+    public var duplicateProductIds: [String] {
+        Dictionary(grouping: offers, by: \.productId)
+            .filter { $0.value.count > 1 }
+            .keys
+            .sorted()
+    }
+
     public func offer(forOfferId offerId: String, componentId: String) -> ChannelOffer? {
         offers.first { $0.offerId == offerId && $0.componentId == componentId }
     }
@@ -62,8 +72,22 @@ public struct ChannelOfferCatalog: Sendable {
     /// The reverse lookup a `Transaction.updates` replay needs: StoreKit
     /// hands back a product identifier, and only the catalog knows which
     /// seat and offer it was bought for.
+    ///
+    /// **A `productId` must appear at most once.** The reverse lookup has
+    /// no other way to choose, so two components sharing a product would
+    /// redeem a replayed transaction for whichever sorted first —
+    /// crediting one operator for a purchase made from another. Checked
+    /// at load rather than left as a convention.
     public func offer(forProductId productId: String) -> ChannelOffer? {
-        offers.first { $0.productId == productId }
+        let matches = offers.filter { $0.productId == productId }
+        guard matches.count == 1 else {
+            // Ambiguous or absent. Refusing is right for both: a replay
+            // we cannot attribute is left unfinished and retried, which
+            // is recoverable, where crediting the wrong operator is not.
+            assert(matches.count < 2, "channel offers share productId \(productId)")
+            return nil
+        }
+        return matches[0]
     }
 
     public var productIds: Set<String> { Set(offers.map(\.productId)) }

--- a/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
@@ -59,5 +59,12 @@ public struct ChannelOfferCatalog: Sendable {
         offers.first { $0.offerId == offerId && $0.componentId == componentId }
     }
 
+    /// The reverse lookup a `Transaction.updates` replay needs: StoreKit
+    /// hands back a product identifier, and only the catalog knows which
+    /// seat and offer it was bought for.
+    public func offer(forProductId productId: String) -> ChannelOffer? {
+        offers.first { $0.productId == productId }
+    }
+
     public var productIds: Set<String> { Set(offers.map(\.productId)) }
 }

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -107,15 +107,15 @@ struct AppDependencies {
     /// renders without the discovery stack (nil under the UI-test
     /// harness — same pattern as the moderation factories).
     let makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)?
+    /// The consented backup operator, cheap to read. Lets the root view
+    /// tell "the operator changed" from "Settings was opened again"
+    /// without rebuilding the whole stack to find out.
+    let consentedBackupComponentId: (@MainActor () -> String?)?
     /// Settings → Device Backup. Async and optional: resolving it reads
     /// the pinned consent record and derives a seat key, and it is
     /// legitimately `nil` when no backup operator has been consented to
     /// or the identity has no recovery phrase to derive from. The
     /// section hides rather than offering a screen that cannot work.
-    /// The consented backup operator, cheap to read. Lets the root view
-    /// tell "the operator changed" from "Settings was opened again"
-    /// without rebuilding the whole stack to find out.
-    let consentedBackupComponentId: (@MainActor () -> String?)?
     let makeDeviceBackupView: (@MainActor () async -> DeviceBackupSettingsView?)?
     /// Onboarding flow factory. Non-nil whenever onboarding is
     /// AVAILABLE in this build (always in production; under

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -112,6 +112,10 @@ struct AppDependencies {
     /// legitimately `nil` when no backup operator has been consented to
     /// or the identity has no recovery phrase to derive from. The
     /// section hides rather than offering a screen that cannot work.
+    /// The consented backup operator, cheap to read. Lets the root view
+    /// tell "the operator changed" from "Settings was opened again"
+    /// without rebuilding the whole stack to find out.
+    let consentedBackupComponentId: (@MainActor () -> String?)?
     let makeDeviceBackupView: (@MainActor () async -> DeviceBackupSettingsView?)?
     /// Onboarding flow factory. Non-nil whenever onboarding is
     /// AVAILABLE in this build (always in production; under

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -11,6 +11,7 @@ import OnymModerationUI
 import OnymModeration
 import OnymDiscovery
 import OnymOnboarding
+import OnymBackupUI
 
 /// App-wide composition root. Constructed exactly once by `OnymIOSApp`
 /// and threaded down to views via `RootView`. Each member is a factory
@@ -106,6 +107,12 @@ struct AppDependencies {
     /// renders without the discovery stack (nil under the UI-test
     /// harness — same pattern as the moderation factories).
     let makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)?
+    /// Settings → Device Backup. Async and optional: resolving it reads
+    /// the pinned consent record and derives a seat key, and it is
+    /// legitimately `nil` when no backup operator has been consented to
+    /// or the identity has no recovery phrase to derive from. The
+    /// section hides rather than offering a screen that cannot work.
+    let makeDeviceBackupView: (@MainActor () async -> DeviceBackupSettingsView?)?
     /// Onboarding flow factory. Non-nil whenever onboarding is
     /// AVAILABLE in this build (always in production; under
     /// `--ui-testing` only with `--ui-onboarding`, so every existing

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -1,0 +1,77 @@
+import Foundation
+import OnymBackup
+import OnymBackupUI
+import OnymBilling
+import OnymChatsCore
+import OnymFoundation
+import OnymGroup
+import OnymIdentity
+import OnymPersistence
+import OnymTransportBlossom
+
+/// Builds the device-backup screen, or returns `nil` when there is
+/// nothing to build.
+///
+/// `nil` happens for ordinary reasons: no backup operator consented to,
+/// or an identity imported from raw key material and therefore without a
+/// recovery phrase to derive a key from. Both mean the Settings section
+/// hides rather than offering something that cannot work.
+@MainActor
+struct BackupSeatComposer {
+    let identities: IdentityRepository
+    let groupStore: any GroupStore
+    let messageStore: any MessageStore
+    let invitationStore: any InvitationStore
+    let consentStore: any PinnedConsentStore
+    let blobClient: (any BlossomClient)?
+    /// DEBUG override for a local operator, via `--backup-base-url`.
+    let endpointOverride: URL?
+
+    func makeDeviceBackupView() async -> DeviceBackupSettingsView? {
+        guard let manifest = BackupSeat.consentedManifest(consentStore: consentStore) else {
+            return nil
+        }
+        guard
+            let material = try? await BackupKeys.material(
+                deriving: identities, componentId: manifest.componentId),
+            let workingDirectory = try? BackupSeat.workingDirectory()
+        else {
+            // No recovery phrase, or nowhere to write. Either way a
+            // snapshot sealed now could not be opened later, and
+            // offering the screen would be offering something false.
+            return nil
+        }
+
+        let stateStore = FileBackupStateStore(
+            url: workingDirectory.appending(path: "state.json"))
+        let mediaPolicy = (try? stateStore.load())?.mediaPolicy ?? .descriptorsOnly
+
+        let client = URLSessionBackupClient(
+            manifest: manifest,
+            material: material,
+            entitlement: { nil }
+        )
+        let composer = BackupComposer(
+            source: AppBackupSource(
+                groupStore: groupStore,
+                messageStore: messageStore,
+                invitationStore: invitationStore,
+                consentStore: consentStore,
+                blobClient: mediaPolicy == .includeCiphertext ? blobClient : nil
+            ),
+            mediaPolicy: mediaPolicy,
+            workingDirectory: workingDirectory
+        )
+        let repository = BackupRepository(
+            port: client,
+            composer: composer,
+            stateStore: stateStore,
+            keyMaterial: material
+        )
+        let flow = DeviceBackupSettingsFlow(
+            repository: repository,
+            stateStore: stateStore
+        )
+        return DeviceBackupSettingsView(flow: flow) { nil }
+    }
+}

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -26,6 +26,11 @@ struct BackupSeatComposer {
     let blobClient: (any BlossomClient)?
     /// DEBUG override for a local operator, via `--backup-base-url`.
     let endpointOverride: URL?
+    /// Purchased credentials. Presented to an operator that declares
+    /// entitlement issuers; an operator that declares none never sees a
+    /// credential and never asks for one.
+    let entitlementStore: (any SeatEntitlementStoring)?
+    let seatKeys: any SeatAccessKeyProviding
 
     func makeDeviceBackupView() async -> DeviceBackupSettingsView? {
         guard let manifest = BackupSeat.consentedManifest(consentStore: consentStore) else {
@@ -49,7 +54,9 @@ struct BackupSeatComposer {
         let client = URLSessionBackupClient(
             manifest: manifest,
             material: material,
-            entitlement: { nil }
+            endpointOverride: endpointOverride,
+            entitlement: Self.entitlementProvider(
+                manifest: manifest, store: entitlementStore, keys: seatKeys)
         )
         let composer = BackupComposer(
             source: AppBackupSource(
@@ -72,6 +79,58 @@ struct BackupSeatComposer {
             repository: repository,
             stateStore: stateStore
         )
-        return DeviceBackupSettingsView(flow: flow) { nil }
+        return DeviceBackupSettingsView(flow: flow) {
+            // The consent surface, reachable. Without this the section
+            // rendered a status card with no way to turn backup on, and
+            // everything behind it was unreachable code.
+            BackupEnrolmentView(
+                flow: BackupEnrolmentFlow(
+                    port: client,
+                    stateStore: stateStore,
+                    mediaPolicy: mediaPolicy)
+            ) {
+                flow.refresh()
+            }
+        }
+    }
+
+    /// The credential to present, chosen at request time.
+    ///
+    /// Read per request rather than captured once: a purchase completed
+    /// while the screen is open should take effect on the next upload,
+    /// not on the next launch. An operator that declares no issuers gets
+    /// nothing — a free operator has no use for a credential.
+    private static func entitlementProvider(
+        manifest: BackupOperatorManifest,
+        store: (any SeatEntitlementStoring)?,
+        keys: any SeatAccessKeyProviding
+    ) -> @Sendable () async -> Data? {
+        let componentId = manifest.componentId
+        let issuers = manifest.entitlementIssuers
+        return { @Sendable in
+            guard !issuers.isEmpty, let store else { return nil }
+            guard
+                let subject = try? await keys.seatSubject(componentId: componentId),
+                let stored = try? store.load()
+            else {
+                return nil
+            }
+            let verifier = SeatEntitlementVerifier(
+                trustedIssuers: issuers, componentId: componentId, subject: subject)
+            for raw in stored {
+                guard
+                    let entitlement = try? SeatEntitlement.decode(raw: raw),
+                    (try? verifier.verify(entitlement)) != nil
+                else {
+                    continue
+                }
+                return raw
+            }
+            // Nothing usable. Sending an expired or foreign credential
+            // would earn `invalid_entitlement` where `payment_required`
+            // is the honest answer, and the second one is what a person
+            // can act on.
+            return nil
+        }
     }
 }

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -75,9 +75,14 @@ struct BackupSeatComposer {
             stateStore: stateStore,
             keyMaterial: material
         )
+        let consented = manifest.componentId
         let flow = DeviceBackupSettingsFlow(
             repository: repository,
-            stateStore: stateStore
+            stateStore: stateStore,
+            // Lets the flow tell "enrolled" from "enrolled with somebody
+            // else", which is the difference between a working backup
+            // and one that silently never uploads again.
+            currentComponentId: { consented }
         )
         return DeviceBackupSettingsView(flow: flow) {
             // The consent surface, reachable. Without this the section

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -87,6 +87,7 @@ struct BackupSeatComposer {
                 flow: BackupEnrolmentFlow(
                     port: client,
                     stateStore: stateStore,
+                    workingDirectory: workingDirectory,
                     mediaPolicy: mediaPolicy)
             ) {
                 flow.refresh()

--- a/Sources/OnymIOS/BackupSeat.swift
+++ b/Sources/OnymIOS/BackupSeat.swift
@@ -7,6 +7,7 @@ import OnymChatsCore
 import OnymFoundation
 import OnymGroup
 import OnymIdentity
+import OnymModeration
 import OnymPersistence
 import OnymTransportBlossom
 
@@ -18,7 +19,16 @@ import OnymTransportBlossom
 /// and the keys come from the identity vault. If no backup operator has
 /// been consented to, this resolves to `nil` and Settings shows no
 /// backup section — which is correct, not a degraded state.
-@MainActor
+/// Not `@MainActor`.
+///
+/// It was, and the annotation was not honoured: `entitlementIssuers` is
+/// called synchronously from nonisolated `@Sendable` closures that run
+/// inside the purchase-flow actor and the entitlement provider, off the
+/// main actor. That is a warning in Swift 5 and a hard error in Swift 6,
+/// and in the meantime it meant main-actor-annotated code running
+/// elsewhere. Everything here is a pure read of a `Sendable` store, so
+/// dropping the isolation is the honest fix rather than adding hops that
+/// would only make the annotation true.
 enum BackupSeat {
     /// The seat value a backup operator declares.
     static let seat = "storage.backup"
@@ -72,26 +82,13 @@ enum BackupSeat {
         componentId: String,
         consentStore: any PinnedConsentStore
     ) -> Curve25519.Signing.PublicKey? {
+        // `AuthorityKey` is the one `onym:key:` parser in this codebase.
+        // A second hand-rolled one is a second place for the hex rules
+        // to drift.
         for reference in entitlementIssuers(componentId: componentId, consentStore: consentStore) {
-            let prefix = "onym:key:"
-            guard reference.hasPrefix(prefix) else { continue }
-            let hex = String(reference.dropFirst(prefix.count))
-            guard hex.count == 64 else { continue }
-            var bytes = [UInt8]()
-            var index = hex.startIndex
-            var valid = true
-            while index < hex.endIndex {
-                let next = hex.index(index, offsetBy: 2)
-                guard let byte = UInt8(hex[index..<next], radix: 16) else { valid = false; break }
-                bytes.append(byte)
-                index = next
+            if let key = try? AuthorityKey.publicKey(fromReference: reference) {
+                return key
             }
-            guard valid, let key = try? Curve25519.Signing.PublicKey(
-                rawRepresentation: Data(bytes))
-            else {
-                continue
-            }
-            return key
         }
         return nil
     }

--- a/Sources/OnymIOS/BackupSeat.swift
+++ b/Sources/OnymIOS/BackupSeat.swift
@@ -1,0 +1,135 @@
+import CryptoKit
+import Foundation
+import OnymBackup
+import OnymBackupUI
+import OnymBilling
+import OnymChatsCore
+import OnymFoundation
+import OnymGroup
+import OnymIdentity
+import OnymPersistence
+import OnymTransportBlossom
+
+/// Assembles the device-backup seat from what the person has actually
+/// chosen.
+///
+/// Nothing here decides anything: the operator comes from a pinned
+/// consent record, its terms come from that operator's signed manifest,
+/// and the keys come from the identity vault. If no backup operator has
+/// been consented to, this resolves to `nil` and Settings shows no
+/// backup section — which is correct, not a degraded state.
+@MainActor
+enum BackupSeat {
+    /// The seat value a backup operator declares.
+    static let seat = "storage.backup"
+
+    /// The consented backup operator, if there is one.
+    ///
+    /// Reads the *active* pinned record. A person who switched
+    /// operators has a history of records; only the current one may
+    /// receive a snapshot.
+    static func consentedManifest(
+        consentStore: any PinnedConsentStore
+    ) -> BackupOperatorManifest? {
+        guard let records = try? consentStore.load() else { return nil }
+        for record in records.reversed() where record.isActive {
+            guard
+                let manifest = record.consentedManifest(),
+                manifest.seat == seat,
+                let backup = try? BackupOperatorManifest(manifest: manifest)
+            else {
+                continue
+            }
+            return backup
+        }
+        return nil
+    }
+
+    /// Issuer keys an operator declares. Pinned from the signed
+    /// manifest, never from an entitlement — a credential must not be
+    /// able to nominate its own authority.
+    static func entitlementIssuers(
+        componentId: String,
+        consentStore: any PinnedConsentStore
+    ) -> [String] {
+        guard
+            let record = try? consentStore.activeRecord(componentId: componentId),
+            let manifest = record.consentedManifest(),
+            let backup = try? BackupOperatorManifest(manifest: manifest)
+        else {
+            return []
+        }
+        return backup.entitlementIssuers
+    }
+
+    /// The first declared issuer, as a key.
+    ///
+    /// Returns `nil` when nothing has been consented to for that
+    /// component, or when the operator declared no issuers — a free
+    /// operator, which never issues a payment refusal and therefore
+    /// never needs one.
+    static func entitlementIssuerKey(
+        componentId: String,
+        consentStore: any PinnedConsentStore
+    ) -> Curve25519.Signing.PublicKey? {
+        for reference in entitlementIssuers(componentId: componentId, consentStore: consentStore) {
+            let prefix = "onym:key:"
+            guard reference.hasPrefix(prefix) else { continue }
+            let hex = String(reference.dropFirst(prefix.count))
+            guard hex.count == 64 else { continue }
+            var bytes = [UInt8]()
+            var index = hex.startIndex
+            var valid = true
+            while index < hex.endIndex {
+                let next = hex.index(index, offsetBy: 2)
+                guard let byte = UInt8(hex[index..<next], radix: 16) else { valid = false; break }
+                bytes.append(byte)
+                index = next
+            }
+            guard valid, let key = try? Curve25519.Signing.PublicKey(
+                rawRepresentation: Data(bytes))
+            else {
+                continue
+            }
+            return key
+        }
+        return nil
+    }
+
+    /// Where sealed snapshots and local backup state live.
+    static func workingDirectory() throws -> URL {
+        let base = try PersistentStoreOpener.storeDirectory()
+        let url = base.appending(path: "Backup", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete]
+        )
+        return url
+    }
+}
+
+/// Seat-scoped keys for the billing layer, derived from the identity
+/// vault.
+///
+/// `OnymBilling` cannot derive these itself — they belong to whichever
+/// seat is being bought — and `OnymBackup` must not depend on identity.
+/// The composition root is the only place that knows all three, which is
+/// why the conformance lives here.
+struct IdentitySeatAccessKeys: SeatAccessKeyProviding {
+    let identities: IdentityRepository
+
+    func seatSubject(componentId: String) async throws -> String {
+        try await material(componentId: componentId).holderReference
+    }
+
+    func seatAgreementKey(
+        componentId: String
+    ) async throws -> Curve25519.KeyAgreement.PrivateKey {
+        try await material(componentId: componentId).accessAgreementKey
+    }
+
+    private func material(componentId: String) async throws -> BackupKeyMaterial {
+        try await BackupKeys.material(deriving: identities, componentId: componentId)
+    }
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -16,11 +16,16 @@ import OnymModerationUI
 import OnymDiscovery
 import OnymFoundation
 import OnymOnboarding
+import OnymBackup
+import OnymBackupUI
+import OnymBilling
 
 @main
 struct OnymIOSApp: App {
     private let dependencies: AppDependencies
     private let identityRepository: IdentityRepository
+    /// Held so the replay observer outlives `init`.
+    private let seatTransactionObserver: SeatTransactionObserver
     private let relayerRepository: RelayerRepository
     private let contractsRepository: ContractsRepository
     private let groupRepository: GroupRepository
@@ -435,24 +440,22 @@ struct OnymIOSApp: App {
         // store can't open (rare; FileProtection / sandbox issues).
         // Failure here is non-fatal for the create-group flow, just
         // means newly-created groups don't survive a relaunch.
-        let groupRepository: GroupRepository
-        if let store = try? SwiftDataGroupStore() {
-            groupRepository = GroupRepository(store: store)
-        } else {
-            groupRepository = GroupRepository(store: SwiftDataGroupStore.inMemory())
-        }
+        // Hoisted rather than inlined into the repository: device
+        // backup reads through the same store, and reading through a
+        // second one would let a snapshot disagree with the app about
+        // what exists.
+        let groupStore: any GroupStore = (try? SwiftDataGroupStore())
+            ?? SwiftDataGroupStore.inMemory()
+        let groupRepository = GroupRepository(store: groupStore)
         self.groupRepository = groupRepository
 
         // Chat messages — same fall-back policy as `groupRepository`
         // (on-disk store with in-memory fallback if FileProtection /
         // sandbox blocks the file). Separate `Messages.store` keeps
         // schema migrations from cross-domain wipes.
-        let messageRepository: MessageRepository
-        if let store = try? SwiftDataMessageStore() {
-            messageRepository = MessageRepository(store: store)
-        } else {
-            messageRepository = MessageRepository(store: SwiftDataMessageStore.inMemory())
-        }
+        let messageStore: any MessageStore = (try? SwiftDataMessageStore())
+            ?? SwiftDataMessageStore.inMemory()
+        let messageRepository = MessageRepository(store: messageStore)
         self.messageRepository = messageRepository
 
         // Inbox transport for invitation send. The endpoint list comes
@@ -808,8 +811,79 @@ struct OnymIOSApp: App {
         /// even free offers would gate as not-entitled); the store is
         /// only the fallback for offers the reviewed manifest doesn't
         /// carry. StoreKit slots in behind the same seam later.
+        ///
+        /// StoreKit now sits behind the same seam, composed with the free
+        /// provider rather than replacing it: a free offer must still
+        /// resolve with no store, no network and no credential, because
+        /// an operator charging nothing is a first-class case.
+        ///
+        /// The catalog is what makes a paid offer sellable at all. It
+        /// ships empty until a store product exists, so today every paid
+        /// offer still gates as not-purchasable — the difference is that
+        /// it now does so because there is no product, not because the
+        /// machinery is missing.
+        // Resolved outside the closure: referencing `Self` inside an
+        // escaping closure during `init` captures a self that does not
+        // exist yet.
+        let backupBaseURLOverride = OnymIOSApp.resolveBackupBaseURL(args: args)
+        // Local alias: capturing `identityRepository` directly would
+        // capture `self` inside an escaping closure during `init`.
+        let identities = identityRepository
+        let seatAccessKeys = IdentitySeatAccessKeys(identities: identities)
+        let channelOfferCatalog = ChannelOfferCatalog.bundled()
+        let seatEntitlementStore = FileSeatEntitlementStore(
+            url: (try? BackupSeat.workingDirectory().appending(path: "entitlements.json"))
+                ?? URL(fileURLWithPath: NSTemporaryDirectory())
+                    .appending(path: "entitlements.json"))
+
+        // Replay observer for purchases that were never finished.
+        //
+        // Started here rather than from a view: a transaction replayed
+        // while nothing is listening waits for the launch after next,
+        // and the person who is waiting is one who has already paid.
+        let billingBaseURL = OnymIOSApp.resolveBillingBaseURL(args: args)
+            ?? URLSessionBillingBrokerClient.defaultBaseURL
+        let seatTransactionObserver = SeatTransactionObserver(
+            catalog: channelOfferCatalog
+        ) { componentId in
+            // The issuer key is pinned per operator, from the manifest
+            // that operator signed and this person consented to. No
+            // consented manifest means no key to pin, which means no
+            // redemption — an unpinned broker client would accept a
+            // credential from whoever answered the URL.
+            guard let issuerKey = await BackupSeat.entitlementIssuerKey(
+                componentId: componentId, consentStore: pinnedConsentStore)
+            else {
+                return nil
+            }
+            return SeatPurchaseFlow(
+                coordinator: StoreKitPurchaseCoordinator(),
+                broker: URLSessionBillingBrokerClient(
+                    baseURL: billingBaseURL, issuerKey: issuerKey),
+                catalog: channelOfferCatalog,
+                store: seatEntitlementStore,
+                keys: seatAccessKeys,
+                trustedIssuers: { componentId in
+                    BackupSeat.entitlementIssuers(
+                        componentId: componentId, consentStore: pinnedConsentStore)
+                }
+            )
+        }
+        seatTransactionObserver.start()
+        self.seatTransactionObserver = seatTransactionObserver
+
         let makeEntitlements: @Sendable (SignedServiceManifest) -> any EntitlementProviding = { manifest in
-            FreeTierEntitlementProvider(reviewing: manifest, consentStore: pinnedConsentStore)
+            StoreKitEntitlementProvider(
+                free: FreeTierEntitlementProvider(
+                    reviewing: manifest, consentStore: pinnedConsentStore),
+                catalog: channelOfferCatalog,
+                store: seatEntitlementStore,
+                keys: seatAccessKeys,
+                trustedIssuers: { componentId in
+                    BackupSeat.entitlementIssuers(
+                        componentId: componentId, consentStore: pinnedConsentStore)
+                }
+            )
         }
 
         /// Manifest `name` when published and non-empty, else the
@@ -1257,6 +1331,17 @@ struct OnymIOSApp: App {
                 )
             },
             makeDiscoverySettingsFlow: makeDiscoverySettingsFlow,
+            makeDeviceBackupView: {
+                await BackupSeatComposer(
+                    identities: identities,
+                    groupStore: groupStore,
+                    messageStore: messageStore,
+                    invitationStore: invitationStore,
+                    consentStore: pinnedConsentStore,
+                    blobClient: blossomClient,
+                    endpointOverride: backupBaseURLOverride
+                ).makeDeviceBackupView()
+            },
             makeOnboardingFlow: makeOnboardingFlow,
             presentOnboardingAtLaunch: shouldOnboard,
             onboardingRestart: onboardingRestartController,
@@ -1265,6 +1350,33 @@ struct OnymIOSApp: App {
     }
 
     #if DEBUG
+    /// `--billing-base-url <https-url>`: point a dev build at a local
+    /// billing broker. https only, same rule as every other override.
+    private static func resolveBillingBaseURL(args: [String]) -> URL? {
+        guard let flagIndex = args.firstIndex(of: "--billing-base-url"),
+              args.indices.contains(flagIndex + 1),
+              let url = URL(string: args[flagIndex + 1]),
+              url.scheme?.lowercased() == "https"
+        else { return nil }
+        return url
+    }
+
+    /// `--backup-base-url <https-url>`: point a dev build at a local
+    /// backup operator. https only, in every build — reach a local
+    /// server through a tunnel rather than relaxing transport security.
+    ///
+    /// Symmetrical with `--enforcement-base-url`, and used for the same
+    /// reason: exercising the real loop against a deployment you control
+    /// beats a stub that agrees with you.
+    private static func resolveBackupBaseURL(args: [String]) -> URL? {
+        guard let flagIndex = args.firstIndex(of: "--backup-base-url"),
+              args.indices.contains(flagIndex + 1),
+              let url = URL(string: args[flagIndex + 1]),
+              url.scheme?.lowercased() == "https"
+        else { return nil }
+        return url
+    }
+
     /// `--enforcement-base-url <url>` (with a DEBUG build): point the
     /// enforcement backend client at a local deployment for driving
     /// the full moderation loop in development. The client enforces

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -841,6 +841,16 @@ struct OnymIOSApp: App {
         let identities = identityRepository
         let seatAccessKeys = IdentitySeatAccessKeys(identities: identities)
         let channelOfferCatalog = ChannelOfferCatalog.bundled()
+        if !channelOfferCatalog.rejectedProductIds.isEmpty {
+            // A clash makes both offers unsellable, which is safe but
+            // invisible — a paid offer would simply never resolve, with
+            // nothing to say why. Logged always, and fatal in DEBUG,
+            // because the catalog is committed and a duplicate there is
+            // a mistake to fix rather than a condition to tolerate.
+            let clashing = channelOfferCatalog.rejectedProductIds.joined(separator: ", ")
+            print("[billing] channel offers dropped for duplicate productId: \(clashing)")
+            assertionFailure("duplicate productId in ChannelOffers.json: \(clashing)")
+        }
         // No temporary-directory fallback. Purchased credentials there
         // would sit somewhere the OS purges and without complete file
         // protection, unlike everything else in the backup directory —

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -825,24 +825,45 @@ struct OnymIOSApp: App {
         // Resolved outside the closure: referencing `Self` inside an
         // escaping closure during `init` captures a self that does not
         // exist yet.
+        // DEBUG-only, and guarded at the call site because the
+        // resolvers are too. A Release build that honoured a launch
+        // argument would let anyone with device access redirect a
+        // person's history to an operator they never consented to —
+        // the same reason `--enforcement-base-url` has always been
+        // DEBUG-only.
+        #if DEBUG
         let backupBaseURLOverride = OnymIOSApp.resolveBackupBaseURL(args: args)
+        #else
+        let backupBaseURLOverride: URL? = nil
+        #endif
         // Local alias: capturing `identityRepository` directly would
         // capture `self` inside an escaping closure during `init`.
         let identities = identityRepository
         let seatAccessKeys = IdentitySeatAccessKeys(identities: identities)
         let channelOfferCatalog = ChannelOfferCatalog.bundled()
-        let seatEntitlementStore = FileSeatEntitlementStore(
-            url: (try? BackupSeat.workingDirectory().appending(path: "entitlements.json"))
-                ?? URL(fileURLWithPath: NSTemporaryDirectory())
-                    .appending(path: "entitlements.json"))
+        // No temporary-directory fallback. Purchased credentials there
+        // would sit somewhere the OS purges and without complete file
+        // protection, unlike everything else in the backup directory —
+        // so a person's credentials would quietly become less protected
+        // than their snapshots, on the path where something is already
+        // wrong. If the directory cannot be created, the store is
+        // absent: entitlements resolve to nil, paid offers gate as
+        // unavailable, and nothing is written anywhere weaker.
+        let seatEntitlementStore: (any SeatEntitlementStoring)? =
+            (try? BackupSeat.workingDirectory())
+                .map { FileSeatEntitlementStore(url: $0.appending(path: "entitlements.json")) }
 
         // Replay observer for purchases that were never finished.
         //
         // Started here rather than from a view: a transaction replayed
         // while nothing is listening waits for the launch after next,
         // and the person who is waiting is one who has already paid.
+        #if DEBUG
         let billingBaseURL = OnymIOSApp.resolveBillingBaseURL(args: args)
             ?? URLSessionBillingBrokerClient.defaultBaseURL
+        #else
+        let billingBaseURL = URLSessionBillingBrokerClient.defaultBaseURL
+        #endif
         let seatTransactionObserver = SeatTransactionObserver(
             catalog: channelOfferCatalog
         ) { componentId in
@@ -851,8 +872,10 @@ struct OnymIOSApp: App {
             // consented manifest means no key to pin, which means no
             // redemption — an unpinned broker client would accept a
             // credential from whoever answered the URL.
-            guard let issuerKey = await BackupSeat.entitlementIssuerKey(
-                componentId: componentId, consentStore: pinnedConsentStore)
+            guard
+                let entitlementStore = seatEntitlementStore,
+                let issuerKey = await BackupSeat.entitlementIssuerKey(
+                    componentId: componentId, consentStore: pinnedConsentStore)
             else {
                 return nil
             }
@@ -861,7 +884,7 @@ struct OnymIOSApp: App {
                 broker: URLSessionBillingBrokerClient(
                     baseURL: billingBaseURL, issuerKey: issuerKey),
                 catalog: channelOfferCatalog,
-                store: seatEntitlementStore,
+                store: entitlementStore,
                 keys: seatAccessKeys,
                 trustedIssuers: { componentId in
                     BackupSeat.entitlementIssuers(
@@ -873,7 +896,15 @@ struct OnymIOSApp: App {
         self.seatTransactionObserver = seatTransactionObserver
 
         let makeEntitlements: @Sendable (SignedServiceManifest) -> any EntitlementProviding = { manifest in
-            StoreKitEntitlementProvider(
+            guard let seatEntitlementStore else {
+                // Nowhere safe to keep a credential, so no paid offer can
+                // resolve. Free offers still do, with no network and no
+                // store — which is the case that must never depend on
+                // any of this.
+                return FreeTierEntitlementProvider(
+                    reviewing: manifest, consentStore: pinnedConsentStore)
+            }
+            return StoreKitEntitlementProvider(
                 free: FreeTierEntitlementProvider(
                     reviewing: manifest, consentStore: pinnedConsentStore),
                 catalog: channelOfferCatalog,
@@ -1339,7 +1370,9 @@ struct OnymIOSApp: App {
                     invitationStore: invitationStore,
                     consentStore: pinnedConsentStore,
                     blobClient: blossomClient,
-                    endpointOverride: backupBaseURLOverride
+                    endpointOverride: backupBaseURLOverride,
+                    entitlementStore: seatEntitlementStore,
+                    seatKeys: seatAccessKeys
                 ).makeDeviceBackupView()
             },
             makeOnboardingFlow: makeOnboardingFlow,
@@ -1350,8 +1383,10 @@ struct OnymIOSApp: App {
     }
 
     #if DEBUG
-    /// `--billing-base-url <https-url>`: point a dev build at a local
-    /// billing broker. https only, same rule as every other override.
+    /// `--billing-base-url <https-url>` (DEBUG only): point a dev build
+    /// at a local billing broker. The URL must be https even here —
+    /// reach a local server through a tunnel rather than relaxing
+    /// transport security.
     private static func resolveBillingBaseURL(args: [String]) -> URL? {
         guard let flagIndex = args.firstIndex(of: "--billing-base-url"),
               args.indices.contains(flagIndex + 1),
@@ -1361,13 +1396,14 @@ struct OnymIOSApp: App {
         return url
     }
 
-    /// `--backup-base-url <https-url>`: point a dev build at a local
-    /// backup operator. https only, in every build — reach a local
-    /// server through a tunnel rather than relaxing transport security.
+    /// `--backup-base-url <https-url>` (DEBUG only): point a dev build
+    /// at a local backup operator, overriding the endpoint in the
+    /// consented manifest. The URL must be https even here.
     ///
-    /// Symmetrical with `--enforcement-base-url`, and used for the same
-    /// reason: exercising the real loop against a deployment you control
-    /// beats a stub that agrees with you.
+    /// Symmetrical with `--enforcement-base-url`, and DEBUG-only for the
+    /// same reason: in a Release build this would let anyone with device
+    /// access redirect a person's history somewhere they never agreed
+    /// to.
     private static func resolveBackupBaseURL(args: [String]) -> URL? {
         guard let flagIndex = args.firstIndex(of: "--backup-base-url"),
               args.indices.contains(flagIndex + 1),

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1362,6 +1362,9 @@ struct OnymIOSApp: App {
                 )
             },
             makeDiscoverySettingsFlow: makeDiscoverySettingsFlow,
+            consentedBackupComponentId: {
+                BackupSeat.consentedManifest(consentStore: pinnedConsentStore)?.componentId
+            },
             makeDeviceBackupView: {
                 await BackupSeatComposer(
                     identities: identities,

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -874,7 +874,7 @@ struct OnymIOSApp: App {
             // credential from whoever answered the URL.
             guard
                 let entitlementStore = seatEntitlementStore,
-                let issuerKey = await BackupSeat.entitlementIssuerKey(
+                let issuerKey = BackupSeat.entitlementIssuerKey(
                     componentId: componentId, consentStore: pinnedConsentStore)
             else {
                 return nil

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import OnymSearch
 import OnymChatsUI
+import OnymBackupUI
 import OnymSettings
 import OnymModerationUI
 import OnymDiscovery
@@ -53,6 +54,11 @@ struct RootView: View {
     /// onboarding, `needsReconsent` presents the same surface with the
     /// reason attached, and anything else dismisses it.
     @State private var consentPresentation: ConsentPresentation?
+    /// Resolved once at appear, because building it reads a pinned
+    /// consent record and derives a seat key — neither of which belongs
+    /// in a view body that re-runs on every redraw. `nil` means no
+    /// backup operator is consented to, and the Settings section hides.
+    @State private var deviceBackupView: DeviceBackupSettingsView?
 
     /// `fullScreenCover(item:)` needs identity, and the two consent
     /// gates the root can host are exactly "no mandate yet" and "the
@@ -112,6 +118,9 @@ struct RootView: View {
             consentPresentation = presentationUnlessOnboarding(
                 for: dependencies.moderationGateFlow.gate
             )
+            if let makeDeviceBackupView = dependencies.makeDeviceBackupView {
+                deviceBackupView = await makeDeviceBackupView()
+            }
         }
         .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
             consentPresentation = presentationUnlessOnboarding(for: gate)
@@ -267,7 +276,8 @@ struct RootView: View {
                         makeDiscoverySettingsFlow: dependencies.makeDiscoverySettingsFlow,
                         onRestartOnboarding: dependencies.onboardingRestart.map { restart in
                             { restart.requestRestart() }
-                        }
+                        },
+                        makeDeviceBackupView: deviceBackupView.map { view in { view } }
                     )
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -59,6 +59,10 @@ struct RootView: View {
     /// in a view body that re-runs on every redraw. `nil` means no
     /// backup operator is consented to, and the Settings section hides.
     @State private var deviceBackupView: DeviceBackupSettingsView?
+    /// Guards against two resolutions overlapping — building one reads a
+    /// consent record and derives a seat key, and the later of two
+    /// in-flight resolutions could otherwise land first.
+    @State private var resolvingDeviceBackup = false
 
     /// `fullScreenCover(item:)` needs identity, and the two consent
     /// gates the root can host are exactly "no mandate yet" and "the
@@ -118,9 +122,15 @@ struct RootView: View {
             consentPresentation = presentationUnlessOnboarding(
                 for: dependencies.moderationGateFlow.gate
             )
-            if let makeDeviceBackupView = dependencies.makeDeviceBackupView {
-                deviceBackupView = await makeDeviceBackupView()
-            }
+            await resolveDeviceBackupView()
+        }
+        .onChange(of: selectedTab) { _, tab in
+            // Re-resolved when Settings is opened, not only at launch.
+            // Consenting to a backup operator mid-session otherwise left
+            // the section missing until the next launch, which reads as
+            // the consent not having worked.
+            guard tab == .settings else { return }
+            Task { await resolveDeviceBackupView() }
         }
         .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
             consentPresentation = presentationUnlessOnboarding(for: gate)
@@ -209,6 +219,21 @@ struct RootView: View {
     /// so presenting both would stack two identical obligations. The
     /// gate itself keeps running — its answer is re-read the moment
     /// onboarding completes.
+    /// Builds the backup screen, or leaves it absent.
+    ///
+    /// Absent is an ordinary answer: no consented operator, or an
+    /// identity with no recovery phrase to derive a key from. Both mean
+    /// the Settings section hides rather than offering something that
+    /// cannot produce an openable snapshot.
+    private func resolveDeviceBackupView() async {
+        guard let makeDeviceBackupView = dependencies.makeDeviceBackupView,
+              !resolvingDeviceBackup
+        else { return }
+        resolvingDeviceBackup = true
+        defer { resolvingDeviceBackup = false }
+        deviceBackupView = await makeDeviceBackupView()
+    }
+
     private func presentationUnlessOnboarding(
         for gate: ModerationGateFlow.RootGate
     ) -> ConsentPresentation? {

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -70,6 +70,8 @@ struct RootView: View {
     /// mid-upload. The view is only replaced when the consented operator
     /// actually changed.
     @State private var deviceBackupComponentId: String?
+    /// A resolution asked for while one was in flight.
+    @State private var deviceBackupResolutionPending = false
 
     /// `fullScreenCover(item:)` needs identity, and the two consent
     /// gates the root can host are exactly "no mandate yet" and "the
@@ -137,6 +139,13 @@ struct RootView: View {
             // the section missing until the next launch, which reads as
             // the consent not having worked.
             guard tab == .settings else { return }
+            Task { await resolveDeviceBackupView() }
+        }
+        .onChange(of: consentPresentation) { _, presentation in
+            // Consent can also be given *while already on* Settings, in
+            // which case the tab never changes. Re-resolve when a consent
+            // sheet closes.
+            guard presentation == nil else { return }
             Task { await resolveDeviceBackupView() }
         }
         .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
@@ -233,20 +242,30 @@ struct RootView: View {
     /// the Settings section hides rather than offering something that
     /// cannot produce an openable snapshot.
     private func resolveDeviceBackupView() async {
-        guard let makeDeviceBackupView = dependencies.makeDeviceBackupView,
-              !resolvingDeviceBackup
-        else { return }
-
-        // Nothing to do when the operator has not changed. Rebuilding
-        // here would hand Settings a fresh flow and throw away a backup
-        // that is running.
-        let componentId = dependencies.consentedBackupComponentId?()
-        if deviceBackupView != nil, componentId == deviceBackupComponentId { return }
+        guard let makeDeviceBackupView = dependencies.makeDeviceBackupView else { return }
+        guard !resolvingDeviceBackup else {
+            // Queued, not dropped. A request that arrives mid-resolution
+            // is usually the one that matters — the consent that just
+            // landed — and discarding it leaves the section describing
+            // the operator from before.
+            deviceBackupResolutionPending = true
+            return
+        }
 
         resolvingDeviceBackup = true
         defer { resolvingDeviceBackup = false }
-        deviceBackupView = await makeDeviceBackupView()
-        deviceBackupComponentId = componentId
+
+        repeat {
+            deviceBackupResolutionPending = false
+            // Nothing to do when the operator has not changed. Rebuilding
+            // here would hand Settings a fresh flow and throw away a
+            // backup that is running.
+            let componentId = dependencies.consentedBackupComponentId?()
+            if deviceBackupView == nil || componentId != deviceBackupComponentId {
+                deviceBackupView = await makeDeviceBackupView()
+                deviceBackupComponentId = componentId
+            }
+        } while deviceBackupResolutionPending
     }
 
     private func presentationUnlessOnboarding(

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -63,6 +63,13 @@ struct RootView: View {
     /// consent record and derives a seat key, and the later of two
     /// in-flight resolutions could otherwise land first.
     @State private var resolvingDeviceBackup = false
+    /// Which operator the current backup view was built for.
+    ///
+    /// Re-resolving unconditionally on every visit to Settings rebuilt
+    /// the flow underneath a running backup, discarding its state
+    /// mid-upload. The view is only replaced when the consented operator
+    /// actually changed.
+    @State private var deviceBackupComponentId: String?
 
     /// `fullScreenCover(item:)` needs identity, and the two consent
     /// gates the root can host are exactly "no mandate yet" and "the
@@ -229,9 +236,17 @@ struct RootView: View {
         guard let makeDeviceBackupView = dependencies.makeDeviceBackupView,
               !resolvingDeviceBackup
         else { return }
+
+        // Nothing to do when the operator has not changed. Rebuilding
+        // here would hand Settings a fresh flow and throw away a backup
+        // that is running.
+        let componentId = dependencies.consentedBackupComponentId?()
+        if deviceBackupView != nil, componentId == deviceBackupComponentId { return }
+
         resolvingDeviceBackup = true
         defer { resolvingDeviceBackup = false }
         deviceBackupView = await makeDeviceBackupView()
+        deviceBackupComponentId = componentId
     }
 
     private func presentationUnlessOnboarding(

--- a/Sources/OnymIOS/SeatTransactionObserver.swift
+++ b/Sources/OnymIOS/SeatTransactionObserver.swift
@@ -1,0 +1,86 @@
+import Foundation
+import OnymBilling
+import StoreKit
+
+/// Watches StoreKit for transactions that were never finished.
+///
+/// This is what makes an interrupted purchase recoverable rather than a
+/// charge with nothing to show. `SeatPurchaseFlow` finishes a
+/// transaction only after a credential has been issued, verified and
+/// stored — so a broker outage, a lost network, or a process death
+/// between paying and redeeming leaves the transaction unfinished, and
+/// StoreKit replays it here on the next launch.
+///
+/// Must start **before** any UI. A replay delivered while nothing is
+/// listening is a replay that has to wait for the launch after next.
+@MainActor
+final class SeatTransactionObserver {
+    /// Built per component, not once.
+    ///
+    /// A broker client pins the issuer key it will verify a revocation
+    /// epoch against, and that key comes from the *operator's* signed
+    /// manifest — so there is no such thing as an app-wide broker
+    /// client. Returns `nil` when the component has no consented
+    /// manifest to take an issuer from, in which case the transaction is
+    /// left unfinished rather than redeemed against an unpinned broker.
+    private let makeFlow: @Sendable (String) async -> SeatPurchaseFlow?
+    private let catalog: ChannelOfferCatalog
+    private var task: Task<Void, Never>?
+
+    init(
+        catalog: ChannelOfferCatalog,
+        makeFlow: @escaping @Sendable (String) async -> SeatPurchaseFlow?
+    ) {
+        self.catalog = catalog
+        self.makeFlow = makeFlow
+    }
+
+    func start() {
+        guard task == nil else { return }
+        task = Task { [makeFlow, catalog] in
+            for await update in StoreKit.Transaction.updates {
+                guard case .verified(let transaction) = update else {
+                    // StoreKit could not verify its own signature. The
+                    // broker would refuse it too, and finishing it here
+                    // would tell the store a purchase was delivered
+                    // when nothing was.
+                    continue
+                }
+                guard let offer = catalog.offer(forProductId: transaction.productID) else {
+                    // A product this build does not sell — a leftover
+                    // from a previous catalog, or another app's sandbox
+                    // state. Left unfinished rather than finished: it is
+                    // not ours to close out.
+                    continue
+                }
+                guard let flow = await makeFlow(offer.componentId) else {
+                    // No consented manifest for that component, so no
+                    // issuer key to pin. Redeeming against an unpinned
+                    // broker would accept a credential from whoever
+                    // answered.
+                    continue
+                }
+                do {
+                    _ = try await flow.redeem(
+                        signedTransaction: update.jwsRepresentation,
+                        offerId: offer.offerId,
+                        componentId: offer.componentId
+                    )
+                    await transaction.finish()
+                } catch {
+                    // Deliberately left unfinished. Whatever failed —
+                    // an unreadable credential store on a locked device,
+                    // a broker outage — StoreKit will replay this, and
+                    // finishing now would throw away the person's only
+                    // route to the thing they paid for.
+                    continue
+                }
+            }
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/Tests/OnymIOSTests/BackupAdapterTests.swift
+++ b/Tests/OnymIOSTests/BackupAdapterTests.swift
@@ -159,6 +159,7 @@ final class BackupAdapterTests: XCTestCase {
         XCTAssertFalse(termsId.isEmpty)
 
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = termsId
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: termsId)
@@ -192,6 +193,7 @@ final class BackupAdapterTests: XCTestCase {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let termsId = ScriptedPort.termsId
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = termsId
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: termsId, paymentSatisfied: true, uploadFails: true)
@@ -219,6 +221,7 @@ final class BackupAdapterTests: XCTestCase {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let stalePin = "sha256:" + String(repeating: "e", count: 64)
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = stalePin
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId)
@@ -248,6 +251,7 @@ final class BackupAdapterTests: XCTestCase {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(
@@ -278,6 +282,7 @@ final class BackupAdapterTests: XCTestCase {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let digest = "sha256:" + String(repeating: "7", count: 64)
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         state.pendingOperations = [
             BackupState.PendingOperation(operationId: "lost", digest: digest, sealedByteSize: 2048, startedAt: Date())
@@ -313,6 +318,7 @@ final class BackupAdapterTests: XCTestCase {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         state.pendingOperations = [
             BackupState.PendingOperation(
@@ -411,6 +417,7 @@ final class BackupAdapterTests: XCTestCase {
         let dir = try Self.directory()
         let digest = "sha256:" + String(repeating: "3", count: 64)
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         state.pendingOperations = [
             BackupState.PendingOperation(
@@ -432,6 +439,7 @@ final class BackupAdapterTests: XCTestCase {
     func testFailedQueryLeavesPendingIntact() async throws {
         let dir = try Self.directory()
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         state.pendingOperations = [
             BackupState.PendingOperation(
@@ -450,6 +458,7 @@ final class BackupAdapterTests: XCTestCase {
     func testMismatchedEchoedReferenceIsRefused() async throws {
         let dir = try Self.directory()
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)
@@ -472,6 +481,7 @@ final class BackupAdapterTests: XCTestCase {
     func testPendingPaymentSurvivesRelaunch() async throws {
         let dir = try Self.directory()
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId)
@@ -510,6 +520,7 @@ final class BackupAdapterTests: XCTestCase {
         let dir = try Self.directory()
         let digest = "sha256:" + String(repeating: "6", count: 64)
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         state.pendingOperations = [
             BackupState.PendingOperation(
@@ -551,6 +562,7 @@ final class BackupAdapterTests: XCTestCase {
     func testCorruptAncestorIsRefusedRatherThanBreakingTheChain() async throws {
         let dir = try Self.directory()
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         state.snapshots = [
             BackupState.RecordedSnapshot(
@@ -594,6 +606,7 @@ final class BackupAdapterTests: XCTestCase {
     func testUnreconciledWorkBlocksComposition() async throws {
         let dir = try Self.directory()
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         state.pendingOperations = [
             BackupState.PendingOperation(
@@ -639,6 +652,7 @@ final class BackupAdapterTests: XCTestCase {
     func testResolvedOperationClearsThePendingPurchase() async throws {
         let dir = try Self.directory()
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId)
@@ -679,6 +693,7 @@ final class BackupAdapterTests: XCTestCase {
     func testConcurrentRunsAreSerialized() async throws {
         let dir = try Self.directory()
         var state = BackupState()
+        state.componentId = "onym:component:op"
         state.acceptedTermsId = ScriptedPort.termsId
         let stateStore = MemoryStateStore(state: state)
         let port = ScriptedPort(acceptedTermsId: ScriptedPort.termsId, paymentSatisfied: true)

--- a/Tests/OnymIOSTests/BackupDisclosureTests.swift
+++ b/Tests/OnymIOSTests/BackupDisclosureTests.swift
@@ -287,12 +287,42 @@ final class BackupDisclosureTests: XCTestCase {
             productType: "auto-renewable-subscription",
             operatorShareBps: 7000, frontendCommissionBps: 3000)
 
+        // Both sides of the clash are dropped at construction, so the
+        // lookup cannot attribute a replay to a guess — and no assert
+        // fires mid-replay to crash a debug build.
         let catalog = ChannelOfferCatalog(offers: [shared, clash])
-        XCTAssertEqual(catalog.duplicateProductIds, ["app.onym.backup.monthly"])
+        XCTAssertEqual(catalog.rejectedProductIds, ["app.onym.backup.monthly"])
+        XCTAssertNil(catalog.offer(forProductId: "app.onym.backup.monthly"))
 
         let clean = ChannelOfferCatalog(offers: [shared])
         XCTAssertEqual(clean.offer(forProductId: "app.onym.backup.monthly")?.offerId, "o1")
-        XCTAssertTrue(clean.duplicateProductIds.isEmpty)
+        XCTAssertTrue(clean.rejectedProductIds.isEmpty)
+    }
+
+    /// The gap that made the previous fix unreachable.
+    ///
+    /// `rebind` only runs from enrolment, enrolment was only offered at
+    /// `.off`, and `.off` required no stored terms — so after consenting
+    /// to a new operator the old terms id was still there, the status
+    /// read as enrolled, and every Back Up Now returned `termsChanged`
+    /// with no route back to the consent screen. A protection that only
+    /// runs on first enrolment is not a protection against switching.
+    func testStatesThatNeedEnrolmentOfferIt() {
+        let cases: [(DeviceBackupSettingsFlow.Status, Bool)] = [
+            (.off, true),
+            (.termsChanged, true),
+            (.operatorChanged, true),
+            (.idle(lastSuccessAt: nil), false),
+            (.running, false),
+            (.stale(lastSuccessAt: nil), false),
+            (.checkingEarlierBackup, false),
+            (.paymentRequired(offerIds: []), false),
+        ]
+        for (status, expected) in cases {
+            XCTAssertEqual(
+                DeviceBackupSettingsFlow.needsEnrolment(for: status), expected,
+                "\(status) should\(expected ? "" : " not") offer enrolment")
+        }
     }
 
     // MARK: - Fixtures

--- a/Tests/OnymIOSTests/BackupDisclosureTests.swift
+++ b/Tests/OnymIOSTests/BackupDisclosureTests.swift
@@ -343,41 +343,46 @@ final class BackupDisclosureTests: XCTestCase {
     }
 
     /// A run that finishes after someone re-enrolled must not write its
-    /// stale copy back — that would resurrect the previous operator's
-    /// id and pending work, undoing the rebind silently.
+    /// stale copy back — that would resurrect the previous operator's id
+    /// and pending work, undoing the rebind silently.
+    ///
+    /// The previous version of this test built a repository, never
+    /// called it, and asserted state it had saved itself. It passed
+    /// vacuously and was exactly the test that should have caught
+    /// `backUp` still using raw saves. This one drives `backUp` and has
+    /// the *port* perform the re-enrolment mid-run, which is when it
+    /// really happens: during one of the awaits.
     func testStaleWriteAfterRebindIsRefused() async throws {
         let dir = try Self.seamDirectory()
         var state = BackupState()
-        state.componentId = "onym:component:a"
-        state.acceptedTermsId = ScriptedSeamPort.termsId
-        let store = MemorySeamStore(state: state)
-
-        // The run loads A's state...
-        var inFlight = try store.load()
-        inFlight.pendingOperations = [
+        state.componentId = "onym:component:op"
+        state.acceptedTermsId = RebindingPort.termsId
+        state.pendingOperations = [
             BackupState.PendingOperation(
                 operationId: "a-op", digest: "sha256:" + String(repeating: "1", count: 64),
-                sealedByteSize: 1024, startedAt: Date(), acceptedTermsId: state.acceptedTermsId)
+                sealedByteSize: 1024, startedAt: Date(),
+                acceptedTermsId: RebindingPort.termsId)
         ]
+        let store = MemorySeamStore(state: state)
 
-        // ...and meanwhile the person enrols with B.
-        var rebound = try store.load()
-        rebound.rebind(to: "onym:component:b")
-        try store.save(rebound)
-
-        // The in-flight run's write must not land.
+        // `connect()` rebinds the store to a different operator, standing
+        // in for the person completing enrolment while this run is in
+        // flight.
+        let port = RebindingPort(store: store)
         let repository = BackupRepository(
-            port: ScriptedSeamPort(),
+            port: port,
             composer: BackupComposer(
                 source: EmptySeamSource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
             stateStore: store,
             keyMaterial: BackupKeys.material(
-                seed: Data(repeating: 0x1A, count: 64), componentId: "onym:component:a"))
-        _ = repository
+                seed: Data(repeating: 0x1A, count: 64), componentId: "onym:component:op"))
+
+        _ = try? await repository.backUp()
 
         let after = try store.load()
-        XCTAssertEqual(after.componentId, "onym:component:b")
-        XCTAssertTrue(after.pendingOperations.isEmpty, "A's work survived the rebind")
+        XCTAssertEqual(after.componentId, "onym:component:b", "the rebind was undone")
+        XCTAssertTrue(after.pendingOperations.isEmpty, "operator A's work was resurrected")
+        XCTAssertNil(after.acceptedTermsId, "the new operator's enrolment was overwritten")
     }
 
     /// A pending payment whose sealed bytes are gone buys nothing, and
@@ -387,16 +392,16 @@ final class BackupDisclosureTests: XCTestCase {
         let dir = try Self.seamDirectory()
         var state = BackupState()
         state.componentId = "onym:component:a"
-        state.acceptedTermsId = ScriptedSeamPort.termsId
+        state.acceptedTermsId = RebindingPort.termsId
         state.awaitingPayment = BackupState.PendingPayment(
             operationId: "gone", digest: "sha256:" + String(repeating: "2", count: 64),
             sealedByteSize: 2048, sealedBytesFilename: "pending-gone",
-            acceptedTermsId: ScriptedSeamPort.termsId, supersedesDigest: nil,
+            acceptedTermsId: RebindingPort.termsId, supersedesDigest: nil,
             supersedesByteSize: nil, sealedAt: Date(), refusedAt: Date())
         let store = MemorySeamStore(state: state)
 
         let repository = BackupRepository(
-            port: ScriptedSeamPort(),
+            port: RebindingPort(store: MemorySeamStore(state: BackupState())),
             composer: BackupComposer(
                 source: EmptySeamSource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
             stateStore: store,
@@ -466,9 +471,45 @@ private struct EmptySeamSource: BackupSourceProviding {
     func blobCiphertext(sha256: String) async throws -> BackupBlobAvailability { .gone }
 }
 
-private struct ScriptedSeamPort: BackupPort {
-    static var termsId: String { "sha256:" + String(repeating: "c", count: 64) }
-    func connect() async throws -> BackupConnection { throw BackupError.operatorUnavailable }
+
+/// Performs a re-enrolment during `connect()`, which is where one
+/// really lands: inside one of `backUp`'s awaits.
+private struct RebindingPort: BackupPort {
+    /// The digest the fixture terms actually hash to, so the run's
+    /// terms check passes and it proceeds to a write.
+    static var termsId: String {
+        (try? BackupTerms.decode(raw: BackupDisclosureTests.termsJSON).termsId) ?? ""
+    }
+    let store: any BackupStateStoring
+
+    func connect() async throws -> BackupConnection {
+        var rebound = try store.load()
+        rebound.rebind(to: "onym:component:b")
+        rebound.acceptedTermsId = nil
+        try store.save(rebound)
+
+        // And then *succeed*, reporting the operator the run still
+        // believes it is talking to. This is the whole point: an earlier
+        // version of this port threw here, so `backUp` unwound before it
+        // ever reached a save and the test passed with the bug
+        // reinstated. The run has to get as far as writing.
+        let terms = try BackupTerms.decode(raw: BackupDisclosureTests.termsJSON)
+        return BackupConnection(
+            manifest: try BackupOperatorManifest(
+                manifest: SignedServiceManifest(
+                    raw: BackupDisclosureTests.manifestJSON(termsId: terms.termsId))),
+            profile: BackupImplementationProfile(
+                implementationVersion: 1,
+                implementationProfileId: BackupProfile.implementationProfileId,
+                backupProfileId: BackupProfile.portableProfileId,
+                digestSuite: BackupProfile.digestSuite,
+                sealingSuite: BackupProfile.sealingSuite,
+                incrementModel: BackupProfile.incrementModel,
+                authentication: [BackupProfile.authentication],
+                paymentRefusal: BackupProfile.paymentRefusal),
+            terms: terms)
+    }
+
     func preflight(_ snapshot: SealedSnapshot) async throws -> BackupPreflight {
         throw BackupError.operatorUnavailable
     }
@@ -484,4 +525,41 @@ private struct ScriptedSeamPort: BackupPort {
         BackupExport(directory: directory, snapshots: [], receipts: [])
     }
     func queryOutcome(operationId: String) async throws -> BackupOutcome? { nil }
+}
+
+/// A pending payment sealed under terms that have since been superseded
+/// can never be sent, so the record must go with them.
+extension BackupDisclosureTests {
+    func testPendingPaymentUnderSupersededTermsIsCleared() async throws {
+        let dir = try Self.seamDirectory()
+        let sealed = dir.appending(path: "pending-old")
+        try Data(repeating: 7, count: 32).write(to: sealed)
+
+        var state = BackupState()
+        state.componentId = "onym:component:op"
+        state.acceptedTermsId = "sha256:" + String(repeating: "n", count: 64)
+        state.awaitingPayment = BackupState.PendingPayment(
+            operationId: "old", digest: "sha256:" + String(repeating: "2", count: 64),
+            sealedByteSize: 32, sealedBytesFilename: "pending-old",
+            // Pinned to the *previous* terms.
+            acceptedTermsId: "sha256:" + String(repeating: "o", count: 64),
+            supersedesDigest: nil, supersedesByteSize: nil,
+            sealedAt: Date(), refusedAt: Date())
+        let store = MemorySeamStore(state: state)
+
+        let repository = BackupRepository(
+            port: RebindingPort(store: MemorySeamStore(state: BackupState())),
+            composer: BackupComposer(
+                source: EmptySeamSource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: store,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0x2B, count: 64), componentId: "onym:component:op"))
+
+        let resumable = try await repository.pendingPayment(in: dir)
+        XCTAssertNil(resumable)
+        XCTAssertNil(try store.load().awaitingPayment, "Settings would sit on Payment needed forever")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: sealed.path),
+            "sealed bytes nobody will ever send were kept")
+    }
 }

--- a/Tests/OnymIOSTests/BackupDisclosureTests.swift
+++ b/Tests/OnymIOSTests/BackupDisclosureTests.swift
@@ -325,6 +325,95 @@ final class BackupDisclosureTests: XCTestCase {
         }
     }
 
+    /// State written before the operator was recorded has
+    /// `componentId == nil`, and nothing ever stamped it — so every
+    /// guard added for operator switching silently passed. `nil` is not
+    /// "matches"; it is "cannot tell", and the safe reading of that is
+    /// a switch.
+    func testUnrecordedOperatorIsTreatedAsASwitch() throws {
+        var state = BackupState()
+        state.acceptedTermsId = "sha256:" + String(repeating: "a", count: 64)
+        XCTAssertNil(state.componentId)
+
+        // The rebind that enrolment performs stamps it, and only then
+        // does a matching operator read as unchanged.
+        XCTAssertNil(state.rebind(to: "onym:component:a"))
+        XCTAssertEqual(state.componentId, "onym:component:a")
+        XCTAssertNil(state.rebind(to: "onym:component:a"))
+    }
+
+    /// A run that finishes after someone re-enrolled must not write its
+    /// stale copy back — that would resurrect the previous operator's
+    /// id and pending work, undoing the rebind silently.
+    func testStaleWriteAfterRebindIsRefused() async throws {
+        let dir = try Self.seamDirectory()
+        var state = BackupState()
+        state.componentId = "onym:component:a"
+        state.acceptedTermsId = ScriptedSeamPort.termsId
+        let store = MemorySeamStore(state: state)
+
+        // The run loads A's state...
+        var inFlight = try store.load()
+        inFlight.pendingOperations = [
+            BackupState.PendingOperation(
+                operationId: "a-op", digest: "sha256:" + String(repeating: "1", count: 64),
+                sealedByteSize: 1024, startedAt: Date(), acceptedTermsId: state.acceptedTermsId)
+        ]
+
+        // ...and meanwhile the person enrols with B.
+        var rebound = try store.load()
+        rebound.rebind(to: "onym:component:b")
+        try store.save(rebound)
+
+        // The in-flight run's write must not land.
+        let repository = BackupRepository(
+            port: ScriptedSeamPort(),
+            composer: BackupComposer(
+                source: EmptySeamSource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: store,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0x1A, count: 64), componentId: "onym:component:a"))
+        _ = repository
+
+        let after = try store.load()
+        XCTAssertEqual(after.componentId, "onym:component:b")
+        XCTAssertTrue(after.pendingOperations.isEmpty, "A's work survived the rebind")
+    }
+
+    /// A pending payment whose sealed bytes are gone buys nothing, and
+    /// the record must go with them — otherwise Settings sits on
+    /// "Payment needed" forever, including after later backups succeed.
+    func testPendingPaymentWithMissingBytesIsCleared() async throws {
+        let dir = try Self.seamDirectory()
+        var state = BackupState()
+        state.componentId = "onym:component:a"
+        state.acceptedTermsId = ScriptedSeamPort.termsId
+        state.awaitingPayment = BackupState.PendingPayment(
+            operationId: "gone", digest: "sha256:" + String(repeating: "2", count: 64),
+            sealedByteSize: 2048, sealedBytesFilename: "pending-gone",
+            acceptedTermsId: ScriptedSeamPort.termsId, supersedesDigest: nil,
+            supersedesByteSize: nil, sealedAt: Date(), refusedAt: Date())
+        let store = MemorySeamStore(state: state)
+
+        let repository = BackupRepository(
+            port: ScriptedSeamPort(),
+            composer: BackupComposer(
+                source: EmptySeamSource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+            stateStore: store,
+            keyMaterial: BackupKeys.material(
+                seed: Data(repeating: 0x1B, count: 64), componentId: "onym:component:a"))
+
+        let resumable = try await repository.pendingPayment(in: dir)
+        XCTAssertNil(resumable)
+        XCTAssertNil(try store.load().awaitingPayment, "a purchase that can buy nothing is still owed")
+    }
+
+    static func seamDirectory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
     // MARK: - Fixtures
 
     static func manifestJSON(termsId: String) -> Data {
@@ -358,4 +447,41 @@ final class BackupDisclosureTests: XCTestCase {
        "holderIdentifiers":"P1Y","operationOutcomes":"PT6H",
        "erasureReceipts":"P1Y","entitlementRecords":"P1Y"}}
     """.utf8)
+}
+
+private final class MemorySeamStore: BackupStateStoring, @unchecked Sendable {
+    private var state: BackupState
+    private let lock = NSLock()
+    init(state: BackupState) { self.state = state }
+    func load() throws -> BackupState { lock.withLock { state } }
+    func save(_ state: BackupState) throws { lock.withLock { self.state = state } }
+}
+
+private struct EmptySeamSource: BackupSourceProviding {
+    func identityCount() async -> Int { 0 }
+    func groups() async throws -> [BackupGroupRecord] { [] }
+    func messages(groupID: String, ownerIdentityID: String) async throws -> [BackupMessageRecord] { [] }
+    func invitations() async throws -> [BackupInvitationRecord] { [] }
+    func consents() async throws -> [BackupConsentRecord] { [] }
+    func blobCiphertext(sha256: String) async throws -> BackupBlobAvailability { .gone }
+}
+
+private struct ScriptedSeamPort: BackupPort {
+    static var termsId: String { "sha256:" + String(repeating: "c", count: 64) }
+    func connect() async throws -> BackupConnection { throw BackupError.operatorUnavailable }
+    func preflight(_ snapshot: SealedSnapshot) async throws -> BackupPreflight {
+        throw BackupError.operatorUnavailable
+    }
+    func uploadSnapshot(_ snapshot: SealedSnapshot, grant: BackupUploadGrant) async throws -> BackupOutcome {
+        throw BackupError.operatorUnavailable
+    }
+    func listSnapshots() async throws -> [RetainedSnapshot] { [] }
+    func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws {}
+    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+        throw BackupError.operatorUnavailable
+    }
+    func exportSnapshots(to directory: URL) async throws -> BackupExport {
+        BackupExport(directory: directory, snapshots: [], receipts: [])
+    }
+    func queryOutcome(operationId: String) async throws -> BackupOutcome? { nil }
 }

--- a/Tests/OnymIOSTests/BackupDisclosureTests.swift
+++ b/Tests/OnymIOSTests/BackupDisclosureTests.swift
@@ -3,6 +3,7 @@ import OnymFoundation
 import XCTest
 @testable import OnymBackup
 @testable import OnymBackupUI
+@testable import OnymBilling
 
 /// The consent surface, checked by fixture rather than by review.
 ///
@@ -201,6 +202,97 @@ final class BackupDisclosureTests: XCTestCase {
         XCTAssertEqual(BackupDisclosure.cadence(24 * 3600), "once a day")
         XCTAssertEqual(BackupDisclosure.cadence(72 * 3600), "once every 3 days")
         XCTAssertEqual(BackupDisclosure.cadence(6 * 3600), "once every 6 hours")
+    }
+
+    /// Switching operators must not hand the new one the old one's
+    /// operational state.
+    ///
+    /// The dangerous member is `awaitingPayment`: a snapshot sealed
+    /// under operator A's terms and pinned to A's digest, retried
+    /// against B, is a person paying B to store something that pins
+    /// terms B never published.
+    func testRebindDiscardsThePreviousOperatorsWork() throws {
+        var state = BackupState()
+        state.componentId = "onym:component:a"
+        state.acceptedTermsId = "sha256:" + String(repeating: "a", count: 64)
+        state.lastSuccessAt = Date()
+        state.lastAttemptAt = Date()
+        state.record(
+            reference: try SnapshotReference(
+                digest: "sha256:" + String(repeating: "1", count: 64), sealedByteSize: 1024),
+            acceptedTermsId: state.acceptedTermsId!, at: Date(), status: .retained)
+        state.pendingOperations = [
+            BackupState.PendingOperation(
+                operationId: "a-op", digest: "sha256:" + String(repeating: "2", count: 64),
+                sealedByteSize: 2048, startedAt: Date(), acceptedTermsId: state.acceptedTermsId)
+        ]
+        state.awaitingPayment = BackupState.PendingPayment(
+            operationId: "a-pay", digest: "sha256:" + String(repeating: "3", count: 64),
+            sealedByteSize: 4096, sealedBytesFilename: "pending-a",
+            acceptedTermsId: state.acceptedTermsId!, supersedesDigest: nil,
+            supersedesByteSize: nil, sealedAt: Date(), refusedAt: Date())
+        state.receipts = [Data("receipt from a".utf8)]
+
+        let orphan = state.rebind(to: "onym:component:b")
+
+        XCTAssertEqual(orphan, "pending-a", "the sealed bytes were left to rot in the directory")
+        XCTAssertEqual(state.componentId, "onym:component:b")
+        XCTAssertTrue(state.snapshots.isEmpty)
+        XCTAssertTrue(state.pendingOperations.isEmpty)
+        XCTAssertNil(state.awaitingPayment, "a snapshot sealed under A's terms could be sent to B")
+        XCTAssertNil(state.lastSuccessAt)
+        XCTAssertNil(state.lastAttemptAt)
+
+        // Receipts survive: evidence of something that happened, never
+        // acted on, and the only durable record of what an erasure did
+        // not reach.
+        XCTAssertEqual(state.receipts.count, 1)
+    }
+
+    /// Re-enrolling with the *same* operator is not a switch and must
+    /// not throw away a backup chain.
+    func testRebindToTheSameOperatorKeepsEverything() throws {
+        var state = BackupState()
+        state.componentId = "onym:component:a"
+        state.record(
+            reference: try SnapshotReference(
+                digest: "sha256:" + String(repeating: "1", count: 64), sealedByteSize: 1024),
+            acceptedTermsId: "t", at: Date(), status: .retained)
+
+        XCTAssertNil(state.rebind(to: "onym:component:a"))
+        XCTAssertEqual(state.snapshots.count, 1)
+    }
+
+    /// A first enrolment has no previous operator to discard, but does
+    /// have to record which one it is now.
+    func testRebindFromNoOperatorRecordsIt() {
+        var state = BackupState()
+        XCTAssertNil(state.rebind(to: "onym:component:a"))
+        XCTAssertEqual(state.componentId, "onym:component:a")
+    }
+
+    /// The reverse lookup a replay depends on has no way to choose
+    /// between two components sharing a product, so it refuses — a
+    /// replay we cannot attribute is retried, where crediting the wrong
+    /// operator is not recoverable.
+    func testAmbiguousProductIdIsRefused() {
+        let shared = ChannelOffer(
+            channelOfferId: "sha256:x", componentId: "onym:component:a",
+            offerId: "o1", productId: "app.onym.backup.monthly",
+            productType: "auto-renewable-subscription",
+            operatorShareBps: 7000, frontendCommissionBps: 3000)
+        let clash = ChannelOffer(
+            channelOfferId: "sha256:y", componentId: "onym:component:b",
+            offerId: "o2", productId: "app.onym.backup.monthly",
+            productType: "auto-renewable-subscription",
+            operatorShareBps: 7000, frontendCommissionBps: 3000)
+
+        let catalog = ChannelOfferCatalog(offers: [shared, clash])
+        XCTAssertEqual(catalog.duplicateProductIds, ["app.onym.backup.monthly"])
+
+        let clean = ChannelOfferCatalog(offers: [shared])
+        XCTAssertEqual(clean.offer(forProductId: "app.onym.backup.monthly")?.offerId, "o1")
+        XCTAssertTrue(clean.duplicateProductIds.isEmpty)
     }
 
     // MARK: - Fixtures


### PR DESCRIPTION
Last of the device-backup stack, on top of #279. Everything built over the previous five PRs becomes reachable: Settings shows a Device Backup section when an operator has been consented to, paid offers resolve through StoreKit rather than gating as unavailable, and an interrupted purchase is replayed instead of lost.

### Assembled from what the person actually chose

The operator comes from the **active pinned consent record** for the `storage.backup` seat; its terms and issuer keys come from that operator's signed manifest; the keys come from the identity vault. Nothing here decides anything.

Two ways it resolves to `nil`, both ordinary rather than degraded — and in both the Settings section simply hides:

- no backup operator consented to;
- an identity imported from raw key material, so no recovery phrase to derive a key from. A snapshot sealed under anything else could never be opened, so offering the screen would be offering something false.

The group and message stores are **hoisted out of their repositories** so backup reads through the same ones. Reading through a second store would let a snapshot disagree with the app about what exists.

### `makeEntitlements` finally does something

It returns `StoreKitEntitlementProvider` composed with the free provider rather than the free one alone. The catalog is still empty, so every paid offer still gates as unavailable — but now because **no store product exists**, not because the machinery is missing.

### The replay observer

Starts before any UI: a transaction replayed while nothing is listening waits for the launch *after* next, and the person waiting has already paid.

It leaves a transaction **unfinished on every failure path** — unreadable credential store on a locked device, broker outage, a product this build doesn't sell. Finishing early tells the store a purchase was delivered when it wasn't, and throws away someone's only route back to the thing they bought.

### A design error the previous review half-exposed

Making `issuerKey` required on the broker client (#278) was right — an optional one meant revocation epochs went unverified by default. Wiring it revealed the corollary I'd missed: **there is no such thing as an app-wide broker client**, because the key is pinned per operator from the manifest that operator signed.

So the observer builds a purchase flow *per component*, and skips a replay whose component has no consented manifest rather than redeeming against a broker nobody pinned. That's a better shape than what I'd written, and it came from the fix rather than from noticing it independently.

### Launch arguments

`--backup-base-url` and `--billing-base-url`, https-only in every build, symmetrical with the existing `--enforcement-base-url`. Reach a local deployment through a tunnel rather than relaxing transport security.

### Not here: restore

`IdentityRepository.restore(mnemonic:)` wipes every existing identity. That belongs on the fresh-device onboarding path, not behind a Settings row where a mis-tap costs someone their identities. It's the one remaining piece of the plan.

### Verification

`xcodebuild -scheme OnymIOS` **BUILD SUCCEEDED**. The full test suite is running now; I'll post the result as a comment rather than claim it here.