### PR TITLE
Let the stores say which of the three things happened

### DIFF
--- a/Packages/OnymGroup/Sources/OnymGroup/GroupRepository.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupRepository.swift
@@ -30,11 +30,24 @@ public actor GroupRepository {
     /// `GroupStore.insertOrUpdate`). Any subsequent insert with the
     /// same id overwrites the row in place — the chain-anchor flow
     /// uses this to flip `isPublishedOnChain` and bump the commitment.
+    ///
+    /// Passes the store's `GroupInsertOutcome` straight through, the
+    /// way `MessageRepository.insert` passes `MessageInsertOutcome`.
+    /// Narrowing it back to `Bool` here would put the ambiguity the
+    /// store just shed one layer up, where the next caller to write
+    /// `if inserted { … }` finds it again — and every caller in this
+    /// repo discards the value anyway, so nothing is paying for the
+    /// wider type.
+    ///
+    /// The refresh is unconditional, including after `.failed`: the
+    /// snapshot is re-read from the store rather than patched, so
+    /// re-yielding what the store actually holds is correct in all
+    /// three cases and costs a list on a path that just did a write.
     @discardableResult
-    public func insert(_ group: ChatGroup) async -> Bool {
-        let inserted = await store.insertOrUpdate(group)
+    public func insert(_ group: ChatGroup) async -> GroupInsertOutcome {
+        let outcome = await store.insertOrUpdate(group)
         await refreshFromStore()
-        return inserted
+        return outcome
     }
 
     /// Mark a group as anchored on chain. The commitment, when

--- a/Packages/OnymGroup/Sources/OnymGroup/GroupStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupStore.swift
@@ -1,5 +1,31 @@
 import Foundation
 
+/// Result of `GroupStore.insertOrUpdate`. Mirrors
+/// `MessageInsertOutcome` case for case, and deliberately is not the
+/// same type: the three stores agree on the *shape* of the answer, not
+/// on what the middle case means. A group `.updated` was overwritten in
+/// place — the row on disk now holds the new field values.
+/// `InvitationSaveOutcome.duplicate` is the opposite, a write the store
+/// declined so the original row survives untouched. A shared enum would
+/// have to pick one of those two words and be wrong about the other
+/// store every time someone read it, which is the class of confusion
+/// this type exists to end. (All three modules do hang off
+/// `OnymFoundation`, so a common type was available and was not the
+/// thing standing in the way.)
+///
+/// What every one of them *does* share is that the last case is
+/// distinct: "nothing was persisted" can never again be spelled the
+/// same way as "persisted, just not as a new row".
+public enum GroupInsertOutcome: Sendable, Equatable {
+    /// New row persisted.
+    case inserted
+    /// A row with the same `(id, owner)` already existed and its
+    /// sensitive + mutable fields were overwritten in place.
+    case updated
+    /// Nothing was persisted — encode gave way.
+    case failed
+}
+
 /// Persistence seam for chat groups. Async surface mirrors
 /// `InvitationStore` (PR #16) so a concrete impl can serialise writes
 /// on its own queue without forcing callers onto a specific actor.
@@ -12,10 +38,18 @@ public protocol GroupStore: Sendable {
     /// Idempotent on `ChatGroup.id`: if the row exists, sensitive +
     /// mutable fields are overwritten in place (so a chain-anchor
     /// retry can flip `isPublishedOnChain` and bump the commitment
-    /// without losing the original `createdAt`). Returns `true` on
-    /// insert, `false` on update.
+    /// without losing the original `createdAt`).
+    ///
+    /// This used to answer `Bool` — `true` on insert, `false` on
+    /// update — and the `false` was doing two jobs, because the encode
+    /// guard returns it too having written nothing. Every caller that
+    /// only ever asks "did that work?" reads `false` and gets no answer.
+    /// The backup sink hit this for real: counting `false` as a failure
+    /// reports every restore onto a device that already holds rows as
+    /// unreadable, and counting it as a success reports a store that
+    /// refused the write as restored.
     @discardableResult
-    func insertOrUpdate(_ group: ChatGroup) async -> Bool
+    func insertOrUpdate(_ group: ChatGroup) async -> GroupInsertOutcome
 
     /// Convenience for the post-anchor flow: flip
     /// `isPublishedOnChain` to true and update the commitment to

--- a/Packages/OnymGroup/Sources/OnymGroup/SwiftDataGroupStore.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/SwiftDataGroupStore.swift
@@ -55,8 +55,11 @@ public actor SwiftDataGroupStore: GroupStore {
     }
 
     @discardableResult
-    public func insertOrUpdate(_ group: ChatGroup) -> Bool {
-        guard let encoded = try? Self.encode(group) else { return false }
+    public func insertOrUpdate(_ group: ChatGroup) -> GroupInsertOutcome {
+        // The one ending that persists nothing. It is spelled `.failed`
+        // rather than sharing a word with the update branch below
+        // precisely so a caller counting rows cannot mistake the two.
+        guard let encoded = try? Self.encode(group) else { return .failed }
 
         let id = group.id
         let owner = encoded.ownerIdentityIDString
@@ -82,12 +85,12 @@ public actor SwiftDataGroupStore: GroupStore {
             existing.encryptedAvatar = encoded.encryptedAvatar
             existing.encryptedInvitationMessage = encoded.encryptedInvitationMessage
             try? context.save()
-            return false
+            return .updated
         }
 
         context.insert(encoded)
         try? context.save()
-        return true
+        return .inserted
     }
 
     public func markPublished(id: String, ownerIDString: String, commitment: Data?) {

--- a/Packages/OnymInbox/Sources/OnymInbox/IncomingInvitationsRepository.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/IncomingInvitationsRepository.swift
@@ -29,16 +29,23 @@ public actor IncomingInvitationsRepository {
         self.currentIdentityID = currentIdentityID
     }
 
-    /// Idempotent on `id`. Returns `true` when a new invitation was
-    /// inserted, `false` if `id` was already present (subscribers don't
-    /// see a snapshot in the no-op case).
+    /// Idempotent on `id`. Passes the store's `InvitationSaveOutcome`
+    /// straight through rather than flattening it back to a `Bool`,
+    /// for the same reason the store stopped returning one: `false`
+    /// here meant "already had it" and "could not store it" at once,
+    /// and this is the layer interactors call.
+    ///
+    /// Subscribers see a snapshot only on `.saved`. `.duplicate` left
+    /// the row exactly as it was and `.failed` wrote nothing at all —
+    /// in neither case did the store's contents change, so re-yielding
+    /// the same list to every subscriber would be churn, not news.
     @discardableResult
     public func recordIncoming(
         id: String,
         ownerIdentityID: IdentityID,
         payload: Data,
         receivedAt: Date
-    ) async -> Bool {
+    ) async -> InvitationSaveOutcome {
         let record = IncomingInvitation(
             id: id,
             ownerIdentityID: ownerIdentityID,
@@ -46,10 +53,10 @@ public actor IncomingInvitationsRepository {
             receivedAt: receivedAt,
             status: .pending
         )
-        let inserted = await store.save(record)
-        guard inserted else { return false }
+        let outcome = await store.save(record)
+        guard outcome == .saved else { return outcome }
         await refreshFromStore()
-        return true
+        return outcome
     }
 
     public func updateStatus(id: String, status: IncomingInvitationStatus) async {

--- a/Packages/OnymPersistence/Sources/OnymPersistence/InvitationStore.swift
+++ b/Packages/OnymPersistence/Sources/OnymPersistence/InvitationStore.swift
@@ -43,6 +43,30 @@ public struct IncomingInvitationRecord: Sendable, Equatable {
     }
 }
 
+/// Result of `InvitationStore.save`. Same three-way shape as
+/// `MessageInsertOutcome` and `GroupInsertOutcome`, and a separate type
+/// from both for the reason spelled out on `GroupInsertOutcome`: the
+/// middle case here is not theirs. Saving over an existing invitation
+/// does not overwrite it — the store declines the write so the original
+/// `receivedAt` and `status` survive, which is the whole point of the
+/// dedup. Calling that `.updated` would say the opposite of what
+/// happened, so it is `.duplicate`.
+///
+/// `.duplicate` and `.failed` used to be the same `false`, which read
+/// as "not new" to anyone asking and as "not stored" to anyone
+/// counting. They are as far apart as two answers get: one means the
+/// row is on the device and has been since the first time, the other
+/// means it is not on the device at all.
+public enum InvitationSaveOutcome: Sendable, Equatable {
+    /// New row persisted.
+    case saved
+    /// A row with this `id` already existed; nothing was written and
+    /// the original row is untouched.
+    case duplicate
+    /// Nothing was persisted — the payload could not be encrypted.
+    case failed
+}
+
 /// Persistence seam for incoming invitations. Async surface so a
 /// concrete impl can serialise writes on its own queue without forcing
 /// callers onto a specific actor.
@@ -50,10 +74,14 @@ public protocol InvitationStore: Sendable {
     func list() async -> [IncomingInvitationRecord]
 
     /// Idempotent on `id`: a second save of the same invitation id is a
-    /// no-op (preserves the original `receivedAt` + `status`). Returns
-    /// `true` when a new row was inserted, `false` on dedup hit.
+    /// no-op (preserves the original `receivedAt` + `status`).
+    ///
+    /// Answered `Bool` until the backup sink needed to tell a dedup hit
+    /// from a payload that would not encrypt, and found both spelled
+    /// `false`. It had to read `list()` first and infer which one it
+    /// had; the store knew all along.
     @discardableResult
-    func save(_ record: IncomingInvitationRecord) async -> Bool
+    func save(_ record: IncomingInvitationRecord) async -> InvitationSaveOutcome
 
     func updateStatus(id: String, status: IncomingInvitationStatus) async
     func delete(id: String) async

--- a/Packages/OnymPersistence/Sources/OnymPersistence/SwiftDataInvitationStore.swift
+++ b/Packages/OnymPersistence/Sources/OnymPersistence/SwiftDataInvitationStore.swift
@@ -86,14 +86,16 @@ public actor SwiftDataInvitationStore: InvitationStore {
     }
 
     @discardableResult
-    public func save(_ record: IncomingInvitationRecord) -> Bool {
+    public func save(_ record: IncomingInvitationRecord) -> InvitationSaveOutcome {
         let id = record.id
         let dup = FetchDescriptor<PersistedInvitation>(
             predicate: #Predicate { $0.id == id }
         )
-        if let count = try? context.fetchCount(dup), count > 0 { return false }
+        // Row already here, left exactly as it was — not a write that
+        // failed, and no longer spelled like one.
+        if let count = try? context.fetchCount(dup), count > 0 { return .duplicate }
 
-        guard let encrypted = try? StorageEncryption.encrypt(record.payload) else { return false }
+        guard let encrypted = try? StorageEncryption.encrypt(record.payload) else { return .failed }
         context.insert(PersistedInvitation(
             id: record.id,
             ownerIdentityIDString: record.ownerIdentityID.rawValue.uuidString,
@@ -102,7 +104,7 @@ public actor SwiftDataInvitationStore: InvitationStore {
             statusRaw: record.status.rawValue
         ))
         try? context.save()
-        return true
+        return .saved
     }
 
     public func updateStatus(id: String, status: IncomingInvitationStatus) {

--- a/Sources/OnymIOS/BackupSinks.swift
+++ b/Sources/OnymIOS/BackupSinks.swift
@@ -27,6 +27,17 @@ import OnymPersistence
 /// made*, and "1 chats, 3 messages" read identically whether three
 /// messages were on the device or none were — which is precisely how a
 /// restore that wrote nothing survived QA looking like a success.
+///
+/// Taking a store at its word requires the word to be unambiguous.
+/// Groups and invitations both used to answer `false` for a row that
+/// was persisted and for one that was not, so this file read `list()`
+/// before writing and inferred which `false` it had from whether the
+/// key was already present. That worked, and it is gone: all three
+/// stores now report their own outcome. The inference is not kept
+/// alongside as a cross-check — two mechanisms answering one question
+/// leaves the next reader unable to tell which one is authoritative,
+/// and the pre-read was always the weaker of the two, reconstructing
+/// from the outside what the store knew from the inside.
 struct AppBackupSink: BackupSinkProviding {
     let groupStore: any GroupStore
     let messageStore: any MessageStore
@@ -46,26 +57,6 @@ struct AppBackupSink: BackupSinkProviding {
     func restore(groups: [BackupGroupRecord]) async throws -> BackupSinkOutcome {
         var landed = 0
         var unreadable = 0
-        // What is already here, before anything is written.
-        //
-        // `GroupStore.insertOrUpdate` answers `true` on insert and
-        // `false` on *both* of the other two endings: a row updated in
-        // place, and an encode that failed having persisted nothing.
-        // Counting `false` as a failure would report every re-restore as
-        // unreadable; counting it as a success would report a store that
-        // refused the write as restored. Neither is true, and the
-        // returned `Bool` cannot tell them apart on its own.
-        //
-        // Knowing which keys existed beforehand does tell them apart:
-        // `false` for a key that was already here is the update branch,
-        // which persisted; `false` for a key that was not is the encode
-        // guard, which did not. One `list()` at the top of a rare
-        // operation buys that, and the alternative — widening
-        // `GroupStore.insertOrUpdate` to an outcome enum the way
-        // `MessageStore` already has — is the better shape but reaches
-        // into every caller of a hot path for the sake of the one caller
-        // that is cold.
-        var present = Set(await groupStore.list().map(Self.key))
         for record in groups {
             // A record we cannot reconstruct is skipped rather than
             // fatal, and the reason is asymmetric: the whole archive was
@@ -84,9 +75,7 @@ struct AppBackupSink: BackupSinkProviding {
                 unreadable += 1
                 continue
             }
-            let key = Self.key(record.id, ownerID)
-            let existed = present.contains(key)
-            let inserted = await groupStore.insertOrUpdate(
+            let outcome = await groupStore.insertOrUpdate(
                 ChatGroup(
                     id: record.id,
                     ownerIdentityID: ownerID,
@@ -108,19 +97,17 @@ struct AppBackupSink: BackupSinkProviding {
                     invitationMessage: record.invitationMessage
                 )
             )
-            if inserted || existed {
-                // Inserted, or updated in place. Either way the group is
-                // on this device now, which is the only thing the
-                // summary claims.
-                present.insert(key)
-                landed += 1
-            } else {
-                // `false` for a key nothing held a moment ago: the store
-                // could not encode the row and persisted nothing. Saying
-                // so is the whole point — a chat the person can see in
-                // the summary and not in their chat list is worse than
-                // one the summary never promised.
+            // `.inserted` or `.updated` — either way the group is on
+            // this device now, which is the only thing the summary
+            // claims. `.failed` is the store saying it could not encode
+            // the row and persisted nothing, and saying so is the whole
+            // point: a chat the person can see in the summary and not in
+            // their chat list is worse than one the summary never
+            // promised.
+            if outcome == .failed {
                 unreadable += 1
+            } else {
+                landed += 1
             }
         }
         return BackupSinkOutcome(landed: landed, unreadable: unreadable)
@@ -141,11 +128,11 @@ struct AppBackupSink: BackupSinkProviding {
                 unreadable += 1
                 continue
             }
-            // No pre-read here: `MessageStore.insertOrUpdate` already
-            // returns the three-way answer that `GroupStore` has to have
-            // reconstructed above. `.inserted` and `.updated` both mean
-            // the row is on the device; `.failed` means the encrypt or
-            // the save gave way and nothing is.
+            // `.inserted` and `.updated` both mean the row is on the
+            // device; `.failed` means the encrypt or the save gave way
+            // and nothing is. `MessageStore` has answered this way since
+            // it was written, which is why the message path never grew
+            // the pre-read the other two have now shed.
             let outcome = await messageStore.insertOrUpdate(
                 ChatMessage(
                     id: id,
@@ -180,12 +167,6 @@ struct AppBackupSink: BackupSinkProviding {
     func restore(invitations: [BackupInvitationRecord]) async throws -> BackupSinkOutcome {
         var landed = 0
         var unreadable = 0
-        // The same ambiguity as groups, in a different disguise:
-        // `InvitationStore.save` answers `false` for a dedup hit *and*
-        // for a payload it could not encrypt. An invitation the device
-        // already holds is the ordinary case on any second restore, and
-        // it must not read as one this build could not parse.
-        var present = Set(await invitationStore.list().map(\.id))
         for record in invitations {
             guard
                 let ownerID = IdentityID(record.ownerIdentityID),
@@ -194,8 +175,7 @@ struct AppBackupSink: BackupSinkProviding {
                 unreadable += 1
                 continue
             }
-            let existed = present.contains(record.id)
-            let inserted = await invitationStore.save(
+            let outcome = await invitationStore.save(
                 IncomingInvitationRecord(
                     id: record.id,
                     ownerIdentityID: ownerID,
@@ -204,11 +184,14 @@ struct AppBackupSink: BackupSinkProviding {
                     status: status
                 )
             )
-            if inserted || existed {
-                present.insert(record.id)
-                landed += 1
-            } else {
+            // `.duplicate` is the ordinary case on any second restore
+            // — an invitation the device already holds — and counting it
+            // as landed is what keeps it from being reported as one this
+            // build could not parse. Only `.failed` wrote nothing.
+            if outcome == .failed {
                 unreadable += 1
+            } else {
+                landed += 1
             }
         }
         return BackupSinkOutcome(landed: landed, unreadable: unreadable)
@@ -275,19 +258,6 @@ struct AppBackupSink: BackupSinkProviding {
             to: blobDirectory.appending(path: blob.sha256),
             options: [.atomic, .completeFileProtection]
         )
-    }
-
-    /// A group's row identity: `(id, owner)`, not `id`. Two local
-    /// identities in the same on-chain group keep separate rows, and
-    /// keying on the id alone would read the second one's arrival as an
-    /// update to the first — counted as landed while the store was
-    /// actually inserting.
-    private static func key(_ group: ChatGroup) -> String {
-        key(group.id, group.ownerIdentityID)
-    }
-
-    private static func key(_ id: String, _ owner: IdentityID) -> String {
-        "\(id)|\(owner.rawValue.uuidString)"
     }
 
     private static func decode<T: Decodable>(_ type: T.Type, _ json: Data?) -> T? {

--- a/Tests/OnymIOSTests/BackupRestoreTests.swift
+++ b/Tests/OnymIOSTests/BackupRestoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OnymChain
 import OnymChatsCore
 import OnymFoundation
 import OnymGroup
@@ -423,6 +424,125 @@ final class BackupRestoreTests: XCTestCase {
             "restoring a chat that was already here read as a chat that could not be read")
     }
 
+    // MARK: - The stores answer for themselves (#293 follow-up)
+
+    /// The point of the whole change, stated once as a contract.
+    ///
+    /// `GroupStore.insertOrUpdate` used to answer `Bool`, and `false`
+    /// covered both a row updated in place and a row it could not encode
+    /// and did not write. A caller counting what landed cannot act on
+    /// that: counting `false` as failure reports every restore onto a
+    /// device that already holds rows as unreadable, and counting it as
+    /// success reports a refused write as restored. Both were shipped
+    /// bugs. Three cases, three answers, and a caller can now tell them
+    /// apart without reading the store first.
+    func testAGroupStoreTellsItsThreeOutcomesApart() async {
+        let store = SwiftDataGroupStore.inMemory()
+        let group = ChatGroup(
+            id: Self.restoredGroupID, ownerIdentityID: IdentityID(),
+            name: "Weekend plans", groupSecret: Data(repeating: 0xEE, count: 32),
+            createdAt: Date(), members: [], memberProfiles: [:], epoch: 0,
+            salt: Data(repeating: 1, count: 32), commitment: nil, tier: .small,
+            groupType: .tyranny, adminPubkeyHex: nil, adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: false, avatarJPEG: nil, lastReadAt: nil,
+            invitationMessage: nil)
+
+        var updated = group
+        updated.epoch = 7
+
+        let first = await store.insertOrUpdate(group)
+        let second = await store.insertOrUpdate(updated)
+        let refused = await RefusingGroupStore().insertOrUpdate(group)
+
+        XCTAssertEqual(first, .inserted)
+        XCTAssertEqual(second, .updated, "an in-place overwrite is not a failed write")
+        XCTAssertEqual(refused, .failed)
+        XCTAssertNotEqual(
+            second, refused,
+            "a row that was persisted and a row that was not must never be the same answer")
+    }
+
+    /// Same contract for invitations, with the middle case meaning the
+    /// opposite thing: a second save is declined so the first row
+    /// survives, which is why it is `.duplicate` and not `.updated`.
+    func testAnInvitationStoreTellsItsThreeOutcomesApart() async {
+        let store = SwiftDataInvitationStore.inMemory()
+        let record = IncomingInvitationRecord(
+            id: "evt-1", ownerIdentityID: IdentityID(), payload: Data("hello".utf8),
+            receivedAt: Date(), status: .pending)
+
+        let first = await store.save(record)
+        let second = await store.save(record)
+        let refused = await RefusingInvitationStore().save(record)
+
+        XCTAssertEqual(first, .saved)
+        XCTAssertEqual(second, .duplicate, "a row already here is not a write that failed")
+        XCTAssertEqual(refused, .failed)
+        XCTAssertNotEqual(
+            second, refused,
+            "a row that is on the device and one that never was must never be the same answer")
+    }
+
+    /// #293 proved this for groups by reading the store before writing.
+    /// It has to keep holding now that the pre-read is gone and the
+    /// store's own word is the only thing the count rests on.
+    func testASecondRestoreOfTheSameInvitationsStillCountsThemAsLanded() async throws {
+        let sink = AppBackupSink(
+            groupStore: SwiftDataGroupStore.inMemory(),
+            messageStore: SwiftDataMessageStore.inMemory(),
+            invitationStore: SwiftDataInvitationStore.inMemory(),
+            consentStore: MemoryConsentStore(),
+            blobDirectory: try directory())
+        let record = Self.invitationRecord(owner: IdentityID())
+
+        let first = try await sink.restore(invitations: [record])
+        let second = try await sink.restore(invitations: [record])
+        XCTAssertEqual(first, BackupSinkOutcome(landed: 1, unreadable: 0))
+        XCTAssertEqual(
+            second, BackupSinkOutcome(landed: 1, unreadable: 0),
+            "an invitation that was already here read as one that could not be read")
+    }
+
+    /// The other half: with `.duplicate` counted as landed, `.failed`
+    /// has to still reach the summary, or the fix would just have
+    /// silenced the honest half of the old `false`.
+    func testAnInvitationTheStoreRefusedIsNotCounted() async throws {
+        let sink = AppBackupSink(
+            groupStore: SwiftDataGroupStore.inMemory(),
+            messageStore: SwiftDataMessageStore.inMemory(),
+            invitationStore: RefusingInvitationStore(),
+            consentStore: MemoryConsentStore(),
+            blobDirectory: try directory())
+
+        let outcome = try await sink.restore(
+            invitations: [Self.invitationRecord(owner: IdentityID())])
+        XCTAssertEqual(outcome, BackupSinkOutcome(landed: 0, unreadable: 1))
+    }
+
+    /// A group updated in place is a group on the device. This is the
+    /// case the naive `if written { landed += 1 }` gets wrong, and it is
+    /// worth pinning at the sink rather than only at the store, because
+    /// the sink is where the number the person reads is computed.
+    func testAGroupUpdatedInPlaceIsCountedAsLandedNotAsUnreadable() async throws {
+        let owner = IdentityID()
+        let groupStore = SwiftDataGroupStore.inMemory()
+        let sink = AppBackupSink(
+            groupStore: groupStore,
+            messageStore: SwiftDataMessageStore.inMemory(),
+            invitationStore: SwiftDataInvitationStore.inMemory(),
+            consentStore: MemoryConsentStore(),
+            blobDirectory: try directory())
+
+        _ = try await sink.restore(groups: [Self.groupRecord(owner: owner)])
+        let again = try await sink.restore(groups: [Self.groupRecord(owner: owner)])
+
+        let rows = await groupStore.list()
+        XCTAssertEqual(again, BackupSinkOutcome(landed: 1, unreadable: 0))
+        XCTAssertEqual(
+            rows.count, 1,
+            "the second restore duplicated the row instead of updating it")
+    }
+
     // MARK: - Fixtures for the above
 
     fileprivate static let restoredGroupID = String(repeating: "c", count: 64)
@@ -489,6 +609,12 @@ final class BackupRestoreTests: XCTestCase {
             groupTypeRaw: "tyranny", adminPubkeyHex: nil, adminEd25519PubkeyHex: nil,
             isPublishedOnChain: false, avatarJPEG: nil, lastReadAt: nil,
             invitationMessage: nil)
+    }
+
+    fileprivate static func invitationRecord(owner: IdentityID) -> BackupInvitationRecord {
+        BackupInvitationRecord(
+            id: "evt-1", ownerIdentityID: owner.rawValue.uuidString,
+            payload: Data("sealed".utf8), receivedAt: Date(), statusRaw: "pending")
     }
 
     fileprivate static func messageRecord(owner: IdentityID) -> BackupMessageRecord {
@@ -646,7 +772,7 @@ private struct OwnedSource: BackupSourceProviding {
 /// when `encode` gives way.
 private actor RefusingGroupStore: GroupStore {
     func list() async -> [ChatGroup] { [] }
-    func insertOrUpdate(_ group: ChatGroup) -> Bool { false }
+    func insertOrUpdate(_ group: ChatGroup) -> GroupInsertOutcome { .failed }
     func markPublished(id: String, ownerIDString: String, commitment: Data?) {}
     func markRead(id: String, ownerIDString: String, at date: Date) {}
     func delete(id: String, ownerIDString: String) {}
@@ -669,6 +795,17 @@ private actor RefusingMessageStore: MessageStore {
     func deleteGroup(groupID: String, ownerIDString: String) {}
     func deleteOwner(_ ownerIDString: String) {}
     func deleteAll() {}
+}
+
+/// A store that cannot encrypt the payload — the one ending where
+/// `save` writes nothing. It used to be indistinguishable from the
+/// dedup hit above it.
+private actor RefusingInvitationStore: InvitationStore {
+    func list() -> [IncomingInvitationRecord] { [] }
+    func save(_ record: IncomingInvitationRecord) -> InvitationSaveOutcome { .failed }
+    func updateStatus(id: String, status: IncomingInvitationStatus) {}
+    func delete(id: String) {}
+    func deleteOwner(_ ownerIDString: String) {}
 }
 
 private final class MemoryConsentStore: PinnedConsentStore, @unchecked Sendable {

--- a/Tests/OnymIOSTests/GroupRepositoryTests.swift
+++ b/Tests/OnymIOSTests/GroupRepositoryTests.swift
@@ -33,8 +33,8 @@ final class GroupRepositoryTests: XCTestCase {
         _ = await iterator.next()  // initial empty snapshot
 
         let group = makeGroup(id: "bb".repeated(32), name: "Friends", owner: ownerA)
-        let inserted = await repo.insert(group)
-        XCTAssertTrue(inserted)
+        let outcome = await repo.insert(group)
+        XCTAssertEqual(outcome, .inserted)
 
         let next = await iterator.next()
         XCTAssertEqual(next?.count, 1)
@@ -197,10 +197,10 @@ private actor InMemoryGroupStore: GroupStore {
     }
 
     @discardableResult
-    func insertOrUpdate(_ group: ChatGroup) -> Bool {
+    func insertOrUpdate(_ group: ChatGroup) -> GroupInsertOutcome {
         let isNew = rows[group.id] == nil
         rows[group.id] = group
-        return isNew
+        return isNew ? .inserted : .updated
     }
 
     func markPublished(id: String, ownerIDString: String, commitment: Data?) {

--- a/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
+++ b/Tests/OnymIOSTests/InboxFanoutInteractorTests.swift
@@ -271,10 +271,10 @@ private actor FanoutInvitationStore: InvitationStore {
     }
 
     @discardableResult
-    func save(_ record: IncomingInvitationRecord) -> Bool {
-        guard rows[record.id] == nil else { return false }
+    func save(_ record: IncomingInvitationRecord) -> InvitationSaveOutcome {
+        guard rows[record.id] == nil else { return .duplicate }
         rows[record.id] = record
-        return true
+        return .saved
     }
 
     func updateStatus(id: String, status: IncomingInvitationStatus) {

--- a/Tests/OnymIOSTests/IncomingInvitationsRepositoryTests.swift
+++ b/Tests/OnymIOSTests/IncomingInvitationsRepositoryTests.swift
@@ -39,13 +39,13 @@ final class IncomingInvitationsRepositoryTests: XCTestCase {
     // MARK: - recordIncoming
 
     func test_recordIncoming_savesViaStore() async {
-        let inserted = await repository.recordIncoming(
+        let outcome = await repository.recordIncoming(
             id: "evt-1",
             ownerIdentityID: ownerA,
             payload: Data("hello".utf8),
             receivedAt: Date()
         )
-        XCTAssertTrue(inserted)
+        XCTAssertEqual(outcome, .saved)
         let stored = await store.list()
         XCTAssertEqual(stored.count, 1)
         XCTAssertEqual(stored[0].id, "evt-1")
@@ -58,8 +58,8 @@ final class IncomingInvitationsRepositoryTests: XCTestCase {
         let now = Date()
         let first = await repository.recordIncoming(id: "evt-1", ownerIdentityID: ownerA, payload: Data(), receivedAt: now)
         let second = await repository.recordIncoming(id: "evt-1", ownerIdentityID: ownerA, payload: Data(), receivedAt: now)
-        XCTAssertTrue(first)
-        XCTAssertFalse(second)
+        XCTAssertEqual(first, .saved)
+        XCTAssertEqual(second, .duplicate)
         let stored = await store.list()
         XCTAssertEqual(stored.count, 1)
     }
@@ -117,8 +117,8 @@ final class IncomingInvitationsRepositoryTests: XCTestCase {
         // Second recordIncoming with same id is a dedup no-op — no
         // snapshot push, otherwise subscribers would see redundant
         // identical lists.
-        let inserted = await repository.recordIncoming(id: "evt-1", ownerIdentityID: ownerA, payload: Data(), receivedAt: Date())
-        XCTAssertFalse(inserted)
+        let outcome = await repository.recordIncoming(id: "evt-1", ownerIdentityID: ownerA, payload: Data(), receivedAt: Date())
+        XCTAssertEqual(outcome, .duplicate)
 
         // Trigger a real mutation to advance the iterator past the
         // would-be dedup tick — if the dedup had pushed, this next

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -1883,10 +1883,10 @@ private actor DispatcherInvitationStore: InvitationStore {
     }
 
     @discardableResult
-    func save(_ record: IncomingInvitationRecord) -> Bool {
-        guard rows[record.id] == nil else { return false }
+    func save(_ record: IncomingInvitationRecord) -> InvitationSaveOutcome {
+        guard rows[record.id] == nil else { return .duplicate }
         rows[record.id] = record
-        return true
+        return .saved
     }
 
     func updateStatus(id: String, status: IncomingInvitationStatus) {

--- a/Tests/OnymIOSTests/JoinFlowTests.swift
+++ b/Tests/OnymIOSTests/JoinFlowTests.swift
@@ -246,10 +246,10 @@ private actor JoinTestableInMemoryGroupStore: GroupStore {
     }
 
     @discardableResult
-    func insertOrUpdate(_ group: ChatGroup) -> Bool {
+    func insertOrUpdate(_ group: ChatGroup) -> GroupInsertOutcome {
         let isNew = rows[group.id] == nil
         rows[group.id] = group
-        return isNew
+        return isNew ? .inserted : .updated
     }
 
     func markPublished(id: String, ownerIDString: String, commitment: Data?) {

--- a/Tests/OnymIOSTests/ShareInviteFlowTests.swift
+++ b/Tests/OnymIOSTests/ShareInviteFlowTests.swift
@@ -286,10 +286,10 @@ private actor TestableInMemoryGroupStore: GroupStore {
     }
 
     @discardableResult
-    func insertOrUpdate(_ group: ChatGroup) -> Bool {
+    func insertOrUpdate(_ group: ChatGroup) -> GroupInsertOutcome {
         let isNew = rows[group.id] == nil
         rows[group.id] = group
-        return isNew
+        return isNew ? .inserted : .updated
     }
 
     func markPublished(id: String, ownerIDString: String, commitment: Data?) {

--- a/Tests/OnymIOSTests/Support/InMemoryInvitationStore.swift
+++ b/Tests/OnymIOSTests/Support/InMemoryInvitationStore.swift
@@ -17,10 +17,10 @@ actor InMemoryInvitationStore: InvitationStore {
     }
 
     @discardableResult
-    func save(_ record: IncomingInvitationRecord) -> Bool {
-        if rows[record.id] != nil { return false }
+    func save(_ record: IncomingInvitationRecord) -> InvitationSaveOutcome {
+        if rows[record.id] != nil { return .duplicate }
         rows[record.id] = record
-        return true
+        return .saved
     }
 
     func updateStatus(id: String, status: IncomingInvitationStatus) {

--- a/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataGroupStoreTests.swift
@@ -33,8 +33,8 @@ final class SwiftDataGroupStoreTests: XCTestCase {
             name: "Family",
             adminPubkeyHex: "ee".repeated(48)
         )
-        let inserted = await store.insertOrUpdate(group)
-        XCTAssertTrue(inserted)
+        let outcome = await store.insertOrUpdate(group)
+        XCTAssertEqual(outcome, .inserted)
 
         let listed = await store.list()
         XCTAssertEqual(listed.count, 1)
@@ -134,8 +134,9 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         var updated = original
         updated.epoch = 7
         updated.commitment = Data(repeating: 0x99, count: 32)
-        let inserted = await store.insertOrUpdate(updated)
-        XCTAssertFalse(inserted, "second insertOrUpdate on the same id is an update")
+        let outcome = await store.insertOrUpdate(updated)
+        XCTAssertEqual(
+            outcome, .updated, "second insertOrUpdate on the same id is an update")
 
         let listed = await store.list()
         XCTAssertEqual(listed.count, 1)
@@ -198,10 +199,12 @@ final class SwiftDataGroupStoreTests: XCTestCase {
         let groupA = makeGroup(id: sharedID, name: "A's copy", ownerIdentityID: ownerA)
         let groupB = makeGroup(id: sharedID, name: "B's copy", ownerIdentityID: ownerB)
 
-        let insertedA = await store.insertOrUpdate(groupA)
-        let insertedB = await store.insertOrUpdate(groupB)
-        XCTAssertTrue(insertedA)
-        XCTAssertTrue(insertedB, "second owner must be a fresh insert, not an in-place overwrite")
+        let outcomeA = await store.insertOrUpdate(groupA)
+        let outcomeB = await store.insertOrUpdate(groupB)
+        XCTAssertEqual(outcomeA, .inserted)
+        XCTAssertEqual(
+            outcomeB, .inserted,
+            "second owner must be a fresh insert, not an in-place overwrite")
 
         let listed = await store.list()
         XCTAssertEqual(listed.count, 2, "both identities keep their own row")

--- a/Tests/OnymIOSTests/SwiftDataInvitationStoreTests.swift
+++ b/Tests/OnymIOSTests/SwiftDataInvitationStoreTests.swift
@@ -28,8 +28,8 @@ final class SwiftDataInvitationStoreTests: XCTestCase {
 
     func test_save_andList_returnsRecord() async {
         let record = Self.makeRecord(id: "evt-1", payload: Data("hello".utf8))
-        let inserted = await store.save(record)
-        XCTAssertTrue(inserted)
+        let outcome = await store.save(record)
+        XCTAssertEqual(outcome, .saved)
 
         let listed = await store.list()
         XCTAssertEqual(listed.count, 1)
@@ -38,12 +38,14 @@ final class SwiftDataInvitationStoreTests: XCTestCase {
         XCTAssertEqual(listed[0].status, .pending)
     }
 
-    func test_save_dedupesById_returnsFalseOnSecondSave() async {
+    func test_save_dedupesById_reportsDuplicateOnSecondSave() async {
         let record = Self.makeRecord(id: "evt-1")
         let first = await store.save(record)
         let second = await store.save(record)
-        XCTAssertTrue(first)
-        XCTAssertFalse(second)
+        XCTAssertEqual(first, .saved)
+        XCTAssertEqual(
+            second, .duplicate,
+            "a row already here is a duplicate, not a write that failed")
 
         let listed = await store.list()
         XCTAssertEqual(listed.count, 1, "duplicate save must not insert a second row")


### PR DESCRIPTION
Follow-up to #293. Reads as one with it.

#293 fixed a restore that counted calls made rather than rows stored,
and hit an obstacle on the way: `GroupStore.insertOrUpdate` answered
`Bool`, and `false` meant a row updated in place *or* a row it could not
encode and did not write. Those are opposite facts. Counting `false` as
a failure reports every restore onto a device that already holds rows as
unreadable — the very bug #293 was fixing — and counting it as a success
reports a store that refused the write as restored.

It worked around it in the sink, reading the store's keys once before
writing so `false` for a key already present is the update branch and
`false` for one absent is the encode guard. Correct, and tested. But it
reconstructs from the outside what the store knew from the inside, and
the next caller to read that `Bool` at face value finds the bug again.
`InvitationStore.save` had the same shape: `false` for a dedup hit and
`false` for a payload it could not encrypt.

`MessageStore` has answered `.inserted` / `.updated` / `.failed` since it
was written, which is exactly why the message path in #293 needed no
pre-read. The other two now do the same, and the pre-read is gone —
kept alongside it would be worse than either, two mechanisms answering
one question with nothing to say which is authoritative.

## Three enums, not one

All three modules hang off `OnymFoundation`, so a shared type was
available; the reason against it is not mechanical. The stores agree on
the *shape* of the answer, not on the middle case. A group `.updated`
was overwritten in place — the row now holds new values.
`InvitationSaveOutcome.duplicate` is the opposite: the store declined
the write so the original `receivedAt` and `status` survive, which is
the entire point of the dedup. One shared type has to pick one of those
words and then be wrong about the other store every time someone reads
it, which is the class of confusion being ended here.

What they do share is the part that mattered: "nothing was persisted"
can never again be spelled the same way as "persisted, just not as a new
row".

## The hot-path objection did not survive the audit

#293 declined this change on the grounds that it reaches into every
caller of a hot path for the benefit of one cold caller. Counting them:

| seam | production callers | what they do with the value |
| --- | --- | --- |
| `GroupStore.insertOrUpdate` | `GroupRepository`, `AppBackupSink` | pass through / count |
| `InvitationStore.save` | `IncomingInvitationsRepository`, `AppBackupSink` | branch on it / count |
| `GroupRepository.insert` | 9 sites across Inbox, Group, ChatsCore | **all nine discard it** |

Not one caller depends on `true`-means-insert. The single caller that
branches on the value at all is
`IncomingInvitationsRepository.recordIncoming`, which skipped its
snapshot refresh on `false`; that is now `guard outcome == .saved`, and
it is more correct than it was, because `.failed` used to take the same
path by accident rather than on purpose. There is no behavioural risk to
handle, only a mechanical migration.

Both repositories widen rather than flatten back to `Bool`, following
`MessageRepository.insert`, which already passes `MessageInsertOutcome`
through. Narrowing at that layer would move the ambiguity up one floor
and leave it for whoever next writes `if inserted`.

`GroupRepository.insert` refreshes unconditionally, including after
`.failed` — the snapshot is re-read from the store rather than patched,
so re-yielding what the store actually holds is right in all three
cases.

## Tests

New: each store's three outcomes distinguished by a caller, with an
explicit assertion that the persisted and the not-persisted answers are
not equal; a group updated in place counted as landed by the sink and
not duplicated in the store; a second restore of the same invitations
still counting them as landed; an invitation store that refuses the
write counted as unreadable.

#293's assertions are untouched. One line in its test file had to
change: `RefusingGroupStore.insertOrUpdate` spells its refusal `.failed`
instead of `false`, because the protocol it conforms to no longer has a
`Bool` to return. That is the change making the fake unable to mean
"updated" by accident.

`xcodebuild test -only-testing:OnymIOSTests` — 1451 tests, 3 skipped,
0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
