### PR TITLE
Restore a purchase, and a backup, on a phone that never made either

### DIFF
--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -32,6 +32,12 @@ public final class DeviceBackupSettingsFlow {
         case failed(message: String)
     }
 
+    /// Whether this operator is waiting on a purchase.
+    public var isPaymentRequired: Bool {
+        if case .paymentRequired = state.status { return true }
+        return false
+    }
+
     /// Whether the person needs to go through enrolment.
     ///
     /// `.off` alone was not enough, and the gap was the whole point of
@@ -294,6 +300,17 @@ public final class DeviceBackupSettingsFlow {
         case .alreadyRunning:
             break
         }
+    }
+
+    /// A credential arrived for an operator that is waiting on one.
+    ///
+    /// The status stays `paymentRequired`, because it is derived from a
+    /// snapshot still sitting unsent — a credential does not place those
+    /// bytes, only a run does. Saying so beats a screen that keeps
+    /// reading "Payment needed" with no explanation after someone has
+    /// just restored the purchase it was asking for.
+    public func noteRestoredPurchase() {
+        lastRunNote = "Purchase restored — tap Back Up Now to finish this backup."
     }
 
     /// Report that a run threw before it could reach a result.

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
@@ -68,8 +68,16 @@ public final class DeviceBackupVendorsFlow {
         /// `heldUnknown` means this phone could not check what it
         /// already holds — different from finding nothing, and not
         /// something to report as an answer about the App Store.
+        /// `syncFailed` means the account-wide sync did not happen or
+        /// did not work, so nothing here is an answer about what the
+        /// App Store holds.
         case finished(
-            restored: Int, held: Int, checked: Int, heldUnknown: Bool, failures: [String])
+            restored: Int,
+            held: Int,
+            checked: Int,
+            heldUnknown: Bool,
+            syncFailed: Bool,
+            failures: [String])
     }
 
     private let fanOut: BackupFanOut
