### PR TITLE
A way to reach the backup seat at all

### DIFF
--- a/Packages/OnymSettings/Sources/OnymSettings/BackupOperatorSettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BackupOperatorSettingsFlow.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Observation
+import OnymDiscovery
+import OnymFoundation
+
+/// `@Observable @MainActor` view-model for Settings → Backup
+/// Operators: the discovery catalog's `storage.backup` entries, and
+/// nothing else.
+///
+/// Thinner than the transport flows on purpose. `RelayerSettingsFlow`
+/// and friends pair the catalog section with a configured list they
+/// can add to, remove from and reorder, because their repository is
+/// the operational source of truth for the seat. The backup seat's
+/// source of truth is the pinned consent record itself — read straight
+/// out of the consent store by `BackupSeat.consentedManifests` — so
+/// there is no configuration for this screen to edit and no custom-URL
+/// field to offer: an operator is adopted by consenting to its signed
+/// manifest and dropped by withdrawing that consent, which is the
+/// Device Backup screen's "Stop backing up".
+///
+/// What is left is the catalog plumbing, and that is shared with the
+/// other pickers (`DiscoveryCatalogState`) rather than copied: the
+/// entries stream, so the section populates when the boot-time
+/// discovery refresh lands while the screen is open, and the memoized
+/// per-component consent lookups, so a row costs a dictionary hit
+/// instead of a full consent-store decode per render.
+@MainActor
+@Observable
+public final class BackupOperatorSettingsFlow {
+    /// Catalog-section state (entries + memoized consent lookups),
+    /// shared plumbing with the relayer/Nostr/Blossom flows.
+    private let catalog: DiscoveryCatalogState
+
+    /// Discovery-sourced `storage.backup` entries. Empty when the app
+    /// runs without discovery, or when no provider this person trusts
+    /// lists a backup operator — the screen says so rather than
+    /// pretending to be loading forever.
+    public var catalogEntries: [AttributedCatalogEntry] { catalog.entries }
+
+    /// Optional discovery seam, `nil` in builds without the discovery
+    /// stack (the UI-test harness) — the same seam the transport flows
+    /// expose, and the reason this screen degrades to an explanation
+    /// instead of a blank list.
+    let discovery: DiscoveryModulePicker?
+
+    public init(discovery: DiscoveryModulePicker?) {
+        self.discovery = discovery
+        self.catalog = DiscoveryCatalogState(discovery: discovery)
+    }
+
+    /// Begin draining discovery catalog updates. Idempotent.
+    public func start() {
+        catalog.start()
+    }
+
+    /// Paired with `start()`: the drain retains the flow and the stream
+    /// never finishes on its own, so without this the continuation
+    /// would accumulate on every visit.
+    public func stop() {
+        catalog.stop()
+    }
+
+    /// Re-read the discovery aggregate once (consent-sheet dismiss — a
+    /// fresh consent changes a row's badge with no catalog change to
+    /// push through the stream).
+    public func refreshCatalog() {
+        catalog.refresh()
+    }
+
+    /// The active pinned consent for a catalog entry's component
+    /// (memoized per catalog refresh).
+    public func activeConsent(for entry: AttributedCatalogEntry) -> PinnedConsentRecord? {
+        catalog.activeConsent(for: entry)
+    }
+
+    /// The offer accepted at consent time, resolved from the pinned
+    /// manifest snapshot (memoized per catalog refresh).
+    public func consentedOffer(for entry: AttributedCatalogEntry) -> ServiceOffer? {
+        catalog.consentedOffer(for: entry)
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/BackupOperatorSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BackupOperatorSettingsView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import OnymDesign
+import OnymDiscovery
+
+/// Settings → Backup → Backup Operators. The one surface from which a
+/// device-backup operator can be found, read and consented to.
+///
+/// Deliberately not a list of "configured" operators: the ones already
+/// holding a copy live on the Device Backup screen, where they can be
+/// enrolled, run and stopped. This screen is the doorway — catalog
+/// entries with their source attribution and consent state, each one
+/// opening the operator's own signed manifest and terms.
+///
+/// Consenting here is what makes the Device Backup section exist at
+/// all: `BackupSeat.consentedManifests` reads the pinned records this
+/// sheet writes, and until one exists there is nothing for that
+/// section to show.
+struct BackupOperatorSettingsView: View {
+    @State private var flow: BackupOperatorSettingsFlow
+    /// The catalog entry whose consent sheet is presented, if any.
+    @State private var consentEntry: AttributedCatalogEntry?
+
+    init(flow: BackupOperatorSettingsFlow) {
+        _flow = State(initialValue: flow)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SettingsLargeTitle("Backup Operators")
+
+                if flow.catalogEntries.isEmpty {
+                    emptyCard
+                } else {
+                    DiscoveryCatalogSection(
+                        entries: flow.catalogEntries,
+                        activeConsent: { flow.activeConsent(for: $0) },
+                        consentedOffer: { flow.consentedOffer(for: $0) },
+                        tileSymbol: "externaldrive.badge.timemachine",
+                        accessibilityPrefix: "backup.catalog",
+                        onSelect: { consentEntry = $0 }
+                    )
+                }
+
+                SettingsFootnote("A backup operator stores sealed copies of this phone's history. The copy is sealed here, before it leaves — the operator keeps bytes it cannot read, and only your recovery phrase can open them. You can back up to more than one operator, and each one holds its own copy under its own terms.")
+            }
+            .padding(.bottom, 32)
+        }
+        .background(OnymTokens.surface.ignoresSafeArea())
+        .navigationTitle("Backup Operators")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { flow.start() }
+        // Paired with `start()`, like every other catalog screen: the
+        // drain retains the flow and the entries stream never finishes
+        // on its own.
+        .onDisappear { flow.stop() }
+        // Consent runs as a sheet; on dismiss the catalog badges
+        // refresh so a fresh consent shows immediately.
+        .sheet(item: $consentEntry, onDismiss: { flow.refreshCatalog() }) { entry in
+            if let discovery = flow.discovery {
+                ModuleConsentView(flow: discovery.makeConsentFlow(entry))
+            }
+        }
+    }
+
+    /// No entries is an ordinary state, not a failure: a build without
+    /// the discovery stack, or a set of trusted providers that lists no
+    /// backup operator. Say why nothing is on offer rather than
+    /// leaving a screen that looks like it is still loading.
+    private var emptyCard: some View {
+        SettingsCard {
+            Text("No backup operators are listed by the discovery providers you trust. Add a provider that lists one, and it will appear here.")
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16).padding(.vertical, 14)
+                .accessibilityIdentifier("backup.catalog.empty")
+        }
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -54,6 +54,17 @@ public struct SettingsView: View {
     /// backup, which is a different thing entirely. One protects the
     /// key; this protects the history.
     let makeDeviceBackupView: (@MainActor () -> DeviceBackupVendorsView)?
+    /// Settings → Backup Operators: the discovery catalog's
+    /// `storage.backup` entries, where a backup operator is found and
+    /// consented to.
+    ///
+    /// Separately optional from `makeDeviceBackupView` because the two
+    /// appear at different times, and the earlier one is this: until
+    /// somebody has consented to an operator there is no Device Backup
+    /// screen to build, so a BACKUP section gated on that factory alone
+    /// could never be reached from a standing start. The section shows
+    /// when EITHER is wired.
+    let makeBackupOperatorSettingsFlow: (@MainActor () -> BackupOperatorSettingsFlow)?
 
     public init(
         makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow,
@@ -68,7 +79,8 @@ public struct SettingsView: View {
         makeModerationCaseFlow: (@MainActor (CaseNotice) -> ModerationCaseFlow)? = nil,
         makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)? = nil,
         onRestartOnboarding: (@MainActor () -> Void)? = nil,
-        makeDeviceBackupView: (@MainActor () -> DeviceBackupVendorsView)? = nil
+        makeDeviceBackupView: (@MainActor () -> DeviceBackupVendorsView)? = nil,
+        makeBackupOperatorSettingsFlow: (@MainActor () -> BackupOperatorSettingsFlow)? = nil
     ) {
         self.makeBackupFlow = makeBackupFlow
         self.makeRelayerSettingsFlow = makeRelayerSettingsFlow
@@ -83,6 +95,7 @@ public struct SettingsView: View {
         self.makeDiscoverySettingsFlow = makeDiscoverySettingsFlow
         self.onRestartOnboarding = onRestartOnboarding
         self.makeDeviceBackupView = makeDeviceBackupView
+        self.makeBackupOperatorSettingsFlow = makeBackupOperatorSettingsFlow
     }
 
     @State private var showRecoveryPhrase = false
@@ -224,24 +237,59 @@ public struct SettingsView: View {
                 // Absent until the app supplies it, like every other
                 // optional section here — a build without backup wired
                 // shows no backup row rather than a dead one.
-                if let makeDeviceBackupView {
+                //
+                // EITHER factory raises the section. Device Backup only
+                // exists once an operator has been consented to, so
+                // gating the section on it alone made the operator
+                // picker unreachable from the state everybody starts
+                // in: no consent, therefore no section, therefore
+                // nowhere to consent.
+                if makeDeviceBackupView != nil || makeBackupOperatorSettingsFlow != nil {
                     SettingsSectionLabel("BACKUP")
                     SettingsCard {
-                        NavigationLink {
-                            makeDeviceBackupView()
-                        } label: {
-                            SettingsRow(
-                                title: "Device Backup",
-                                subtitle: "Sealed copies of this phone's history",
-                                last: true
-                            ) {
-                                SettingsIconTile(
-                                    symbol: "externaldrive.badge.timemachine",
-                                    bg: SettingsTile.blue)
+                        if let makeDeviceBackupView {
+                            NavigationLink {
+                                makeDeviceBackupView()
+                            } label: {
+                                SettingsRow(
+                                    title: "Device Backup",
+                                    subtitle: "Sealed copies of this phone's history",
+                                    // Last only when the picker row is
+                                    // absent, so the card never draws a
+                                    // divider under its final row.
+                                    last: makeBackupOperatorSettingsFlow == nil
+                                ) {
+                                    SettingsIconTile(
+                                        symbol: "externaldrive.badge.timemachine",
+                                        bg: SettingsTile.blue)
+                                }
                             }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("settings.device_backup_row")
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityIdentifier("settings.device_backup_row")
+                        if let makeBackupOperatorSettingsFlow {
+                            NavigationLink {
+                                BackupOperatorSettingsView(flow: makeBackupOperatorSettingsFlow())
+                            } label: {
+                                SettingsRow(
+                                    title: "Backup Operators",
+                                    // Names the second copy on purpose:
+                                    // consenting to another operator
+                                    // adds one, it does not move the
+                                    // first, and that is the sentence
+                                    // the enrolment screen goes on to
+                                    // repeat.
+                                    subtitle: "Find an operator to hold a copy",
+                                    last: true
+                                ) {
+                                    SettingsIconTile(
+                                        symbol: "externaldrive.badge.plus",
+                                        bg: SettingsTile.blue)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("settings.backup_operators_row")
+                        }
                     }
                     SettingsFootnote("A backup is sealed on this phone before it leaves. The operator keeps bytes it cannot read, and only your recovery phrase can open them.")
                 }

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -117,6 +117,21 @@ struct AppDependencies {
     /// or the identity has no recovery phrase to derive from. The
     /// section hides rather than offering a screen that cannot work.
     let makeDeviceBackupView: (@MainActor () async -> DeviceBackupVendorsView?)?
+    /// Settings → Backup Operators: the catalog picker a backup
+    /// operator is discovered and consented to through. Optional on the
+    /// same terms as the discovery factories — nil in a build with no
+    /// discovery stack, where there is no catalog to pick from.
+    ///
+    /// Non-nil independently of `makeDeviceBackupView`, and that is the
+    /// point: this is the surface that exists BEFORE any consent, and
+    /// the one that makes the other appear.
+    let makeBackupOperatorSettingsFlow: (@MainActor () -> BackupOperatorSettingsFlow)?
+    /// Raised by the backup picker's consent apply step so the root
+    /// view re-resolves the Device Backup screen immediately. Without
+    /// it a consent given from a Settings sheet — where the tab never
+    /// changes — leaves the section missing until the tab is visited
+    /// again.
+    let backupConsentSignal: BackupConsentSignal?
     /// Onboarding flow factory. Non-nil whenever onboarding is
     /// AVAILABLE in this build (always in production; under
     /// `--ui-testing` only with `--ui-onboarding`, so every existing

--- a/Sources/OnymIOS/BackupCatalogConsent.swift
+++ b/Sources/OnymIOS/BackupCatalogConsent.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Observation
+import OnymBackup
+import OnymDiscovery
+import OnymFoundation
+
+/// Apply step of the backup catalog picker's consent flow, extracted
+/// from the `OnymIOSApp` composition root for the same reason
+/// `BlossomCatalogConsent` was: the one piece with real behavior should
+/// be unit-testable without standing up a screen.
+///
+/// **It writes nothing, and that is the whole design.** The three
+/// transport pickers apply a consent by copying an endpoint into a
+/// repository, because their repositories — not the consent store —
+/// are the operational source of truth for what the app connects to.
+/// The backup seat has no such repository: `BackupSeat.consentedManifests`
+/// reads the pinned consent records directly, and
+/// `BackupSeatComposer` builds one stack per record it finds there. A
+/// second copy of the operator kept anywhere else would be a second
+/// place for "who holds my history" to drift from what the person
+/// actually agreed to, and the two could disagree after a withdrawal —
+/// `stopBackingUp` withdraws the consent and nothing else, which is
+/// exactly right only while consent IS the record.
+///
+/// So the apply step's job is not to add anything. It is to refuse:
+/// this is the last moment before the person is told "Service added",
+/// and it is where a manifest that cannot back anything up has to say
+/// so.
+enum BackupCatalogConsent {
+    /// Validate that the consented manifest describes an operator this
+    /// build can actually use, and throw if it does not.
+    ///
+    /// The check is `BackupOperatorManifest(manifest:)` itself — the
+    /// same initializer `BackupSeat.consentedManifests` runs over every
+    /// pinned record — rather than a hand-rolled endpoint scan beside
+    /// it. Anything the parse refuses here is something
+    /// `consentedManifests` would silently skip later, and the
+    /// difference between the two spellings is what a person sees: a
+    /// sentence saying this operator's manifest is unusable, versus a
+    /// "Service added" screen followed by a Settings section that never
+    /// appears.
+    ///
+    /// `invalidEndpoint` is translated to `ModuleApplyError.noUsableEndpoint`
+    /// because it is precisely the condition that error names — a
+    /// manifest with no read-write https endpoint is as unusable to the
+    /// backup seat as a manifest with no wss endpoint is to a Nostr
+    /// relay — and because the consent flow renders that case with the
+    /// honest two-part message: the consent was recorded, the service
+    /// was not added. The other refusals (an unimplemented profile,
+    /// missing terms, a capability set short of what the profile needs)
+    /// are rethrown as themselves and land on the flow's generic
+    /// "couldn't be added" wording; inventing a fake `noUsableEndpoint`
+    /// for them would tell the person to look at an endpoint that is
+    /// fine.
+    ///
+    /// Nothing is undone on the way out. By the time `apply` runs the
+    /// consent record is already pinned — `ModuleConsentFlow` writes it
+    /// first on purpose — and a refused manifest simply never becomes a
+    /// `BackupOperatorManifest`, so it contributes no stack, no upload
+    /// and no Settings row. The record stays as history of what was
+    /// reviewed, which is what the consent store is for.
+    static func apply(manifest: SignedServiceManifest) throws {
+        do {
+            _ = try BackupOperatorManifest(manifest: manifest)
+        } catch BackupError.invalidEndpoint {
+            throw ModuleApplyError.noUsableEndpoint
+        }
+    }
+}
+
+/// Raised when a backup operator is consented to, so the root view
+/// re-resolves the Device Backup screen without waiting for the
+/// Settings tab to be visited again.
+///
+/// RootView already re-resolves on two events: the Settings tab being
+/// selected, and the moderation consent cover closing. Neither fires
+/// here. Consent to a backup operator is given from a sheet pushed on
+/// top of the Settings tab, so the tab never changes — and the person
+/// who just agreed to back up their history walks back to a Settings
+/// screen with no Device Backup row on it, which reads exactly like
+/// the consent not having worked.
+///
+/// A signal rather than a direct call because the two ends belong to
+/// different layers: the picker's apply closure is built in the
+/// composition root and knows nothing about view state, and the
+/// resolution is `RootView`'s, guarded by its own in-flight bookkeeping
+/// so a rebuild never lands twice. Same shape, and the same reason, as
+/// `OnboardingRestartController`.
+///
+/// The revision is a counter, not a flag, so two consents in a row are
+/// two changes: an `onChange` on a `Bool` that was already true would
+/// swallow the second. Nothing consumes the value itself.
+@MainActor
+@Observable
+final class BackupConsentSignal {
+    private(set) var revision = 0
+
+    /// A consent record was just written for a backup operator.
+    func consentRecorded() {
+        revision &+= 1
+    }
+}

--- a/Sources/OnymIOS/DiscoverySeatAdapters.swift
+++ b/Sources/OnymIOS/DiscoverySeatAdapters.swift
@@ -96,6 +96,21 @@ enum SeatManifestVocabulary {
         // because `SignedServiceManifest`'s docs and onym-system's
         // moderation pages name the seat that way.
         "moderation": ["moderation", "authority"],
+        // onym-backup's operator manifest declares
+        // `seat: "storage.backup"`, and `BackupOperatorManifest`
+        // refuses any manifest whose seat is not exactly that string.
+        // So this entry accepts precisely what the strict fallback
+        // below would accept, and it is written out anyway: the table
+        // is the readable list of every seat this app will consent to,
+        // and a seat absent from it reads as one nobody considered
+        // rather than one deliberately left on the default.
+        //
+        // No aliases. The three above earn theirs from manifests that
+        // really were published under the older spelling; this seat has
+        // never been published under any other, so an alias invented
+        // here would be a second accepted spelling that only a
+        // MISLABELED catalog entry could ever use.
+        "storage.backup": ["storage.backup"],
     ]
 
     /// Unknown catalog seat types (nothing in the table) accept only

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1058,6 +1058,103 @@ struct OnymIOSApp: App {
             )
         }
 
+        // The backup seat's entitlement resolution, which cannot be the
+        // shared `makeEntitlements` above.
+        //
+        // That one pins its trusted issuers from the ACTIVE consent
+        // record (`BackupSeat.entitlementIssuers`), which is the right
+        // rule everywhere except here, on the surface where the record
+        // does not exist yet. On a first consent it answers with no
+        // issuers, every stored credential then fails verification, no
+        // paid offer resolves as entitled — and `canAccept` refuses a
+        // manifest that carries only paid offers. A person who has
+        // already bought this operator's storage (on this phone before
+        // withdrawing, or on the phone they just restored from a
+        // recovery phrase) would find Accept permanently disabled with
+        // nothing on screen to explain it.
+        //
+        // So the issuers come from the manifest UNDER REVIEW: the exact
+        // digest-pinned, signature-verified bytes on the consent screen,
+        // read through `BackupOperatorManifest` rather than a second
+        // hand-rolled field read. That keeps the rule this codebase
+        // actually cares about — a credential never nominates its own
+        // authority — while sourcing the pin from the document the
+        // person is being asked to agree to. Any OTHER component falls
+        // back to the pinned record, because a manifest may only speak
+        // for itself.
+        let makeBackupEntitlements: @Sendable (SignedServiceManifest) -> any EntitlementProviding = { manifest in
+            let free = FreeTierEntitlementProvider(
+                reviewing: manifest, consentStore: pinnedConsentStore)
+            guard let seatEntitlementStore else {
+                // Nowhere safe to keep a credential — same answer as the
+                // shared provider: free offers still resolve with no
+                // store and no network.
+                return free
+            }
+            let reviewedIssuers = (try? BackupOperatorManifest(manifest: manifest))?
+                .entitlementIssuers ?? []
+            return StoreKitEntitlementProvider(
+                free: free,
+                catalog: channelOfferCatalog,
+                store: seatEntitlementStore,
+                keys: seatAccessKeys,
+                trustedIssuers: { componentId in
+                    guard componentId == manifest.componentId else {
+                        return BackupSeat.entitlementIssuers(
+                            componentId: componentId, consentStore: pinnedConsentStore)
+                    }
+                    return reviewedIssuers
+                }
+            )
+        }
+
+        // Raised on every accepted backup consent so the root view
+        // rebuilds the Device Backup screen there and then.
+        let backupConsentSignal = BackupConsentSignal()
+
+        let backupCatalogPicker = discoveryCatalog.map { catalog in
+            DiscoveryModulePicker(
+                // `BackupSeat.seat` is the catalog seat type as well as
+                // the manifest seat: there is no legacy known-list
+                // fetcher for this seat to borrow a constant from,
+                // because backup has no published default list and no
+                // auto-populate — an operator is only ever adopted by an
+                // explicit consent, which is exactly what this picker
+                // is.
+                entries: { await catalog.entries(BackupSeat.seat) },
+                activeConsent: { try? pinnedConsentStore.activeRecord(componentId: $0) },
+                entriesStream: makeSeatEntriesStream.map { make in
+                    { make(BackupSeat.seat) }
+                },
+                makeConsentFlow: { entry in
+                    ModuleConsentFlow(
+                        entry: entry,
+                        fetchManifestBytes: catalog.fetchManifestBytes,
+                        consentStore: pinnedConsentStore,
+                        selectionStore: seatSelectionStore,
+                        makeEntitlements: makeBackupEntitlements,
+                        apply: { manifest in
+                            // Nothing is written anywhere: the pinned
+                            // consent record IS the enrolment, and
+                            // `BackupSeat.consentedManifests` reads it
+                            // directly. What this step does is refuse a
+                            // manifest the seat cannot use, so nobody is
+                            // shown "Service added" over an operator
+                            // that will never produce a Settings row.
+                            // Extracted (BackupCatalogConsent) so that
+                            // refusal is unit-tested.
+                            try BackupCatalogConsent.apply(manifest: manifest)
+                            // Only after the manifest is known usable —
+                            // a signal raised before it would rebuild
+                            // the backup stack for an operator that is
+                            // about to be reported as not added.
+                            backupConsentSignal.consentRecorded()
+                        }
+                    )
+                }
+            )
+        }
+
         // Settings-flow factories, declared once because the
         // onboarding steps reuse them VERBATIM: a step surface and its
         // Settings screen are the same flow over the same repository +
@@ -1081,6 +1178,12 @@ struct OnymIOSApp: App {
         }
         let makeDiscoverySettingsFlow = discoveryRepository.map { repo in
             { @MainActor in DiscoverySettingsFlow(repository: repo) }
+        }
+        // Built from the picker, so a build without discovery has no
+        // Backup Operators row at all rather than one leading to a list
+        // that can never fill.
+        let makeBackupOperatorSettingsFlow = backupCatalogPicker.map { picker in
+            { @MainActor in BackupOperatorSettingsFlow(discovery: picker) }
         }
 
         // Onboarding factories. Built whenever onboarding is AVAILABLE
@@ -1409,6 +1512,8 @@ struct OnymIOSApp: App {
                     }
                 ).makeDeviceBackupView()
             },
+            makeBackupOperatorSettingsFlow: makeBackupOperatorSettingsFlow,
+            backupConsentSignal: backupConsentSignal,
             makeOnboardingFlow: makeOnboardingFlow,
             presentOnboardingAtLaunch: shouldOnboard,
             onboardingRestart: onboardingRestartController,

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -149,6 +149,16 @@ struct RootView: View {
             guard presentation == nil else { return }
             Task { await resolveDeviceBackupView() }
         }
+        .onChange(of: dependencies.backupConsentSignal?.revision) { _, _ in
+            // And a backup operator is consented to from a sheet over
+            // the Settings tab — no tab change, and the moderation
+            // cover above is a different surface entirely. Neither
+            // trigger fires, so the picker raises this one itself.
+            // `resolveDeviceBackupView` still decides whether anything
+            // is rebuilt: it compares the consented operators and
+            // leaves a running backup alone when they have not changed.
+            Task { await resolveDeviceBackupView() }
+        }
         .onChange(of: dependencies.moderationGateFlow.gate) { _, gate in
             consentPresentation = presentationUnlessOnboarding(for: gate)
         }
@@ -337,7 +347,8 @@ struct RootView: View {
                         onRestartOnboarding: dependencies.onboardingRestart.map { restart in
                             { restart.requestRestart() }
                         },
-                        makeDeviceBackupView: deviceBackupView.map { view in { view } }
+                        makeDeviceBackupView: deviceBackupView.map { view in { view } },
+                        makeBackupOperatorSettingsFlow: dependencies.makeBackupOperatorSettingsFlow
                     )
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/Tests/OnymIOSTests/BackupCatalogConsentTests.swift
+++ b/Tests/OnymIOSTests/BackupCatalogConsentTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import OnymIOS
+import OnymBackup
+import OnymDiscovery
+import OnymFoundation
+
+/// The backup catalog picker's consent-`apply` step
+/// (`BackupCatalogConsent.apply`) and the signal it raises.
+///
+/// Apply writes nothing here — the pinned consent record is the
+/// enrolment, and `BackupSeat.consentedManifests` reads it directly —
+/// so the behavior worth locking down is the REFUSAL: a manifest the
+/// backup seat cannot use must stop the flow, because the alternative
+/// is a "Service added" screen followed by a Device Backup section
+/// that never appears.
+final class BackupCatalogConsentTests: XCTestCase {
+
+    func test_apply_usableManifest_succeeds() throws {
+        let manifest = try Self.manifest()
+        XCTAssertNoThrow(try BackupCatalogConsent.apply(manifest: manifest))
+    }
+
+    /// The `ModuleApplyError.noUsableEndpoint` translation: this is the
+    /// one refusal the consent flow renders with its honest two-part
+    /// message ("your consent was recorded, but it wasn't added"),
+    /// which is exactly what happened.
+    func test_apply_noReadWriteEndpoint_throwsNoUsableEndpoint() throws {
+        let manifest = try Self.manifest(
+            endpoints: [["uri": "https://backup.example", "role": "read-only"]]
+        )
+        do {
+            try BackupCatalogConsent.apply(manifest: manifest)
+            XCTFail("expected ModuleApplyError.noUsableEndpoint")
+        } catch let error as ModuleApplyError {
+            XCTAssertEqual(error, .noUsableEndpoint)
+        }
+    }
+
+    /// Same refusal for the scheme, and for the same reason a Nostr
+    /// relay refuses a manifest without `wss`: a sealed snapshot does
+    /// not go over plaintext http, and nothing here rewrites an
+    /// endpoint into something that would work.
+    func test_apply_httpEndpoint_throwsNoUsableEndpoint() throws {
+        let manifest = try Self.manifest(
+            endpoints: [["uri": "http://backup.example", "role": "read-write"]]
+        )
+        do {
+            try BackupCatalogConsent.apply(manifest: manifest)
+            XCTFail("expected ModuleApplyError.noUsableEndpoint")
+        } catch let error as ModuleApplyError {
+            XCTAssertEqual(error, .noUsableEndpoint)
+        }
+    }
+
+    /// A read-write entry that is malformed does not condemn the
+    /// manifest while a usable one sits behind it — `BackupOperatorManifest`
+    /// binds to the first USABLE entry, and apply must not be stricter
+    /// than the parser every other read of this record goes through.
+    func test_apply_skipsMalformedEndpointAndBindsToTheUsableOne() throws {
+        let manifest = try Self.manifest(endpoints: [
+            ["uri": "not a url at all", "role": "read-write"],
+            ["uri": "https://backup.example", "role": "read-write"],
+        ])
+        XCTAssertNoThrow(try BackupCatalogConsent.apply(manifest: manifest))
+    }
+
+    /// Not every refusal is an endpoint. A profile this build does not
+    /// implement is rethrown as itself rather than dressed up as a
+    /// missing endpoint, which would send somebody looking at a URL
+    /// that is perfectly fine.
+    func test_apply_unsupportedProfile_rethrowsBackupError() throws {
+        let manifest = try Self.manifest(backupProfileId: "onym:backup-profile:something-else-v9")
+        do {
+            try BackupCatalogConsent.apply(manifest: manifest)
+            XCTFail("expected BackupError.unsupportedProfile")
+        } catch let error as BackupError {
+            XCTAssertEqual(error, .unsupportedProfile)
+        }
+    }
+
+    /// Terms are a precondition of enrolment, so a manifest that
+    /// declares none can never be backed up to. Also rethrown as
+    /// itself.
+    func test_apply_missingDeclaredTerms_rethrowsBackupError() throws {
+        let manifest = try Self.manifest(declaredTerms: nil)
+        do {
+            try BackupCatalogConsent.apply(manifest: manifest)
+            XCTFail("expected BackupError.termsUnavailable")
+        } catch let error as BackupError {
+            XCTAssertEqual(error, .termsUnavailable)
+        }
+    }
+
+    /// The manifests apply accepts are exactly the ones
+    /// `BackupSeat.consentedManifests` will later parse out of the
+    /// pinned record. If these two ever disagree, a person is told the
+    /// operator was added and then finds no section — the failure this
+    /// whole step exists to prevent.
+    func test_apply_acceptsExactlyWhatTheSeatCanLaterParse() throws {
+        let usable = try Self.manifest()
+        let unusable = try Self.manifest(
+            endpoints: [["uri": "https://backup.example", "role": "read-only"]]
+        )
+        XCTAssertNoThrow(try BackupCatalogConsent.apply(manifest: usable))
+        XCTAssertNotNil(try? BackupOperatorManifest(manifest: usable))
+        XCTAssertThrowsError(try BackupCatalogConsent.apply(manifest: unusable))
+        XCTAssertNil(try? BackupOperatorManifest(manifest: unusable))
+    }
+
+    // MARK: - Consent signal
+
+    @MainActor
+    func test_consentSignal_countsEveryConsent() {
+        let signal = BackupConsentSignal()
+        XCTAssertEqual(signal.revision, 0)
+        signal.consentRecorded()
+        let afterFirst = signal.revision
+        signal.consentRecorded()
+        XCTAssertNotEqual(signal.revision, afterFirst,
+                          "a counter, not a flag — two consents must be two changes for onChange")
+    }
+
+    // MARK: - helpers
+
+    /// A backup-seat manifest spine with the fields
+    /// `BackupOperatorManifest` reads. No signature verification runs
+    /// in `SignedServiceManifest(raw:)` or in the apply step — review
+    /// already ran upstream in `ModuleConsentFlow`.
+    private static func manifest(
+        componentId: String = "onym:component:test-backup",
+        endpoints: [[String: Any]] = [["uri": "https://backup.example", "role": "read-write"]],
+        backupProfileId: String = BackupProfile.portableProfileId,
+        declaredTerms: String? = "sha256:" + String(repeating: "9", count: 64),
+        capabilities: [String] = ["upload", "list", "download", "erase", "export"]
+    ) throws -> SignedServiceManifest {
+        var object: [String: Any] = [
+            "version": 1,
+            "componentId": componentId,
+            "seat": "storage.backup",
+            "operator": "onym:key:" + String(repeating: "ab", count: 32),
+            "validUntil": "2030-01-01T00:00:00Z",
+            "backupProfileId": backupProfileId,
+            "implementationProfileId": BackupProfile.implementationProfileId,
+            "endpoints": endpoints,
+            "capabilities": capabilities,
+        ]
+        if let declaredTerms { object["declaredTerms"] = declaredTerms }
+        let bytes = try JSONSerialization.data(withJSONObject: object)
+        return try SignedServiceManifest(raw: bytes)
+    }
+}

--- a/Tests/OnymIOSTests/BackupOperatorSettingsFlowTests.swift
+++ b/Tests/OnymIOSTests/BackupOperatorSettingsFlowTests.swift
@@ -1,0 +1,195 @@
+import CryptoKit
+import XCTest
+@testable import OnymIOS
+import OnymDiscovery
+import OnymFoundation
+import OnymSettings
+
+/// Settings → Backup Operators, the surface that made the device-backup
+/// seat reachable at all: without it nothing could ever write a
+/// `storage.backup` consent record, so `BackupSeat.consentedManifests`
+/// answered empty forever and the Device Backup section could not
+/// appear.
+///
+/// The flow is the catalog half of the transport pickers with the
+/// configured-list half removed — an operator is adopted by consent
+/// and dropped by withdrawal, not by editing a configuration — so what
+/// is tested here is what remains: the entries stream, the memoized
+/// consent lookups, and the empty answer a build without discovery
+/// must keep giving.
+@MainActor
+final class BackupOperatorSettingsFlowTests: XCTestCase {
+
+    func test_start_drainsCatalogEntriesFromThePicker() async throws {
+        let (entry, _) = try Self.consentedCatalogFixture()
+        let flow = BackupOperatorSettingsFlow(
+            discovery: DiscoveryModulePicker(
+                entries: { [entry] },
+                activeConsent: { _ in nil },
+                makeConsentFlow: { _ in fatalError("not exercised") }
+            )
+        )
+        flow.start()
+        defer { flow.stop() }
+
+        try await waitFor { !flow.catalogEntries.isEmpty }
+        XCTAssertEqual(flow.catalogEntries.map(\.entry.componentId),
+                       [entry.entry.componentId])
+    }
+
+    /// The badge on a row is the consent state of the exact bytes the
+    /// catalog lists, and it is memoized per catalog install — the
+    /// lookup decodes the whole consent store, far too heavy per row
+    /// per render.
+    func test_activeConsent_resolvesConsentedEntry() async throws {
+        let (entry, record) = try Self.consentedCatalogFixture()
+        let flow = BackupOperatorSettingsFlow(
+            discovery: DiscoveryModulePicker(
+                entries: { [entry] },
+                activeConsent: { $0 == entry.entry.componentId ? record : nil },
+                makeConsentFlow: { _ in fatalError("not exercised") }
+            )
+        )
+        flow.start()
+        defer { flow.stop() }
+
+        try await waitFor { !flow.catalogEntries.isEmpty }
+        XCTAssertEqual(flow.activeConsent(for: entry)?.manifestHash, record.manifestHash)
+        XCTAssertEqual(flow.activeConsent(for: entry)?.manifestHash,
+                       entry.entry.manifest.digest,
+                       "same digest as the entry lists — the row renders CONSENTED, not TERMS CHANGED")
+    }
+
+    /// A consent pinned over OLDER bytes than the catalog now lists is
+    /// the republish case: the record is present, its hash is not the
+    /// entry's, and the row must be able to say TERMS CHANGED rather
+    /// than reporting a consent to bytes nobody reviewed.
+    func test_activeConsent_republishedEntry_keepsTheOldHash() async throws {
+        let (entry, _) = try Self.consentedCatalogFixture()
+        let (_, staleRecord) = try Self.consentedCatalogFixture(
+            componentId: entry.entry.componentId,
+            endpointURL: URL(string: "https://old.backup.example")!
+        )
+        let flow = BackupOperatorSettingsFlow(
+            discovery: DiscoveryModulePicker(
+                entries: { [entry] },
+                activeConsent: { _ in staleRecord },
+                makeConsentFlow: { _ in fatalError("not exercised") }
+            )
+        )
+        flow.start()
+        defer { flow.stop() }
+
+        try await waitFor { !flow.catalogEntries.isEmpty }
+        XCTAssertNotNil(flow.activeConsent(for: entry))
+        XCTAssertNotEqual(flow.activeConsent(for: entry)?.manifestHash,
+                          entry.entry.manifest.digest)
+    }
+
+    /// No discovery stack (the UI-test harness) keeps the flow
+    /// permanently empty rather than crashing on a missing seam — the
+    /// screen renders its "nothing listed" card, and the Settings row
+    /// is not built at all in that build.
+    func test_withoutDiscovery_staysEmpty() async throws {
+        let flow = BackupOperatorSettingsFlow(discovery: nil)
+        flow.start()
+        defer { flow.stop() }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertTrue(flow.catalogEntries.isEmpty)
+    }
+
+    // MARK: - Catalog fixtures
+
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func digest(of raw: Data) -> String {
+        "sha256:" + hex(Data(SHA256.hash(data: raw)))
+    }
+
+    /// Raw bytes of a freshly signed backup-seat manifest. Signed for
+    /// real because `ServiceManifestReviewer` is hard-enforced — there
+    /// is no accept-anyway path to push a fixture through.
+    private static func signedManifestRaw(
+        key: Curve25519.Signing.PrivateKey,
+        componentId: String,
+        endpointURL: URL
+    ) throws -> Data {
+        var object: [String: Any] = [
+            "componentId": componentId,
+            "seat": "storage.backup",
+            "operator": "onym:key:\(hex(key.publicKey.rawRepresentation))",
+            "validUntil": "2030-01-01T00:00:00Z",
+            "endpoints": [["uri": endpointURL.absoluteString, "role": "read-write"]],
+        ]
+        let unsigned = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        let signature = try key.signature(for: ServiceManifestCanonical.signingBytes(of: unsigned))
+        object["signature"] = signature.base64EncodedString()
+        return try JSONSerialization.data(
+            withJSONObject: object, options: [.withoutEscapingSlashes])
+    }
+
+    /// A verified `storage.backup` catalog entry plus the pinned
+    /// consent over the same bytes.
+    private static func consentedCatalogFixture(
+        componentId: String = "onym:component:test-backup",
+        endpointURL: URL = URL(string: "https://backup.example")!
+    ) throws -> (AttributedCatalogEntry, PinnedConsentRecord) {
+        let key = Curve25519.Signing.PrivateKey()
+        let raw = try signedManifestRaw(
+            key: key, componentId: componentId, endpointURL: endpointURL)
+        let reviewed = try ServiceManifestReviewer().review(
+            raw: raw, expectedDigest: digest(of: raw))
+        let record = PinnedConsentRecord(reviewed: reviewed, acceptedAt: Date())
+        let entryJSON: [String: Any] = [
+            "componentId": componentId,
+            "seatType": "storage.backup",
+            "manifest": [
+                "uri": "https://provider.example/manifests/backup.json",
+                "digest": digest(of: raw),
+            ],
+            "operator": "onym:key:\(hex(key.publicKey.rawRepresentation))",
+            "listedAt": "2026-01-01T00:00:00Z",
+            "relationship": "none",
+            "placement": "neutral",
+        ]
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let entry = try decoder.decode(
+            CatalogEntry.self,
+            from: JSONSerialization.data(withJSONObject: entryJSON)
+        )
+        return (
+            AttributedCatalogEntry(
+                entry: entry,
+                source: SourceAttribution(
+                    providerId: "onym:component:test-provider",
+                    sourceLabel: "Test Provider",
+                    catalogId: "public",
+                    snapshotDigest: "sha256:" + String(repeating: "0", count: 64),
+                    relationship: "none",
+                    placement: "neutral"
+                )
+            ),
+            record
+        )
+    }
+
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        _ predicate: @MainActor @escaping () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTFail("Timed out", file: file, line: line)
+    }
+}

--- a/Tests/OnymIOSTests/DiscoverySeatAdaptersTests.swift
+++ b/Tests/OnymIOSTests/DiscoverySeatAdaptersTests.swift
@@ -1086,4 +1086,34 @@ final class DiscoverySeatAdaptersTests: XCTestCase {
         let result = try await wrapped.fetchLatest()
         XCTAssertEqual(result, StubRelayersFallback.sentinel)
     }
+
+    // MARK: - Seat vocabulary
+
+    /// The backup seat is pinned in the table even though its accepted
+    /// set is what the strict fallback would produce anyway: the table
+    /// is the readable list of seats this app consents to, and the
+    /// entry is what stops `storage.backup` reading as a seat nobody
+    /// considered.
+    func test_backupSeatType_acceptsOnlyItsOwnSeat() {
+        XCTAssertTrue(SeatManifestVocabulary.accepts(
+            catalogSeatType: "storage.backup", manifestSeat: "storage.backup"))
+        XCTAssertEqual(SeatManifestVocabulary.acceptedManifestSeats["storage.backup"],
+                       ["storage.backup"],
+                       "no aliases — this seat has never been published under another name")
+    }
+
+    /// The reason the table exists at all: a catalog must not be able
+    /// to put some other service in the backup seat by mislabeling its
+    /// entry, nor a backup operator into a seat that would hand it a
+    /// different job.
+    func test_backupSeatType_refusesAnyOtherManifestSeat() {
+        for seat in ["blob.storage", "blossom", "notary", "transport.message", "backup", "storage"] {
+            XCTAssertFalse(
+                SeatManifestVocabulary.accepts(
+                    catalogSeatType: "storage.backup", manifestSeat: seat),
+                "\(seat) must not be accepted into the backup seat")
+        }
+        XCTAssertFalse(SeatManifestVocabulary.accepts(
+            catalogSeatType: "blob.storage", manifestSeat: "storage.backup"))
+    }
 }


### PR DESCRIPTION
## What was unreachable

The device-backup seat has been complete since #280 and reachable in
none of the PRs since. The chain breaks in one place:

- `BackupSeat.consentedManifests` reads pinned consent records whose
  `seat` is `storage.backup`.
- The only writer of a pinned consent record is
  `ModuleConsentAcceptance.accept`.
- The only caller of that is `ModuleConsentFlow`, which is only ever
  built inside a `DiscoveryModulePicker`.
- There were exactly three pickers — relayers, Nostr relays, Blossom
  servers — and none of them is for `storage.backup`.

So `consentedManifests` always returned empty,
`BackupSeatComposer.makeDeviceBackupView()` always resolved to `nil`,
and the Settings BACKUP section — gated on that view alone — never
appeared. The surface a person would consent from was gated on their
having already consented. Everything downstream (sealing, upload,
fan-out, restore, erase, purchases) worked and had no way to be
started.

This adds the fourth picker and the screen that reaches it.

## What is here

- **`BackupCatalogConsent`** — the picker's `apply` step, extracted the
  way `BlossomCatalogConsent` was so the one piece with behavior is
  unit-tested.
- **`BackupOperatorSettingsFlow` / `BackupOperatorSettingsView`**
  (OnymSettings) — the catalog half of the transport pickers, with the
  configured-list half removed.
- **`SettingsView`** — the BACKUP section now raises on *either*
  factory, and carries a Backup Operators row beside Device Backup.
- **`BackupConsentSignal`** — a consent raises it, `RootView`
  re-resolves.
- **`SeatManifestVocabulary`** — an explicit `storage.backup` entry.
- Tests for each, in the established style.

## The four judgement calls

**Apply writes nothing, and says so.** The transport pickers apply by
copying an endpoint into a repository, because their repository is the
operational source of truth for the seat. Backup has none: the pinned
record *is* the enrolment, read directly by `consentedManifests`, and
`BackupSeatComposer` builds one stack per record it finds. A second
copy anywhere else would be a second place for "who holds my history"
to drift from what was agreed — the Device Backup screen's Stop
Backing Up withdraws the consent and nothing else, which is right only
while consent is the record.

What apply does instead is **refuse**. It runs
`BackupOperatorManifest(manifest:)` — the same parse
`consentedManifests` runs over every pinned record — and translates
`BackupError.invalidEndpoint` into `ModuleApplyError.noUsableEndpoint`,
which the consent flow renders with its honest two-part message: your
consent was recorded, the service was not added. A backup manifest
with no read-write https endpoint is exactly as unusable as a Nostr
manifest with no `wss`, and without this check it would earn a
"Service added" screen followed by a Settings section that never
appears. Other refusals (unimplemented profile, missing declared
terms) are rethrown as themselves rather than dressed up as a missing
endpoint that is in fact fine.

**Entitlements pin from the manifest under review.** The shared
`makeEntitlements` resolves trusted issuers through
`BackupSeat.entitlementIssuers`, i.e. from the active consent record —
correct everywhere except on the one surface where that record does
not exist yet. On a first consent it answers with no issuers, so every
stored credential fails verification, no paid offer resolves as
entitled, and `canAccept` refuses a paid-only manifest outright.
Somebody restoring onto a new phone — who has already paid, and whose
credential is derivable from the recovery phrase — would find Accept
permanently disabled with nothing on screen to explain it. So
`makeBackupEntitlements` reads the issuers from the digest-pinned,
signature-verified bytes the person is being asked to agree to, via
`BackupOperatorManifest` rather than a second hand-rolled field read.
Any *other* component still falls back to its pinned record: a
manifest may only speak for itself, and a credential still never
nominates its own authority.

**The section, and making a fresh consent show up.** The BACKUP
section now appears when either factory is wired, so the picker is
reachable from the state everybody starts in. `RootView` previously
re-resolved on two events — the Settings tab being selected, and the
moderation consent cover closing. Backup consent is given from a sheet
pushed over the Settings tab, so neither fires, and the person who has
just agreed to back up their history would return to a Settings screen
with no Device Backup row on it. `BackupConsentSignal` (same shape and
same reason as `OnboardingRestartController`) is raised by the apply
step *after* the manifest is known usable, and `RootView` observes it.
The resolution itself is untouched: it still compares the consented
operators and rebuilds only when they changed, so re-reading an
operator's terms does not throw away a running backup.

**Vocabulary: explicit, no aliases.** `storage.backup` is written into
`acceptedManifestSeats` even though it accepts precisely what the
strict fallback would. The table is the readable list of every seat
this app will consent to, and a seat absent from it reads as one
nobody considered rather than one deliberately left on the default. No
aliases: the other three earn theirs from manifests really published
under an older spelling; this seat has never had one, and an invented
alias would be a second accepted spelling only a mislabeled catalog
entry could use.

## Verification

`xcodebuild build` and `xcodebuild test -only-testing:OnymIOSTests` on
an iPhone 17 simulator: **1421 tests, 3 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
