### PR TITLE
Back up one history to several operators at once

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
@@ -46,13 +46,19 @@ public actor BackupComposer {
         supersedes: SnapshotReference? = nil,
         now: Date = Date()
     ) async throws -> SealedSnapshot {
+        // Minted before a byte is written, not between the seal and the
+        // return. The refactor had it second, where a failure would
+        // throw *after* `seal` had produced a full-size file — one that
+        // no state record mentions, so nothing claims it and nothing
+        // ever deletes it.
+        let operationId = try Self.newIdentifier()
         let archive = try await composeArchive(now: now)
         // Before the upload, not after: the plaintext is the one
         // artefact here that is readable without the recovery phrase.
         defer { archive.destroy() }
         let prepared = try seal(archive, archiveRoot: keyMaterial.archiveRoot)
         return prepared.addressed(
-            operationId: try Self.newIdentifier(),
+            operationId: operationId,
             acceptedTermsId: acceptedTermsId,
             supersedes: supersedes
         )
@@ -173,12 +179,30 @@ public actor BackupComposer {
     /// Age-guarded because a manual per-operator run can be sealing into
     /// this directory right now, and a sweep is not worth a race with
     /// it.
+    /// Two ages, because two kinds of file are at stake.
+    ///
+    /// `plaintextAge` covers everything readable without the recovery
+    /// phrase: the archive a compose writes, the scratch it builds it
+    /// in, and `restore-<digest>`, which is the *whole history in the
+    /// clear* and is cleaned today only by an in-process `defer` — a
+    /// force-quit or a jetsam during a several-hundred-megabyte restore
+    /// skips it. Keeping that for a day to avoid racing a concurrent
+    /// compose is the wrong trade; an hour is long enough that no live
+    /// run is touching it.
+    ///
+    /// `ciphertextAge` covers sealed bytes, where the cost of being
+    /// early is a re-upload and the cost of being wrong is deleting
+    /// something a purchase is waiting on.
     public func sweepWorkingDirectory(
         claiming claimed: Set<String>,
-        olderThan age: TimeInterval = 24 * 60 * 60,
+        plaintextAge: TimeInterval = 60 * 60,
+        ciphertextAge: TimeInterval = 24 * 60 * 60,
         now: Date = Date()
     ) {
-        let prefixes = ["pending-", "archive-", "scratch-"]
+        // `sealed-` is the restore path's download: ciphertext, so space
+        // only, and it leaks by the same route as `restore-`.
+        let plaintextPrefixes = ["archive-", "scratch-", "restore-"]
+        let ciphertextPrefixes = ["pending-", "sealed-"]
         guard
             let entries = try? FileManager.default.contentsOfDirectory(
                 at: workingDirectory,
@@ -189,7 +213,15 @@ public actor BackupComposer {
         }
         for url in entries {
             let name = url.lastPathComponent
-            guard prefixes.contains(where: name.hasPrefix), !claimed.contains(name) else { continue }
+            guard !claimed.contains(name) else { continue }
+            let age: TimeInterval
+            if plaintextPrefixes.contains(where: name.hasPrefix) {
+                age = plaintextAge
+            } else if ciphertextPrefixes.contains(where: name.hasPrefix) {
+                age = ciphertextAge
+            } else {
+                continue
+            }
             let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
                 .contentModificationDate
             guard let modified, now.timeIntervalSince(modified) > age else { continue }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
@@ -46,22 +46,35 @@ public actor BackupComposer {
         supersedes: SnapshotReference? = nil,
         now: Date = Date()
     ) async throws -> SealedSnapshot {
+        let archive = try await composeArchive(now: now)
+        // Before the upload, not after: the plaintext is the one
+        // artefact here that is readable without the recovery phrase.
+        defer { archive.destroy() }
+        let prepared = try seal(archive, archiveRoot: keyMaterial.archiveRoot)
+        return prepared.addressed(
+            operationId: try Self.newIdentifier(),
+            acceptedTermsId: acceptedTermsId,
+            supersedes: supersedes
+        )
+    }
+
+    /// Read the whole history into one plaintext archive.
+    ///
+    /// The expensive half, and the half that is the same for every
+    /// operator: someone keeping their history with two operators reads
+    /// it once and seals it twice. The caller owns the result and must
+    /// `destroy()` it — including on the failure path, and before the
+    /// first upload rather than after the last.
+    public func composeArchive(now: Date = Date()) async throws -> BackupPlaintextArchive {
         try FileManager.default.createDirectory(
             at: workingDirectory,
             withIntermediateDirectories: true,
             attributes: [.protectionKey: FileProtectionType.complete]
         )
-        let operationId = try SecureRandom.data(16).map { String(format: "%02x", $0) }.joined()
-        let plaintextURL = workingDirectory.appending(path: "archive-\(operationId)")
-        let scratchURL = workingDirectory.appending(path: "scratch-\(operationId)")
-
-        // The plaintext archive is the one artefact on disk that is
-        // readable without the seed, so it is removed the moment the
-        // seal exists — including on the throwing path.
-        defer {
-            try? FileManager.default.removeItem(at: plaintextURL)
-            try? FileManager.default.removeItem(at: scratchURL)
-        }
+        let runId = try Self.newIdentifier()
+        let plaintextURL = workingDirectory.appending(path: "archive-\(runId)")
+        let scratchURL = workingDirectory.appending(path: "scratch-\(runId)")
+        defer { try? FileManager.default.removeItem(at: scratchURL) }
 
         let writer = try BackupArchiveWriter(scratchURL: scratchURL)
         writer.setIdentityCount(await source.identityCount())
@@ -71,37 +84,61 @@ public actor BackupComposer {
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         encoder.dateEncodingStrategy = .iso8601
 
-        let groups = try await source.groups()
-        try writer.append(kind: .groups, bytes: try encoder.encode(groups))
+        do {
+            let groups = try await source.groups()
+            try writer.append(kind: .groups, bytes: try encoder.encode(groups))
 
-        var messages: [BackupMessageRecord] = []
-        for group in groups {
-            messages += try await source.messages(
-                groupID: group.id,
-                ownerIdentityID: group.ownerIdentityID
-            )
-        }
-        try writer.append(kind: .messages, bytes: try encoder.encode(messages))
-
-        try writer.append(kind: .invitations, bytes: try encoder.encode(try await source.invitations()))
-        try writer.append(kind: .consents, bytes: try encoder.encode(try await source.consents()))
-
-        if mediaPolicy == .includeCiphertext {
-            let blobs = try await collectBlobs(from: messages)
-            if !blobs.isEmpty {
-                try writer.append(kind: .blobCiphertext, bytes: try encoder.encode(blobs))
+            var messages: [BackupMessageRecord] = []
+            for group in groups {
+                messages += try await source.messages(
+                    groupID: group.id,
+                    ownerIdentityID: group.ownerIdentityID
+                )
             }
+            try writer.append(kind: .messages, bytes: try encoder.encode(messages))
+
+            try writer.append(kind: .invitations, bytes: try encoder.encode(try await source.invitations()))
+            try writer.append(kind: .consents, bytes: try encoder.encode(try await source.consents()))
+
+            if mediaPolicy == .includeCiphertext {
+                let blobs = try await collectBlobs(from: messages)
+                if !blobs.isEmpty {
+                    try writer.append(kind: .blobCiphertext, bytes: try encoder.encode(blobs))
+                }
+            }
+
+            try writer.finish(writingTo: plaintextURL, createdAt: now)
+        } catch {
+            // A half-written plaintext archive is readable without the
+            // seed. It does not survive the throw.
+            try? FileManager.default.removeItem(at: plaintextURL)
+            throw error
         }
+        return BackupPlaintextArchive(url: plaintextURL, createdAt: now)
+    }
 
-        try writer.finish(writingTo: plaintextURL, createdAt: now)
-
-        let sealedURL = workingDirectory.appending(path: "pending-\(operationId)")
+    /// Seal one archive for one operator.
+    ///
+    /// Called once per operator, and each call mints a fresh snapshot
+    /// salt — so the same history sealed for two operators produces two
+    /// unrelated ciphertexts under two unrelated references. Handing both
+    /// operators the same bytes would be cheaper and would hand a pair of
+    /// colluding operators the link between their two holders.
+    ///
+    /// `archiveRoot` is derived from the seed alone and is therefore the
+    /// same at every operator: the snapshot must be openable by whoever
+    /// holds the recovery phrase, not by whoever stored it.
+    public func seal(
+        _ archive: BackupPlaintextArchive,
+        archiveRoot: SymmetricKey
+    ) throws -> PreparedSnapshot {
+        let sealedURL = workingDirectory.appending(path: "pending-\(try Self.newIdentifier())")
         let reference: SnapshotReference
         do {
             reference = try BackupSealer.seal(
-                plaintextURL: plaintextURL,
+                plaintextURL: archive.url,
                 to: sealedURL,
-                archiveRoot: keyMaterial.archiveRoot
+                archiveRoot: archiveRoot
             )
         } catch {
             // A half-written seal is ciphertext, so it is not a
@@ -111,14 +148,15 @@ public actor BackupComposer {
             try? FileManager.default.removeItem(at: sealedURL)
             throw error
         }
-        return SealedSnapshot(
-            operationId: operationId,
+        return PreparedSnapshot(
             snapshotReference: reference,
             sealedBytesURL: sealedURL,
-            sealedAt: now,
-            acceptedTermsId: acceptedTermsId,
-            supersedes: supersedes
+            sealedAt: archive.createdAt
         )
+    }
+
+    static func newIdentifier() throws -> String {
+        try SecureRandom.data(16).map { String(format: "%02x", $0) }.joined()
     }
 
     /// Fetch the ciphertext behind every attachment the messages

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupComposer.swift
@@ -155,6 +155,48 @@ public actor BackupComposer {
         )
     }
 
+    /// Delete working files nobody will claim.
+    ///
+    /// Written because a comment in `BackupRepository` claimed the
+    /// working directory "is swept on the next run" and nothing ever
+    /// swept it. The claim mattered: a run that ends `unknown` keeps its
+    /// sealed bytes deliberately — the upload may have landed — but
+    /// reconciliation resolves that by asking the operator, never by
+    /// re-reading the file, so nothing ever deleted it. Every unresolved
+    /// run left a full-size snapshot on the device, permanently, once
+    /// per operator.
+    ///
+    /// `claimed` is the filenames that must survive: the sealed bytes of
+    /// snapshots awaiting a purchase, which are the one case where the
+    /// file itself is still needed. Everything else here is scratch.
+    ///
+    /// Age-guarded because a manual per-operator run can be sealing into
+    /// this directory right now, and a sweep is not worth a race with
+    /// it.
+    public func sweepWorkingDirectory(
+        claiming claimed: Set<String>,
+        olderThan age: TimeInterval = 24 * 60 * 60,
+        now: Date = Date()
+    ) {
+        let prefixes = ["pending-", "archive-", "scratch-"]
+        guard
+            let entries = try? FileManager.default.contentsOfDirectory(
+                at: workingDirectory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles])
+        else {
+            return
+        }
+        for url in entries {
+            let name = url.lastPathComponent
+            guard prefixes.contains(where: name.hasPrefix), !claimed.contains(name) else { continue }
+            let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate
+            guard let modified, now.timeIntervalSince(modified) > age else { continue }
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
     static func newIdentifier() throws -> String {
         try SecureRandom.data(16).map { String(format: "%02x", $0) }.joined()
     }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupError.swift
@@ -169,3 +169,76 @@ extension BackupError {
         }
     }
 }
+
+/// Sentences, not enum dumps.
+///
+/// Three surfaces render one of these straight at a person: the backup
+/// status row, the consent screen when terms cannot be fetched, and the
+/// restore screen. `String(describing:)` on this enum produces
+/// `rejected(code: "quota_exceeded", message: Optional("…"))`, which is
+/// a debugger's output shown to somebody trying to find out whether
+/// their history is safe.
+///
+/// `rejected` prefers the operator's own message for the same reason
+/// the rest of this type keeps its code and message rather than
+/// flattening them: an unrecognised refusal's own account of itself
+/// beats a local guess at what it meant.
+extension BackupError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .incompleteSnapshot:
+            return "The backup did not arrive complete."
+        case .retentionExpired:
+            return "The operator no longer holds this backup."
+        case .accessRefused:
+            return "The operator did not accept this device's key."
+        case .operatorUnavailable:
+            return "The operator could not be reached."
+        case .termsUnavailable:
+            return "The operator's terms could not be checked."
+        case .termsChanged:
+            return "The operator published new terms, so nothing is uploaded until you have read them."
+        case .paymentRequired:
+            return "The operator needs a subscription before it will keep a backup."
+        case .invalidReference:
+            return "The operator described a backup this device cannot make sense of."
+        case .invalidEndpoint:
+            return "That operator's address is not one this device will connect to."
+        case .termsRegression(let field):
+            // Named rather than smoothed over: the operator's new terms
+            // are worse than the ones consented to, on this axis.
+            return "The operator's new terms changed \(field) in a way this device will not accept automatically."
+        case .invalidEntitlement:
+            return "The operator did not accept this device's proof of purchase."
+        case .snapshotTooLarge:
+            return "This history is larger than the operator will store in one backup."
+        case .quotaExceeded:
+            return "The operator has no room left for this backup."
+        case .unsupportedProfile:
+            return "This version of Onym does not understand how that operator stores backups."
+        case .exportWithheld:
+            // A conformance violation, and worth saying plainly: export
+            // is unconditional, so an operator refusing it has broken
+            // the terms it published.
+            return "The operator refused to export your backup, which its own terms do not allow."
+        case .erasureUnconfirmed:
+            return "The operator acknowledged the erasure but has not confirmed it finished."
+        case .rejected(let code, let message):
+            if let message, !message.isEmpty { return message }
+            return "The operator refused the request (\(code))."
+        case .localFailure(let reason):
+            switch reason {
+            case .stateUnreadable:
+                return "This device's backup settings could not be read."
+            case .archiveUnreadable:
+                return "The backup could not be read on this device."
+            case .restoreInterrupted:
+                return "The restore stopped partway. Restoring again is safe and will finish the job."
+            case .noRecoveryPhrase:
+                return "This identity has no recovery phrase, so it has no backups."
+            default:
+                return "Something went wrong on this device."
+            }
+        }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupFanOut.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupFanOut.swift
@@ -96,6 +96,15 @@ public actor BackupFanOut {
     ///    last; and
     /// 7. upload, one operator at a time.
     ///
+    /// Step 2 and step 7 both connect and reconcile, so a run costs two
+    /// round trips per operator rather than one. That is deliberate: the
+    /// second is a small request immediately before a multi-hundred-
+    /// megabyte upload, it re-checks the terms pin against what the
+    /// operator is publishing *now* rather than what it published before
+    /// the seal, and the alternative — carrying a `BackupConnection`
+    /// forward from step 2 — makes the upload's precondition a stale
+    /// one.
+    ///
     /// Uploads are sequential rather than concurrent. A snapshot is
     /// routinely hundreds of megabytes and this is a phone: two at once
     /// halves neither's time and doubles the chance both are interrupted.
@@ -119,7 +128,21 @@ public actor BackupFanOut {
             // screen says "not set up", which is the honest word and the
             // one with something to do about it — a row here reading
             // "termsUnavailable" would be neither.
-            guard (try? vendor.stateStore.load())?.acceptedTermsId != nil else { continue }
+            //
+            // An *unreadable* state file is a different thing entirely
+            // and must not take the same exit: a locked device or a
+            // corrupt file would silently drop the operator out of the
+            // run, and a person would read the absence of a row as
+            // nothing being wrong. The store already refuses to return
+            // an empty state for that case; this refuses to invent one.
+            let stored: BackupState
+            do {
+                stored = try vendor.stateStore.load()
+            } catch {
+                outcomes[vendor.componentId] = .failed(message: String(describing: error))
+                continue
+            }
+            guard stored.acceptedTermsId != nil else { continue }
 
             if let settled = await retryPendingPayment(at: vendor, now: now) {
                 outcomes[vendor.componentId] = settled

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupFanOut.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupFanOut.swift
@@ -1,0 +1,239 @@
+import CryptoKit
+import Foundation
+
+/// Keeps one history with several operators at once.
+///
+/// The reason this exists rather than a loop at the call site is that the
+/// expensive half of a backup is shared and the cheap half is not. The
+/// history is read once; the seal, the terms pin, the chain position, the
+/// operation id, the payment and the reconciliation are all per operator
+/// and none of them may be borrowed from a neighbour
+/// (`UI-Backup.md` §14.12: one operator never receives another's
+/// entitlement, token, access proof, or authorization).
+///
+/// What a person gets out of it is the thing a single operator cannot
+/// give them: an operator can shut down, be seized, lose a region, or
+/// decide it no longer wants their business, and none of those is a
+/// reason to lose a history. What it costs them is stated plainly on the
+/// consent surface — a second operator is a second copy, in a second
+/// jurisdiction, extending this history's life for everyone in it a
+/// second time (§14.11), and it is paid for twice.
+///
+/// Operators are independent all the way down. One failing, refusing
+/// payment, publishing new terms, or never having been enrolled does not
+/// stop the others: each returns its own outcome and the caller shows
+/// them side by side.
+public actor BackupFanOut {
+    /// One operator, and the machinery pointed at it.
+    public struct Vendor: Sendable {
+        public let componentId: String
+        /// What to call it on screen.
+        public let displayName: String
+        public let repository: BackupRepository
+        /// This operator's local state, read for status without going
+        /// through the actor.
+        public let stateStore: any BackupStateStoring
+
+        public init(
+            componentId: String,
+            displayName: String,
+            repository: BackupRepository,
+            stateStore: any BackupStateStoring
+        ) {
+            self.componentId = componentId
+            self.displayName = displayName
+            self.repository = repository
+            self.stateStore = stateStore
+        }
+    }
+
+    /// What happened at one operator.
+    public enum VendorResult: Sendable, Equatable {
+        case ran(BackupRepository.RunResult)
+        /// The run threw. Kept as a message rather than an error so a
+        /// result set stays `Sendable` and comparable — and so one
+        /// operator's outage is a row on a screen rather than a thrown
+        /// error that takes the other operators' results with it.
+        case failed(message: String)
+    }
+
+    public struct Outcome: Sendable, Equatable, Identifiable {
+        public let componentId: String
+        public let displayName: String
+        public let result: VendorResult
+        public var id: String { componentId }
+    }
+
+    private let vendors: [Vendor]
+    private let composer: BackupComposer
+    /// The archive key ladder, which is derived from the recovery seed
+    /// alone and is therefore identity-wide rather than per operator: a
+    /// snapshot must be openable by whoever holds the phrase, not by
+    /// whoever stored it. The *access* keys are per operator and live
+    /// inside each repository.
+    private let archiveRoot: SymmetricKey
+
+    public init(vendors: [Vendor], composer: BackupComposer, archiveRoot: SymmetricKey) {
+        self.vendors = vendors
+        self.composer = composer
+        self.archiveRoot = archiveRoot
+    }
+
+    public var componentIds: [String] { vendors.map(\.componentId) }
+
+    /// Back up to every enrolled operator.
+    ///
+    /// The order is the whole design:
+    ///
+    /// 1. retry anything already sealed and refused for payment, byte for
+    ///    byte, at the operator that refused it;
+    /// 2. ask each operator whether a run may proceed at all;
+    /// 3. if nobody can take one, stop — reading a whole history and
+    ///    sealing it for an audience of nobody is expense for nothing;
+    /// 4. read the history once;
+    /// 5. seal it once *per* operator, each with its own fresh salt;
+    /// 6. destroy the plaintext — before the first upload, not after the
+    ///    last; and
+    /// 7. upload, one operator at a time.
+    ///
+    /// Uploads are sequential rather than concurrent. A snapshot is
+    /// routinely hundreds of megabytes and this is a phone: two at once
+    /// halves neither's time and doubles the chance both are interrupted.
+    ///
+    /// The cost of step 5 before step 7 is disk: every operator's sealed
+    /// copy exists at once, so a run needs the snapshot's size times the
+    /// number of operators. That is the deliberate side to pay on. The
+    /// alternative — seal, upload, seal the next — keeps the plaintext
+    /// archive on disk for the length of every transfer, and the
+    /// plaintext is the one artefact here that anybody who reaches the
+    /// container can read. An operator whose seal fails for want of
+    /// space is reported as failed on its own row; the others still
+    /// run.
+    public func backUpAll(now: Date = Date()) async -> [Outcome] {
+        var outcomes: [String: VendorResult] = [:]
+        var candidates: [Vendor] = []
+
+        for vendor in vendors {
+            // An operator that has been consented to but never set up is
+            // not part of this run and is not a failure of it. Its own
+            // screen says "not set up", which is the honest word and the
+            // one with something to do about it — a row here reading
+            // "termsUnavailable" would be neither.
+            guard (try? vendor.stateStore.load())?.acceptedTermsId != nil else { continue }
+
+            if let settled = await retryPendingPayment(at: vendor, now: now) {
+                outcomes[vendor.componentId] = settled
+                continue
+            }
+            do {
+                switch try await vendor.repository.prepare(now: now) {
+                case .ready:
+                    candidates.append(vendor)
+                case .blocked(let result):
+                    outcomes[vendor.componentId] = .ran(result)
+                }
+            } catch {
+                outcomes[vendor.componentId] = .failed(message: String(describing: error))
+            }
+        }
+
+        guard !candidates.isEmpty else { return collate(outcomes) }
+
+        let archive: BackupPlaintextArchive
+        do {
+            archive = try await composer.composeArchive(now: now)
+        } catch {
+            let message = String(describing: error)
+            for vendor in candidates {
+                outcomes[vendor.componentId] = .failed(message: message)
+            }
+            return collate(outcomes)
+        }
+
+        // Seal for everybody first, then destroy the plaintext. Sealing
+        // is local and quick; uploading is neither. Destroying only
+        // after the last upload would leave the one seed-readable
+        // artefact on disk for the length of every transfer.
+        var sealed: [(vendor: Vendor, snapshot: PreparedSnapshot)] = []
+        for vendor in candidates {
+            do {
+                sealed.append((vendor, try await composer.seal(archive, archiveRoot: archiveRoot)))
+            } catch {
+                outcomes[vendor.componentId] = .failed(message: String(describing: error))
+            }
+        }
+        archive.destroy()
+
+        for (vendor, snapshot) in sealed {
+            do {
+                let result = try await vendor.repository.place(prepared: snapshot, now: now)
+                outcomes[vendor.componentId] = .ran(result)
+                switch result {
+                case .paymentRequired, .unknown:
+                    // Still owed something: a purchase to resolve, or an
+                    // operator to say what it did with them.
+                    // `pendingPayment` and the next run's reconciliation
+                    // both need the file where it is.
+                    break
+                case .retained, .alreadyRetained:
+                    // The repository drops the bytes itself on the paths
+                    // where it recorded a retention.
+                    break
+                case .termsChanged, .operatorChanged, .awaitingReconciliation, .alreadyRunning:
+                    // Sealed for an operator that turned out not to be
+                    // able to take it. Ciphertext nobody will claim.
+                    snapshot.discard()
+                }
+            } catch {
+                outcomes[vendor.componentId] = .failed(message: String(describing: error))
+                // Deliberately kept. The upload may have landed and only
+                // the answer been lost; the next run reconciles it, and
+                // deleting the bytes now would leave nothing to retry
+                // if it turns out it did not.
+            }
+        }
+        return collate(outcomes)
+    }
+
+    /// Retry a snapshot one operator refused for payment.
+    ///
+    /// Per operator, byte for byte, and never across operators: those
+    /// bytes are sealed for that operator, pinned to its terms, and owed
+    /// a purchase made in its name. Returns `nil` when there was nothing
+    /// to retry, or when the retry told us this operator needs something
+    /// else first — in which case the ordinary run below decides what.
+    private func retryPendingPayment(at vendor: Vendor, now: Date) async -> VendorResult? {
+        let pending: SealedSnapshot?
+        do {
+            pending = try await vendor.repository.pendingPayment()
+        } catch {
+            return .failed(message: String(describing: error))
+        }
+        guard let pending else { return nil }
+        do {
+            let result = try await vendor.repository.retry(pending, now: now)
+            switch result {
+            case .retained, .alreadyRetained, .paymentRequired, .unknown, .alreadyRunning:
+                return .ran(result)
+            case .termsChanged, .operatorChanged, .awaitingReconciliation:
+                // This snapshot is not sendable, and `pendingPayment`
+                // has already cleared a record it cannot honour. What
+                // this operator needs now is whatever the ordinary run
+                // reports.
+                return nil
+            }
+        } catch {
+            return .failed(message: String(describing: error))
+        }
+    }
+
+    /// One row per operator, in the order they were configured, so a
+    /// screen does not reorder itself between runs.
+    private func collate(_ outcomes: [String: VendorResult]) -> [Outcome] {
+        vendors.compactMap { vendor in
+            outcomes[vendor.componentId].map {
+                Outcome(componentId: vendor.componentId, displayName: vendor.displayName, result: $0)
+            }
+        }
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupFanOut.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupFanOut.swift
@@ -61,10 +61,23 @@ public actor BackupFanOut {
         public let componentId: String
         public let displayName: String
         public let result: VendorResult
+        /// True when this operator's row is the result of resuming a
+        /// snapshot that had been refused for payment, rather than of
+        /// this run's fresh one.
+        ///
+        /// The distinction is not pedantic. A resumed snapshot is as old
+        /// as its contents, and the operator that took it is *not*
+        /// holding what the others just received — so "backed up just
+        /// now", which is what a local success time reads as, would be
+        /// the summary rounding up again.
+        public let resumedPayment: Bool
         public var id: String { componentId }
     }
 
     private let vendors: [Vendor]
+    /// Operators whose row in the current run came from resuming a
+    /// payment rather than from this run's snapshot.
+    private var resumedPayments: Set<String> = []
     private let composer: BackupComposer
     /// The archive key ladder, which is derived from the recovery seed
     /// alone and is therefore identity-wide rather than per operator: a
@@ -121,6 +134,13 @@ public actor BackupFanOut {
     public func backUpAll(now: Date = Date()) async -> [Outcome] {
         var outcomes: [String: VendorResult] = [:]
         var candidates: [Vendor] = []
+        resumedPayments = []
+
+        // Before anything else: collect what earlier runs left. Sealed
+        // bytes from a run that ended `unknown` are never re-read, and
+        // without this they accumulate at full snapshot size, once per
+        // operator, for the life of the install.
+        await composer.sweepWorkingDirectory(claiming: claimedSealedBytes())
 
         for vendor in vendors {
             // An operator that has been consented to but never set up is
@@ -146,6 +166,13 @@ public actor BackupFanOut {
 
             if let settled = await retryPendingPayment(at: vendor, now: now) {
                 outcomes[vendor.componentId] = settled
+                // Resumed, so this operator is out of this run's fresh
+                // compose: it has just been paid for and stored the
+                // older snapshot, and sending the new one on top would
+                // charge for storing the same history twice in one run.
+                // The row says so rather than letting a fresh success
+                // time imply otherwise.
+                resumedPayments.insert(vendor.componentId)
                 continue
             }
             do {
@@ -192,11 +219,17 @@ public actor BackupFanOut {
                 let result = try await vendor.repository.place(prepared: snapshot, now: now)
                 outcomes[vendor.componentId] = .ran(result)
                 switch result {
-                case .paymentRequired, .unknown:
-                    // Still owed something: a purchase to resolve, or an
-                    // operator to say what it did with them.
-                    // `pendingPayment` and the next run's reconciliation
-                    // both need the file where it is.
+                case .paymentRequired:
+                    // Owed a purchase, and `pendingPayment` resumes it
+                    // from this exact file.
+                    break
+                case .unknown:
+                    // Kept, but not because anything reads it back:
+                    // reconciliation asks the operator and never
+                    // re-opens the bytes. They are kept because the
+                    // upload may have landed and deleting them mid-
+                    // flight is worse than keeping them for a day. The
+                    // sweep at the top of the next run collects them.
                     break
                 case .retained, .alreadyRetained:
                     // The repository drops the bytes itself on the paths
@@ -216,6 +249,16 @@ public actor BackupFanOut {
             }
         }
         return collate(outcomes)
+    }
+
+    /// Filenames the sweep must not touch: sealed bytes an operator is
+    /// waiting on a purchase for, which are resumed byte for byte.
+    private func claimedSealedBytes() -> Set<String> {
+        Set(
+            vendors.compactMap {
+                (try? $0.stateStore.load())?.awaitingPayment?.sealedBytesFilename
+            }
+        )
     }
 
     /// Retry a snapshot one operator refused for payment.
@@ -255,7 +298,12 @@ public actor BackupFanOut {
     private func collate(_ outcomes: [String: VendorResult]) -> [Outcome] {
         vendors.compactMap { vendor in
             outcomes[vendor.componentId].map {
-                Outcome(componentId: vendor.componentId, displayName: vendor.displayName, result: $0)
+                Outcome(
+                    componentId: vendor.componentId,
+                    displayName: vendor.displayName,
+                    result: $0,
+                    resumedPayment: resumedPayments.contains(vendor.componentId)
+                )
             }
         }
     }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupFanOut.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupFanOut.swift
@@ -140,7 +140,9 @@ public actor BackupFanOut {
         // bytes from a run that ended `unknown` are never re-read, and
         // without this they accumulate at full snapshot size, once per
         // operator, for the life of the install.
-        await composer.sweepWorkingDirectory(claiming: claimedSealedBytes())
+        if let claimed = claimedSealedBytes() {
+            await composer.sweepWorkingDirectory(claiming: claimed)
+        }
 
         for vendor in vendors {
             // An operator that has been consented to but never set up is
@@ -166,13 +168,15 @@ public actor BackupFanOut {
 
             if let settled = await retryPendingPayment(at: vendor, now: now) {
                 outcomes[vendor.componentId] = settled
-                // Resumed, so this operator is out of this run's fresh
-                // compose: it has just been paid for and stored the
-                // older snapshot, and sending the new one on top would
-                // charge for storing the same history twice in one run.
-                // The row says so rather than letting a fresh success
-                // time imply otherwise.
-                resumedPayments.insert(vendor.componentId)
+                if case .ran(let result) = settled, Self.isRetention(result) {
+                    // Only a retention earns the row that says the paid
+                    // backup went up.
+                    resumedPayments.insert(vendor.componentId)
+                }
+                // Either way this operator is out of this run's fresh
+                // compose: a resumed snapshot has just been paid for and
+                // stored, and sending the new one on top would charge
+                // for storing the same history twice in one run.
                 continue
             }
             do {
@@ -196,6 +200,7 @@ public actor BackupFanOut {
             let message = String(describing: error)
             for vendor in candidates {
                 outcomes[vendor.componentId] = .failed(message: message)
+                await vendor.repository.cancelReservation()
             }
             return collate(outcomes)
         }
@@ -210,6 +215,10 @@ public actor BackupFanOut {
                 sealed.append((vendor, try await composer.seal(archive, archiveRoot: archiveRoot)))
             } catch {
                 outcomes[vendor.componentId] = .failed(message: String(describing: error))
+                // Reserved by `prepare` and never placed. Left set, it
+                // would refuse this operator's every later run as
+                // `alreadyRunning` — a lock held by nobody.
+                await vendor.repository.cancelReservation()
             }
         }
         archive.destroy()
@@ -251,14 +260,39 @@ public actor BackupFanOut {
         return collate(outcomes)
     }
 
+    /// Whether a result means the operator is holding the bytes.
+    ///
+    /// `paymentRequired`, `unknown` and `alreadyRunning` are all
+    /// non-nil answers from the retry path and none of them uploaded
+    /// anything — a row reading "payment needed · the backup you paid
+    /// for went up" says two contradictory things at once, and the
+    /// reassuring half is the false one.
+    private static func isRetention(_ result: BackupRepository.RunResult) -> Bool {
+        switch result {
+        case .retained, .alreadyRetained: true
+        default: false
+        }
+    }
+
     /// Filenames the sweep must not touch: sealed bytes an operator is
     /// waiting on a purchase for, which are resumed byte for byte.
-    private func claimedSealedBytes() -> Set<String> {
-        Set(
-            vendors.compactMap {
-                (try? $0.stateStore.load())?.awaitingPayment?.sealedBytesFilename
+    ///
+    /// Returns `nil` when any operator's state could not be read, which
+    /// cancels the sweep. A `try?` here would read an unreadable state
+    /// as "claims nothing" and hand the sweep permission to delete the
+    /// one file a purchase already made is waiting for — deleting data
+    /// on the strength of a failed read is exactly what the store
+    /// throwing, rather than returning an empty state, exists to
+    /// prevent.
+    private func claimedSealedBytes() -> Set<String>? {
+        var claimed: Set<String> = []
+        for vendor in vendors {
+            guard let state = try? vendor.stateStore.load() else { return nil }
+            if let filename = state.awaitingPayment?.sealedBytesFilename {
+                claimed.insert(filename)
             }
-        )
+        }
+        return claimed
     }
 
     /// Retry a snapshot one operator refused for payment.

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -20,6 +20,19 @@ public actor BackupRepository {
     /// rather than merged.
     private var isRunning = false
 
+    /// Set between `prepare()` saying yes and the `place(prepared:)`
+    /// that answers it.
+    ///
+    /// `isRunning` alone was not enough once a run had two calls. A
+    /// fan-out asks every operator first and only then reads the
+    /// history and seals — minutes, on a large one — and `prepare`'s
+    /// `defer` released the lock immediately, so the whole expensive
+    /// window was unguarded. A person tapping this operator's own Back
+    /// Up Now during it composed a second archive through the same
+    /// composer and uploaded a second snapshot: one action, two
+    /// snapshots, two charges, twice the peak disk.
+    private var isReserved = false
+
     public init(
         port: any BackupPort,
         composer: BackupComposer,
@@ -65,7 +78,7 @@ public actor BackupRepository {
 
     /// Compose a fresh snapshot and try to place it.
     public func backUp(now: Date = Date()) async throws -> RunResult {
-        guard !isRunning else { return .alreadyRunning }
+        guard !isRunning, !isReserved else { return .alreadyRunning }
         isRunning = true
         defer { isRunning = false }
 
@@ -113,7 +126,12 @@ public actor BackupRepository {
     public func place(prepared: PreparedSnapshot, now: Date = Date()) async throws -> RunResult {
         guard !isRunning else { return .alreadyRunning }
         isRunning = true
-        defer { isRunning = false }
+        // The reservation this call answers, released whichever way it
+        // goes.
+        defer {
+            isRunning = false
+            isReserved = false
+        }
 
         var state: BackupState
         let acceptedTermsId: String
@@ -144,7 +162,7 @@ public actor BackupRepository {
     /// somebody can take it. Reconciliation of earlier work happens
     /// here, which is why this is not a pure read.
     public func prepare(now: Date = Date()) async throws -> Readiness {
-        guard !isRunning else { return .blocked(.alreadyRunning) }
+        guard !isRunning, !isReserved else { return .blocked(.alreadyRunning) }
         isRunning = true
         defer { isRunning = false }
 
@@ -159,8 +177,23 @@ public actor BackupRepository {
             // screen would keep reporting a terms change that has
             // already been resolved.
             try commit(state, expecting: state.componentId)
+            // Held until `place(prepared:)` or `cancelReservation()`.
+            // Anything else that would upload is turned away in the
+            // meantime, because the snapshot for this run is already
+            // being made.
+            isReserved = true
             return .ready
         }
+    }
+
+    /// Release a reservation whose snapshot never arrived.
+    ///
+    /// Called for an operator the caller promised to place at and then
+    /// could not — a seal that failed, a run abandoned. Without it the
+    /// operator stays reserved and refuses every later run as
+    /// `alreadyRunning`, which is a lock nobody holds.
+    public func cancelReservation() {
+        isReserved = false
     }
 
     private enum Preconditions {
@@ -215,6 +248,20 @@ public actor BackupRepository {
             return .blocked(mismatch)
         }
 
+        // The refusal is disproved the moment the operator and the terms
+        // check out, so it is cleared *here* — before the
+        // reconciliation return below, which used to skip the clear
+        // entirely, and committed immediately rather than left for a
+        // caller. `backUp` does not commit until after composing, so a
+        // compose that throws would otherwise leave a refusal on file
+        // that this call had just shown to be false: the screen reports
+        // "Terms changed" for good, Back Up Now is hidden, and Restore
+        // goes with it.
+        if state.lastBlockedReason != nil {
+            state.lastBlockedReason = nil
+            try commit(state, expecting: enrolled)
+        }
+
         // Only now: an operation whose result we never learned may well
         // have succeeded, and composing a second snapshot on top of an
         // unresolved first is how a person ends up paying to store the
@@ -234,12 +281,8 @@ public actor BackupRepository {
             return .blocked(.awaitingReconciliation(
                 operationIds: state.pendingOperations.map(\.operationId)))
         }
-        // Cleared by getting past the check that set it: the operator
-        // is the one this state was enrolled with, publishing the terms
-        // it pinned. Every caller commits the state it is handed — see
-        // `prepare`, which commits precisely so a later failure cannot
-        // resurrect a refusal that no longer holds.
-        state.lastBlockedReason = nil
+        // Cleared by getting past the check that set it, and never
+        // carried further than that.
         return .ready(state, acceptedTermsId: acceptedTermsId)
     }
 
@@ -321,7 +364,7 @@ public actor BackupRepository {
     /// and would charge the person for a second copy of the same
     /// history.
     public func retry(_ snapshot: SealedSnapshot, now: Date = Date()) async throws -> RunResult {
-        guard !isRunning else { return .alreadyRunning }
+        guard !isRunning, !isReserved else { return .alreadyRunning }
         isRunning = true
         defer { isRunning = false }
 
@@ -338,6 +381,8 @@ public actor BackupRepository {
         // under. A snapshot left over from earlier terms is not one to
         // send now.
         guard snapshot.acceptedTermsId == state.acceptedTermsId else {
+            state.lastBlockedReason = .termsChanged
+            try commit(state, expecting: state.componentId)
             return .termsChanged(currentTermsId: state.acceptedTermsId)
         }
         return try await place(snapshot, state: &state, now: now)
@@ -432,6 +477,14 @@ public actor BackupRepository {
                 return .paymentRequired(
                     componentId: componentId, offerIds: offerIds, pending: snapshot)
             case .termsChanged(let currentTermsId):
+                // The operator republished between `connect` and here.
+                // Recorded, not merely returned: a refusal that lives
+                // only in a return value is one the next launch cannot
+                // see, and the screen would report a device that last
+                // backed up successfully as On while uploads have
+                // stopped.
+                state.lastBlockedReason = .termsChanged
+                try commit(state, expecting: enrolled)
                 return .termsChanged(currentTermsId: currentTermsId)
             default:
                 throw error

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -55,17 +55,123 @@ public actor BackupRepository {
         case alreadyRunning
     }
 
+    /// Whether a run may proceed at this operator right now.
+    public enum Readiness: Sendable, Equatable {
+        case ready
+        /// The reason nothing may be sent, in the same words a run would
+        /// have returned.
+        case blocked(RunResult)
+    }
+
     /// Compose a fresh snapshot and try to place it.
     public func backUp(now: Date = Date()) async throws -> RunResult {
         guard !isRunning else { return .alreadyRunning }
         isRunning = true
         defer { isRunning = false }
 
+        var state: BackupState
+        let acceptedTermsId: String
+        switch try await evaluatePreconditions(now: now) {
+        case .blocked(let result):
+            return result
+        case .ready(let ready, let terms):
+            state = ready
+            acceptedTermsId = terms
+        }
+        let enrolled = state.componentId
+
+        let snapshot = try await composer.compose(
+            keyMaterial: keyMaterial,
+            acceptedTermsId: acceptedTermsId,
+            supersedes: try supersededReference(in: state),
+            now: now
+        )
+        state.lastAttemptAt = now
+        try commit(state, expecting: enrolled)
+        return try await place(snapshot, state: &state, now: now)
+    }
+
+    /// Place bytes sealed elsewhere in this run at *this* operator.
+    ///
+    /// The seam that lets one person keep the same history with more
+    /// than one operator at once. The history is read once and sealed
+    /// once per operator (`BackupComposer.seal`); everything an operator
+    /// is told is stamped here, because none of it is a property of the
+    /// bytes:
+    ///
+    /// - the terms digest **this** device pinned with **this** operator,
+    ///   never another's;
+    /// - the position the snapshot takes in **this** operator's chain,
+    ///   which is not the same as another's — one operator may have
+    ///   missed the snapshot the other is superseding; and
+    /// - a fresh operation id, so two operators never reconcile on a
+    ///   shared identifier that would link their two holders.
+    ///
+    /// On a blocked result the sealed bytes are left untouched: the
+    /// caller minted them and is the only one that knows whether another
+    /// operator is still to receive its own copy.
+    public func place(prepared: PreparedSnapshot, now: Date = Date()) async throws -> RunResult {
+        guard !isRunning else { return .alreadyRunning }
+        isRunning = true
+        defer { isRunning = false }
+
+        var state: BackupState
+        let acceptedTermsId: String
+        switch try await evaluatePreconditions(now: now) {
+        case .blocked(let result):
+            return result
+        case .ready(let ready, let terms):
+            state = ready
+            acceptedTermsId = terms
+        }
+        let enrolled = state.componentId
+
+        let snapshot = prepared.addressed(
+            operationId: try BackupComposer.newIdentifier(),
+            acceptedTermsId: acceptedTermsId,
+            supersedes: try supersededReference(in: state)
+        )
+        state.lastAttemptAt = now
+        try commit(state, expecting: enrolled)
+        return try await place(snapshot, state: &state, now: now)
+    }
+
+    /// Ask whether a run may proceed, without composing anything.
+    ///
+    /// Reading a whole history and sealing it is expensive, and a
+    /// snapshot no operator will accept is expense for nothing — so a
+    /// fan-out over several operators asks first and composes only if
+    /// somebody can take it. Reconciliation of earlier work happens
+    /// here, which is why this is not a pure read.
+    public func prepare(now: Date = Date()) async throws -> Readiness {
+        guard !isRunning else { return .blocked(.alreadyRunning) }
+        isRunning = true
+        defer { isRunning = false }
+
+        switch try await evaluatePreconditions(now: now) {
+        case .blocked(let result): return .blocked(result)
+        case .ready: return .ready
+        }
+    }
+
+    private enum Preconditions {
+        case ready(BackupState, acceptedTermsId: String)
+        case blocked(RunResult)
+    }
+
+    /// Everything that must hold before a byte is sent, in order.
+    ///
+    /// Extracted rather than duplicated: `backUp`, `place(prepared:)` and
+    /// `prepare` must apply the *same* rules, and a second copy of this
+    /// sequence is a second place for one of them to drift — which on
+    /// this path means a snapshot reaching an operator nobody consented
+    /// to.
+    private func evaluatePreconditions(now: Date) async throws -> Preconditions {
         var state = try stateStore.load()
         // Captured before the first suspension. Every write below is
-        // conditional on the enrolment still being this one — `backUp`
-        // awaits `connect`, `reconcile` and `compose`, and a
-        // re-enrolment can land during any of them.
+        // conditional on the enrolment still being this one — this
+        // awaits `connect` and `reconcile`, and a re-enrolment can land
+        // during either.
         let enrolled = state.componentId
 
         guard let acceptedTermsId = state.acceptedTermsId else {
@@ -88,9 +194,8 @@ public actor BackupRepository {
         if let mismatch = try await operatorOrTermsMismatch(state: state, now: now) {
             state.lastAttemptAt = now
             try commit(state, expecting: enrolled)
-            return mismatch
+            return .blocked(mismatch)
         }
-        _ = acceptedTermsId
 
         // Only now: an operation whose result we never learned may well
         // have succeeded, and composing a second snapshot on top of an
@@ -108,31 +213,32 @@ public actor BackupRepository {
         guard state.pendingOperations.isEmpty else {
             state.lastAttemptAt = now
             try commit(state, expecting: enrolled)
-            return .awaitingReconciliation(
-                operationIds: state.pendingOperations.map(\.operationId))
+            return .blocked(.awaitingReconciliation(
+                operationIds: state.pendingOperations.map(\.operationId)))
         }
+        return .ready(state, acceptedTermsId: acceptedTermsId)
+    }
 
-        let snapshot = try await composer.compose(
-            keyMaterial: keyMaterial,
-            acceptedTermsId: acceptedTermsId,
-            supersedes: try state.newestSnapshot.map {
-                // `try?` here would turn an unreadable ancestor into a
-                // snapshot claiming to supersede nothing, quietly
-                // breaking the chain. The store refuses to *read*
-                // corrupt state for the same reason; it should not be
-                // written past here either.
-                do {
-                    return try SnapshotReference(
-                        digest: $0.digest, sealedByteSize: $0.sealedByteSize)
-                } catch {
-                    throw BackupError.localFailure(reason: .stateUnreadable)
-                }
-            },
-            now: now
-        )
-        state.lastAttemptAt = now
-        try commit(state, expecting: enrolled)
-        return try await place(snapshot, state: &state, now: now)
+    /// The snapshot a new one supersedes *at this operator*.
+    ///
+    /// Read from this operator's own chain, never from another's: two
+    /// operators enrolled at different times, or one that missed a run,
+    /// hold different newest snapshots, and pointing one at the other's
+    /// ancestor would describe a chain it never had.
+    private func supersededReference(in state: BackupState) throws -> SnapshotReference? {
+        try state.newestSnapshot.map {
+            // `try?` here would turn an unreadable ancestor into a
+            // snapshot claiming to supersede nothing, quietly breaking
+            // the chain. The store refuses to *read* corrupt state for
+            // the same reason; it should not be written past here
+            // either.
+            do {
+                return try SnapshotReference(
+                    digest: $0.digest, sealedByteSize: $0.sealedByteSize)
+            } catch {
+                throw BackupError.localFailure(reason: .stateUnreadable)
+            }
+        }
     }
 
     /// The snapshot waiting on a purchase, if one survived a relaunch.

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -714,7 +714,10 @@ public actor BackupRepository {
     /// Remove sealed bytes once they are no longer needed.
     ///
     /// Not throwing: failing to delete is not worth failing a completed
-    /// backup over, and the working directory is swept on the next run.
+    /// backup over. What it leaves behind is collected by
+    /// `BackupComposer.sweepWorkingDirectory`, which a fan-out runs
+    /// before it composes — this used to claim a sweep that did not
+    /// exist.
     private func discard(_ snapshot: SealedSnapshot) {
         try? FileManager.default.removeItem(at: snapshot.sealedBytesURL)
     }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -193,6 +193,15 @@ public actor BackupRepository {
         // Fresh consent is a screen, not an inference.
         if let mismatch = try await operatorOrTermsMismatch(state: state, now: now) {
             state.lastAttemptAt = now
+            // Written down, not just returned. A caller that forgets to
+            // render the return value is one bug; a device that forgets
+            // it was refused is every subsequent launch reporting a
+            // backup that has not run since.
+            switch mismatch {
+            case .termsChanged: state.lastBlockedReason = .termsChanged
+            case .operatorChanged: state.lastBlockedReason = .operatorChanged
+            default: break
+            }
             try commit(state, expecting: enrolled)
             return .blocked(mismatch)
         }
@@ -216,6 +225,11 @@ public actor BackupRepository {
             return .blocked(.awaitingReconciliation(
                 operationIds: state.pendingOperations.map(\.operationId)))
         }
+        // Cleared only by getting past the check that set it: the
+        // operator is the one this state was enrolled with, publishing
+        // the terms it pinned. The caller commits this along with
+        // whatever the run does next.
+        state.lastBlockedReason = nil
         return .ready(state, acceptedTermsId: acceptedTermsId)
     }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -149,8 +149,17 @@ public actor BackupRepository {
         defer { isRunning = false }
 
         switch try await evaluatePreconditions(now: now) {
-        case .blocked(let result): return .blocked(result)
-        case .ready: return .ready
+        case .blocked(let result):
+            return .blocked(result)
+        case .ready(let state, _):
+            // Committed here, not left to the caller. A fan-out asks
+            // every operator before it composes anything, and if
+            // composing then fails there is no later write — the
+            // refusal this call just disproved would survive, and the
+            // screen would keep reporting a terms change that has
+            // already been resolved.
+            try commit(state, expecting: state.componentId)
+            return .ready
         }
     }
 
@@ -225,10 +234,11 @@ public actor BackupRepository {
             return .blocked(.awaitingReconciliation(
                 operationIds: state.pendingOperations.map(\.operationId)))
         }
-        // Cleared only by getting past the check that set it: the
-        // operator is the one this state was enrolled with, publishing
-        // the terms it pinned. The caller commits this along with
-        // whatever the run does next.
+        // Cleared by getting past the check that set it: the operator
+        // is the one this state was enrolled with, publishing the terms
+        // it pinned. Every caller commits the state it is handed — see
+        // `prepare`, which commits precisely so a later failure cannot
+        // resurrect a refusal that no longer holds.
         state.lastBlockedReason = nil
         return .ready(state, acceptedTermsId: acceptedTermsId)
     }

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupStateStore.swift
@@ -28,6 +28,24 @@ public struct BackupState: Sendable, Equatable, Codable {
     /// survive until the retry resolves.
     public var awaitingPayment: PendingPayment?
     public var receipts: [Data] = []
+    /// Why the last run refused to send, when nothing else here would
+    /// show it.
+    ///
+    /// Terms moving and the operator changing are the two refusals that
+    /// leave no other trace: no pending operation, no sealed bytes, no
+    /// failed upload — the run simply stops. Without a record, the next
+    /// read of this file describes a device that last backed up
+    /// successfully, and a surface built on it says "On" for an operator
+    /// that has not accepted an upload since. It is the same rule as
+    /// `pendingOperations`: an uncertainty that does not survive a
+    /// relaunch is not one the person will ever be told about.
+    public var lastBlockedReason: BlockedReason?
+
+    /// A refusal that has to outlive the run that hit it.
+    public enum BlockedReason: String, Sendable, Equatable, Codable {
+        case termsChanged
+        case operatorChanged
+    }
 
     public struct RecordedSnapshot: Sendable, Equatable, Codable {
         public let digest: String

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupVendorStorage.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupVendorStorage.swift
@@ -81,10 +81,18 @@ public enum BackupVendorStorage {
         }
         let destination = stateURL(componentId: componentId, in: directory)
         guard !FileManager.default.fileExists(atPath: destination.path) else {
-            // Already migrated, and the per-operator file is the live
-            // one. The legacy file is a stale copy; removing it keeps a
-            // second, older answer from ever being read.
-            try? FileManager.default.removeItem(at: legacy)
+            // Both files exist, and nothing here can say which is newer.
+            // It used to delete the legacy one as "a stale copy", which
+            // is a guess — and the wrong one to be confident about,
+            // because that file may hold erasure receipts, an
+            // outstanding operation, or a snapshot awaiting a purchase
+            // already made. Ten lines above, this same function declines
+            // to delete an unattributable legacy file for exactly that
+            // reason.
+            //
+            // So it stays. Nothing reads it once the per-operator file
+            // exists, so it costs a few kilobytes; deleting it can cost
+            // the only record of what an erasure did and did not reach.
             return componentId
         }
         do {

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupVendorStorage.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupVendorStorage.swift
@@ -1,0 +1,94 @@
+import CryptoKit
+import Foundation
+
+/// Where one operator's local backup state lives.
+///
+/// A person may keep the same history with more than one operator at
+/// once, and nothing about those enrolments is shared: each pins its own
+/// terms, holds its own chain, reconciles its own operations and is paid
+/// for separately. Two operators sharing one state file would mean an
+/// enrolment with the second silently discarding the first's chain — the
+/// `rebind` that is correct for *switching* operators is exactly wrong
+/// for *adding* one.
+///
+/// So state is per operator, in its own file, and the operator is part of
+/// the filename rather than a field inside it.
+public enum BackupVendorStorage {
+    /// The single-operator filename, from before more than one was
+    /// possible.
+    public static let legacyStateFilename = "state.json"
+
+    /// `state-<32 hex>.json`.
+    ///
+    /// A digest rather than the componentId itself: a componentId is a
+    /// URN with colons in it, and the set of operators a person keeps
+    /// backups with should not be readable from a directory listing by
+    /// anyone who gets as far as the container.
+    public static func stateFilename(componentId: String) -> String {
+        let digest = SHA256.hash(data: Data(("onym-backup-vendor-v1|" + componentId).utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return "state-\(hex.prefix(32)).json"
+    }
+
+    public static func stateURL(componentId: String, in directory: URL) -> URL {
+        directory.appending(path: stateFilename(componentId: componentId))
+    }
+
+    public static func stateStore(
+        componentId: String,
+        in directory: URL
+    ) -> FileBackupStateStore {
+        FileBackupStateStore(url: stateURL(componentId: componentId, in: directory))
+    }
+
+    /// Move a single-operator install's `state.json` onto the per-operator
+    /// path, once.
+    ///
+    /// Without this, the first launch after this change reads no state for
+    /// the operator a person is already enrolled with: backup would show
+    /// as off, an enrolment screen would appear for something already set
+    /// up, and the next snapshot would supersede nothing — the operator
+    /// would be paid to store a second copy of a history it already holds.
+    ///
+    /// A legacy file whose `componentId` is `nil` is left where it is.
+    /// It was written before the operator was recorded at all, so there is
+    /// no operator to attribute it to; the surfaces already treat that
+    /// state as "cannot tell" and route to enrolment, and inventing an
+    /// attribution here would be the guess those surfaces refuse to make.
+    ///
+    /// Returns the componentId migrated, if any.
+    @discardableResult
+    public static func migrateLegacyState(in directory: URL) -> String? {
+        let legacy = directory.appending(path: legacyStateFilename)
+        guard FileManager.default.fileExists(atPath: legacy.path) else { return nil }
+        guard
+            let data = try? Data(contentsOf: legacy),
+            let state = try? JSONDecoder().decode(BackupState.self, from: data),
+            let componentId = state.componentId
+        else {
+            // Unreadable, or unattributable. Either way: leave it alone.
+            // Deleting it would destroy erasure receipts, which are
+            // evidence of something that happened and are never
+            // reconstructible.
+            return nil
+        }
+        let destination = stateURL(componentId: componentId, in: directory)
+        guard !FileManager.default.fileExists(atPath: destination.path) else {
+            // Already migrated, and the per-operator file is the live
+            // one. The legacy file is a stale copy; removing it keeps a
+            // second, older answer from ever being read.
+            try? FileManager.default.removeItem(at: legacy)
+            return componentId
+        }
+        do {
+            try FileManager.default.moveItem(at: legacy, to: destination)
+        } catch {
+            // A failed move must not read as a migration: returning the
+            // componentId would tell the caller a file exists that does
+            // not, and the enrolment it describes would look lost. The
+            // legacy file stays, and the next launch tries again.
+            return nil
+        }
+        return componentId
+    }
+}

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupVendorStorage.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupVendorStorage.swift
@@ -20,10 +20,17 @@ public enum BackupVendorStorage {
 
     /// `state-<32 hex>.json`.
     ///
-    /// A digest rather than the componentId itself: a componentId is a
-    /// URN with colons in it, and the set of operators a person keeps
-    /// backups with should not be readable from a directory listing by
-    /// anyone who gets as far as the container.
+    /// A digest rather than the componentId itself, because a
+    /// componentId is a URN with colons in it and a filename should not
+    /// have to escape one.
+    ///
+    /// It is obfuscation and not a privacy property: the digest is
+    /// deterministic and unsalted, so anyone who reaches the container
+    /// can confirm enrolment with an operator they can name by hashing
+    /// its componentId. Salting it would mean storing the salt beside
+    /// the files it hides, which buys nothing against the same reader.
+    /// What actually keeps this directory closed is file protection, not
+    /// the filenames.
     public static func stateFilename(componentId: String) -> String {
         let digest = SHA256.hash(data: Data(("onym-backup-vendor-v1|" + componentId).utf8))
         let hex = digest.map { String(format: "%02x", $0) }.joined()

--- a/Packages/OnymBackup/Sources/OnymBackup/PreparedSnapshot.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/PreparedSnapshot.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// The plaintext archive of one run, before it is sealed for anybody.
+///
+/// It exists as its own type because composing it is the expensive half
+/// of a backup — it reads the whole history and fetches every blob —
+/// while sealing is cheap. A person keeping their history with more than
+/// one operator reads their history once and seals it once per operator.
+///
+/// It is also the one artefact in the working directory that is readable
+/// without the recovery phrase, so it is destroyed as soon as the last
+/// seal exists — before any upload starts, not after.
+public struct BackupPlaintextArchive: Sendable {
+    public let url: URL
+    public let createdAt: Date
+
+    init(url: URL, createdAt: Date) {
+        self.url = url
+        self.createdAt = createdAt
+    }
+
+    /// Not throwing, and safe to call twice: this runs on the failure
+    /// path as well, where a second error would replace a real one.
+    public func destroy() {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+/// Sealed bytes addressed to nobody yet.
+///
+/// Every operator gets its own seal, minted with its own fresh salt from
+/// the same plaintext, so two operators hold two unrelated ciphertexts
+/// under two unrelated references. Sending one set of bytes to both would
+/// give colluding operators a digest that links their two holders —
+/// undoing by convenience exactly what per-operator key derivation
+/// (`BackupKeys.signingInfo`) and the profile's prohibition on convergent
+/// keying (`UI-Backup.md` §8.2) exist to prevent.
+///
+/// What is deliberately absent is everything an operator was told: the
+/// terms this device pinned with it, the position the snapshot takes in
+/// *its* chain, and the operation id it reconciles on. Those are stamped
+/// per operator by `BackupRepository.place(prepared:)`, because none of
+/// them is a property of the bytes.
+public struct PreparedSnapshot: Sendable, Equatable {
+    public let snapshotReference: SnapshotReference
+    public let sealedBytesURL: URL
+    public let sealedAt: Date
+
+    public init(snapshotReference: SnapshotReference, sealedBytesURL: URL, sealedAt: Date) {
+        self.snapshotReference = snapshotReference
+        self.sealedBytesURL = sealedBytesURL
+        self.sealedAt = sealedAt
+    }
+
+    /// Address these bytes to one operator.
+    public func addressed(
+        operationId: String,
+        acceptedTermsId: String,
+        supersedes: SnapshotReference?
+    ) -> SealedSnapshot {
+        SealedSnapshot(
+            operationId: operationId,
+            snapshotReference: snapshotReference,
+            sealedBytesURL: sealedBytesURL,
+            sealedAt: sealedAt,
+            acceptedTermsId: acceptedTermsId,
+            supersedes: supersedes
+        )
+    }
+
+    /// Drop bytes no operator will receive.
+    ///
+    /// A seal minted for an operator that then refused its own
+    /// preconditions is ciphertext nobody will claim — not a disclosure,
+    /// but a file the person never sees and would otherwise keep.
+    public func discard() {
+        try? FileManager.default.removeItem(at: sealedBytesURL)
+    }
+}

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupCopy.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupCopy.swift
@@ -1,0 +1,27 @@
+import Foundation
+import OnymBackup
+
+/// Turns anything thrown below this layer into a sentence.
+///
+/// Every screen in this module renders one of these directly — the
+/// backup status row, the consent surface when terms cannot be
+/// fetched, the restore screen — and `String(describing:)` on a
+/// `BackupError` produces `rejected(code: "quota_exceeded", message:
+/// Optional("…"))`. That is a debugger's output shown to somebody
+/// trying to find out whether their history is safe.
+///
+/// The types themselves know how to say it (`BackupError` and
+/// `BillingError` both conform to `LocalizedError`); this is the one
+/// place that asks, so a surface cannot forget to.
+enum BackupCopy {
+    static func describe(_ error: Error) -> String {
+        if let described = (error as? LocalizedError)?.errorDescription { return described }
+        if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
+            return "This phone is not online."
+        }
+        // Deliberately not the error's type name. Someone reading this
+        // has learned nothing either way, and a type name invites them
+        // to think it means something.
+        return "Something went wrong."
+    }
+}

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
@@ -29,6 +29,15 @@ public struct BackupDisclosure: Sendable, Equatable {
     /// promises "automatic" while uploads are foreground-only would be
     /// the easiest lie in the product.
     public let whenBackupsHappen: String
+    /// Present only when this identity already backs up somewhere else.
+    ///
+    /// Adding an operator is not the same decision as choosing one, and
+    /// the surface must not let it read as one: a second operator is a
+    /// second complete copy, in a second jurisdiction, under a second
+    /// company's terms, paid for twice — and it extends the life of
+    /// everyone else's messages a second time (`UI-Backup.md` §14.11).
+    /// A person who thinks they are switching should find out here.
+    public let additionalCopies: String?
     public let operatorName: String
     public let items: [Item]
 
@@ -36,12 +45,14 @@ public struct BackupDisclosure: Sendable, Equatable {
         thirdPartyConsequence: String,
         noResetPath: String,
         whenBackupsHappen: String,
+        additionalCopies: String? = nil,
         operatorName: String,
         items: [Item]
     ) {
         self.thirdPartyConsequence = thirdPartyConsequence
         self.noResetPath = noResetPath
         self.whenBackupsHappen = whenBackupsHappen
+        self.additionalCopies = additionalCopies
         self.operatorName = operatorName
         self.items = items
     }
@@ -53,10 +64,13 @@ public struct BackupDisclosure: Sendable, Equatable {
     /// keeps access logs, or names four sub-processors, has said so in a
     /// signed document, and the surface's job is to repeat it rather
     /// than summarise it into something more comfortable.
+    /// `otherOperators` names the operators this identity is *already*
+    /// enrolled with, so the surface can say what adding one more does.
     public static func from(
         connection: BackupConnection,
         schedule: BackupSchedule,
-        mediaPolicy: BackupMediaPolicy
+        mediaPolicy: BackupMediaPolicy,
+        otherOperators: [String] = []
     ) -> BackupDisclosure {
         let terms = connection.terms
         var items: [Item] = [
@@ -145,9 +159,23 @@ public struct BackupDisclosure: Sendable, Equatable {
                 and nobody can make one for you.
                 """,
             whenBackupsHappen: Self.scheduleSentence(schedule),
+            additionalCopies: Self.additionalCopiesSentence(otherOperators),
             operatorName: connection.manifest.componentId,
             items: items
         )
+    }
+
+    /// What a second operator actually means, when there already is one.
+    static func additionalCopiesSentence(_ otherOperators: [String]) -> String? {
+        guard !otherOperators.isEmpty else { return nil }
+        let names = otherOperators.joined(separator: ", ")
+        return """
+            You already back up to \(names). Setting this one up does not replace it — it adds a second complete \
+            copy of your history, held by a different company, in a different country, under \
+            different terms, and paid for separately. Everyone in your chats has their \
+            messages kept in one more place. Setting this one up does not turn the other \
+            one off.
+            """
     }
 
     /// Describes the configured interval rather than asserting a day.

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
@@ -205,11 +205,19 @@ public struct BackupDisclosure: Sendable, Equatable {
     ) -> String? {
         guard !otherOperators.isEmpty else { return nil }
         let names = otherOperators.map(\.name).joined(separator: ", ")
+        // Counted, not assumed to be two. With two operators already
+        // enrolled, "a second complete copy" understates the number of
+        // places this history now lives, on the one screen §14.11 exists
+        // to make exact.
+        let existing = otherOperators.count == 1
+            ? "You already back up to \(names)."
+            : "You already back up to \(otherOperators.count) operators: \(names)."
+        let ordinal = otherOperators.count == 1 ? "a second" : "another"
         var sentence = """
-            You already back up to \(names). Setting this one up does not replace it — it adds \
-            a second complete copy of your history, kept under this operator's own terms and \
-            paid for separately. Everyone in your chats has their messages kept in one more \
-            place. Setting this one up does not turn the other one off.
+            \(existing) Setting this one up does not replace them — it adds \(ordinal) complete \
+            copy of your history, kept under this operator's own terms and paid for separately. \
+            Everyone in your chats has their messages kept in one more place. Setting this one \
+            up does not turn the others off.
             """
         if let jurisdiction = Self.jurisdictionSentence(otherOperators, jurisdictions: jurisdictions) {
             sentence += " " + jurisdiction
@@ -217,7 +225,7 @@ public struct BackupDisclosure: Sendable, Equatable {
         return sentence
     }
 
-    /// Where the two copies actually sit, when both sides said so.
+    /// Where the copies actually sit, when both sides said so.
     ///
     /// Silent when either side's terms did not reach us. An unstated
     /// jurisdiction is not evidence of a different one.
@@ -227,22 +235,39 @@ public struct BackupDisclosure: Sendable, Equatable {
     ) -> String? {
         let known = otherOperators.filter { !$0.jurisdictions.isEmpty }
         guard !jurisdictions.isEmpty, !known.isEmpty else { return nil }
-        let mine = Set(jurisdictions)
-        let shared = known.filter { !mine.isDisjoint(with: Set($0.jurisdictions)) }
-        if shared.isEmpty {
+        let mine = Set(jurisdictions.map(Self.normalizedJurisdiction))
+        let shared = known.filter {
+            !mine.isDisjoint(with: Set($0.jurisdictions.map(Self.normalizedJurisdiction)))
+        }
+        guard !shared.isEmpty else {
+            // Stated as two lists, and nothing more. "Stores your backup
+            // somewhere else" would be a reassurance drawn from two
+            // free-text fields that no two operators write the same way
+            // — "Estonia" and "EE" are the same country and different
+            // strings, and the reassuring reading is the one that would
+            // be wrong.
+            let theirs = known
+                .map { "\($0.name) declares \($0.jurisdictions.joined(separator: ", "))" }
+                .joined(separator: "; ")
             return """
-                This one stores in \(jurisdictions.joined(separator: ", ")); \
-                \(known.map(\.name).joined(separator: ", ")) stores your backup somewhere else.
+                This operator declares \(jurisdictions.joined(separator: ", ")); \(theirs). \
+                Whether those are the same place is not something this app can check.
                 """
         }
         let overlap = shared
             .flatMap { $0.jurisdictions }
-            .filter { mine.contains($0) }
+            .filter { mine.contains(Self.normalizedJurisdiction($0)) }
         return """
             Both this operator and \(shared.map(\.name).joined(separator: ", ")) store in \
             \(Array(Set(overlap)).sorted().joined(separator: ", ")), so one authority can reach \
-            both copies.
+            those copies.
             """
+    }
+
+    /// Case- and whitespace-insensitive, which is as far as comparing
+    /// two operators' free text can honestly go.
+    static func normalizedJurisdiction(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
     /// Describes the configured interval rather than asserting a day.

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupDisclosure.swift
@@ -64,13 +64,30 @@ public struct BackupDisclosure: Sendable, Equatable {
     /// keeps access logs, or names four sub-processors, has said so in a
     /// signed document, and the surface's job is to repeat it rather
     /// than summarise it into something more comfortable.
-    /// `otherOperators` names the operators this identity is *already*
-    /// enrolled with, so the surface can say what adding one more does.
+    /// An operator this identity is already enrolled with, as far as
+    /// its *pinned* terms describe it.
+    ///
+    /// Jurisdictions come from the terms bytes the person consented to,
+    /// not from a live fetch and not from a guess. Nothing here knows
+    /// who owns an operator, so nothing here says anything about it.
+    public struct OtherOperator: Sendable, Equatable {
+        public let name: String
+        public let jurisdictions: [String]
+
+        public init(name: String, jurisdictions: [String]) {
+            self.name = name
+            self.jurisdictions = jurisdictions
+        }
+    }
+
+    /// `otherOperators` describes the operators this identity is
+    /// *already* enrolled with, so the surface can say what adding one
+    /// more does.
     public static func from(
         connection: BackupConnection,
         schedule: BackupSchedule,
         mediaPolicy: BackupMediaPolicy,
-        otherOperators: [String] = []
+        otherOperators: [OtherOperator] = []
     ) -> BackupDisclosure {
         let terms = connection.terms
         var items: [Item] = [
@@ -159,22 +176,72 @@ public struct BackupDisclosure: Sendable, Equatable {
                 and nobody can make one for you.
                 """,
             whenBackupsHappen: Self.scheduleSentence(schedule),
-            additionalCopies: Self.additionalCopiesSentence(otherOperators),
+            additionalCopies: Self.additionalCopiesSentence(
+                otherOperators, jurisdictions: terms.jurisdictions),
             operatorName: connection.manifest.componentId,
             items: items
         )
     }
 
     /// What a second operator actually means, when there already is one.
-    static func additionalCopiesSentence(_ otherOperators: [String]) -> String? {
+    ///
+    /// Every clause is checkable against something signed. An earlier
+    /// draft said the new operator was "held by a different company, in
+    /// a different country, under different terms" — of which this knows
+    /// exactly one: the terms are its own, because a terms digest is
+    /// what enrolment pins. Nothing here knows who owns an operator, and
+    /// two operators can perfectly well be in the same country, which
+    /// would have made a consent screen state something false in order
+    /// to sound more reassuring. That is the precise failure §14.11
+    /// exists to prevent.
+    ///
+    /// Jurisdiction is the one part that *is* knowable, from the pinned
+    /// terms on both sides — so it is stated as what it is, including
+    /// when it is the unhelpful answer: two copies under the same
+    /// authorities are two copies one order can reach.
+    static func additionalCopiesSentence(
+        _ otherOperators: [OtherOperator],
+        jurisdictions: [String]
+    ) -> String? {
         guard !otherOperators.isEmpty else { return nil }
-        let names = otherOperators.joined(separator: ", ")
+        let names = otherOperators.map(\.name).joined(separator: ", ")
+        var sentence = """
+            You already back up to \(names). Setting this one up does not replace it — it adds \
+            a second complete copy of your history, kept under this operator's own terms and \
+            paid for separately. Everyone in your chats has their messages kept in one more \
+            place. Setting this one up does not turn the other one off.
+            """
+        if let jurisdiction = Self.jurisdictionSentence(otherOperators, jurisdictions: jurisdictions) {
+            sentence += " " + jurisdiction
+        }
+        return sentence
+    }
+
+    /// Where the two copies actually sit, when both sides said so.
+    ///
+    /// Silent when either side's terms did not reach us. An unstated
+    /// jurisdiction is not evidence of a different one.
+    static func jurisdictionSentence(
+        _ otherOperators: [OtherOperator],
+        jurisdictions: [String]
+    ) -> String? {
+        let known = otherOperators.filter { !$0.jurisdictions.isEmpty }
+        guard !jurisdictions.isEmpty, !known.isEmpty else { return nil }
+        let mine = Set(jurisdictions)
+        let shared = known.filter { !mine.isDisjoint(with: Set($0.jurisdictions)) }
+        if shared.isEmpty {
+            return """
+                This one stores in \(jurisdictions.joined(separator: ", ")); \
+                \(known.map(\.name).joined(separator: ", ")) stores your backup somewhere else.
+                """
+        }
+        let overlap = shared
+            .flatMap { $0.jurisdictions }
+            .filter { mine.contains($0) }
         return """
-            You already back up to \(names). Setting this one up does not replace it — it adds a second complete \
-            copy of your history, held by a different company, in a different country, under \
-            different terms, and paid for separately. Everyone in your chats has their \
-            messages kept in one more place. Setting this one up does not turn the other \
-            one off.
+            Both this operator and \(shared.map(\.name).joined(separator: ", ")) store in \
+            \(Array(Set(overlap)).sorted().joined(separator: ", ")), so one authority can reach \
+            both copies.
             """
     }
 
@@ -189,17 +256,26 @@ public struct BackupDisclosure: Sendable, Equatable {
         return "once an hour"
     }
 
+    /// What this build actually does, which is less than the schedule
+    /// describes.
+    ///
+    /// `BackupSchedule` models an opportunistic run — on Wi-Fi, while
+    /// charging, at most once per interval — and `backUpIfDue` executes
+    /// it, and *nothing calls it*. So the sentence this screen used to
+    /// show ("Onym may also back up on its own while the app is open, on
+    /// Wi-Fi") described a policy rather than a behaviour, on the one
+    /// screen whose entire job is to say what will happen. Someone
+    /// reading it would reasonably never tap the button again.
+    ///
+    /// It says tap-only until something calls `backUpIfDue`. The
+    /// conditions stay in the schedule, where they will be true the day
+    /// they are wired.
     static func scheduleSentence(_ schedule: BackupSchedule) -> String {
-        var conditions: [String] = []
-        if schedule.requiresWiFi { conditions.append("on Wi-Fi") }
-        if schedule.requiresCharging { conditions.append("while charging") }
-        let when = conditions.isEmpty ? "" : " " + conditions.joined(separator: " and ")
-        let cadence = Self.cadence(schedule.minimumInterval)
+        _ = schedule
         return """
-            Backups run when you tap Back Up Now. Onym may also back up on its own while \
-            the app is open\(when), at most \(cadence). It cannot back up in the background, \
-            so if you never open the app, nothing is backed up. Each backup uploads your \
-            whole history, not just what changed.
+            Backups run when you tap Back Up Now, and only then. This version does not back up \
+            on its own — not in the background, and not while the app is open. Each backup \
+            uploads your whole history, not just what changed.
             """
     }
 }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
@@ -90,6 +90,18 @@ public final class BackupEnrolmentFlow {
             stored.acceptedTermsId = connection.acceptedTermsId
             stored.acceptedTermsRaw = connection.terms.rawBytes
             stored.mediaPolicy = mediaPolicy
+            // The refusal this screen exists to resolve. Leaving it set
+            // locks the person in a loop they cannot leave: the status
+            // still reads "Terms changed", which routes straight back to
+            // this screen, and with a single operator the vendors screen
+            // hides Back Up Now — so the run that would have cleared the
+            // reason is not reachable. Accepting terms would appear to
+            // do nothing, permanently.
+            //
+            // Cleared here rather than only by a successful run because
+            // this *is* the resolution: the reason a run refused was
+            // that nobody had read these terms, and somebody just has.
+            stored.lastBlockedReason = nil
             try stateStore.save(stored)
             if let orphaned {
                 // Sealed bytes nobody will claim now. Ciphertext, so not

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
@@ -31,7 +31,7 @@ public final class BackupEnrolmentFlow {
     /// Operators this identity is already enrolled with. Only used to
     /// say what adding another one does — enrolling here changes
     /// nothing about them.
-    private let otherOperators: [String]
+    private let otherOperators: [BackupDisclosure.OtherOperator]
     private var connection: BackupConnection?
 
     public init(
@@ -40,7 +40,7 @@ public final class BackupEnrolmentFlow {
         workingDirectory: URL,
         schedule: BackupSchedule = .default,
         mediaPolicy: BackupMediaPolicy = .descriptorsOnly,
-        otherOperators: [String] = []
+        otherOperators: [BackupDisclosure.OtherOperator] = []
     ) {
         self.port = port
         self.stateStore = stateStore

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
@@ -63,7 +63,7 @@ public final class BackupEnrolmentFlow {
                     otherOperators: otherOperators))
         } catch {
             self.connection = nil
-            state = .unavailable(message: String(describing: error))
+            state = .unavailable(message: BackupCopy.describe(error))
         }
     }
 
@@ -115,7 +115,7 @@ public final class BackupEnrolmentFlow {
             // Not enrolled. Reporting success over a failed write would
             // leave someone believing their history is being backed up
             // when nothing is pinned.
-            state = .unavailable(message: String(describing: error))
+            state = .unavailable(message: BackupCopy.describe(error))
         }
     }
 }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentFlow.swift
@@ -28,6 +28,10 @@ public final class BackupEnrolmentFlow {
     private let schedule: BackupSchedule
     private let mediaPolicy: BackupMediaPolicy
     private let workingDirectory: URL
+    /// Operators this identity is already enrolled with. Only used to
+    /// say what adding another one does — enrolling here changes
+    /// nothing about them.
+    private let otherOperators: [String]
     private var connection: BackupConnection?
 
     public init(
@@ -35,13 +39,15 @@ public final class BackupEnrolmentFlow {
         stateStore: any BackupStateStoring,
         workingDirectory: URL,
         schedule: BackupSchedule = .default,
-        mediaPolicy: BackupMediaPolicy = .descriptorsOnly
+        mediaPolicy: BackupMediaPolicy = .descriptorsOnly,
+        otherOperators: [String] = []
     ) {
         self.port = port
         self.stateStore = stateStore
         self.workingDirectory = workingDirectory
         self.schedule = schedule
         self.mediaPolicy = mediaPolicy
+        self.otherOperators = otherOperators
     }
 
     public func load() async {
@@ -53,7 +59,8 @@ public final class BackupEnrolmentFlow {
                 BackupDisclosure.from(
                     connection: connection,
                     schedule: schedule,
-                    mediaPolicy: mediaPolicy))
+                    mediaPolicy: mediaPolicy,
+                    otherOperators: otherOperators))
         } catch {
             self.connection = nil
             state = .unavailable(message: String(describing: error))

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
@@ -16,14 +16,14 @@ import SwiftUI
 /// operator that keeps access logs or excludes a great deal from
 /// erasure has published that, and this screen repeats it.
 public struct BackupEnrolmentView: View {
-    @State private var flow: BackupEnrolmentFlow
+    private let flow: BackupEnrolmentFlow
     private let onEnrolled: () -> Void
     @Environment(\.dismiss) private var dismiss
 
     @State private var scrolledToEnd = false
 
     public init(flow: BackupEnrolmentFlow, onEnrolled: @escaping () -> Void = {}) {
-        _flow = State(wrappedValue: flow)
+        self.flow = flow
         self.onEnrolled = onEnrolled
     }
 

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
@@ -85,6 +85,16 @@ public struct BackupEnrolmentView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .accessibilityIdentifier("backup.enrolment.operator")
 
+                if let additionalCopies = disclosure.additionalCopies {
+                    // Above the rest, because it changes what the whole
+                    // screen is: not "choose an operator" but "add one".
+                    headline(
+                        "This adds a second copy — it does not move the first",
+                        additionalCopies,
+                        symbol: "square.on.square",
+                        identifier: "backup.enrolment.additional_copies")
+                }
+
                 headline(
                     "This copies other people's messages too",
                     disclosure.thirdPartyConsequence,

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreFlow.swift
@@ -1,31 +1,6 @@
 import Foundation
 import OnymBackup
 
-/// Restoring history from a snapshot.
-///
-/// **This does not restore an identity and does not wipe one.** The two
-/// are separate and it is worth being precise, because conflating them
-/// is how a restore screen becomes dangerous:
-///
-/// - *Identity* restore replaces the keys this device holds, wiping
-///   every existing identity. It lives in onboarding, where nothing is
-///   at stake, and is not reachable from here.
-/// - *History* restore — this — derives its key from the identity the
-///   device already has and writes messages and groups through the app's
-///   own stores. Nothing is replaced, nothing is deleted; a restored row
-///   that already exists is updated in place.
-///
-/// So someone moving to a new phone restores their identity from the
-/// recovery phrase during onboarding, chooses their backup operator, and
-/// then comes here for their history.
-///
-/// It reads from every operator the person keeps backups with, not one.
-/// Each operator sealed its own copy with its own salt, so their
-/// snapshots are separate rows with separate references — a copy is not
-/// interchangeable with another copy on the wire, only in what it
-/// contains. That is the point of keeping two: if one operator cannot be
-/// reached, or its copy will not open, the other's is a different set of
-/// bytes and may well do.
 /// One operator a restore may read from.
 public struct BackupRestoreSource: Sendable {
     public let componentId: String
@@ -59,6 +34,31 @@ public struct RestorableSnapshot: Identifiable, Equatable, Sendable {
     }
 }
 
+/// Restoring history from a snapshot.
+///
+/// **This does not restore an identity and does not wipe one.** The two
+/// are separate and it is worth being precise, because conflating them
+/// is how a restore screen becomes dangerous:
+///
+/// - *Identity* restore replaces the keys this device holds, wiping
+///   every existing identity. It lives in onboarding, where nothing is
+///   at stake, and is not reachable from here.
+/// - *History* restore — this — derives its key from the identity the
+///   device already has and writes messages and groups through the app's
+///   own stores. Nothing is replaced, nothing is deleted; a restored row
+///   that already exists is updated in place.
+///
+/// So someone moving to a new phone restores their identity from the
+/// recovery phrase during onboarding, chooses their backup operator, and
+/// then comes here for their history.
+///
+/// It reads from every operator the person keeps backups with, not one.
+/// Each operator sealed its own copy with its own salt, so their
+/// snapshots are separate rows with separate references — a copy is not
+/// interchangeable with another copy on the wire, only in what it
+/// contains. That is the point of keeping two: if one operator cannot be
+/// reached, or its copy will not open, the other's is a different set of
+/// bytes and may well do.
 @MainActor
 @Observable
 public final class BackupRestoreFlow {

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreFlow.swift
@@ -18,15 +18,56 @@ import OnymBackup
 /// So someone moving to a new phone restores their identity from the
 /// recovery phrase during onboarding, chooses their backup operator, and
 /// then comes here for their history.
+///
+/// It reads from every operator the person keeps backups with, not one.
+/// Each operator sealed its own copy with its own salt, so their
+/// snapshots are separate rows with separate references — a copy is not
+/// interchangeable with another copy on the wire, only in what it
+/// contains. That is the point of keeping two: if one operator cannot be
+/// reached, or its copy will not open, the other's is a different set of
+/// bytes and may well do.
+/// One operator a restore may read from.
+public struct BackupRestoreSource: Sendable {
+    public let componentId: String
+    public let displayName: String
+    public let repository: BackupRepository
+
+    public init(componentId: String, displayName: String, repository: BackupRepository) {
+        self.componentId = componentId
+        self.displayName = displayName
+        self.repository = repository
+    }
+}
+
+/// One snapshot, and which operator is holding it.
+///
+/// The operator is part of the row rather than a filter above the list
+/// because it is part of the choice: these are different bytes in
+/// different jurisdictions, taken at different moments, and which one a
+/// person restores from is a decision only they can make.
+public struct RestorableSnapshot: Identifiable, Equatable, Sendable {
+    public let snapshot: RetainedSnapshot
+    public let componentId: String
+    public let operatorName: String
+
+    public var id: String { componentId + "|" + snapshot.snapshotReference.digest }
+
+    public init(snapshot: RetainedSnapshot, componentId: String, operatorName: String) {
+        self.snapshot = snapshot
+        self.componentId = componentId
+        self.operatorName = operatorName
+    }
+}
+
 @MainActor
 @Observable
 public final class BackupRestoreFlow {
     public enum State: Equatable {
         case loading
-        /// What the operator holds for this holder key. Empty is an
+        /// What the operators hold for this holder key. Empty is an
         /// ordinary answer — a different operator, or a different
         /// identity, has a different holder key and sees nothing.
-        case ready(snapshots: [RetainedSnapshot])
+        case ready(snapshots: [RestorableSnapshot])
         case restoring(SnapshotReference)
         case restored(BackupRestoreSummary)
         /// `partial` is true when writing had already begun, so the
@@ -35,19 +76,23 @@ public final class BackupRestoreFlow {
     }
 
     public private(set) var state: State = .loading
+    /// Operators that could not be listed, by name. Named rather than
+    /// swallowed: a person deciding whether their history is recoverable
+    /// should not be shown a short list that looks complete.
+    public private(set) var unreachableOperators: [String] = []
 
-    private let repository: BackupRepository
+    private let sources: [BackupRestoreSource]
     private let restorer: BackupRestorer
     private let keyMaterial: BackupKeyMaterial
     private let workingDirectory: URL
 
     public init(
-        repository: BackupRepository,
+        sources: [BackupRestoreSource],
         restorer: BackupRestorer,
         keyMaterial: BackupKeyMaterial,
         workingDirectory: URL
     ) {
-        self.repository = repository
+        self.sources = sources
         self.restorer = restorer
         self.keyMaterial = keyMaterial
         self.workingDirectory = workingDirectory
@@ -55,22 +100,52 @@ public final class BackupRestoreFlow {
 
     public func load() async {
         state = .loading
-        do {
-            let snapshots = try await repository.listSnapshots()
-            // Newest first: the one a person almost always wants is the
-            // last one taken, and making them read dates to find it is
-            // work the screen can do.
-            state = .ready(snapshots: snapshots.sorted { $0.retainedAt > $1.retainedAt })
-        } catch {
-            // Listing failed; nothing was written because nothing was
-            // attempted.
-            state = .failed(message: Self.describe(error), partial: false)
+        unreachableOperators = []
+        var rows: [RestorableSnapshot] = []
+        var unreachable: [String] = []
+        for source in sources {
+            do {
+                let snapshots = try await source.repository.listSnapshots()
+                rows += snapshots.map {
+                    RestorableSnapshot(
+                        snapshot: $0,
+                        componentId: source.componentId,
+                        operatorName: source.displayName)
+                }
+            } catch {
+                // One operator being unreachable is not a failed
+                // restore screen — the others may be holding exactly
+                // what this person needs. It is also not nothing, so it
+                // is named.
+                unreachable.append(source.displayName)
+            }
         }
+        unreachableOperators = unreachable
+        if rows.isEmpty, !sources.isEmpty, unreachable.count == sources.count {
+            // Nothing answered. Reporting "no backups" here would tell
+            // someone their history is gone on the evidence of a network
+            // failure.
+            state = .failed(
+                message: "No backup operator could be reached, so what they hold is unknown.",
+                partial: false)
+            return
+        }
+        // Newest first, across operators: the one a person almost always
+        // wants is the last one taken, and making them read dates to find
+        // it is work the screen can do.
+        state = .ready(snapshots: rows.sorted { $0.snapshot.retainedAt > $1.snapshot.retainedAt })
     }
 
-    /// Download, verify, and apply one snapshot.
-    public func restore(_ snapshot: RetainedSnapshot) async {
-        let reference = snapshot.snapshotReference
+    /// Download, verify, and apply one snapshot, from the operator that
+    /// holds it.
+    public func restore(_ row: RestorableSnapshot) async {
+        guard let source = sources.first(where: { $0.componentId == row.componentId }) else {
+            state = .failed(
+                message: "That backup's operator is no longer set up on this device.",
+                partial: false)
+            return
+        }
+        let reference = row.snapshot.snapshotReference
         state = .restoring(reference)
         // `sealed-`, not `restore-`. The restorer decrypts to
         // `restore-<digest>` in this same directory, so the two used to
@@ -83,7 +158,7 @@ public final class BackupRestoreFlow {
         defer { try? FileManager.default.removeItem(at: downloaded) }
 
         do {
-            try await repository.download(reference, to: downloaded)
+            try await source.repository.download(reference, to: downloaded)
             let summary = try await restorer.restore(
                 sealedURL: downloaded,
                 reference: reference,

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreFlow.swift
@@ -113,11 +113,20 @@ public final class BackupRestoreFlow {
                         operatorName: source.displayName)
                 }
             } catch {
-                // One operator being unreachable is not a failed
-                // restore screen — the others may be holding exactly
-                // what this person needs. It is also not nothing, so it
-                // is named.
-                unreachable.append(source.displayName)
+                // Only silence counts as unknown. An operator that
+                // answered — refusing this holder's key, or asking for
+                // payment — has told us it is holding nothing *for us*,
+                // and reporting that as "could not reach" points someone
+                // at an operator that has provably never held a byte of
+                // their history. The restore surface exists to stop that
+                // misreport, not to make it.
+                //
+                // This is the ordinary state of an operator someone
+                // consented to and never set up, which is also every
+                // operator on a phone where restore matters most.
+                if Self.isSilence(error) {
+                    unreachable.append(source.displayName)
+                }
             }
         }
         unreachableOperators = unreachable
@@ -182,6 +191,26 @@ public final class BackupRestoreFlow {
                 partial = false
             }
             state = .failed(message: Self.describe(error), partial: partial)
+        }
+    }
+
+    /// Whether an operator failed to answer, as opposed to answering
+    /// with something we do not like.
+    nonisolated static func isSilence(_ error: Error) -> Bool {
+        guard let error = error as? BackupError else {
+            // Transport failures, timeouts, anything the adapter did not
+            // normalise. The honest word is "unknown".
+            return true
+        }
+        switch error {
+        case .accessRefused, .retentionExpired, .paymentRequired, .rejected:
+            // All of these are answers. Nothing is held for this holder
+            // here, or nothing this device may read — which is the
+            // ordinary state of an operator someone consented to and
+            // never set up.
+            return false
+        default:
+            return true
         }
     }
 

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// Settings → Device Backup → Restore.
 public struct BackupRestoreView: View {
     @State private var flow: BackupRestoreFlow
-    @State private var confirming: RetainedSnapshot?
+    @State private var confirming: RestorableSnapshot?
 
     public init(flow: BackupRestoreFlow) {
         _flow = State(wrappedValue: flow)
@@ -59,9 +59,9 @@ public struct BackupRestoreView: View {
             titleVisibility: .visible
         ) {
             Button("Restore") {
-                if let snapshot = confirming {
+                if let row = confirming {
                     confirming = nil
-                    Task { await flow.restore(snapshot) }
+                    Task { await flow.restore(row) }
                 }
             }
             Button("Cancel", role: .cancel) { confirming = nil }
@@ -79,7 +79,7 @@ public struct BackupRestoreView: View {
             Image(systemName: "tray").font(.largeTitle)
             Text("No backups here")
                 .font(.headline)
-            Text("This operator holds nothing for this identity. If you backed up with a different operator, or under a different identity, choose that one instead.")
+            Text("No operator you have set up holds anything for this identity. If you backed up under a different identity, or with an operator this device has not been set up with, that is where it will be.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -89,18 +89,17 @@ public struct BackupRestoreView: View {
         .accessibilityIdentifier("backup.restore.empty")
     }
 
-    private func list(_ snapshots: [RetainedSnapshot]) -> some View {
+    private func list(_ snapshots: [RestorableSnapshot]) -> some View {
         Group {
             SettingsSectionLabel("BACKUPS")
             SettingsCard {
-                ForEach(Array(snapshots.enumerated()), id: \.element.snapshotReference) {
-                    index, snapshot in
+                ForEach(Array(snapshots.enumerated()), id: \.element.id) { index, row in
                     Button {
-                        confirming = snapshot
+                        confirming = row
                     } label: {
                         SettingsRow(
                             title: index == 0 ? "Most recent" : "Earlier backup",
-                            subtitle: Self.subtitle(for: snapshot),
+                            subtitle: Self.subtitle(for: row),
                             last: index == snapshots.count - 1
                         ) {
                             SettingsIconTile(symbol: "shippingbox", bg: SettingsTile.blue)
@@ -108,11 +107,20 @@ public struct BackupRestoreView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier(
-                        "backup.restore.snapshot.\(snapshot.snapshotReference.digestHex)")
+                        "backup.restore.snapshot.\(row.snapshot.snapshotReference.digestHex)")
                 }
             }
             SettingsFootnote(
                 "Sizes are rounded into buckets, so they do not tell you how much history a backup holds.")
+
+            if !flow.unreachableOperators.isEmpty {
+                // A short list that looks complete is the failure mode
+                // here: someone deciding whether their history is
+                // recoverable must not be shown one operator's silence
+                // as another's answer.
+                SettingsFootnote(
+                    verbatim: "Could not reach \(flow.unreachableOperators.joined(separator: ", ")). Anything held there is not in this list.")
+            }
         }
     }
 
@@ -182,10 +190,13 @@ public struct BackupRestoreView: View {
         return parts.isEmpty ? "Nothing to add — it was all already here." : parts.joined(separator: ", ")
     }
 
-    static func subtitle(for snapshot: RetainedSnapshot) -> String {
-        let date = snapshot.retainedAt.formatted(date: .abbreviated, time: .shortened)
+    /// The operator's name leads, because with more than one set up it
+    /// is the first thing that distinguishes two otherwise identical
+    /// rows — and because restoring is choosing whose copy to trust.
+    static func subtitle(for row: RestorableSnapshot) -> String {
+        let date = row.snapshot.retainedAt.formatted(date: .abbreviated, time: .shortened)
         let size = ByteCountFormatter.string(
-            fromByteCount: Int64(snapshot.snapshotReference.sealedByteSize), countStyle: .file)
-        return "\(date) · about \(size)"
+            fromByteCount: Int64(row.snapshot.snapshotReference.sealedByteSize), countStyle: .file)
+        return "\(row.operatorName) · \(date) · about \(size)"
     }
 }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreView.swift
@@ -27,6 +27,13 @@ public struct BackupRestoreView: View {
                     } else {
                         list(snapshots)
                     }
+                    // Outside both branches on purpose. It used to live
+                    // inside `list`, so an outage that left the list
+                    // empty rendered "no operator holds anything" with
+                    // nothing to say that one of them never answered —
+                    // telling someone their history is gone on the
+                    // evidence of a network failure.
+                    unreachableNote
 
                 case .restoring(let reference):
                     VStack(spacing: 10) {
@@ -74,12 +81,18 @@ public struct BackupRestoreView: View {
     /// operator or a different identity has a different holder key and
     /// sees nothing. Saying so beats leaving someone to conclude their
     /// history is gone.
+    ///
+    /// Unless an operator did not answer, in which case the list is not
+    /// an answer at all and must not be phrased as one.
     private var empty: some View {
         VStack(spacing: 10) {
-            Image(systemName: "tray").font(.largeTitle)
-            Text("No backups here")
+            Image(systemName: flow.unreachableOperators.isEmpty ? "tray" : "wifi.exclamationmark")
+                .font(.largeTitle)
+            Text(flow.unreachableOperators.isEmpty ? "No backups here" : "Nothing found yet")
                 .font(.headline)
-            Text("No operator you have set up holds anything for this identity. If you backed up under a different identity, or with an operator this device has not been set up with, that is where it will be.")
+            Text(flow.unreachableOperators.isEmpty
+                ? "No operator you have set up holds anything for this identity. If you backed up under a different identity, or with an operator this device has not been set up with, that is where it will be."
+                : "The operators that answered hold nothing for this identity. That is not the whole picture — one of them could not be reached, and what it holds is unknown.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -87,6 +100,18 @@ public struct BackupRestoreView: View {
         .frame(maxWidth: .infinity)
         .padding(.top, 40)
         .accessibilityIdentifier("backup.restore.empty")
+    }
+
+    /// Named rather than swallowed: someone deciding whether their
+    /// history is recoverable must not read one operator's silence as
+    /// another's answer.
+    @ViewBuilder
+    private var unreachableNote: some View {
+        if !flow.unreachableOperators.isEmpty {
+            SettingsFootnote(
+                verbatim: "Could not reach \(flow.unreachableOperators.joined(separator: ", ")). Anything held there is not in this list.")
+                .accessibilityIdentifier("backup.restore.unreachable")
+        }
     }
 
     private func list(_ snapshots: [RestorableSnapshot]) -> some View {
@@ -112,15 +137,6 @@ public struct BackupRestoreView: View {
             }
             SettingsFootnote(
                 "Sizes are rounded into buckets, so they do not tell you how much history a backup holds.")
-
-            if !flow.unreachableOperators.isEmpty {
-                // A short list that looks complete is the failure mode
-                // here: someone deciding whether their history is
-                // recoverable must not be shown one operator's silence
-                // as another's answer.
-                SettingsFootnote(
-                    verbatim: "Could not reach \(flow.unreachableOperators.joined(separator: ", ")). Anything held there is not in this list.")
-            }
         }
     }
 

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreView.swift
@@ -4,11 +4,11 @@ import SwiftUI
 
 /// Settings → Device Backup → Restore.
 public struct BackupRestoreView: View {
-    @State private var flow: BackupRestoreFlow
+    private let flow: BackupRestoreFlow
     @State private var confirming: RestorableSnapshot?
 
     public init(flow: BackupRestoreFlow) {
-        _flow = State(wrappedValue: flow)
+        self.flow = flow
     }
 
     public var body: some View {
@@ -92,7 +92,7 @@ public struct BackupRestoreView: View {
                 .font(.headline)
             Text(flow.unreachableOperators.isEmpty
                 ? "No operator you have set up holds anything for this identity. If you backed up under a different identity, or with an operator this device has not been set up with, that is where it will be."
-                : "The operators that answered hold nothing for this identity. That is not the whole picture — one of them could not be reached, and what it holds is unknown.")
+                : "The operators that answered hold nothing for this identity. That is not the whole picture — what the ones below hold is unknown.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -123,7 +123,18 @@ public struct BackupRestoreView: View {
                         confirming = row
                     } label: {
                         SettingsRow(
-                            title: index == 0 ? "Most recent" : "Earlier backup",
+                            // Per operator, not per list. These rows come
+                            // from independent operators now: the newest
+                            // row overall might be one operator's copy
+                            // taken 35 seconds after another's, and — the
+                            // case that matters — an operator's only copy
+                            // reads "Earlier backup" merely because
+                            // somebody else ran later. That is the row a
+                            // person reaches for when the other one will
+                            // not open.
+                            title: Self.isNewestForItsOperator(row, in: snapshots)
+                                ? "Most recent"
+                                : "Earlier backup",
                             subtitle: Self.subtitle(for: row),
                             last: index == snapshots.count - 1
                         ) {
@@ -204,6 +215,18 @@ public struct BackupRestoreView: View {
         if summary.invitations > 0 { parts.append("\(summary.invitations) invitations") }
         if summary.blobs > 0 { parts.append("\(summary.blobs) attachments") }
         return parts.isEmpty ? "Nothing to add — it was all already here." : parts.joined(separator: ", ")
+    }
+
+    /// Whether this row is the newest snapshot *its own operator*
+    /// holds.
+    static func isNewestForItsOperator(
+        _ row: RestorableSnapshot,
+        in rows: [RestorableSnapshot]
+    ) -> Bool {
+        let newest = rows
+            .filter { $0.componentId == row.componentId }
+            .max { $0.snapshot.retainedAt < $1.snapshot.retainedAt }
+        return newest?.id == row.id
     }
 
     /// The operator's name leads, because with more than one set up it

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -120,6 +120,22 @@ public final class DeviceBackupSettingsFlow {
             state.status = .operatorChanged
             return
         }
+        // A refusal recorded by the last run outranks everything below
+        // it, including a pending payment: an operator that has stopped
+        // accepting uploads is not idle however recent its last
+        // success, and a purchase made before the terms moved buys
+        // nothing until somebody has read them. This is the state that
+        // routes to the screen where they can.
+        switch stored.lastBlockedReason {
+        case .termsChanged:
+            state.status = .termsChanged
+            return
+        case .operatorChanged:
+            state.status = .operatorChanged
+            return
+        case nil:
+            break
+        }
         // A snapshot already sealed and refused for payment outranks
         // idle: it is owed a retry, and showing "On" would leave a person
         // who has since paid wondering why nothing happens.
@@ -171,28 +187,56 @@ public final class DeviceBackupSettingsFlow {
                     break
                 }
             }
-            switch try await repository.backUp() {
-            case .retained, .alreadyRetained:
-                refresh()
-            case .paymentRequired(_, let offerIds, _):
-                state.status = .paymentRequired(offerIds: offerIds)
-            case .termsChanged:
-                state.status = .termsChanged
-            case .operatorChanged:
-                state.status = .operatorChanged
-            case .awaitingReconciliation:
-                state.status = .checkingEarlierBackup
-            case .unknown:
-                // Never rendered as success. The bytes may be held; only
-                // the operator can say, and it has not.
-                state.status = .failed(
-                    message: "The result of the last backup is still unknown.")
-            case .alreadyRunning:
+            let result = try await repository.backUp()
+            if case .alreadyRunning = result {
                 state.status = .running
+            } else {
+                apply(result)
             }
         } catch {
             state.status = .failed(message: String(describing: error))
         }
+    }
+
+    /// Take on the result of a run this flow did not make.
+    ///
+    /// A fan-out drives the repositories directly, so its results never
+    /// pass through here — and most of what a run can report is not
+    /// written to local state at all. `termsChanged` and
+    /// `operatorChanged` in particular stop uploads without recording
+    /// anything, so `refresh()` alone reads the state of a device that
+    /// last backed up successfully and says "On". An operator that has
+    /// stopped accepting uploads until somebody re-reads its terms would
+    /// show as healthy until it happened to go stale, with no route to
+    /// the screen that fixes it.
+    ///
+    /// So the run tells the flow what it learned. Only downwards:
+    /// `retained` re-reads state rather than asserting success from a
+    /// return value.
+    public func apply(_ result: BackupRepository.RunResult) {
+        switch result {
+        case .retained, .alreadyRetained:
+            refresh()
+        case .paymentRequired(_, let offerIds, _):
+            state.status = .paymentRequired(offerIds: offerIds)
+        case .termsChanged:
+            state.status = .termsChanged
+        case .operatorChanged:
+            state.status = .operatorChanged
+        case .awaitingReconciliation:
+            state.status = .checkingEarlierBackup
+        case .unknown:
+            // Never rendered as success. The bytes may be held; only the
+            // operator can say, and it has not.
+            state.status = .failed(message: "The result of the last backup is still unknown.")
+        case .alreadyRunning:
+            break
+        }
+    }
+
+    /// Report that a run threw before it could reach a result.
+    public func applyFailure(message: String) {
+        state.status = .failed(message: message)
     }
 
     /// Run only if the schedule permits it — the opportunistic path.

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -74,6 +74,18 @@ public final class DeviceBackupSettingsFlow {
     public let componentId: String
     /// What to call this operator on screen.
     public let displayName: String
+    /// This operator was set up with attachments included, and is no
+    /// longer getting them.
+    ///
+    /// One archive is composed for every operator, so its media policy
+    /// is the strictest any of them was consented under. That is the
+    /// right direction to be wrong in — nobody receives more than they
+    /// were agreed to — but it narrows what an already-enrolled operator
+    /// gets, without anything having changed on its own screen. Silently
+    /// dropping attachments from an operator someone chose *for*
+    /// attachments is the kind of quiet downgrade this seat says it does
+    /// not do.
+    public let attachmentsWithheld: Bool
 
     private let repository: BackupRepository
     private let stateStore: any BackupStateStoring
@@ -88,10 +100,12 @@ public final class DeviceBackupSettingsFlow {
         displayName: String,
         repository: BackupRepository,
         stateStore: any BackupStateStoring,
-        schedule: BackupSchedule = .default
+        schedule: BackupSchedule = .default,
+        attachmentsWithheld: Bool = false
     ) {
         self.componentId = componentId
         self.displayName = displayName
+        self.attachmentsWithheld = attachmentsWithheld
         self.repository = repository
         self.stateStore = stateStore
         self.schedule = schedule

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -65,6 +65,14 @@ public final class DeviceBackupSettingsFlow {
 
     public private(set) var state = State()
 
+    /// A sentence about the last run that state alone cannot say.
+    ///
+    /// Cleared by `refresh()`, so it cannot outlive the run it
+    /// describes: a fan-out failure used to sit in the vendors list
+    /// beside a later, successful per-operator backup, reading
+    /// "backed up today · last run: <last week's error>".
+    public private(set) var lastRunNote: String?
+
     /// The operator this screen is about.
     ///
     /// One flow per operator: a person may keep the same history with
@@ -87,9 +95,17 @@ public final class DeviceBackupSettingsFlow {
     /// not do.
     public let attachmentsWithheld: Bool
 
+    /// What happened the last time someone asked to leave this
+    /// operator, if it did not simply work.
+    public private(set) var stopFailure: String?
+
     private let repository: BackupRepository
     private let stateStore: any BackupStateStoring
     private let schedule: BackupSchedule
+    /// Withdraws consent and forgets this operator. Supplied by the
+    /// composition root, which owns the consent store; `nil` in a build
+    /// that does not offer leaving.
+    private let onStopBackingUp: (@MainActor @Sendable () -> Void)?
     /// Drawn once for this flow's lifetime. Re-drawing per check would
     /// let frequent polling sample until it found a small value, which
     /// is the same as no jitter.
@@ -101,11 +117,13 @@ public final class DeviceBackupSettingsFlow {
         repository: BackupRepository,
         stateStore: any BackupStateStoring,
         schedule: BackupSchedule = .default,
-        attachmentsWithheld: Bool = false
+        attachmentsWithheld: Bool = false,
+        onStopBackingUp: (@MainActor @Sendable () -> Void)? = nil
     ) {
         self.componentId = componentId
         self.displayName = displayName
         self.attachmentsWithheld = attachmentsWithheld
+        self.onStopBackingUp = onStopBackingUp
         self.repository = repository
         self.stateStore = stateStore
         self.schedule = schedule
@@ -113,6 +131,7 @@ public final class DeviceBackupSettingsFlow {
     }
 
     public func refresh() {
+        lastRunNote = nil
         guard let stored = try? stateStore.load() else {
             // An unreadable state file is not "no backup configured".
             // Saying so would invite someone to enrol again on top of
@@ -176,8 +195,20 @@ public final class DeviceBackupSettingsFlow {
     /// An explicit request bypasses the schedule entirely — someone who
     /// taps the button has already decided the upload is worth it, and
     /// second-guessing them about battery would be presumptuous.
+    /// Show this operator as busy while somebody else's run covers it.
+    ///
+    /// A fan-out drives the repositories directly, so without this the
+    /// per-operator screen reads `.idle` for minutes while its snapshot
+    /// is being sealed — and its Back Up Now, whose only guard is that
+    /// status, is tappable.
+    public func markRunning() {
+        state.status = .running
+        lastRunNote = nil
+    }
+
     public func backUpNow() async {
         state.status = .running
+        lastRunNote = nil
         do {
             // A snapshot refused for payment is retried byte for byte
             // before anything new is composed. Composing instead would
@@ -227,10 +258,14 @@ public final class DeviceBackupSettingsFlow {
     /// So the run tells the flow what it learned. Only downwards:
     /// `retained` re-reads state rather than asserting success from a
     /// return value.
-    public func apply(_ result: BackupRepository.RunResult) {
+    public func apply(_ result: BackupRepository.RunResult, resumedPayment: Bool = false) {
         switch result {
         case .retained, .alreadyRetained:
             refresh()
+            if resumedPayment {
+                // It backed up, and not the same thing the others got.
+                lastRunNote = "The backup you paid for went up; the newest changes go next time."
+            }
         case .paymentRequired(_, let offerIds, _):
             state.status = .paymentRequired(offerIds: offerIds)
         case .termsChanged:
@@ -241,8 +276,21 @@ public final class DeviceBackupSettingsFlow {
             state.status = .checkingEarlierBackup
         case .unknown:
             // Never rendered as success. The bytes may be held; only the
-            // operator can say, and it has not.
-            state.status = .failed(message: "The result of the last backup is still unknown.")
+            // operator can say, and it has not — but *how* that is
+            // rendered comes from the state file, which recorded a
+            // pending operation before the upload and therefore reads as
+            // "checking an earlier backup". Overwriting that with
+            // "something went wrong" gave one unchanged state two
+            // different words and two different icons depending on which
+            // screen you were looking at, with the alarming one on the
+            // summary.
+            refresh()
+            if case .idle = state.status {
+                state.status = .failed(message: "The result of the last backup is still unknown.")
+            }
+            if case .stale = state.status {
+                state.status = .failed(message: "The result of the last backup is still unknown.")
+            }
         case .alreadyRunning:
             break
         }
@@ -251,6 +299,7 @@ public final class DeviceBackupSettingsFlow {
     /// Report that a run threw before it could reach a result.
     public func applyFailure(message: String) {
         state.status = .failed(message: message)
+        lastRunNote = message
     }
 
     /// Run only if the schedule permits it — the opportunistic path.
@@ -261,6 +310,60 @@ public final class DeviceBackupSettingsFlow {
 
     public func loadSnapshots() async {
         state.snapshots = (try? await repository.listSnapshots()) ?? []
+    }
+
+    public var canStopBackingUp: Bool { onStopBackingUp != nil }
+
+    /// Stop backing up to this operator.
+    ///
+    /// The route out that did not exist. Consenting to a second operator
+    /// adds one rather than replacing the first — that is the whole
+    /// point of the seat — so without this, every operator a person ever
+    /// chose keeps receiving their history and keeps charging for it,
+    /// and the only way to stop is to delete the app.
+    ///
+    /// `erasingFirst` asks the operator to destroy what it holds and
+    /// keeps the receipt. It is offered rather than assumed: erasure is
+    /// a request to a counterparty that can fail or be refused, and
+    /// someone who wants to stop paying today should not be blocked by
+    /// an operator that will not answer. What is *not* offered is
+    /// pretending: a failed erasure says so and leaves the choice of
+    /// stopping anyway to the person.
+    ///
+    /// Local state goes either way. It describes a relationship that has
+    /// ended — except the receipts, which are evidence of something that
+    /// happened and are the one thing kept.
+    public func stopBackingUp(erasingFirst: Bool) async {
+        stopFailure = nil
+        if erasingFirst {
+            do {
+                state.lastReceipt = try await repository.erase(scope: .all)
+            } catch {
+                // Not stopped, and not erased. Saying so beats reporting
+                // either one as done.
+                stopFailure = """
+                    \(displayName) did not confirm that it erased your backup, so nothing was \
+                    changed. You can try again, or stop without erasing — what it already holds \
+                    stays until its own retention period ends.
+                    """
+                return
+            }
+        }
+        do {
+            var cleared = BackupState()
+            // Receipts survive. They record what an erasure did and did
+            // not reach, they are never acted on, and destroying them
+            // because a relationship ended would discard the only
+            // durable evidence of it.
+            cleared.receipts = ((try? stateStore.load())?.receipts ?? [])
+            try stateStore.save(cleared)
+        } catch {
+            stopFailure = "This device could not update its backup settings, so nothing was changed."
+            return
+        }
+        state.status = .off
+        lastRunNote = nil
+        onStopBackingUp?()
     }
 
     /// Erase, and keep the receipt.

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -65,11 +65,18 @@ public final class DeviceBackupSettingsFlow {
 
     public private(set) var state = State()
 
+    /// The operator this screen is about.
+    ///
+    /// One flow per operator: a person may keep the same history with
+    /// several at once, and each has its own terms pin, its own chain,
+    /// its own payment and its own idea of whether it is up to date.
+    /// Nothing here aggregates — `DeviceBackupVendorsFlow` does that.
+    public let componentId: String
+    /// What to call this operator on screen.
+    public let displayName: String
+
     private let repository: BackupRepository
     private let stateStore: any BackupStateStoring
-    /// The operator consented to *now*, which is not necessarily the one
-    /// this state was enrolled with.
-    private let currentComponentId: @Sendable () -> String?
     private let schedule: BackupSchedule
     /// Drawn once for this flow's lifetime. Re-drawing per check would
     /// let frequent polling sample until it found a small value, which
@@ -77,14 +84,16 @@ public final class DeviceBackupSettingsFlow {
     private let sessionJitter: TimeInterval
 
     public init(
+        componentId: String,
+        displayName: String,
         repository: BackupRepository,
         stateStore: any BackupStateStoring,
-        currentComponentId: @escaping @Sendable () -> String? = { nil },
         schedule: BackupSchedule = .default
     ) {
+        self.componentId = componentId
+        self.displayName = displayName
         self.repository = repository
         self.stateStore = stateStore
-        self.currentComponentId = currentComponentId
         self.schedule = schedule
         self.sessionJitter = schedule.drawJitter()
     }
@@ -101,14 +110,13 @@ public final class DeviceBackupSettingsFlow {
             state.status = .off
             return
         }
-        // The consented operator moved out from under this state. Nothing
-        // recorded here means anything to the new one, so the only honest
-        // next step is enrolment.
-        // Includes state written before the operator was recorded at
-        // all: nil is not "matches", it is "cannot tell", and guessing
-        // in favour of proceeding is how a snapshot reaches the wrong
-        // operator. Re-enrolment is the cost, and it is one screen.
-        if currentComponentId() != stored.componentId {
+        // This state does not belong to the operator this screen is
+        // about. With one state file per operator that means state
+        // written before the operator was recorded at all. `nil` is not
+        // "matches", it is "cannot tell", and guessing in favour of
+        // proceeding is how a snapshot reaches the wrong operator.
+        // Re-enrolment is the cost, and it is one screen.
+        if stored.componentId != componentId {
             state.status = .operatorChanged
             return
         }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -239,7 +239,7 @@ public final class DeviceBackupSettingsFlow {
                 apply(result)
             }
         } catch {
-            state.status = .failed(message: String(describing: error))
+            state.status = .failed(message: BackupCopy.describe(error))
         }
     }
 
@@ -381,7 +381,7 @@ public final class DeviceBackupSettingsFlow {
             // something a person may need long afterwards — a failure
             // here is not a reason to destroy the record of an earlier
             // success.
-            state.status = .failed(message: String(describing: error))
+            state.status = .failed(message: BackupCopy.describe(error))
         }
     }
 }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
@@ -33,6 +33,12 @@ public struct DeviceBackupSettingsView: View {
                 }
                 SettingsFootnote(verbatim: statusFootnote)
 
+                if flow.attachmentsWithheld {
+                    SettingsFootnote(
+                        "You set this operator up with attachments included, but another operator you back up to was not. One backup is made for all of them, so attachments are currently left out of every one — including this operator's.")
+                        .accessibilityIdentifier("backup.attachments_withheld")
+                }
+
                 if flow.needsEnrolment {
                     if let enrolment = makeEnrolment() {
                         SettingsCard {

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
@@ -26,7 +26,14 @@ public struct DeviceBackupSettingsView: View {
             VStack(alignment: .leading, spacing: 16) {
                 SettingsSectionLabel("STATUS")
                 SettingsCard {
-                    SettingsRow(title: statusTitle, subtitle: statusSubtitle, last: true) {
+                    SettingsRow(
+                        title: statusTitle,
+                        subtitle: statusSubtitle,
+                        // A failure message renders here, and one line
+                        // middle-truncates it exactly when it matters.
+                        subtitleLineLimit: 3,
+                        last: true
+                    ) {
                         SettingsIconTile(symbol: statusSymbol, bg: SettingsTile.blue)
                     }
                     .accessibilityIdentifier("backup.status_row")
@@ -191,7 +198,7 @@ public struct DeviceBackupSettingsView: View {
     private var statusFootnote: String {
         switch flow.state.status {
         case .stale:
-            "Backups only run while the app is open. If you have not opened Onym in a while, nothing has been backed up."
+            "Backups run only when you tap Back Up Now. Nothing is uploaded on its own, so if you have not backed up in a while, nothing has been backed up."
         case .checkingEarlierBackup:
             "Nothing new is uploaded until the earlier one is resolved, so you are not charged to store the same history twice."
         default:

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
@@ -10,14 +10,16 @@ import SwiftUI
 /// nobody else. Restore is not here — it reads across every operator at
 /// once, so it belongs one level up.
 public struct DeviceBackupSettingsView: View {
-    @State private var flow: DeviceBackupSettingsFlow
+    private let flow: DeviceBackupSettingsFlow
     private let makeEnrolment: () -> BackupEnrolmentView?
+
+    @State private var confirmingStop = false
 
     public init(
         flow: DeviceBackupSettingsFlow,
         makeEnrolment: @escaping () -> BackupEnrolmentView?
     ) {
-        _flow = State(wrappedValue: flow)
+        self.flow = flow
         self.makeEnrolment = makeEnrolment
     }
 
@@ -85,6 +87,7 @@ public struct DeviceBackupSettingsView: View {
                         "Each backup uploads everything, not just what changed — there is no incremental upload yet.")
 
                     snapshotsSection
+                    stopSection
                 }
             }
             .padding(.horizontal, 16)
@@ -93,6 +96,26 @@ public struct DeviceBackupSettingsView: View {
         // The operator's own name: with several set up, "Device Backup"
         // on every one of them is a screen you cannot tell from the last.
         .navigationTitle(Text(verbatim: flow.displayName))
+        .confirmationDialog(
+            "Stop backing up to this operator?",
+            isPresented: $confirmingStop,
+            titleVisibility: .visible
+        ) {
+            Button("Erase My Backup and Stop", role: .destructive) {
+                Task { await flow.stopBackingUp(erasingFirst: true) }
+            }
+            // Offered as its own choice rather than a fallback: erasure
+            // is a request to a counterparty that can fail or be
+            // refused, and somebody who wants to stop paying today
+            // should not be held there by an operator that will not
+            // answer.
+            Button("Stop Without Erasing") {
+                Task { await flow.stopBackingUp(erasingFirst: false) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Your history stays on this phone, and your other operators are not affected. Erasing cannot reach copies other people in your chats already have.")
+        }
         .navigationBarTitleDisplayMode(.inline)
         .task {
             flow.refresh()
@@ -108,6 +131,41 @@ public struct DeviceBackupSettingsView: View {
         case .termsChanged: "Review New Terms"
         case .operatorChanged: "Set Up With New Operator"
         default: "Set Up Backup"
+        }
+    }
+
+    /// Leaving.
+    ///
+    /// Below the snapshots, because it is the last thing anyone should
+    /// do by accident, and offered at all because consenting to another
+    /// operator adds one rather than replacing this one — without a way
+    /// out, every operator a person ever chose keeps billing them for a
+    /// copy of a history they thought they had moved.
+    @ViewBuilder
+    private var stopSection: some View {
+        if flow.canStopBackingUp {
+            SettingsCard {
+                Button(role: .destructive) {
+                    confirmingStop = true
+                } label: {
+                    SettingsRow(
+                        title: "Stop Backing Up Here",
+                        subtitle: "Ends this operator's copy and stops paying for it",
+                        last: true
+                    ) {
+                        SettingsIconTile(symbol: "xmark.bin", bg: SettingsTile.red)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("backup.stop_row")
+            }
+            if let failure = flow.stopFailure {
+                SettingsFootnote(verbatim: failure)
+                    .accessibilityIdentifier("backup.stop_failed")
+            } else {
+                SettingsFootnote(
+                    "Your other operators are not affected. Erasing asks this operator to destroy what it holds and keeps its signed receipt; stopping without erasing leaves what it has until its own retention period ends.")
+            }
         }
     }
 

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
@@ -2,29 +2,23 @@ import OnymBackup
 import OnymDesign
 import SwiftUI
 
-/// Settings → Device Backup.
+/// Settings → Device Backup → one operator.
+///
+/// One screen per operator, reached from `DeviceBackupVendorsView`.
+/// Everything here is about this operator alone: its terms, its
+/// snapshots, its payment, and a Back Up Now that sends to it and to
+/// nobody else. Restore is not here — it reads across every operator at
+/// once, so it belongs one level up.
 public struct DeviceBackupSettingsView: View {
     @State private var flow: DeviceBackupSettingsFlow
     private let makeEnrolment: () -> BackupEnrolmentView?
 
-    /// Whether restore is available at all, and separately how to build
-    /// it. Split because the row's *presence* is evaluated on every body
-    /// pass while the screen itself is needed only when someone taps
-    /// through — asking the factory each time built a whole flow, and a
-    /// repository with it, to answer a yes/no question.
-    private let canRestore: Bool
-    private let makeRestore: () -> BackupRestoreView
-
     public init(
         flow: DeviceBackupSettingsFlow,
-        canRestore: Bool = false,
-        makeEnrolment: @escaping () -> BackupEnrolmentView?,
-        makeRestore: @escaping () -> BackupRestoreView
+        makeEnrolment: @escaping () -> BackupEnrolmentView?
     ) {
         _flow = State(wrappedValue: flow)
         self.makeEnrolment = makeEnrolment
-        self.canRestore = canRestore
-        self.makeRestore = makeRestore
     }
 
     public var body: some View {
@@ -64,7 +58,7 @@ public struct DeviceBackupSettingsView: View {
                         } label: {
                             SettingsRow(
                                 title: "Back Up Now",
-                                subtitle: "Uploads your whole history",
+                                subtitle: "Uploads your whole history to this operator",
                                 last: true
                             ) {
                                 SettingsIconTile(symbol: "arrow.up.circle", bg: SettingsTile.blue)
@@ -77,14 +71,15 @@ public struct DeviceBackupSettingsView: View {
                     SettingsFootnote(
                         "Each backup uploads everything, not just what changed — there is no incremental upload yet.")
 
-                    restoreSection
                     snapshotsSection
                 }
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
         }
-        .navigationTitle("Device Backup")
+        // The operator's own name: with several set up, "Device Backup"
+        // on every one of them is a screen you cannot tell from the last.
+        .navigationTitle(Text(verbatim: flow.displayName))
         .navigationBarTitleDisplayMode(.inline)
         .task {
             flow.refresh()
@@ -100,33 +95,6 @@ public struct DeviceBackupSettingsView: View {
         case .termsChanged: "Review New Terms"
         case .operatorChanged: "Set Up With New Operator"
         default: "Set Up Backup"
-        }
-    }
-
-    /// Restore is offered whenever backup is set up, not only on a
-    /// fresh device.
-    ///
-    /// It adds history rather than replacing it, and it does not touch
-    /// the identity — the wiping kind of restore is identity restore,
-    /// which lives in onboarding and is not reachable from here. Someone
-    /// who lost a chat, or who set up a second device, has the same
-    /// reason to want this as someone with a new phone.
-    @ViewBuilder
-    private var restoreSection: some View {
-        if canRestore {
-            SettingsCard {
-                NavigationLink { makeRestore() } label: {
-                    SettingsRow(
-                        title: "Restore From Backup",
-                        subtitle: "Adds messages and chats — nothing is deleted",
-                        last: true
-                    ) {
-                        SettingsIconTile(symbol: "arrow.down.circle", bg: SettingsTile.green)
-                    }
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("backup.restore_row")
-            }
         }
     }
 

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
@@ -32,7 +32,9 @@ public final class DeviceBackupVendorsFlow {
         /// Operators are consented to, but none has been set up.
         case off(consented: Int)
         /// Every enrolled operator is holding a current backup.
-        case on(operators: Int, lastSuccessAt: Date?)
+        /// `notSetUp` is still reported, because a consented operator
+        /// holding nothing is not covered by the ones that are.
+        case on(operators: Int, notSetUp: Int, lastSuccessAt: Date?)
         case running
         /// Some operators are fine and some are not. `attention` is
         /// never folded into `on`, however small it is.
@@ -67,6 +69,7 @@ public final class DeviceBackupVendorsFlow {
         var healthy = 0
         var attention = 0
         var notSetUp = 0
+        var running = 0
         var lastSuccess: Date?
         for vendor in vendors {
             switch vendor.flow.state.status {
@@ -74,9 +77,16 @@ public final class DeviceBackupVendorsFlow {
                 notSetUp += 1
             case .idle(let at):
                 healthy += 1
-                lastSuccess = [lastSuccess, at].compactMap { $0 }.max()
+                // The *oldest* success, not the newest. Two operators,
+                // one an hour old and one six days old, are not both an
+                // hour old — and the number a person reads as "how far
+                // back am I exposed" is the older one.
+                lastSuccess = [lastSuccess, at].compactMap { $0 }.min()
             case .running:
-                healthy += 1
+                // Somebody else's run, or this operator's own. In
+                // flight is not up to date: it may never have retained
+                // anything.
+                running += 1
             case .stale, .paymentRequired, .termsChanged, .operatorChanged,
                  .checkingEarlierBackup, .failed:
                 // Every one of these means this operator is not
@@ -88,8 +98,11 @@ public final class DeviceBackupVendorsFlow {
                 attention += 1
             }
         }
+        if running > 0 { return .running }
         if attention > 0 { return .needsAttention(attention: attention, healthy: healthy) }
-        if healthy > 0 { return .on(operators: healthy, lastSuccessAt: lastSuccess) }
+        if healthy > 0 {
+            return .on(operators: healthy, notSetUp: notSetUp, lastSuccessAt: lastSuccess)
+        }
         return .off(consented: notSetUp)
     }
 
@@ -116,6 +129,13 @@ public final class DeviceBackupVendorsFlow {
     public func backUpAllNow() async {
         guard !isRunning else { return }
         isRunning = true
+        // Every operator that could be part of this run shows as busy
+        // for its duration, so its own screen cannot offer a second
+        // Back Up Now over the top of it.
+        for vendor in vendors where !DeviceBackupSettingsFlow.needsEnrolment(
+            for: vendor.flow.state.status) {
+            vendor.flow.markRunning()
+        }
         let outcomes = await fanOut.backUpAll()
         lastRun = outcomes
         isRunning = false
@@ -129,7 +149,8 @@ public final class DeviceBackupVendorsFlow {
         for outcome in outcomes {
             guard let vendor = vendors.first(where: { $0.id == outcome.componentId }) else { continue }
             switch outcome.result {
-            case .ran(let result): vendor.flow.apply(result)
+            case .ran(let result):
+                vendor.flow.apply(result, resumedPayment: outcome.resumedPayment)
             case .failed(let message): vendor.flow.applyFailure(message: message)
             }
         }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
@@ -1,0 +1,134 @@
+import Foundation
+import OnymBackup
+
+/// Settings → Device Backup, when there may be more than one operator.
+///
+/// It aggregates and it routes; it decides nothing. Each operator keeps
+/// its own `DeviceBackupSettingsFlow` — its own status, its own payment,
+/// its own terms — and this exists so a person can see at a glance how
+/// many copies of their history exist and which of them is in trouble,
+/// without a screen that averages four different situations into one
+/// reassuring word.
+///
+/// The summary is deliberately pessimistic. "On" here means every
+/// enrolled operator is up to date; anything else names the number that
+/// are not. A backup surface that rounds up is the one failure mode this
+/// whole stack is built to avoid.
+@MainActor
+@Observable
+public final class DeviceBackupVendorsFlow {
+    public struct Vendor: Identifiable {
+        public let flow: DeviceBackupSettingsFlow
+        public var id: String { flow.componentId }
+        public var displayName: String { flow.displayName }
+
+        public init(flow: DeviceBackupSettingsFlow) {
+            self.flow = flow
+        }
+    }
+
+    /// The one-line answer, for the status card.
+    public enum Summary: Equatable {
+        /// Operators are consented to, but none has been set up.
+        case off(consented: Int)
+        /// Every enrolled operator is holding a current backup.
+        case on(operators: Int, lastSuccessAt: Date?)
+        case running
+        /// Some operators are fine and some are not. `attention` is
+        /// never folded into `on`, however small it is.
+        case needsAttention(attention: Int, healthy: Int)
+    }
+
+    public private(set) var vendors: [Vendor]
+    public private(set) var isRunning = false
+    /// The last fan-out's per-operator results, newest run only. Shown
+    /// beneath the list so a run that half-worked reads as a run that
+    /// half-worked.
+    public private(set) var lastRun: [BackupFanOut.Outcome] = []
+
+    private let fanOut: BackupFanOut
+    private let schedule: BackupSchedule
+    private let sessionJitter: TimeInterval
+
+    public init(
+        vendors: [Vendor],
+        fanOut: BackupFanOut,
+        schedule: BackupSchedule = .default
+    ) {
+        self.vendors = vendors
+        self.fanOut = fanOut
+        self.schedule = schedule
+        self.sessionJitter = schedule.drawJitter()
+    }
+
+    public var summary: Summary {
+        if isRunning { return .running }
+        let statuses = vendors.map(\.flow.state.status)
+        let enrolled = statuses.filter { !DeviceBackupSettingsFlow.needsEnrolment(for: $0) }
+        guard !enrolled.isEmpty else { return .off(consented: vendors.count) }
+
+        var healthy = 0
+        var attention = 0
+        var lastSuccess: Date?
+        for status in enrolled {
+            switch status {
+            case .idle(let at):
+                healthy += 1
+                lastSuccess = [lastSuccess, at].compactMap { $0 }.max()
+            case .running:
+                healthy += 1
+            default:
+                // stale, paymentRequired, checkingEarlierBackup, failed.
+                // Each of these means this operator is not currently
+                // holding what it is supposed to hold.
+                attention += 1
+            }
+        }
+        if attention > 0 { return .needsAttention(attention: attention, healthy: healthy) }
+        return .on(operators: healthy, lastSuccessAt: lastSuccess)
+    }
+
+    /// How many operators hold at least one snapshot right now.
+    public var enrolledCount: Int {
+        vendors.filter { !DeviceBackupSettingsFlow.needsEnrolment(for: $0.flow.state.status) }.count
+    }
+
+    public func refresh() {
+        for vendor in vendors { vendor.flow.refresh() }
+    }
+
+    public func loadSnapshots() async {
+        for vendor in vendors { await vendor.flow.loadSnapshots() }
+    }
+
+    /// Back up to every enrolled operator.
+    ///
+    /// One run of the history, one seal per operator. A person who set up
+    /// two operators asked for two copies, and a button that quietly sent
+    /// to whichever one answered first would be giving them one.
+    public func backUpAllNow() async {
+        guard !isRunning else { return }
+        isRunning = true
+        lastRun = await fanOut.backUpAll()
+        isRunning = false
+        // Each operator's own screen reads its own state file; the
+        // fan-out wrote them all.
+        refresh()
+    }
+
+    /// The opportunistic path: run only if the schedule permits it.
+    ///
+    /// Checked once for the device rather than once per operator. The
+    /// schedule is about this phone's battery and network, which are not
+    /// facts about an operator.
+    public func backUpIfDue(conditions: BackupSchedule.Conditions) async {
+        guard schedule.permitsOpportunisticRun(conditions, jitter: sessionJitter) else { return }
+        await backUpAllNow()
+    }
+
+    /// What one operator reported in the last run, if it reported
+    /// anything.
+    public func lastResult(for componentId: String) -> BackupFanOut.VendorResult? {
+        lastRun.first { $0.componentId == componentId }?.result
+    }
+}

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
@@ -93,7 +93,9 @@ public final class DeviceBackupVendorsFlow {
         return .off(consented: notSetUp)
     }
 
-    /// How many operators hold at least one snapshot right now.
+    /// How many operators are set up — that is, are not waiting on
+    /// enrolment, new terms, or a re-enrolment. Not the same as how many
+    /// hold a snapshot: one set up a minute ago holds nothing yet.
     public var enrolledCount: Int {
         vendors.filter { !DeviceBackupSettingsFlow.needsEnrolment(for: $0.flow.state.status) }.count
     }
@@ -145,7 +147,7 @@ public final class DeviceBackupVendorsFlow {
 
     /// What one operator reported in the last run, if it reported
     /// anything.
-    public func lastResult(for componentId: String) -> BackupFanOut.VendorResult? {
-        lastRun.first { $0.componentId == componentId }?.result
+    public func lastRun(for componentId: String) -> BackupFanOut.Outcome? {
+        lastRun.first { $0.componentId == componentId }
     }
 }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
@@ -63,29 +63,34 @@ public final class DeviceBackupVendorsFlow {
 
     public var summary: Summary {
         if isRunning { return .running }
-        let statuses = vendors.map(\.flow.state.status)
-        let enrolled = statuses.filter { !DeviceBackupSettingsFlow.needsEnrolment(for: $0) }
-        guard !enrolled.isEmpty else { return .off(consented: vendors.count) }
 
         var healthy = 0
         var attention = 0
+        var notSetUp = 0
         var lastSuccess: Date?
-        for status in enrolled {
-            switch status {
+        for vendor in vendors {
+            switch vendor.flow.state.status {
+            case .off:
+                notSetUp += 1
             case .idle(let at):
                 healthy += 1
                 lastSuccess = [lastSuccess, at].compactMap { $0 }.max()
             case .running:
                 healthy += 1
-            default:
-                // stale, paymentRequired, checkingEarlierBackup, failed.
-                // Each of these means this operator is not currently
-                // holding what it is supposed to hold.
+            case .stale, .paymentRequired, .termsChanged, .operatorChanged,
+                 .checkingEarlierBackup, .failed:
+                // Every one of these means this operator is not
+                // currently holding what it is supposed to hold.
+                // `termsChanged` and `operatorChanged` are counted here
+                // rather than folded in with "not set up": uploads have
+                // stopped at an operator that *is* set up, and calling
+                // that Off would read as a choice the person made.
                 attention += 1
             }
         }
         if attention > 0 { return .needsAttention(attention: attention, healthy: healthy) }
-        return .on(operators: healthy, lastSuccessAt: lastSuccess)
+        if healthy > 0 { return .on(operators: healthy, lastSuccessAt: lastSuccess) }
+        return .off(consented: notSetUp)
     }
 
     /// How many operators hold at least one snapshot right now.
@@ -109,11 +114,23 @@ public final class DeviceBackupVendorsFlow {
     public func backUpAllNow() async {
         guard !isRunning else { return }
         isRunning = true
-        lastRun = await fanOut.backUpAll()
+        let outcomes = await fanOut.backUpAll()
+        lastRun = outcomes
         isRunning = false
         // Each operator's own screen reads its own state file; the
         // fan-out wrote them all.
         refresh()
+        // And then what the state files cannot say. A run blocked on new
+        // terms or a changed operator writes nothing, so a refresh alone
+        // would show the last successful backup and call it On — for an
+        // operator that has stopped accepting uploads.
+        for outcome in outcomes {
+            guard let vendor = vendors.first(where: { $0.id == outcome.componentId }) else { continue }
+            switch outcome.result {
+            case .ran(let result): vendor.flow.apply(result)
+            case .failed(let message): vendor.flow.applyFailure(message: message)
+            }
+        }
     }
 
     /// The opportunistic path: run only if the schedule permits it.

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -99,7 +99,12 @@ public struct DeviceBackupVendorsView: View {
                     } label: {
                         SettingsRow(
                             title: "Operator",
-                            subtitle: Self.subtitle(for: vendor, run: flow.lastResult(for: vendor.id)),
+                            subtitle: Self.subtitle(for: vendor, run: flow.lastRun(for: vendor.id)),
+                            // Two lines, because the thing worth reading
+                            // here is a failure message, and one line
+                            // middle-truncates it exactly when it
+                            // matters.
+                            subtitleLineLimit: 2,
                             last: index == flow.vendors.count - 1
                         ) {
                             SettingsIconTile(
@@ -124,11 +129,14 @@ public struct DeviceBackupVendorsView: View {
     /// as one would be a bug waiting for a translator.
     private static func subtitle(
         for vendor: DeviceBackupVendorsFlow.Vendor,
-        run: BackupFanOut.VendorResult?
+        run: BackupFanOut.Outcome?
     ) -> String {
         var line = vendor.displayName + " · " + describe(vendor.flow.state.status)
-        if case .failed(let message) = run {
+        if case .failed(let message) = run?.result {
             line += " · last run: " + message
+        } else if run?.resumedPayment == true {
+            // It backed up, and not the same thing everyone else got.
+            line += " · the backup you paid for went up; the newest changes go next time"
         }
         return line
     }
@@ -207,7 +215,7 @@ public struct DeviceBackupVendorsView: View {
         case .needsAttention:
             "An operator that is out of date is not holding your recent history. Open it below to see what it is waiting for."
         default:
-            "Backups only run while the app is open. If you have not opened Onym in a while, nothing has been backed up."
+            "Backups run only when you tap Back Up Now. Nothing is uploaded on its own, so if you have not backed up in a while, nothing has been backed up."
         }
     }
 

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -4,8 +4,17 @@ import SwiftUI
 
 /// Settings → Device Backup, listing every operator this identity keeps
 /// its history with.
+/// The flow is held as a plain `let`, not `@State`.
+///
+/// `@State(wrappedValue:)` keeps the *first* value for the lifetime of
+/// the view's identity, so once this screen was on the navigation stack
+/// a newly consented operator never reached it: the root view rebuilds
+/// the whole stack when the consented set changes, and the pushed screen
+/// went on listing the operators it was born with. `@Observable` needs
+/// no `@State` to be observed — only to be owned, and this one is owned
+/// by the composition root.
 public struct DeviceBackupVendorsView: View {
-    @State private var flow: DeviceBackupVendorsFlow
+    private let flow: DeviceBackupVendorsFlow
     private let makeEnrolment: (String) -> BackupEnrolmentView?
     private let makeRestore: () -> BackupRestoreView
 
@@ -14,7 +23,7 @@ public struct DeviceBackupVendorsView: View {
         makeEnrolment: @escaping (String) -> BackupEnrolmentView?,
         makeRestore: @escaping () -> BackupRestoreView
     ) {
-        _flow = State(wrappedValue: flow)
+        self.flow = flow
         self.makeEnrolment = makeEnrolment
         self.makeRestore = makeRestore
     }
@@ -51,19 +60,28 @@ public struct DeviceBackupVendorsView: View {
                     SettingsFootnote(
                         "Each backup uploads everything, not just what changed — there is no incremental upload yet.")
 
-                    SettingsCard {
-                        NavigationLink { makeRestore() } label: {
-                            SettingsRow(
-                                title: "Restore From Backup",
-                                subtitle: "Adds messages and chats — nothing is deleted",
-                                last: true
-                            ) {
-                                SettingsIconTile(symbol: "arrow.down.circle", bg: SettingsTile.green)
-                            }
+                }
+
+                // Outside the enrolled gate on purpose. Reading a backup
+                // needs the recovery phrase and the operator's name, not
+                // a terms pin — `listSnapshots` and `download` consult no
+                // local state at all. Inside the gate it disappeared
+                // exactly when it was most wanted: a new phone with
+                // nothing set up yet, or every operator republishing its
+                // terms at once, which now counts as not-enrolled and
+                // took the restore route down with it.
+                SettingsCard {
+                    NavigationLink { makeRestore() } label: {
+                        SettingsRow(
+                            title: "Restore From Backup",
+                            subtitle: "Adds messages and chats — nothing is deleted",
+                            last: true
+                        ) {
+                            SettingsIconTile(symbol: "arrow.down.circle", bg: SettingsTile.green)
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityIdentifier("backup.restore_row")
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("backup.restore_row")
                 }
 
                 operators
@@ -99,7 +117,7 @@ public struct DeviceBackupVendorsView: View {
                     } label: {
                         SettingsRow(
                             title: "Operator",
-                            subtitle: Self.subtitle(for: vendor, run: flow.lastRun(for: vendor.id)),
+                            subtitle: Self.subtitle(for: vendor),
                             // Two lines, because the thing worth reading
                             // here is a failure message, and one line
                             // middle-truncates it exactly when it
@@ -109,9 +127,7 @@ public struct DeviceBackupVendorsView: View {
                         ) {
                             SettingsIconTile(
                                 symbol: Self.symbol(for: vendor.flow.state.status),
-                                bg: DeviceBackupSettingsFlow.needsEnrolment(for: vendor.flow.state.status)
-                                    ? SettingsTile.gray
-                                    : SettingsTile.green)
+                                bg: Self.tint(for: vendor.flow.state.status))
                         }
                     }
                     .buttonStyle(.plain)
@@ -127,16 +143,13 @@ public struct DeviceBackupVendorsView: View {
     /// runtime data, so it lives in the subtitle: `SettingsRow` takes a
     /// localization key for its title, and looking up user-facing data
     /// as one would be a bug waiting for a translator.
-    private static func subtitle(
-        for vendor: DeviceBackupVendorsFlow.Vendor,
-        run: BackupFanOut.Outcome?
-    ) -> String {
+    /// The note comes from the operator's own flow rather than from the
+    /// last fan-out, so it cannot outlive the run it describes — a
+    /// per-operator backup refreshes that flow and clears it.
+    private static func subtitle(for vendor: DeviceBackupVendorsFlow.Vendor) -> String {
         var line = vendor.displayName + " · " + describe(vendor.flow.state.status)
-        if case .failed(let message) = run?.result {
-            line += " · last run: " + message
-        } else if run?.resumedPayment == true {
-            // It backed up, and not the same thing everyone else got.
-            line += " · the backup you paid for went up; the newest changes go next time"
+        if let note = vendor.flow.lastRunNote {
+            line += " · " + note
         }
         return line
     }
@@ -154,6 +167,27 @@ public struct DeviceBackupVendorsView: View {
         case .operatorChanged: "needs setting up again"
         case .checkingEarlierBackup: "checking an earlier backup"
         case .failed: "something went wrong"
+        }
+    }
+
+    /// Green is reserved for an operator that is actually holding what
+    /// it is supposed to hold.
+    ///
+    /// It used to be keyed on `needsEnrolment` alone, which painted
+    /// every failing, stale, unpaid and unresolved operator the same
+    /// green as a healthy one — on the list whose whole purpose is
+    /// finding out which operator is the problem — and gave the two
+    /// stopped-accepting-uploads states the same gray as one that was
+    /// never turned on.
+    private static func tint(for status: DeviceBackupSettingsFlow.Status) -> Color {
+        switch status {
+        case .idle, .running: SettingsTile.green
+        case .off: SettingsTile.gray
+        case .failed: SettingsTile.red
+        case .stale, .paymentRequired, .checkingEarlierBackup: SettingsTile.amber
+        // Set up, and no longer accepting uploads until somebody reads
+        // something. Not a failure, and not "off" either.
+        case .termsChanged, .operatorChanged: SettingsTile.orange
         }
     }
 
@@ -193,11 +227,23 @@ public struct DeviceBackupVendorsView: View {
             return consented == 0
                 ? "Your history stays on this phone only"
                 : "Your history stays on this phone until you set an operator up"
-        case .on(let operators, let lastSuccessAt):
+        case .on(let operators, let notSetUp, let lastSuccessAt):
+            // The oldest of the operators' last successes, so the
+            // sentence describes the copy a person is actually relying
+            // on rather than the freshest one.
             let when = lastSuccessAt.map {
-                "last backup \($0.formatted(date: .abbreviated, time: .shortened))"
+                "oldest copy \($0.formatted(date: .abbreviated, time: .shortened))"
             } ?? "no backup has completed yet"
-            return operators == 1 ? "1 operator · \(when)" : "\(operators) operators · \(when)"
+            var line = operators == 1 ? "1 operator · \(when)" : "\(operators) operators · \(when)"
+            if notSetUp > 0 {
+                // A consented operator holding nothing is not covered by
+                // the ones that are, and it is the row someone would
+                // otherwise never notice.
+                line += notSetUp == 1
+                    ? " · 1 more not set up"
+                    : " · \(notSetUp) more not set up"
+            }
+            return line
         case .running:
             return "Uploading"
         case .needsAttention(let attention, let healthy):

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -193,9 +193,10 @@ public struct DeviceBackupVendorsView: View {
         case .running:
             return "Uploading"
         case .needsAttention(let attention, let healthy):
-            return healthy == 0
-                ? "\(attention) of your operators needs attention"
-                : "\(healthy) up to date · \(attention) needs attention"
+            let needing = attention == 1
+                ? "1 operator needs attention"
+                : "\(attention) operators need attention"
+            return healthy == 0 ? needing : "\(healthy) up to date · \(needing)"
         }
     }
 

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -1,0 +1,221 @@
+import OnymBackup
+import OnymDesign
+import SwiftUI
+
+/// Settings → Device Backup, listing every operator this identity keeps
+/// its history with.
+public struct DeviceBackupVendorsView: View {
+    @State private var flow: DeviceBackupVendorsFlow
+    private let makeEnrolment: (String) -> BackupEnrolmentView?
+    private let makeRestore: () -> BackupRestoreView
+
+    public init(
+        flow: DeviceBackupVendorsFlow,
+        makeEnrolment: @escaping (String) -> BackupEnrolmentView?,
+        makeRestore: @escaping () -> BackupRestoreView
+    ) {
+        _flow = State(wrappedValue: flow)
+        self.makeEnrolment = makeEnrolment
+        self.makeRestore = makeRestore
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                SettingsSectionLabel("STATUS")
+                SettingsCard {
+                    SettingsRow(title: statusTitle, subtitle: statusSubtitle, last: true) {
+                        SettingsIconTile(symbol: statusSymbol, bg: SettingsTile.blue)
+                    }
+                    .accessibilityIdentifier("backup.status_row")
+                }
+                SettingsFootnote(verbatim: statusFootnote)
+
+                if flow.enrolledCount > 0 {
+                    SettingsCard {
+                        Button {
+                            Task { await flow.backUpAllNow() }
+                        } label: {
+                            SettingsRow(
+                                title: flow.enrolledCount > 1 ? "Back Up To All" : "Back Up Now",
+                                subtitle: backUpSubtitle,
+                                last: true
+                            ) {
+                                SettingsIconTile(symbol: "arrow.up.circle", bg: SettingsTile.blue)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(flow.isRunning)
+                        .accessibilityIdentifier("backup.back_up_now_row")
+                    }
+                    SettingsFootnote(
+                        "Each backup uploads everything, not just what changed — there is no incremental upload yet.")
+
+                    SettingsCard {
+                        NavigationLink { makeRestore() } label: {
+                            SettingsRow(
+                                title: "Restore From Backup",
+                                subtitle: "Adds messages and chats — nothing is deleted",
+                                last: true
+                            ) {
+                                SettingsIconTile(symbol: "arrow.down.circle", bg: SettingsTile.green)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("backup.restore_row")
+                    }
+                }
+
+                operators
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+        }
+        .navigationTitle("Device Backup")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            flow.refresh()
+            await flow.loadSnapshots()
+        }
+    }
+
+    /// One row per operator, each leading to its own screen.
+    ///
+    /// Never merged into a single "backup" row, however tidy that would
+    /// be. These are separate companies, in separate jurisdictions, under
+    /// separate terms, each paid separately and each able to fail on its
+    /// own — and the row is where a person finds out which one is the
+    /// problem.
+    private var operators: some View {
+        Group {
+            SettingsSectionLabel("OPERATORS")
+            SettingsCard {
+                ForEach(Array(flow.vendors.enumerated()), id: \.element.id) { index, vendor in
+                    NavigationLink {
+                        DeviceBackupSettingsView(
+                            flow: vendor.flow,
+                            makeEnrolment: { makeEnrolment(vendor.id) }
+                        )
+                    } label: {
+                        SettingsRow(
+                            title: "Operator",
+                            subtitle: Self.subtitle(for: vendor, run: flow.lastResult(for: vendor.id)),
+                            last: index == flow.vendors.count - 1
+                        ) {
+                            SettingsIconTile(
+                                symbol: Self.symbol(for: vendor.flow.state.status),
+                                bg: DeviceBackupSettingsFlow.needsEnrolment(for: vendor.flow.state.status)
+                                    ? SettingsTile.gray
+                                    : SettingsTile.green)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("backup.operator_row.\(vendor.id)")
+                }
+            }
+            SettingsFootnote(
+                "Every operator you set up keeps its own separate copy, sealed with its own key and paid for separately. One of them shutting down or losing your data does not take the others with it — and each one extends the life of this history for everyone in it, under its own jurisdiction.")
+        }
+    }
+
+    /// The operator's name, then what it is actually doing. The name is
+    /// runtime data, so it lives in the subtitle: `SettingsRow` takes a
+    /// localization key for its title, and looking up user-facing data
+    /// as one would be a bug waiting for a translator.
+    private static func subtitle(
+        for vendor: DeviceBackupVendorsFlow.Vendor,
+        run: BackupFanOut.VendorResult?
+    ) -> String {
+        var line = vendor.displayName + " · " + describe(vendor.flow.state.status)
+        if case .failed(let message) = run {
+            line += " · last run: " + message
+        }
+        return line
+    }
+
+    private static func describe(_ status: DeviceBackupSettingsFlow.Status) -> String {
+        switch status {
+        case .off: "not set up"
+        case .idle(let at):
+            at.map { "backed up \($0.formatted(date: .abbreviated, time: .shortened))" }
+                ?? "set up, nothing uploaded yet"
+        case .running: "backing up…"
+        case .stale: "out of date"
+        case .paymentRequired: "payment needed"
+        case .termsChanged: "new terms to read"
+        case .operatorChanged: "needs setting up again"
+        case .checkingEarlierBackup: "checking an earlier backup"
+        case .failed: "something went wrong"
+        }
+    }
+
+    private static func symbol(for status: DeviceBackupSettingsFlow.Status) -> String {
+        switch status {
+        case .off, .operatorChanged: "externaldrive"
+        case .idle: "externaldrive.badge.checkmark"
+        case .running: "arrow.triangle.2.circlepath"
+        case .stale: "exclamationmark.triangle"
+        case .paymentRequired: "creditcard"
+        case .termsChanged: "doc.badge.ellipsis"
+        case .checkingEarlierBackup: "questionmark.circle"
+        case .failed: "xmark.octagon"
+        }
+    }
+
+    private var backUpSubtitle: String {
+        flow.enrolledCount > 1
+            ? "Uploads your whole history to all \(flow.enrolledCount) operators"
+            : "Uploads your whole history"
+    }
+
+    private var statusTitle: LocalizedStringKey {
+        switch flow.summary {
+        case .off: "Off"
+        case .on: "On"
+        case .running: "Backing up…"
+        case .needsAttention: "Needs attention"
+        }
+    }
+
+    /// Counts, not adjectives. "On" with one of three operators failing
+    /// is the reassuring summary this stack exists to refuse.
+    private var statusSubtitle: String {
+        switch flow.summary {
+        case .off(let consented):
+            return consented == 0
+                ? "Your history stays on this phone only"
+                : "Your history stays on this phone until you set an operator up"
+        case .on(let operators, let lastSuccessAt):
+            let when = lastSuccessAt.map {
+                "last backup \($0.formatted(date: .abbreviated, time: .shortened))"
+            } ?? "no backup has completed yet"
+            return operators == 1 ? "1 operator · \(when)" : "\(operators) operators · \(when)"
+        case .running:
+            return "Uploading"
+        case .needsAttention(let attention, let healthy):
+            return healthy == 0
+                ? "\(attention) of your operators needs attention"
+                : "\(healthy) up to date · \(attention) needs attention"
+        }
+    }
+
+    private var statusFootnote: String {
+        switch flow.summary {
+        case .off:
+            "Only your recovery phrase can open a backup. An operator stores bytes it cannot read."
+        case .needsAttention:
+            "An operator that is out of date is not holding your recent history. Open it below to see what it is waiting for."
+        default:
+            "Backups only run while the app is open. If you have not opened Onym in a while, nothing has been backed up."
+        }
+    }
+
+    private var statusSymbol: String {
+        switch flow.summary {
+        case .off: "externaldrive"
+        case .on: "externaldrive.badge.checkmark"
+        case .running: "arrow.triangle.2.circlepath"
+        case .needsAttention: "exclamationmark.triangle"
+        }
+    }
+}

--- a/Packages/OnymFoundation/Sources/OnymFoundation/PinnedConsentStore.swift
+++ b/Packages/OnymFoundation/Sources/OnymFoundation/PinnedConsentStore.swift
@@ -113,6 +113,40 @@ public extension PinnedConsentStore {
         return record
     }
 
+    /// Withdraw consent for a component: every record for it becomes
+    /// history, and none is active.
+    ///
+    /// There was no way to do this, and for a single-seat consent it did
+    /// not show: consenting to a replacement deactivated the previous
+    /// record for the *same* componentId, so switching worked and
+    /// leaving was never asked for. A seat a person can hold with
+    /// several operators at once makes the gap expensive — every
+    /// operator ever consented to stays active, keeps receiving a copy
+    /// of the history, and keeps charging for it, with no route out.
+    ///
+    /// The records are kept, deactivated, exactly as a switch keeps
+    /// them. A consent artifact is evidence that something was agreed;
+    /// leaving is a new fact about it, not a reason to erase it.
+    ///
+    /// Returns whether anything changed, so a caller can tell a
+    /// withdrawal from a no-op.
+    @discardableResult
+    func withdraw(componentId: String) throws -> Bool {
+        PinnedConsentStoreSerialization.lock.lock()
+        defer { PinnedConsentStoreSerialization.lock.unlock() }
+
+        var records = try load()
+        var changed = false
+        for index in records.indices
+        where records[index].componentId == componentId && records[index].isActive {
+            records[index].isActive = false
+            changed = true
+        }
+        guard changed else { return false }
+        try save(records)
+        return true
+    }
+
     /// The active consent for a component, if any. Throws
     /// `corruptStore` rather than pretending no consent exists.
     func activeRecord(componentId: String) throws -> PinnedConsentRecord? {

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -53,7 +53,7 @@ public struct SettingsView: View {
     /// Note the name: `makeBackupFlow` above is the *recovery phrase*
     /// backup, which is a different thing entirely. One protects the
     /// key; this protects the history.
-    let makeDeviceBackupView: (@MainActor () -> DeviceBackupSettingsView)?
+    let makeDeviceBackupView: (@MainActor () -> DeviceBackupVendorsView)?
 
     public init(
         makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow,
@@ -68,7 +68,7 @@ public struct SettingsView: View {
         makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil,
         makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)? = nil,
         onRestartOnboarding: (@MainActor () -> Void)? = nil,
-        makeDeviceBackupView: (@MainActor () -> DeviceBackupSettingsView)? = nil
+        makeDeviceBackupView: (@MainActor () -> DeviceBackupVendorsView)? = nil
     ) {
         self.makeBackupFlow = makeBackupFlow
         self.makeRelayerSettingsFlow = makeRelayerSettingsFlow
@@ -232,7 +232,7 @@ public struct SettingsView: View {
                         } label: {
                             SettingsRow(
                                 title: "Device Backup",
-                                subtitle: "A sealed copy of this phone's history",
+                                subtitle: "Sealed copies of this phone's history",
                                 last: true
                             ) {
                                 SettingsIconTile(

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -107,16 +107,16 @@ struct AppDependencies {
     /// renders without the discovery stack (nil under the UI-test
     /// harness — same pattern as the moderation factories).
     let makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)?
-    /// The consented backup operator, cheap to read. Lets the root view
-    /// tell "the operator changed" from "Settings was opened again"
-    /// without rebuilding the whole stack to find out.
-    let consentedBackupComponentId: (@MainActor () -> String?)?
+    /// The consented backup operators, cheap to read. Lets the root view
+    /// tell "an operator was added, removed or changed" from "Settings
+    /// was opened again" without rebuilding the whole stack to find out.
+    let consentedBackupComponentIds: (@MainActor () -> [String])?
     /// Settings → Device Backup. Async and optional: resolving it reads
     /// the pinned consent record and derives a seat key, and it is
     /// legitimately `nil` when no backup operator has been consented to
     /// or the identity has no recovery phrase to derive from. The
     /// section hides rather than offering a screen that cannot work.
-    let makeDeviceBackupView: (@MainActor () async -> DeviceBackupSettingsView?)?
+    let makeDeviceBackupView: (@MainActor () async -> DeviceBackupVendorsView?)?
     /// Onboarding flow factory. Non-nil whenever onboarding is
     /// AVAILABLE in this build (always in production; under
     /// `--ui-testing` only with `--ui-onboarding`, so every existing

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -3,6 +3,7 @@ import OnymBackup
 import OnymBackupUI
 import OnymBilling
 import OnymChatsCore
+import OnymDiscovery
 import OnymFoundation
 import OnymGroup
 import OnymIdentity
@@ -85,7 +86,24 @@ struct BackupSeatComposer {
             }
             let stateStore = BackupVendorStorage.stateStore(
                 componentId: manifest.componentId, in: workingDirectory)
-            let stored = try? stateStore.load()
+            // `try?` would be wrong here in the one direction that
+            // matters. An unreadable state file — a corrupt one, or one
+            // read while the device is locked and the container is under
+            // complete protection — would drop this operator's policy
+            // from the vote, and the vote is unanimity: with its
+            // descriptors-only vote missing, a single includeCiphertext
+            // operator carries it, and attachments go to an operator the
+            // person never agreed to give them to. So an unreadable
+            // state votes for the strictest policy, which is what
+            // `FileBackupStateStore` throwing rather than returning an
+            // empty state is for.
+            let stored: BackupState?
+            do {
+                stored = try stateStore.load()
+            } catch {
+                stored = nil
+                policies.append(.descriptorsOnly)
+            }
             let consented = stored?.acceptedTermsId == nil ? nil : stored?.mediaPolicy
             if let consented { policies.append(consented) }
             enrolments.append((manifest, stateStore, material, consented))
@@ -115,6 +133,17 @@ struct BackupSeatComposer {
             workingDirectory: workingDirectory
         )
 
+        // An operator's name is a string it wrote in its own manifest,
+        // and nothing stops two of them writing the same one. That
+        // string is the only thing telling operators apart on every
+        // surface here — the rows, the restore list, the unreachable
+        // note, and the "you already back up to X" sentence someone
+        // reads while consenting to a *different* X. Pinning stops an
+        // operator relabelling itself after consent; it does not stop it
+        // colliding at consent time.
+        let displayNames = Self.distinctDisplayNames(
+            for: enrolments.map(\.manifest.componentId), consentStore: consentStore)
+
         let stacks: [Stack] = enrolments.map { enrolment in
             let client = URLSessionBackupClient(
                 manifest: enrolment.manifest,
@@ -125,8 +154,8 @@ struct BackupSeatComposer {
             )
             return Stack(
                 componentId: enrolment.manifest.componentId,
-                displayName: BackupSeat.displayName(
-                    componentId: enrolment.manifest.componentId, consentStore: consentStore),
+                displayName: displayNames[enrolment.manifest.componentId]
+                    ?? enrolment.manifest.componentId,
                 consentedMediaPolicy: enrolment.consentedMediaPolicy,
                 client: client,
                 stateStore: enrolment.stateStore,
@@ -151,7 +180,9 @@ struct BackupSeatComposer {
                         // Consented to with media, and not getting it,
                         // because somebody else was not.
                         attachmentsWithheld: $0.consentedMediaPolicy == .includeCiphertext
-                            && mediaPolicy == .descriptorsOnly
+                            && mediaPolicy == .descriptorsOnly,
+                        onStopBackingUp: Self.stopBackingUp(
+                            componentId: $0.componentId, consentStore: consentStore)
                     )
                 )
             },
@@ -202,9 +233,17 @@ struct BackupSeatComposer {
                         // Named so the surface can say what adding a
                         // second operator does rather than let it read
                         // as switching.
-                        otherOperators: stacks
-                            .filter { $0.componentId != componentId }
-                            .compactMap(Self.otherOperator(from:))
+                        // Only when this operator is not already one of
+                        // the copies. Re-reading an operator's new terms
+                        // routes through this same screen, and it used
+                        // to greet someone with "This adds a second copy
+                        // — it does not move the first" for an operator
+                        // that has been holding a copy for months.
+                        otherOperators: Self.isEnrolled(stack)
+                            ? []
+                            : stacks
+                                .filter { $0.componentId != componentId }
+                                .compactMap(Self.otherOperator(from:))
                     )
                 ) {
                     flow.refresh()
@@ -231,6 +270,59 @@ struct BackupSeatComposer {
         )
     }
 
+    /// Names that tell the operators apart, whatever they call
+    /// themselves.
+    ///
+    /// A collision falls back to the component id for *both* sides, not
+    /// just the newcomer: disambiguating only one leaves the other
+    /// wearing the plain name, which reads as the authentic one.
+    @MainActor
+    private static func distinctDisplayNames(
+        for componentIds: [String],
+        consentStore: any PinnedConsentStore
+    ) -> [String: String] {
+        var claimed: [String: [String]] = [:]
+        for componentId in componentIds {
+            let name = BackupSeat.displayName(componentId: componentId, consentStore: consentStore)
+            claimed[name, default: []].append(componentId)
+        }
+        var resolved: [String: String] = [:]
+        for (name, componentIds) in claimed {
+            for componentId in componentIds {
+                resolved[componentId] = componentIds.count == 1
+                    ? name
+                    : "\(name) (\(ModuleConsentFlow.shortComponentId(componentId)))"
+            }
+        }
+        return resolved
+    }
+
+    /// Withdraw consent so this operator stops being part of the seat.
+    ///
+    /// The local state is already cleared by the flow; this is the other
+    /// half, and without it the operator reappears in the list on the
+    /// next visit to Settings — consented, unenrolled, and offering to
+    /// be set up again.
+    private static func stopBackingUp(
+        componentId: String,
+        consentStore: any PinnedConsentStore
+    ) -> @MainActor @Sendable () -> Void {
+        { @MainActor @Sendable in
+            // A failed withdrawal is not reported here: the flow has
+            // already cleared this device's state, so nothing is being
+            // uploaded to this operator either way. The row returning
+            // as "not set up" is the visible consequence, and setting
+            // it up again is a screen.
+            try? consentStore.withdraw(componentId: componentId)
+        }
+    }
+
+    /// Whether this operator already holds a copy — that is, whether
+    /// this enrolment is a first one or a re-reading of new terms.
+    private static func isEnrolled(_ stack: Stack) -> Bool {
+        (try? stack.stateStore.load())?.acceptedTermsId != nil
+    }
+
     /// One already-enrolled operator, described only by what it signed.
     ///
     /// Its jurisdictions come from the terms bytes this device pinned
@@ -241,13 +333,18 @@ struct BackupSeatComposer {
     /// jurisdictions rather than guessing when the pinned bytes will not
     /// decode.
     private static func otherOperator(from stack: Stack) -> BackupDisclosure.OtherOperator? {
-        guard
-            let stored = try? stack.stateStore.load(),
-            stored.acceptedTermsId != nil
-        else {
-            return nil
-        }
-        let jurisdictions = stored.acceptedTermsRaw
+        let stored = try? stack.stateStore.load()
+        // Only a state that loaded *and* says so is "not enrolled". An
+        // unreadable one is named anyway, without jurisdictions: the
+        // consequence of over-naming is a person told they may already
+        // have a copy somewhere they do not, and the consequence of
+        // under-naming is the whole "this adds a second copy" headline
+        // silently disappearing from the consent screen — someone agrees
+        // to a second copy of everyone's messages in a second
+        // jurisdiction believing they are switching. This disclosure
+        // fails loud.
+        if let stored, stored.acceptedTermsId == nil { return nil }
+        let jurisdictions = stored?.acceptedTermsRaw
             .flatMap { try? BackupTerms.decode(raw: $0) }?
             .jurisdictions ?? []
         return BackupDisclosure.OtherOperator(

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -46,6 +46,9 @@ struct BackupSeatComposer {
     private struct Stack {
         let componentId: String
         let displayName: String
+        /// What *this* operator was consented under, which is not
+        /// necessarily what the shared archive ends up carrying.
+        let consentedMediaPolicy: BackupMediaPolicy?
         let client: URLSessionBackupClient
         let stateStore: FileBackupStateStore
         let material: BackupKeyMaterial
@@ -68,7 +71,7 @@ struct BackupSeatComposer {
         // operator and its media policy therefore has to be decided
         // before the composer exists.
         var enrolments: [(manifest: BackupOperatorManifest, stateStore: FileBackupStateStore,
-                          material: BackupKeyMaterial)] = []
+                          material: BackupKeyMaterial, consentedMediaPolicy: BackupMediaPolicy?)] = []
         var policies: [BackupMediaPolicy] = []
         for manifest in manifests {
             guard
@@ -83,10 +86,9 @@ struct BackupSeatComposer {
             let stateStore = BackupVendorStorage.stateStore(
                 componentId: manifest.componentId, in: workingDirectory)
             let stored = try? stateStore.load()
-            if let stored, stored.acceptedTermsId != nil {
-                policies.append(stored.mediaPolicy)
-            }
-            enrolments.append((manifest, stateStore, material))
+            let consented = stored?.acceptedTermsId == nil ? nil : stored?.mediaPolicy
+            if let consented { policies.append(consented) }
+            enrolments.append((manifest, stateStore, material, consented))
         }
         guard let first = enrolments.first else { return nil }
 
@@ -125,6 +127,7 @@ struct BackupSeatComposer {
                 componentId: enrolment.manifest.componentId,
                 displayName: BackupSeat.displayName(
                     componentId: enrolment.manifest.componentId, consentStore: consentStore),
+                consentedMediaPolicy: enrolment.consentedMediaPolicy,
                 client: client,
                 stateStore: enrolment.stateStore,
                 material: enrolment.material,
@@ -144,7 +147,11 @@ struct BackupSeatComposer {
                         componentId: $0.componentId,
                         displayName: $0.displayName,
                         repository: $0.repository,
-                        stateStore: $0.stateStore
+                        stateStore: $0.stateStore,
+                        // Consented to with media, and not getting it,
+                        // because somebody else was not.
+                        attachmentsWithheld: $0.consentedMediaPolicy == .includeCiphertext
+                            && mediaPolicy == .descriptorsOnly
                     )
                 )
             },

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -16,6 +16,16 @@ import OnymTransportBlossom
 /// or an identity imported from raw key material and therefore without a
 /// recovery phrase to derive a key from. Both mean the Settings section
 /// hides rather than offering something that cannot work.
+///
+/// A person may keep the same history with more than one operator, so
+/// this assembles one stack per consented operator and one fan-out over
+/// all of them. What is shared is the part that is a property of the
+/// identity: the source of truth being read, and the archive key ladder,
+/// which comes from the recovery seed alone so that a snapshot is
+/// openable by whoever holds the phrase rather than by whoever stored
+/// it. Everything else — the access keys, the terms pin, the chain, the
+/// entitlement, the local state file — is per operator, because
+/// `UI-Backup.md` §14.12 says one operator never receives another's.
 @MainActor
 struct BackupSeatComposer {
     let identities: IdentityRepository
@@ -32,32 +42,65 @@ struct BackupSeatComposer {
     let entitlementStore: (any SeatEntitlementStoring)?
     let seatKeys: any SeatAccessKeyProviding
 
-    func makeDeviceBackupView() async -> DeviceBackupSettingsView? {
-        guard let manifest = BackupSeat.consentedManifest(consentStore: consentStore) else {
+    /// One operator's assembled stack, before it becomes a screen.
+    private struct Stack {
+        let componentId: String
+        let displayName: String
+        let client: URLSessionBackupClient
+        let stateStore: FileBackupStateStore
+        let material: BackupKeyMaterial
+        let repository: BackupRepository
+    }
+
+    func makeDeviceBackupView() async -> DeviceBackupVendorsView? {
+        let manifests = BackupSeat.consentedManifests(consentStore: consentStore)
+        guard !manifests.isEmpty, let workingDirectory = try? BackupSeat.workingDirectory() else {
             return nil
         }
-        guard
-            let material = try? await BackupKeys.material(
-                deriving: identities, componentId: manifest.componentId),
-            let workingDirectory = try? BackupSeat.workingDirectory()
-        else {
-            // No recovery phrase, or nowhere to write. Either way a
-            // snapshot sealed now could not be opened later, and
-            // offering the screen would be offering something false.
-            return nil
+        // A single-operator install kept its state in `state.json`.
+        // Without moving it onto the per-operator path, this launch
+        // would read no state for the operator the person is already
+        // enrolled with: backup would show as off, and the next snapshot
+        // would supersede nothing and be paid for twice.
+        BackupVendorStorage.migrateLegacyState(in: workingDirectory)
+
+        // Two passes, because the archive is composed once for every
+        // operator and its media policy therefore has to be decided
+        // before the composer exists.
+        var enrolments: [(manifest: BackupOperatorManifest, stateStore: FileBackupStateStore,
+                          material: BackupKeyMaterial)] = []
+        var policies: [BackupMediaPolicy] = []
+        for manifest in manifests {
+            guard
+                let material = try? await BackupKeys.material(
+                    deriving: identities, componentId: manifest.componentId)
+            else {
+                // No recovery phrase. A snapshot sealed now could not be
+                // opened later, and that is true at every operator, so
+                // there is nothing to build at all.
+                return nil
+            }
+            let stateStore = BackupVendorStorage.stateStore(
+                componentId: manifest.componentId, in: workingDirectory)
+            let stored = try? stateStore.load()
+            if let stored, stored.acceptedTermsId != nil {
+                policies.append(stored.mediaPolicy)
+            }
+            enrolments.append((manifest, stateStore, material))
         }
+        guard let first = enrolments.first else { return nil }
 
-        let stateStore = FileBackupStateStore(
-            url: workingDirectory.appending(path: "state.json"))
-        let mediaPolicy = (try? stateStore.load())?.mediaPolicy ?? .descriptorsOnly
+        // The strictest policy any enrolled operator was consented under
+        // wins, because one archive is composed for all of them. The
+        // other direction would send an operator attachments the person
+        // agreed to give somebody else — a widening of the eligible set
+        // by composition order, and §14.10 says the eligible set never
+        // widens without an explicit choice.
+        let mediaPolicy: BackupMediaPolicy =
+            !policies.isEmpty && policies.allSatisfy { $0 == .includeCiphertext }
+                ? .includeCiphertext
+                : .descriptorsOnly
 
-        let client = URLSessionBackupClient(
-            manifest: manifest,
-            material: material,
-            endpointOverride: endpointOverride,
-            entitlement: Self.entitlementProvider(
-                manifest: manifest, store: entitlementStore, keys: seatKeys)
-        )
         let composer = BackupComposer(
             source: AppBackupSource(
                 groupStore: groupStore,
@@ -69,21 +112,60 @@ struct BackupSeatComposer {
             mediaPolicy: mediaPolicy,
             workingDirectory: workingDirectory
         )
-        let repository = BackupRepository(
-            port: client,
-            composer: composer,
-            stateStore: stateStore,
-            keyMaterial: material
+
+        let stacks: [Stack] = enrolments.map { enrolment in
+            let client = URLSessionBackupClient(
+                manifest: enrolment.manifest,
+                material: enrolment.material,
+                endpointOverride: endpointOverride,
+                entitlement: Self.entitlementProvider(
+                    manifest: enrolment.manifest, store: entitlementStore, keys: seatKeys)
+            )
+            return Stack(
+                componentId: enrolment.manifest.componentId,
+                displayName: BackupSeat.displayName(
+                    componentId: enrolment.manifest.componentId, consentStore: consentStore),
+                client: client,
+                stateStore: enrolment.stateStore,
+                material: enrolment.material,
+                repository: BackupRepository(
+                    port: client,
+                    composer: composer,
+                    stateStore: enrolment.stateStore,
+                    keyMaterial: enrolment.material
+                )
+            )
+        }
+
+        let flow = DeviceBackupVendorsFlow(
+            vendors: stacks.map {
+                DeviceBackupVendorsFlow.Vendor(
+                    flow: DeviceBackupSettingsFlow(
+                        componentId: $0.componentId,
+                        displayName: $0.displayName,
+                        repository: $0.repository,
+                        stateStore: $0.stateStore
+                    )
+                )
+            },
+            fanOut: BackupFanOut(
+                vendors: stacks.map {
+                    BackupFanOut.Vendor(
+                        componentId: $0.componentId,
+                        displayName: $0.displayName,
+                        repository: $0.repository,
+                        stateStore: $0.stateStore
+                    )
+                },
+                composer: composer,
+                // Identity-wide by derivation: `BackupKeys.archiveRootKey`
+                // takes the seed and nothing else, so every operator's
+                // material carries the same one. Taking it from the first
+                // is not a choice about which operator is special.
+                archiveRoot: first.material.archiveRoot
+            )
         )
-        let consented = manifest.componentId
-        let flow = DeviceBackupSettingsFlow(
-            repository: repository,
-            stateStore: stateStore,
-            // Lets the flow tell "enrolled" from "enrolled with somebody
-            // else", which is the difference between a working backup
-            // and one that silently never uploads again.
-            currentComponentId: { consented }
-        )
+
         // Restored attachment ciphertext, and the client that will
         // actually serve it. Writing bytes to a directory no loader
         // reads would let the summary report attachments "restored"
@@ -97,31 +179,52 @@ struct BackupSeatComposer {
                 consentStore: consentStore,
                 blobDirectory: restoredBlobs))
 
-        return DeviceBackupSettingsView(flow: flow, canRestore: true) {
-            // The consent surface, reachable. Without this the section
-            // rendered a status card with no way to turn backup on, and
-            // everything behind it was unreachable code.
-            BackupEnrolmentView(
-                flow: BackupEnrolmentFlow(
-                    port: client,
-                    stateStore: stateStore,
-                    workingDirectory: workingDirectory,
-                    mediaPolicy: mediaPolicy)
-            ) {
-                flow.refresh()
+        return DeviceBackupVendorsView(
+            flow: flow,
+            makeEnrolment: { componentId in
+                guard let stack = stacks.first(where: { $0.componentId == componentId })
+                else {
+                    return nil
+                }
+                return BackupEnrolmentView(
+                    flow: BackupEnrolmentFlow(
+                        port: stack.client,
+                        stateStore: stack.stateStore,
+                        workingDirectory: workingDirectory,
+                        mediaPolicy: mediaPolicy,
+                        // Named so the surface can say what adding a
+                        // second operator does rather than let it read
+                        // as switching.
+                        otherOperators: stacks
+                            .filter {
+                                $0.componentId != componentId
+                                    && (try? $0.stateStore.load())?.acceptedTermsId != nil
+                            }
+                            .map(\.displayName)
+                    )
+                ) {
+                    flow.refresh()
+                }
+            },
+            makeRestore: {
+                BackupRestoreView(
+                    flow: BackupRestoreFlow(
+                        sources: stacks.map {
+                            BackupRestoreSource(
+                                componentId: $0.componentId,
+                                displayName: $0.displayName,
+                                repository: $0.repository)
+                        },
+                        restorer: restorer,
+                        // Opening a snapshot uses the archive root,
+                        // which is the same for every operator; the
+                        // per-operator access keys are inside each
+                        // repository and are not used to decrypt
+                        // anything.
+                        keyMaterial: first.material,
+                        workingDirectory: workingDirectory))
             }
-        } makeRestore: {
-            // Reachable from the moment backup is set up. Building it
-            // here rather than leaving a `nil` factory is deliberate:
-            // every unreachable screen in this stack has been a screen
-            // someone believed shipped.
-            BackupRestoreView(
-                flow: BackupRestoreFlow(
-                    repository: repository,
-                    restorer: restorer,
-                    keyMaterial: material,
-                    workingDirectory: workingDirectory))
-        }
+        )
     }
 
     /// The credential to present, chosen at request time.

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -203,11 +203,8 @@ struct BackupSeatComposer {
                         // second operator does rather than let it read
                         // as switching.
                         otherOperators: stacks
-                            .filter {
-                                $0.componentId != componentId
-                                    && (try? $0.stateStore.load())?.acceptedTermsId != nil
-                            }
-                            .map(\.displayName)
+                            .filter { $0.componentId != componentId }
+                            .compactMap(Self.otherOperator(from:))
                     )
                 ) {
                     flow.refresh()
@@ -232,6 +229,29 @@ struct BackupSeatComposer {
                         workingDirectory: workingDirectory))
             }
         )
+    }
+
+    /// One already-enrolled operator, described only by what it signed.
+    ///
+    /// Its jurisdictions come from the terms bytes this device pinned
+    /// when the person consented — `acceptedTermsRaw`, kept for exactly
+    /// this kind of question — rather than from a fetch that could
+    /// answer differently today. Returns `nil` for an operator that is
+    /// not enrolled, which has no copy to speak of, and reports empty
+    /// jurisdictions rather than guessing when the pinned bytes will not
+    /// decode.
+    private static func otherOperator(from stack: Stack) -> BackupDisclosure.OtherOperator? {
+        guard
+            let stored = try? stack.stateStore.load(),
+            stored.acceptedTermsId != nil
+        else {
+            return nil
+        }
+        let jurisdictions = stored.acceptedTermsRaw
+            .flatMap { try? BackupTerms.decode(raw: $0) }?
+            .jurisdictions ?? []
+        return BackupDisclosure.OtherOperator(
+            name: stack.displayName, jurisdictions: jurisdictions)
     }
 
     /// The credential to present, chosen at request time.

--- a/Sources/OnymIOS/BackupSeat.swift
+++ b/Sources/OnymIOS/BackupSeat.swift
@@ -34,8 +34,9 @@ enum BackupSeat {
     /// The seat value a backup operator declares.
     static let seat = "storage.backup"
 
-    /// Every backup operator this identity has consented to, in the
-    /// order the consents were accepted.
+    /// Every backup operator this identity has consented to, in a
+    /// stable order (by componentId — see below; it is deliberately not
+    /// acceptance order, which moves).
     ///
     /// Reads the *active* pinned record per operator. A person who
     /// switched away from an operator has a history of records for it;

--- a/Sources/OnymIOS/BackupSeat.swift
+++ b/Sources/OnymIOS/BackupSeat.swift
@@ -4,6 +4,7 @@ import OnymBackup
 import OnymBackupUI
 import OnymBilling
 import OnymChatsCore
+import OnymDiscovery
 import OnymFoundation
 import OnymGroup
 import OnymIdentity
@@ -33,26 +34,66 @@ enum BackupSeat {
     /// The seat value a backup operator declares.
     static let seat = "storage.backup"
 
-    /// The consented backup operator, if there is one.
+    /// Every backup operator this identity has consented to, in the
+    /// order the consents were accepted.
     ///
-    /// Reads the *active* pinned record. A person who switched
-    /// operators has a history of records; only the current one may
-    /// receive a snapshot.
-    static func consentedManifest(
+    /// Reads the *active* pinned record per operator. A person who
+    /// switched away from an operator has a history of records for it;
+    /// only a current one may receive a snapshot. A person who added a
+    /// second operator has two active records, and both may — that is
+    /// what keeping a history in two places means.
+    static func consentedManifests(
         consentStore: any PinnedConsentStore
-    ) -> BackupOperatorManifest? {
-        guard let records = try? consentStore.load() else { return nil }
+    ) -> [BackupOperatorManifest] {
+        guard let records = try? consentStore.load() else { return [] }
+        var seen: Set<String> = []
+        var manifests: [BackupOperatorManifest] = []
+        // Newest record first, so the active pin wins for a component
+        // that has been re-consented; the result is then flipped back
+        // into acceptance order so the list on screen does not reshuffle
+        // when somebody re-reads terms.
         for record in records.reversed() where record.isActive {
             guard
+                !seen.contains(record.componentId),
                 let manifest = record.consentedManifest(),
                 manifest.seat == seat,
                 let backup = try? BackupOperatorManifest(manifest: manifest)
             else {
                 continue
             }
-            return backup
+            seen.insert(record.componentId)
+            manifests.append(backup)
         }
-        return nil
+        return manifests.reversed()
+    }
+
+    /// The most recently consented backup operator, if there is one.
+    static func consentedManifest(
+        consentStore: any PinnedConsentStore
+    ) -> BackupOperatorManifest? {
+        consentedManifests(consentStore: consentStore).last
+    }
+
+    /// What to call an operator on screen.
+    ///
+    /// The manifest `name` the person consented to, else the component
+    /// id minus its prefix — the same rule as the seat adapters and the
+    /// Blossom catalog, so one operator is not called two different
+    /// things in two places. Read from the *pinned* bytes rather than a
+    /// live fetch: an operator does not get to relabel itself into
+    /// looking like the one beside it in the list.
+    @MainActor
+    static func displayName(
+        componentId: String,
+        consentStore: any PinnedConsentStore
+    ) -> String {
+        if let record = try? consentStore.activeRecord(componentId: componentId),
+           let manifest = record.consentedManifest(),
+           let name = SeatManifestFields(rawBytes: manifest.rawBytes).name,
+           !name.isEmpty {
+            return name
+        }
+        return ModuleConsentFlow.shortComponentId(componentId)
     }
 
     /// Issuer keys an operator declares. Pinned from the signed

--- a/Sources/OnymIOS/BackupSeat.swift
+++ b/Sources/OnymIOS/BackupSeat.swift
@@ -49,9 +49,7 @@ enum BackupSeat {
         var seen: Set<String> = []
         var manifests: [BackupOperatorManifest] = []
         // Newest record first, so the active pin wins for a component
-        // that has been re-consented; the result is then flipped back
-        // into acceptance order so the list on screen does not reshuffle
-        // when somebody re-reads terms.
+        // that has been re-consented.
         for record in records.reversed() where record.isActive {
             guard
                 !seen.contains(record.componentId),
@@ -64,14 +62,19 @@ enum BackupSeat {
             seen.insert(record.componentId)
             manifests.append(backup)
         }
-        return manifests.reversed()
-    }
-
-    /// The most recently consented backup operator, if there is one.
-    static func consentedManifest(
-        consentStore: any PinnedConsentStore
-    ) -> BackupOperatorManifest? {
-        consentedManifests(consentStore: consentStore).last
+        // Sorted by componentId, which is the only key here that does
+        // not move.
+        //
+        // Store position looks like acceptance order and is not one:
+        // `accept` appends, so re-reading an operator's terms moves it
+        // to the tail and reorders the list. `acceptedAt` on the active
+        // record moves for the same reason, and the *earliest* record
+        // for a component is evicted once its history passes the cap. A
+        // list that reshuffles is not cosmetic here — the root view
+        // rebuilds the whole backup stack when this list changes, which
+        // would throw away a running backup because somebody re-read
+        // some terms.
+        return manifests.sorted { $0.componentId < $1.componentId }
     }
 
     /// What to call an operator on screen.

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1382,8 +1382,8 @@ struct OnymIOSApp: App {
                 )
             },
             makeDiscoverySettingsFlow: makeDiscoverySettingsFlow,
-            consentedBackupComponentId: {
-                BackupSeat.consentedManifest(consentStore: pinnedConsentStore)?.componentId
+            consentedBackupComponentIds: {
+                BackupSeat.consentedManifests(consentStore: pinnedConsentStore).map(\.componentId)
             },
             makeDeviceBackupView: {
                 await BackupSeatComposer(

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -58,18 +58,19 @@ struct RootView: View {
     /// consent record and derives a seat key — neither of which belongs
     /// in a view body that re-runs on every redraw. `nil` means no
     /// backup operator is consented to, and the Settings section hides.
-    @State private var deviceBackupView: DeviceBackupSettingsView?
+    @State private var deviceBackupView: DeviceBackupVendorsView?
     /// Guards against two resolutions overlapping — building one reads a
     /// consent record and derives a seat key, and the later of two
     /// in-flight resolutions could otherwise land first.
     @State private var resolvingDeviceBackup = false
-    /// Which operator the current backup view was built for.
+    /// Which operators the current backup view was built for.
     ///
     /// Re-resolving unconditionally on every visit to Settings rebuilt
-    /// the flow underneath a running backup, discarding its state
-    /// mid-upload. The view is only replaced when the consented operator
-    /// actually changed.
-    @State private var deviceBackupComponentId: String?
+    /// the flows underneath a running backup, discarding their state
+    /// mid-upload. The view is only replaced when the set of consented
+    /// operators actually changed — adding a second operator is such a
+    /// change, and re-reading one's terms is not.
+    @State private var deviceBackupComponentIds: [String]?
     /// A resolution asked for while one was in flight.
     @State private var deviceBackupResolutionPending = false
 
@@ -257,13 +258,13 @@ struct RootView: View {
 
         repeat {
             deviceBackupResolutionPending = false
-            // Nothing to do when the operator has not changed. Rebuilding
-            // here would hand Settings a fresh flow and throw away a
-            // backup that is running.
-            let componentId = dependencies.consentedBackupComponentId?()
-            if deviceBackupView == nil || componentId != deviceBackupComponentId {
+            // Nothing to do when the operators have not changed.
+            // Rebuilding here would hand Settings fresh flows and throw
+            // away a backup that is running.
+            let componentIds = dependencies.consentedBackupComponentIds?()
+            if deviceBackupView == nil || componentIds != deviceBackupComponentIds {
                 deviceBackupView = await makeDeviceBackupView()
-                deviceBackupComponentId = componentId
+                deviceBackupComponentIds = componentIds
             }
         } while deviceBackupResolutionPending
     }

--- a/Tests/OnymIOSTests/BackupDisclosureTests.swift
+++ b/Tests/OnymIOSTests/BackupDisclosureTests.swift
@@ -72,11 +72,13 @@ final class BackupDisclosureTests: XCTestCase {
     }
 
     /// The schedule copy must not promise more than the build does.
-    /// Uploads are foreground-only, so "automatic" would be a lie, and
-    /// whole-snapshot means every run re-uploads everything.
+    /// Uploads happen on a tap and nowhere else — nothing calls
+    /// `backUpIfDue` — so "automatic" would be a lie, and whole-snapshot
+    /// means every run re-uploads everything.
     func testScheduleCopyDoesNotOverpromise() throws {
         let text = try disclosure().whenBackupsHappen.lowercased()
-        XCTAssertTrue(text.contains("cannot back up in the background"))
+        XCTAssertTrue(text.contains("not in the background"))
+        XCTAssertTrue(text.contains("does not back up on its own"))
         XCTAssertTrue(text.contains("whole history"))
         XCTAssertFalse(text.contains("automatically"))
     }
@@ -99,14 +101,21 @@ final class BackupDisclosureTests: XCTestCase {
         XCTAssertEqual(included.value, "Included in the backup")
     }
 
-    /// The schedule sentence follows the policy rather than being
-    /// written beside it.
-    func testScheduleSentenceTracksThePolicy() {
-        var schedule = BackupSchedule.default
-        schedule.requiresCharging = false
-        let sentence = BackupDisclosure.scheduleSentence(schedule).lowercased()
-        XCTAssertTrue(sentence.contains("on wi-fi"))
-        XCTAssertFalse(sentence.contains("charging"))
+    /// The schedule sentence describes what this build does, not what
+    /// `BackupSchedule` could do.
+    ///
+    /// It used to assert the sentence tracked the policy — Wi-Fi in,
+    /// charging out — which was a fine rule for copy about a behaviour
+    /// that existed. `backUpIfDue` has no caller, so the sentence was
+    /// describing an opportunistic run that never happens, on the screen
+    /// whose whole job is to say what will happen. This pins the honest
+    /// claim instead, and will fail the day somebody wires the schedule
+    /// without revisiting the copy.
+    func testScheduleSentenceClaimsOnlyWhatThisBuildDoes() {
+        let sentence = BackupDisclosure.scheduleSentence(.default).lowercased()
+        XCTAssertTrue(sentence.contains("when you tap back up now"))
+        XCTAssertTrue(sentence.contains("does not back up on its own"))
+        XCTAssertFalse(sentence.contains("may also"))
     }
 
     func testOpportunisticRunRespectsConditions() {

--- a/Tests/OnymIOSTests/BackupRestoreTests.swift
+++ b/Tests/OnymIOSTests/BackupRestoreTests.swift
@@ -36,11 +36,16 @@ final class BackupRestoreTests: XCTestCase {
 
         let sink = RecordingSink()
         let flow = await BackupRestoreFlow(
-            repository: BackupRepository(
-                port: HoldingPort(snapshot: snapshot),
-                composer: composer,
-                stateStore: EmptyStateStore(),
-                keyMaterial: material),
+            sources: [
+                BackupRestoreSource(
+                    componentId: "onym:component:test-operator",
+                    displayName: "Test Operator",
+                    repository: BackupRepository(
+                        port: HoldingPort(snapshot: snapshot),
+                        composer: composer,
+                        stateStore: EmptyStateStore(),
+                        keyMaterial: material))
+            ],
             restorer: BackupRestorer(sink: sink),
             keyMaterial: material,
             workingDirectory: dir)
@@ -80,11 +85,16 @@ final class BackupRestoreTests: XCTestCase {
 
         let sink = RecordingSink()
         let flow = await BackupRestoreFlow(
-            repository: BackupRepository(
-                port: HoldingPort(snapshot: snapshot),
-                composer: composer,
-                stateStore: EmptyStateStore(),
-                keyMaterial: material),
+            sources: [
+                BackupRestoreSource(
+                    componentId: "onym:component:test-operator",
+                    displayName: "Test Operator",
+                    repository: BackupRepository(
+                        port: HoldingPort(snapshot: snapshot),
+                        composer: composer,
+                        stateStore: EmptyStateStore(),
+                        keyMaterial: material))
+            ],
             restorer: BackupRestorer(sink: sink),
             keyMaterial: material,
             workingDirectory: dir)
@@ -108,12 +118,17 @@ final class BackupRestoreTests: XCTestCase {
         let dir = try directory()
         let material = material()
         let flow = await BackupRestoreFlow(
-            repository: BackupRepository(
-                port: HoldingPort(snapshot: nil),
-                composer: BackupComposer(
-                    source: SeededSource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
-                stateStore: EmptyStateStore(),
-                keyMaterial: material),
+            sources: [
+                BackupRestoreSource(
+                    componentId: "onym:component:test-operator",
+                    displayName: "Test Operator",
+                    repository: BackupRepository(
+                        port: HoldingPort(snapshot: nil),
+                        composer: BackupComposer(
+                            source: SeededSource(), mediaPolicy: .descriptorsOnly, workingDirectory: dir),
+                        stateStore: EmptyStateStore(),
+                        keyMaterial: material))
+            ],
             restorer: BackupRestorer(sink: RecordingSink()),
             keyMaterial: material,
             workingDirectory: dir)
@@ -177,11 +192,16 @@ final class BackupRestoreTests: XCTestCase {
             acceptedTermsId: "sha256:" + String(repeating: "d", count: 64))
 
         let flow = await BackupRestoreFlow(
-            repository: BackupRepository(
-                port: HoldingPort(snapshot: snapshot),
-                composer: composer,
-                stateStore: EmptyStateStore(),
-                keyMaterial: material),
+            sources: [
+                BackupRestoreSource(
+                    componentId: "onym:component:test-operator",
+                    displayName: "Test Operator",
+                    repository: BackupRepository(
+                        port: HoldingPort(snapshot: snapshot),
+                        composer: composer,
+                        stateStore: EmptyStateStore(),
+                        keyMaterial: material))
+            ],
             // Groups land, then invitations throw — the shape the
             // reviewer identified in the real sink.
             restorer: BackupRestorer(sink: FailsMidWriteSink()),


### PR DESCRIPTION
A person could choose a backup operator; they could not keep a backup with two. Everything below the UI assumed one: a single `state.json`, a single consented manifest, and `rebind(to:)` — which is correct for *switching* operators and exactly wrong for *adding* one, since it discards the previous operator's chain the moment a second is enrolled.

What one operator cannot offer is the reason to want two. An operator can shut down, be seized, lose a region, or decide it no longer wants your business, and none of those is a reason to lose a history.

## The choice worth reviewing

**The snapshot is sealed once per operator, not once.** The archive root comes from the recovery seed alone, so one seal would be openable at every operator — tempting, and wrong. Identical bytes at two operators is a digest that links their two holders, undoing what per-operator key derivation and the profile's ban on convergent keying (`UI-Backup-Object-HTTP.md` §8.2) exist to prevent. So `BackupComposer` splits: `composeArchive` reads the history once, `seal` mints a fresh salt per operator.

The cost is disk — every operator's sealed copy exists at once during a run. That is the deliberate side to pay on: the alternative (seal, upload, seal the next) keeps the plaintext archive, the one seed-readable artefact, on disk for the length of every transfer.

## What changed

- **State is per operator**, in its own file, with the operator in the filename rather than a field inside it. Terms pins, chains, operation ids, entitlements, payments and access keys were already per operator; §14.12 says one operator never receives another's, and the only way that stays true is for none of them to have a shared home. A single-operator install's `state.json` is migrated on first launch — without it, backup reads as off for an operator already enrolled, and the next snapshot supersedes nothing and is paid for twice.
- **`BackupRepository.place(prepared:)`** is where bytes become addressed. Terms digest, chain position and operation id are stamped there because none is a property of the bytes: two operators enrolled at different times supersede different ancestors. `prepare()` lets the fan-out ask before it composes — a snapshot no operator will accept is a whole history read and sealed for nobody. Preconditions are extracted so all three entry points apply the same rules.
- **`BackupFanOut`** runs the order that matters: retry anything already sealed and refused for payment, ask each operator, compose once, seal per operator, destroy the plaintext *before* the first upload, then upload one at a time. One operator failing, refusing payment, publishing new terms or never having been set up does not stop the others.
- **The summary is pessimistic on purpose.** "On" means every enrolled operator is up to date; anything else names the number that are not. A backup surface that rounds up is the failure mode this stack exists to avoid. Restore reads across every operator, labels each snapshot with who holds it, and names operators it could not reach rather than showing a short list that looks complete.
- **Enrolment says what it is doing.** With another operator already set up, the consent surface leads with the fact that this adds a second complete copy — different company, different country, different terms, paid separately, and everyone in those chats has their messages kept in one more place (§14.11). Someone who thinks they are switching finds out before they consent.
- **Media policy is the strictest any enrolled operator was consented under**, because one archive is composed for all of them. The other direction would send an operator attachments the person agreed to give somebody else — a widening of the eligible set by composition order, which §14.10 forbids without an explicit choice.

## Testing

- `OnymIOS` app and the `OnymBackup` / `OnymBackupUI` packages build for the simulator.
- `OnymIOSTests`: 1403 tests, 0 failures. `BackupRestoreTests` updated for the new `sources:` initializer.
- A later serial run hit an unrelated CoreData crash in `VerdictValidatorTests`; reproduced on clean `origin/main` with these changes stashed, so it is pre-existing.

## Known gaps

- No tests for the fan-out, the per-operator state paths, or the multi-operator surfaces yet — they belong in a following PR.
- No erase action on the per-operator screen. The disclosure copy that would have promised one was removed rather than left pointing at a button that does not exist.
- The DEBUG `--backup-base-url` override applies to every operator, so a multi-operator debug run points them all at the same endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
