### PR TITLE
InviteIntroducer: make the shared-link queue first-in-first-out

### DIFF
--- a/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
@@ -122,12 +122,34 @@ public actor InviteIntroducer {
     ) async throws -> IntroCapability {
         let key = owner.rawValue.uuidString + ":"
             + groupId.map { String(format: "%02x", $0) }.joined()
-        // Wait out any predecessor; its failure is not ours to handle.
-        while let running = inFlight[key] {
-            _ = try? await running.value
-            if inFlight[key] == running { inFlight[key] = nil }
+
+        // Chained, not polled. The previous version awaited the running
+        // task *before* installing its own:
+        //
+        //     while let running = inFlight[key] { await running.value; … }
+        //     let task = Task { try await body() }
+        //     inFlight[key] = task
+        //
+        // That `await` is a suspension point with nothing installed
+        // behind it, so arrival order was not preserved — two callers
+        // could both pass the loop and the later arrival could run
+        // first. Concretely: `rotate` and `currentOrMint` racing, with
+        // `currentOrMint` winning, hands a caller the old shared link
+        // and then `rotate` revokes it. The caller walks away with a
+        // link that is already dead, which is the one outcome this
+        // serialization exists to prevent.
+        //
+        // Installing the successor synchronously — before any
+        // suspension — makes the queue first-in-first-out by
+        // construction: whoever entered the actor first is ahead, and
+        // each body waits for exactly the one in front of it.
+        let predecessor = inFlight[key]
+        let task = Task {
+            // A predecessor's failure is not ours to handle; we only
+            // need it finished.
+            _ = try? await predecessor?.value
+            return try await body()
         }
-        let task = Task { try await body() }
         inFlight[key] = task
         defer { if inFlight[key] == task { inFlight[key] = nil } }
         return try await task.value


### PR DESCRIPTION
Fixes the race that #281 surfaced. Should land before it, so the suite is green there.

### The bug

`serializingLink` awaited the running task **before** installing its own:

```swift
while let running = inFlight[key] {
    _ = try? await running.value
    …
}
let task = Task { try await body() }
inFlight[key] = task
```

That `await` is a suspension point with nothing installed behind it, so arrival order wasn't preserved — two callers could both clear the loop, and the later arrival could run first. Installing the successor synchronously (before any suspension) and having each body wait on its predecessor makes the queue FIFO by construction.

**The visible symptom:** `rotate` racing `currentOrMint`, with `currentOrMint` winning — a caller is handed the old shared link, `rotate` revokes it, and they walk away with a link that's already dead. That's the one outcome this serialization exists to prevent.

### How it was found, and how it was verified

Not by reading this file. The existing single-shot test passes on `main` and started failing the moment an unrelated test file in #281 changed the bundle's timing. I traced that to rule out my own changes (removing only the new test file made it pass again), which pointed here.

Verified properly rather than by observing it pass:

```
polling loop reinstated  →  repetition harness FAILS at iteration 30
FIFO chain               →  passes
full unit suite          →  1396 tests, 3 skipped, 0 failures
```

### ⚠️ There is a second, deeper problem, and it is not fixed here

The repetition harness I used to verify this **also fails under full-suite load with the fix applied** — for a different reason, so I've deliberately left it out of the commit rather than ship a red test or weaken an existing assertion.

When `currentOrMint` genuinely arrives first, FIFO faithfully runs it first, it returns the live key, and the rotation queued behind it revokes that key. The caller still ends up holding a dead link. FIFO can't help: the ordering is *correct*, and the outcome is still wrong for the person.

Fixing that means deciding whether **a pending rotation should win regardless of arrival order**. I think it probably should — a user who taps "Generate new link" while a share sheet is opening should get the new link, not a revoked one — but that's a product decision about invite-link revocation in a component I don't own, not a scheduling bug, and it changes what `currentOrMint` promises. Happy to do it as a follow-up if you agree with that reading.

The single-shot test in the suite passes reliably with this fix, so this PR is green; the residual is a narrower race than the one it closes.