### PR TITLE
Verify the terms signature that actually covers the bytes

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupTerms.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupTerms.swift
@@ -38,7 +38,17 @@ public struct BackupTerms: Sendable, Equatable {
     public let metadataRetention: MetadataRetention
 
     public let rawBytes: Data
-    public let signature: Data?
+    /// The document's own `signature` field, which covers the canonical
+    /// bytes with `termsId` and `signature` removed.
+    ///
+    /// Read from the document rather than accepted from a caller. The
+    /// detached `.sig` sibling served beside it signs *different bytes*
+    /// — the exact served ones — so the two are not interchangeable, and
+    /// checking one against the other's message rejects a document that
+    /// is perfectly valid.
+    public let embeddedSignature: Data?
+    /// The detached `.sig` sibling, which covers `rawBytes` verbatim.
+    public let detachedSignature: Data?
 
     public struct Retention: Sendable, Equatable {
         /// `measurable` or `best-effort`, verbatim.
@@ -114,7 +124,7 @@ extension BackupTerms {
     /// a partial value: terms are a precondition for enrolment
     /// (`UI-Backup.md` §13), and half-read terms are worse than none —
     /// they would be pinned and later compared against.
-    public static func decode(raw: Data, signature: Data? = nil) throws -> BackupTerms {
+    public static func decode(raw: Data, detachedSignature: Data? = nil) throws -> BackupTerms {
         guard let object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any] else {
             throw BackupError.termsUnavailable
         }
@@ -202,7 +212,9 @@ extension BackupTerms {
                 entitlementRecords: try string(metadataObject, "entitlementRecords")
             ),
             rawBytes: raw,
-            signature: signature
+            embeddedSignature: (object["signature"] as? String)
+                .flatMap { Data(base64Encoded: $0) },
+            detachedSignature: detachedSignature
         )
         return terms
     }

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
@@ -294,24 +294,49 @@ extension URLSessionBackupClient {
         }
     }
 
+    /// Check the terms against the operator key the manifest pins.
+    ///
+    /// **Two signatures cover two different messages, and confusing them
+    /// rejects an honest operator.** The document's own `signature`
+    /// covers the canonical bytes with `termsId` and `signature`
+    /// removed; the detached `.sig` served beside it covers the exact
+    /// served bytes. This checked the detached one against the
+    /// canonical message, which cannot verify for any correct operator
+    /// — every enrolment failed with "terms could not be verified"
+    /// while the operator was serving a perfectly valid document.
+    ///
+    /// Both are checked now, each against the bytes it actually signs.
+    /// They are independent guarantees rather than a belt-and-braces
+    /// pair: the embedded one is what a pinned `termsId` is a digest
+    /// of, and the detached one is what proves the bytes on the wire
+    /// were not altered in transit by something that could also
+    /// recanonicalize them.
     func verifyTermsSignature(_ terms: BackupTerms) throws {
         guard
-            let signature = terms.signature,
             let keyHex = manifest.operatorKey.split(separator: ":").last.map(String.init),
             let keyBytes = BackupFormat.data(fromLowercaseHex: keyHex),
-            let key = try? Curve25519.Signing.PublicKey(rawRepresentation: keyBytes)
+            let key = try? Curve25519.Signing.PublicKey(rawRepresentation: keyBytes),
+            let embedded = terms.embeddedSignature
         else {
             // An unsigned or unverifiable terms document is not terms.
             // Enrolment stops here rather than pinning something nobody
             // can be held to.
             throw BackupError.termsUnavailable
         }
-        let signingBytes = try ServiceManifestCanonical.signingBytes(
+        let canonical = try ServiceManifestCanonical.signingBytes(
             of: terms.rawBytes,
             omitting: ["termsId", "signature"]
         )
-        guard key.isValidSignature(signature, for: signingBytes) else {
+        guard key.isValidSignature(embedded, for: canonical) else {
             throw BackupError.termsUnavailable
+        }
+        // The `.sig` sibling is optional on the wire, but a served one
+        // that does not verify is worse than an absent one: it is a
+        // disagreement between two things the same operator published.
+        if let detached = terms.detachedSignature {
+            guard key.isValidSignature(detached, for: terms.rawBytes) else {
+                throw BackupError.termsUnavailable
+            }
         }
     }
 }

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
@@ -124,7 +124,9 @@ public struct URLSessionBackupClient: BackupPort {
         let termsBytes = try await get(url: termsURL, signed: false)
         let signature = try? await get(url: termsURL.appendingPathExtension("sig"), signed: false)
 
-        let terms = try BackupTerms.decode(raw: termsBytes, signature: signature.flatMap {
+        let terms = try BackupTerms.decode(raw: termsBytes, detachedSignature: signature.flatMap {
+            // The `.sig` is base64 text; fall back to raw bytes for an
+            // operator that serves them unencoded.
             Data(base64Encoded: $0) ?? $0
         })
         // The manifest is what the person consented to, so it is the

--- a/Tests/OnymIOSTests/BackupTermsSignatureTests.swift
+++ b/Tests/OnymIOSTests/BackupTermsSignatureTests.swift
@@ -1,0 +1,120 @@
+import CryptoKit
+import Foundation
+import XCTest
+@testable import OnymBackup
+@testable import OnymFoundation
+
+/// The two signatures on a terms document cover **different bytes**, and
+/// treating them as interchangeable rejects an operator that is doing
+/// everything right.
+///
+/// This is not hypothetical. `verifyTermsSignature` checked the detached
+/// `.sig` against the canonical message, which cannot verify for any
+/// correct operator: every enrolment against the deployed
+/// `backup.onym.app` failed with "the operator's terms could not be
+/// verified" while the served document was valid on both counts.
+final class BackupTermsSignatureTests: XCTestCase {
+    private let key = Curve25519.Signing.PrivateKey()
+
+    /// A terms document signed the way the profile says: the embedded
+    /// `signature` over canonical bytes with `termsId` and `signature`
+    /// removed, and a detached sibling over the exact served bytes.
+    private func signedTerms() throws -> (raw: Data, detached: Data) {
+        let body: [String: Any] = [
+            "termsVersion": 1,
+            "operator": "onym:key:" + key.publicKey.rawRepresentation.map { String(format: "%02x", $0) }.joined(),
+            "retention": [
+                "class": "best-effort", "maximumRetentionPeriod": "until-erased",
+                "snapshotsRetained": "2", "expiryBehavior": "notify-then-erase",
+            ],
+            "erasure": [
+                "acknowledgementDeadline": "PT1H", "completionDeadline": "P7D",
+                "scope": "the primary copy", "excluded": "copies held by other participants",
+            ],
+            "jurisdictions": ["EE"],
+            "subProcessors": [],
+            "lawfulAccess": [
+                "disclosureWhatIsProduced": "sealed-bytes-and-declared-metadata-only",
+                "notifyHolderWhenPermitted": true,
+            ],
+            "breachDisclosure": ["holderNotice": "P3D"],
+            "export": ["format": "tar", "availableWhileUnpaid": true],
+            "shutdownNotice": "P90D",
+            "endOfPayment": [
+                "notice": "P14D", "grace": "P30D",
+                "duringGrace": ["download", "export", "erase"], "afterGrace": "erase",
+            ],
+            "metadataRetention": [
+                "accessLogs": "none", "sizeAndTiming": "while the snapshot is retained",
+                "holderIdentifiers": "while any snapshot is held", "operationOutcomes": "PT6H",
+                "erasureReceipts": "P365D", "entitlementRecords": "PT15M",
+            ],
+        ]
+        let unsigned = try JSONSerialization.data(withJSONObject: body)
+        let canonical = try ServiceManifestCanonical.signingBytes(
+            of: unsigned, omitting: ["termsId", "signature"])
+        let embedded = try key.signature(for: canonical)
+
+        var signed = body
+        signed["termsId"] = "sha256:" + SHA256.hash(data: canonical)
+            .map { String(format: "%02x", $0) }.joined()
+        signed["signature"] = embedded.base64EncodedString()
+        let raw = try JSONSerialization.data(withJSONObject: signed)
+        // The detached sibling signs the served bytes verbatim — which
+        // is why it is not the same signature as the embedded one.
+        return (raw, try key.signature(for: raw))
+    }
+
+    /// The regression. Both signatures present and correct, and the
+    /// document must be accepted.
+    func testACorrectlySignedTermsDocumentVerifies() throws {
+        let (raw, detached) = try signedTerms()
+        let terms = try BackupTerms.decode(raw: raw, detachedSignature: detached)
+
+        let canonical = try ServiceManifestCanonical.signingBytes(
+            of: raw, omitting: ["termsId", "signature"])
+        let embedded = try XCTUnwrap(terms.embeddedSignature)
+
+        XCTAssertTrue(
+            key.publicKey.isValidSignature(embedded, for: canonical),
+            "the embedded signature must verify over canonical bytes")
+        XCTAssertTrue(
+            key.publicKey.isValidSignature(detached, for: raw),
+            "the detached signature must verify over the exact served bytes")
+    }
+
+    /// The bug itself, asserted so nobody re-introduces it by deciding
+    /// the two signatures are the same thing.
+    func testTheTwoSignaturesDoNotCoverTheSameBytes() throws {
+        let (raw, detached) = try signedTerms()
+        let canonical = try ServiceManifestCanonical.signingBytes(
+            of: raw, omitting: ["termsId", "signature"])
+
+        XCTAssertNotEqual(raw, canonical, "the fixture no longer distinguishes the two messages")
+        XCTAssertFalse(
+            key.publicKey.isValidSignature(detached, for: canonical),
+            "the detached signature must NOT verify over canonical bytes — checking it that way is what rejected every honest operator")
+    }
+
+    /// `decode` reads the embedded signature from the document rather
+    /// than taking it from the caller, so the two can never be swapped
+    /// by a call site again.
+    func testDecodeReadsTheEmbeddedSignatureFromTheDocument() throws {
+        let (raw, detached) = try signedTerms()
+        let terms = try BackupTerms.decode(raw: raw, detachedSignature: detached)
+        XCTAssertNotEqual(terms.embeddedSignature, detached)
+        XCTAssertEqual(terms.detachedSignature, detached)
+    }
+
+    /// A document with no embedded signature is not terms, however
+    /// convincing its detached sibling looks.
+    func testAnUnsignedDocumentIsRefused() throws {
+        let (raw, detached) = try signedTerms()
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        object.removeValue(forKey: "signature")
+        let unsigned = try JSONSerialization.data(withJSONObject: object)
+        let terms = try BackupTerms.decode(raw: unsigned, detachedSignature: detached)
+        XCTAssertNil(terms.embeddedSignature)
+    }
+}


### PR DESCRIPTION
Enrolment against a correct operator always failed with **"The operator's terms could not be verified"**, and Status stayed off. The operator was serving a valid document; the client was checking the wrong signature against the wrong message.

## The two signatures cover different bytes

- The document's **embedded `signature`** covers the canonical bytes with `termsId` and `signature` removed. It is what the pinned `termsId` is a digest of.
- The detached **`.sig` sibling** covers the **exact served bytes**, which are *not* canonical — they still carry both of those fields.

`connect()` fetched the detached `.sig`, passed it in as `signature`, and `verifyTermsSignature` checked it against the canonical message. That cannot verify for any honest operator.

Measured against the deployed `backup.onym.app`:

```
detached sig over RAW served bytes : VERIFIES
detached sig over CANONICAL bytes  : FAILS      ← what this code did
embedded sig over CANONICAL bytes  : VERIFIES   ← what it ignored
raw == canonical bytes?  False
```

## The fix

`BackupTerms` now carries `embeddedSignature` and `detachedSignature`, named for what they cover, and **reads the embedded one out of the document** rather than accepting it from a caller — so a call site cannot swap them again. That parameter confusion is the whole bug.

Both are verified, each against the bytes it signs. The detached one stays optional on the wire, but a served `.sig` that does not verify is refused rather than ignored: that is two things the same operator published disagreeing with each other, which is worse than an absent sibling.

## Tests

Four, including one that asserts the detached signature does **not** verify over canonical bytes — so nobody re-introduces this by concluding the two signatures are interchangeable. The fixture also asserts `raw != canonical`, so it fails loudly if it ever stops distinguishing the two messages.

**I ran only `BackupTermsSignatureTests` (4 passed), not the full suite.** The change touches `BackupTerms.decode`'s signature and one call site, so a wider run is worth doing before merge — `ConsentedTermsEnforcementTests` in particular constructs terms fixtures.

Note `./generate-xcodeproj.sh` must be re-run after pulling this, since it adds a source file and the `.xcodeproj` is gitignored.

## Not an operator bug

`backup.onym.app` is serving correctly: detached `.sig` verifies over the served bytes, the embedded signature verifies over canonical bytes, and `termsId` recomputes to its own content address. Nothing to change there or in the discovery catalog.

Worth noting onym-backup's own commit adding those routes predicted this exactly — *"the embedded signature covers the canonical document minus itself, so a verifier checking the detached one the same way would reject a valid document."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)