### PR TITLE
Name an identity after its recovery phrase, not after a dice roll

### DIFF
--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityID.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityID.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Stable opaque handle for one of the user's identities.
@@ -13,8 +14,83 @@ import Foundation
 public struct IdentityID: Hashable, Codable, Sendable, CustomStringConvertible {
     public let rawValue: UUID
 
+    /// Random ID. Only correct for an identity that has no entropy behind
+    /// it — which, in the app, is none of them: every production identity
+    /// is minted from BIP39 entropy and must use
+    /// `init(derivedFromEntropy:)` instead, or the identity stops being
+    /// recoverable (see that initialiser). The default argument is kept
+    /// because tests mint hundreds of throwaway owner IDs that never touch
+    /// a mnemonic, and forcing them through a fake entropy blob would buy
+    /// nothing. If a second production call site ever wants this, that is
+    /// the moment to delete the default and make callers say `IdentityID(UUID())`
+    /// out loud.
     public init(_ rawValue: UUID = UUID()) {
         self.rawValue = rawValue
+    }
+
+    /// Derive the ID from the BIP39 entropy that backs the identity, so
+    /// importing a recovery phrase reproduces the *same* ID it had before.
+    ///
+    /// This is load-bearing for backup restore. Groups and messages are
+    /// scoped by owner (`MessageStore.list(groupID:ownerIDString:)`,
+    /// `ChatGroup.ownerIdentityID`), so an archive written by identity A
+    /// is invisible to identity B. When the ID was a fresh random UUID on
+    /// every creation — including on import — restoring after entering a
+    /// recovery phrase produced a device holding every row and showing
+    /// none of them: the restore summary counted the chats, the chat list
+    /// stayed empty. The entropy is the only thing an import actually
+    /// carries across devices, so the ID has to come from it.
+    ///
+    /// **Domain separation.** The entropy is also the root of the Nostr
+    /// and BLS secret keys, and this value is not secret: it lands in a
+    /// keychain service name and in plaintext SwiftData rows. HKDF with a
+    /// distinct `info` label is what keeps those worlds apart — the ID is
+    /// computationally unrelated to any key derived from the same seed, so
+    /// possessing it reveals nothing about them and it can never be
+    /// mistaken for, or fed in as, key material. The label is
+    /// `identity-id-v1`; the `v1` is there so a future change of scheme
+    /// can be a new label rather than a silent reinterpretation of the
+    /// same bytes. The salt matches `Bip39.deriveNostrKey` /
+    /// `deriveBlsKey` (`app.onym.bip39`) so the whole seed hierarchy has
+    /// one root salt and the labels alone do the separating — that is
+    /// exactly the job HKDF's `info` parameter exists to do.
+    ///
+    /// Note this takes the raw entropy, not the PBKDF2 seed the secret
+    /// keys are derived from. Both are deterministic functions of the
+    /// mnemonic so either would reproduce, but the entropy is one step
+    /// further from the key material and far cheaper for another platform
+    /// to match — Android has to compute the identical ID from the
+    /// identical phrase or a cross-platform restore shows an empty app
+    /// for the same reason this bug did.
+    ///
+    /// **Version bits.** The output is stamped as a v4 (random) UUID even
+    /// though it is derived. `IdentityID` round-trips through
+    /// `UUID(uuidString:)` for keychain service names and persisted
+    /// `ChatGroup` rows, so the value must be a well-formed UUID or it
+    /// fails to parse somewhere far away from here. RFC 9562's v8
+    /// ("custom") is the more literally honest version nibble, and it was
+    /// rejected: it would make every derived ID visually distinguishable
+    /// from a legacy random one, printing "this identity is seed-derived"
+    /// into every keychain service name and every stored row. Nothing
+    /// downstream needs to know which way an ID was minted, and a value
+    /// that quietly announces something about its owner is the shape of
+    /// thing this codebase is meant not to emit.
+    public init(derivedFromEntropy entropy: Data) {
+        let derived = HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: entropy),
+            salt: Data("app.onym.bip39".utf8),
+            info: Data("identity-id-v1".utf8),
+            outputByteCount: 16
+        )
+        var bytes = derived.withUnsafeBytes { [UInt8]($0) }
+        bytes[6] = (bytes[6] & 0x0F) | 0x40  // version 4
+        bytes[8] = (bytes[8] & 0x3F) | 0x80  // RFC 4122 variant
+        self.rawValue = UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 
     /// `nil` if `string` isn't a parseable UUID. Used when reconstructing

