### PR TITLE
Arriving is not consenting: a link resolves to a screen, not a request

### DIFF
--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
@@ -84,6 +84,10 @@ public struct ChatsView: View {
     /// inside the pending thread, which is precisely the screen a failed
     /// join never reaches.
     @State private var scanJoinError: String?
+    /// A scanned invite awaiting confirmation. A scan is a deliberate
+    /// act, but what it discloses is the same, so it gets the same
+    /// review as a link before anything is sent.
+    @State private var scanConfirmation: PendingChatsFlow.JoinConfirmation?
     /// The chat awaiting a swipe-to-delete confirmation, if any.
     @State private var pendingDelete: ChatListItem?
 
@@ -194,6 +198,24 @@ public struct ChatsView: View {
                 onCancel: { showScanner = false }
             )
         }
+        .sheet(item: $scanConfirmation) { confirmation in
+            JoinConfirmView(
+                confirmation: confirmation,
+                onSend: { label in
+                    let flow = pendingChatsFlow
+                    let navigation = navigation
+                    scanConfirmation = nil
+                    Task { @MainActor in
+                        if case .waiting(let rowID) = await flow.confirmJoin(
+                            confirmation, label: label
+                        ) {
+                            navigation.openPending(rowID: rowID)
+                        }
+                    }
+                },
+                onCancel: { scanConfirmation = nil }
+            )
+        }
         .reasonAlert("Couldn\u{2019}t use that invite", reason: $scanJoinError)
         .alert("Not an Onym invite", isPresented: $scanRejected) {
             Button("OK", role: .cancel) {}
@@ -214,11 +236,13 @@ public struct ChatsView: View {
             let flow = pendingChatsFlow
             let navigation = navigation
             Task { @MainActor in
-                switch await flow.join(capability: cap) {
+                switch await flow.prepareJoin(capability: cap) {
                 case .alreadyJoined(let groupIDHex):
                     navigation.openChat(groupID: groupIDHex)
                 case .waiting(let rowID):
                     navigation.openPending(rowID: rowID)
+                case .confirm(let confirmation):
+                    scanConfirmation = confirmation
                 case .failed(let reason):
                     scanJoinError = reason
                 }

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
@@ -186,8 +186,10 @@ public struct ChatsView: View {
             QRCodeScannerView(
                 onScanned: { raw in
                     // Same allowlist + decode the deeplink path uses, so
-                    // a scanned link and a tapped link reach `join`
-                    // identically. A non-invite QR yields nil → reject.
+                    // a scanned link and a tapped link resolve through
+                    // `prepareJoin` identically — a scan is deliberate,
+                    // but it discloses the same things, so it gets the
+                    // same review. A non-invite QR yields nil → reject.
                     if let cap = DeeplinkCapture.introCapability(fromString: raw) {
                         scannedCapability = cap
                     } else {
@@ -206,10 +208,19 @@ public struct ChatsView: View {
                     let navigation = navigation
                     scanConfirmation = nil
                     Task { @MainActor in
-                        if case .waiting(let rowID) = await flow.confirmJoin(
-                            confirmation, label: label
-                        ) {
+                        // Every outcome, not just the happy one: the
+                        // sheet closes either way, so a row that
+                        // couldn't be written would otherwise look
+                        // exactly like a request that went out.
+                        switch await flow.confirmJoin(confirmation, label: label) {
+                        case .waiting(let rowID):
                             navigation.openPending(rowID: rowID)
+                        case .alreadyJoined(let groupIDHex):
+                            navigation.openChat(groupID: groupIDHex)
+                        case .failed(let reason):
+                            scanJoinError = reason
+                        case .confirm:
+                            break
                         }
                     }
                 },
@@ -228,8 +239,9 @@ public struct ChatsView: View {
     /// dismissed — see the `scannedCapability` note above.
     ///
     /// A scan used to open the join sheet. It now does exactly what a
-    /// tapped link does: sends the request and opens the chat that is on
-    /// its way, so the two entry points can't drift apart.
+    /// tapped link does — resolves to a screen, and sends nothing until
+    /// someone taps Send on it — so the two entry points can't drift
+    /// apart.
     private func handleScannerDismiss() {
         if let cap = scannedCapability {
             scannedCapability = nil

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/JoinConfirmView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/JoinConfirmView.swift
@@ -33,7 +33,6 @@ public struct JoinConfirmView: View {
 
     @State private var label: String = ""
     @State private var isSending = false
-    @FocusState private var nameFocused: Bool
 
     public var body: some View {
         NavigationStack {
@@ -107,6 +106,10 @@ public struct JoinConfirmView: View {
             .accessibilityIdentifier("join_confirm.invitation_message")
     }
 
+    /// Pre-filled, never blank: the identity's own name is the answer
+    /// almost every time, so joining is Send and nothing else. The field
+    /// is here for the times it isn't — a name you'd rather this room
+    /// used — not as a question to answer first.
     private var nameField: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Ask to join as")
@@ -115,7 +118,6 @@ public struct JoinConfirmView: View {
             TextField("Your name in this chat", text: $label)
                 .textInputAutocapitalization(.words)
                 .autocorrectionDisabled()
-                .focused($nameFocused)
                 .padding(12)
                 .background(OnymTokens.surface2)
                 .overlay(
@@ -176,12 +178,18 @@ public struct JoinConfirmView: View {
     }
 
     /// A name is required: an empty one reaches the founder as a blank
-    /// row they are asked to admit.
+    /// row they are asked to admit. It is pre-filled from the identity,
+    /// so this only bites if someone deliberately clears it.
     private var canSend: Bool {
         !isSending && !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private func row(_ key: String, value: String) -> some View {
+    /// `LocalizedStringKey`, not `String`: passing a `String` picks
+    /// `Text`'s non-localizing overload, and these two labels rendered
+    /// English under every locale while their catalog entries sat
+    /// unused. `test_localizable_xcstrings_everyKey_hasEnAndRu` can't
+    /// see this — the key is there, the lookup is what was missing.
+    private func row(_ key: LocalizedStringKey, value: String) -> some View {
         HStack {
             Text(key)
                 .font(.system(size: 11, weight: .semibold))

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/JoinConfirmView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/JoinConfirmView.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+import OnymDesign
+import OnymInbox
+
+/// The screen between an invitation and a join request.
+///
+/// It exists because arriving is not consenting. A link reaches this app
+/// through an exported entry point — another app on the device can open
+/// it, and so can a page in a browser — and the request it would send
+/// carries this identity's name and its long-term public keys to
+/// whoever holds the invite key. Acting on delivery alone let anything
+/// that could form a URL disclose all of that silently. So the link
+/// resolves to this screen, and only the Send below sends.
+///
+/// It also earns its place for the person who *did* tap the link: the
+/// name they arrive under is the name the founder decides on, and until
+/// now they had no chance to set it.
+public struct JoinConfirmView: View {
+    let confirmation: PendingChatsFlow.JoinConfirmation
+    /// Called with the typed name. The caller owns the send.
+    let onSend: (String) -> Void
+    let onCancel: () -> Void
+
+    public init(
+        confirmation: PendingChatsFlow.JoinConfirmation,
+        onSend: @escaping (String) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.confirmation = confirmation
+        self.onSend = onSend
+        self.onCancel = onCancel
+    }
+
+    @State private var label: String = ""
+    @State private var isSending = false
+    @FocusState private var nameFocused: Bool
+
+    public var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 18) {
+                    header
+                    if let message = confirmation.invitationMessage,
+                       !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        invitationCard(message)
+                    }
+                    nameField
+                    disclosure
+                    sendButton
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+                .padding(.bottom, 24)
+            }
+            .background(OnymTokens.bg.ignoresSafeArea())
+            .navigationTitle("Join this chat")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel", action: onCancel)
+                        .accessibilityIdentifier("join_confirm.cancel")
+                }
+            }
+        }
+        .onAppear {
+            if label.isEmpty { label = confirmation.suggestedLabel }
+        }
+    }
+
+    private var displayName: String {
+        let name = confirmation.groupName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let name, !name.isEmpty else { return String(localized: "(Unnamed)") }
+        return name
+    }
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            OnymGroupAvatar(
+                size: 72,
+                accent: OnymAccent.blue.color,
+                ringPulse: false,
+                spinning: false,
+                brand: false,
+                imageData: nil
+            )
+            Text(displayName)
+                .font(.system(size: 20, weight: .bold))
+                .foregroundStyle(OnymTokens.text)
+            let alias = confirmation.inviterAlias.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !alias.isEmpty {
+                Text("\(alias) invited you")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+        }
+    }
+
+    private func invitationCard(_ message: String) -> some View {
+        Text(message)
+            .font(.system(size: 14))
+            .foregroundStyle(OnymTokens.text)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(OnymTokens.surface2)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .textSelection(.enabled)
+            .accessibilityIdentifier("join_confirm.invitation_message")
+    }
+
+    private var nameField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Ask to join as")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(OnymTokens.text3)
+            TextField("Your name in this chat", text: $label)
+                .textInputAutocapitalization(.words)
+                .autocorrectionDisabled()
+                .focused($nameFocused)
+                .padding(12)
+                .background(OnymTokens.surface2)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(OnymTokens.hairline, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .accessibilityIdentifier("join_confirm.name_field")
+            // The name rides with this join only. One identity can be
+            // "Sam" in a book club and "S." in a tenants' group without
+            // either being a second identity.
+            Text("Only this chat sees this name. It doesn\u{2019}t rename your identity.")
+                .font(.system(size: 11))
+                .foregroundStyle(OnymTokens.text2)
+        }
+    }
+
+    /// Names what leaves the device and who receives it, in that order,
+    /// while there is still a way out.
+    private var disclosure: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label {
+                Text("Sending shares your name and this identity\u{2019}s public keys with whoever holds this invite.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+            } icon: {
+                Image(systemName: "person.badge.key")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnymTokens.text2)
+            }
+            row("group", value: shortHex(confirmation.groupIDHex))
+            row("invite key", value: shortHex(hex(confirmation.introPublicKey)))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(OnymTokens.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .accessibilityIdentifier("join_confirm.disclosure")
+    }
+
+    private var sendButton: some View {
+        Button {
+            isSending = true
+            onSend(label.trimmingCharacters(in: .whitespacesAndNewlines))
+        } label: {
+            Text(isSending
+                 ? String(localized: "Sending\u{2026}")
+                 : String(localized: "Send join request"))
+                .font(.system(size: 15, weight: .semibold))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(OnymAccent.blue.color.opacity(canSend ? 1.0 : 0.5))
+                .foregroundStyle(OnymTokens.onAccent)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .disabled(!canSend)
+        .accessibilityIdentifier("join_confirm.send")
+    }
+
+    /// A name is required: an empty one reaches the founder as a blank
+    /// row they are asked to admit.
+    private var canSend: Bool {
+        !isSending && !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func row(_ key: String, value: String) -> some View {
+        HStack {
+            Text(key)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(OnymTokens.text3)
+            Spacer()
+            Text(value)
+                .font(.system(size: 12, weight: .regular, design: .monospaced))
+                .foregroundStyle(OnymTokens.text2)
+        }
+    }
+
+    private func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Enough to compare against what the host is showing, short enough
+    /// to read out loud.
+    private func shortHex(_ value: String) -> String {
+        guard value.count > 12 else { return value }
+        return value.prefix(6) + "\u{2026}" + value.suffix(6)
+    }
+}

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/PendingChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/PendingChatThreadView.swift
@@ -35,6 +35,9 @@ struct PendingChatThreadView: View {
     /// same review, and the same chance to choose a name, whichever door
     /// the invitation came through.
     @State private var confirmation: PendingChatsFlow.JoinConfirmation?
+    /// A Send that never became a request. The confirmation sheet
+    /// dismisses on tap, so this is the only surface left to say so on.
+    @State private var confirmError: String?
 
     var body: some View {
         Group {
@@ -67,6 +70,10 @@ struct PendingChatThreadView: View {
         // The other way a row ends: dismissed from the list, or
         // consumed with no mapping recorded. Nothing to swap to, so
         // leave rather than stand on a screen whose subject is gone.
+        .onChange(of: flow.row(id: rowID) == nil) { _, gone in
+            guard gone, flow.materializedGroupID(for: rowID) == nil else { return }
+            dismiss()
+        }
         .sheet(item: $confirmation) { pending in
             JoinConfirmView(
                 confirmation: pending,
@@ -74,16 +81,21 @@ struct PendingChatThreadView: View {
                     let flow = flow
                     confirmation = nil
                     Task { @MainActor in
-                        await flow.confirmJoin(pending, label: label)
+                        // The sheet is already gone by the time this
+                        // answers, so a failure has nowhere to show
+                        // itself but here — and unshown, it reads as a
+                        // request that went out.
+                        if case .failed(let reason) = await flow.confirmJoin(
+                            pending, label: label
+                        ) {
+                            confirmError = reason
+                        }
                     }
                 },
                 onCancel: { confirmation = nil }
             )
         }
-        .onChange(of: flow.row(id: rowID) == nil) { _, gone in
-            guard gone, flow.materializedGroupID(for: rowID) == nil else { return }
-            dismiss()
-        }
+        .reasonAlert("Couldn\u{2019}t use that invite", reason: $confirmError)
         .accessibilityIdentifier("pending_chat.thread")
     }
 

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/PendingChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/PendingChatThreadView.swift
@@ -31,6 +31,10 @@ struct PendingChatThreadView: View {
     /// the other one. Standing on a screen whose subject no longer
     /// exists is not a state worth rendering.
     @Environment(\.dismiss) private var dismiss
+    /// Accept opens the confirmation screen rather than sending: the
+    /// same review, and the same chance to choose a name, whichever door
+    /// the invitation came through.
+    @State private var confirmation: PendingChatsFlow.JoinConfirmation?
 
     var body: some View {
         Group {
@@ -63,6 +67,19 @@ struct PendingChatThreadView: View {
         // The other way a row ends: dismissed from the list, or
         // consumed with no mapping recorded. Nothing to swap to, so
         // leave rather than stand on a screen whose subject is gone.
+        .sheet(item: $confirmation) { pending in
+            JoinConfirmView(
+                confirmation: pending,
+                onSend: { label in
+                    let flow = flow
+                    confirmation = nil
+                    Task { @MainActor in
+                        await flow.confirmJoin(pending, label: label)
+                    }
+                },
+                onCancel: { confirmation = nil }
+            )
+        }
         .onChange(of: flow.row(id: rowID) == nil) { _, gone in
             guard gone, flow.materializedGroupID(for: rowID) == nil else { return }
             dismiss()
@@ -149,7 +166,11 @@ struct PendingChatThreadView: View {
                     identifier: "pending_chat.accept",
                     disabled: row.isSending
                 ) {
-                    flow.accept(row.id)
+                    let flow = flow
+                    let rowID = row.id
+                    Task { @MainActor in
+                        confirmation = await flow.prepareAccept(rowID: rowID)
+                    }
                 }
             case .waiting:
                 waiting(

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingChat.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingChat.swift
@@ -69,6 +69,17 @@ public struct PendingChat: Identifiable, Equatable, Sendable {
     public let inviterAlias: String
     /// The founder's free-text invitation, when the offer carried one.
     public let invitationMessage: String?
+    /// The name this device asked to be let in under, as typed on the
+    /// confirmation screen.
+    ///
+    /// Kept because a re-send has to introduce the same person. Falling
+    /// back to the identity's current alias would quietly change the
+    /// name the founder is looking at between the first request and the
+    /// second — and they are deciding partly on that name.
+    ///
+    /// `nil` until the person has confirmed a join, which is also the
+    /// marker that nothing has been sent for this row yet.
+    public var joinerLabel: String?
     /// When this device first saw the offer or tapped the link — the
     /// row's sort key in the chats list.
     public let receivedAt: Date
@@ -96,7 +107,8 @@ public struct PendingChat: Identifiable, Equatable, Sendable {
         inviterAlias: String,
         invitationMessage: String?,
         receivedAt: Date,
-        status: Status
+        status: Status,
+        joinerLabel: String? = nil
     ) {
         self.groupID = groupID
         self.groupIDHex = groupID.map { String(format: "%02x", $0) }.joined()
@@ -107,6 +119,7 @@ public struct PendingChat: Identifiable, Equatable, Sendable {
         self.invitationMessage = invitationMessage
         self.receivedAt = receivedAt
         self.status = status
+        self.joinerLabel = joinerLabel
     }
 }
 

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingChatRepository.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingChatRepository.swift
@@ -68,6 +68,13 @@ public actor PendingChatRepository: PendingChatRecording {
         await refreshFromStore()
     }
 
+    /// Remember the name this device asked under, so a re-send
+    /// introduces the same person.
+    public func attachJoinerLabel(id: String, label: String) async {
+        await store.setJoinerLabel(id: id, label: label)
+        await refreshFromStore()
+    }
+
     /// Drop a row the user swiped away. Local only — no NACK to the
     /// founder, whose outstanding intro key simply goes unused.
     public func remove(id: String) async {

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingChatStore.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingChatStore.swift
@@ -31,6 +31,10 @@ public protocol PendingChatStore: Sendable {
         inviterAlias: String,
         invitationMessage: String?
     ) async
+    /// Remember the name this device asked to be let in under, so a
+    /// re-send introduces the same person — see
+    /// `PendingChat.joinerLabel`.
+    func setJoinerLabel(id: String, label: String) async
     func delete(id: String) async
     /// Drop rows by id — `<group id hex>:<owner uuid>`, the same key
     /// `insert` dedupes on. Ids rather than group hexes because two
@@ -83,6 +87,11 @@ public actor InMemoryPendingChatStore: PendingChatStore {
             receivedAt: existing.receivedAt,
             status: existing.status
         )
+    }
+
+    public func setJoinerLabel(id: String, label: String) async {
+        guard let index = rows.firstIndex(where: { $0.id == id }) else { return }
+        rows[index].joinerLabel = label
     }
 
     public func delete(id: String) async {

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingChatsFlow.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingChatsFlow.swift
@@ -363,6 +363,13 @@ public final class PendingChatsFlow {
             guard let chat = pending.first(where: { $0.id == rowID }) else {
                 return .failed(reason: String(localized: "Couldn\u{2019}t save this invite on your device."))
             }
+            // The same `.offered` check `prepareAccept` made, re-made
+            // here: an open screen can outlive the state it was opened
+            // on, and a row that has already asked has nothing left to
+            // send — the wait is the whole answer. `send`'s debounce
+            // catches the double tap; this catches the row that moved
+            // on underneath.
+            guard chat.status == .offered else { return .waiting(rowID: rowID) }
             await repository.attachJoinerLabel(id: rowID, label: trimmed)
             send(chat, label: trimmed)
             return .waiting(rowID: rowID)
@@ -403,8 +410,6 @@ public final class PendingChatsFlow {
         }
     }
 
-
-
     /// Act on whatever this row is stuck on: re-drive a stalled
     /// verification, or ask again — a request that never left, or one
     /// that left and was never answered.
@@ -430,11 +435,26 @@ public final class PendingChatsFlow {
             }
             guard let chat = pending.first(where: { $0.id == id }) else { return }
             // Under the name this row already asked under — a re-send
-            // that renamed the asker would arrive from a stranger. A row
-            // with no label has sent nothing yet, and there is nothing
-            // for a retry to repeat.
-            guard let label = chat.joinerLabel else { return }
-            send(chat, label: label)
+            // that renamed the asker would arrive from a stranger.
+            //
+            // A row can have no label and still have asked: every row
+            // written before the confirmation screen existed sent under
+            // the identity's own name, and those are the rows most
+            // likely to need this, having waited through an update. So
+            // the fallback is that name, attached on the way out so the
+            // one after this repeats it rather than re-deriving it from
+            // an identity that may since have been renamed.
+            if let label = chat.joinerLabel {
+                send(chat, label: label)
+                return
+            }
+            let repository = self.repository
+            let displayLabel = self.displayLabel
+            Task { @MainActor [weak self] in
+                let label = await displayLabel()
+                await repository.attachJoinerLabel(id: id, label: label)
+                self?.send(chat, label: label)
+            }
         case .offered, .chainSettling:
             break
         }

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingChatsFlow.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingChatsFlow.swift
@@ -222,35 +222,63 @@ public final class PendingChatsFlow {
         materialized[rowID]
     }
 
-    /// Where a tapped invite link (or scanned QR) leaves the user.
-    public enum JoinOutcome: Equatable, Sendable {
+    /// What a tapped invite link (or scanned QR) resolves to.
+    ///
+    /// Note what is *not* here: sending. A link arrives through an
+    /// exported entry point — any app on the device can open it, and so
+    /// can a page in a browser — so the arrival is a request to show
+    /// something, never permission to speak. Every case below is
+    /// therefore a screen; the request goes out from
+    /// `confirmJoin(_:label:)`, which only a person can reach.
+    public enum JoinDestination: Equatable, Sendable {
         /// Already a member — the link was an old one, or a second tap.
         /// Carries the hex group id so the caller can just open the chat.
         case alreadyJoined(groupIDHex: String)
-        /// A pending row exists and the wait is under way. The request
-        /// is either on its way or already out — an unanswered offer for
-        /// the same group is sent here, one already asked for is not
-        /// asked twice.
+        /// This device has already asked. Nothing more to send, and
+        /// nothing more to disclose: open the wait.
         case waiting(rowID: String)
-        /// Nothing could be recorded, so there is nothing to show and
-        /// nothing to come back to. The caller has to say so out loud.
+        /// Show the confirmation screen.
+        case confirm(JoinConfirmation)
+        /// Nothing could be resolved, and the caller has to say so.
         case failed(reason: String)
     }
 
-    /// Take a capability from a tapped link or a scanned QR and turn it
-    /// into a chat that is on its way.
+    /// Everything the confirmation screen shows, and everything
+    /// `confirmJoin` needs to act on it.
     ///
-    /// This is what replaced the join sheet. The sheet asked for a
-    /// display name and a Send tap before anything happened, and held
-    /// the entire wait in memory behind a modal the user was told to
-    /// keep open. Tapping the link *is* the intent, so the request goes
-    /// out with the active identity's name and the wait becomes a row —
-    /// which survives a force-quit, unlike the sheet.
-    ///
-    /// Re-tapping a link the user already acted on is deliberately not a
-    /// second request: an existing row is returned as-is, and a Retry
-    /// inside it is the way to send again.
-    public func join(capability: IntroCapability) async -> JoinOutcome {
+    /// It exists so the screen can name *who* is about to learn *what*
+    /// before anything leaves the device: the group, the person who
+    /// invited (when one did), and the invite key the request would be
+    /// sealed to.
+    public struct JoinConfirmation: Identifiable, Equatable, Sendable {
+        /// Where the confirmation came from — a link this device just
+        /// received, or an offer already sitting in the list.
+        public enum Origin: Equatable, Sendable {
+            case link(IntroCapability)
+            case offer(rowID: String)
+        }
+
+        public var id: String { rowID }
+        /// The row this will create or act on — `<group hex>:<owner>`.
+        public let rowID: String
+        public let groupIDHex: String
+        public let groupName: String?
+        /// Empty for a link: nobody introduced themselves.
+        public let inviterAlias: String
+        public let invitationMessage: String?
+        /// The invite key the request is sealed to, for display. Whoever
+        /// holds its private half is who this discloses to, and that is
+        /// worth showing rather than describing.
+        public let introPublicKey: Data
+        /// Pre-filled into the name field: the identity's own alias, or
+        /// the name a previous attempt on this row used.
+        public let suggestedLabel: String
+        let origin: Origin
+    }
+
+    /// Resolve a capability into the next screen. Records nothing, sends
+    /// nothing — see `JoinDestination`.
+    public func prepareJoin(capability: IntroCapability) async -> JoinDestination {
         guard let owner = await currentIdentityID() else {
             return .failed(reason: String(localized: "Sign in first."))
         }
@@ -261,48 +289,121 @@ public final class PendingChatsFlow {
         if groups.contains(where: { $0.id == groupIDHex && $0.ownerIdentityID == owner }) {
             return .alreadyJoined(groupIDHex: groupIDHex)
         }
-        let chat = PendingChat(
-            groupID: capability.groupId,
-            ownerIdentityID: owner,
-            introPublicKey: capability.introPublicKey,
-            groupName: capability.groupName,
-            // Nobody introduced themselves over a link — the row shows
-            // the group, not a person who never said their name.
-            inviterAlias: "",
-            invitationMessage: nil,
-            receivedAt: Date(),
-            status: .offered
+        let rowID = "\(groupIDHex):\(owner.rawValue.uuidString)"
+        let existing = await repository.currentChats().first { $0.id == rowID }
+        // Already asked, on this link or a pushed offer for the same
+        // group: one tap, one request. The wait is the whole answer.
+        if let existing, existing.status != .offered {
+            return .waiting(rowID: rowID)
+        }
+        // `??` takes an autoclosure, which can't await — and the name
+        // this row asked under, when it has one, is the one to offer
+        // back.
+        let suggested: String
+        if let asked = existing?.joinerLabel {
+            suggested = asked
+        } else {
+            suggested = await displayLabel()
+        }
+        return .confirm(
+            JoinConfirmation(
+                rowID: rowID,
+                groupIDHex: groupIDHex,
+                groupName: capability.groupName ?? existing?.groupName,
+                inviterAlias: existing?.inviterAlias ?? "",
+                invitationMessage: existing?.invitationMessage,
+                introPublicKey: capability.introPublicKey,
+                suggestedLabel: suggested,
+                origin: .link(capability)
+            )
         )
-        switch await repository.record(chat) {
-        case .inserted:
-            send(chat)
-            return .waiting(rowID: chat.id)
-        case .alreadyPresent:
-            // A pushed offer for this group arrived first and is still
-            // unanswered. Tapping the link *is* the answer — leaving the
-            // row at `.offered` would land the user on a screen asking
-            // for the intent they just expressed, which is the whole
-            // thing this change removes. An already-`.requested` row is
-            // left alone: one link tap, one request.
-            let existing = await repository.currentChats().first { $0.id == chat.id }
-            if let existing, existing.status == .offered {
-                send(existing)
+    }
+
+    /// The same screen, reached from the Accept on a pushed offer.
+    ///
+    /// One path for both, so what a person is shown before their name
+    /// and keys leave the device does not depend on which door the
+    /// invitation came through.
+    public func prepareAccept(rowID: String) async -> JoinConfirmation? {
+        guard let chat = pending.first(where: { $0.id == rowID }), chat.status == .offered
+        else { return nil }
+        let suggested: String
+        if let asked = chat.joinerLabel {
+            suggested = asked
+        } else {
+            suggested = await displayLabel()
+        }
+        return JoinConfirmation(
+            rowID: chat.id,
+            groupIDHex: chat.groupIDHex,
+            groupName: chat.groupName,
+            inviterAlias: chat.inviterAlias,
+            invitationMessage: chat.invitationMessage,
+            introPublicKey: chat.introPublicKey,
+            suggestedLabel: suggested,
+            origin: .offer(rowID: chat.id)
+        )
+    }
+
+    /// The one place a join request is sent, and the only one a person
+    /// can reach: the Send on the confirmation screen.
+    ///
+    /// `label` is what they typed. It rides with this join and does not
+    /// touch the identity — one identity can introduce itself
+    /// differently to different rooms — and it is stored on the row so a
+    /// later re-send says the same thing.
+    @discardableResult
+    public func confirmJoin(
+        _ confirmation: JoinConfirmation,
+        label: String
+    ) async -> JoinDestination {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch confirmation.origin {
+        case .offer(let rowID):
+            guard let chat = pending.first(where: { $0.id == rowID }) else {
+                return .failed(reason: String(localized: "Couldn\u{2019}t save this invite on your device."))
             }
-            return .waiting(rowID: chat.id)
-        case .failed, .notRecorded:
-            return .failed(reason: String(localized: "Couldn\u{2019}t save this invite on your device."))
+            await repository.attachJoinerLabel(id: rowID, label: trimmed)
+            send(chat, label: trimmed)
+            return .waiting(rowID: rowID)
+        case .link(let capability):
+            guard let owner = await currentIdentityID() else {
+                return .failed(reason: String(localized: "Sign in first."))
+            }
+            let chat = PendingChat(
+                groupID: capability.groupId,
+                ownerIdentityID: owner,
+                introPublicKey: capability.introPublicKey,
+                groupName: capability.groupName,
+                // Nobody introduced themselves over a link — the row
+                // shows the group, not a person who never said their
+                // name.
+                inviterAlias: "",
+                invitationMessage: nil,
+                receivedAt: Date(),
+                status: .offered,
+                joinerLabel: trimmed
+            )
+            switch await repository.record(chat) {
+            case .inserted:
+                send(chat, label: trimmed)
+                return .waiting(rowID: chat.id)
+            case .alreadyPresent:
+                // A pushed offer for this group arrived first and is
+                // still unanswered — this Send is the answer to it.
+                await repository.attachJoinerLabel(id: chat.id, label: trimmed)
+                let existing = await repository.currentChats().first { $0.id == chat.id }
+                if let existing, existing.status == .offered {
+                    send(existing, label: trimmed)
+                }
+                return .waiting(rowID: chat.id)
+            case .failed, .notRecorded:
+                return .failed(reason: String(localized: "Couldn\u{2019}t save this invite on your device."))
+            }
         }
     }
 
-    /// Explicit Accept on a pushed offer: ship a join request to the
-    /// offer's intro key. No-op once something is in flight, or once the
-    /// row has moved past `.offered`.
-    public func accept(_ id: String) {
-        guard let chat = pending.first(where: { $0.id == id }), chat.status == .offered else {
-            return
-        }
-        send(chat)
-    }
+
 
     /// Act on whatever this row is stuck on: re-drive a stalled
     /// verification, or ask again — a request that never left, or one
@@ -328,15 +429,24 @@ public final class PendingChatsFlow {
                 return
             }
             guard let chat = pending.first(where: { $0.id == id }) else { return }
-            send(chat)
+            // Under the name this row already asked under — a re-send
+            // that renamed the asker would arrive from a stranger. A row
+            // with no label has sent nothing yet, and there is nothing
+            // for a retry to repeat.
+            guard let label = chat.joinerLabel else { return }
+            send(chat, label: label)
         case .offered, .chainSettling:
             break
         }
     }
 
-    /// The one send path, shared by Accept and by Retry-after-failure.
-    /// Debounced on `sendingIDs` so a double tap ships one request.
-    private func send(_ chat: PendingChat) {
+    /// The one send path, shared by the confirmation screen's Send and
+    /// by a re-send. Debounced on `sendingIDs` so a double tap ships one
+    /// request.
+    ///
+    /// `label` is always supplied by a caller a person reached: there is
+    /// no path from an inbound link or event to here.
+    private func send(_ chat: PendingChat, label: String) {
         let id = chat.id
         guard !sendingIDs.contains(id) else { return }
         let capability: IntroCapability
@@ -353,11 +463,10 @@ public final class PendingChatsFlow {
         sendingIDs.insert(id)
         lastError = nil
         rebuild()
-        let displayLabel = self.displayLabel
         let submitJoin = self.submitJoin
         let repository = self.repository
         Task { @MainActor [weak self] in
-            let outcome = await submitJoin(capability, await displayLabel())
+            let outcome = await submitJoin(capability, label)
             switch outcome {
             case .sent:
                 await repository.markRequested(id: id)

--- a/Packages/OnymInbox/Sources/OnymInbox/PersistedPendingChat.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PersistedPendingChat.swift
@@ -50,6 +50,10 @@ final class PersistedPendingChat {
     var encryptedGroupName: Data?
     var encryptedInviterAlias: Data
     var encryptedInvitationMessage: Data?
+    /// The name typed on the confirmation screen. Encrypted with the
+    /// rest of the person-supplied text; `nil` means nothing has been
+    /// sent for this row yet.
+    var encryptedJoinerLabel: Data?
 
     init(
         id: String,
@@ -61,7 +65,8 @@ final class PersistedPendingChat {
         encryptedIntroPublicKey: Data,
         encryptedGroupName: Data?,
         encryptedInviterAlias: Data,
-        encryptedInvitationMessage: Data?
+        encryptedInvitationMessage: Data?,
+        encryptedJoinerLabel: Data? = nil
     ) {
         self.id = id
         self.ownerIdentityIDString = ownerIdentityIDString
@@ -73,5 +78,6 @@ final class PersistedPendingChat {
         self.encryptedGroupName = encryptedGroupName
         self.encryptedInviterAlias = encryptedInviterAlias
         self.encryptedInvitationMessage = encryptedInvitationMessage
+        self.encryptedJoinerLabel = encryptedJoinerLabel
     }
 }

--- a/Packages/OnymInbox/Sources/OnymInbox/SwiftDataPendingChatStore.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/SwiftDataPendingChatStore.swift
@@ -125,6 +125,17 @@ public actor SwiftDataPendingChatStore: PendingChatStore {
         try? context.save()
     }
 
+    public func setJoinerLabel(id: String, label: String) async {
+        let descriptor = FetchDescriptor<PersistedPendingChat>(
+            predicate: #Predicate { $0.id == id }
+        )
+        guard let row = (try? context.fetch(descriptor))?.first,
+              let encrypted = try? StorageEncryption.encrypt(label)
+        else { return }
+        row.encryptedJoinerLabel = encrypted
+        try? context.save()
+    }
+
     public func delete(id: String) async {
         let descriptor = FetchDescriptor<PersistedPendingChat>(
             predicate: #Predicate { $0.id == id }
@@ -204,7 +215,8 @@ public actor SwiftDataPendingChatStore: PendingChatStore {
             encryptedIntroPublicKey: try StorageEncryption.encrypt(chat.introPublicKey),
             encryptedGroupName: try chat.groupName.map(StorageEncryption.encrypt),
             encryptedInviterAlias: try StorageEncryption.encrypt(chat.inviterAlias),
-            encryptedInvitationMessage: try chat.invitationMessage.map(StorageEncryption.encrypt)
+            encryptedInvitationMessage: try chat.invitationMessage.map(StorageEncryption.encrypt),
+            encryptedJoinerLabel: try chat.joinerLabel.map(StorageEncryption.encrypt)
         )
     }
 
@@ -230,7 +242,9 @@ public actor SwiftDataPendingChatStore: PendingChatStore {
             invitationMessage: row.encryptedInvitationMessage
                 .flatMap { try? StorageEncryption.decryptString($0) },
             receivedAt: row.receivedAt,
-            status: status(raw: row.statusRaw, failure: row.failureRaw)
+            status: status(raw: row.statusRaw, failure: row.failureRaw),
+            joinerLabel: row.encryptedJoinerLabel
+                .flatMap { try? StorageEncryption.decryptString($0) }
         )
     }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -166,6 +166,23 @@
         }
       }
     },
+    "Ask to join as": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ask to join as"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Попросить впустить как"
+          }
+        }
+      }
+    },
     "Back": {
       "localizations": {
         "en": {
@@ -457,6 +474,40 @@
         }
       }
     },
+    "group": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "group"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "группа"
+          }
+        }
+      }
+    },
+    "invite key": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "invite key"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ключ приглашения"
+          }
+        }
+      }
+    },
     "Its catalogs are being fetched and verified now — the next steps can offer what it lists.": {
       "localizations": {
         "en": {
@@ -469,6 +520,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Его каталоги уже загружаются и проверяются — следующие шаги смогут предложить то, что он публикует."
+          }
+        }
+      }
+    },
+    "Join this chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Join this chat"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Присоединиться к чату"
           }
         }
       }
@@ -665,6 +733,23 @@
         }
       }
     },
+    "Only this chat sees this name. It doesn’t rename your identity.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only this chat sees this name. It doesn’t rename your identity."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это имя видит только этот чат. Оно не переименовывает вашу личность."
+          }
+        }
+      }
+    },
     "Pin Key & Confirm": {
       "localizations": {
         "en": {
@@ -806,6 +891,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Запускает первичную настройку заново: доставка сообщений, хранилище файлов, нотариус и модерация. Ваша идентичность, чаты и сообщения сохраняются, а текущий выбор остаётся в силе, пока вы его не измените."
+          }
+        }
+      }
+    },
+    "Sending shares your name and this identity’s public keys with whoever holds this invite.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending shares your name and this identity’s public keys with whoever holds this invite."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "При отправке ваше имя и открытые ключи этой личности получит тот, у кого есть это приглашение."
           }
         }
       }
@@ -1194,6 +1296,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ваши ключи — ваши сервисы. Выберите, кто доставляет ваши сообщения, хранит ваши файлы и заверяет вашу историю. Каждый выбор — ваш, и любой можно изменить позже в настройках."
+          }
+        }
+      }
+    },
+    "Your name in this chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your name in this chat"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваше имя в этом чате"
           }
         }
       }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -75,6 +75,9 @@ struct OnymIOSApp: App {
     /// can come back to. Rare, and silent failure here would leave
     /// someone waiting on a request that was never recorded.
     @State private var joinLinkError: String?
+    /// The confirmation a tapped link resolved to, if any. Nothing has
+    /// been recorded or sent while this is set — that is the point.
+    @State private var joinConfirmation: PendingChatsFlow.JoinConfirmation?
 
     init() {
         let args = ProcessInfo.processInfo.arguments
@@ -1974,26 +1977,59 @@ struct OnymIOSApp: App {
                     pendingCapability = nil
                     Task { await handleCapability(captured) }
                 }
+                .sheet(item: $joinConfirmation) { confirmation in
+                    JoinConfirmView(
+                        confirmation: confirmation,
+                        onSend: { label in
+                            Task { await sendConfirmedJoin(confirmation, label: label) }
+                        },
+                        onCancel: { joinConfirmation = nil }
+                    )
+                }
                 .reasonAlert("Couldn\u{2019}t use that invite", reason: $joinLinkError)
         }
     }
 
