### PR TITLE
Rules a joiner can read, and a signature that says they agreed

### DIFF
--- a/Packages/OnymGroup/Sources/OnymGroup/GroupRules.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupRules.swift
@@ -1,0 +1,148 @@
+import Foundation
+import CryptoKit
+
+/// The rules a founder sets for a group, and the joiner's signed
+/// agreement to them.
+///
+/// ## Why a signature at all
+///
+/// A founder admitting a stranger is deciding on two things: who is
+/// asking, and what they have agreed to. The first was already
+/// provable — the request carries the joiner's long-term keys. The
+/// second was not, and could not be inferred from the envelope: the
+/// sealed envelope's Ed25519 signature covers the *ephemeral public
+/// key* only (`IdentityRepository.sealInvitation`), not the payload
+/// under it. A founder holding such an envelope can produce a
+/// different plaintext for the same signature, so it proves nothing to
+/// a third party about what the joiner said.
+///
+/// So agreement gets its own detached signature, over bytes that name
+/// what is being agreed to and by whom.
+///
+/// ## The statement
+///
+///     "onym-group-rules-v1" ‖ group_id (32) ‖ SHA256(rules) (32)
+///                           ‖ joiner_sending_pub (32)
+///
+/// Every component after the domain string is fixed-length, so the
+/// concatenation is unambiguous without length prefixes.
+///
+///  - The **domain string** keeps this signature from being replayable
+///    as any other signature this identity produces — the same Ed25519
+///    key signs moderation mandates and report disclosures.
+///  - **`group_id`** binds the agreement to one group. Without it, an
+///    acceptance collected for a permissive group could be shown as
+///    agreement to a stricter group's rules that happen to be equal.
+///  - **`SHA256(rules)`** is what makes it an agreement to *these*
+///    rules rather than to the idea of rules. Changing a comma
+///    invalidates it.
+///  - **`joiner_sending_pub`** names the signer inside the signed
+///    bytes, so a signature lifted from one request cannot be
+///    re-attributed to another joiner.
+///
+/// Deliberately **not** signed: a timestamp. A joiner-supplied one is
+/// unverifiable, and the only trustworthy time is when the founder's
+/// device received the request — which the founder records itself.
+///
+/// ## Keeping the proof
+///
+/// A signature is only evidence if the bytes it covers can be produced
+/// again. The verifier therefore stores the exact rules text alongside
+/// the signature; a stored hash with no text proves that *something*
+/// was agreed to and never what. This is the same discipline the
+/// moderation layer follows for mandates, where the signed manifest
+/// bytes are retained rather than re-derived.
+public enum GroupRules {
+    /// The longest rules text an invite may carry.
+    ///
+    /// The binding constraint is the QR code, not the screen. An invite
+    /// link is `base64(JSON)` in a URL, rendered at correction level M
+    /// (`SettingsQRCode`), whose byte-mode ceiling is 2331 bytes.
+    /// Measured end to end, with both 32-byte keys and a 30-character
+    /// group name in the JSON:
+    ///
+    ///     500 ASCII characters     →   924-byte link
+    ///     500 Cyrillic characters  →  1591-byte link
+    ///     500 CJK characters       →  2258-byte link
+    ///
+    /// So 500 fits even when every character costs three UTF-8 bytes,
+    /// which is the case that decides the cap. A longer one would
+    /// produce links that encode fine and then fail to scan — the worst
+    /// way to find out.
+    ///
+    /// The headroom in that last row is thin, and it is shared with the
+    /// group name, which has no cap of its own: a 300-character name
+    /// alongside 500 characters of CJK rules would push the link past
+    /// the ceiling. The failure is soft — `CIQRCodeGenerator` returns
+    /// no image and the link stays copyable — but it is why this
+    /// number should not be raised without re-measuring the pair.
+    public static let maxLength = 500
+
+    /// Domain separator. Versioned: a change to the statement's shape
+    /// must not let old signatures verify under the new reading.
+    static let domain = "onym-group-rules-v1"
+
+    /// The one canonical form, applied by *both* sides before hashing.
+    ///
+    /// Ends-only trimming, nothing else: the founder wrote this text
+    /// and a joiner is agreeing to it, so collapsing inner whitespace
+    /// or normalising case would mean signing something other than what
+    /// was displayed. Trailing newlines from a text field are the one
+    /// difference that carries no meaning, and letting them through
+    /// would make agreement fail on an invisible character.
+    public static func canonical(_ rules: String) -> String {
+        rules.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// `nil` for rules that are absent or blank — a group with no rules
+    /// asks for no agreement, and an empty string must not become a
+    /// thing to sign.
+    public static func normalized(_ rules: String?) -> String? {
+        guard let rules else { return nil }
+        let canonical = canonical(rules)
+        return canonical.isEmpty ? nil : canonical
+    }
+
+    /// SHA-256 over the canonical text's UTF-8. The identity of a set
+    /// of rules, and what the founder compares against.
+    public static func hash(_ rules: String) -> Data {
+        Data(SHA256.hash(data: Data(canonical(rules).utf8)))
+    }
+
+    /// The exact bytes both sides sign and verify. See the type doc.
+    public static func statement(
+        groupID: Data,
+        rulesHash: Data,
+        joinerSendingPublicKey: Data
+    ) -> Data {
+        var bytes = Data(domain.utf8)
+        bytes.append(groupID)
+        bytes.append(rulesHash)
+        bytes.append(joinerSendingPublicKey)
+        return bytes
+    }
+
+    /// Whether `signature` is this joiner agreeing to exactly `rules`
+    /// for exactly this group.
+    ///
+    /// Takes the rules *text* rather than a hash on purpose: the caller
+    /// that can't produce the text has nothing to verify against, and
+    /// making that impossible to express is cheaper than documenting
+    /// it.
+    public static func isAgreement(
+        signature: Data,
+        rules: String,
+        groupID: Data,
+        joinerSendingPublicKey: Data
+    ) -> Bool {
+        guard let key = try? Curve25519.Signing.PublicKey(
+            rawRepresentation: joinerSendingPublicKey
+        ) else { return false }
+        let statement = statement(
+            groupID: groupID,
+            rulesHash: hash(rules),
+            joinerSendingPublicKey: joinerSendingPublicKey
+        )
+        return key.isValidSignature(signature, for: statement)
+    }
+}

--- a/Packages/OnymGroup/Sources/OnymGroup/GroupRules.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupRules.swift
@@ -53,34 +53,78 @@ import CryptoKit
 /// moderation layer follows for mandates, where the signed manifest
 /// bytes are retained rather than re-derived.
 public enum GroupRules {
-    /// The longest rules text an invite may carry.
+    /// The most rules an invite may carry, in **UTF-8 bytes**.
     ///
-    /// The binding constraint is the QR code, not the screen. An invite
-    /// link is `base64(JSON)` in a URL, rendered at correction level M
-    /// (`SettingsQRCode`), whose byte-mode ceiling is 2331 bytes.
-    /// Measured end to end, with both 32-byte keys and a 30-character
-    /// group name in the JSON:
+    /// Bytes, not characters, for two reasons that both bite.
     ///
-    ///     500 ASCII characters     →   924-byte link
-    ///     500 Cyrillic characters  →  1591-byte link
-    ///     500 CJK characters       →  2258-byte link
+    /// A character cap doesn't bound the payload it exists to bound. A
+    /// ZWJ emoji cluster (👨‍👩‍👧‍👦) is one `Character` and 25 UTF-8
+    /// bytes, so 500 of them is a legal 500-"character" rules text and
+    /// a ~12.5 KB payload — seven times the ceiling below.
     ///
-    /// So 500 fits even when every character costs three UTF-8 bytes,
-    /// which is the case that decides the cap. A longer one would
-    /// produce links that encode fine and then fail to scan — the worst
-    /// way to find out.
+    /// And a character cap isn't the same cap on both platforms.
+    /// Swift's `String.count` counts grapheme clusters; Kotlin's
+    /// `String.length` counts UTF-16 units. One non-BMP character makes
+    /// them disagree, and because decode *rejects* an over-long value
+    /// rather than truncating it, disagreement is an unusable link
+    /// rather than a cosmetic difference. UTF-8 byte count is the only
+    /// unit the two compute identically.
     ///
-    /// The headroom in that last row is thin, and it is shared with the
-    /// group name, which has no cap of its own: a 300-character name
-    /// alongside 500 characters of CJK rules would push the link past
-    /// the ceiling. The failure is soft — `CIQRCodeGenerator` returns
-    /// no image and the link stays copyable — but it is why this
-    /// number should not be raised without re-measuring the pair.
+    /// The value: a QR code at correction level M (`SettingsQRCode`)
+    /// holds 2331 bytes, and the link is `base64(JSON)`, so the rules
+    /// get ~1500 bytes of it. Measured end to end, with both 32-byte
+    /// keys and a 30-character Latin group name:
+    ///
+    ///     1500 bytes as 1500 ASCII characters  →  2273-byte link
+    ///     1500 bytes as  750 Cyrillic chars    →  2273-byte link
+    ///     1500 bytes as  500 CJK characters    →  2273-byte link
+    ///
+    /// — the same link length, which is the point of measuring the
+    /// budget in the unit the wire actually spends.
+    ///
+    /// The remaining headroom is shared with the group name, which has
+    /// no cap of its own: 1500 bytes of rules alongside a 30-character
+    /// CJK name overruns. The failure is soft — `CIQRCodeGenerator`
+    /// returns no image and the link stays copyable — but it is why
+    /// this number should not be raised without re-measuring the pair.
+    /// `GroupRulesWireTests` pins both sides of that boundary.
+    public static let maxBytes = 1500
+
+    /// What the compose field counts down from, in characters. A
+    /// guide for the person typing, not the limit that decides whether
+    /// a link is valid — `maxBytes` is. Latin text hits neither before
+    /// the other; scripts that cost more per character hit the byte
+    /// cap first, which is correct and is why the field checks both.
     public static let maxLength = 500
 
     /// Domain separator. Versioned: a change to the statement's shape
     /// must not let old signatures verify under the new reading.
     static let domain = "onym-group-rules-v1"
+
+    /// Exactly the codepoints `canonical` trims from the ends, pinned
+    /// rather than named.
+    ///
+    /// `Foundation.whitespacesAndNewlines` and Kotlin's `String.trim()`
+    /// are not the same set: `Character.isWhitespace` excludes NBSP
+    /// (U+00A0) and the narrow/figure spaces, which Foundation trims.
+    /// Text pasted from a web page routinely carries a leading or
+    /// trailing NBSP, so the difference is not theoretical — one
+    /// platform would hash the NBSP and the other wouldn't, a genuine
+    /// agreement would fail to verify, and the founder would read that
+    /// as a signature that doesn't check out rather than as a
+    /// whitespace disagreement.
+    ///
+    /// So the set is written out, and Android must write out the same
+    /// one. These are the codepoints of
+    /// `CharacterSet.whitespacesAndNewlines` as of this writing;
+    /// spelling them here also stops a Foundation revision from
+    /// silently changing what a signature covers.
+    public static let trimmedCodepoints = CharacterSet(charactersIn:
+        "\u{0009}\u{000A}\u{000B}\u{000C}\u{000D}\u{0020}\u{0085}\u{00A0}"
+        + "\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}"
+        + "\u{2007}\u{2008}\u{2009}\u{200A}\u{2028}\u{2029}\u{202F}\u{205F}"
+        + "\u{3000}"
+    )
 
     /// The one canonical form, applied by *both* sides before hashing.
     ///
@@ -90,8 +134,15 @@ public enum GroupRules {
     /// was displayed. Trailing newlines from a text field are the one
     /// difference that carries no meaning, and letting them through
     /// would make agreement fail on an invisible character.
+    ///
+    /// See `trimmedCodepoints` for why the set is spelled out.
     public static func canonical(_ rules: String) -> String {
-        rules.trimmingCharacters(in: .whitespacesAndNewlines)
+        rules.trimmingCharacters(in: trimmedCodepoints)
+    }
+
+    /// Whether this text fits an invite, in the unit the wire spends.
+    public static func fits(_ rules: String) -> Bool {
+        canonical(rules).utf8.count <= maxBytes
     }
 
     /// `nil` for rules that are absent or blank — a group with no rules
@@ -110,11 +161,24 @@ public enum GroupRules {
     }
 
     /// The exact bytes both sides sign and verify. See the type doc.
+    ///
+    /// The preconditions are the unambiguity argument, enforced: the
+    /// concatenation needs no length prefixes *because* all three
+    /// components are fixed-length, and a caller that passed a short
+    /// group id would silently produce a preimage some other triple
+    /// could also produce. Every caller already holds validated
+    /// values, so this fires only on a programming error.
     public static func statement(
         groupID: Data,
         rulesHash: Data,
         joinerSendingPublicKey: Data
     ) -> Data {
+        precondition(groupID.count == 32, "groupID must be 32 bytes")
+        precondition(rulesHash.count == 32, "rulesHash must be 32 bytes")
+        precondition(
+            joinerSendingPublicKey.count == 32,
+            "joinerSendingPublicKey must be 32 bytes"
+        )
         var bytes = Data(domain.utf8)
         bytes.append(groupID)
         bytes.append(rulesHash)
@@ -135,6 +199,10 @@ public enum GroupRules {
         groupID: Data,
         joinerSendingPublicKey: Data
     ) -> Bool {
+        // Sizes checked before `statement`, whose preconditions are for
+        // programming errors: everything here arrives from a stranger,
+        // and wrong-sized bytes are a "no" rather than a crash.
+        guard groupID.count == 32, joinerSendingPublicKey.count == 32 else { return false }
         guard let key = try? Curve25519.Signing.PublicKey(
             rawRepresentation: joinerSendingPublicKey
         ) else { return false }

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroCapability.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroCapability.swift
@@ -41,9 +41,10 @@ import Foundation
 /// not agreed to anything. For sensitive group names or rules, leave
 /// them nil and let the inviter convey context out-of-band.
 ///
-/// `rules` is capped at `GroupRules.maxLength` so the encoded link
-/// still fits a scannable QR code; see that constant for the
-/// arithmetic.
+/// `rules` is capped at `GroupRules.maxBytes` — UTF-8 bytes, which is
+/// the only unit Swift and Kotlin compute identically, and the unit the
+/// link actually spends — so the encoded link still fits a scannable QR
+/// code. See that constant for the measurements.
 ///
 /// ## Cross-platform contract
 ///
@@ -119,9 +120,10 @@ public struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
             )
         }
         let normalizedRules = GroupRules.normalized(rules)
-        if let normalizedRules, normalizedRules.count > GroupRules.maxLength {
+        if let normalizedRules, !GroupRules.fits(normalizedRules) {
             throw InvalidIntroCapability.shape(
-                "rules: expected at most \(GroupRules.maxLength) characters, got \(normalizedRules.count)"
+                "rules: expected at most \(GroupRules.maxBytes) UTF-8 bytes, "
+                + "got \(normalizedRules.utf8.count)"
             )
         }
         self.introPublicKey = introPublicKey
@@ -154,9 +156,10 @@ public struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
         // sign rules that end mid-sentence, and dropping the field
         // would walk them into a group whose rules they were never
         // shown while the founder believes otherwise.
-        if let rules, rules.count > GroupRules.maxLength {
+        if let rules, !GroupRules.fits(rules) {
             throw InvalidIntroCapability.shape(
-                "rules: expected at most \(GroupRules.maxLength) characters, got \(rules.count)"
+                "rules: expected at most \(GroupRules.maxBytes) UTF-8 bytes, "
+                + "got \(rules.utf8.count)"
             )
         }
         self.introPublicKey = pub

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroCapability.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroCapability.swift
@@ -29,20 +29,28 @@ import Foundation
 /// → the link goes silent. It also means link interception doesn't
 /// leak the inviter's long-term inbox key.
 ///
-/// ## What's safe to ship in `groupName`
+/// ## What's safe to ship in `groupName` and `rules`
 ///
-/// Optional, plaintext, **public**. The link transits cleartext
-/// channels (Telegram, SMS, etc.) — anyone observing the link can
-/// read this string. Useful for the joiner's "join this group?"
-/// preview. For sensitive group names, leave nil and let the inviter
-/// convey context out-of-band.
+/// Optional, plaintext, **public** — both of them. The link transits
+/// cleartext channels (Telegram, SMS, etc.), so anyone observing the
+/// link can read them. `groupName` is the joiner's "join this group?"
+/// preview; `rules` is what they are asked to agree to before their
+/// name and keys leave the device, and it has to travel *with* the
+/// link because there is no other channel to fetch it from before
+/// joining — a joiner asked to agree to a hash they cannot read has
+/// not agreed to anything. For sensitive group names or rules, leave
+/// them nil and let the inviter convey context out-of-band.
+///
+/// `rules` is capped at `GroupRules.maxLength` so the encoded link
+/// still fits a scannable QR code; see that constant for the
+/// arithmetic.
 ///
 /// ## Cross-platform contract
 ///
 /// The wire shape mirrors onym-android's `IntroCapability.kt` byte
 /// for byte:
 ///
-///  - JSON keys: `intro_pub`, `group_id`, `group_name`
+///  - JSON keys: `intro_pub`, `group_id`, `group_name`, `rules`
 ///  - Inner field encoding: standard base64 *with* padding
 ///    (Swift's default `JSONEncoder.dataEncodingStrategy = .base64`,
 ///     matching Android's `Base64.getEncoder()`)
@@ -73,6 +81,17 @@ public struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
     /// Optional display name. Public — see type doc.
     public let groupName: String?
 
+    /// The group's rules, as the founder wrote them. Public — see type
+    /// doc. Canonical (ends-trimmed) and non-empty, or nil.
+    ///
+    /// Carried so the joiner can read them on the confirmation screen
+    /// and sign them: the signature in `JoinRequestPayload` covers
+    /// `SHA256` of exactly this text, which is why it is stored the way
+    /// `GroupRules.canonical` produces rather than however it was
+    /// typed. A link minted by an older build has none, and a joiner
+    /// reaching it is asked to agree to nothing.
+    public let rules: String?
+
     static let appLinkBase = "https://onym.app/join?c="
     static let customSchemeBase = "onym://join?c="
 
@@ -80,9 +99,15 @@ public struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
         case introPublicKey = "intro_pub"
         case groupId = "group_id"
         case groupName = "group_name"
+        case rules = "rules"
     }
 
-    public init(introPublicKey: Data, groupId: Data, groupName: String? = nil) throws {
+    public init(
+        introPublicKey: Data,
+        groupId: Data,
+        groupName: String? = nil,
+        rules: String? = nil
+    ) throws {
         guard introPublicKey.count == 32 else {
             throw InvalidIntroCapability.shape(
                 "introPublicKey: expected 32 bytes, got \(introPublicKey.count)"
@@ -93,9 +118,16 @@ public struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
                 "groupId: expected 32 bytes, got \(groupId.count)"
             )
         }
+        let normalizedRules = GroupRules.normalized(rules)
+        if let normalizedRules, normalizedRules.count > GroupRules.maxLength {
+            throw InvalidIntroCapability.shape(
+                "rules: expected at most \(GroupRules.maxLength) characters, got \(normalizedRules.count)"
+            )
+        }
         self.introPublicKey = introPublicKey
         self.groupId = groupId
         self.groupName = groupName
+        self.rules = normalizedRules
     }
 
     public init(from decoder: Decoder) throws {
@@ -112,9 +144,25 @@ public struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
                 "groupId: expected 32 bytes, got \(gid.count)"
             )
         }
+        let rules = GroupRules.normalized(
+            try c.decodeIfPresent(String.self, forKey: .rules)
+        )
+        // Rejected, not truncated. Both platforms enforce the cap when
+        // they mint a link, so an over-long one is corruption or
+        // mischief — and the failure modes of the alternatives are
+        // worse than an unusable link: truncating would have the joiner
+        // sign rules that end mid-sentence, and dropping the field
+        // would walk them into a group whose rules they were never
+        // shown while the founder believes otherwise.
+        if let rules, rules.count > GroupRules.maxLength {
+            throw InvalidIntroCapability.shape(
+                "rules: expected at most \(GroupRules.maxLength) characters, got \(rules.count)"
+            )
+        }
         self.introPublicKey = pub
         self.groupId = gid
         self.groupName = try c.decodeIfPresent(String.self, forKey: .groupName)
+        self.rules = rules
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -122,6 +170,7 @@ public struct IntroCapability: Codable, Equatable, Sendable, Identifiable {
         try c.encode(introPublicKey, forKey: .introPublicKey)
         try c.encode(groupId, forKey: .groupId)
         try c.encodeIfPresent(groupName, forKey: .groupName)
+        try c.encodeIfPresent(rules, forKey: .rules)
     }
 
     /// Encode to the base64-of-JSON payload that lands in the URL

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestPayload.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestPayload.swift
@@ -19,6 +19,10 @@ import Foundation
 ///    verify out-of-band when the label can't be cross-checked.
 ///  - `groupId` — echoed back so the inviter's approval handler can
 ///    cross-check that the joiner is asking about the right group.
+///  - `rulesHash` / `rulesSignature` — the joiner's agreement to the
+///    group's rules, if the invitation carried any. See `GroupRules`
+///    for the statement these cover and why the envelope's own
+///    signature could not serve.
 ///
 /// The OUTER envelope is the standard `SealedEnvelope` (X25519 +
 /// AES-GCM sealed to the inviter's intro pubkey + Ed25519-signed
@@ -58,6 +62,21 @@ public struct JoinRequestPayload: Codable, Equatable, Sendable {
     public let joinerSendingPublicKey: Data
     public let joinerDisplayLabel: String
     public let groupId: Data
+    /// 32-byte `SHA256` of the canonical rules text the joiner was
+    /// shown. Absent when the invitation carried no rules, and when the
+    /// joiner runs a build that predates them.
+    ///
+    /// Carried even though the inviter knows their own rules, because
+    /// it is what distinguishes "agreed to an older version" from
+    /// "signed nothing that verifies" — without it a stale agreement
+    /// and a forged one look the same, and only one of them is worth
+    /// asking the joiner to redo.
+    public let rulesHash: Data?
+    /// 64-byte Ed25519 signature over
+    /// `GroupRules.statement(groupID:rulesHash:joinerSendingPublicKey:)`,
+    /// made with the joiner's `joinerSendingPublicKey`. Verifiable by
+    /// any member, since that key is announced to all of them.
+    public let rulesSignature: Data?
 
     enum CodingKeys: String, CodingKey {
         case joinerInboxPublicKey = "joiner_inbox_pub"
@@ -66,6 +85,8 @@ public struct JoinRequestPayload: Codable, Equatable, Sendable {
         case joinerSendingPublicKey = "joiner_sending_pub"
         case joinerDisplayLabel = "joiner_display_label"
         case groupId = "group_id"
+        case rulesHash = "rules_hash"
+        case rulesSignature = "rules_signature"
     }
 
     public init(
@@ -74,7 +95,9 @@ public struct JoinRequestPayload: Codable, Equatable, Sendable {
         joinerLeafHash: Data?,
         joinerSendingPublicKey: Data,
         joinerDisplayLabel: String,
-        groupId: Data
+        groupId: Data,
+        rulesHash: Data? = nil,
+        rulesSignature: Data? = nil
     ) throws {
         guard joinerInboxPublicKey.count == 32 else {
             throw JoinRequestPayloadError.shape(
@@ -105,8 +128,39 @@ public struct JoinRequestPayload: Codable, Equatable, Sendable {
         self.joinerBlsPublicKey = joinerBlsPublicKey
         self.joinerLeafHash = joinerLeafHash
         self.joinerSendingPublicKey = joinerSendingPublicKey
+        try Self.validateAgreement(hash: rulesHash, signature: rulesSignature)
         self.joinerDisplayLabel = joinerDisplayLabel
         self.groupId = groupId
+        self.rulesHash = rulesHash
+        self.rulesSignature = rulesSignature
+    }
+
+    /// Shape only — whether the signature *verifies* is
+    /// `GroupRules.isAgreement`, which needs the rules text this type
+    /// deliberately doesn't carry (the inviter has it; sending it back
+    /// would let a joiner choose the text their own signature is
+    /// checked against).
+    private static func validateAgreement(hash: Data?, signature: Data?) throws {
+        if let hash, hash.count != 32 {
+            throw JoinRequestPayloadError.shape(
+                "rulesHash: expected 32 bytes, got \(hash.count)"
+            )
+        }
+        if let signature, signature.count != 64 {
+            throw JoinRequestPayloadError.shape(
+                "rulesSignature: expected 64 bytes, got \(signature.count)"
+            )
+        }
+        // Half an agreement is not one. A signature with nothing naming
+        // what it covers can't be checked, and a hash with no signature
+        // is a claim rather than a proof — either alone would have to
+        // be treated as "didn't sign", so say so at the boundary
+        // instead of leaving every reader to remember it.
+        if (hash == nil) != (signature == nil) {
+            throw JoinRequestPayloadError.shape(
+                "rulesHash and rulesSignature must be present together"
+            )
+        }
     }
 
     public init(from decoder: Decoder) throws {
@@ -146,8 +200,13 @@ public struct JoinRequestPayload: Codable, Equatable, Sendable {
         self.joinerBlsPublicKey = bls
         self.joinerLeafHash = leaf
         self.joinerSendingPublicKey = sending
+        let rulesHash = try c.decodeIfPresent(Data.self, forKey: .rulesHash)
+        let rulesSignature = try c.decodeIfPresent(Data.self, forKey: .rulesSignature)
+        try Self.validateAgreement(hash: rulesHash, signature: rulesSignature)
         self.joinerDisplayLabel = label
         self.groupId = gid
+        self.rulesHash = rulesHash
+        self.rulesSignature = rulesSignature
     }
 }
 

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestSender.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestSender.swift
@@ -41,6 +41,12 @@ public actor JoinRequestSender {
     ///   - agreedRules: the rules text the joiner was shown and
     ///     accepted, or nil when the invitation carried none.
     ///
+    ///     No default value on purpose. The whole reason it is a
+    ///     parameter is that it cannot be derived from `capability`,
+    ///     so a default would make "forgot to pass it" the quiet
+    ///     answer — and the quiet answer reaches the founder as a
+    ///     joiner who declined to agree.
+    ///
     ///     Passed in rather than read off `capability`, because the
     ///     signature has to cover what a person actually saw. The two
     ///     are the same for a link, but an invitation pushed to this
@@ -50,7 +56,7 @@ public actor JoinRequestSender {
     public func send(
         capability: IntroCapability,
         joinerDisplayLabel: String,
-        agreedRules: String? = nil
+        agreedRules: String?
     ) async -> Outcome {
         guard let active = await identity.currentIdentity() else {
             return .noIdentityLoaded
@@ -76,17 +82,33 @@ public actor JoinRequestSender {
         // `joinerSendingPublicKey`, so every member who is later told
         // about this joiner can check it — not just the founder who
         // admitted them.
+        // An invitation that carried rules and a send with none is a
+        // wiring mistake, not a person who declined — and the two are
+        // indistinguishable by the time they reach the founder. Fail
+        // here, where it is still a bug report.
+        if capability.rules != nil, GroupRules.normalized(agreedRules) == nil {
+            return .transportFailed("rules agreement missing for an invite that carries rules")
+        }
         var rulesHash: Data?
         var rulesSignature: Data?
         if let rules = GroupRules.normalized(agreedRules) {
             let hash = GroupRules.hash(rules)
             do {
+                // Bound to the key the payload announces, not to
+                // whichever identity happens to be selected when this
+                // await resumes. A switch across the gap would
+                // otherwise yield a signature verifying against no
+                // announced key — silently, and read by the founder as
+                // a forgery rather than as a race.
                 rulesSignature = try await identity.signWithStellarKey(
                     GroupRules.statement(
                         groupID: capability.groupId,
                         rulesHash: hash,
                         joinerSendingPublicKey: active.stellarPublicKey
-                    )
+                    ),
+                    matchingPublicKeyHex: active.stellarPublicKey
+                        .map { String(format: "%02x", $0) }
+                        .joined()
                 )
                 rulesHash = hash
             } catch {

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestSender.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestSender.swift
@@ -38,9 +38,19 @@ public actor JoinRequestSender {
     ///     prompt. Joiner-controlled untrusted text — keep short
     ///     (Nostr relays typically cap event size at ~64KB and we
     ///     don't want to bloat the request envelope).
+    ///   - agreedRules: the rules text the joiner was shown and
+    ///     accepted, or nil when the invitation carried none.
+    ///
+    ///     Passed in rather than read off `capability`, because the
+    ///     signature has to cover what a person actually saw. The two
+    ///     are the same for a link, but an invitation pushed to this
+    ///     device carries its rules on the stored offer instead, and a
+    ///     sender that reached for the capability's copy would sign
+    ///     text that was never on screen in that case.
     public func send(
         capability: IntroCapability,
-        joinerDisplayLabel: String
+        joinerDisplayLabel: String,
+        agreedRules: String? = nil
     ) async -> Outcome {
         guard let active = await identity.currentIdentity() else {
             return .noIdentityLoaded
@@ -61,6 +71,33 @@ public actor JoinRequestSender {
         } catch {
             return .transportFailed("leaf_hash: \(error)")
         }
+        // The agreement, when there is one to make. Signed with the
+        // same long-term key the request already announces as
+        // `joinerSendingPublicKey`, so every member who is later told
+        // about this joiner can check it — not just the founder who
+        // admitted them.
+        var rulesHash: Data?
+        var rulesSignature: Data?
+        if let rules = GroupRules.normalized(agreedRules) {
+            let hash = GroupRules.hash(rules)
+            do {
+                rulesSignature = try await identity.signWithStellarKey(
+                    GroupRules.statement(
+                        groupID: capability.groupId,
+                        rulesHash: hash,
+                        joinerSendingPublicKey: active.stellarPublicKey
+                    )
+                )
+                rulesHash = hash
+            } catch {
+                // Nothing is sent unsigned behind the person's back:
+                // they were shown rules and told that Send agrees to
+                // them, and a request that arrives without the
+                // signature reads to the founder as someone who
+                // declined to agree.
+                return .transportFailed("rules signature: \(error)")
+            }
+        }
         let payload: JoinRequestPayload
         do {
             payload = try JoinRequestPayload(
@@ -69,7 +106,9 @@ public actor JoinRequestSender {
                 joinerLeafHash: leafHash,
                 joinerSendingPublicKey: active.stellarPublicKey,
                 joinerDisplayLabel: joinerDisplayLabel,
-                groupId: capability.groupId
+                groupId: capability.groupId,
+                rulesHash: rulesHash,
+                rulesSignature: rulesSignature
             )
         } catch {
             return .transportFailed("payload: \(error)")

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -788,7 +788,13 @@ struct OnymIOSApp: App {
             submitJoin: { cap, label in
                 await pendingChatsSender.send(
                     capability: cap,
-                    joinerDisplayLabel: label
+                    joinerDisplayLabel: label,
+                    // Nothing collects an agreement yet: the screen
+                    // that shows rules and the flow that carries the
+                    // answer land with the joiner UI. Spelled out
+                    // rather than defaulted, so this reads as a stage
+                    // the stack is at and not as a caller that forgot.
+                    agreedRules: nil
                 )
             },
             displayLabel: { [repository] in

--- a/Tests/OnymIOSTests/GroupRulesVectorTests.swift
+++ b/Tests/OnymIOSTests/GroupRulesVectorTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+import CryptoKit
+@testable import OnymIOS
+@testable import OnymGroup
+
+/// Golden vectors for the bytes Android has to reproduce, plus the two
+/// boundary rules that decide whether a link is usable at all.
+///
+/// These live in the same PR as the format rather than with the rest of
+/// the tests, because a stack can land partially and these bytes are a
+/// cross-platform contract: `statement()` is what the other
+/// implementation is written against, and a fixture is a cheaper
+/// specification than prose.
+///
+/// Every constant below is fixed on purpose. If one of them has to
+/// change, the wire format changed, and the domain string carries a
+/// version for exactly that.
+final class GroupRulesVectorTests: XCTestCase {
+
+    /// A 32-byte Ed25519 seed, fixed. Not a real identity's.
+    private let seed = Data(repeating: 0x07, count: 32)
+    private let groupID = Data((0..<32).map { UInt8($0) })
+    private let rules = "Be kind. No links."
+
+    private var key: Curve25519.Signing.PrivateKey {
+        try! Curve25519.Signing.PrivateKey(rawRepresentation: seed)
+    }
+
+    /// The expected values below were derived from an independent
+    /// RFC 8032 implementation, not read back out of CryptoKit — a
+    /// vector copied from the code it checks pins nothing.
+    func test_vector_rulesHash() {
+        // SHA-256 of the canonical text's UTF-8, and nothing else — no
+        // length prefix, no domain, no normalisation beyond trimming.
+        XCTAssertEqual(
+            hex(GroupRules.hash(rules)),
+            "440518f597c71a23fe7d99980df8c2156ac86dcc7f5b49493a4d403819b16473"
+        )
+    }
+
+    func test_vector_publicKeyFromTheFixedSeed() {
+        XCTAssertEqual(
+            hex(key.publicKey.rawRepresentation),
+            "ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c"
+        )
+    }
+
+    func test_vector_statementBytes() {
+        // The preimage, byte for byte: 19-byte domain, then three
+        // 32-byte fields in this order.
+        let statement = GroupRules.statement(
+            groupID: groupID,
+            rulesHash: GroupRules.hash(rules),
+            joinerSendingPublicKey: key.publicKey.rawRepresentation
+        )
+        XCTAssertEqual(
+            hex(statement.prefix(19)),
+            hex(Data("onym-group-rules-v1".utf8)),
+            "domain string, unversioned changes to which must break this"
+        )
+        XCTAssertEqual(hex(statement.dropFirst(19).prefix(32)), hex(groupID))
+        XCTAssertEqual(
+            hex(statement.dropFirst(51).prefix(32)),
+            hex(GroupRules.hash(rules))
+        )
+        XCTAssertEqual(
+            hex(statement.suffix(32)),
+            hex(key.publicKey.rawRepresentation)
+        )
+        XCTAssertEqual(statement.count, 115)
+    }
+
+    /// The vector is a signature to **verify**, not one to reproduce.
+    ///
+    /// CryptoKit's Ed25519 signing is randomized: signing the same
+    /// bytes with the same key twice gives two different signatures,
+    /// both valid. So "sign and compare hex" cannot be the contract in
+    /// either direction, and asserting it would have pinned a value
+    /// that changes run to run.
+    ///
+    /// What can be pinned — and is the thing that has to hold across
+    /// platforms — is that a signature produced *elsewhere* over these
+    /// exact bytes verifies here. The value below came from an
+    /// independent RFC 8032 implementation, which is also the shape
+    /// Android's Ed25519 produces. If `statement()` ever disagrees with
+    /// its counterpart by one byte, this test fails and the wire format
+    /// has changed.
+    func test_vector_aForeignSignatureOverTheseBytesVerifies() {
+        let fromAnotherImplementation =
+            "d1b32ae2d65faad6f3867c7a47dec90a1c040ccbcb14e70cfbf5c4ce29229eb9"
+            + "c39055e12bacbfb46c3c83940fd5fed61a9747a5c2ef8fc6468db5fc9421810e"
+        XCTAssertTrue(GroupRules.isAgreement(
+            signature: Data(hexString: fromAnotherImplementation)!,
+            rules: rules,
+            groupID: groupID,
+            joinerSendingPublicKey: key.publicKey.rawRepresentation
+        ))
+    }
+
+    func test_ourOwnSignature_verifies() {
+        let signature = try! key.signature(for: GroupRules.statement(
+            groupID: groupID,
+            rulesHash: GroupRules.hash(rules),
+            joinerSendingPublicKey: key.publicKey.rawRepresentation
+        ))
+        XCTAssertTrue(GroupRules.isAgreement(
+            signature: signature,
+            rules: rules,
+            groupID: groupID,
+            joinerSendingPublicKey: key.publicKey.rawRepresentation
+        ))
+    }
+
+    // MARK: - Canonicalization across platforms
+
+    func test_canonical_trimsTheCodepointsKotlinDoesNot() {
+        // The reason `trimmedCodepoints` is spelled out. NBSP rides in
+        // on text pasted from a web page; if the two platforms disagree
+        // about it, a genuine agreement reads to the founder as a
+        // signature that doesn't check out.
+        for scalar in ["\u{00A0}", "\u{202F}", "\u{205F}", "\u{2007}", "\u{0085}"] {
+            XCTAssertEqual(
+                GroupRules.canonical("\(scalar)\(rules)\(scalar)"),
+                rules,
+                "U+\(String(scalar.unicodeScalars.first!.value, radix: 16, uppercase: true)) must be trimmed on both platforms"
+            )
+        }
+    }
+
+    func test_canonical_leavesInnerTextExactlyAsWritten() {
+        // Only the ends. Inner shape is the founder's, and it is what
+        // the joiner reads and signs.
+        let shaped = "One.\u{00A0}\u{00A0}Two.\n\n  Three."
+        XCTAssertEqual(GroupRules.canonical("  \(shaped)  "), shaped)
+    }
+
+    // MARK: - The cap, in the unit the wire spends
+
+    func test_theCap_isBytesNotCharacters() throws {
+        // A character cap would admit this: 500 grapheme clusters and
+        // ~12.5 KB, seven times the QR ceiling it exists to defend.
+        let family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}"
+        let emoji = String(repeating: family, count: 500)
+        XCTAssertEqual(emoji.count, 500, "500 characters by Swift's count")
+        XCTAssertGreaterThan(emoji.utf8.count, 12_000)
+        XCTAssertThrowsError(
+            try IntroCapability(
+                introPublicKey: Data(repeating: 0x44, count: 32),
+                groupId: groupID,
+                rules: emoji
+            ),
+            "a character cap would have let this through"
+        )
+    }
+
+    func test_rulesAtTheByteCap_areAccepted() throws {
+        let capability = try IntroCapability(
+            introPublicKey: Data(repeating: 0x44, count: 32),
+            groupId: groupID,
+            rules: String(repeating: "則", count: GroupRules.maxBytes / 3)
+        )
+        XCTAssertEqual(capability.rules?.utf8.count, GroupRules.maxBytes)
+    }
+
+    func test_overLongRulesOnTheWire_areRejectedNotTruncated() {
+        // The mint-time cap is not a defence: a hostile link never
+        // passes through it. Truncating would have someone sign rules
+        // that end mid-sentence.
+        let payload = """
+        {"intro_pub":"\(Data(repeating: 0x44, count: 32).base64EncodedString())",\
+        "group_id":"\(groupID.base64EncodedString())",\
+        "rules":"\(String(repeating: "x", count: GroupRules.maxBytes + 1))"}
+        """
+        XCTAssertThrowsError(try IntroCapability.decode(urlSafe(Data(payload.utf8))))
+    }
+
+    // MARK: - Pairing
+
+    func test_halfAnAgreement_isRejected() {
+        // A signature with nothing naming what it covers can't be
+        // checked; a hash with no signature is a claim, not a proof.
+        XCTAssertThrowsError(try request(hash: GroupRules.hash(rules), signature: nil))
+        XCTAssertThrowsError(try request(hash: nil, signature: Data(repeating: 0x55, count: 64)))
+    }
+
+    // MARK: - Helpers
+
+    private func request(hash: Data?, signature: Data?) throws -> JoinRequestPayload {
+        try JoinRequestPayload(
+            joinerInboxPublicKey: Data(repeating: 0xAA, count: 32),
+            joinerBlsPublicKey: nil,
+            joinerLeafHash: nil,
+            joinerSendingPublicKey: key.publicKey.rawRepresentation,
+            joinerDisplayLabel: "Bob",
+            groupId: groupID,
+            rulesHash: hash,
+            rulesSignature: signature
+        )
+    }
+
+    private func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func urlSafe(_ data: Data) -> String {
+        var s = data.base64EncodedString()
+        s = s.replacingOccurrences(of: "+", with: "-")
+        s = s.replacingOccurrences(of: "/", with: "_")
+        while s.hasSuffix("=") { s.removeLast() }
+        return s
+    }
+
+}
+
+private extension Data {
+    /// Test-only, so the golden signature can be written as the hex a
+    /// reader can compare against another implementation's output.
+    init?(hexString: String) {
+        var bytes: [UInt8] = []
+        var index = hexString.startIndex
+        while index < hexString.endIndex {
+            let next = hexString.index(index, offsetBy: 2, limitedBy: hexString.endIndex)
+            guard let next, let byte = UInt8(hexString[index..<next], radix: 16) else {
+                return nil
+            }
+            bytes.append(byte)
+            index = next
+        }
+        self.init(bytes)
+    }
+}


### PR DESCRIPTION
An invite carried a group's name but not its terms. A founder admitting a stranger could prove *who* was asking and never *what they had agreed to*. This is the wire and the crypto for the second half; the screens follow in the PRs stacked on this one.

**Why this can't reuse the envelope's signature.** `IdentityRepository.sealInvitation` signs the *ephemeral public key* — not the payload beneath it. Whoever holds the envelope can produce a different plaintext for the same signature, so it is proof of delivery and never of content. That is the same defect class as #290, and it means agreement needs a signature of its own rather than a reinterpretation of an existing one.

**The statement.**

```
"onym-group-rules-v1" ‖ group_id ‖ SHA256(rules) ‖ joiner_sending_pub
```

Domain-separated, so it can't be replayed as one of the other things this Ed25519 key signs (moderation mandates, report disclosures). Bound to `group_id`, so an acceptance collected for a permissive group can't be shown as agreement to a stricter group whose text happens to match. Bound to the joiner's key, so a signature can't be lifted from one request and re-attributed. No timestamp: a joiner-supplied one is unverifiable, and the founder's receipt time is already theirs.

Because it is signed with `joinerSendingPublicKey` — which is already announced to every member — **any member can verify any other member's agreement**, not just the founder who admitted them.

**The link carries the text, not a hash.** There is no channel to fetch rules from before joining, and someone asked to agree to a hash they cannot read has not agreed to anything. So `IntroCapability` gains `rules`: public and cleartext, exactly as `groupName` is already documented to be, and capped at 500 characters. The cap is the QR code's, and it is measured rather than estimated — 500 CJK characters plus a 30-character group name comes to a 2258-byte link against a 2331-byte ceiling at correction level M. `GroupRules.maxLength` carries the numbers and the thin case.

An over-long `rules` on decode is rejected, not truncated: signing text that ends mid-sentence, and walking someone into a group whose rules they were never shown, are both worse failures than a link that doesn't work.

**`JoinRequestPayload`** carries the hash beside the signature. The inviter knows their own rules, but the hash is what separates "agreed to an older version" from "signed something that doesn't verify" — only one of those is worth asking a person to redo. Both fields are optional, absent together, and rejected if only one arrives.

**The sender signs what was shown**, taking the text as an argument rather than reading it back off the capability. Those agree for a link, but a pushed invitation keeps its rules on the stored offer, and reaching for the capability's copy would sign text that was never on screen. A signing failure fails the send: nothing goes out unsigned behind someone who was just told that Send means agreement.

Nothing calls this with rules yet — that arrives with the screens.

Cross-platform: the JSON keys (`rules`, `rules_hash`, `rules_signature`) are additions to a wire shape documented as byte-for-byte with Android. Unknown keys are ignored on decode, so old builds degrade to "signed nothing" rather than breaking. The same work is owed on onym-android.

Verification: 1497 existing unit tests green. Tests for this land in the final PR of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)