--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
@@ -743,9 +743,27 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
     }
 
     /// Mints a fresh BIP39 identity (or restores from `mnemonic` when
-    /// non-nil), persists it under a new `IdentityID`, and inserts
-    /// into the in-memory cache. Does NOT broadcast or touch
-    /// `currentID`; callers do.
+    /// non-nil), persists it under the `IdentityID` derived from its
+    /// entropy, and inserts into the in-memory cache. Does NOT broadcast
+    /// or touch `currentID`; callers do.
+    ///
+    /// Both branches derive: a freshly-generated phrase gets a derived ID
+    /// for exactly the reason an imported one does — today's new identity
+    /// is the one someone re-imports from a recovery phrase in a year, and
+    /// if its ID were random at birth the restore would find nothing.
+    /// Randomising only the generate path would have left the bug
+    /// perfectly intact for every identity that has not been created yet.
+    ///
+    /// Because the ID is now a function of the entropy, adding a mnemonic
+    /// the device already holds resolves to an ID that is already loaded.
+    /// That returns the existing identity untouched rather than appending
+    /// a second slot: under random IDs it produced two indistinguishable
+    /// identities with identical keys (already a latent bug); appending it
+    /// now would put the same ID in `orderedIDs` twice and double every
+    /// broadcast summary. The caller's `name` is deliberately not applied
+    /// to the existing identity — an import is not a rename, and silently
+    /// relabelling an identity the user already has is a worse surprise
+    /// than ignoring a name they probably did not type.
     private func addLocked(name: String?, mnemonic: String?) throws -> IdentityID {
         var entropy: Data
         if let mnemonic {
@@ -763,7 +781,8 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
             entropy = parsed
         }
         defer { entropy.resetBytes(in: 0..<entropy.count) }
-        let id = IdentityID()
+        let id = IdentityID(derivedFromEntropy: entropy)
+        if cache[id] != nil { return id }
         let resolvedName = name?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
             ?? Self.fallbackName(forNewSlot: orderedIDs.count + 1)
         var snapshot = Self.snapshot(fromEntropy: entropy)

--- a/Tests/OnymIOSTests/IdentityIDTests.swift
+++ b/Tests/OnymIOSTests/IdentityIDTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import OnymIOS
+import OnymFoundation
 import OnymIdentity
 
 final class IdentityIDTests: XCTestCase {
@@ -49,4 +50,88 @@ final class IdentityIDTests: XCTestCase {
         XCTAssertEqual(a, b)
         XCTAssertEqual(a.hashValue, b.hashValue)
     }
+
+    // MARK: - Derivation from entropy
+
+    /// The whole point: a recovery phrase that produced identity A must
+    /// keep producing identity A. Chats and messages are owner-scoped, so
+    /// an ID that changes on import is an archive nobody can see.
+    func test_derivedFromEntropy_sameEntropyGivesSameID() {
+        let entropy = Bip39.entropyFromMnemonic(Self.canonicalMnemonic)!
+
+        XCTAssertEqual(
+            IdentityID(derivedFromEntropy: entropy),
+            IdentityID(derivedFromEntropy: entropy),
+            "the same recovery phrase must always name the same identity"
+        )
+    }
+
+    func test_derivedFromEntropy_differentEntropyGivesDifferentID() {
+        let a = Bip39.entropyFromMnemonic(Self.canonicalMnemonic)!
+        let b = Bip39.entropyFromMnemonic(Self.otherMnemonic)!
+
+        XCTAssertNotEqual(
+            IdentityID(derivedFromEntropy: a),
+            IdentityID(derivedFromEntropy: b),
+            "two identities must not collide onto one keychain slot"
+        )
+    }
+
+    /// A one-bit change in the entropy must not leave the ID recognisably
+    /// close to the original — the ID lands in plaintext SwiftData rows,
+    /// and "adjacent seeds look adjacent" would make it a hint about the
+    /// key material it shares a root with.
+    func test_derivedFromEntropy_oneBitFlipChangesID() {
+        var entropy = Bip39.entropyFromMnemonic(Self.canonicalMnemonic)!
+        let original = IdentityID(derivedFromEntropy: entropy)
+        entropy[0] ^= 0x01
+
+        XCTAssertNotEqual(original, IdentityID(derivedFromEntropy: entropy))
+    }
+
+    /// `IdentityID` is reconstructed from a keychain service suffix
+    /// (`app.onym.ios.identity.<uuidString>`) and from persisted
+    /// `ChatGroup` rows via `UUID(uuidString:)`. A derived value that is
+    /// not a well-formed UUID would fail to parse a long way from here, so
+    /// assert the round trip rather than trusting the bit-twiddling.
+    func test_derivedFromEntropy_isWellFormedUUIDAndSurvivesStringRoundTrip() throws {
+        let entropy = Bip39.entropyFromMnemonic(Self.canonicalMnemonic)!
+        let id = IdentityID(derivedFromEntropy: entropy)
+
+        let string = id.rawValue.uuidString
+        let reparsed = try XCTUnwrap(
+            IdentityID(string),
+            "derived ID must survive the keychain-suffix / ChatGroup-row round trip"
+        )
+        XCTAssertEqual(reparsed, id)
+
+        // Version 4 + RFC 4122 variant, so a derived ID is indistinguishable
+        // from a random one everywhere it is stored or printed.
+        let bytes = withUnsafeBytes(of: id.rawValue.uuid) { [UInt8]($0) }
+        XCTAssertEqual(bytes[6] & 0xF0, 0x40, "version nibble must say 4")
+        XCTAssertEqual(bytes[8] & 0xC0, 0x80, "variant bits must say RFC 4122")
+    }
+
+    /// **Derivation fixture.** Pins the `identity-id-v1` HKDF label and the
+    /// `app.onym.bip39` salt against the canonical BIP39 test vector.
+    /// Changing either silently would orphan every identity already minted
+    /// under the old label — the same invisible-chats failure this
+    /// derivation exists to fix. Break loudly instead.
+    ///
+    /// onym-android must reproduce this exact value from this exact phrase
+    /// for a cross-platform restore to show anything.
+    func test_derivedFromEntropy_matchesFixture() {
+        let entropy = Bip39.entropyFromMnemonic(Self.canonicalMnemonic)!
+
+        XCTAssertEqual(
+            IdentityID(derivedFromEntropy: entropy).description,
+            Self.canonicalDerivedID
+        )
+    }
+
+    private static let canonicalMnemonic =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    private static let otherMnemonic =
+        "legal winner thank year wave sausage worth useful legal winner thank yellow"
+    private static let canonicalDerivedID = "59B0B267-F746-46B7-AD6C-31863606156F"
 }

--- a/Tests/OnymIOSTests/IdentityRepositoryTests.swift
+++ b/Tests/OnymIOSTests/IdentityRepositoryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import OnymIOS
+import OnymFoundation
 @testable import OnymIdentity
 
 /// Each test uses its own Keychain service so test runs are isolated and
@@ -151,6 +152,112 @@ final class IdentityRepositoryTests: XCTestCase {
         }
     }
 