-    /// Ship the join request for a tapped link and open what it made.
+    /// Resolve a tapped link into the next screen — and nothing else.
     ///
-    /// Both outcomes are a navigation: a link the user is already inside
-    /// opens that chat rather than starting a second wait, and a fresh
-    /// one opens the pending chat the request created. The alert is for
-    /// the case where neither exists — without it a failed link is
-    /// indistinguishable from a link that worked.
+    /// The URL types this app registers are open to anything on the
+    /// device that can form a link, so arrival cannot be treated as
+    /// permission to introduce this identity to a stranger. A link the
+    /// user is already inside opens that chat; one they have already
+    /// asked about opens the wait; anything else opens the confirmation
+    /// screen, which is the only place a request is sent from. The alert
+    /// is for the case where none of those exist — without it a failed
+    /// link is indistinguishable from a link that worked.
     @MainActor
     private func handleCapability(_ capability: IntroCapability) async {
-        switch await dependencies.pendingChatsFlow.join(capability: capability) {
+        switch await dependencies.pendingChatsFlow.prepareJoin(capability: capability) {
         case .alreadyJoined(let groupIDHex):
             dependencies.chatsNavigation.openChat(groupID: groupIDHex)
         case .waiting(let rowID):
             dependencies.chatsNavigation.openPending(rowID: rowID)
+        case .confirm(let confirmation):
+            joinConfirmation = confirmation
         case .failed(let reason):
             joinLinkError = reason
+        }
+    }
+
+    /// Send what the person confirmed, then open the wait it started.
+    @MainActor
+    private func sendConfirmedJoin(
+        _ confirmation: PendingChatsFlow.JoinConfirmation,
+        label: String
+    ) async {
+        joinConfirmation = nil
+        switch await dependencies.pendingChatsFlow.confirmJoin(confirmation, label: label) {
+        case .waiting(let rowID):
+            dependencies.chatsNavigation.openPending(rowID: rowID)
+        case .alreadyJoined(let groupIDHex):
+            dependencies.chatsNavigation.openChat(groupID: groupIDHex)
+        case .failed(let reason):
+            joinLinkError = reason
+        case .confirm:
+            break
         }
     }
 }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -794,16 +794,27 @@ struct OnymIOSApp: App {
             displayLabel: { [repository] in
                 // Repository, not `identitiesFlow` — the same cold-start
                 // reason as `currentIdentityID` below. A link that
-                // launches the app sends before any tab has populated
-                // the flow, and an empty name is what the founder would
-                // have been asked to let in.
-                await repository.currentIdentityName() ?? ""
+                // launches the app resolves before any tab has populated
+                // the flow.
+                //
+                // `currentIdentityName()` is a cache read that answers
+                // nil until the keychain has been walked, and on the
+                // cold-start link it hadn't been: the confirmation
+                // screen opened with an empty name field, and joining a
+                // chat meant typing your own name first. `ensureLoaded`
+                // is what `currentIdentities()` is for.
+                _ = try? await repository.currentIdentities()
+                return await repository.currentIdentityName() ?? ""
             },
             retryVerification: { [groupStateVerifier] groupIDHex in
                 await groupStateVerifier.retry(groupIDHex: groupIDHex)
             },
             currentIdentityID: { [repository] in
-                await repository.currentSelectedID()
+                // Same cold start, same cache: the selection is restored
+                // during the load, so asking before it answers "sign in
+                // first" for a link that launched the app.
+                _ = try? await repository.currentIdentities()
+                return await repository.currentSelectedID()
             }
         )
 