@@ -85,9 +93,12 @@ public final class DeviceBackupVendorsFlow {
     /// as "the store has nothing".
     private let restorePurchasesForOperator:
         (@Sendable (String) async -> SeatPurchaseFlow.RestoreResult?)?
-    /// Asks StoreKit to sync. Account-wide, and prompts for an App Store
-    /// password, so it happens once per tap and never per operator.
-    private let syncPurchasesWithStore: (@Sendable () async -> Void)?
+    /// Asks StoreKit to sync. Account-wide, and prompts for an App
+    /// Store password, so it happens once per tap and never per
+    /// operator — and it reports whether it worked, because a sweep
+    /// that follows a failed sync must not go on to say the App Store
+    /// has nothing.
+    private let syncPurchasesWithStore: (@Sendable () async -> Bool)?
     /// Guards the sweep itself, rather than what the screen is showing.
     /// The quiet sweep displays nothing, so a status-based guard did not
     /// hold it — and a tap during one started a second concurrent sweep,
@@ -100,7 +111,7 @@ public final class DeviceBackupVendorsFlow {
         schedule: BackupSchedule = .default,
         restorePurchasesForOperator:
             (@Sendable (String) async -> SeatPurchaseFlow.RestoreResult?)? = nil,
-        syncPurchasesWithStore: (@Sendable () async -> Void)? = nil
+        syncPurchasesWithStore: (@Sendable () async -> Bool)? = nil
     ) {
         self.vendors = vendors
         self.fanOut = fanOut
@@ -257,13 +268,27 @@ public final class DeviceBackupVendorsFlow {
         // prompts for a password: doing it per operator asked a person
         // with two operators to authenticate twice for one tap, the
         // second time seconds later and out of context.
-        if syncWithStore { await syncPurchasesWithStore?() }
+        // A sync that did not happen is not a sync that found nothing.
+        // Skipping it silently — or swallowing its failure — and then
+        // reporting "the App Store has no purchase for this identity"
+        // is a definitive answer to a question nobody managed to ask,
+        // told to the one person who most needs it to be right: someone
+        // on a replacement phone.
+        var syncFailed = false
+        if syncWithStore {
+            syncFailed = await syncPurchasesWithStore?() == false
+        }
 
         var restored = 0
         var held = 0
         var checked = 0
         var heldUnknown = false
         var failures: [String] = []
+        /// The operators a credential was actually recovered for. A
+        /// total is not enough: with two paid operators, one restore and
+        /// one failure, a total would tell the operator that got nothing
+        /// that its purchase had been restored.
+        var restoredFor: Set<String> = []
         for vendor in vendors {
             guard let result = await restore(vendor.id) else {
                 // Not checked: no pinned issuer, or nothing this build
@@ -274,6 +299,7 @@ public final class DeviceBackupVendorsFlow {
             }
             checked += 1
             restored += result.restored.count
+            if !result.restored.isEmpty { restoredFor.insert(vendor.id) }
             held += result.alreadyHeld.count
             // Named by operator: with several set up, "something went
             // wrong" without saying where is not something a person can
@@ -309,6 +335,7 @@ public final class DeviceBackupVendorsFlow {
                 held: held,
                 checked: checked,
                 heldUnknown: heldUnknown,
+                syncFailed: syncFailed,
                 failures: failures)
         } else {
             purchaseRestore = .idle
@@ -319,8 +346,9 @@ public final class DeviceBackupVendorsFlow {
         // is derived from a snapshot still awaiting payment, and only a
         // run that actually places those bytes resolves it.
         refresh()
-        if restored > 0 {
-            for vendor in vendors where vendor.flow.isPaymentRequired {
+        if !restoredFor.isEmpty {
+            for vendor in vendors
+            where restoredFor.contains(vendor.id) && vendor.flow.isPaymentRequired {
                 vendor.flow.noteRestoredPurchase()
             }
             // A credential is what lets a paid operator answer at all,

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
@@ -62,7 +62,10 @@ public final class DeviceBackupVendorsFlow {
         /// separate because "nothing to restore" and "already set up"
         /// are different answers, and only one of them means something
         /// went wrong.
-        case finished(restored: Int, held: Int, failures: [String])
+        /// `checked` is how many operators were actually asked about.
+        /// Zero means nothing was, which is not a fact about the App
+        /// Store.
+        case finished(restored: Int, held: Int, checked: Int, failures: [String])
     }
 
     private let fanOut: BackupFanOut
@@ -72,88 +75,38 @@ public final class DeviceBackupVendorsFlow {
     /// operator. `nil` when this build cannot sell anything — a free
     /// operator, or a build with no store products — in which case the
     /// row does not appear.
+    /// Recovers a credential for one operator. `nil` from the closure
+    /// means this operator was not checked at all — no pinned issuer, or
+    /// nothing this build can sell for it — which is not the same answer
+    /// as "the store has nothing".
     private let restorePurchasesForOperator:
-        (@Sendable (String, Bool) async -> SeatPurchaseFlow.RestoreResult?)?
+        (@Sendable (String) async -> SeatPurchaseFlow.RestoreResult?)?
+    /// Asks StoreKit to sync. Account-wide, and prompts for an App Store
+    /// password, so it happens once per tap and never per operator.
+    private let syncPurchasesWithStore: (@Sendable () async -> Void)?
+    /// Guards the sweep itself, rather than what the screen is showing.
+    /// The quiet sweep displays nothing, so a status-based guard did not
+    /// hold it — and a tap during one started a second concurrent sweep,
+    /// with its own `AppStore.sync()`.
+    private var isSweepingPurchases = false
 
     public init(
         vendors: [Vendor],
         fanOut: BackupFanOut,
         schedule: BackupSchedule = .default,
         restorePurchasesForOperator:
-            (@Sendable (String, Bool) async -> SeatPurchaseFlow.RestoreResult?)? = nil
+            (@Sendable (String) async -> SeatPurchaseFlow.RestoreResult?)? = nil,
+        syncPurchasesWithStore: (@Sendable () async -> Void)? = nil
     ) {
         self.vendors = vendors
         self.fanOut = fanOut
         self.schedule = schedule
         self.sessionJitter = schedule.drawJitter()
         self.restorePurchasesForOperator = restorePurchasesForOperator
+        self.syncPurchasesWithStore = syncPurchasesWithStore
     }
 
     public var canRestorePurchases: Bool { restorePurchasesForOperator != nil }
-
-    /// Recover what was already paid for, for every operator.
-    ///
-    /// The new-phone path. Someone who restored their identity from the
-    /// recovery phrase has the keys to prove who they are to the broker
-    /// and to open a snapshot, but no credential — the purchase was
-    /// finished on a phone they no longer have. Without this the only
-    /// route past a paid operator's refusal is to buy the same thing
-    /// again.
-    ///
-    /// `syncWithStore` asks StoreKit to sync first, which prompts for an
-    /// App Store password. Passed as false for the sweep that runs on
-    /// its own, true for the button someone taps.
-    public func restorePurchases(syncWithStore: Bool = true) async {
-        await restorePurchases(syncWithStore: syncWithStore, announcingNothingFound: true)
-    }
-
-    /// The quiet sweep, once per screen.
-    ///
-    /// Costs nothing when there is nothing to do: `currentEntitlement`
-    /// is answered from what the device already holds, and the broker is
-    /// contacted only for a purchase the store knows about and this
-    /// device has no credential for. After the first success it
-    /// short-circuits on the credential it just stored.
-    ///
-    /// It runs without being asked because the person it exists for does
-    /// not know to ask: on a new phone nothing has been uploaded, so no
-    /// operator has refused anything yet, and the refusal that would
-    /// have mentioned a purchase has not happened.
-    public func restorePurchasesIfNeeded() async {
-        guard !hasSweptPurchases else { return }
-        hasSweptPurchases = true
-        await restorePurchases(syncWithStore: false, announcingNothingFound: false)
-    }
-
-    private func restorePurchases(syncWithStore: Bool, announcingNothingFound: Bool) async {
-        guard let restore = restorePurchasesForOperator, purchaseRestore != .running else { return }
-        if announcingNothingFound { purchaseRestore = .running }
-        var restored = 0
-        var held = 0
-        var failures: [String] = []
-        for vendor in vendors {
-            guard let result = await restore(vendor.id, syncWithStore) else { continue }
-            restored += result.restored.count
-            held += result.alreadyHeld.count
-            // Named by operator: with several set up, "something went
-            // wrong" without saying where is not something a person can
-            // act on.
-            failures += result.failures.values.map { "\(vendor.displayName): \($0)" }
-        }
-        if announcingNothingFound || restored > 0 || !failures.isEmpty {
-            // A sweep nobody asked for stays quiet unless it has news.
-            // Announcing "the App Store has no purchase to restore" on a
-            // screen someone opened to check their backups would be an
-            // answer to a question they did not ask.
-            purchaseRestore = .finished(restored: restored, held: held, failures: failures)
-        } else {
-            purchaseRestore = .idle
-        }
-        // A recovered credential changes what the next upload can do, so
-        // an operator sitting on "Payment needed" should stop saying so
-        // once it no longer is.
-        refresh()
-    }
 
     public var summary: Summary {
         if isRunning { return .running }
@@ -256,6 +209,116 @@ public final class DeviceBackupVendorsFlow {
     public func backUpIfDue(conditions: BackupSchedule.Conditions) async {
         guard schedule.permitsOpportunisticRun(conditions, jitter: sessionJitter) else { return }
         await backUpAllNow()
+    }
+
+    /// Recover what was already paid for, for every operator.
+    ///
+    /// The new-phone path. Someone who restored their identity from the
+    /// recovery phrase has the keys to prove who they are to the broker
+    /// and to open a snapshot, but no credential — the purchase was
+    /// finished on a phone they no longer have. Without this the only
+    /// route past a paid operator's refusal is to buy the same thing
+    /// again.
+    ///
+    /// `syncWithStore` asks StoreKit to sync first, which prompts for an
+    /// App Store password. Passed as false for the sweep that runs on
+    /// its own, true for the button someone taps.
+    public func restorePurchases(syncWithStore: Bool = true) async {
+        await restorePurchases(syncWithStore: syncWithStore, announcingNothingFound: true)
+    }
+
+    /// The quiet sweep, once per screen.
+    ///
+    /// Costs nothing when there is nothing to do: `currentEntitlement`
+    /// is answered from what the device already holds, and the broker is
+    /// contacted only for a purchase the store knows about and this
+    /// device has no credential for. After the first success it
+    /// short-circuits on the credential it just stored.
+    ///
+    /// It runs without being asked because the person it exists for does
+    /// not know to ask: on a new phone nothing has been uploaded, so no
+    /// operator has refused anything yet, and the refusal that would
+    /// have mentioned a purchase has not happened.
+    public func restorePurchasesIfNeeded() async {
+        guard !hasSweptPurchases else { return }
+        await restorePurchases(syncWithStore: false, announcingNothingFound: false)
+    }
+
+    private func restorePurchases(syncWithStore: Bool, announcingNothingFound: Bool) async {
+        guard let restore = restorePurchasesForOperator, !isSweepingPurchases else { return }
+        isSweepingPurchases = true
+        defer { isSweepingPurchases = false }
+        if announcingNothingFound { purchaseRestore = .running }
+        // Once, before the loop. `AppStore.sync()` is account-wide and
+        // prompts for a password: doing it per operator asked a person
+        // with two operators to authenticate twice for one tap, the
+        // second time seconds later and out of context.
+        if syncWithStore { await syncPurchasesWithStore?() }
+
+        var restored = 0
+        var held = 0
+        var checked = 0
+        var failures: [String] = []
+        for vendor in vendors {
+            guard let result = await restore(vendor.id) else {
+                // Not checked: no pinned issuer, or nothing this build
+                // sells for it. Counting it as checked would let the row
+                // say the App Store has nothing to restore without
+                // anything having asked the App Store.
+                continue
+            }
+            checked += 1
+            restored += result.restored.count
+            held += result.alreadyHeld.count
+            // Named by operator: with several set up, "something went
+            // wrong" without saying where is not something a person can
+            // act on.
+            failures += result.failures.values
+                .filter { !Self.isCancellation($0) }
+                .map { "\(vendor.displayName): \($0)" }
+        }
+
+        if Task.isCancelled {
+            // The screen was left mid-sweep. Nothing is known, so
+            // nothing is claimed — and the quiet sweep is left un-swept
+            // so the next visit tries again rather than reporting a
+            // cancellation forever.
+            if announcingNothingFound { purchaseRestore = .idle }
+            return
+        }
+        hasSweptPurchases = true
+
+        if announcingNothingFound || restored > 0 || !failures.isEmpty {
+            // A sweep nobody asked for stays quiet unless it has news.
+            // Announcing "the App Store has no purchase to restore" on a
+            // screen someone opened to check their backups would be an
+            // answer to a question they did not ask.
+            purchaseRestore = .finished(
+                restored: restored, held: held, checked: checked, failures: failures)
+        } else {
+            purchaseRestore = .idle
+        }
+        // A recovered credential changes what the next upload can do, so
+        // an operator sitting on "Payment needed" is told what to do
+        // about it. `refresh()` cannot clear that state on its own: it
+        // is derived from a snapshot still awaiting payment, and only a
+        // run that actually places those bytes resolves it.
+        refresh()
+        if restored > 0 {
+            for vendor in vendors where vendor.flow.isPaymentRequired {
+                vendor.flow.noteRestoredPurchase()
+            }
+            // A credential is what lets a paid operator answer at all,
+            // so the list it refused a moment ago is worth asking again.
+            await loadSnapshots()
+        }
+    }
+
+    /// A cancelled request is not a failed one. Leaving the screen
+    /// mid-sweep used to leave a raw `URLError` in the row.
+    private static func isCancellation(_ message: String) -> Bool {
+        message.contains("cancelled") || message.contains("Cancelled")
+            || message.contains("CancellationError")
     }
 
     /// What one operator reported in the last run, if it reported

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OnymBackup
+import OnymBilling
 
 /// Settings → Device Backup, when there may be more than one operator.
 ///
@@ -48,19 +49,110 @@ public final class DeviceBackupVendorsFlow {
     /// half-worked.
     public private(set) var lastRun: [BackupFanOut.Outcome] = []
 
+    /// What a restore-purchases sweep reported, per operator.
+    public private(set) var purchaseRestore: PurchaseRestore = .idle
+    /// Whether the quiet sweep has already run for this flow.
+    private var hasSweptPurchases = false
+
+    public enum PurchaseRestore: Equatable {
+        case idle
+        case running
+        /// `restored` counts credentials this device did not have
+        /// before; `held` counts the ones it already had. They are
+        /// separate because "nothing to restore" and "already set up"
+        /// are different answers, and only one of them means something
+        /// went wrong.
+        case finished(restored: Int, held: Int, failures: [String])
+    }
+
     private let fanOut: BackupFanOut
     private let schedule: BackupSchedule
     private let sessionJitter: TimeInterval
+    /// Recovers credentials for purchases made on another device, per
+    /// operator. `nil` when this build cannot sell anything — a free
+    /// operator, or a build with no store products — in which case the
+    /// row does not appear.
+    private let restorePurchasesForOperator:
+        (@Sendable (String, Bool) async -> SeatPurchaseFlow.RestoreResult?)?
 
     public init(
         vendors: [Vendor],
         fanOut: BackupFanOut,
-        schedule: BackupSchedule = .default
+        schedule: BackupSchedule = .default,
+        restorePurchasesForOperator:
+            (@Sendable (String, Bool) async -> SeatPurchaseFlow.RestoreResult?)? = nil
     ) {
         self.vendors = vendors
         self.fanOut = fanOut
         self.schedule = schedule
         self.sessionJitter = schedule.drawJitter()
+        self.restorePurchasesForOperator = restorePurchasesForOperator
+    }
+
+    public var canRestorePurchases: Bool { restorePurchasesForOperator != nil }
+
+    /// Recover what was already paid for, for every operator.
+    ///
+    /// The new-phone path. Someone who restored their identity from the
+    /// recovery phrase has the keys to prove who they are to the broker
+    /// and to open a snapshot, but no credential — the purchase was
+    /// finished on a phone they no longer have. Without this the only
+    /// route past a paid operator's refusal is to buy the same thing
+    /// again.
+    ///
+    /// `syncWithStore` asks StoreKit to sync first, which prompts for an
+    /// App Store password. Passed as false for the sweep that runs on
+    /// its own, true for the button someone taps.
+    public func restorePurchases(syncWithStore: Bool = true) async {
+        await restorePurchases(syncWithStore: syncWithStore, announcingNothingFound: true)
+    }
+
+    /// The quiet sweep, once per screen.
+    ///
+    /// Costs nothing when there is nothing to do: `currentEntitlement`
+    /// is answered from what the device already holds, and the broker is
+    /// contacted only for a purchase the store knows about and this
+    /// device has no credential for. After the first success it
+    /// short-circuits on the credential it just stored.
+    ///
+    /// It runs without being asked because the person it exists for does
+    /// not know to ask: on a new phone nothing has been uploaded, so no
+    /// operator has refused anything yet, and the refusal that would
+    /// have mentioned a purchase has not happened.
+    public func restorePurchasesIfNeeded() async {
+        guard !hasSweptPurchases else { return }
+        hasSweptPurchases = true
+        await restorePurchases(syncWithStore: false, announcingNothingFound: false)
+    }
+
+    private func restorePurchases(syncWithStore: Bool, announcingNothingFound: Bool) async {
+        guard let restore = restorePurchasesForOperator, purchaseRestore != .running else { return }
+        if announcingNothingFound { purchaseRestore = .running }
+        var restored = 0
+        var held = 0
+        var failures: [String] = []
+        for vendor in vendors {
+            guard let result = await restore(vendor.id, syncWithStore) else { continue }
+            restored += result.restored.count
+            held += result.alreadyHeld.count
+            // Named by operator: with several set up, "something went
+            // wrong" without saying where is not something a person can
+            // act on.
+            failures += result.failures.values.map { "\(vendor.displayName): \($0)" }
+        }
+        if announcingNothingFound || restored > 0 || !failures.isEmpty {
+            // A sweep nobody asked for stays quiet unless it has news.
+            // Announcing "the App Store has no purchase to restore" on a
+            // screen someone opened to check their backups would be an
+            // answer to a question they did not ask.
+            purchaseRestore = .finished(restored: restored, held: held, failures: failures)
+        } else {
+            purchaseRestore = .idle
+        }
+        // A recovered credential changes what the next upload can do, so
+        // an operator sitting on "Payment needed" should stop saying so
+        // once it no longer is.
+        refresh()
     }
 
     public var summary: Summary {

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsFlow.swift
@@ -65,7 +65,11 @@ public final class DeviceBackupVendorsFlow {
         /// `checked` is how many operators were actually asked about.
         /// Zero means nothing was, which is not a fact about the App
         /// Store.
-        case finished(restored: Int, held: Int, checked: Int, failures: [String])
+        /// `heldUnknown` means this phone could not check what it
+        /// already holds — different from finding nothing, and not
+        /// something to report as an answer about the App Store.
+        case finished(
+            restored: Int, held: Int, checked: Int, heldUnknown: Bool, failures: [String])
     }
 
     private let fanOut: BackupFanOut
@@ -258,6 +262,7 @@ public final class DeviceBackupVendorsFlow {
         var restored = 0
         var held = 0
         var checked = 0
+        var heldUnknown = false
         var failures: [String] = []
         for vendor in vendors {
             guard let result = await restore(vendor.id) else {
@@ -273,9 +278,15 @@ public final class DeviceBackupVendorsFlow {
             // Named by operator: with several set up, "something went
             // wrong" without saying where is not something a person can
             // act on.
-            failures += result.failures.values
+            // Sorted by offer id, so two failing offers do not produce
+            // a different subtitle on every run — `Dictionary.values`
+            // has no order, and the row shows the first one.
+            failures += result.failures
+                .sorted { $0.key < $1.key }
+                .map(\.value)
                 .filter { !Self.isCancellation($0) }
                 .map { "\(vendor.displayName): \($0)" }
+            if result.heldUnknown { heldUnknown = true }
         }
 
         if Task.isCancelled {
@@ -294,7 +305,11 @@ public final class DeviceBackupVendorsFlow {
             // screen someone opened to check their backups would be an
             // answer to a question they did not ask.
             purchaseRestore = .finished(
-                restored: restored, held: held, checked: checked, failures: failures)
+                restored: restored,
+                held: held,
+                checked: checked,
+                heldUnknown: heldUnknown,
+                failures: failures)
         } else {
             purchaseRestore = .idle
         }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -59,17 +59,19 @@ public struct DeviceBackupVendorsView: View {
                     }
                     SettingsFootnote(
                         "Each backup uploads everything, not just what changed — there is no incremental upload yet.")
-
                 }
 
                 // Outside the enrolled gate on purpose. Reading a backup
                 // needs the recovery phrase and the operator's name, not
                 // a terms pin — `listSnapshots` and `download` consult no
                 // local state at all. Inside the gate it disappeared
-                // exactly when it was most wanted: a new phone with
-                // nothing set up yet, or every operator republishing its
-                // terms at once, which now counts as not-enrolled and
-                // took the restore route down with it.
+                // exactly when it was most wanted: a new phone with an
+                // operator consented to and nothing set up yet, or every
+                // operator republishing its terms at once, which counts
+                // as not-enrolled and took the restore route with it.
+                // Hiding restore until someone agrees to *store* a
+                // backup asks them to take on a new obligation before
+                // they may read what they already have.
                 SettingsCard {
                     NavigationLink { makeRestore() } label: {
                         SettingsRow(
@@ -84,6 +86,8 @@ public struct DeviceBackupVendorsView: View {
                     .accessibilityIdentifier("backup.restore_row")
                 }
 
+                restorePurchases
+
                 operators
             }
             .padding(.horizontal, 16)
@@ -93,7 +97,66 @@ public struct DeviceBackupVendorsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             flow.refresh()
+            // Before the snapshot list, because a credential recovered
+            // here is what lets a paid operator answer that list at all.
+            await flow.restorePurchasesIfNeeded()
             await flow.loadSnapshots()
+        }
+    }
+
+    /// Recovering what was already paid for.
+    ///
+    /// Its own row rather than a line inside the payment-needed state,
+    /// because the person who needs it most cannot see that state yet:
+    /// on a new phone nothing has been uploaded, so no operator has
+    /// refused anything, and the refusal that would have offered a
+    /// purchase has not happened. They arrive knowing only that they
+    /// paid for this once.
+    @ViewBuilder
+    private var restorePurchases: some View {
+        if flow.canRestorePurchases {
+            SettingsCard {
+                Button {
+                    Task { await flow.restorePurchases() }
+                } label: {
+                    SettingsRow(
+                        title: "Restore Purchases",
+                        subtitle: purchaseRestoreSubtitle,
+                        last: true
+                    ) {
+                        SettingsIconTile(symbol: "arrow.clockwise.circle", bg: SettingsTile.gray)
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(flow.purchaseRestore == .running)
+                .accessibilityIdentifier("backup.restore_purchases_row")
+            }
+            SettingsFootnote(
+                "If you paid for storage on another phone, this brings that purchase to this one. You are not charged again.")
+        }
+    }
+
+    private var purchaseRestoreSubtitle: String {
+        switch flow.purchaseRestore {
+        case .idle:
+            return "Bring a subscription bought on another phone to this one"
+        case .running:
+            return "Checking with the App Store…"
+        case .finished(let restored, let held, let failures):
+            if let first = failures.first {
+                // The operator's own words, not a count. A failure here
+                // is the difference between someone getting what they
+                // paid for and buying it twice.
+                return first
+            }
+            if restored > 0 {
+                return restored == 1
+                    ? "1 purchase restored"
+                    : "\(restored) purchases restored"
+            }
+            return held > 0
+                ? "Nothing to restore — this phone is already set up"
+                : "The App Store has no purchase for this identity to restore"
         }
     }
 
@@ -226,7 +289,7 @@ public struct DeviceBackupVendorsView: View {
         case .off(let consented):
             return consented == 0
                 ? "Your history stays on this phone only"
-                : "Your history stays on this phone until you set an operator up"
+                : "Nothing is being backed up yet — you can still restore an earlier backup below"
         case .on(let operators, let notSetUp, let lastSuccessAt):
             // The oldest of the operators' last successes, so the
             // sentence describes the copy a person is actually relying

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -149,7 +149,7 @@ public struct DeviceBackupVendorsView: View {
             return "Bring a subscription bought on another phone to this one"
         case .running:
             return "Checking with the App Store…"
-        case .finished(let restored, let held, let checked, let failures):
+        case .finished(let restored, let held, let checked, let heldUnknown, let failures):
             if let first = failures.first {
                 // The operator's own words, not a count. A failure here
                 // is the difference between someone getting what they
@@ -160,6 +160,12 @@ public struct DeviceBackupVendorsView: View {
                 return restored == 1
                     ? "1 purchase restored"
                     : "\(restored) purchases restored"
+            }
+            if heldUnknown {
+                // Neither "already set up" nor "nothing there": this
+                // phone could not read what it holds, and both of the
+                // other answers would be claims it cannot make.
+                return "Could not check what this phone already has — try again"
             }
             if held > 0 { return "Nothing to restore — this phone is already set up" }
             // Only claimable if something actually asked. An operator

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -149,7 +149,8 @@ public struct DeviceBackupVendorsView: View {
             return "Bring a subscription bought on another phone to this one"
         case .running:
             return "Checking with the App Store…"
-        case .finished(let restored, let held, let checked, let heldUnknown, let failures):
+        case .finished(
+            let restored, let held, let checked, let heldUnknown, let syncFailed, let failures):
             if let first = failures.first {
                 // The operator's own words, not a count. A failure here
                 // is the difference between someone getting what they
@@ -160,6 +161,12 @@ public struct DeviceBackupVendorsView: View {
                 return restored == 1
                     ? "1 purchase restored"
                     : "\(restored) purchases restored"
+            }
+            if syncFailed, restored == 0 {
+                // Nothing was asked, so nothing may be concluded. The
+                // person on a replacement phone is exactly who would
+                // act on a wrong answer here.
+                return "Could not reach the App Store — try again"
             }
             if heldUnknown {
                 // Neither "already set up" nor "nothing there": this

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -97,10 +97,17 @@ public struct DeviceBackupVendorsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             flow.refresh()
-            // Before the snapshot list, because a credential recovered
-            // here is what lets a paid operator answer that list at all.
-            await flow.restorePurchasesIfNeeded()
             await flow.loadSnapshots()
+        }
+        // Its own task, so it runs beside the snapshot list rather than
+        // in front of it. On the overwhelmingly common path it recovers
+        // nothing, and making everyone wait for StoreKit and a credential
+        // verification per operator to find that out delays the screen
+        // for no one's benefit. The sweep reloads the list itself if it
+        // actually recovers something — which is the only case where the
+        // list's answer would have changed.
+        .task {
+            await flow.restorePurchasesIfNeeded()
         }
     }
 
@@ -142,7 +149,7 @@ public struct DeviceBackupVendorsView: View {
             return "Bring a subscription bought on another phone to this one"
         case .running:
             return "Checking with the App Store…"
-        case .finished(let restored, let held, let failures):
+        case .finished(let restored, let held, let checked, let failures):
             if let first = failures.first {
                 // The operator's own words, not a count. A failure here
                 // is the difference between someone getting what they
@@ -154,9 +161,14 @@ public struct DeviceBackupVendorsView: View {
                     ? "1 purchase restored"
                     : "\(restored) purchases restored"
             }
-            return held > 0
-                ? "Nothing to restore — this phone is already set up"
-                : "The App Store has no purchase for this identity to restore"
+            if held > 0 { return "Nothing to restore — this phone is already set up" }
+            // Only claimable if something actually asked. An operator
+            // with no pinned issuer is never checked, and reporting that
+            // as the App Store's answer is a positive claim made without
+            // a question.
+            return checked > 0
+                ? "The App Store has no purchase for this identity to restore"
+                : "No operator here sells storage through this app"
         }
     }
 

--- a/Packages/OnymBilling/Sources/OnymBilling/BillingError.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/BillingError.swift
@@ -36,3 +36,61 @@ public enum BillingError: Error, Equatable, Sendable {
     case brokerRejected(code: String, message: String?)
     case brokerUnavailable
 }
+
+/// Sentences, not enum dumps.
+///
+/// These reach a person: a restore sweep puts a failed offer's reason
+/// straight into the Device Backup screen, because the difference
+/// between getting what you paid for and buying it twice is what that
+/// row is for. `String(describing:)` on this enum produces
+/// `brokerRejected(code: "invalid_transaction", message: Optional("…"))`,
+/// which is a debugger's output rendered at somebody who is trying to
+/// find out whether their subscription came across.
+///
+/// `brokerRejected` prefers the broker's own words. It is the one case
+/// that carries a message written for a person, and a local guess at
+/// what a refusal meant is worse than the refusal's own account of
+/// itself.
+extension BillingError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .malformedEntitlement:
+            return "The purchase record could not be read."
+        case .untrustedIssuer:
+            return "The purchase was signed by someone this operator does not recognise."
+        case .signatureInvalid:
+            return "The purchase record's signature did not check out."
+        case .audienceMismatch:
+            return "That purchase belongs to a different operator."
+        case .subjectMismatch:
+            return "That purchase belongs to a different identity."
+        case .expired:
+            return "The subscription has expired."
+        case .notYetValid(let notBefore):
+            return "This purchase does not start until "
+                + notBefore.formatted(date: .abbreviated, time: .shortened) + "."
+        case .revoked:
+            return "The purchase was refunded or reversed, so it no longer covers storage."
+        case .envelopeUnreadable:
+            return "The purchase record could not be opened on this device."
+        case .offerNotSellable:
+            return "This version of Onym cannot sell that operator's storage."
+        case .purchaseFailed(let reason):
+            // StoreKit's own words for its own refusal, and the two
+            // that are not failures at all.
+            switch reason {
+            case "cancelled": return "The purchase was cancelled."
+            case "pending": return "The purchase is waiting for approval."
+            default: return "The App Store could not complete the purchase."
+            }
+        case .brokerRejected(let code, let message):
+            // Its own account of itself beats our guess at what it
+            // meant — and an unrecognised code is still worth naming,
+            // because it is what support will ask for.
+            if let message, !message.isEmpty { return message }
+            return "The billing service refused this purchase (\(code))."
+        case .brokerUnavailable:
+            return "The billing service could not be reached."
+        }
+    }
+}

--- a/Packages/OnymBilling/Sources/OnymBilling/BillingError.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/BillingError.swift
@@ -32,6 +32,14 @@ public enum BillingError: Error, Equatable, Sendable {
     case offerNotSellable(offerId: String)
     /// StoreKit refused, or the person cancelled.
     case purchaseFailed(reason: String)
+    /// StoreKit produced a transaction whose own signature did not
+    /// check out.
+    ///
+    /// Its own case because it is not an absence and must never be
+    /// reported as one: the store *has* a record of this purchase, and
+    /// telling somebody there is nothing to restore is how they buy it
+    /// again.
+    case transactionUnverified(reason: String)
     /// The broker rejected the submission, with its own code preserved.
     case brokerRejected(code: String, message: String?)
     case brokerUnavailable
@@ -83,6 +91,8 @@ extension BillingError: LocalizedError {
             case "pending": return "The purchase is waiting for approval."
             default: return "The App Store could not complete the purchase."
             }
+        case .transactionUnverified:
+            return "The App Store's record of this purchase did not verify on this phone. Try again."
         case .brokerRejected(let code, let message):
             // Its own account of itself beats our guess at what it
             // meant — and an unrecognised code is still worth naming,

--- a/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/ChannelOfferCatalog.swift
@@ -94,5 +94,15 @@ public struct ChannelOfferCatalog: Sendable {
         offers.first { $0.productId == productId }
     }
 
+    /// Everything this app can sell for one seat operator.
+    ///
+    /// What a restore-purchases sweep iterates: StoreKit can only be
+    /// asked about a product identifier it knows, so recovering a
+    /// purchase on a new device means asking about each product this
+    /// operator's offers map to.
+    public func offers(forComponentId componentId: String) -> [ChannelOffer] {
+        offers.filter { $0.componentId == componentId }
+    }
+
     public var productIds: Set<String> { Set(offers.map(\.productId)) }
 }

--- a/Packages/OnymBilling/Sources/OnymBilling/SeatEntitlementStore.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/SeatEntitlementStore.swift
@@ -12,6 +12,40 @@ public protocol SeatEntitlementStoring: Sendable {
     func save(_ rawEntitlements: [Data]) throws
 }
 
+/// Serializes every read-modify-write of the credential store in this
+/// process.
+///
+/// `redeem` loads, edits and saves, and every `SeatPurchaseFlow` is a
+/// *fresh actor instance* built per component — so the actor isolates
+/// nothing across callers. Two redeems interleaving lose one credential
+/// outright: A loads, B loads, A saves, B saves over it. The lost one is
+/// not recoverable, because its transaction was finished the moment it
+/// was redeemed and `Transaction.updates` will not replay it.
+///
+/// That was survivable while redeeming happened only when somebody
+/// bought something. A restore sweep that runs whenever the Device
+/// Backup screen opens makes the overlap ordinary.
+///
+/// A process-wide lock rather than an actor, for the same reason
+/// `PinnedConsentStore` uses one: the mutation is synchronous, and an
+/// actor hop would force every caller async for the same guarantee. It
+/// does not reach across processes.
+enum SeatEntitlementStoreSerialization {
+    static let lock = NSLock()
+}
+
+public extension SeatEntitlementStoring {
+    /// Read, change, and write back as one step.
+    ///
+    /// Callers that mutate must go through this rather than pairing
+    /// `load()` with `save()` themselves.
+    func mutate(_ body: ([Data]) throws -> [Data]) throws {
+        SeatEntitlementStoreSerialization.lock.lock()
+        defer { SeatEntitlementStoreSerialization.lock.unlock() }
+        try save(try body(try load()))
+    }
+}
+
 /// File-backed, under complete protection.
 public struct FileSeatEntitlementStore: SeatEntitlementStoring {
     private let url: URL

--- a/Packages/OnymBilling/Sources/OnymBilling/SeatPurchaseFlow.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/SeatPurchaseFlow.swift
@@ -57,6 +57,126 @@ public actor SeatPurchaseFlow {
         return entitlement
     }
 
+    /// What a restore sweep found.
+    public struct RestoreResult: Sendable, Equatable {
+        /// Offers this device now holds a verified credential for.
+        public let restored: [String]
+        /// Offers already covered before the sweep ran.
+        public let alreadyHeld: [String]
+        /// Offers the store has no entitlement for. The ordinary answer
+        /// for something never bought, or a subscription that lapsed —
+        /// not an error, and not phrased as one.
+        public let notPurchased: [String]
+        /// Offers the store *did* have an entitlement for and this
+        /// device could not turn into a credential, by offer id.
+        public let failures: [String: String]
+
+        public var isEmpty: Bool { restored.isEmpty && alreadyHeld.isEmpty }
+    }
+
+    /// Ask the store to sync before a sweep.
+    ///
+    /// Separate, and only ever an explicit action: `AppStore.sync()`
+    /// prompts for App Store authentication, and a screen that demands a
+    /// password on appear is a screen people learn to back out of. The
+    /// silent sweep below needs none of it.
+    public func syncWithStore() async throws {
+        try await coordinator.sync()
+    }
+
+    /// Recover credentials for purchases this device did not make.
+    ///
+    /// The new-phone path, and the reason it needs its own method:
+    /// `Transaction.updates` replays only transactions that were never
+    /// *finished*, and a purchase completed on the old phone was
+    /// finished there. On the new one it exists solely in
+    /// `Transaction.currentEntitlement`, which nothing was asking.
+    /// Without this, someone who restored their identity from the
+    /// recovery phrase met `payment_required` at an operator they had
+    /// already paid, and the only offered way out was to pay again.
+    ///
+    /// Everything the broker needs is derivable from the recovery
+    /// phrase: the subject is the seat access key for this operator, and
+    /// the credential is sealed to the agreement key derived beside it.
+    /// So this works on a device that has never seen the old one.
+    ///
+    /// One offer failing does not stop the others, and a failure is
+    /// reported rather than swallowed — a sweep that quietly restored
+    /// nothing would look identical to one that had nothing to restore.
+    public func restorePurchases(componentId: String) async -> RestoreResult {
+        var restored: [String] = []
+        var alreadyHeld: [String] = []
+        var notPurchased: [String] = []
+        var failures: [String: String] = [:]
+
+        let held = (try? await heldOfferIds(componentId: componentId)) ?? []
+        for channelOffer in catalog.offers(forComponentId: componentId) {
+            if held.contains(channelOffer.offerId) {
+                // A credential that still verifies needs no broker round
+                // trip. Redeeming anyway would spend the person's
+                // network and the broker's rate limit to arrive back
+                // where we started.
+                alreadyHeld.append(channelOffer.offerId)
+                continue
+            }
+            guard
+                let (jws, transaction) = await coordinator.currentTransaction(
+                    for: channelOffer.productId)
+            else {
+                notPurchased.append(channelOffer.offerId)
+                continue
+            }
+            do {
+                _ = try await redeem(
+                    signedTransaction: jws,
+                    offerId: channelOffer.offerId,
+                    componentId: componentId
+                )
+                restored.append(channelOffer.offerId)
+                // Ordinarily already finished — this transaction came
+                // from `currentEntitlement`, not from a purchase. It is
+                // called anyway for the case that is not ordinary: a
+                // purchase made on this device whose redemption never
+                // completed, which is delivered now.
+                await coordinator.finish(transaction)
+            } catch {
+                failures[channelOffer.offerId] = String(describing: error)
+            }
+        }
+        return RestoreResult(
+            restored: restored,
+            alreadyHeld: alreadyHeld,
+            notPurchased: notPurchased,
+            failures: failures
+        )
+    }
+
+    /// Offers this device already holds a credential for that verifies
+    /// today — not merely one that is stored.
+    private func heldOfferIds(componentId: String) async throws -> Set<String> {
+        let subject = try await keys.seatSubject(componentId: componentId)
+        let verifier = SeatEntitlementVerifier(
+            trustedIssuers: trustedIssuers(componentId),
+            componentId: componentId,
+            subject: subject
+        )
+        var offerIds: Set<String> = []
+        for raw in try store.load() {
+            guard
+                let entitlement = try? SeatEntitlement.decode(raw: raw),
+                (try? verifier.verify(entitlement)) != nil
+            else {
+                // Expired, revoked, or for somebody else. Not held, so
+                // the sweep should try to replace it — which is exactly
+                // what a lapsed subscription that has since been renewed
+                // needs.
+                continue
+            }
+            offerIds.insert(entitlement.offerId)
+        }
+        return offerIds
+    }
+
     /// The Ed25519 keys behind a set of `onym:key:` references.
     ///
     /// An unparseable reference is dropped rather than failing the whole

--- a/Packages/OnymBilling/Sources/OnymBilling/SeatPurchaseFlow.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/SeatPurchaseFlow.swift
@@ -151,10 +151,17 @@ public actor SeatPurchaseFlow {
                 alreadyHeld.append(channelOffer.offerId)
                 continue
             }
-            guard
-                let (jws, transaction) = await coordinator.currentTransaction(
-                    for: channelOffer.productId)
-            else {
+            let current: (jws: String, transaction: StoreKit.Transaction)?
+            do {
+                current = try await coordinator.currentTransaction(for: channelOffer.productId)
+            } catch {
+                // The store had something and it did not verify. That is
+                // not "never bought", and reporting it as such is how
+                // somebody pays twice.
+                failures[channelOffer.offerId] = Self.describe(error)
+                continue
+            }
+            guard let (jws, transaction) = current else {
                 // The ordinary answer for something never bought, or a
                 // subscription that lapsed. Not an error, and not
                 // counted as one.

--- a/Packages/OnymBilling/Sources/OnymBilling/SeatPurchaseFlow.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/SeatPurchaseFlow.swift
@@ -63,15 +63,38 @@ public actor SeatPurchaseFlow {
         public let restored: [String]
         /// Offers already covered before the sweep ran.
         public let alreadyHeld: [String]
-        /// Offers the store has no entitlement for. The ordinary answer
-        /// for something never bought, or a subscription that lapsed —
-        /// not an error, and not phrased as one.
-        public let notPurchased: [String]
+        /// Whether the check for what is already held could not be
+        /// made — an unreadable credential store, or a subject that
+        /// could not be derived.
+        ///
+        /// The sweep still runs, re-redeeming everything, which is the
+        /// safe direction. It is reported because "this phone is
+        /// already set up" and "this phone could not tell" are
+        /// different answers and only one of them is a reason to stop
+        /// looking.
+        public let heldUnknown: Bool
         /// Offers the store *did* have an entitlement for and this
         /// device could not turn into a credential, by offer id.
+        ///
+        /// Sentences, not enum dumps: one of these is rendered straight
+        /// onto the Device Backup screen, and the difference between
+        /// getting what you paid for and buying it twice is what that
+        /// row is for.
         public let failures: [String: String]
 
         public var isEmpty: Bool { restored.isEmpty && alreadyHeld.isEmpty }
+
+        public init(
+            restored: [String],
+            alreadyHeld: [String],
+            heldUnknown: Bool,
+            failures: [String: String]
+        ) {
+            self.restored = restored
+            self.alreadyHeld = alreadyHeld
+            self.heldUnknown = heldUnknown
+            self.failures = failures
+        }
     }
 
     /// Ask the store to sync before a sweep.
@@ -106,10 +129,19 @@ public actor SeatPurchaseFlow {
     public func restorePurchases(componentId: String) async -> RestoreResult {
         var restored: [String] = []
         var alreadyHeld: [String] = []
-        var notPurchased: [String] = []
         var failures: [String: String] = [:]
 
-        let held = (try? await heldOfferIds(componentId: componentId)) ?? []
+        var held: Set<String> = []
+        var heldUnknown = false
+        do {
+            held = try await heldOfferIds(componentId: componentId)
+        } catch {
+            // Could not tell. Everything is re-checked, which is the
+            // safe direction — but it is not the same as knowing
+            // nothing is held, and the caller is told which one this
+            // was.
+            heldUnknown = true
+        }
         for channelOffer in catalog.offers(forComponentId: componentId) {
             if held.contains(channelOffer.offerId) {
                 // A credential that still verifies needs no broker round
@@ -123,7 +155,9 @@ public actor SeatPurchaseFlow {
                 let (jws, transaction) = await coordinator.currentTransaction(
                     for: channelOffer.productId)
             else {
-                notPurchased.append(channelOffer.offerId)
+                // The ordinary answer for something never bought, or a
+                // subscription that lapsed. Not an error, and not
+                // counted as one.
                 continue
             }
             do {
@@ -140,15 +174,31 @@ public actor SeatPurchaseFlow {
                 // completed, which is delivered now.
                 await coordinator.finish(transaction)
             } catch {
-                failures[channelOffer.offerId] = String(describing: error)
+                failures[channelOffer.offerId] = Self.describe(error)
             }
         }
         return RestoreResult(
             restored: restored,
             alreadyHeld: alreadyHeld,
-            notPurchased: notPurchased,
+            heldUnknown: heldUnknown,
             failures: failures
         )
+    }
+
+    /// A sentence somebody can act on.
+    ///
+    /// `String(describing:)` on a `BillingError` produces
+    /// `brokerRejected(code: "invalid_transaction", message: Optional("…"))`
+    /// — a debugger's output, rendered at a person trying to find out
+    /// whether the subscription they paid for came across. Every error
+    /// this can see already knows how to say itself; anything that does
+    /// not gets a sentence rather than its type name.
+    static func describe(_ error: Error) -> String {
+        if let described = (error as? LocalizedError)?.errorDescription { return described }
+        if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
+            return "This phone is not online, so the App Store could not be checked."
+        }
+        return "The purchase could not be restored on this device."
     }
 
     /// Offers this device already holds a credential for that verifies

--- a/Packages/OnymBilling/Sources/OnymBilling/SeatPurchaseFlow.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/SeatPurchaseFlow.swift
@@ -249,32 +249,41 @@ public actor SeatPurchaseFlow {
             subject: subject
         ).verify(entitlement)
 
-        // Not `try?`. A failed load here would be followed by a save
-        // that writes only this credential over every other one — and
-        // this is the `Transaction.updates` replay path, which fires at
-        // launch, where a read can legitimately fail because the file is
-        // under complete protection and the device has not been
-        // unlocked. One replayed transaction would then destroy every
-        // purchase the person had made.
+        // Not `try?`. A failed load inside the mutation propagates
+        // rather than being followed by a save that writes only this
+        // credential over every other one — and this is the
+        // `Transaction.updates` replay path, which fires at launch,
+        // where a read can legitimately fail because the file is under
+        // complete protection and the device has not been unlocked. One
+        // replayed transaction would then destroy every purchase the
+        // person had made.
         //
         // Throwing leaves the transaction unfinished, so the store
         // replays it once the device is readable. A delayed credential
         // is recoverable; deleted credentials are not.
-        var stored = try store.load()
-
-        // One live credential per offer. Keeping the superseded one
-        // would leave a verifier free to pick either.
-        //
-        // Entries this build cannot decode are *kept*. A newer client
-        // may have written a version we do not understand, and an older
-        // build silently deleting it during an unrelated redeem is a
-        // downgrade that eats data. Only positively matched entries go.
-        stored.removeAll { existing in
-            guard let decoded = try? SeatEntitlement.decode(raw: existing) else { return false }
-            return decoded.audience == componentId && decoded.offerId == offerId
+        // One step, under the store's lock. A `load()` here and a
+        // `save()` three lines later is a read-modify-write across a
+        // shared file, and every `SeatPurchaseFlow` is a separate actor
+        // instance — the replay observer and a restore sweep redeeming
+        // at once would drop one of the two credentials, permanently,
+        // because a redeemed transaction is finished and never replayed.
+        try store.mutate { stored in
+            var stored = stored
+            // One live credential per offer. Keeping the superseded one
+            // would leave a verifier free to pick either.
+            //
+            // Entries this build cannot decode are *kept*. A newer
+            // client may have written a version we do not understand,
+            // and an older build silently deleting it during an
+            // unrelated redeem is a downgrade that eats data. Only
+            // positively matched entries go.
+            stored.removeAll { existing in
+                guard let decoded = try? SeatEntitlement.decode(raw: existing) else { return false }
+                return decoded.audience == componentId && decoded.offerId == offerId
+            }
+            stored.append(raw)
+            return stored
         }
-        stored.append(raw)
-        try store.save(stored)
         return entitlement
     }
 }

--- a/Packages/OnymBilling/Sources/OnymBilling/StoreKitPurchaseCoordinator.swift
+++ b/Packages/OnymBilling/Sources/OnymBilling/StoreKitPurchaseCoordinator.swift
@@ -48,11 +48,24 @@ public actor StoreKitPurchaseCoordinator {
 
     /// Current entitlement for a product, if the store has one — the
     /// restore-purchases and cross-device path.
-    public func currentTransaction(for productId: String) async -> (String, StoreKit.Transaction)? {
+    ///
+    /// `nil` means one thing only: the store has no entitlement for
+    /// this product. A verification failure throws.
+    ///
+    /// It used to `try?` the verification, which collapsed those two
+    /// into the same answer — and the caller reports that answer to
+    /// somebody as "the App Store has no purchase for this identity to
+    /// restore". A person on a replacement phone reads that and buys
+    /// their subscription a second time, having been told a signature
+    /// problem was an absence. `jws(from:)` throws on `.unverified`
+    /// precisely so this cannot be mistaken for nothing.
+    public func currentTransaction(
+        for productId: String
+    ) async throws -> (String, StoreKit.Transaction)? {
         guard let verification = await StoreKit.Transaction.currentEntitlement(for: productId) else {
             return nil
         }
-        return try? Self.jws(from: verification)
+        return try Self.jws(from: verification)
     }
 
     /// Ask the store to sync, for an explicit "Restore Purchases".
@@ -80,7 +93,12 @@ public actor StoreKitPurchaseCoordinator {
             // StoreKit could not verify its own signature. The broker
             // would refuse it too; failing here saves a round trip and
             // keeps an unverifiable receipt off the network.
-            throw BillingError.purchaseFailed(reason: "unverified: \(error)")
+            //
+            // Its own case rather than `purchaseFailed`: on the restore
+            // path this is a purchase that exists and could not be
+            // read, which is the opposite of the "no purchase" the
+            // caller would otherwise report.
+            throw BillingError.transactionUnverified(reason: String(describing: error))
         }
     }
 }

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -42,6 +42,11 @@ struct BackupSeatComposer {
     /// credential and never asks for one.
     let entitlementStore: (any SeatEntitlementStoring)?
     let seatKeys: any SeatAccessKeyProviding
+    /// Recovers a credential for a purchase made on another device.
+    /// `nil` when this build cannot sell anything, in which case the
+    /// screen offers no restore-purchases row rather than one that
+    /// always reports nothing.
+    let makePurchaseFlow: (@Sendable (String) async -> SeatPurchaseFlow?)?
 
     /// One operator's assembled stack, before it becomes a screen.
     private struct Stack {
@@ -201,7 +206,8 @@ struct BackupSeatComposer {
                 // material carries the same one. Taking it from the first
                 // is not a choice about which operator is special.
                 archiveRoot: first.material.archiveRoot
-            )
+            ),
+            restorePurchasesForOperator: Self.purchaseRestorer(makePurchaseFlow)
         )
 
         // Restored attachment ciphertext, and the client that will
@@ -349,6 +355,32 @@ struct BackupSeatComposer {
             .jurisdictions ?? []
         return BackupDisclosure.OtherOperator(
             name: stack.displayName, jurisdictions: jurisdictions)
+    }
+
+    /// Turns the purchase-flow factory into the sweep the screen calls.
+    ///
+    /// Per operator, because a `SeatPurchaseFlow` pins the issuer key it
+    /// will verify a broker's answer against, and that key comes from
+    /// the operator's own signed manifest. There is no app-wide broker
+    /// client, and a credential must not be able to nominate its own
+    /// authority.
+    private static func purchaseRestorer(
+        _ makePurchaseFlow: (@Sendable (String) async -> SeatPurchaseFlow?)?
+    ) -> (@Sendable (String, Bool) async -> SeatPurchaseFlow.RestoreResult?)? {
+        guard let makePurchaseFlow else { return nil }
+        return { @Sendable componentId, syncWithStore in
+            guard let flow = await makePurchaseFlow(componentId) else { return nil }
+            if syncWithStore {
+                // A sync failure is not a reason to skip the sweep:
+                // `currentEntitlement` answers from what the device
+                // already knows, and that is usually everything needed.
+                // Someone who just signed in to a different Apple
+                // account is the case sync is for, and they will tap
+                // again.
+                try? await flow.syncWithStore()
+            }
+            return await flow.restorePurchases(componentId: componentId)
+        }
     }
 
     /// The credential to present, chosen at request time.

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -216,7 +216,7 @@ struct BackupSeatComposer {
             restorePurchasesForOperator: stacks.contains(where: { sellsOffers?($0.componentId) == true })
                 ? Self.purchaseRestorer(makePurchaseFlow)
                 : nil,
-            syncPurchasesWithStore: Self.storeSyncer(makePurchaseFlow, componentId: first.manifest.componentId)
+            syncPurchasesWithStore: Self.storeSyncer()
         )
 
         // Restored attachment ciphertext, and the client that will
@@ -386,21 +386,32 @@ struct BackupSeatComposer {
         }
     }
 
-    /// The account-wide sync, done once per tap.
+    /// The account-wide sync, done once per tap and belonging to no
+    /// operator.
     ///
-    /// It needs a flow to reach StoreKit through, and any operator's
-    /// will do: `AppStore.sync()` is a property of the Apple account,
-    /// not of a seat. A sync failure is not a reason to skip the sweep
-    /// that follows — `currentEntitlement` answers from what the device
-    /// already knows, and that is usually everything needed.
-    private static func storeSyncer(
-        _ makePurchaseFlow: (@Sendable (String) async -> SeatPurchaseFlow?)?,
-        componentId: String
-    ) -> (@Sendable () async -> Void)? {
-        guard let makePurchaseFlow else { return nil }
+    /// It used to be routed through the first operator's
+    /// `SeatPurchaseFlow`, which was wrong twice over. That flow exists
+    /// only when the operator pins an entitlement issuer, so a free
+    /// operator sorting first made the sync a silent no-op — and the
+    /// sweep then went on to report that the App Store had no purchase
+    /// for this identity, which nothing had asked it. `AppStore.sync()`
+    /// is a property of the Apple account: no seat, no broker, no
+    /// issuer, so it is built from a bare coordinator and cannot be
+    /// skipped by whichever operator happens to sort first.
+    ///
+    /// Returns whether it actually synced. A failure is not a reason to
+    /// skip the sweep — `currentEntitlement` answers from what the
+    /// device already knows — but it is a reason for the sweep to stop
+    /// short of concluding anything about what the store holds.
+    private static func storeSyncer() -> (@Sendable () async -> Bool)? {
+        let coordinator = StoreKitPurchaseCoordinator()
         return { @Sendable in
-            guard let flow = await makePurchaseFlow(componentId) else { return }
-            try? await flow.syncWithStore()
+            do {
+                try await coordinator.sync()
+                return true
+            } catch {
+                return false
+            }
         }
     }
 

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -47,6 +47,12 @@ struct BackupSeatComposer {
     /// screen offers no restore-purchases row rather than one that
     /// always reports nothing.
     let makePurchaseFlow: (@Sendable (String) async -> SeatPurchaseFlow?)?
+    /// Whether this build can actually sell anything for an operator.
+    /// A free operator declares no offers, and a build whose bundled
+    /// catalog is missing sells nothing at all — in both cases a Restore
+    /// Purchases row would prompt for an App Store password and then
+    /// always answer "nothing to restore".
+    let sellsOffers: (@Sendable (String) -> Bool)?
 
     /// One operator's assembled stack, before it becomes a screen.
     private struct Stack {
@@ -207,7 +213,10 @@ struct BackupSeatComposer {
                 // is not a choice about which operator is special.
                 archiveRoot: first.material.archiveRoot
             ),
-            restorePurchasesForOperator: Self.purchaseRestorer(makePurchaseFlow)
+            restorePurchasesForOperator: stacks.contains(where: { sellsOffers?($0.componentId) == true })
+                ? Self.purchaseRestorer(makePurchaseFlow)
+                : nil,
+            syncPurchasesWithStore: Self.storeSyncer(makePurchaseFlow, componentId: first.manifest.componentId)
         )
 
         // Restored attachment ciphertext, and the client that will
@@ -366,20 +375,32 @@ struct BackupSeatComposer {
     /// authority.
     private static func purchaseRestorer(
         _ makePurchaseFlow: (@Sendable (String) async -> SeatPurchaseFlow?)?
-    ) -> (@Sendable (String, Bool) async -> SeatPurchaseFlow.RestoreResult?)? {
+    ) -> (@Sendable (String) async -> SeatPurchaseFlow.RestoreResult?)? {
         guard let makePurchaseFlow else { return nil }
-        return { @Sendable componentId, syncWithStore in
+        return { @Sendable componentId in
+            // `nil` means this operator was not checked — no pinned
+            // issuer to verify a broker's answer against — which the
+            // caller must not report as the App Store having nothing.
             guard let flow = await makePurchaseFlow(componentId) else { return nil }
-            if syncWithStore {
-                // A sync failure is not a reason to skip the sweep:
-                // `currentEntitlement` answers from what the device
-                // already knows, and that is usually everything needed.
-                // Someone who just signed in to a different Apple
-                // account is the case sync is for, and they will tap
-                // again.
-                try? await flow.syncWithStore()
-            }
             return await flow.restorePurchases(componentId: componentId)
+        }
+    }
+
+    /// The account-wide sync, done once per tap.
+    ///
+    /// It needs a flow to reach StoreKit through, and any operator's
+    /// will do: `AppStore.sync()` is a property of the Apple account,
+    /// not of a seat. A sync failure is not a reason to skip the sweep
+    /// that follows — `currentEntitlement` answers from what the device
+    /// already knows, and that is usually everything needed.
+    private static func storeSyncer(
+        _ makePurchaseFlow: (@Sendable (String) async -> SeatPurchaseFlow?)?,
+        componentId: String
+    ) -> (@Sendable () async -> Void)? {
+        guard let makePurchaseFlow else { return nil }
+        return { @Sendable in
+            guard let flow = await makePurchaseFlow(componentId) else { return }
+            try? await flow.syncWithStore()
         }
     }
 

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -884,9 +884,12 @@ struct OnymIOSApp: App {
         #else
         let billingBaseURL = URLSessionBillingBrokerClient.defaultBaseURL
         #endif
-        let seatTransactionObserver = SeatTransactionObserver(
-            catalog: channelOfferCatalog
-        ) { componentId in
+        // One factory, two callers: the observer that redeems replayed
+        // transactions, and the restore-purchases sweep that recovers a
+        // purchase made on a phone this one has never met. Both need the
+        // same per-operator pinning, and a second copy of it would be a
+        // second place for the issuer rule to drift.
+        let makeSeatPurchaseFlow: @Sendable (String) async -> SeatPurchaseFlow? = { componentId in
             // The issuer key is pinned per operator, from the manifest
             // that operator signed and this person consented to. No
             // consented manifest means no key to pin, which means no
@@ -912,6 +915,10 @@ struct OnymIOSApp: App {
                 }
             )
         }
+        let seatTransactionObserver = SeatTransactionObserver(
+            catalog: channelOfferCatalog,
+            makeFlow: makeSeatPurchaseFlow
+        )
         seatTransactionObserver.start()
         self.seatTransactionObserver = seatTransactionObserver
 
@@ -1395,7 +1402,8 @@ struct OnymIOSApp: App {
                     blobClient: blossomClient,
                     endpointOverride: backupBaseURLOverride,
                     entitlementStore: seatEntitlementStore,
-                    seatKeys: seatAccessKeys
+                    seatKeys: seatAccessKeys,
+                    makePurchaseFlow: makeSeatPurchaseFlow
                 ).makeDeviceBackupView()
             },
             makeOnboardingFlow: makeOnboardingFlow,

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1403,7 +1403,10 @@ struct OnymIOSApp: App {
                     endpointOverride: backupBaseURLOverride,
                     entitlementStore: seatEntitlementStore,
                     seatKeys: seatAccessKeys,
-                    makePurchaseFlow: makeSeatPurchaseFlow
+                    makePurchaseFlow: makeSeatPurchaseFlow,
+                    sellsOffers: { componentId in
+                        !channelOfferCatalog.offers(forComponentId: componentId).isEmpty
+                    }
                 ).makeDeviceBackupView()
             },
             makeOnboardingFlow: makeOnboardingFlow,

--- a/Tests/OnymIOSTests/BackupPurchaseRestoreTests.swift
+++ b/Tests/OnymIOSTests/BackupPurchaseRestoreTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import XCTest
+@testable import OnymBackup
+@testable import OnymBackupUI
+@testable import OnymBilling
+
+/// The two things a restore sweep must not get wrong across several
+/// operators: who a recovered purchase belongs to, and what may be
+/// claimed when the App Store was never successfully asked.
+///
+/// Both are cross-operator properties, which is why neither showed up
+/// in a single-operator build and why they are pinned here rather than
+/// left to the next review.
+@MainActor
+final class BackupPurchaseRestoreTests: XCTestCase {
+    /// A purchase recovered for one operator says nothing about
+    /// another.
+    ///
+    /// With two paid operators, one restore and one that recovered
+    /// nothing, a total-based check told the operator that got nothing
+    /// that its purchase had been restored — on the row whose whole job
+    /// is telling someone whether they still owe a payment.
+    func testARestoredPurchaseIsAttributedOnlyToTheOperatorItWasRestoredFor() async throws {
+        let paidA = try vendor(componentId: "onym:component:a", displayName: "A")
+        let paidB = try vendor(componentId: "onym:component:b", displayName: "B")
+        // Both operators are sitting on a refusal for payment, which is
+        // the only state in which the note under test is rendered — and
+        // it comes from their state files, because the sweep refreshes
+        // from those before it notes anything.
+        paidA.flow.refresh()
+        paidB.flow.refresh()
+        XCTAssertTrue(paidA.flow.isPaymentRequired)
+        XCTAssertTrue(paidB.flow.isPaymentRequired)
+
+        let flow = DeviceBackupVendorsFlow(
+            vendors: [paidA, paidB],
+            fanOut: BackupFanOut(vendors: [], composer: try composer(), archiveRoot: material().archiveRoot),
+            restorePurchasesForOperator: { componentId in
+                // Only A's purchase is on this device's Apple account.
+                componentId == "onym:component:a"
+                    ? SeatPurchaseFlow.RestoreResult(
+                        restored: ["o"], alreadyHeld: [], heldUnknown: false, failures: [:])
+                    : SeatPurchaseFlow.RestoreResult(
+                        restored: [], alreadyHeld: [], heldUnknown: false, failures: [:])
+            },
+            syncPurchasesWithStore: { true }
+        )
+
+        await flow.restorePurchases()
+
+        XCTAssertEqual(
+            paidA.flow.lastRunNote,
+            "Purchase restored — tap Back Up Now to finish this backup.",
+            "the operator whose purchase was restored should say so")
+        XCTAssertNil(
+            paidB.flow.lastRunNote,
+            "an operator that recovered nothing must not claim a restored purchase")
+    }
+
+    /// A sync that did not work is not an answer about what the store
+    /// holds.
+    ///
+    /// The person this matters to is on a replacement phone with a
+    /// subscription they have already paid for; "the App Store has no
+    /// purchase for this identity" is the one sentence that would send
+    /// them to buy it again.
+    func testAFailedSyncDoesNotProduceANoPurchaseClaim() async throws {
+        let paid = try vendor(componentId: "onym:component:a", displayName: "A")
+        let flow = DeviceBackupVendorsFlow(
+            vendors: [paid],
+            fanOut: BackupFanOut(vendors: [], composer: try composer(), archiveRoot: material().archiveRoot),
+            restorePurchasesForOperator: { _ in
+                SeatPurchaseFlow.RestoreResult(
+                    restored: [], alreadyHeld: [], heldUnknown: false, failures: [:])
+            },
+            syncPurchasesWithStore: { false }
+        )
+
+        await flow.restorePurchases()
+
+        guard case .finished(_, _, _, _, let syncFailed, _) = flow.purchaseRestore else {
+            return XCTFail("the sweep did not finish: \(flow.purchaseRestore)")
+        }
+        XCTAssertTrue(syncFailed, "a failed sync must reach the surface that renders the claim")
+    }
+
+    // MARK: - Fixtures
+
+    private func material() -> BackupKeyMaterial {
+        BackupKeys.material(seed: Data(repeating: 0x5E, count: 64), componentId: "onym:component:a")
+    }
+
+    private func directory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func composer() throws -> BackupComposer {
+        BackupComposer(
+            source: SilentSource(), mediaPolicy: .descriptorsOnly, workingDirectory: try directory())
+    }
+
+    /// An operator enrolled, and holding a snapshot the operator
+    /// refused for payment.
+    private func vendor(componentId: String, displayName: String) throws -> DeviceBackupVendorsFlow.Vendor {
+        var state = BackupState()
+        state.componentId = componentId
+        state.acceptedTermsId = "sha256:" + String(repeating: "b", count: 64)
+        state.awaitingPayment = BackupState.PendingPayment(
+            operationId: "0123456789abcdef",
+            digest: "sha256:" + String(repeating: "a", count: 64),
+            sealedByteSize: 16,
+            sealedBytesFilename: "pending-test",
+            acceptedTermsId: state.acceptedTermsId!,
+            supersedesDigest: nil,
+            supersedesByteSize: nil,
+            sealedAt: Date(timeIntervalSince1970: 0),
+            refusedAt: Date(timeIntervalSince1970: 0)
+        )
+        let store = SilentStateStore(state: state)
+        return DeviceBackupVendorsFlow.Vendor(
+            flow: DeviceBackupSettingsFlow(
+                componentId: componentId,
+                displayName: displayName,
+                repository: BackupRepository(
+                    port: SilentPort(),
+                    composer: try composer(),
+                    stateStore: store,
+                    keyMaterial: material()),
+                stateStore: store
+            )
+        )
+    }
+}
+
+private struct SilentStateStore: BackupStateStoring {
+    var state = BackupState()
+    func load() throws -> BackupState { state }
+    func save(_ state: BackupState) throws {}
+}
+
+private struct SilentPort: BackupPort {
+    func connect() async throws -> BackupConnection { throw BackupError.operatorUnavailable }
+    func preflight(_ snapshot: SealedSnapshot) async throws -> BackupPreflight {
+        throw BackupError.operatorUnavailable
+    }
+    func uploadSnapshot(_ snapshot: SealedSnapshot, grant: BackupUploadGrant) async throws -> BackupOutcome {
+        throw BackupError.operatorUnavailable
+    }
+    func listSnapshots() async throws -> [RetainedSnapshot] { [] }
+    func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws {
+        throw BackupError.operatorUnavailable
+    }
+    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+        throw BackupError.operatorUnavailable
+    }
+    func exportSnapshots(to directory: URL) async throws -> BackupExport {
+        throw BackupError.operatorUnavailable
+    }
+    func queryOutcome(operationId: String) async throws -> BackupOutcome? { nil }
+}
+
+private actor SilentSource: BackupSourceProviding {
+    func identityCount() async -> Int { 0 }
+    func groups() async throws -> [BackupGroupRecord] { [] }
+    func messages(groupID: String, ownerIdentityID: String) async throws -> [BackupMessageRecord] { [] }
+    func invitations() async throws -> [BackupInvitationRecord] { [] }
+    func consents() async throws -> [BackupConsentRecord] { [] }
+    func blobCiphertext(sha256: String) async throws -> BackupBlobAvailability { .gone }
+}

--- a/Tests/OnymIOSTests/BackupPurchaseRestoreTests.swift
+++ b/Tests/OnymIOSTests/BackupPurchaseRestoreTests.swift
@@ -84,6 +84,58 @@ final class BackupPurchaseRestoreTests: XCTestCase {
         XCTAssertTrue(syncFailed, "a failed sync must reach the surface that renders the claim")
     }
 
+    /// A purchase the store has but cannot verify is not a purchase
+    /// the store does not have.
+    ///
+    /// The third instance of one shape in this flow: something unknown
+    /// rendered as a definitive negative. Here the negative is "the App
+    /// Store has no purchase for this identity", and the person reading
+    /// it is deciding whether to buy their subscription again.
+    func testAnUnverifiableTransactionIsReportedRatherThanReadAsNoPurchase() async throws {
+        let paid = try vendor(componentId: "onym:component:a", displayName: "A")
+        let flow = DeviceBackupVendorsFlow(
+            vendors: [paid],
+            fanOut: BackupFanOut(vendors: [], composer: try composer(), archiveRoot: material().archiveRoot),
+            restorePurchasesForOperator: { _ in
+                SeatPurchaseFlow.RestoreResult(
+                    restored: [],
+                    alreadyHeld: [],
+                    heldUnknown: false,
+                    failures: [
+                        "o": BillingError.transactionUnverified(reason: "signature")
+                            .errorDescription ?? "",
+                    ])
+            },
+            syncPurchasesWithStore: { true }
+        )
+
+        await flow.restorePurchases()
+
+        guard case .finished(_, _, _, _, _, let failures) = flow.purchaseRestore else {
+            return XCTFail("the sweep did not finish: \(flow.purchaseRestore)")
+        }
+        XCTAssertEqual(failures.count, 1, "an unverifiable transaction must survive to the surface")
+        XCTAssertTrue(
+            failures[0].contains("did not verify"),
+            "the row must say what happened, not report an absence: \(failures[0])")
+    }
+
+    /// And the error itself must not read as a debugger's output.
+    func testUnverifiedTransactionsSayWhatHappened() {
+        XCTAssertEqual(
+            BillingError.transactionUnverified(reason: "anything").errorDescription,
+            "The App Store's record of this purchase did not verify on this phone. Try again.")
+        XCTAssertEqual(
+            BillingError.brokerRejected(code: "invalid_transaction", message: "Already refunded.")
+                .errorDescription,
+            "Already refunded.",
+            "the broker's own words are the ones worth showing")
+        XCTAssertEqual(
+            BillingError.brokerRejected(code: "invalid_transaction", message: nil).errorDescription,
+            "The billing service refused this purchase (invalid_transaction).",
+            "an unrecognised refusal still names its code, which is what support asks for")
+    }
+
     // MARK: - Fixtures
 
     private func material() -> BackupKeyMaterial {


### PR DESCRIPTION
Stacked on #284.

A person whose phone is gone restores their identity from the recovery phrase, opens Device Backup, and meets two dead ends.

## The purchase they already made was invisible

`Transaction.updates` replays only transactions that were never *finished*, and a purchase completed on the old phone was finished there. On the new one it exists solely in `Transaction.currentEntitlement` — which nothing was asking. `StoreKitPurchaseCoordinator` has had `currentTransaction(for:)` and `sync()` since #278, with no caller anywhere in the app. So a paid operator answered `payment_required` and the only route offered was to buy the same storage a second time.

`SeatPurchaseFlow.restorePurchases(componentId:)` sweeps the catalog's products for that operator, redeems what the store confirms, and stores the credential. Everything the broker needs is derivable from the recovery phrase — the subject is the seat access key for this operator, and the credential is sealed to the agreement key derived beside it — so none of it depends on the device that made the purchase.

Offers already covered by a credential that verifies *today* are skipped rather than re-redeemed. That also handles a lapsed subscription since renewed: the stale credential fails verification, so the offer is not counted as held and the sweep replaces it.

It runs two ways, and the difference matters:

- **Quiet, when the screen appears.** The person who needs this does not know to ask — nothing has been uploaded yet, so no operator has refused anything, and the refusal that would have mentioned a purchase has not happened. It announces nothing unless it has news.
- **A Restore Purchases row they can tap**, which asks StoreKit to sync first. Only the tapped path syncs: `AppStore.sync()` prompts for an App Store password, and a screen that demands one on appear is a screen people learn to back out of.

## Restore was hidden behind enrolment

The row lived inside the enrolled gate, so someone who had consented to an operator and set nothing up saw "Off" and no way to read the backup they came for. Reading one needs the recovery phrase and the operator's name, not a terms pin — `listSnapshots` and `download` never consult local state. Asking someone to agree to *store* a backup before they may read what they already have is an obligation taken on for nothing.

## Also

One factory now serves both the transaction observer and the sweep. A `SeatPurchaseFlow` pins the issuer key it will verify a broker's answer against, and that key comes from the operator's own signed manifest — there is no app-wide broker client, and a second copy of that rule is a second place for it to drift.

## Testing

- App and packages build; `OnymIOSTests` 1403/1403 pass.
- Not exercised end to end against a sandbox Apple ID on a second device — that path needs a real StoreKit environment, and it is the one I would most want covered before shipping.

## Known gaps

- Nothing in the recovery phrase records *which* operator held the backups. On a new phone the person must remember, or recognise it in the discovery list; with two operators set up, remembering either one recovers the history. Worth a line on the enrolment screen telling people to write it down — not in this PR.
- Tests for the sweep (already-held short-circuit, lapsed-then-renewed, broker failure reporting) belong in the tests PR that follows #284.
