### PR TITLE
Tests for the waiting room now that it is a chat row

### DIFF
--- a/Packages/OnymInbox/Sources/OnymInbox/PendingVerificationStore.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingVerificationStore.swift
@@ -64,10 +64,7 @@ public actor PendingVerificationStore {
 
     /// Idempotent on `groupIDHex`. A re-deferred snapshot (re-delivery)
     /// keeps the existing entry/status rather than resetting it.
-    /// Public because the state it holds is rendered a module away, by
-    /// `PendingChatsFlow` — a test of that overlay has to be able to put
-    /// a verification in without standing up the whole verifier.
-    public func record(_ entry: PendingGroupVerification) {
+    func record(_ entry: PendingGroupVerification) {
         guard !all.contains(where: { $0.groupIDHex == entry.groupIDHex }) else { return }
         all.append(entry)
         publish()

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingVerificationStore.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingVerificationStore.swift
@@ -64,7 +64,10 @@ public actor PendingVerificationStore {
 
     /// Idempotent on `groupIDHex`. A re-deferred snapshot (re-delivery)
     /// keeps the existing entry/status rather than resetting it.
-    func record(_ entry: PendingGroupVerification) {
+    /// Public because the state it holds is rendered a module away, by
+    /// `PendingChatsFlow` — a test of that overlay has to be able to put
+    /// a verification in without standing up the whole verifier.
+    public func record(_ entry: PendingGroupVerification) {
         guard !all.contains(where: { $0.groupIDHex == entry.groupIDHex }) else { return }
         all.append(entry)
         publish()

--- a/Packages/OnymInbox/Sources/OnymInbox/SwiftDataPendingChatStore.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/SwiftDataPendingChatStore.swift
@@ -51,11 +51,15 @@ public actor SwiftDataPendingChatStore: PendingChatStore {
         return SwiftDataPendingChatStore(container: container)
     }
 
-    /// A second store over the same container — a relaunch, modelled.
-    /// Durability is the reason this store exists at all, so a test has
-    /// to be able to close the context and read the rows back through a
-    /// fresh one rather than trust the cache it just wrote.
-    public func reopened() -> SwiftDataPendingChatStore {
+    /// A second store over the same container, reading through a fresh
+    /// `ModelContext`.
+    ///
+    /// Not a relaunch: the container here is the same object and, for
+    /// `inMemory()`, never touches disk. What it does show is that a
+    /// write reached the container's store rather than sitting in the
+    /// context that made it — the half of durability a test can check
+    /// without a device.
+    func reopened() -> SwiftDataPendingChatStore {
         SwiftDataPendingChatStore(container: container)
     }
 

--- a/Packages/OnymInbox/Sources/OnymInbox/SwiftDataPendingChatStore.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/SwiftDataPendingChatStore.swift
@@ -51,6 +51,14 @@ public actor SwiftDataPendingChatStore: PendingChatStore {
         return SwiftDataPendingChatStore(container: container)
     }
 
+    /// A second store over the same container — a relaunch, modelled.
+    /// Durability is the reason this store exists at all, so a test has
+    /// to be able to close the context and read the rows back through a
+    /// fresh one rather than trust the cache it just wrote.
+    public func reopened() -> SwiftDataPendingChatStore {
+        SwiftDataPendingChatStore(container: container)
+    }
+
     private init(container: ModelContainer) {
         self.container = container
         self.context = ModelContext(container)

--- a/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
+++ b/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
@@ -77,7 +77,7 @@ final class PendingChatRepositoryTests: XCTestCase {
         XCTAssertEqual(snapshot.first?.status, .failed(reason: "no relay connection"))
     }
 
-    func test_consumeForMaterializedGroups_dropsTheWaitThatIsOver() async throws {
+    func test_consumeForMaterialized_dropsTheWaitThatIsOver() async throws {
         let repository = PendingChatRepository(store: InMemoryPendingChatStore())
         await repository.setCurrentIdentity(alice)
         let landed = makeChat(group: 0x11, owner: alice)
@@ -85,28 +85,53 @@ final class PendingChatRepositoryTests: XCTestCase {
         await repository.record(landed)
         await repository.record(waiting)
 
-        await repository.consumeForMaterializedGroups([landed.groupIDHex])
+        await repository.consumeForMaterialized([(landed.groupIDHex, alice)])
 
         let snapshot = try await firstSnapshot(from: repository)
         XCTAssertEqual(snapshot.map(\.groupIDHex), [waiting.groupIDHex])
     }
 
-    func test_consumeForMaterializedGroups_ignoresGroupsWithNoPendingRow() async throws {
+    func test_consumeForMaterialized_touchesNothingWhenNoRowMatches() async throws {
         // Every group snapshot flows through here on every emission, and
-        // almost none of them match. Touching the store for those would
-        // re-yield the whole list to every subscriber on each repaint.
-        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        // almost none of them match. Counting the writes rather than the
+        // surviving rows is the point: a row count of 1 also passes for
+        // an implementation that deleted nothing but re-yielded the whole
+        // list to every subscriber on each repaint.
+        let store = CountingPendingChatStore()
+        let repository = PendingChatRepository(store: store)
         await repository.setCurrentIdentity(alice)
-        let chat = makeChat(group: 0x11, owner: alice)
-        await repository.record(chat)
+        await repository.record(makeChat(group: 0x11, owner: alice))
+        await store.resetCounts()
 
-        await repository.consumeForMaterializedGroups(["ffff"])
+        await repository.consumeForMaterialized([("ffff", alice)])
 
+        let deletes = await store.deleteForIDsCalls
+        let lists = await store.listCalls
+        XCTAssertEqual(deletes, 0, "no row matched, so nothing may be written")
+        XCTAssertEqual(lists, 0, "and the list must not be re-read to say so")
         let snapshot = try await firstSnapshot(from: repository)
         XCTAssertEqual(snapshot.count, 1)
     }
 
-    func test_consumeForMaterializedGroups_worksAgainstAColdCache() async throws {
+    func test_consumeForMaterialized_leavesTheOtherIdentitysRowAlone() async throws {
+        // The group stream is filtered to the selected identity, so the
+        // pairs arriving here name one owner. Matching on the group
+        // alone deleted the other identity's row for the same chat.
+        let store = InMemoryPendingChatStore()
+        let repository = PendingChatRepository(store: store)
+        let mine = makeChat(group: 0x11, owner: alice)
+        let theirs = makeChat(group: 0x11, owner: bob)
+        await repository.setCurrentIdentity(alice)
+        await repository.record(mine)
+        await repository.record(theirs)
+
+        await repository.consumeForMaterialized([(mine.groupIDHex, alice)])
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.map(\.ownerIdentityID), [bob])
+    }
+
+    func test_consumeForMaterialized_worksAgainstAColdCache() async throws {
         // Launch order isn't guaranteed: the group watcher starts from
         // the flow while the startup `reload()` runs from another task,
         // so the first emission can arrive before anything has been
@@ -118,7 +143,7 @@ final class PendingChatRepositoryTests: XCTestCase {
 
         let repository = PendingChatRepository(store: store)
         await repository.setCurrentIdentity(alice)
-        await repository.consumeForMaterializedGroups([chat.groupIDHex])
+        await repository.consumeForMaterialized([(chat.groupIDHex, alice)])
 
         let snapshot = try await firstSnapshot(from: repository)
         XCTAssertTrue(snapshot.isEmpty, "the row must go even if the cache was never read")
@@ -135,6 +160,38 @@ final class PendingChatRepositoryTests: XCTestCase {
 
         let snapshot = try await firstSnapshot(from: repository)
         XCTAssertTrue(snapshot.isEmpty)
+    }
+
+    func test_remove_dropsTheRowTheUserSwipedAway() async throws {
+        // The only user-initiated delete in the feature, and the one the
+        // row's swipe action is gated on.
+        let store = InMemoryPendingChatStore()
+        let repository = PendingChatRepository(store: store)
+        await repository.setCurrentIdentity(alice)
+        let chat = makeChat(group: 0x11, owner: alice)
+        await repository.record(chat)
+
+        await repository.remove(id: chat.id)
+
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertTrue(snapshot.isEmpty)
+        let rows = await store.list()
+        XCTAssertTrue(rows.isEmpty, "local-only, but it does have to be local")
+    }
+
+    func test_currentChats_readsThroughAColdCache() async {
+        // The deeplink path's first question on a cold start, before
+        // anything has read the store: without the read-through it
+        // answers "no rows" and a second waiting room is created beside
+        // the one already on disk.
+        let store = InMemoryPendingChatStore()
+        let chat = makeChat(group: 0x11, owner: alice)
+        await store.insert(chat)
+
+        let repository = PendingChatRepository(store: store)
+        let all = await repository.currentChats()
+
+        XCTAssertEqual(all.map(\.id), [chat.id])
     }
 
     func test_currentChats_readsAcrossIdentities() async {
@@ -172,5 +229,50 @@ final class PendingChatRepositoryTests: XCTestCase {
             receivedAt: Date(),
             status: .offered
         )
+    }
+
+    // MARK: - Spy
+
+    /// Counts what actually reached the store. Used where the claim is
+    /// "this did no work" — a claim the surviving rows cannot make.
+    private actor CountingPendingChatStore: PendingChatStore {
+        private var rows: [PendingChat] = []
+        private(set) var deleteForIDsCalls = 0
+        private(set) var listCalls = 0
+
+        func resetCounts() {
+            deleteForIDsCalls = 0
+            listCalls = 0
+        }
+
+        @discardableResult
+        func insert(_ chat: PendingChat) async -> PendingChatWriteOutcome {
+            guard !rows.contains(where: { $0.id == chat.id }) else { return .alreadyPresent }
+            rows.append(chat)
+            return .inserted
+        }
+
+        func setStatus(id: String, status: PendingChat.Status) async {
+            guard let index = rows.firstIndex(where: { $0.id == id }) else { return }
+            rows[index].status = status
+        }
+
+        func delete(id: String) async {
+            rows.removeAll { $0.id == id }
+        }
+
+        func deleteForIDs(_ ids: Set<String>) async {
+            deleteForIDsCalls += 1
+            rows.removeAll { ids.contains($0.id) }
+        }
+
+        func deleteOwner(_ ownerIDString: String) async {
+            rows.removeAll { $0.ownerIdentityID.rawValue.uuidString == ownerIDString }
+        }
+
+        func list() async -> [PendingChat] {
+            listCalls += 1
+            return rows.sorted { $0.receivedAt > $1.receivedAt }
+        }
     }
 }

--- a/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
+++ b/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import OnymInbox
+@testable import OnymIdentity
+
+/// The per-identity snapshot layer over `PendingChatStore`. Same
+/// contract as `GroupRepository`, because it feeds the same list:
+/// subscribers see one identity's rows, and every mutation re-yields.
+final class PendingChatRepositoryTests: XCTestCase {
+
+    private let alice = IdentityID()
+    private let bob = IdentityID()
+
+    func test_snapshots_areFilteredToTheCurrentIdentity() async throws {
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        await repository.record(makeChat(group: 0x11, owner: alice))
+        await repository.record(makeChat(group: 0x22, owner: bob))
+
+        let mine = try await firstSnapshot(from: repository)
+        XCTAssertEqual(mine.map(\.ownerIdentityID), [alice])
+    }
+
+    func test_switchingIdentity_reyieldsTheOtherIdentitysRows() async throws {
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        await repository.record(makeChat(group: 0x22, owner: bob))
+
+        let asAlice = try await firstSnapshot(from: repository)
+        XCTAssertTrue(asAlice.isEmpty)
+        await repository.setCurrentIdentity(bob)
+        let asBob = try await firstSnapshot(from: repository)
+        XCTAssertEqual(asBob.count, 1)
+    }
+
+    func test_noIdentitySelected_yieldsNothing() async throws {
+        // Cold start before the selection lands. Showing another
+        // identity's invitations "until the filter arrives" would be a
+        // cross-identity leak on the most-looked-at screen in the app.
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.record(makeChat(group: 0x11, owner: alice))
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertTrue(snapshot.isEmpty)
+    }
+
+    func test_record_reportsWhatTheWriteDid() async {
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        let chat = makeChat(group: 0x11, owner: alice)
+
+        let first = await repository.record(chat)
+        let second = await repository.record(chat)
+        XCTAssertEqual(first, .inserted)
+        XCTAssertEqual(second, .alreadyPresent)
+    }
+
+    func test_markRequested_isVisibleToSubscribers() async throws {
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        let chat = makeChat(group: 0x11, owner: alice)
+        await repository.record(chat)
+
+        await repository.markRequested(id: chat.id)
+
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertEqual(snapshot.first?.status, .requested)
+    }
+
+    func test_markFailed_carriesTheReasonTheThreadShows() async throws {
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        let chat = makeChat(group: 0x11, owner: alice)
+        await repository.record(chat)
+
+        await repository.markFailed(id: chat.id, reason: "no relay connection")
+
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertEqual(snapshot.first?.status, .failed(reason: "no relay connection"))
+    }
+
+    func test_consumeForMaterializedGroups_dropsTheWaitThatIsOver() async throws {
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        let landed = makeChat(group: 0x11, owner: alice)
+        let waiting = makeChat(group: 0x22, owner: alice)
+        await repository.record(landed)
+        await repository.record(waiting)
+
+        await repository.consumeForMaterializedGroups([landed.groupIDHex])
+
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertEqual(snapshot.map(\.groupIDHex), [waiting.groupIDHex])
+    }
+
+    func test_consumeForMaterializedGroups_ignoresGroupsWithNoPendingRow() async throws {
+        // Every group snapshot flows through here on every emission, and
+        // almost none of them match. Touching the store for those would
+        // re-yield the whole list to every subscriber on each repaint.
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        let chat = makeChat(group: 0x11, owner: alice)
+        await repository.record(chat)
+
+        await repository.consumeForMaterializedGroups(["ffff"])
+
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertEqual(snapshot.count, 1)
+    }
+
+    func test_removeForOwner_cascades() async throws {
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        await repository.record(makeChat(group: 0x11, owner: alice))
+
+        await repository.removeForOwner(alice)
+
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertTrue(snapshot.isEmpty)
+    }
+
+    func test_currentChats_readsAcrossIdentities() async {
+        // The deeplink path asks "does this device already have a row
+        // for this group?" before creating one, and the answer must not
+        // depend on which identity happens to be selected.
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        await repository.record(makeChat(group: 0x11, owner: alice))
+        await repository.record(makeChat(group: 0x22, owner: bob))
+
+        let all = await repository.currentChats()
+        XCTAssertEqual(Set(all.map(\.ownerIdentityID)), [alice, bob])
+    }
+
+    // MARK: - Helpers
+
+    /// Subscribers get the current list on subscribe, so one read of a
+    /// fresh stream is the current snapshot.
+    private func firstSnapshot(
+        from repository: PendingChatRepository
+    ) async throws -> [PendingChat] {
+        for await snapshot in repository.snapshots { return snapshot }
+        return []
+    }
+
+    private func makeChat(group: UInt8, owner: IdentityID) -> PendingChat {
+        PendingChat(
+            groupID: Data(repeating: group, count: 32),
+            ownerIdentityID: owner,
+            introPublicKey: Data(repeating: 0x44, count: 32),
+            groupName: "Maple Garden",
+            inviterAlias: "Alice",
+            invitationMessage: nil,
+            receivedAt: Date(),
+            status: .offered
+        )
+    }
+}

--- a/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
+++ b/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
@@ -106,6 +106,26 @@ final class PendingChatRepositoryTests: XCTestCase {
         XCTAssertEqual(snapshot.count, 1)
     }
 
+    func test_consumeForMaterializedGroups_worksAgainstAColdCache() async throws {
+        // Launch order isn't guaranteed: the group watcher starts from
+        // the flow while the startup `reload()` runs from another task,
+        // so the first emission can arrive before anything has been
+        // read. Deciding "no rows match" from an unread cache leaves the
+        // stale row in the list until some unrelated group mutation.
+        let store = InMemoryPendingChatStore()
+        let chat = makeChat(group: 0x11, owner: alice)
+        await store.insert(chat)
+
+        let repository = PendingChatRepository(store: store)
+        await repository.setCurrentIdentity(alice)
+        await repository.consumeForMaterializedGroups([chat.groupIDHex])
+
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertTrue(snapshot.isEmpty, "the row must go even if the cache was never read")
+        let rows = await store.list()
+        XCTAssertTrue(rows.isEmpty, "and it must go from the store, not just the cache")
+    }
+
     func test_removeForOwner_cascades() async throws {
         let repository = PendingChatRepository(store: InMemoryPendingChatStore())
         await repository.setCurrentIdentity(alice)

--- a/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
+++ b/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
@@ -65,16 +65,16 @@ final class PendingChatRepositoryTests: XCTestCase {
         XCTAssertEqual(snapshot.first?.status, .requested)
     }
 
-    func test_markFailed_carriesTheReasonTheThreadShows() async throws {
+    func test_markFailed_carriesACodeTheThreadCanRenderInAnyLanguage() async throws {
         let repository = PendingChatRepository(store: InMemoryPendingChatStore())
         await repository.setCurrentIdentity(alice)
         let chat = makeChat(group: 0x11, owner: alice)
         await repository.record(chat)
 
-        await repository.markFailed(id: chat.id, reason: "no relay connection")
+        await repository.markFailed(id: chat.id, failure: .transport)
 
         let snapshot = try await firstSnapshot(from: repository)
-        XCTAssertEqual(snapshot.first?.status, .failed(reason: "no relay connection"))
+        XCTAssertEqual(snapshot.first?.status, .failed(.transport))
     }
 
     func test_consumeForMaterialized_dropsTheWaitThatIsOver() async throws {
@@ -160,6 +160,39 @@ final class PendingChatRepositoryTests: XCTestCase {
 
         let snapshot = try await firstSnapshot(from: repository)
         XCTAssertTrue(snapshot.isEmpty)
+    }
+
+    func test_record_onARepeatOffer_takesTheNewerReplyChannel() async throws {
+        // A re-invite mints a fresh intro key and revokes the old one.
+        // Keeping the first would seal Accept to a dead address — sent,
+        // never heard, waiting forever.
+        let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+        await repository.setCurrentIdentity(alice)
+        let first = makeChat(group: 0x11, owner: alice)
+        await repository.record(first)
+        await repository.markRequested(id: first.id)
+
+        var reinvite = makeChat(group: 0x11, owner: alice)
+        reinvite = PendingChat(
+            groupID: reinvite.groupID,
+            ownerIdentityID: alice,
+            introPublicKey: Data(repeating: 0x99, count: 32),
+            groupName: "Maple Garden (renamed)",
+            inviterAlias: "Alice",
+            invitationMessage: nil,
+            receivedAt: Date(),
+            status: .offered
+        )
+        let outcome = await repository.record(reinvite)
+
+        XCTAssertEqual(outcome, .alreadyPresent)
+        let snapshot = try await firstSnapshot(from: repository)
+        XCTAssertEqual(snapshot.first?.introPublicKey, Data(repeating: 0x99, count: 32))
+        XCTAssertEqual(snapshot.first?.groupName, "Maple Garden (renamed)")
+        XCTAssertEqual(
+            snapshot.first?.status, .requested,
+            "the newer key changes where to ask, not what was asked"
+        )
     }
 
     func test_remove_dropsTheRowTheUserSwipedAway() async throws {
@@ -255,6 +288,27 @@ final class PendingChatRepositoryTests: XCTestCase {
         func setStatus(id: String, status: PendingChat.Status) async {
             guard let index = rows.firstIndex(where: { $0.id == id }) else { return }
             rows[index].status = status
+        }
+
+        func refreshOffer(
+            id: String,
+            introPublicKey: Data,
+            groupName: String?,
+            inviterAlias: String,
+            invitationMessage: String?
+        ) async {
+            guard let index = rows.firstIndex(where: { $0.id == id }) else { return }
+            let existing = rows[index]
+            rows[index] = PendingChat(
+                groupID: existing.groupID,
+                ownerIdentityID: existing.ownerIdentityID,
+                introPublicKey: introPublicKey,
+                groupName: groupName,
+                inviterAlias: inviterAlias,
+                invitationMessage: invitationMessage,
+                receivedAt: existing.receivedAt,
+                status: existing.status
+            )
         }
 
         func delete(id: String) async {

--- a/Tests/OnymIOSTests/PendingChatStoreTests.swift
+++ b/Tests/OnymIOSTests/PendingChatStoreTests.swift
@@ -58,15 +58,36 @@ final class PendingChatStoreTests: XCTestCase {
 
     // MARK: - Status
 
-    func test_setStatus_carriesTheFailureReason() async {
+    func test_setStatus_carriesTheFailureCode() async {
         let store = SwiftDataPendingChatStore.inMemory()
         let chat = makeChat(group: 0x11, owner: owner)
         await store.insert(chat)
 
-        await store.setStatus(id: chat.id, status: .failed(reason: "relay rejected"))
+        await store.setStatus(id: chat.id, status: .failed(.noIdentity))
 
         let rows = await store.list()
-        XCTAssertEqual(rows.first?.status, .failed(reason: "relay rejected"))
+        XCTAssertEqual(rows.first?.status, .failed(.noIdentity))
+    }
+
+    func test_refreshOffer_replacesTheReplyChannelButNotTheStatus() async {
+        let store = SwiftDataPendingChatStore.inMemory()
+        let chat = makeChat(group: 0x11, owner: owner)
+        await store.insert(chat)
+        await store.setStatus(id: chat.id, status: .requested)
+
+        await store.refreshOffer(
+            id: chat.id,
+            introPublicKey: Data(repeating: 0x99, count: 32),
+            groupName: "Maple Garden (renamed)",
+            inviterAlias: "Alice",
+            invitationMessage: nil
+        )
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.first?.introPublicKey, Data(repeating: 0x99, count: 32))
+        XCTAssertEqual(rows.first?.groupName, "Maple Garden (renamed)")
+        XCTAssertNil(rows.first?.invitationMessage)
+        XCTAssertEqual(rows.first?.status, .requested)
     }
 
     func test_setStatus_onAMissingRowIsANoOp() async {
@@ -197,9 +218,20 @@ final class PendingChatStoreTests: XCTestCase {
             file: file, line: line
         )
 
-        await store.setStatus(id: old.id, status: .failed(reason: "relay rejected"))
+        await store.setStatus(id: old.id, status: .failed(.transport))
         let afterStatus = await store.list().first { $0.id == old.id }
-        XCTAssertEqual(afterStatus?.status, .failed(reason: "relay rejected"), file: file, line: line)
+        XCTAssertEqual(afterStatus?.status, .failed(.transport), file: file, line: line)
+
+        await store.refreshOffer(
+            id: new.id,
+            introPublicKey: Data(repeating: 0x99, count: 32),
+            groupName: "renamed",
+            inviterAlias: "Alice",
+            invitationMessage: nil
+        )
+        let refreshed = await store.list().first { $0.id == new.id }
+        XCTAssertEqual(refreshed?.introPublicKey, Data(repeating: 0x99, count: 32), file: file, line: line)
+        XCTAssertEqual(refreshed?.groupName, "renamed", file: file, line: line)
         // A row that isn't there absorbs the write rather than creating one.
         await store.setStatus(id: "nobody:home", status: .requested)
         let afterGhost = await store.list()

--- a/Tests/OnymIOSTests/PendingChatStoreTests.swift
+++ b/Tests/OnymIOSTests/PendingChatStoreTests.swift
@@ -81,17 +81,33 @@ final class PendingChatStoreTests: XCTestCase {
 
     // MARK: - Removal
 
-    func test_deleteForGroups_dropsOnlyTheMaterializedOnes() async {
+    func test_deleteForIDs_dropsOnlyTheMaterializedOnes() async {
         let store = SwiftDataPendingChatStore.inMemory()
         let landed = makeChat(group: 0x11, owner: owner)
         let waiting = makeChat(group: 0x22, owner: owner)
         await store.insert(landed)
         await store.insert(waiting)
 
-        await store.deleteForGroups(hexes: [landed.groupIDHex])
+        await store.deleteForIDs([landed.id])
 
         let rows = await store.list()
         XCTAssertEqual(rows.map(\.groupIDHex), [waiting.groupIDHex])
+    }
+
+    func test_deleteForIDs_leavesTheOtherIdentitysRowForTheSameGroup() async {
+        // Deleting by group alone took the other identity's waiting room
+        // with it the moment this one got in — the same composite-key
+        // mistake `PersistedGroup` documents one layer down.
+        let store = SwiftDataPendingChatStore.inMemory()
+        let mine = makeChat(group: 0x11, owner: owner)
+        let theirs = makeChat(group: 0x11, owner: other)
+        await store.insert(mine)
+        await store.insert(theirs)
+
+        await store.deleteForIDs([mine.id])
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.map(\.ownerIdentityID), [other])
     }
 
     func test_deleteOwner_cascadesForARemovedIdentity() async {
@@ -107,10 +123,15 @@ final class PendingChatStoreTests: XCTestCase {
 
     // MARK: - Durability + ordering
 
-    func test_rowsSurviveAReopen() async {
-        // The whole reason this store is on disk: a link join is
-        // replayed by nothing, so a force-quit would otherwise leave
-        // someone waiting on a request their device has no record of.
+    func test_rowsSurviveAFreshContext() async {
+        // Not a relaunch — `inMemory()` never touches disk and the
+        // container outlives both stores. What this shows is that the
+        // write reached the container's store rather than sitting in the
+        // context that made it, which is the half of durability a test
+        // can check here. The other half is why the production store is
+        // SQLite: a link join is replayed by nothing, so a force-quit
+        // would otherwise leave someone waiting on a request their
+        // device has no record of.
         let store = SwiftDataPendingChatStore.inMemory()
         let chat = makeChat(group: 0x11, owner: owner)
         await store.insert(chat)
@@ -136,24 +157,65 @@ final class PendingChatStoreTests: XCTestCase {
         XCTAssertEqual(rows.map(\.groupIDHex), [new.groupIDHex, old.groupIDHex])
     }
 
-    func test_inMemoryStore_matchesTheOnDiskContract() async {
+    // MARK: - Both conformers, one contract
+
+    func test_swiftDataStore_honoursTheContract() async throws {
+        try await assertHonoursContract(SwiftDataPendingChatStore.inMemory())
+    }
+
+    func test_inMemoryStore_honoursTheContract() async throws {
         // The fallback for a device whose store won't open has to behave
         // the same, or a failed open changes what the app does rather
-        // than only where it keeps it.
-        let store = InMemoryPendingChatStore()
-        let chat = makeChat(group: 0x11, owner: owner)
-        let first = await store.insert(chat)
-        let second = await store.insert(chat)
-        XCTAssertEqual(first, .inserted)
-        XCTAssertEqual(second, .alreadyPresent)
+        // than only where it keeps its rows. Hand-checking three of the
+        // six methods let `delete`, `deleteOwner` and ordering diverge in
+        // silence, so both conformers run the same exercise.
+        try await assertHonoursContract(InMemoryPendingChatStore())
+    }
 
-        await store.setStatus(id: chat.id, status: .requested)
-        let requested = await store.list()
-        XCTAssertEqual(requested.first?.status, .requested)
+    /// Every method on `PendingChatStore`, in one pass.
+    private func assertHonoursContract(
+        _ store: any PendingChatStore,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let old = makeChat(group: 0x11, owner: owner, receivedAt: Date(timeIntervalSince1970: 100))
+        let new = makeChat(group: 0x22, owner: owner, receivedAt: Date(timeIntervalSince1970: 200))
+        let theirs = makeChat(group: 0x33, owner: other)
 
-        await store.deleteForGroups(hexes: [chat.groupIDHex])
-        let emptied = await store.list()
-        XCTAssertTrue(emptied.isEmpty)
+        let inserted = await store.insert(old)
+        let duplicate = await store.insert(old)
+        XCTAssertEqual(inserted, .inserted, file: file, line: line)
+        XCTAssertEqual(duplicate, .alreadyPresent, file: file, line: line)
+        await store.insert(new)
+        await store.insert(theirs)
+
+        // Newest first.
+        let listed = await store.list()
+        XCTAssertEqual(
+            listed.map(\.id),
+            [theirs, new, old].sorted { $0.receivedAt > $1.receivedAt }.map(\.id),
+            file: file, line: line
+        )
+
+        await store.setStatus(id: old.id, status: .failed(reason: "relay rejected"))
+        let afterStatus = await store.list().first { $0.id == old.id }
+        XCTAssertEqual(afterStatus?.status, .failed(reason: "relay rejected"), file: file, line: line)
+        // A row that isn't there absorbs the write rather than creating one.
+        await store.setStatus(id: "nobody:home", status: .requested)
+        let afterGhost = await store.list()
+        XCTAssertEqual(afterGhost.count, 3, file: file, line: line)
+
+        await store.delete(id: old.id)
+        let afterDelete = await store.list()
+        XCTAssertEqual(Set(afterDelete.map(\.id)), [new.id, theirs.id], file: file, line: line)
+
+        await store.deleteForIDs([new.id])
+        let afterSweep = await store.list()
+        XCTAssertEqual(afterSweep.map(\.id), [theirs.id], file: file, line: line)
+
+        await store.deleteOwner(other.rawValue.uuidString)
+        let afterCascade = await store.list()
+        XCTAssertTrue(afterCascade.isEmpty, file: file, line: line)
     }
 
     // MARK: - Helpers

--- a/Tests/OnymIOSTests/PendingChatStoreTests.swift
+++ b/Tests/OnymIOSTests/PendingChatStoreTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+@testable import OnymInbox
+@testable import OnymIdentity
+
+/// The store under the chats-list rows for a chat that hasn't opened
+/// yet. What matters here is dedup (a relay replays an offer on every
+/// reconnect), status transitions (asked / failed), and that the rows
+/// survive the relaunch the old in-memory store did not.
+final class PendingChatStoreTests: XCTestCase {
+
+    private let owner = IdentityID()
+    private let other = IdentityID()
+
+    // MARK: - Dedup
+
+    func test_insert_isKeyedByGroupAndOwner_notByDelivery() async {
+        let store = SwiftDataPendingChatStore.inMemory()
+        let first = await store.insert(makeChat(group: 0x11, owner: owner))
+        // Same group, same identity, later delivery: the same waiting
+        // room, not a second one.
+        let second = await store.insert(
+            makeChat(group: 0x11, owner: owner, receivedAt: Date().addingTimeInterval(60))
+        )
+
+        XCTAssertEqual(first, .inserted)
+        XCTAssertEqual(second, .alreadyPresent)
+        let rows = await store.list()
+        XCTAssertEqual(rows.count, 1)
+    }
+
+    func test_insert_keepsOneRowPerIdentityForTheSameGroup() async {
+        // Two identities on one device can be invited to the same chat.
+        // Collapsing them would hide one person's invitation behind the
+        // other's, which is the bug `PersistedGroup`'s composite key
+        // exists to prevent one layer down.
+        let store = SwiftDataPendingChatStore.inMemory()
+        await store.insert(makeChat(group: 0x11, owner: owner))
+        await store.insert(makeChat(group: 0x11, owner: other))
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.count, 2)
+    }
+
+    func test_replayedOffer_doesNotResetAnAcceptedRow() async {
+        // The failure this key exists to prevent: the relay re-delivers
+        // the offer, and a chat the user already accepted goes back to
+        // asking them to accept it.
+        let store = SwiftDataPendingChatStore.inMemory()
+        let chat = makeChat(group: 0x11, owner: owner)
+        await store.insert(chat)
+        await store.setStatus(id: chat.id, status: .requested)
+
+        await store.insert(chat)
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.first?.status, .requested)
+    }
+
+    // MARK: - Status
+
+    func test_setStatus_carriesTheFailureReason() async {
+        let store = SwiftDataPendingChatStore.inMemory()
+        let chat = makeChat(group: 0x11, owner: owner)
+        await store.insert(chat)
+
+        await store.setStatus(id: chat.id, status: .failed(reason: "relay rejected"))
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.first?.status, .failed(reason: "relay rejected"))
+    }
+
+    func test_setStatus_onAMissingRowIsANoOp() async {
+        // The ordinary race: the group materializes while a join request
+        // is still in flight, so the row is gone by the time the send
+        // reports back.
+        let store = SwiftDataPendingChatStore.inMemory()
+        await store.setStatus(id: "nobody:home", status: .requested)
+        let rows = await store.list()
+        XCTAssertTrue(rows.isEmpty)
+    }
+
+    // MARK: - Removal
+
+    func test_deleteForGroups_dropsOnlyTheMaterializedOnes() async {
+        let store = SwiftDataPendingChatStore.inMemory()
+        let landed = makeChat(group: 0x11, owner: owner)
+        let waiting = makeChat(group: 0x22, owner: owner)
+        await store.insert(landed)
+        await store.insert(waiting)
+
+        await store.deleteForGroups(hexes: [landed.groupIDHex])
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.map(\.groupIDHex), [waiting.groupIDHex])
+    }
+
+    func test_deleteOwner_cascadesForARemovedIdentity() async {
+        let store = SwiftDataPendingChatStore.inMemory()
+        await store.insert(makeChat(group: 0x11, owner: owner))
+        await store.insert(makeChat(group: 0x22, owner: other))
+
+        await store.deleteOwner(owner.rawValue.uuidString)
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.map(\.ownerIdentityID), [other])
+    }
+
+    // MARK: - Durability + ordering
+
+    func test_rowsSurviveAReopen() async {
+        // The whole reason this store is on disk: a link join is
+        // replayed by nothing, so a force-quit would otherwise leave
+        // someone waiting on a request their device has no record of.
+        let store = SwiftDataPendingChatStore.inMemory()
+        let chat = makeChat(group: 0x11, owner: owner)
+        await store.insert(chat)
+        await store.setStatus(id: chat.id, status: .requested)
+
+        let relaunched = await store.reopened()
+        let rows = await relaunched.list()
+
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.status, .requested)
+        XCTAssertEqual(rows.first?.groupName, "Maple Garden")
+        XCTAssertEqual(rows.first?.introPublicKey, Data(repeating: 0x44, count: 32))
+    }
+
+    func test_list_isNewestFirst() async {
+        let store = SwiftDataPendingChatStore.inMemory()
+        let old = makeChat(group: 0x11, owner: owner, receivedAt: Date(timeIntervalSince1970: 100))
+        let new = makeChat(group: 0x22, owner: owner, receivedAt: Date(timeIntervalSince1970: 200))
+        await store.insert(old)
+        await store.insert(new)
+
+        let rows = await store.list()
+        XCTAssertEqual(rows.map(\.groupIDHex), [new.groupIDHex, old.groupIDHex])
+    }
+
+    func test_inMemoryStore_matchesTheOnDiskContract() async {
+        // The fallback for a device whose store won't open has to behave
+        // the same, or a failed open changes what the app does rather
+        // than only where it keeps it.
+        let store = InMemoryPendingChatStore()
+        let chat = makeChat(group: 0x11, owner: owner)
+        let first = await store.insert(chat)
+        let second = await store.insert(chat)
+        XCTAssertEqual(first, .inserted)
+        XCTAssertEqual(second, .alreadyPresent)
+
+        await store.setStatus(id: chat.id, status: .requested)
+        let requested = await store.list()
+        XCTAssertEqual(requested.first?.status, .requested)
+
+        await store.deleteForGroups(hexes: [chat.groupIDHex])
+        let emptied = await store.list()
+        XCTAssertTrue(emptied.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeChat(
+        group: UInt8,
+        owner: IdentityID,
+        receivedAt: Date = Date(),
+        status: PendingChat.Status = .offered
+    ) -> PendingChat {
+        PendingChat(
+            groupID: Data(repeating: group, count: 32),
+            ownerIdentityID: owner,
+            introPublicKey: Data(repeating: 0x44, count: 32),
+            groupName: "Maple Garden",
+            inviterAlias: "Alice",
+            invitationMessage: "come in",
+            receivedAt: receivedAt,
+            status: status
+        )
+    }
+}

--- a/Tests/OnymIOSTests/PendingChatsFlowTests.swift
+++ b/Tests/OnymIOSTests/PendingChatsFlowTests.swift
@@ -1,0 +1,392 @@
+import XCTest
+@testable import OnymInbox
+@testable import OnymGroup
+@testable import OnymIdentity
+@testable import OnymChain
+
+/// The flow behind the pending rows in the chats list. It folds three
+/// sources into one row per chat-in-progress, so most of what matters
+/// here is which source wins and when a row stops existing.
+@MainActor
+final class PendingChatsFlowTests: XCTestCase {
+
+    private let owner = IdentityID()
+
+    // MARK: - Offers
+
+    func test_offer_becomesAnAcceptableRow() async throws {
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+        await harness.repository.record(harness.makeChat())
+
+        try await waitFor { harness.flow.rows.count == 1 }
+        let row = try XCTUnwrap(harness.flow.rows.first)
+        XCTAssertEqual(row.state, .offered)
+        XCTAssertEqual(row.name, "Maple Garden")
+        XCTAssertEqual(row.inviterAlias, "Alice")
+        XCTAssertTrue(row.isDismissable)
+    }
+
+    func test_accept_shipsTheRequestAndTheRowStartsWaiting() async throws {
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        harness.flow.accept(chat.id)
+
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+        let calls = await harness.sender.calls
+        let call = try XCTUnwrap(calls.first)
+        XCTAssertEqual(call.capability.groupId, chat.groupID)
+        XCTAssertEqual(call.label, "Bob", "the joiner is introduced by the active identity's name")
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+    }
+
+    func test_accept_isDebouncedWhileTheSendIsInFlight() async throws {
+        let harness = Harness(owner: owner)
+        await harness.sender.hold()
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        harness.flow.accept(chat.id)
+        harness.flow.accept(chat.id)
+
+        try await waitFor { harness.flow.rows.first?.isSending == true }
+        await harness.sender.release()
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+    }
+
+    func test_failedSend_showsTheReasonAndRetryResends() async throws {
+        let harness = Harness(owner: owner)
+        await harness.sender.setOutcome(.transportFailed("relay rejected"))
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        harness.flow.accept(chat.id)
+        try await waitFor {
+            if case .sendFailed(let reason)? = harness.flow.rows.first?.state {
+                return reason.contains("relay rejected")
+            }
+            return false
+        }
+        XCTAssertTrue(harness.flow.rows.first?.state.isRetryable == true)
+
+        await harness.sender.setOutcome(.sent)
+        harness.flow.retry(chat.id)
+
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+        let sent2 = await harness.sender.calls.count
+        XCTAssertEqual(sent2, 2)
+    }
+
+    // MARK: - Verification overlay
+
+    func test_verification_winsOverTheStoredStatus() async throws {
+        // Past the founder's approval, what the person is waiting on has
+        // moved on from them — showing "waiting on the founder" then
+        // would name someone who has already done their part.
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.repository.markRequested(id: chat.id)
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+
+        await harness.verifications.record(makeVerification(
+            groupIDHex: chat.groupIDHex, owner: owner, status: .unreachable
+        ))
+
+        try await waitFor { harness.flow.rows.first?.state == .founderUnreachable }
+        XCTAssertEqual(harness.flow.rows.count, 1, "one row, not one per source")
+    }
+
+    func test_retry_onAStuckVerification_redrivesTheVerifier() async throws {
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.verifications.record(makeVerification(
+            groupIDHex: chat.groupIDHex, owner: owner, status: .chainUnreachable
+        ))
+        try await waitFor { harness.flow.rows.first?.state == .chainUnreachable }
+
+        harness.flow.retry(chat.id)
+
+        try await waitForAsync { await harness.verifierRetries.values == [chat.groupIDHex] }
+        let sent0 = await harness.sender.calls.count
+        XCTAssertEqual(sent0, 0, "a verification retry is not a re-send")
+    }
+
+    func test_chainSettling_offersNoRetry() async throws {
+        // It clears itself. Offering an action implies the user is
+        // holding it up.
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.verifications.record(makeVerification(
+            groupIDHex: chat.groupIDHex, owner: owner, status: .chainSettling
+        ))
+
+        try await waitFor { harness.flow.rows.first?.state == .chainSettling }
+        XCTAssertFalse(harness.flow.rows.first?.state.isRetryable == true)
+    }
+
+    func test_verificationWithNoOffer_stillGetsARow() async throws {
+        // A stale invitation replayed onto a device that never asked in
+        // this install. Without a row the group is stuck forever, hidden
+        // from the list by design, with no screen left to surface it.
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+        await harness.verifications.record(makeVerification(
+            groupIDHex: String(repeating: "ab", count: 32),
+            owner: owner,
+            status: .unreachable
+        ))
+
+        try await waitFor { harness.flow.rows.count == 1 }
+        let row = try XCTUnwrap(harness.flow.rows.first)
+        XCTAssertEqual(row.state, .founderUnreachable)
+        XCTAssertFalse(row.isDismissable, "there is no stored offer under it to drop")
+    }
+
+    // MARK: - End of the wait
+
+    func test_theRowDisappearsWhenTheGroupLands() async throws {
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        await harness.groups.insert(harness.makeGroup(id: chat.groupIDHex))
+
+        try await waitFor { harness.flow.rows.isEmpty }
+    }
+
+    // MARK: - Joining from a link
+
+    func test_join_recordsARowAndSendsWithoutAsking() async throws {
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+
+        let outcome = await harness.flow.join(capability: harness.capability())
+
+        XCTAssertEqual(outcome, .waiting(rowID: harness.makeChat().id))
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+    }
+
+    func test_join_twiceOnTheSameLink_doesNotAskTwice() async throws {
+        let harness = Harness(owner: owner)
+        await harness.flow.start()
+
+        _ = await harness.flow.join(capability: harness.capability())
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+        let second = await harness.flow.join(capability: harness.capability())
+
+        XCTAssertEqual(second, .waiting(rowID: harness.makeChat().id))
+        let sent1 = await harness.sender.calls.count
+        XCTAssertEqual(sent1, 1, "a second tap is not a second request")
+    }
+
+    func test_join_whenAlreadyAMember_opensTheChatInstead() async throws {
+        let harness = Harness(owner: owner)
+        let capability = harness.capability()
+        let hex = capability.groupId.map { String(format: "%02x", $0) }.joined()
+        await harness.groups.insert(harness.makeGroup(id: hex))
+        await harness.flow.start()
+
+        let outcome = await harness.flow.join(capability: capability)
+
+        XCTAssertEqual(outcome, .alreadyJoined(groupIDHex: hex))
+        let sent0 = await harness.sender.calls.count
+        XCTAssertEqual(sent0, 0)
+    }
+
+    func test_join_withNoIdentity_saysSoRatherThanWaitingSilently() async throws {
+        let harness = Harness(owner: nil)
+        await harness.flow.start()
+
+        let outcome = await harness.flow.join(capability: harness.capability())
+
+        guard case .failed = outcome else {
+            return XCTFail("expected a failure the caller can surface, got \(outcome)")
+        }
+        let sent0 = await harness.sender.calls.count
+        XCTAssertEqual(sent0, 0)
+    }
+
+    // MARK: - Harness
+
+    @MainActor
+    private struct Harness {
+        let repository: PendingChatRepository
+        let verifications = PendingVerificationStore()
+        let groups: GroupRepository
+        let sender = SpyJoinSender()
+        let verifierRetries = Recorder()
+        let flow: PendingChatsFlow
+        let owner: IdentityID?
+
+        init(owner: IdentityID?) {
+            self.owner = owner
+            let repository = PendingChatRepository(store: InMemoryPendingChatStore())
+            self.repository = repository
+            let groups = GroupRepository(store: SwiftDataGroupStore.inMemory())
+            self.groups = groups
+            let sender = self.sender
+            let retries = self.verifierRetries
+            self.flow = PendingChatsFlow(
+                repository: repository,
+                verificationStore: verifications,
+                groupRepository: groups,
+                submitJoin: { capability, label in
+                    await sender.send(capability: capability, label: label)
+                },
+                displayLabel: { "Bob" },
+                retryVerification: { hex in await retries.record(hex) },
+                currentIdentityID: { owner }
+            )
+            Task { [repository, verifications, groups, owner] in
+                await repository.setCurrentIdentity(owner)
+                await verifications.setCurrentIdentity(owner)
+                await groups.setCurrentIdentity(owner)
+            }
+        }
+
+        func capability() -> IntroCapability {
+            try! IntroCapability(
+                introPublicKey: Data(repeating: 0x44, count: 32),
+                groupId: Data(repeating: 0x11, count: 32),
+                groupName: "Maple Garden"
+            )
+        }
+
+        func makeChat() -> PendingChat {
+            PendingChat(
+                groupID: Data(repeating: 0x11, count: 32),
+                ownerIdentityID: owner ?? IdentityID(),
+                introPublicKey: Data(repeating: 0x44, count: 32),
+                groupName: "Maple Garden",
+                inviterAlias: "Alice",
+                invitationMessage: "come in",
+                receivedAt: Date(),
+                status: .offered
+            )
+        }
+
+        func makeGroup(id: String) -> ChatGroup {
+            ChatGroup(
+                id: id,
+                ownerIdentityID: owner ?? IdentityID(),
+                name: "Maple Garden",
+                groupSecret: Data(repeating: 0x33, count: 32),
+                createdAt: Date(),
+                members: [],
+                memberProfiles: [:],
+                epoch: 0,
+                salt: Data(repeating: 0x44, count: 32),
+                commitment: nil,
+                tier: .small,
+                groupType: .tyranny,
+                adminPubkeyHex: nil,
+                adminEd25519PubkeyHex: nil,
+                isPublishedOnChain: false
+            )
+        }
+    }
+
+    private func makeVerification(
+        groupIDHex: String,
+        owner: IdentityID,
+        status: PendingGroupVerification.Status
+    ) -> PendingGroupVerification {
+        PendingGroupVerification(
+            groupIDHex: groupIDHex,
+            ownerIdentityID: owner,
+            groupName: "Maple Garden",
+            status: status,
+            receivedAt: Date()
+        )
+    }
+
+    // MARK: - Waiting
+
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        interval: TimeInterval = 0.02,
+        _ predicate: @MainActor @escaping () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("Timed out waiting for predicate", file: file, line: line)
+    }
+
+    private func waitForAsync(
+        timeout: TimeInterval = 2,
+        interval: TimeInterval = 0.02,
+        _ predicate: @escaping () async -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await predicate() { return }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("Timed out waiting for predicate", file: file, line: line)
+    }
+}
+
+// MARK: - Stubs
+
+/// Stands in for `JoinRequestSender`, with a gate so a test can hold a
+/// send open and observe the in-flight state.
+private actor SpyJoinSender {
+    struct Call: Sendable {
+        let capability: IntroCapability
+        let label: String
+    }
+
+    private(set) var calls: [Call] = []
+    private var outcome: JoinRequestSender.Outcome = .sent
+    private var gate: CheckedContinuation<Void, Never>?
+    private var held = false
+
+    func setOutcome(_ outcome: JoinRequestSender.Outcome) { self.outcome = outcome }
+
+    func hold() { held = true }
+
+    func release() {
+        held = false
+        gate?.resume()
+        gate = nil
+    }
+
+    func send(capability: IntroCapability, label: String) async -> JoinRequestSender.Outcome {
+        calls.append(Call(capability: capability, label: label))
+        if held {
+            await withCheckedContinuation { continuation in
+                if held { gate = continuation } else { continuation.resume() }
+            }
+        }
+        return outcome
+    }
+}
+
+private actor Recorder {
+    private(set) var values: [String] = []
+    func record(_ value: String) { values.append(value) }
+}

--- a/Tests/OnymIOSTests/PendingChatsFlowTests.swift
+++ b/Tests/OnymIOSTests/PendingChatsFlowTests.swift
@@ -76,12 +76,9 @@ final class PendingChatsFlowTests: XCTestCase {
         try await waitFor { harness.flow.rows.count == 1 }
 
         harness.flow.accept(chat.id)
-        try await waitFor {
-            if case .sendFailed(let reason)? = harness.flow.rows.first?.state {
-                return reason.contains("relay rejected")
-            }
-            return false
-        }
+        // The transport's own words are deliberately not kept: the row
+        // is on disk and outlives the language it was written in.
+        try await waitFor { harness.flow.rows.first?.state == .sendFailed(.transport) }
         XCTAssertTrue(harness.flow.rows.first?.state.isRetryable == true)
 
         await harness.sender.setOutcome(.sent)
@@ -102,9 +99,7 @@ final class PendingChatsFlowTests: XCTestCase {
 
         harness.flow.accept(chat.id)
 
-        try await waitFor {
-            harness.flow.rows.first?.state == .sendFailed(reason: String(localized: "Sign in first."))
-        }
+        try await waitFor { harness.flow.rows.first?.state == .sendFailed(.noIdentity) }
         XCTAssertTrue(harness.flow.rows.first?.state.isRetryable == true)
     }
 
@@ -167,6 +162,9 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
+        // Requested first, because that is the only way a verification
+        // for this row can exist: it follows the founder's approval.
+        await harness.repository.markRequested(id: chat.id)
         await harness.verifications.record(makeVerification(
             groupIDHex: chat.groupIDHex, owner: owner, status: .chainUnreachable
         ))
@@ -186,6 +184,9 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
+        // Requested first, because that is the only way a verification
+        // for this row can exist: it follows the founder's approval.
+        await harness.repository.markRequested(id: chat.id)
         await harness.verifications.record(makeVerification(
             groupIDHex: chat.groupIDHex, owner: owner, status: .chainSettling
         ))
@@ -209,6 +210,9 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
+        // Requested first, because that is the only way a verification
+        // for this row can exist: it follows the founder's approval.
+        await harness.repository.markRequested(id: chat.id)
         await harness.verifications.record(makeVerification(
             groupIDHex: chat.groupIDHex, owner: owner, status: .verifying
         ))
@@ -224,6 +228,9 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
+        // Requested first, because that is the only way a verification
+        // for this row can exist: it follows the founder's approval.
+        await harness.repository.markRequested(id: chat.id)
         await harness.verifications.record(makeVerification(
             groupIDHex: chat.groupIDHex, owner: owner, status: .chainNotConfigured
         ))
@@ -252,12 +259,70 @@ final class PendingChatsFlowTests: XCTestCase {
         XCTAssertFalse(row.isDismissable, "there is no stored offer under it to drop")
     }
 
+    func test_askAgain_onAWaitingRow_resendsToTheFounder() async throws {
+        // A request can be sent and never answered — a revoked link, or
+        // one that died in a relay. Before this there was no way out but
+        // swiping the row away.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.repository.markRequested(id: chat.id)
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+        XCTAssertTrue(harness.flow.rows.first?.state.isRetryable == true)
+
+        harness.flow.retry(chat.id)
+
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+        let retries = await harness.verifierRetries.values
+        XCTAssertTrue(retries.isEmpty, "the founder is who this wait belongs to")
+    }
+
+    func test_askAgain_whileVerifying_redrivesTheVerifierInstead() async throws {
+        // Past the approval the wait has changed hands: asking the
+        // founder again would achieve nothing, because they already
+        // said yes.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.repository.markRequested(id: chat.id)
+        await harness.verifications.record(makeVerification(
+            groupIDHex: chat.groupIDHex, owner: owner, status: .verifying
+        ))
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+
+        harness.flow.retry(chat.id)
+
+        try await waitForAsync { await harness.verifierRetries.values == [chat.groupIDHex] }
+        let sends = await harness.sender.calls.count
+        XCTAssertEqual(sends, 0)
+    }
+
+    func test_anUnansweredOffer_keepsItsAcceptEvenWhileVerifying() async throws {
+        // A verification describes a join that was asked for. An offer
+        // has asked for nothing, and letting the overlay win there took
+        // the Accept button away with no way to say yes.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        // Deliberately left unanswered: a stale verification arriving
+        // over an offer must not decide what this row can do.
+        await harness.verifications.record(makeVerification(
+            groupIDHex: chat.groupIDHex, owner: owner, status: .unreachable
+        ))
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        XCTAssertEqual(harness.flow.rows.first?.state, .offered)
+    }
+
     // MARK: - End of the wait
 
     func test_theGroupThatEndedTheWaitIsRememberedAfterTheRowIsGone() async throws {
-        // The pending thread reads this to know where to go. Recorded
-        // before the row is consumed, and kept after — the row vanishing
-        // is exactly the moment the screen needs the answer.
+        // The pending thread reads this to know where to go, and it is
+        // derived from the group snapshot rather than from `rows` —
+        // which may not have arrived when the first emission lands.
         let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()

--- a/Tests/OnymIOSTests/PendingChatsFlowTests.swift
+++ b/Tests/OnymIOSTests/PendingChatsFlowTests.swift
@@ -15,7 +15,7 @@ final class PendingChatsFlowTests: XCTestCase {
     // MARK: - Offers
 
     func test_offer_becomesAnAcceptableRow() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         await harness.repository.record(harness.makeChat())
 
@@ -28,7 +28,7 @@ final class PendingChatsFlowTests: XCTestCase {
     }
 
     func test_accept_shipsTheRequestAndTheRowStartsWaiting() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
@@ -45,7 +45,7 @@ final class PendingChatsFlowTests: XCTestCase {
     }
 
     func test_accept_isDebouncedWhileTheSendIsInFlight() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.sender.hold()
         await harness.flow.start()
         let chat = harness.makeChat()
@@ -61,7 +61,7 @@ final class PendingChatsFlowTests: XCTestCase {
     }
 
     func test_failedSend_showsTheReasonAndRetryResends() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.sender.setOutcome(.transportFailed("relay rejected"))
         await harness.flow.start()
         let chat = harness.makeChat()
@@ -91,7 +91,7 @@ final class PendingChatsFlowTests: XCTestCase {
         // Past the founder's approval, what the person is waiting on has
         // moved on from them — showing "waiting on the founder" then
         // would name someone who has already done their part.
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
@@ -107,7 +107,7 @@ final class PendingChatsFlowTests: XCTestCase {
     }
 
     func test_retry_onAStuckVerification_redrivesTheVerifier() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
@@ -126,7 +126,7 @@ final class PendingChatsFlowTests: XCTestCase {
     func test_chainSettling_offersNoRetry() async throws {
         // It clears itself. Offering an action implies the user is
         // holding it up.
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
@@ -142,7 +142,7 @@ final class PendingChatsFlowTests: XCTestCase {
         // A stale invitation replayed onto a device that never asked in
         // this install. Without a row the group is stuck forever, hidden
         // from the list by design, with no screen left to surface it.
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         await harness.verifications.record(makeVerification(
             groupIDHex: String(repeating: "ab", count: 32),
@@ -158,8 +158,24 @@ final class PendingChatsFlowTests: XCTestCase {
 
     // MARK: - End of the wait
 
+    func test_theGroupThatEndedTheWaitIsRememberedAfterTheRowIsGone() async throws {
+        // The pending thread reads this to know where to go. Recorded
+        // before the row is consumed, and kept after — the row vanishing
+        // is exactly the moment the screen needs the answer.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        await harness.groups.insert(harness.makeGroup(id: chat.groupIDHex))
+
+        try await waitFor { harness.flow.materializedGroupID(for: chat.id) == chat.groupIDHex }
+        XCTAssertTrue(harness.flow.rows.isEmpty)
+    }
+
     func test_theRowDisappearsWhenTheGroupLands() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
@@ -173,7 +189,7 @@ final class PendingChatsFlowTests: XCTestCase {
     // MARK: - Joining from a link
 
     func test_join_recordsARowAndSendsWithoutAsking() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
 
         let outcome = await harness.flow.join(capability: harness.capability())
@@ -184,7 +200,7 @@ final class PendingChatsFlowTests: XCTestCase {
     }
 
     func test_join_twiceOnTheSameLink_doesNotAskTwice() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         await harness.flow.start()
 
         _ = await harness.flow.join(capability: harness.capability())
@@ -197,7 +213,7 @@ final class PendingChatsFlowTests: XCTestCase {
     }
 
     func test_join_whenAlreadyAMember_opensTheChatInstead() async throws {
-        let harness = Harness(owner: owner)
+        let harness = await Harness.make(owner: owner)
         let capability = harness.capability()
         let hex = capability.groupId.map { String(format: "%02x", $0) }.joined()
         await harness.groups.insert(harness.makeGroup(id: hex))
@@ -211,7 +227,7 @@ final class PendingChatsFlowTests: XCTestCase {
     }
 
     func test_join_withNoIdentity_saysSoRatherThanWaitingSilently() async throws {
-        let harness = Harness(owner: nil)
+        let harness = await Harness.make(owner: nil)
         await harness.flow.start()
 
         let outcome = await harness.flow.join(capability: harness.capability())
@@ -235,7 +251,7 @@ final class PendingChatsFlowTests: XCTestCase {
         let flow: PendingChatsFlow
         let owner: IdentityID?
 
-        init(owner: IdentityID?) {
+        private init(owner: IdentityID?) {
             self.owner = owner
             let repository = PendingChatRepository(store: InMemoryPendingChatStore())
             self.repository = repository
@@ -254,11 +270,20 @@ final class PendingChatsFlowTests: XCTestCase {
                 retryVerification: { hex in await retries.record(hex) },
                 currentIdentityID: { owner }
             )
-            Task { [repository, verifications, groups, owner] in
-                await repository.setCurrentIdentity(owner)
-                await verifications.setCurrentIdentity(owner)
-                await groups.setCurrentIdentity(owner)
-            }
+        }
+
+        /// The only way to build one. The identity filter has to be in
+        /// place before a test reads anything: fired off in an
+        /// un-awaited `Task`, it raced every assertion that didn't
+        /// happen to poll — `currentGroups()` is read synchronously, so
+        /// that one test was deciding on a repository that had not been
+        /// told whose groups it holds.
+        static func make(owner: IdentityID?) async -> Harness {
+            let harness = Harness(owner: owner)
+            await harness.repository.setCurrentIdentity(owner)
+            await harness.verifications.setCurrentIdentity(owner)
+            await harness.groups.setCurrentIdentity(owner)
+            return harness
         }
 
         func capability() -> IntroCapability {

--- a/Tests/OnymIOSTests/PendingChatsFlowTests.swift
+++ b/Tests/OnymIOSTests/PendingChatsFlowTests.swift
@@ -55,9 +55,16 @@ final class PendingChatsFlowTests: XCTestCase {
         harness.flow.accept(chat.id)
         harness.flow.accept(chat.id)
 
-        try await waitFor { harness.flow.rows.first?.isSending == true }
-        await harness.sender.release()
+        // Wait on the *spy* being entered, not on `isSending`: that flag
+        // is set synchronously inside `send` before `submitJoin` is ever
+        // awaited, so releasing on it could unblock a gate nobody had
+        // reached yet and prove nothing about the second tap.
         try await waitForAsync { await harness.sender.calls.count == 1 }
+        XCTAssertTrue(harness.flow.rows.first?.isSending == true)
+        await harness.sender.release()
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+        let sent = await harness.sender.calls.count
+        XCTAssertEqual(sent, 1, "the second tap must not ship a second request")
     }
 
     func test_failedSend_showsTheReasonAndRetryResends() async throws {
@@ -83,6 +90,55 @@ final class PendingChatsFlowTests: XCTestCase {
         try await waitFor { harness.flow.rows.first?.state == .waiting }
         let sent2 = await harness.sender.calls.count
         XCTAssertEqual(sent2, 2)
+    }
+
+    func test_noIdentityLoaded_leavesTheRowRetryableWithSomethingToRead() async throws {
+        let harness = await Harness.make(owner: owner)
+        await harness.sender.setOutcome(.noIdentityLoaded)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        harness.flow.accept(chat.id)
+
+        try await waitFor {
+            harness.flow.rows.first?.state == .sendFailed(reason: String(localized: "Sign in first."))
+        }
+        XCTAssertTrue(harness.flow.rows.first?.state.isRetryable == true)
+    }
+
+    func test_malformedInvite_saysSoWithoutTouchingTheSender() async throws {
+        // A capability that can't be rebuilt from the stored row: there
+        // is nothing to send and nothing a Retry could fix, so the row
+        // keeps its state and the error is the whole message.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let malformed = harness.makeChat(introPublicKey: Data([0x01]))
+        await harness.repository.record(malformed)
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        harness.flow.accept(malformed.id)
+
+        XCTAssertNotNil(harness.flow.lastError)
+        let sends = await harness.sender.calls.count
+        XCTAssertEqual(sends, 0)
+        XCTAssertEqual(harness.flow.rows.first?.state, .offered)
+
+        harness.flow.dismissError()
+        XCTAssertNil(harness.flow.lastError)
+    }
+
+    func test_dismiss_dropsTheRow() async throws {
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        try await waitFor { harness.flow.rows.count == 1 }
+
+        harness.flow.dismiss(chat.id)
+
+        try await waitFor { harness.flow.rows.isEmpty }
     }
 
     // MARK: - Verification overlay
@@ -135,7 +191,47 @@ final class PendingChatsFlowTests: XCTestCase {
         ))
 
         try await waitFor { harness.flow.rows.first?.state == .chainSettling }
-        XCTAssertFalse(harness.flow.rows.first?.state.isRetryable == true)
+
+        // Not just "the enum says so": a Retry tapped here must reach
+        // neither the verifier nor the sender.
+        harness.flow.retry(chat.id)
+
+        let retries = await harness.verifierRetries.values
+        let sends = await harness.sender.calls.count
+        XCTAssertTrue(retries.isEmpty)
+        XCTAssertEqual(sends, 0)
+    }
+
+    func test_verifyingStatus_readsAsTheSameWaitAsAskingDoes() async throws {
+        // Before and after the founder's approval are one wait to the
+        // person doing the waiting, so they must not render differently.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.verifications.record(makeVerification(
+            groupIDHex: chat.groupIDHex, owner: owner, status: .verifying
+        ))
+
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+    }
+
+    func test_chainNotConfigured_isRetryableAndSaysSoOnItsOwn() async throws {
+        // Split from `chainUnreachable` because the remedy differs: this
+        // one is usually a cold-launch race, and its Retry re-fetches
+        // the lists rather than asking the founder for anything.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.verifications.record(makeVerification(
+            groupIDHex: chat.groupIDHex, owner: owner, status: .chainNotConfigured
+        ))
+        try await waitFor { harness.flow.rows.first?.state == .chainNotConfigured }
+
+        harness.flow.retry(chat.id)
+
+        try await waitForAsync { await harness.verifierRetries.values == [chat.groupIDHex] }
     }
 
     func test_verificationWithNoOffer_stillGetsARow() async throws {
@@ -204,12 +300,33 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.flow.start()
 
         _ = await harness.flow.join(capability: harness.capability())
-        try await waitForAsync { await harness.sender.calls.count == 1 }
+        // Wait for the row to actually reach `.requested`: on `.offered`
+        // a second tap now (correctly) sends, so asserting before the
+        // status lands would be testing the race, not the rule.
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
         let second = await harness.flow.join(capability: harness.capability())
 
         XCTAssertEqual(second, .waiting(rowID: harness.makeChat().id))
         let sent1 = await harness.sender.calls.count
         XCTAssertEqual(sent1, 1, "a second tap is not a second request")
+    }
+
+    func test_join_onAnUnansweredOffer_sendsInsteadOfAskingAgain() async throws {
+        // The dispatcher got there first. Tapping the link *is* the
+        // answer, so the row must not be left sitting at `.offered`
+        // asking for it a second time.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let offered = harness.makeChat()
+        await harness.repository.record(offered)
+        try await waitFor { harness.flow.rows.first?.state == .offered }
+
+        let outcome = await harness.flow.join(capability: harness.capability())
+
+        XCTAssertEqual(outcome, .waiting(rowID: offered.id))
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+        let sends = await harness.sender.calls.count
+        XCTAssertEqual(sends, 1)
     }
 
     func test_join_whenAlreadyAMember_opensTheChatInstead() async throws {
@@ -294,11 +411,11 @@ final class PendingChatsFlowTests: XCTestCase {
             )
         }
 
-        func makeChat() -> PendingChat {
+        func makeChat(introPublicKey: Data = Data(repeating: 0x44, count: 32)) -> PendingChat {
             PendingChat(
                 groupID: Data(repeating: 0x11, count: 32),
                 ownerIdentityID: owner ?? IdentityID(),
-                introPublicKey: Data(repeating: 0x44, count: 32),
+                introPublicKey: introPublicKey,
                 groupName: "Maple Garden",
                 inviterAlias: "Alice",
                 invitationMessage: "come in",


### PR DESCRIPTION
Stacked on #296.

Three files, one per layer, and each one holds a claim the previous PRs made in prose.

`PendingChatStoreTests` — the key is `(group, owner)`, so a relay replaying an offer collapses onto the row that exists and a chat the user already accepted does not come back asking to be accepted again; two identities on one device keep their own rows for the same group; and rows survive a reopen, which is the entire reason the store is on disk rather than in memory. `reopened()` exists for that last one: a cache that answers correctly right after writing proves nothing about durability.

`PendingChatRepositoryTests` — the per-identity filter, including the cold-start case where no identity is selected yet and the honest answer is nothing rather than someone else's invitations. Also that a group snapshot which matches no pending row touches nothing: every group emission runs through that path, and re-yielding the list each time would repaint the chats list on every unrelated change.

`PendingChatsFlowTests` — where the three sources meet. A verification overlays the stored status rather than adding a second row, because past the founder's approval the wait has moved on from them; a verification with no offer under it still gets a row, undismissable, since that is the stale-invitation case with nowhere else left to show; `chainSettling` offers no Retry; and a link tapped twice is not two requests.

`PendingVerificationStore.record` became public for the overlay tests. The state it holds is rendered a module away, so a test of that seam either gets to write one, or has to stand up the whole verifier to assert on how a row reads.

Full suite: 1474 unit tests green, plus `MultiIdentityChatUITests`, `DeleteChatUITests` and `SearchUITests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)