@@ -1964,14 +1975,15 @@ struct OnymIOSApp: App {
                         pendingCapability = cap
                     }
                 }
-                // A tapped link no longer opens anything of its own. It
-                // sends the request and lands the user in the chat it
-                // created — pending until the founder lets them in.
+                // A tapped link resolves to a screen — the chat if
+                // this identity is already in, the wait if it has
+                // already asked, otherwise the confirmation sheet
+                // below. Nothing is sent from here.
                 // Deliberately not `.task(id:)`: clearing the capture
                 // would change the id and cancel the very task doing the
-                // work, mid-send. This one outlives the view's task
-                // lifetime, which is right — the request has to go out
-                // whether or not the user stays on this screen.
+                // work, mid-resolve. This one outlives the view's task
+                // lifetime, which is right — the link has to reach its
+                // screen whether or not this view stays mounted.
                 .onChange(of: pendingCapability) { _, captured in
                     guard let captured else { return }
                     pendingCapability = nil

--- a/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
+++ b/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
@@ -311,6 +311,11 @@ final class PendingChatRepositoryTests: XCTestCase {
             )
         }
 
+        func setJoinerLabel(id: String, label: String) async {
+            guard let index = rows.firstIndex(where: { $0.id == id }) else { return }
+            rows[index].joinerLabel = label
+        }
+
         func delete(id: String) async {
             rows.removeAll { $0.id == id }
         }

