### PR TITLE
Show a restored chat to the person who restored it, and count what landed

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRestorer.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRestorer.swift
@@ -95,10 +95,10 @@ public actor BackupRestorer {
         // earlier writes have landed. Reported as `restoreInterrupted`
         // so the screen can say so, rather than inheriting the
         // pre-write promise.
-        let wroteGroups: Int
-        let wroteMessages: Int
-        let wroteInvitations: Int
-        let wroteConsents: Int
+        let wroteGroups: BackupSinkOutcome
+        let wroteMessages: BackupSinkOutcome
+        let wroteInvitations: BackupSinkOutcome
+        let wroteConsents: BackupSinkOutcome
         do {
             wroteGroups = try await sink.restore(groups: groups)
             wroteMessages = try await sink.restore(messages: messages)
@@ -111,14 +111,31 @@ public actor BackupRestorer {
             throw BackupError.localFailure(reason: .restoreInterrupted)
         }
 
+        // What could not be read is what the sink *said* could not be
+        // read, not what is left over after subtracting what it wrote.
+        //
+        // The subtraction was `held - written`, and it was wrong for
+        // every row that was already on the device. A restore's writes
+        // are `insertOrUpdate` precisely so that restoring twice, or
+        // onto a phone that has since received some of the same
+        // messages, converges rather than duplicating — and a sink that
+        // reported only *new* rows made every one of those convergences
+        // look like a parse failure. The consent list made it
+        // unmissable: you cannot reach an operator's snapshot without
+        // having consented to that operator, so the consents in the
+        // archive are always already held, and the screen said all of
+        // them "could not be read by this version of Onym".
+        //
+        // Only the sink knows which of the two happened, so only the
+        // sink may say. Arithmetic here cannot recover the distinction.
         var skipped: [String: Int] = [:]
-        for (name, held, written) in [
-            ("groups", groups.count, wroteGroups),
-            ("messages", messages.count, wroteMessages),
-            ("invitations", invitations.count, wroteInvitations),
-            ("consents", consents.count, wroteConsents),
-        ] where held > written {
-            skipped[name] = held - written
+        for (name, outcome) in [
+            ("groups", wroteGroups),
+            ("messages", wroteMessages),
+            ("invitations", wroteInvitations),
+            ("consents", wroteConsents),
+        ] where outcome.unreadable > 0 {
+            skipped[name] = outcome.unreadable
         }
 
         // Only a snapshot that meant to carry blobs can be missing any.
@@ -135,10 +152,10 @@ public actor BackupRestorer {
         }
 
         return BackupRestoreSummary(
-            groups: wroteGroups,
-            messages: wroteMessages,
-            invitations: wroteInvitations,
-            consents: wroteConsents,
+            groups: wroteGroups.landed,
+            messages: wroteMessages.landed,
+            invitations: wroteInvitations.landed,
+            consents: wroteConsents.landed,
             blobs: blobs.count,
             skipped: skipped,
             unresolvedBlobs: unresolved

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupSource.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupSource.swift
@@ -64,18 +64,54 @@ public enum BackupBlobAvailability: Sendable, Equatable {
     case gone
 }
 
+/// What one kind of row did on its way into local state.
+///
+/// Two numbers rather than one, because a single count cannot tell the
+/// difference between the two reasons a row is not *new* on this device,
+/// and the screen says something very different about each:
+///
+/// - `landed` — the row is on the device now. Freshly inserted, updated
+///   in place, or already present and left alone: all three mean the
+///   history is here, which is the only question the summary asks.
+/// - `unreadable` — the row was handed over and did not land. A shape
+///   from a schema this build does not know, an id that will not parse,
+///   a store that refused the write. Worth saying out loud, because part
+///   of someone's history did not arrive.
+///
+/// The previous shape returned `landed` alone and let `BackupRestorer`
+/// subtract it from what the archive held. That subtraction is where the
+/// two meanings collapsed: a consent already present on the device — and
+/// every restore has at least one, since consenting to an operator is
+/// how you reach its snapshot at all — came out the far side as "could
+/// not be read by this version of Onym". Nothing was wrong; the
+/// arithmetic simply had no way to say so. So the sink says so instead.
+public struct BackupSinkOutcome: Sendable, Equatable {
+    /// Rows that are on the device now, however they got there.
+    public let landed: Int
+    /// Rows handed over that this build could not put anywhere.
+    public let unreadable: Int
+
+    public init(landed: Int, unreadable: Int) {
+        self.landed = landed
+        self.unreadable = unreadable
+    }
+
+    public static let none = BackupSinkOutcome(landed: 0, unreadable: 0)
+}
+
 /// Where a restored snapshot's contents go.
 ///
-/// Every method returns **how many rows it actually wrote**, not how
-/// many it was handed. An implementation that cannot reconstruct a row —
-/// an enum case from a newer schema, an unparseable id — skips it, and a
-/// summary built from the archive's counts would then report restoring
-/// things that are not there. The count has to come from the writer.
+/// Every method reports **what actually landed**, not how many rows it
+/// was handed. An implementation that cannot reconstruct a row — an enum
+/// case from a newer schema, an unparseable id — skips it, and a summary
+/// built from the archive's counts would then report restoring things
+/// that are not there. The count has to come from the writer, and so
+/// does the reason a row is missing from it.
 public protocol BackupSinkProviding: Sendable {
-    @discardableResult func restore(groups: [BackupGroupRecord]) async throws -> Int
-    @discardableResult func restore(messages: [BackupMessageRecord]) async throws -> Int
-    @discardableResult func restore(invitations: [BackupInvitationRecord]) async throws -> Int
-    @discardableResult func restore(consents: [BackupConsentRecord]) async throws -> Int
+    @discardableResult func restore(groups: [BackupGroupRecord]) async throws -> BackupSinkOutcome
+    @discardableResult func restore(messages: [BackupMessageRecord]) async throws -> BackupSinkOutcome
+    @discardableResult func restore(invitations: [BackupInvitationRecord]) async throws -> BackupSinkOutcome
+    @discardableResult func restore(consents: [BackupConsentRecord]) async throws -> BackupSinkOutcome
     /// Hand back one attachment blob. The implementation is responsible
     /// for putting it somewhere the media loaders will find it.
     func restore(blob: BackupBlobRecord) async throws

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreFlow.swift
@@ -85,17 +85,50 @@ public final class BackupRestoreFlow {
     private let restorer: BackupRestorer
     private let keyMaterial: BackupKeyMaterial
     private let workingDirectory: URL
+    /// Run after a restore has written and *before* the summary is
+    /// shown. The composition root uses it to make the repositories
+    /// re-read the stores the restore wrote straight into.
+    ///
+    /// It lives here, and it has no default, for two reasons.
+    ///
+    /// The restore writes through the app's stores rather than through
+    /// the repositories, deliberately: that is what re-encrypts every
+    /// row under this device's at-rest key. The cost is that the
+    /// in-memory caches the chat list and the open thread subscribe to
+    /// know nothing about it — a restored chat appeared only once some
+    /// unrelated mutation happened to refresh the group cache, and its
+    /// messages never appeared at all, because that thread's cache had
+    /// been populated empty before the restore and was serving what it
+    /// held then. Teaching `AppBackupSink` about repositories would
+    /// have fixed it by making a thin store adapter into something that
+    /// knows about view state; teaching `BackupRestorer` would have put
+    /// UI cache invalidation inside the crypto and I/O it exists to do.
+    /// Neither of those seams should carry this, and the composition
+    /// root is the one place that already holds both the repositories
+    /// and the restorer.
+    ///
+    /// It sits *inside* the flow rather than at the call site because
+    /// the ordering is the requirement: the person must not read
+    /// "1 chats, 3 messages" over a list that has not caught up yet.
+    /// This class is the one thing that knows both that the write
+    /// finished and that the summary is about to be presented, so it can
+    /// enforce that ordering rather than ask each caller to remember it.
+    /// No default value for the same reason — a caller that has nothing
+    /// to refresh should have to write `{}` and mean it.
+    private let didRestore: @Sendable () async -> Void
 
     public init(
         sources: [BackupRestoreSource],
         restorer: BackupRestorer,
         keyMaterial: BackupKeyMaterial,
-        workingDirectory: URL
+        workingDirectory: URL,
+        didRestore: @escaping @Sendable () async -> Void
     ) {
         self.sources = sources
         self.restorer = restorer
         self.keyMaterial = keyMaterial
         self.workingDirectory = workingDirectory
+        self.didRestore = didRestore
     }
 
     public func load() async {
@@ -174,6 +207,11 @@ public final class BackupRestoreFlow {
                 keyMaterial: keyMaterial,
                 workingDirectory: workingDirectory
             )
+            // Before `.restored`, never after. The summary and the chat
+            // list behind it are read in the same glance, and a screen
+            // that says three messages arrived over a thread still
+            // showing none is worse than no summary at all.
+            await didRestore()
             state = .restored(summary)
         } catch {
             // Nothing partial has been written: the restorer verifies the

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/MessageRepository.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/MessageRepository.swift
@@ -154,6 +154,33 @@ public actor MessageRepository {
         notifyChange()
     }
 
+    /// Re-read every cached thread from the store.
+    ///
+    /// For writes that went into the `MessageStore` without passing
+    /// through here — the only one today is a backup restore, which
+    /// writes through the app's stores so each row is re-encrypted under
+    /// this device's at-rest key, and therefore bypasses the repository
+    /// that owns this cache. Without this, a thread whose cache was
+    /// populated *before* the restore keeps serving what it held then,
+    /// and an open chat stays empty while its messages sit on disk.
+    ///
+    /// Every cached thread, not the ones a caller believes were
+    /// touched. Threads this session never opened are not in `cached` at
+    /// all and will read the store on first subscribe, so they need
+    /// nothing; the cached ones are the entire exposure, and there are
+    /// only ever as many of those as the person has opened since launch.
+    /// Narrowing it to "affected" threads would mean the restore telling
+    /// the repository which keys it wrote — a list that is wrong the
+    /// moment a record is skipped, and whose failure mode is a chat that
+    /// silently stays empty. A restore is rare; a restore that
+    /// half-refreshes is the bug this method exists to close.
+    public func reload() async {
+        for key in cached.keys {
+            await refresh(key)
+        }
+        notifyChange()
+    }
+
     // MARK: - Subscriptions
 
     /// Reactive stream of messages for one thread. Emits the current

--- a/Sources/OnymIOS/BackupComposition.swift
+++ b/Sources/OnymIOS/BackupComposition.swift
@@ -32,6 +32,13 @@ struct BackupSeatComposer {
     let identities: IdentityRepository
     let groupStore: any GroupStore
     let messageStore: any MessageStore
+    /// The repositories that own the caches the chat list and the open
+    /// thread actually read from. Held alongside the stores, not instead
+    /// of them: a restore still writes through the stores, so each row
+    /// is re-encrypted under this device's at-rest key, and these are
+    /// here only so the caches can be told to catch up once it has.
+    let groupRepository: GroupRepository
+    let messageRepository: MessageRepository
     let invitationStore: any InvitationStore
     let consentStore: any PinnedConsentStore
     let blobClient: (any BlossomClient)?
@@ -280,7 +287,25 @@ struct BackupSeatComposer {
                         // repository and are not used to decrypt
                         // anything.
                         keyMaterial: first.material,
-                        workingDirectory: workingDirectory))
+                        workingDirectory: workingDirectory,
+                        // The restored rows are on disk; nothing that
+                        // renders them knows it yet. `GroupRepository`
+                        // serves a cached roster to every `snapshots`
+                        // subscriber and only re-reads on its own
+                        // mutations, so a restored chat used to surface
+                        // whenever the person next created one — and
+                        // `MessageRepository` caches per thread, so a
+                        // thread opened before the restore kept serving
+                        // the empty list it had cached.
+                        //
+                        // Groups first: the chat list resolves each
+                        // row's latest message, and refreshing messages
+                        // into a roster that does not hold their group
+                        // yet is work thrown away.
+                        didRestore: { [groupRepository, messageRepository] in
+                            await groupRepository.reload()
+                            await messageRepository.reload()
+                        }))
             }
         )
     }

--- a/Sources/OnymIOS/BackupSinks.swift
+++ b/Sources/OnymIOS/BackupSinks.swift
@@ -18,6 +18,15 @@ import OnymPersistence
 /// Writes are `insertOrUpdate`, so restoring twice — or restoring onto a
 /// device that has since received some of the same messages — converges
 /// instead of duplicating.
+///
+/// Every method reports a `BackupSinkOutcome` and every one of them
+/// takes the store at its word about whether the write happened. The
+/// counting used to be `await store.insertOrUpdate(…)` followed by an
+/// unconditional `written += 1`, throwing away a `Bool` that meant
+/// exactly the thing being counted. So the summary reported *calls
+/// made*, and "1 chats, 3 messages" read identically whether three
+/// messages were on the device or none were — which is precisely how a
+/// restore that wrote nothing survived QA looking like a success.
 struct AppBackupSink: BackupSinkProviding {
     let groupStore: any GroupStore
     let messageStore: any MessageStore
@@ -34,8 +43,29 @@ struct AppBackupSink: BackupSinkProviding {
     }()
 
     @discardableResult
-    func restore(groups: [BackupGroupRecord]) async throws -> Int {
-        var written = 0
+    func restore(groups: [BackupGroupRecord]) async throws -> BackupSinkOutcome {
+        var landed = 0
+        var unreadable = 0
+        // What is already here, before anything is written.
+        //
+        // `GroupStore.insertOrUpdate` answers `true` on insert and
+        // `false` on *both* of the other two endings: a row updated in
+        // place, and an encode that failed having persisted nothing.
+        // Counting `false` as a failure would report every re-restore as
+        // unreadable; counting it as a success would report a store that
+        // refused the write as restored. Neither is true, and the
+        // returned `Bool` cannot tell them apart on its own.
+        //
+        // Knowing which keys existed beforehand does tell them apart:
+        // `false` for a key that was already here is the update branch,
+        // which persisted; `false` for a key that was not is the encode
+        // guard, which did not. One `list()` at the top of a rare
+        // operation buys that, and the alternative — widening
+        // `GroupStore.insertOrUpdate` to an outcome enum the way
+        // `MessageStore` already has — is the better shape but reaches
+        // into every caller of a hot path for the sake of the one caller
+        // that is cold.
+        var present = Set(await groupStore.list().map(Self.key))
         for record in groups {
             // A record we cannot reconstruct is skipped rather than
             // fatal, and the reason is asymmetric: the whole archive was
@@ -51,9 +81,12 @@ struct AppBackupSink: BackupSinkProviding {
                 let profiles = try? Self.decoder.decode(
                     [String: MemberProfile].self, from: record.memberProfilesJSON)
             else {
+                unreadable += 1
                 continue
             }
-            await groupStore.insertOrUpdate(
+            let key = Self.key(record.id, ownerID)
+            let existed = present.contains(key)
+            let inserted = await groupStore.insertOrUpdate(
                 ChatGroup(
                     id: record.id,
                     ownerIdentityID: ownerID,
@@ -75,14 +108,28 @@ struct AppBackupSink: BackupSinkProviding {
                     invitationMessage: record.invitationMessage
                 )
             )
-            written += 1
+            if inserted || existed {
+                // Inserted, or updated in place. Either way the group is
+                // on this device now, which is the only thing the
+                // summary claims.
+                present.insert(key)
+                landed += 1
+            } else {
+                // `false` for a key nothing held a moment ago: the store
+                // could not encode the row and persisted nothing. Saying
+                // so is the whole point — a chat the person can see in
+                // the summary and not in their chat list is worse than
+                // one the summary never promised.
+                unreadable += 1
+            }
         }
-        return written
+        return BackupSinkOutcome(landed: landed, unreadable: unreadable)
     }
 
     @discardableResult
-    func restore(messages: [BackupMessageRecord]) async throws -> Int {
-        var written = 0
+    func restore(messages: [BackupMessageRecord]) async throws -> BackupSinkOutcome {
+        var landed = 0
+        var unreadable = 0
         for record in messages {
             guard
                 let id = UUID(uuidString: record.id),
@@ -91,9 +138,15 @@ struct AppBackupSink: BackupSinkProviding {
                 let status = MessageStatus(rawValue: record.statusRaw),
                 let groupType = SEPGroupType(rawValue: record.groupTypeRaw)
             else {
+                unreadable += 1
                 continue
             }
-            await messageStore.insertOrUpdate(
+            // No pre-read here: `MessageStore.insertOrUpdate` already
+            // returns the three-way answer that `GroupStore` has to have
+            // reconstructed above. `.inserted` and `.updated` both mean
+            // the row is on the device; `.failed` means the encrypt or
+            // the save gave way and nothing is.
+            let outcome = await messageStore.insertOrUpdate(
                 ChatMessage(
                     id: id,
                     groupID: record.groupID,
@@ -114,22 +167,35 @@ struct AppBackupSink: BackupSinkProviding {
                     systemEvent: Self.decode(ChatSystemEvent.self, record.systemEventJSON)
                 )
             )
-            written += 1
+            if outcome == .failed {
+                unreadable += 1
+            } else {
+                landed += 1
+            }
         }
-        return written
+        return BackupSinkOutcome(landed: landed, unreadable: unreadable)
     }
 
     @discardableResult
-    func restore(invitations: [BackupInvitationRecord]) async throws -> Int {
-        var written = 0
+    func restore(invitations: [BackupInvitationRecord]) async throws -> BackupSinkOutcome {
+        var landed = 0
+        var unreadable = 0
+        // The same ambiguity as groups, in a different disguise:
+        // `InvitationStore.save` answers `false` for a dedup hit *and*
+        // for a payload it could not encrypt. An invitation the device
+        // already holds is the ordinary case on any second restore, and
+        // it must not read as one this build could not parse.
+        var present = Set(await invitationStore.list().map(\.id))
         for record in invitations {
             guard
                 let ownerID = IdentityID(record.ownerIdentityID),
                 let status = IncomingInvitationStatus(rawValue: record.statusRaw)
             else {
+                unreadable += 1
                 continue
             }
-            await invitationStore.save(
+            let existed = present.contains(record.id)
+            let inserted = await invitationStore.save(
                 IncomingInvitationRecord(
                     id: record.id,
                     ownerIdentityID: ownerID,
@@ -138,17 +204,29 @@ struct AppBackupSink: BackupSinkProviding {
                     status: status
                 )
             )
-            written += 1
+            if inserted || existed {
+                present.insert(record.id)
+                landed += 1
+            } else {
+                unreadable += 1
+            }
         }
-        return written
+        return BackupSinkOutcome(landed: landed, unreadable: unreadable)
     }
 
     @discardableResult
-    func restore(consents: [BackupConsentRecord]) async throws -> Int {
+    func restore(consents: [BackupConsentRecord]) async throws -> BackupSinkOutcome {
         let restored = consents.compactMap {
             try? Self.decoder.decode(PinnedConsentRecord.self, from: $0.raw)
         }
-        guard !restored.isEmpty else { return 0 }
+        // A consent that would not decode is the one genuinely alarming
+        // case, and it is the only one counted as unreadable. Everything
+        // below this line is about consents that decoded perfectly well
+        // and are simply already here.
+        let unreadable = consents.count - restored.count
+        guard !restored.isEmpty else {
+            return BackupSinkOutcome(landed: 0, unreadable: unreadable)
+        }
         // Merged, not replaced: a device may already have consented to
         // something since the snapshot was taken, and a restore that
         // overwrote it would silently revoke a choice the person made
@@ -164,7 +242,15 @@ struct AppBackupSink: BackupSinkProviding {
         let existing = try consentStore.load()
         let known = Set(existing.map { "\($0.componentId)|\($0.manifestHash)" })
         let additions = restored.filter { !known.contains("\($0.componentId)|\($0.manifestHash)") }
-        guard !additions.isEmpty else { return 0 }
+        // Nothing to add is not nothing restored. Every consent in this
+        // archive is on the device, which is what the summary counts;
+        // reporting zero here is what made a normal restore announce
+        // that four consents "could not be read by this version of
+        // Onym", for four consents the person had granted themselves —
+        // one of which had to be the operator the snapshot came from.
+        guard !additions.isEmpty else {
+            return BackupSinkOutcome(landed: restored.count, unreadable: unreadable)
+        }
         try consentStore.save(existing + additions.map {
             // Restored consents land inactive. Re-activating one would
             // silently re-select an operator the person has not seen
@@ -173,7 +259,7 @@ struct AppBackupSink: BackupSinkProviding {
             record.isActive = false
             return record
         })
-        return additions.count
+        return BackupSinkOutcome(landed: restored.count, unreadable: unreadable)
     }
 
     func restore(blob: BackupBlobRecord) async throws {
@@ -189,6 +275,19 @@ struct AppBackupSink: BackupSinkProviding {
             to: blobDirectory.appending(path: blob.sha256),
             options: [.atomic, .completeFileProtection]
         )
+    }
+
+    /// A group's row identity: `(id, owner)`, not `id`. Two local
+    /// identities in the same on-chain group keep separate rows, and
+    /// keying on the id alone would read the second one's arrival as an
+    /// update to the first — counted as landed while the store was
+    /// actually inserting.
+    private static func key(_ group: ChatGroup) -> String {
+        key(group.id, group.ownerIdentityID)
+    }
+
+    private static func key(_ id: String, _ owner: IdentityID) -> String {
+        "\(id)|\(owner.rawValue.uuidString)"
     }
 
     private static func decode<T: Decodable>(_ type: T.Type, _ json: Data?) -> T? {

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1500,6 +1500,8 @@ struct OnymIOSApp: App {
                     identities: identities,
                     groupStore: groupStore,
                     messageStore: messageStore,
+                    groupRepository: groupRepository,
+                    messageRepository: messageRepository,
                     invitationStore: invitationStore,
                     consentStore: pinnedConsentStore,
                     blobClient: blossomClient,

--- a/Tests/OnymIOSTests/BackupCompositionTests.swift
+++ b/Tests/OnymIOSTests/BackupCompositionTests.swift
@@ -229,16 +229,16 @@ private actor StubSink: BackupSinkProviding {
     var messages: [BackupMessageRecord] = []
     var blobs: [BackupBlobRecord] = []
 
-    func restore(groups: [BackupGroupRecord]) async throws -> Int {
+    func restore(groups: [BackupGroupRecord]) async throws -> BackupSinkOutcome {
         self.groups = groups
-        return groups.count
+        return BackupSinkOutcome(landed: groups.count, unreadable: 0)
     }
-    func restore(messages: [BackupMessageRecord]) async throws -> Int {
+    func restore(messages: [BackupMessageRecord]) async throws -> BackupSinkOutcome {
         self.messages = messages
-        return messages.count
+        return BackupSinkOutcome(landed: messages.count, unreadable: 0)
     }
-    func restore(invitations: [BackupInvitationRecord]) async throws -> Int { 0 }
-    func restore(consents: [BackupConsentRecord]) async throws -> Int { 0 }
+    func restore(invitations: [BackupInvitationRecord]) async throws -> BackupSinkOutcome { .none }
+    func restore(consents: [BackupConsentRecord]) async throws -> BackupSinkOutcome { .none }
     func restore(blob: BackupBlobRecord) async throws { blobs.append(blob) }
 }
 
@@ -246,9 +246,13 @@ private actor StubSink: BackupSinkProviding {
 /// Writes only the first group it is handed, standing in for a sink that
 /// meets a row from a schema it does not understand.
 private actor RefusingSink: BackupSinkProviding {
-    func restore(groups: [BackupGroupRecord]) async throws -> Int { min(groups.count, 1) }
-    func restore(messages: [BackupMessageRecord]) async throws -> Int { messages.count }
-    func restore(invitations: [BackupInvitationRecord]) async throws -> Int { 0 }
-    func restore(consents: [BackupConsentRecord]) async throws -> Int { 0 }
+    func restore(groups: [BackupGroupRecord]) async throws -> BackupSinkOutcome {
+        BackupSinkOutcome(landed: min(groups.count, 1), unreadable: groups.count - min(groups.count, 1))
+    }
+    func restore(messages: [BackupMessageRecord]) async throws -> BackupSinkOutcome {
+        BackupSinkOutcome(landed: messages.count, unreadable: 0)
+    }
+    func restore(invitations: [BackupInvitationRecord]) async throws -> BackupSinkOutcome { .none }
+    func restore(consents: [BackupConsentRecord]) async throws -> BackupSinkOutcome { .none }
     func restore(blob: BackupBlobRecord) async throws {}
 }

--- a/Tests/OnymIOSTests/BackupRestoreTests.swift
+++ b/Tests/OnymIOSTests/BackupRestoreTests.swift
@@ -1,7 +1,13 @@
 import Foundation
+import OnymChatsCore
+import OnymFoundation
+import OnymGroup
+import OnymIdentity
+import OnymPersistence
 import XCTest
 @testable import OnymBackup
 @testable import OnymBackupUI
+@testable import OnymIOS
 
 /// History restore.
 ///
@@ -48,7 +54,8 @@ final class BackupRestoreTests: XCTestCase {
             ],
             restorer: BackupRestorer(sink: sink),
             keyMaterial: material,
-            workingDirectory: dir)
+            workingDirectory: dir,
+            didRestore: {})
 
         await flow.load()
         guard case .ready(let snapshots) = await flow.state, let first = snapshots.first else {
@@ -97,7 +104,8 @@ final class BackupRestoreTests: XCTestCase {
             ],
             restorer: BackupRestorer(sink: sink),
             keyMaterial: material,
-            workingDirectory: dir)
+            workingDirectory: dir,
+            didRestore: {})
 
         await flow.load()
         guard case .ready(let snapshots) = await flow.state, let first = snapshots.first else {
@@ -131,7 +139,8 @@ final class BackupRestoreTests: XCTestCase {
             ],
             restorer: BackupRestorer(sink: RecordingSink()),
             keyMaterial: material,
-            workingDirectory: dir)
+            workingDirectory: dir,
+            didRestore: {})
 
         await flow.load()
         guard case .ready(let snapshots) = await flow.state else {
@@ -206,7 +215,8 @@ final class BackupRestoreTests: XCTestCase {
             // reviewer identified in the real sink.
             restorer: BackupRestorer(sink: FailsMidWriteSink()),
             keyMaterial: material,
-            workingDirectory: dir)
+            workingDirectory: dir,
+            didRestore: {})
 
         await flow.load()
         guard case .ready(let snapshots) = await flow.state, let first = snapshots.first else {
@@ -253,6 +263,261 @@ final class BackupRestoreTests: XCTestCase {
                     groups: 2, messages: 5, invitations: 0, consents: 0, blobs: 0,
                     unresolvedBlobs: [])),
             "2 chats, 5 messages")
+    }
+
+    // MARK: - What the person sees when the summary appears
+
+    /// The bug QA found, from the outside: a restore reported "1 chats"
+    /// over a chat list that stayed empty, and the chat surfaced only
+    /// once the person happened to create another one — because
+    /// creating one is a `GroupRepository` mutation and a restore is
+    /// not.
+    ///
+    /// So this subscribes *before* the restore, which is what primes the
+    /// cache with the empty roster, and then asks for the next snapshot
+    /// with nothing else touching the repository in between.
+    func testARestoredGroupReachesSubscribersWithNoOtherMutation() async throws {
+        let dir = try directory()
+        let owner = IdentityID()
+        let groupStore = SwiftDataGroupStore.inMemory()
+        let messageStore = SwiftDataMessageStore.inMemory()
+        let groups = GroupRepository(store: groupStore, currentIdentityID: owner)
+        let messages = MessageRepository(store: messageStore)
+
+        let stream = groups.snapshots
+        var roster = stream.makeAsyncIterator()
+        let before = await roster.next()
+        XCTAssertEqual(before?.count, 0, "the roster was not primed empty")
+
+        try await Self.runRestore(
+            in: dir, owner: owner, groupStore: groupStore, messageStore: messageStore,
+            didRestore: {
+                await groups.reload()
+                await messages.reload()
+            })
+
+        let after = await roster.next()
+        XCTAssertEqual(
+            after?.first?.name, "Weekend plans",
+            "the restored chat never reached the list the person was looking at")
+    }
+
+    /// The half of it that survived the first sighting: the chat came
+    /// back and the thread stayed empty. `MessageRepository` caches per
+    /// thread, so a thread whose cache was filled *before* the restore
+    /// keeps serving what it held then — an empty list, forever, since
+    /// nothing else in the app writes those rows.
+    func testRestoredMessagesReachAThreadCachedEmptyBeforeTheRestore() async throws {
+        let dir = try directory()
+        let owner = IdentityID()
+        let groupStore = SwiftDataGroupStore.inMemory()
+        let messageStore = SwiftDataMessageStore.inMemory()
+        let groups = GroupRepository(store: groupStore, currentIdentityID: owner)
+        let messages = MessageRepository(store: messageStore)
+
+        let stream = messages.snapshots(groupID: Self.restoredGroupID, owner: owner)
+        var thread = stream.makeAsyncIterator()
+        let before = await thread.next()
+        XCTAssertEqual(before?.count, 0, "the thread was not primed empty")
+
+        try await Self.runRestore(
+            in: dir, owner: owner, groupStore: groupStore, messageStore: messageStore,
+            didRestore: {
+                await groups.reload()
+                await messages.reload()
+            })
+
+        let after = await thread.next()
+        XCTAssertEqual(
+            after?.first?.body, "see you at six",
+            "the restored messages never reached the open thread")
+    }
+
+    /// A store that refuses the write is not a row restored. The sink
+    /// used to `await store.insertOrUpdate(…)` and then add one
+    /// regardless, so "1 chats, 3 messages" read the same whether three
+    /// messages had landed or none had — which is most of why this took
+    /// a QA pass to see at all.
+    func testAWriteTheStoreRefusedIsNotCounted() async throws {
+        let sink = AppBackupSink(
+            groupStore: RefusingGroupStore(),
+            messageStore: RefusingMessageStore(),
+            invitationStore: SwiftDataInvitationStore.inMemory(),
+            consentStore: MemoryConsentStore(),
+            blobDirectory: try directory())
+
+        let groups = try await sink.restore(groups: [Self.groupRecord(owner: IdentityID())])
+        XCTAssertEqual(groups, BackupSinkOutcome(landed: 0, unreadable: 1))
+
+        let messages = try await sink.restore(messages: [Self.messageRecord(owner: IdentityID())])
+        XCTAssertEqual(messages, BackupSinkOutcome(landed: 0, unreadable: 1))
+    }
+
+    /// Already here is not unreadable.
+    ///
+    /// Every restore carries at least one consent the device already
+    /// holds — you cannot reach an operator's snapshot without having
+    /// consented to that operator — and the summary was rendering the
+    /// shortfall as "could not be read by this version of Onym". Someone
+    /// was told four consents were unreadable for four consents that
+    /// were simply already theirs.
+    func testAConsentAlreadyOnTheDeviceIsNotReportedAsUnreadable() async throws {
+        let (record, raw) = try Self.consent(componentId: "onym:component:op")
+        let store = MemoryConsentStore([record])
+        let sink = AppBackupSink(
+            groupStore: SwiftDataGroupStore.inMemory(),
+            messageStore: SwiftDataMessageStore.inMemory(),
+            invitationStore: SwiftDataInvitationStore.inMemory(),
+            consentStore: store,
+            blobDirectory: try directory())
+
+        let outcome = try await sink.restore(
+            consents: [BackupConsentRecord(componentId: "onym:component:op", raw: raw)])
+        XCTAssertEqual(
+            outcome.unreadable, 0,
+            "a consent the device already held was reported as unparseable")
+        XCTAssertEqual(outcome.landed, 1)
+        XCTAssertEqual(
+            try store.load().count, 1, "an already-held consent was written a second time")
+    }
+
+    /// The alarming sentence still has to be reachable, or the fix above
+    /// would just have silenced it. Bytes that are not a consent record
+    /// are the one case that earns it.
+    func testAConsentThatWillNotDecodeIsReportedAsUnreadable() async throws {
+        let sink = AppBackupSink(
+            groupStore: SwiftDataGroupStore.inMemory(),
+            messageStore: SwiftDataMessageStore.inMemory(),
+            invitationStore: SwiftDataInvitationStore.inMemory(),
+            consentStore: MemoryConsentStore(),
+            blobDirectory: try directory())
+
+        let outcome = try await sink.restore(
+            consents: [
+                BackupConsentRecord(
+                    componentId: "onym:component:op",
+                    raw: Data(#"{"from":"a later schema"}"#.utf8))
+            ])
+        XCTAssertEqual(outcome, BackupSinkOutcome(landed: 0, unreadable: 1))
+    }
+
+    /// Restoring the same snapshot twice converges rather than
+    /// duplicating — and the second run must report the same thing the
+    /// first did. Counting only *new* rows would have the second restore
+    /// announce that everything in the archive was unreadable.
+    func testASecondRestoreOfTheSameRowsStillCountsThemAsLanded() async throws {
+        let owner = IdentityID()
+        let sink = AppBackupSink(
+            groupStore: SwiftDataGroupStore.inMemory(),
+            messageStore: SwiftDataMessageStore.inMemory(),
+            invitationStore: SwiftDataInvitationStore.inMemory(),
+            consentStore: MemoryConsentStore(),
+            blobDirectory: try directory())
+        let record = Self.groupRecord(owner: owner)
+
+        let first = try await sink.restore(groups: [record])
+        let second = try await sink.restore(groups: [record])
+        XCTAssertEqual(first, BackupSinkOutcome(landed: 1, unreadable: 0))
+        XCTAssertEqual(
+            second, BackupSinkOutcome(landed: 1, unreadable: 0),
+            "restoring a chat that was already here read as a chat that could not be read")
+    }
+
+    // MARK: - Fixtures for the above
+
+    fileprivate static let restoredGroupID = String(repeating: "c", count: 64)
+
+    /// Seal a snapshot holding one group and one message for `owner`,
+    /// serve it from a stand-in operator, and restore it through the
+    /// real `AppBackupSink` and the real flow — so the ordering under
+    /// test is the shipped one: refresh first, summary second.
+    private static func runRestore(
+        in dir: URL,
+        owner: IdentityID,
+        groupStore: any GroupStore,
+        messageStore: any MessageStore,
+        didRestore: @escaping @Sendable () async -> Void
+    ) async throws {
+        let material = BackupKeys.material(
+            seed: Data(repeating: 0x5E, count: 64), componentId: "onym:component:op")
+        let composer = BackupComposer(
+            source: OwnedSource(owner: owner), mediaPolicy: .descriptorsOnly,
+            workingDirectory: dir)
+        let snapshot = try await composer.compose(
+            keyMaterial: material,
+            acceptedTermsId: "sha256:" + String(repeating: "a", count: 64))
+
+        let flow = await BackupRestoreFlow(
+            sources: [
+                BackupRestoreSource(
+                    componentId: "onym:component:test-operator",
+                    displayName: "Test Operator",
+                    repository: BackupRepository(
+                        port: HoldingPort(snapshot: snapshot),
+                        composer: composer,
+                        stateStore: EmptyStateStore(),
+                        keyMaterial: material))
+            ],
+            restorer: BackupRestorer(
+                sink: AppBackupSink(
+                    groupStore: groupStore,
+                    messageStore: messageStore,
+                    invitationStore: SwiftDataInvitationStore.inMemory(),
+                    consentStore: MemoryConsentStore(),
+                    blobDirectory: dir.appending(path: "blobs"))),
+            keyMaterial: material,
+            workingDirectory: dir,
+            didRestore: didRestore)
+
+        await flow.load()
+        guard case .ready(let rows) = await flow.state, let row = rows.first else {
+            throw XCTSkip("the operator's snapshot was not listed")
+        }
+        await flow.restore(row)
+        guard case .restored = await flow.state else {
+            throw XCTSkip("restore did not complete: \(await flow.state)")
+        }
+    }
+
+    fileprivate static func groupRecord(owner: IdentityID) -> BackupGroupRecord {
+        BackupGroupRecord(
+            id: restoredGroupID, ownerIdentityID: owner.rawValue.uuidString,
+            name: "Weekend plans", groupSecret: Data(repeating: 0xEE, count: 32),
+            createdAt: Date(), membersJSON: Data("[]".utf8),
+            memberProfilesJSON: Data("{}".utf8), epoch: 0,
+            salt: Data(repeating: 1, count: 32), commitment: nil, tierRaw: 0,
+            groupTypeRaw: "tyranny", adminPubkeyHex: nil, adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: false, avatarJPEG: nil, lastReadAt: nil,
+            invitationMessage: nil)
+    }
+
+    fileprivate static func messageRecord(owner: IdentityID) -> BackupMessageRecord {
+        BackupMessageRecord(
+            id: UUID().uuidString, groupID: restoredGroupID,
+            ownerIdentityID: owner.rawValue.uuidString,
+            senderBlsPubkeyHex: "ab", body: "see you at six", sentAt: Date(),
+            directionRaw: "outgoing", statusRaw: "sent", groupTypeRaw: "tyranny",
+            replyToMessageID: nil, failureReasonRaw: nil, moderationAuthenticityProof: nil,
+            imageAttachmentJSON: nil, videoAttachmentJSON: nil, albumAttachmentsJSON: nil,
+            voiceAttachmentJSON: nil, systemEventJSON: nil)
+    }
+
+    /// One pinned consent, and the exact bytes an archive would carry
+    /// for it. Built by decoding the bytes rather than by minting a
+    /// signed manifest: what is under test is the *counting*, and the
+    /// record only has to be one the sink's decoder accepts.
+    private static func consent(componentId: String) throws -> (PinnedConsentRecord, Data) {
+        let raw = try JSONSerialization.data(withJSONObject: [
+            "componentId": componentId,
+            "seatType": "storage.backup",
+            "manifestHash": "sha256:" + String(repeating: "1", count: 64),
+            "manifestBytes": Data("{}".utf8).base64EncodedString(),
+            "acceptedAt": "2026-01-01T00:00:00Z",
+            "isActive": true,
+        ])
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try decoder.decode(PinnedConsentRecord.self, from: raw), raw)
     }
 }
 
@@ -339,23 +604,80 @@ private actor RecordingSink: BackupSinkProviding {
             && consents.isEmpty && blobs.isEmpty
     }
 
-    func restore(groups: [BackupGroupRecord]) async throws -> Int {
+    func restore(groups: [BackupGroupRecord]) async throws -> BackupSinkOutcome {
         self.groups = groups
-        return groups.count
+        return BackupSinkOutcome(landed: groups.count, unreadable: 0)
     }
-    func restore(messages: [BackupMessageRecord]) async throws -> Int {
+    func restore(messages: [BackupMessageRecord]) async throws -> BackupSinkOutcome {
         self.messages = messages
-        return messages.count
+        return BackupSinkOutcome(landed: messages.count, unreadable: 0)
     }
-    func restore(invitations: [BackupInvitationRecord]) async throws -> Int {
+    func restore(invitations: [BackupInvitationRecord]) async throws -> BackupSinkOutcome {
         self.invitations = invitations
-        return invitations.count
+        return BackupSinkOutcome(landed: invitations.count, unreadable: 0)
     }
-    func restore(consents: [BackupConsentRecord]) async throws -> Int {
+    func restore(consents: [BackupConsentRecord]) async throws -> BackupSinkOutcome {
         self.consents = consents
-        return consents.count
+        return BackupSinkOutcome(landed: consents.count, unreadable: 0)
     }
     func restore(blob: BackupBlobRecord) async throws { blobs.append(blob) }
+}
+
+/// One group and one message, both owned by a caller-chosen identity —
+/// `SeededSource` mints a fresh owner each call, which is fine when
+/// nothing downstream has to *find* the rows and useless when a
+/// repository filtered by identity does.
+private struct OwnedSource: BackupSourceProviding {
+    let owner: IdentityID
+
+    func identityCount() async -> Int { 1 }
+    func groups() async throws -> [BackupGroupRecord] {
+        [BackupRestoreTests.groupRecord(owner: owner)]
+    }
+    func messages(groupID: String, ownerIdentityID: String) async throws -> [BackupMessageRecord] {
+        [BackupRestoreTests.messageRecord(owner: owner)]
+    }
+    func invitations() async throws -> [BackupInvitationRecord] { [] }
+    func consents() async throws -> [BackupConsentRecord] { [] }
+    func blobCiphertext(sha256: String) async throws -> BackupBlobAvailability { .gone }
+}
+
+/// A store that persists nothing and says so, the way the real one does
+/// when `encode` gives way.
+private actor RefusingGroupStore: GroupStore {
+    func list() async -> [ChatGroup] { [] }
+    func insertOrUpdate(_ group: ChatGroup) -> Bool { false }
+    func markPublished(id: String, ownerIDString: String, commitment: Data?) {}
+    func markRead(id: String, ownerIDString: String, at date: Date) {}
+    func delete(id: String, ownerIDString: String) {}
+    func deleteOwner(_ ownerIDString: String) {}
+}
+
+private actor RefusingMessageStore: MessageStore {
+    func list(groupID: String, ownerIDString: String) -> [ChatMessage] { [] }
+    func latestMessage(groupID: String, ownerIDString: String) -> ChatMessage? { nil }
+    func unreadCount(groupID: String, ownerIDString: String, since: Date) -> Int { 0 }
+    func search(ownerIDString: String, query: String, limit: Int) -> [ChatMessage] { [] }
+    func insertOrUpdate(_ message: ChatMessage) -> MessageInsertOutcome { .failed }
+    func updateStatus(
+        id: UUID, ownerIDString: String, status: MessageStatus,
+        failureReason: SendFailureReason?
+    ) {}
+    func needsDeliveredAck(id: UUID, ownerIDString: String) -> Bool { false }
+    func markDeliveredAckSent(id: UUID, ownerIDString: String) {}
+    func delete(id: UUID, ownerIDString: String) {}
+    func deleteGroup(groupID: String, ownerIDString: String) {}
+    func deleteOwner(_ ownerIDString: String) {}
+    func deleteAll() {}
+}
+
+private final class MemoryConsentStore: PinnedConsentStore, @unchecked Sendable {
+    private var records: [PinnedConsentRecord]
+
+    init(_ records: [PinnedConsentRecord] = []) { self.records = records }
+
+    func load() throws -> [PinnedConsentRecord] { records }
+    func save(_ records: [PinnedConsentRecord]) throws { self.records = records }
 }
 
 private struct EmptyStateStore: BackupStateStoring {
@@ -367,11 +689,15 @@ private struct EmptyStateStore: BackupStateStoring {
 /// Writes groups, then fails — the shape of a consent or blob write
 /// throwing after earlier rows have already landed.
 private actor FailsMidWriteSink: BackupSinkProviding {
-    func restore(groups: [BackupGroupRecord]) async throws -> Int { groups.count }
-    func restore(messages: [BackupMessageRecord]) async throws -> Int { messages.count }
-    func restore(invitations: [BackupInvitationRecord]) async throws -> Int {
+    func restore(groups: [BackupGroupRecord]) async throws -> BackupSinkOutcome {
+        BackupSinkOutcome(landed: groups.count, unreadable: 0)
+    }
+    func restore(messages: [BackupMessageRecord]) async throws -> BackupSinkOutcome {
+        BackupSinkOutcome(landed: messages.count, unreadable: 0)
+    }
+    func restore(invitations: [BackupInvitationRecord]) async throws -> BackupSinkOutcome {
         throw BackupError.localFailure(reason: .archiveUnreadable)
     }
-    func restore(consents: [BackupConsentRecord]) async throws -> Int { 0 }
+    func restore(consents: [BackupConsentRecord]) async throws -> BackupSinkOutcome { .none }
     func restore(blob: BackupBlobRecord) async throws {}
 }


### PR DESCRIPTION
QA restored a backup, read "1 chats, 3 messages", and watched the chat
list stay empty. The chat appeared later — but only once they created a
new one — and the thread it opened onto was still empty. The rows were
on disk and correct; #292 fixed that. What was broken is that nothing
which renders them knew.

## What was wrong

`AppBackupSink` writes through `GroupStore` and `MessageStore`. That is
deliberate: it is what re-encrypts every restored row under *this*
device's at-rest key rather than importing another device's database
file. The cost is that it bypasses the repositories that own the caches
the UI subscribes to.

- `GroupRepository` serves `filteredCache()` to every `snapshots`
  subscriber and calls `refreshFromStore()` only from its own mutators.
  A restore is not one of them. Creating a chat is — which is exactly
  why the restored chat surfaced then, and not before.
- `MessageRepository` caches per `(group, owner)` thread and yields
  `cached[key] ?? []` on subscribe. A thread whose cache was populated
  before the restore keeps serving what it held then, and since nothing
  else in the app writes those rows, it stays empty for good.

Two more things were wrong in the same family, and they are why this
took a QA pass to see at all.

**The counts were of calls made, not rows stored.** Both sinks did
`await store.insertOrUpdate(…)` and then `written += 1`, discarding a
`@discardableResult Bool` that meant precisely the thing being counted.
`SwiftDataGroupStore.insertOrUpdate` returns `false` having persisted
nothing when `try? Self.encode(group)` gives way. So "1 chats, 3
messages" read identically whether the rows had landed or not — the
direct contradiction of `BackupRestorer`'s own comment about counts
coming from the sink so the summary cannot "claim to have restored
things that are not there".

**"Already here" and "could not be read" were the same number.**
`restore(consents:)` returned only *newly added* records, `BackupRestorer`
computed `skipped = held - written`, and `BackupRestoreView` renders any
shortfall as "could not be read by this version of Onym". Every restore
carries consents the device already holds — you cannot reach an
operator's snapshot without having consented to that operator — so a
perfectly ordinary restore told someone four of their own consents were
unreadable.

## The fix

### Making a restore visible

`BackupRestoreFlow` gains a `didRestore` hook, supplied by
`BackupSeatComposer`, that reloads `GroupRepository` and
`MessageRepository`.

**Not in the sink, and not in the restorer.** Teaching `AppBackupSink`
about repositories turns a thin store adapter into something that knows
about view state. Teaching `BackupRestorer` puts UI cache invalidation
inside the crypto and I/O it exists to do. The composition root is the
one place that already holds both the repositories and the restorer.

**Inside the flow rather than at the call site**, because the ordering
*is* the requirement: the refresh runs before `state = .restored`, so the
summary and the list behind it are read in the same glance and agree. The
flow is the one object that knows both that the write finished and that
the summary is about to be presented, so it can enforce that rather than
ask every caller to remember it. The parameter has no default value for
the same reason — a caller with nothing to refresh should have to write
`{}` and mean it.

`MessageRepository.reload()` is new, in the shape of the existing
`GroupRepository.reload()`. It refreshes **every** cached thread rather
than ones a caller believes were touched: threads never opened this
session are not in the cache at all and read the store on first
subscribe, so the cached ones are the entire exposure — and there are
only ever as many as the person has opened since launch. Narrowing it
would mean the restore handing over a list of written keys, which is
wrong the moment one record is skipped, and whose failure mode is a chat
that silently stays empty.

### Counting what landed

`BackupSinkOutcome` replaces the sinks' bare `Int`, carrying `landed`
and `unreadable` separately, and `skipped` in the summary is now what
the sink *said* was unreadable rather than what is left after
subtracting.

Honouring the return value alone would have moved the same conflation
one layer down: `GroupStore.insertOrUpdate` answers `false` for a row
updated in place **and** for one it could not encode, so counting
`false` as a failure would report every second restore — and every
restore onto a phone that has since received some of the same rows — as
unreadable. The sink reads the store's keys once before writing;
`false` for a key that was already present is the update branch, which
persisted, and `false` for one that was not is the encode guard, which
did not. `MessageStore` already returns `.inserted` / `.updated` /
`.failed`, so messages need no pre-read.

Invitations had the identical ambiguity — `InvitationStore.save` returns
`false` for a dedup hit and for a payload it could not encrypt — and are
handled the same way. Consents count every record that decoded, since
all of them are on the device afterwards, and reserve `unreadable` for
bytes that are not a consent record at all.

Widening `GroupStore.insertOrUpdate` into an outcome enum the way
`MessageStore` has one is the better shape and was **not** taken here:
it reaches into every caller of a hot path for the sake of the one
caller that is cold.

## Tests

In `Tests/OnymIOSTests/BackupRestoreTests.swift`, in the file's
established iterator-over-`snapshots` style:

- a restored group reaches a `snapshots` subscriber with no other
  mutation, subscribing *before* the restore so the cache is primed
  empty first;
- restored messages reach a thread cached empty before the restore;
- a sink whose store refuses the write counts nothing as landed;
- a consent already on the device is not reported as unreadable, and one
  that will not decode still is;
- a second restore of the same rows still counts them as landed.

The two visibility tests were checked against a build with the refresh
removed, and fail there — they are not vacuous.

`xcodebuild test -project OnymIOS.xcodeproj -scheme OnymIOS -destination
"platform=iOS Simulator,name=iPhone 17,OS=latest"
-only-testing:OnymIOSTests` — 1446 tests, 0 failures, 3 pre-existing
skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