+    // MARK: - Entropy-derived IdentityID
+
+    /// The restore bug in one test. Chats and messages are owner-scoped,
+    /// so if importing a phrase minted a new `IdentityID` the restored
+    /// archive belonged to an identity that no longer existed on the
+    /// device: the summary counted "1 chats, 50 messages" and the chat
+    /// list stayed empty, across restarts. The ID must survive a wipe and
+    /// a re-import of the same phrase.
+    func test_restore_sameMnemonicYieldsSameIdentityID() async throws {
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        _ = try await repo.restore(mnemonic: mnemonic)
+        let first = try await selectedID()
+
+        try await repo.wipe()
+        _ = try await repo.restore(mnemonic: mnemonic)
+        let second = try await selectedID()
+
+        XCTAssertEqual(first, second,
+                       "re-importing a recovery phrase must land on the identity that owns the backed-up rows")
+    }
+
+    func test_restore_differentMnemonicsYieldDifferentIdentityIDs() async throws {
+        _ = try await repo.restore(
+            mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        )
+        let first = try await selectedID()
+
+        try await repo.wipe()
+        _ = try await repo.restore(
+            mnemonic: "legal winner thank year wave sausage worth useful legal winner thank yellow"
+        )
+        let second = try await selectedID()
+
+        XCTAssertNotEqual(first, second,
+                          "two phrases must not collide onto one identity slot")
+    }
+
+    /// A freshly-generated identity is derived too — it is the identity
+    /// someone re-imports from a recovery phrase later, and that import
+    /// has to find it.
+    func test_bootstrap_generatedIdentityIsReachableByItsOwnPhrase() async throws {
+        let generated = try await repo.bootstrap()
+        let id = try await selectedID()
+        let phrase = try XCTUnwrap(generated.recoveryPhrase)
+
+        try await repo.wipe()
+        _ = try await repo.restore(mnemonic: phrase)
+
+        let reimported = await repo.currentSelectedID()
+        XCTAssertEqual(reimported, id,
+                       "an identity minted today must be restorable from its own phrase tomorrow")
+    }
+
+    /// Adding a phrase the device already holds resolves to the ID it is
+    /// already stored under. It must return that identity, not append a
+    /// duplicate `orderedIDs` entry that doubles every broadcast summary.
+    func test_add_sameMnemonicTwice_doesNotDuplicateTheIdentity() async throws {
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        let first = try await repo.add(mnemonic: mnemonic)
+        let second = try await repo.add(mnemonic: mnemonic)
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(try keychain.list().count, 1,
+                       "one phrase is one identity, however many times it is imported")
+        let summaries = try await repo.currentIdentities()
+        XCTAssertEqual(summaries.count, 1)
+    }
+
+    /// **No migration, on purpose.** Identities that already exist on a
+    /// device keep the random UUID they were persisted under — this change
+    /// derives IDs at mint time and rewrites nothing. Loading must
+    /// therefore hand back the stored ID untouched, even though its
+    /// entropy would now derive a different one. The visible consequence
+    /// is stated in the PR: a backup taken by a pre-existing identity
+    /// still will not restore after a re-import. Assert the property
+    /// rather than assume it, because a well-meaning "fix up the ID on
+    /// load" would silently orphan every row already keyed to the old one.
+    func test_load_preexistingIdentity_keepsItsPersistedRandomID() async throws {
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        let entropy = try XCTUnwrap(Bip39.entropyFromMnemonic(mnemonic))
+        let legacyID = IdentityID()  // what the old code minted: random, unrelated to the entropy
+        XCTAssertNotEqual(legacyID, IdentityID(derivedFromEntropy: entropy))
+
+        let seed = Bip39.seedFromMnemonic(mnemonic)
+        try keychain.write(legacyID, StoredSnapshot(
+            name: "Legacy",
+            entropy: entropy,
+            nostrSecretKey: Bip39.deriveNostrKey(from: seed),
+            blsSecretKey: Bip39.deriveBlsKey(from: seed)
+        ))
+
+        let freshRepo = IdentityRepository(
+            keychain: keychain,
+            selectionStore: .inMemory(),
+            installMarker: .inMemory(initiallySet: true),
+            protectedData: .always
+        )
+        _ = try await freshRepo.bootstrap()
+
+        let loadedID = await freshRepo.currentSelectedID()
+        XCTAssertEqual(loadedID, legacyID,
+                       "an already-persisted identity must not be re-keyed under it")
+        XCTAssertEqual(try keychain.list(), [legacyID],
+                       "no migration: nothing is rewritten under the derived ID")
+    }
+
     // MARK: - wipe
 
     func test_wipe_clearsKeychainAndCurrentIdentity() async throws {
@@ -294,6 +401,19 @@ final class IdentityRepositoryTests: XCTestCase {
         let bSnaps = await b.snapshots
         XCTAssertEqual(aSnaps, [nil, identity])
         XCTAssertEqual(bSnaps, [nil, identity])
+    }
+
+    // MARK: - Helpers
+
+    /// `currentSelectedID()` is actor-isolated and `XCTUnwrap` takes an
+    /// autoclosure, which can't await — hop once here so the ID assertions
+    /// stay one line each.
+    private func selectedID(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> IdentityID {
+        let id = await repo.currentSelectedID()
+        return try XCTUnwrap(id, "no identity is selected", file: file, line: line)
     }
 }
 


### PR DESCRIPTION
Restoring a backup after importing a recovery phrase produced a device
that held every row and showed none of them. QA saw the restore summary
report "1 chats, 50 messages" and the chat list stay empty across an app
restart, with the identity renamed to "Identity".

## What was wrong

`IdentityID` was a random UUID, minted by `IdentityID()` in
`IdentityRepository.addLocked` on **every** creation — importing an
existing mnemonic included. The entropy never touched the ID.

So importing a phrase minted identity B while the archive's groups and
messages carried identity A. Everything downstream is owner-scoped —
`MessageStore.list(groupID:ownerIDString:)`, `ChatGroup.ownerIdentityID`,
the chat surfaces — so nothing matched. The "Identity" name is the same
cause showing through `fallbackName(forNewSlot:)`; it was the only
visible tell that anything was wrong. (This PR does not fix the name.
That is archive-carried data and a separate change; the ID is what
unblocks the chat list.)

## The fix

The entropy is the one thing an import actually carries across devices,
so the ID now comes from it:

```
HKDF-SHA256(
    ikm:  BIP39 entropy,
    salt: "app.onym.bip39",
    info: "identity-id-v1",
    len:  16
)
```

with the version and variant bits stamped into the result.

**Domain separation is the point of the label.** This value is not
secret — it lands in a keychain service name and in plaintext SwiftData
rows — while the same entropy roots the Nostr and BLS secret keys.
HKDF's `info` is exactly the mechanism that keeps those worlds apart:
the ID is computationally unrelated to any key derived from the same
seed, so possessing it reveals nothing about them and it can never be
mistaken for, or fed in as, key material. The `v1` is there so a future
change of scheme is a new label rather than a silent reinterpretation of
the same bytes. The salt matches `Bip39.deriveNostrKey` /
`deriveBlsKey` so the whole seed hierarchy has one root salt and the
labels alone do the separating.

It takes the raw entropy rather than the PBKDF2 seed the secret keys
come from — both reproduce, but the entropy is one step further from the
key material and far cheaper for another platform to match.

**Both branches derive**, generated and imported. Today's new identity
is the one someone re-imports from a phrase in a year; randomising only
the generate path would have left the bug perfectly intact for every
identity that does not exist yet.

**The output is stamped v4** even though it is derived. `IdentityID`
round-trips through `UUID(uuidString:)` for keychain service names
(`app.onym.ios.identity.<uuidString>`) and persisted `ChatGroup` rows,
so it has to be a well-formed UUID or it fails to parse a long way from
here. RFC 9562's v8 ("custom") is the more literally honest nibble, and
it was rejected: it would make every derived ID visually distinguishable
from a legacy random one, printing "this identity is seed-derived" into
every service name and every stored row. Nothing downstream needs to
know which way an ID was minted.

Importing a phrase the device already holds now resolves to an ID that
is already loaded, and returns that identity instead of appending a
second `orderedIDs` entry that would double every broadcast summary.
Under random IDs it produced two indistinguishable identities with
identical keys.

`IdentityID()` stays available — tests mint hundreds of throwaway owner
IDs that never touch a mnemonic — but `addLocked` was its only
production call site, and its doc comment now says so, so a second one
has to argue for itself.

## No migration — read this before you test

**This is deliberate, and it has a consequence.** Identities that
already exist on a device keep the random UUID they were persisted
under. Nothing is rewritten. **A backup taken by one of those identities
still will not restore after a re-import.** Only identities created or
imported after this change are restorable.

If you test with pre-existing data you will see the old empty chat list
and conclude the fix does not work. Mint or import an identity on this
build first.

`test_load_preexistingIdentity_keepsItsPersistedRandomID` asserts the
no-migration property rather than leaving it assumed — a well-meaning
"fix up the ID on load" would silently orphan every row already keyed to
the old one.

## Why a seed-derived ID is safe here

A value derived from the seed would be a stable cross-service
correlator if it ever left the device. Audited independently: it does
not.

- **No wire payload carries it.** `ChatMessagePayload`,
  `ChatReceiptPayload`, `GroupInvitationPayload`,
  `GroupInviteOfferPayload`, `JoinRequestPayload`,
  `MemberAnnouncementPayload`, `GroupStateRefreshRequest`,
  `SealedEnvelope`, and the on-chain SEP types contain no identity
  field.
- **No invite link or QR carries it.** The deeplink payload in
  `IntroCapability` is exactly `intro_pub`, `group_id`, `group_name`.
  `InviteIntroducer.mint` takes an owner but uses it only for a keychain
  row and an in-process actor dictionary key.
- **`IdentityID` is not referenced at all** in OnymTransport,
  OnymTransportNostr, OnymTransportBlossom, OnymDiscovery, OnymChain,
  OnymBilling, OnymModeration, OnymRecovery, or OnymFoundation.
- **No telemetry**: there is no analytics or crash-reporting SDK, and no
  log site prints it.
- **The one network path is inside the seal.** `BackupArchiveRecords`
  carries `ownerIdentityID`, but that plaintext is AES-GCM sealed under
  a random per-snapshot salt before upload; preflight sends only a
  digest, size, and terms ID. The operator sees opaque, non-convergent
  ciphertext.

The `ownerIdentityID` fields in `BackupArchiveRecords` are the single
place a future change — a plaintext manifest, a preflight index, an
unsealed export — would turn this into a leak. Worth a note on whoever
touches that next.

## Android is not ready for this

Cross-platform restore (profile §18.18) needs both platforms to derive
the *same* ID from the same phrase. onym-android currently cannot:

- `IdentityId` is `IdentityId(UUID.randomUUID().toString())` —
  `modules/identity/.../IdentityId.kt:27`, its only mint site.
- Re-minted on every restore: `IdentityRepository.kt:303` (`restore`),
  `:356` (`add`), `:643` (`generateNewLocked`) — all
  `IdentityId.new()`, all independent of the entropy sitting on the
  line above.
- Worse, and independent of this PR: Android's restore sink writes
  archived `ownerIdentityId` values back verbatim
  (`app/.../BackupSinks.kt:65,97`) with no remap, while
  `GroupRepository.snapshots` filters by the active owner — so Android
  already orphans restored chats on its own platform, not just across
  platforms.

Android needs the same HKDF, the same salt, and the same
`identity-id-v1` label. `test_derivedFromEntropy_matchesFixture` pins
the value it must reproduce: the canonical BIP39 phrase must derive
`59B0B267-F746-46B7-AD6C-31863606156F`. Note that the existing
cross-platform fixture comment already records that the `chat.onym.*`
rebrand diverged the salts from onym-android, so key-derivation interop
is separately broken today.

No changes were made to onym-android.

## Tests

Added to `IdentityIDTests`: same entropy gives the same ID; different
entropy gives different IDs; a one-bit entropy flip changes the ID; the
derived value is a well-formed v4/RFC-4122 UUID that survives the
`uuidString` round trip; and a derivation fixture pinning the label and
salt against the canonical BIP39 vector.

Added to `IdentityRepositoryTests`: re-importing a phrase lands on the
same `IdentityID` across a wipe; two phrases do not collide; a
generated identity is reachable by its own phrase; importing the same
phrase twice does not duplicate the identity; and the no-migration
property above.

```
xcodebuild test -project OnymIOS.xcodeproj -scheme OnymIOS \
  -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
  -only-testing:OnymIOSTests
```

`** TEST SUCCEEDED **` — 1431 tests, 3 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