--- a/Tests/OnymIOSTests/PendingChatsFlowTests.swift
+++ b/Tests/OnymIOSTests/PendingChatsFlowTests.swift
@@ -315,6 +315,35 @@ final class PendingChatsFlowTests: XCTestCase {
         XCTAssertTrue(retries.isEmpty, "the founder is who this wait belongs to")
     }
 
+    func test_askAgain_onARowFromBeforeTheScreen_asksUnderTheIdentityName() async throws {
+        // Every row already on disk when this version installs has no
+        // stored label: the field is new. Those rows asked under the
+        // identity's own name, and they are the ones most likely to
+        // need asking again, having sat through an update. A retry that
+        // bailed on the missing label made "Ask again" a button that
+        // did nothing for exactly them.
+        //
+        // Seeded the pre-#299 way — recorded and marked requested, with
+        // no trip through the confirmation screen.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.repository.markRequested(id: chat.id)
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+
+        harness.flow.retry(chat.id)
+
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+        let label = await harness.sender.calls.first?.label
+        XCTAssertEqual(label, "Bob", "the name it asked under the first time")
+        // And attached, so the next repeat says the same thing even if
+        // the identity is renamed in between.
+        try await waitForAsync {
+            await harness.repository.currentChats().first?.joinerLabel == "Bob"
+        }
+    }
+
     func test_askAgain_whileVerifying_redrivesTheVerifierInstead() async throws {
         // Past the approval the wait has changed hands: asking the
         // founder again would achieve nothing, because they already
@@ -322,12 +351,21 @@ final class PendingChatsFlowTests: XCTestCase {
         let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()
-        await harness.repository.record(chat)
-        await harness.repository.markRequested(id: chat.id)
+        // The verification first, and waited for by the row it
+        // synthesises on its own: `.requested` and "verifying" both
+        // read as `.waiting`, so waiting on the state can't tell
+        // whether the flow has seen the verification yet — and a retry
+        // that ran before it had would ask the founder again, which is
+        // the exact thing this test says doesn't happen.
         await harness.verifications.record(makeVerification(
             groupIDHex: chat.groupIDHex, owner: owner, status: .verifying
         ))
-        try await waitFor { harness.flow.rows.first?.state == .waiting }
+        try await waitFor { harness.flow.rows.first?.id == chat.groupIDHex }
+        await harness.repository.record(chat)
+        await harness.repository.markRequested(id: chat.id)
+        try await waitFor {
+            harness.flow.rows.count == 1 && harness.flow.rows.first?.state == .waiting
+        }
 
         harness.flow.retry(chat.id)
 
@@ -407,6 +445,21 @@ final class PendingChatsFlowTests: XCTestCase {
         let stored = await harness.repository.currentChats()
         XCTAssertTrue(stored.isEmpty, "nothing may be persisted before a person says so")
         XCTAssertTrue(harness.flow.rows.isEmpty)
+    }
+
+    func test_theConfirmationArrivesPreFilledWithTheIdentitysName() async throws {
+        // Joining is one tap. The name a person asks under is almost
+        // always their own, so the field carries it already and Send is
+        // the only thing left to do — typing your own name to get into a
+        // chat is a question with a known answer.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+
+        guard case .confirm(let confirmation) =
+                await harness.flow.prepareJoin(capability: harness.capability())
+        else { return XCTFail("expected a confirmation") }
+
+        XCTAssertEqual(confirmation.suggestedLabel, "Bob")
     }
 
     func test_confirmingALink_recordsTheRowAndSendsUnderTheTypedName() async throws {

--- a/Tests/OnymIOSTests/PendingChatsFlowTests.swift
+++ b/Tests/OnymIOSTests/PendingChatsFlowTests.swift
@@ -27,21 +27,51 @@ final class PendingChatsFlowTests: XCTestCase {
         XCTAssertTrue(row.isDismissable)
     }
 
-    func test_accept_shipsTheRequestAndTheRowStartsWaiting() async throws {
+    func test_acceptingAnOffer_sendsOnlyOnceConfirmed() async throws {
         let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
         try await waitFor { harness.flow.rows.count == 1 }
 
-        harness.flow.accept(chat.id)
+        // Preparing the screen is not sending. Accept is a tap on a row
+        // that only a real inbound offer can create, and it still shows
+        // what is about to be disclosed before anything leaves.
+        let prepared = await harness.flow.prepareAccept(rowID: chat.id)
+        let confirmation = try XCTUnwrap(prepared)
+        XCTAssertEqual(confirmation.groupName, "Maple Garden")
+        XCTAssertEqual(confirmation.inviterAlias, "Alice")
+        XCTAssertEqual(confirmation.introPublicKey, chat.introPublicKey)
+        XCTAssertEqual(
+            confirmation.suggestedLabel, "Bob",
+            "pre-filled with the identity's own alias"
+        )
+        var sent = await harness.sender.calls.count
+        XCTAssertEqual(sent, 0)
+
+        await harness.flow.confirmJoin(confirmation, label: "Bobby")
 
         try await waitForAsync { await harness.sender.calls.count == 1 }
+        sent = await harness.sender.calls.count
+        XCTAssertEqual(sent, 1)
         let calls = await harness.sender.calls
         let call = try XCTUnwrap(calls.first)
         XCTAssertEqual(call.capability.groupId, chat.groupID)
-        XCTAssertEqual(call.label, "Bob", "the joiner is introduced by the active identity's name")
+        XCTAssertEqual(call.label, "Bobby", "the name they typed, not the identity's")
         try await waitFor { harness.flow.rows.first?.state == .waiting }
+    }
+
+    func test_prepareAccept_onARowThatAlreadyAsked_offersNothing() async throws {
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat()
+        await harness.repository.record(chat)
+        await harness.repository.markRequested(id: chat.id)
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+
+        let confirmation = await harness.flow.prepareAccept(rowID: chat.id)
+
+        XCTAssertNil(confirmation, "one tap, one request")
     }
 
     func test_accept_isDebouncedWhileTheSendIsInFlight() async throws {
@@ -52,8 +82,10 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.repository.record(chat)
         try await waitFor { harness.flow.rows.count == 1 }
 
-        harness.flow.accept(chat.id)
-        harness.flow.accept(chat.id)
+        let prepared = await harness.flow.prepareAccept(rowID: chat.id)
+        let confirmation = try XCTUnwrap(prepared)
+        await harness.flow.confirmJoin(confirmation, label: "Bob")
+        await harness.flow.confirmJoin(confirmation, label: "Bob")
 
         // Wait on the *spy* being entered, not on `isSending`: that flag
         // is set synchronously inside `send` before `submitJoin` is ever
@@ -75,7 +107,7 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.repository.record(chat)
         try await waitFor { harness.flow.rows.count == 1 }
 
-        harness.flow.accept(chat.id)
+        await harness.acceptThroughTheScreen(chat.id)
         // The transport's own words are deliberately not kept: the row
         // is on disk and outlives the language it was written in.
         try await waitFor { harness.flow.rows.first?.state == .sendFailed(.transport) }
@@ -97,7 +129,7 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.repository.record(chat)
         try await waitFor { harness.flow.rows.count == 1 }
 
-        harness.flow.accept(chat.id)
+        await harness.acceptThroughTheScreen(chat.id)
 
         try await waitFor { harness.flow.rows.first?.state == .sendFailed(.noIdentity) }
         XCTAssertTrue(harness.flow.rows.first?.state.isRetryable == true)
@@ -113,7 +145,7 @@ final class PendingChatsFlowTests: XCTestCase {
         await harness.repository.record(malformed)
         try await waitFor { harness.flow.rows.count == 1 }
 
-        harness.flow.accept(malformed.id)
+        await harness.acceptThroughTheScreen(malformed.id)
 
         XCTAssertNotNil(harness.flow.lastError)
         let sends = await harness.sender.calls.count
@@ -263,17 +295,22 @@ final class PendingChatsFlowTests: XCTestCase {
         // A request can be sent and never answered — a revoked link, or
         // one that died in a relay. Before this there was no way out but
         // swiping the row away.
+        //
+        // Seeded through the screen, because that is the only way a row
+        // reaches `.requested` — and the name it asked under comes with
+        // it.
         let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let chat = harness.makeChat()
         await harness.repository.record(chat)
-        await harness.repository.markRequested(id: chat.id)
+        try await waitFor { harness.flow.rows.count == 1 }
+        await harness.acceptThroughTheScreen(chat.id)
         try await waitFor { harness.flow.rows.first?.state == .waiting }
         XCTAssertTrue(harness.flow.rows.first?.state.isRetryable == true)
 
         harness.flow.retry(chat.id)
 
-        try await waitForAsync { await harness.sender.calls.count == 1 }
+        try await waitForAsync { await harness.sender.calls.count == 2 }
         let retries = await harness.verifierRetries.values
         XCTAssertTrue(retries.isEmpty, "the founder is who this wait belongs to")
     }
@@ -349,70 +386,122 @@ final class PendingChatsFlowTests: XCTestCase {
 
     // MARK: - Joining from a link
 
-    func test_join_recordsARowAndSendsWithoutAsking() async throws {
+    func test_aTappedLink_recordsNothingAndSendsNothing() async throws {
+        // The security rule this screen exists for: the URL types are
+        // exported, so anything on the device — or a page in a browser —
+        // can deliver a capability. Delivery must not disclose this
+        // identity's name or keys, and must not leave a row behind
+        // either.
         let harness = await Harness.make(owner: owner)
         await harness.flow.start()
 
-        let outcome = await harness.flow.join(capability: harness.capability())
+        let destination = await harness.flow.prepareJoin(capability: harness.capability())
+
+        guard case .confirm(let confirmation) = destination else {
+            return XCTFail("a link must resolve to a screen, got \(destination)")
+        }
+        XCTAssertEqual(confirmation.groupName, "Maple Garden")
+        XCTAssertEqual(confirmation.introPublicKey, harness.capability().introPublicKey)
+        let sent = await harness.sender.calls.count
+        XCTAssertEqual(sent, 0)
+        let stored = await harness.repository.currentChats()
+        XCTAssertTrue(stored.isEmpty, "nothing may be persisted before a person says so")
+        XCTAssertTrue(harness.flow.rows.isEmpty)
+    }
+
+    func test_confirmingALink_recordsTheRowAndSendsUnderTheTypedName() async throws {
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        guard case .confirm(let confirmation) =
+                await harness.flow.prepareJoin(capability: harness.capability())
+        else { return XCTFail("expected a confirmation") }
+
+        let outcome = await harness.flow.confirmJoin(confirmation, label: "Bobby")
 
         XCTAssertEqual(outcome, .waiting(rowID: harness.makeChat().id))
+        // The row is written before `confirmJoin` returns; the send runs
+        // on its own task, so it is waited on rather than read.
         try await waitForAsync { await harness.sender.calls.count == 1 }
+        let calls = await harness.sender.calls
+        XCTAssertEqual(calls.map(\.label), ["Bobby"])
         try await waitFor { harness.flow.rows.first?.state == .waiting }
     }
 
-    func test_join_twiceOnTheSameLink_doesNotAskTwice() async throws {
+    func test_theNameAskedUnderIsRememberedForTheNextAsk() async throws {
+        // A re-send that fell back to the identity's alias would arrive
+        // from a stranger — the founder is deciding partly on the name.
         let harness = await Harness.make(owner: owner)
         await harness.flow.start()
-
-        _ = await harness.flow.join(capability: harness.capability())
-        // Wait for the row to actually reach `.requested`: on `.offered`
-        // a second tap now (correctly) sends, so asserting before the
-        // status lands would be testing the race, not the rule.
+        guard case .confirm(let confirmation) =
+                await harness.flow.prepareJoin(capability: harness.capability())
+        else { return XCTFail("expected a confirmation") }
+        await harness.flow.confirmJoin(confirmation, label: "Bobby")
         try await waitFor { harness.flow.rows.first?.state == .waiting }
-        let second = await harness.flow.join(capability: harness.capability())
 
-        XCTAssertEqual(second, .waiting(rowID: harness.makeChat().id))
-        let sent1 = await harness.sender.calls.count
-        XCTAssertEqual(sent1, 1, "a second tap is not a second request")
+        harness.flow.retry(harness.makeChat().id)
+
+        try await waitForAsync { await harness.sender.calls.count == 2 }
+        let calls = await harness.sender.calls
+        XCTAssertEqual(calls.map(\.label), ["Bobby", "Bobby"])
     }
 
-    func test_join_onAnUnansweredOffer_sendsInsteadOfAskingAgain() async throws {
-        // The dispatcher got there first. Tapping the link *is* the
-        // answer, so the row must not be left sitting at `.offered`
-        // asking for it a second time.
+    func test_aSecondLinkAfterAsking_opensTheWaitWithoutAskingAgain() async throws {
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        guard case .confirm(let confirmation) =
+                await harness.flow.prepareJoin(capability: harness.capability())
+        else { return XCTFail("expected a confirmation") }
+        await harness.flow.confirmJoin(confirmation, label: "Bobby")
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+
+        let second = await harness.flow.prepareJoin(capability: harness.capability())
+
+        XCTAssertEqual(second, .waiting(rowID: harness.makeChat().id))
+        let sent = await harness.sender.calls.count
+        XCTAssertEqual(sent, 1, "a second delivery is not a second request")
+    }
+
+    func test_aLinkOnAnUnansweredOffer_confirmsAgainstTheOffersDetails() async throws {
+        // The dispatcher got there first, so the screen can name who
+        // invited and what they wrote — and confirming answers that
+        // offer rather than starting a second one.
         let harness = await Harness.make(owner: owner)
         await harness.flow.start()
         let offered = harness.makeChat()
         await harness.repository.record(offered)
         try await waitFor { harness.flow.rows.first?.state == .offered }
 
-        let outcome = await harness.flow.join(capability: harness.capability())
+        guard case .confirm(let confirmation) =
+                await harness.flow.prepareJoin(capability: harness.capability())
+        else { return XCTFail("an unanswered offer must still be confirmable") }
+        XCTAssertEqual(confirmation.inviterAlias, "Alice")
+        await harness.flow.confirmJoin(confirmation, label: "Bobby")
 
-        XCTAssertEqual(outcome, .waiting(rowID: offered.id))
         try await waitFor { harness.flow.rows.first?.state == .waiting }
         let sends = await harness.sender.calls.count
         XCTAssertEqual(sends, 1)
+        XCTAssertEqual(harness.flow.rows.count, 1, "one waiting room, not two")
     }
 
-    func test_join_whenAlreadyAMember_opensTheChatInstead() async throws {
+    func test_aLinkIntoAChatYouAreIn_opensItWithoutDisclosingAnything() async throws {
         let harness = await Harness.make(owner: owner)
         let capability = harness.capability()
         let hex = capability.groupId.map { String(format: "%02x", $0) }.joined()
         await harness.groups.insert(harness.makeGroup(id: hex))
         await harness.flow.start()
 
-        let outcome = await harness.flow.join(capability: capability)
+        let outcome = await harness.flow.prepareJoin(capability: capability)
 
         XCTAssertEqual(outcome, .alreadyJoined(groupIDHex: hex))
-        let sent0 = await harness.sender.calls.count
-        XCTAssertEqual(sent0, 0)
+        let sent = await harness.sender.calls.count
+        XCTAssertEqual(sent, 0)
     }
 
-    func test_join_withNoIdentity_saysSoRatherThanWaitingSilently() async throws {
+    func test_aLinkWithNoIdentity_saysSoRatherThanWaitingSilently() async throws {
         let harness = await Harness.make(owner: nil)
         await harness.flow.start()
 
-        let outcome = await harness.flow.join(capability: harness.capability())
+        let outcome = await harness.flow.prepareJoin(capability: harness.capability())
 
         guard case .failed = outcome else {
             return XCTFail("expected a failure the caller can surface, got \(outcome)")
@@ -466,6 +555,12 @@ final class PendingChatsFlowTests: XCTestCase {
             await harness.verifications.setCurrentIdentity(owner)
             await harness.groups.setCurrentIdentity(owner)
             return harness
+        }
+
+        /// Accept as a person performs it: open the screen, then Send.
+        func acceptThroughTheScreen(_ rowID: String, label: String = "Bob") async {
+            guard let confirmation = await flow.prepareAccept(rowID: rowID) else { return }
+            await flow.confirmJoin(confirmation, label: label)
         }
 
         func capability() -> IntroCapability {

--- a/Tests/OnymIOSUITests/MultiIdentityChatUITests.swift
+++ b/Tests/OnymIOSUITests/MultiIdentityChatUITests.swift
@@ -84,7 +84,13 @@ final class MultiIdentityChatUITests: XCTestCase {
         let confirm = JoinConfirmScreen(app: app)
         XCTAssertTrue(confirm.waitReady(),
                       "join confirmation never appeared from the --open-url deeplink")
-        confirm.typeName("Bob")
+        // Joining is one tap: the name field arrives holding the active
+        // identity's own alias, so nobody has to type their own name to
+        // get into a chat. Asserting it here is what keeps that true —
+        // the cold-start link is exactly the moment the identity cache
+        // is unread, and an empty field would make Send unavailable.
+        XCTAssertEqual(confirm.prefilledName, "Bob",
+                       "the confirmation must arrive pre-filled with the identity's name")
         confirm.send()
 
         let pending = PendingChatScreen(app: app)

--- a/Tests/OnymIOSUITests/MultiIdentityChatUITests.swift
+++ b/Tests/OnymIOSUITests/MultiIdentityChatUITests.swift
@@ -77,12 +77,19 @@ final class MultiIdentityChatUITests: XCTestCase {
         app.launchArguments = baseArgs + ["--open-url", inviteLink]
         app.launch()
 
-        // Identity 2 (Bob) joins from the deeplink. There is nothing to
-        // fill in: the tap sends the request and opens the chat it
-        // created, waiting until Alice lets him in.
+        // Identity 2 (Bob) joins from the deeplink. The link opens a
+        // confirmation screen — delivery is not consent, since anything
+        // on the device can open the app's URL types — and the request
+        // goes out only on Send, under the name typed there.
+        let confirm = JoinConfirmScreen(app: app)
+        XCTAssertTrue(confirm.waitReady(),
+                      "join confirmation never appeared from the --open-url deeplink")
+        confirm.typeName("Bob")
+        confirm.send()
+
         let pending = PendingChatScreen(app: app)
         XCTAssertTrue(pending.waitReady(),
-                      "pending chat never appeared from the --open-url deeplink")
+                      "pending chat never appeared after confirming the join")
         pending.back()
 
         // Identity 1 (Alice) approves the join request — from inside the

--- a/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
+++ b/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
@@ -107,6 +107,41 @@ struct ShareInviteScreen {
     }
 }
 
+// MARK: - Join confirmation
+
+/// The screen between an invitation and a request. A link resolves here
+/// and nothing is sent until Send is tapped — the app's URL types are
+/// exported, so delivery cannot be treated as consent.
+struct JoinConfirmScreen {
+    let app: XCUIApplication
+
+    var nameField: XCUIElement { app.textFields["join_confirm.name_field"] }
+    var sendButton: XCUIElement { app.buttons["join_confirm.send"] }
+
+    @discardableResult
+    func waitReady(timeout: TimeInterval = 20) -> Bool {
+        sendButton.waitForExistence(timeout: timeout)
+    }
+
+    /// Replaces the pre-filled identity alias with a name chosen for
+    /// this chat alone.
+    func typeName(_ name: String) {
+        guard nameField.waitForExistence(timeout: 5) else { return }
+        nameField.tap()
+        // The field arrives pre-filled; clear it before typing so the
+        // assertion is about the typed name and not a concatenation.
+        if let current = nameField.value as? String, !current.isEmpty {
+            nameField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: current.count))
+        }
+        nameField.typeText(name)
+    }
+
+    func send() {
+        XCTAssertTrue(sendButton.waitForExistence(timeout: 5), "Send join request button missing")
+        sendButton.tap()
+    }
+}
+
 // MARK: - Join (pending chat)
 
 /// A tapped invite link no longer opens a screen of its own: the request

--- a/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
+++ b/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
@@ -150,18 +150,19 @@ struct JoinConfirmScreen {
 
 // MARK: - Join (pending chat)
 
-/// A tapped invite link no longer opens a screen of its own: the request
-/// goes out on the tap and the app pushes the chat it created, pending
-/// until the founder lets the joiner in. So this page object waits on
-/// that thread rather than driving a form.
+/// Where a confirmed join lands: the chat it created, pending until the
+/// founder lets the joiner in. So this page object waits on that thread
+/// rather than driving a form — the one form in this flow is the
+/// confirmation screen above, and it is already behind us.
 struct PendingChatScreen {
     let app: XCUIApplication
 
     var waiting: XCUIElement { app.staticTexts["pending_chat.waiting"] }
     var stuck: XCUIElement { app.staticTexts["pending_chat.stuck"] }
 
-    /// The request ships without a tap, so "ready" is the waiting state
-    /// itself — reaching it is proof the join left the device.
+    /// "Ready" is the waiting state itself — reaching it is proof the
+    /// join left the device, which by now means someone tapped Send on
+    /// the confirmation screen.
     @discardableResult
     func waitReady(timeout: TimeInterval = 20) -> Bool {
         waiting.waitForExistence(timeout: timeout)

--- a/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
+++ b/Tests/OnymIOSUITests/PageObjects/ChatFlowScreens.swift
@@ -123,13 +123,19 @@ struct JoinConfirmScreen {
         sendButton.waitForExistence(timeout: timeout)
     }
 
-    /// Replaces the pre-filled identity alias with a name chosen for
-    /// this chat alone.
+    /// The name the field arrives pre-filled with — the active
+    /// identity's own alias.
+    var prefilledName: String? {
+        guard nameField.waitForExistence(timeout: 5) else { return nil }
+        return nameField.value as? String
+    }
+
+    /// Replaces the pre-filled alias with a name chosen for this chat
+    /// alone. Not used by the happy path, which is Send and nothing
+    /// else.
     func typeName(_ name: String) {
         guard nameField.waitForExistence(timeout: 5) else { return }
         nameField.tap()
-        // The field arrives pre-filled; clear it before typing so the
-        // assertion is about the typed name and not a concatenation.
         if let current = nameField.value as? String, !current.isEmpty {
             nameField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: current.count))
         }


### PR DESCRIPTION
Fixes a HIGH from security review, raised against the Android twin and true of both apps.

**The finding.** The URL types this app registers are exported. Any app on the device can open `onym://join?c=…`, and so can a page in a browser. Since #296, receiving a decoded capability immediately recorded a row and sent a signed join request — carrying this identity's display name and its stable inbox, BLS and signing public keys — to whoever minted the invite key. The person's first sight of it was a new row in their chats list. That was my error: "tapping the link is the intent" holds for a person tapping a link, not for the channel that delivers it, which anything can speak into.

**The fix.** A capability now resolves to a screen. `prepareJoin` records nothing and sends nothing; it answers *already in* (open the chat), *already asked* (open the wait), or *ask them* — the confirmation screen. That screen names the group, the inviter when there is one, the invite key the request would be sealed to, and in as many words what Send discloses. `confirmJoin` is the only path to a send, and only a person can reach it. The scan path resolves identically: a scan is deliberate, but it discloses the same things, so it gets the same review.

Accept on a pushed offer goes through the same screen rather than sending on tap — one path, so what someone is shown before their name and keys leave the device doesn't depend on which door the invitation came through.

**And the name is theirs to choose — without having to type it.** The field arrives pre-filled with the identity's own alias, read through the identity *repository* rather than the identities flow, because a link that launches the app resolves before any tab has populated that flow and the field would otherwise open empty. So joining stays one tap: Send, and nothing else. The name rides with this join only: one identity can be "Sam" to a book club and "S." to a tenants' group without being two identities. It is stored on the row (encrypted, like the rest of the person-supplied text), so "Ask again" re-introduces the same person rather than whoever the identity has since been renamed to — a founder is deciding partly on that name, and a rename between the first request and the second would make it arrive from a stranger.

`test_aTappedLink_recordsNothingAndSendsNothing` is the rule as a test: it asserts the sender was never called *and* that no row was written. Both halves matter — a row left behind is a disclosure of its own to anyone who later looks at the device.

Verification: 1497 unit tests green; `MultiIdentityChatUITests` green end to end. It asserts the name field arrives holding `"Bob"` and then taps Send without typing — the two halves of the rule: a link no longer sends on arrival, and confirming it costs one tap rather than typing your own name.

The same fix is still owed on Android (onymchat/onym-android#240), where the finding was originally raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
