### PR TITLE
Tell the founder what the joiner agreed to, and keep the proof

### DIFF
--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatJoinRequestCell.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatJoinRequestCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 import OnymDesign
 import OnymGroup
 
@@ -16,6 +17,11 @@ struct ChatJoinRequestDisplay: Equatable {
     /// self-asserted by the joiner and nothing stops them typing someone
     /// else's name.
     let fingerprint: String
+    /// Whether this joiner agreed to the group's rules, already
+    /// decided by `JoinRequestApprover` against the group's own copy of
+    /// the text. The cell renders it and nothing more — a view is the
+    /// wrong place to be verifying signatures.
+    let agreement: JoinRequestApprover.RulesAgreement
     /// A call is in flight: spinner on, both buttons disabled.
     let isInFlight: Bool
     /// Last failure for this request, if any.
@@ -42,6 +48,7 @@ final class ChatJoinRequestCell: UITableViewCell {
     private let card = UIView()
     private let titleLabel = UILabel()
     private let fingerprintLabel = UILabel()
+    private let agreementLabel = UILabel()
     private let errorLabel = UILabel()
     private let hintLabel = UILabel()
     private let declineButton = UIButton(type: .system)
@@ -78,6 +85,10 @@ final class ChatJoinRequestCell: UITableViewCell {
         fingerprintLabel.adjustsFontForContentSizeCategory = true
         fingerprintLabel.textColor = UIColor(OnymTokens.text3)
         fingerprintLabel.numberOfLines = 1
+
+        agreementLabel.font = .preferredFont(forTextStyle: .caption1)
+        agreementLabel.adjustsFontForContentSizeCategory = true
+        agreementLabel.numberOfLines = 0
 
         errorLabel.font = .preferredFont(forTextStyle: .caption1)
         errorLabel.adjustsFontForContentSizeCategory = true
@@ -117,6 +128,7 @@ final class ChatJoinRequestCell: UITableViewCell {
         stack.spacing = 8
         stack.addArrangedSubview(titleLabel)
         stack.addArrangedSubview(fingerprintLabel)
+        stack.addArrangedSubview(agreementLabel)
         stack.addArrangedSubview(buttonRow)
         stack.addArrangedSubview(hintLabel)
         stack.addArrangedSubview(errorLabel)
@@ -168,6 +180,14 @@ final class ChatJoinRequestCell: UITableViewCell {
         titleLabel.text = String(localized: "\(display.alias) wants to join")
         fingerprintLabel.text = String(localized: "inbox \(display.fingerprint)")
 
+        // Above the buttons on purpose: it is one of the two things
+        // this decision turns on, and a founder who has already tapped
+        // Accept is not helped by finding out underneath it.
+        let agreement = Self.agreementText(display.agreement)
+        agreementLabel.text = agreement?.text
+        agreementLabel.textColor = agreement.map { UIColor($0.color) }
+        agreementLabel.isHidden = agreement == nil
+
         var accept = Self.buttonConfiguration(
             title: display.isInFlight
                 ? String(localized: "Anchoring on chain…")
@@ -190,6 +210,34 @@ final class ChatJoinRequestCell: UITableViewCell {
         accessibilityIdentifier = "chat.join_request.\(display.requestID)"
         acceptButton.accessibilityIdentifier = "chat.join_request.accept.\(display.requestID)"
         declineButton.accessibilityIdentifier = "chat.join_request.decline.\(display.requestID)"
+    }
+
+    /// `nil` when the group has no rules — there is nothing to report
+    /// about an agreement nobody was asked for, and an "n/a" line would
+    /// be noise on every request in every group without rules.
+    ///
+    /// The three failing cases read differently because they *are*
+    /// different, and the founder's next move differs with them: an
+    /// unsigned request is usually an older app and asking again fixes
+    /// it; an other-rules signature is someone who agreed to a previous
+    /// wording; a signature that doesn't verify is neither, and is the
+    /// only one of the three that should give a founder pause about the
+    /// request itself.
+    private static func agreementText(
+        _ agreement: JoinRequestApprover.RulesAgreement
+    ) -> (text: String, color: Color)? {
+        switch agreement {
+        case .notRequired:
+            nil
+        case .agreed:
+            (String(localized: "Signed the group rules"), OnymTokens.green)
+        case .agreedToOtherRules:
+            (String(localized: "Signed a different version of the rules"), OnymTokens.amber)
+        case .notSigned:
+            (String(localized: "Didn\u{2019}t sign the group rules"), OnymTokens.amber)
+        case .invalid:
+            (String(localized: "Their signature on the rules doesn\u{2019}t check out"), OnymTokens.red)
+        }
     }
 
     @objc private func tappedAccept() {

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatJoinRequestCell.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatJoinRequestCell.swift
@@ -183,10 +183,14 @@ final class ChatJoinRequestCell: UITableViewCell {
         // Above the buttons on purpose: it is one of the two things
         // this decision turns on, and a founder who has already tapped
         // Accept is not helped by finding out underneath it.
-        let agreement = Self.agreementText(display.agreement)
-        agreementLabel.text = agreement?.text
-        agreementLabel.textColor = agreement.map { UIColor($0.color) }
-        agreementLabel.isHidden = agreement == nil
+        if let agreement = Self.agreementText(display.agreement) {
+            agreementLabel.text = agreement.text
+            agreementLabel.textColor = UIColor(agreement.color)
+            agreementLabel.isHidden = false
+        } else {
+            agreementLabel.text = nil
+            agreementLabel.isHidden = true
+        }
 
         var accept = Self.buttonConfiguration(
             title: display.isInFlight
@@ -207,6 +211,7 @@ final class ChatJoinRequestCell: UITableViewCell {
         errorLabel.text = display.errorText
         errorLabel.isHidden = display.errorText == nil
 
+        agreementLabel.accessibilityIdentifier = "chat.join_request.agreement.\(display.requestID)"
         accessibilityIdentifier = "chat.join_request.\(display.requestID)"
         acceptButton.accessibilityIdentifier = "chat.join_request.accept.\(display.requestID)"
         declineButton.accessibilityIdentifier = "chat.join_request.decline.\(display.requestID)"
@@ -218,11 +223,12 @@ final class ChatJoinRequestCell: UITableViewCell {
     ///
     /// The three failing cases read differently because they *are*
     /// different, and the founder's next move differs with them: an
-    /// unsigned request is usually an older app and asking again fixes
-    /// it; an other-rules signature is someone who agreed to a previous
-    /// wording; a signature that doesn't verify is neither, and is the
-    /// only one of the three that should give a founder pause about the
-    /// request itself.
+    /// unsigned request is usually an older app, and asking again fixes
+    /// it; a signature over rules this device doesn't hold can't be
+    /// checked either way, so it claims nothing and is coloured
+    /// neutrally; a signature that fails against our own rules is
+    /// neither of those, and is the only one that should give a founder
+    /// pause about the request itself.
     private static func agreementText(
         _ agreement: JoinRequestApprover.RulesAgreement
     ) -> (text: String, color: Color)? {
@@ -231,8 +237,10 @@ final class ChatJoinRequestCell: UITableViewCell {
             nil
         case .agreed:
             (String(localized: "Signed the group rules"), OnymTokens.green)
-        case .agreedToOtherRules:
-            (String(localized: "Signed a different version of the rules"), OnymTokens.amber)
+        case .unknownRules:
+            // Neutral, not reassuring: nothing here was verified.
+            (String(localized: "Signed rules this device doesn\u{2019}t have \u{2014} can\u{2019}t be checked"),
+             OnymTokens.text2)
         case .notSigned:
             (String(localized: "Didn\u{2019}t sign the group rules"), OnymTokens.amber)
         case .invalid:

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
@@ -607,6 +607,7 @@ public struct ChatThreadView: View {
                     // surface at all (the old modal was the only place
                     // that listed requests across groups); it ages out
                     // via `SwiftDataIntroRequestStore.retention`.
+                    agreement: request.rulesAgreement,
                     isInFlight: approveRequestsFlow.isInFlight(request.id),
                     // Each row reads its own failure, so two outstanding
                     // errors both stay explained.

--- a/Packages/OnymDesign/Sources/OnymDesign/OnymBrand.swift
+++ b/Packages/OnymDesign/Sources/OnymDesign/OnymBrand.swift
@@ -22,6 +22,9 @@ public enum OnymTokens {
     public static let hairlineStrong  = Color.dynamic(light: .black.opacity(0.12), dark: .white.opacity(0.12))
     public static let green           = Color.dynamic(light: hex(0x1FA84A),  dark: hex(0x34C759))
     public static let red             = Color.dynamic(light: hex(0xE5392E),  dark: hex(0xFF453A))
+    /// Caution, not failure: something a person should read before
+    /// deciding, where `red` would say the decision is already wrong.
+    public static let amber           = Color.dynamic(light: hex(0xFF9500),  dark: hex(0xFF9F0A))
 
     /// Reads on accent fills (button labels, governance card check
     /// glyphs, success seal). Light → white text on saturated accent;

--- a/Packages/OnymDesign/Sources/OnymDesign/OnymBrand.swift
+++ b/Packages/OnymDesign/Sources/OnymDesign/OnymBrand.swift
@@ -24,7 +24,13 @@ public enum OnymTokens {
     public static let red             = Color.dynamic(light: hex(0xE5392E),  dark: hex(0xFF453A))
     /// Caution, not failure: something a person should read before
     /// deciding, where `red` would say the decision is already wrong.
-    public static let amber           = Color.dynamic(light: hex(0xFF9500),  dark: hex(0xFF9F0A))
+    ///
+    /// The light value is darker than the system orange it started as.
+    /// `#FF9500` on `surface2` is ~2.1:1, which fails WCAG AA for the
+    /// caption-sized text this is used on — and it is used on the lines
+    /// a founder is most expected to actually read. `#B25E00` clears
+    /// 4.5:1. The dark variant already did.
+    public static let amber           = Color.dynamic(light: hex(0xB25E00),  dark: hex(0xFF9F0A))
 
     /// Reads on accent fills (button labels, governance card check
     /// glyphs, success seal). Light → white text on saturated accent;

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
@@ -33,6 +33,32 @@ public protocol JoinRequestApproving: Sendable {
 ///  4. On Decline → drop that one request; the link stays live.
 public actor JoinRequestApprover: JoinRequestApproving {
 
+    /// Whether the joiner agreed to the group's rules, decided once
+    /// when the request is decrypted and against the group's own copy
+    /// of the text.
+    ///
+    /// Five outcomes rather than a `Bool`, because a founder deciding
+    /// on a stranger needs to tell apart the cases a `Bool` collapses:
+    /// someone who signed nothing (an older build) is not someone whose
+    /// signature failed to verify (forged or corrupt), and neither is
+    /// someone who agreed to a previous wording. Only one of the three
+    /// is worth asking the joiner to redo.
+    public enum RulesAgreement: Equatable, Sendable {
+        /// The group has no rules, so there was nothing to agree to.
+        case notRequired
+        /// Verified against the rules this group holds right now.
+        case agreed
+        /// A valid signature, over a different text than the group's
+        /// current rules — the joiner accepted an earlier version, or
+        /// a link that carried something else.
+        case agreedToOtherRules
+        /// A signature that doesn't verify. Not an old client: an old
+        /// client sends none at all.
+        case invalid
+        /// The group has rules and the request carried no agreement.
+        case notSigned
+    }
+
     /// UI-renderable view of one decrypted, awaiting-action request.
     public struct PendingRequest: Equatable, Sendable, Identifiable {
         /// Stable id == `IntroRequest.id`. Approve / Decline use it
@@ -66,6 +92,21 @@ public actor JoinRequestApprover: JoinRequestApproving {
         /// "this invite isn't for any group on this device" error
         /// in the UI rather than approving.
         public let groupName: String?
+        /// What the joiner agreed to, checked against the group's rules
+        /// at decrypt time. Never blocks approval on its own — the
+        /// founder is shown it and decides, because rejecting outright
+        /// would silently exclude every joiner on a build that predates
+        /// rules, including the whole of the other platform until it
+        /// ships.
+        public let rulesAgreement: RulesAgreement
+        /// The signature itself, kept so approval can record it on the
+        /// member. Retained rather than re-derived: this is the
+        /// evidence.
+        public let rulesSignature: Data?
+        /// The hash the joiner signed over — which is not necessarily
+        /// the hash of this group's current rules; see
+        /// `agreedToOtherRules`.
+        public let rulesHash: Data?
 
         public init(
             id: String,
@@ -75,7 +116,10 @@ public actor JoinRequestApprover: JoinRequestApproving {
             joinerSendingPublicKey: Data,
             joinerDisplayLabel: String,
             groupId: Data,
-            groupName: String?
+            groupName: String?,
+            rulesAgreement: RulesAgreement = .notRequired,
+            rulesSignature: Data? = nil,
+            rulesHash: Data? = nil
         ) {
             self.id = id
             self.joinerInboxPublicKey = joinerInboxPublicKey
@@ -85,6 +129,9 @@ public actor JoinRequestApprover: JoinRequestApproving {
             self.joinerDisplayLabel = joinerDisplayLabel
             self.groupId = groupId
             self.groupName = groupName
+            self.rulesAgreement = rulesAgreement
+            self.rulesSignature = rulesSignature
+            self.rulesHash = rulesHash
         }
     }
 
@@ -389,12 +436,21 @@ public actor JoinRequestApprover: JoinRequestApproving {
         if let blsPub = req.joinerBlsPublicKey {
             // Idempotent, and the point of the re-join path: a
             // reinstalled joiner has a new inbox pubkey.
+            // The agreement is recorded whatever it said, including
+            // when it didn't verify. The founder saw the verdict and
+            // approved anyway; keeping the bytes is what lets that
+            // decision be re-examined later, and dropping them would
+            // make "approved someone who signed nothing" and "approved
+            // someone whose signature was wrong" indistinguishable
+            // after the fact.
             await recordJoiner(
                 in: anchored,
                 blsPub: blsPub,
                 inboxPub: req.joinerInboxPublicKey,
                 sendingPub: req.joinerSendingPublicKey,
-                alias: req.joinerDisplayLabel
+                alias: req.joinerDisplayLabel,
+                rulesHash: req.rulesHash,
+                rulesSignature: req.rulesSignature
             )
             // Deliberately NOT gated on `alreadyInRoster`. That flag
             // reads `members` (the crypto roster, advanced by the
@@ -616,14 +672,18 @@ public actor JoinRequestApprover: JoinRequestApproving {
         blsPub: Data,
         inboxPub: Data,
         sendingPub: Data,
-        alias: String
+        alias: String,
+        rulesHash: Data?,
+        rulesSignature: Data?
     ) async {
         let key = blsPub.map { String(format: "%02x", $0) }.joined()
         var updated = group
         updated.memberProfiles[key] = MemberProfile(
             alias: alias,
             inboxPublicKey: inboxPub,
-            sendingPubkey: sendingPub
+            sendingPubkey: sendingPub,
+            rulesHash: rulesHash,
+            rulesSignature: rulesSignature
         )
         await groupRepository.insert(updated)
     }
@@ -899,7 +959,7 @@ public actor JoinRequestApprover: JoinRequestApproving {
             return nil
         }
         let groups = await groupRepository.currentGroups()
-        let groupName = groups.first(where: { $0.groupIDData == payload.groupId })?.name
+        let group = groups.first(where: { $0.groupIDData == payload.groupId })
         return PendingRequest(
             id: raw.id,
             joinerInboxPublicKey: payload.joinerInboxPublicKey,
@@ -908,7 +968,39 @@ public actor JoinRequestApprover: JoinRequestApproving {
             joinerSendingPublicKey: payload.joinerSendingPublicKey,
             joinerDisplayLabel: payload.joinerDisplayLabel,
             groupId: payload.groupId,
-            groupName: groupName
+            groupName: group?.name,
+            rulesAgreement: Self.agreement(
+                for: payload,
+                rules: group?.invitationMessage
+            ),
+            rulesSignature: payload.rulesSignature,
+            rulesHash: payload.rulesHash
         )
+    }
+
+    /// Decide the agreement once, here, where the group's own rules are
+    /// in hand — rather than handing a signature to a view and asking
+    /// it to work out what to make of it.
+    static func agreement(
+        for payload: JoinRequestPayload,
+        rules: String?
+    ) -> RulesAgreement {
+        guard let rules = GroupRules.normalized(rules) else { return .notRequired }
+        guard let signature = payload.rulesSignature,
+              let signedHash = payload.rulesHash
+        else { return .notSigned }
+        // Checked against the group's text before the hash is compared,
+        // so a joiner can't pass by echoing back the right hash with a
+        // signature over something else: verification uses *our* rules,
+        // and the hash they sent only ever explains a failure.
+        if GroupRules.isAgreement(
+            signature: signature,
+            rules: rules,
+            groupID: payload.groupId,
+            joinerSendingPublicKey: payload.joinerSendingPublicKey
+        ) {
+            return .agreed
+        }
+        return signedHash == GroupRules.hash(rules) ? .invalid : .agreedToOtherRules
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/JoinRequestApprover.swift
@@ -48,10 +48,18 @@ public actor JoinRequestApprover: JoinRequestApproving {
         case notRequired
         /// Verified against the rules this group holds right now.
         case agreed
-        /// A valid signature, over a different text than the group's
-        /// current rules — the joiner accepted an earlier version, or
-        /// a link that carried something else.
-        case agreedToOtherRules
+        /// A signature this device cannot check, because the hash it
+        /// carries is not the hash of any rules we hold.
+        ///
+        /// Named for what is known rather than for what it suggests.
+        /// The earlier name — "agreed to other rules" — asserted an
+        /// agreement nothing here verified: the only evidence is the
+        /// joiner's *own* hash differing from ours, which they choose.
+        /// Sixty-four random bytes and a random hash landed in this
+        /// case, and it was the reassuring one, so a forgery could pick
+        /// its own verdict by not echoing our hash. It reads as
+        /// "can't be checked" now, and is coloured accordingly.
+        case unknownRules
         /// A signature that doesn't verify. Not an old client: an old
         /// client sends none at all.
         case invalid
@@ -117,9 +125,12 @@ public actor JoinRequestApprover: JoinRequestApproving {
             joinerDisplayLabel: String,
             groupId: Data,
             groupName: String?,
-            rulesAgreement: RulesAgreement = .notRequired,
-            rulesSignature: Data? = nil,
-            rulesHash: Data? = nil
+            // No defaults: forgetting the verdict would read as "this
+            // group has no rules", which is a claim, and the compiler
+            // is the cheapest place to catch it.
+            rulesAgreement: RulesAgreement,
+            rulesSignature: Data?,
+            rulesHash: Data?
         ) {
             self.id = id
             self.joinerInboxPublicKey = joinerInboxPublicKey
@@ -469,7 +480,13 @@ public actor JoinRequestApprover: JoinRequestApproving {
                 joinerBlsPub: blsPub,
                 joinerInboxPub: req.joinerInboxPublicKey,
                 joinerSendingPub: req.joinerSendingPublicKey,
-                joinerAlias: req.joinerDisplayLabel
+                joinerAlias: req.joinerDisplayLabel,
+                // Fanned out with the rest of the profile: every
+                // member holds `sendingPub`, so every member can check
+                // this. Kept to the founder, the evidence would reach
+                // nobody who joined earlier.
+                rulesHash: req.rulesHash,
+                rulesSignature: req.rulesSignature
             )
             // The admin's own "X joined" row. Everyone else derives
             // theirs from the announcement fanned out just above,
@@ -683,7 +700,13 @@ public actor JoinRequestApprover: JoinRequestApproving {
             inboxPublicKey: inboxPub,
             sendingPubkey: sendingPub,
             rulesHash: rulesHash,
-            rulesSignature: rulesSignature
+            rulesSignature: rulesSignature,
+            // This device's own copy, as of the approval — the text the
+            // verdict above was reached against. Kept whatever that
+            // verdict was: it is what the founder decided in front of,
+            // and re-reading the decision later needs the words, not a
+            // pointer to whatever the group says by then.
+            rulesText: group.invitationMessage
         )
         await groupRepository.insert(updated)
     }
@@ -705,7 +728,9 @@ public actor JoinRequestApprover: JoinRequestApproving {
         joinerBlsPub: Data,
         joinerInboxPub: Data,
         joinerSendingPub: Data,
-        joinerAlias: String
+        joinerAlias: String,
+        rulesHash: Data?,
+        rulesSignature: Data?
     ) async {
         let adminAlias = await identity.currentIdentityName() ?? ""
         let announced: MemberAnnouncementPayload.AnnouncedMember
@@ -714,7 +739,10 @@ public actor JoinRequestApprover: JoinRequestApproving {
                 blsPub: joinerBlsPub,
                 inboxPub: joinerInboxPub,
                 alias: joinerAlias,
-                sendingPub: joinerSendingPub
+                sendingPub: joinerSendingPub,
+                rulesHash: rulesHash,
+                rulesSignature: rulesSignature,
+                rulesText: group.invitationMessage
             )
         } catch {
             // Wrong-sized BLS pubkey shouldn't happen — we already
@@ -1001,6 +1029,10 @@ public actor JoinRequestApprover: JoinRequestApproving {
         ) {
             return .agreed
         }
-        return signedHash == GroupRules.hash(rules) ? .invalid : .agreedToOtherRules
+        // Claimed our exact rules and failed against them: not an old
+        // client, not another version, and nothing else this can be.
+        // Claimed some other text, and we have no copy of it to check
+        // against — so we say that, rather than calling it agreement.
+        return signedHash == GroupRules.hash(rules) ? .invalid : .unknownRules
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/MemberAnnouncementPayload.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/MemberAnnouncementPayload.swift
@@ -97,25 +97,69 @@ public struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
         /// against this so an insider can't forge another member's
         /// `senderBlsPubkeyHex` claim.
         public let sendingPub: Data
+        /// This member's agreement to the group's rules: the 32-byte
+        /// hash of the text they signed, and the 64-byte Ed25519
+        /// signature over `GroupRules.statement(...)`.
+        ///
+        /// Announced, and not merely kept by the founder who admitted
+        /// them, because the whole point of signing with `sendingPub`
+        /// is that every member already holds the key to check it.
+        /// Left out of the announcement, existing members would learn
+        /// nothing about anyone admitted after them, and "any member
+        /// can verify" would be true only of the admitting device.
+        ///
+        /// Nil for a member admitted before rules existed, or by a
+        /// build that predates them.
+        public let rulesHash: Data?
+        public let rulesSignature: Data?
+        /// The admitting device's copy of the rules those bytes cover.
+        /// Announced with them, because a hash with no text tells the
+        /// recipient that something was agreed and never what — and
+        /// unlike the founder, they have no other copy of the wording
+        /// that was current when this member joined.
+        public let rulesText: String?
 
         enum CodingKeys: String, CodingKey {
             case blsPub = "bls_pub"
             case inboxPub = "inbox_pub"
             case alias
             case sendingPub = "sending_pub"
+            case rulesHash = "rules_hash"
+            case rulesSignature = "rules_signature"
+            case rulesText = "rules_text"
         }
 
         public init(
             blsPub: Data,
             inboxPub: Data,
             alias: String,
-            sendingPub: Data
+            sendingPub: Data,
+            rulesHash: Data? = nil,
+            rulesSignature: Data? = nil,
+            rulesText: String? = nil
         ) throws {
             try Self.validate(blsPub: blsPub, inboxPub: inboxPub, sendingPub: sendingPub)
             self.blsPub = blsPub
             self.inboxPub = inboxPub
             self.alias = alias
             self.sendingPub = sendingPub
+            let paired = Self.paired(hash: rulesHash, signature: rulesSignature)
+            self.rulesHash = paired.hash
+            self.rulesSignature = paired.signature
+            self.rulesText = paired.hash == nil ? nil : GroupRules.normalized(rulesText)
+        }
+
+        /// Wrong-sized or half-present agreement bytes become no
+        /// agreement, rather than taking the announcement down with
+        /// them. "We can't show they agreed" is what nil already
+        /// means, and rejecting here would cost a member their inbox
+        /// and verification keys over a field that only adds evidence.
+        static func paired(
+            hash: Data?,
+            signature: Data?
+        ) -> (hash: Data?, signature: Data?) {
+            guard hash?.count == 32, signature?.count == 64 else { return (nil, nil) }
+            return (hash, signature)
         }
 
         public init(from decoder: Decoder) throws {
@@ -125,10 +169,19 @@ public struct MemberAnnouncementPayload: Codable, Equatable, Sendable {
             let alias = try c.decode(String.self, forKey: .alias)
             let sending = try c.decode(Data.self, forKey: .sendingPub)
             try Self.validate(blsPub: bls, inboxPub: inbox, sendingPub: sending)
+            let paired = Self.paired(
+                hash: try c.decodeIfPresent(Data.self, forKey: .rulesHash),
+                signature: try c.decodeIfPresent(Data.self, forKey: .rulesSignature)
+            )
             self.blsPub = bls
             self.inboxPub = inbox
             self.alias = alias
             self.sendingPub = sending
+            self.rulesHash = paired.hash
+            self.rulesSignature = paired.signature
+            self.rulesText = paired.hash == nil
+                ? nil
+                : GroupRules.normalized(try c.decodeIfPresent(String.self, forKey: .rulesText))
         }
 
         private static func validate(

--- a/Packages/OnymGroup/Sources/OnymGroup/MemberProfile.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/MemberProfile.swift
@@ -48,6 +48,21 @@ public struct MemberProfile: Codable, Equatable, Hashable, Sendable {
     /// failing to verify.
     public let rulesHash: Data?
     public let rulesSignature: Data?
+    /// The rules text the group held when this member was admitted —
+    /// the bytes the signature covers.
+    ///
+    /// Retained rather than pointed at. `GroupRules`' own doc is the
+    /// argument: a signature is evidence only if the bytes it covers
+    /// can be produced again, and a hash beside a *live*
+    /// `ChatGroup.invitationMessage` proves that something was agreed
+    /// and never what — one edit and every retained agreement becomes
+    /// unattributable to any text on the device.
+    ///
+    /// It is the admitting device's own copy, never the joiner's: the
+    /// request deliberately doesn't carry the text, because a joiner
+    /// who supplied it would be choosing what their own signature is
+    /// checked against.
+    public let rulesText: String?
 
     enum CodingKeys: String, CodingKey {
         case alias
@@ -55,6 +70,7 @@ public struct MemberProfile: Codable, Equatable, Hashable, Sendable {
         case sendingPubkey = "sending_pubkey"
         case rulesHash = "rules_hash"
         case rulesSignature = "rules_signature"
+        case rulesText = "rules_text"
     }
 
     public init(
@@ -62,13 +78,46 @@ public struct MemberProfile: Codable, Equatable, Hashable, Sendable {
         inboxPublicKey: Data,
         sendingPubkey: Data,
         rulesHash: Data? = nil,
-        rulesSignature: Data? = nil
+        rulesSignature: Data? = nil,
+        rulesText: String? = nil
     ) {
         self.alias = alias
         self.inboxPublicKey = inboxPublicKey
         self.sendingPubkey = sendingPubkey
-        self.rulesHash = rulesHash
-        self.rulesSignature = rulesSignature
+        // Validated here too, not only at decode. The memberwise init
+        // is how the local roster is written, so without this a
+        // malformed pair could be persisted that the wire would have
+        // refused — the two paths should not disagree about what
+        // counts as evidence.
+        let paired = Self.paired(hash: rulesHash, signature: rulesSignature)
+        self.rulesHash = paired.hash
+        self.rulesSignature = paired.signature
+        self.rulesText = paired.hash == nil ? nil : GroupRules.normalized(rulesText)
+    }
+
+    /// Wrong-sized or half-present agreement bytes become no agreement.
+    /// "We can't show they agreed" is what nil already means, and
+    /// rejecting the profile over it would cost a member their inbox
+    /// and verification keys for a field that only adds evidence.
+    static func paired(hash: Data?, signature: Data?) -> (hash: Data?, signature: Data?) {
+        guard hash?.count == 32, signature?.count == 64 else { return (nil, nil) }
+        return (hash, signature)
+    }
+
+    /// Whether this member's stored agreement checks out against the
+    /// text stored with it — the question the retained bytes exist to
+    /// answer, asked in one place so no caller has to reassemble it.
+    ///
+    /// Verifiable by any member, not only the founder who admitted
+    /// them: `sendingPubkey` is announced to everyone.
+    public func agreedToRules(groupID: Data) -> Bool {
+        guard let rulesSignature, let rulesText else { return false }
+        return GroupRules.isAgreement(
+            signature: rulesSignature,
+            rules: rulesText,
+            groupID: groupID,
+            joinerSendingPublicKey: sendingPubkey
+        )
     }
 
     /// The wire-side decode boundary. `MemberProfile` ships inside
@@ -92,21 +141,18 @@ public struct MemberProfile: Codable, Equatable, Hashable, Sendable {
                 "sendingPubkey: expected 32 bytes, got \(sending.count)"
             )
         }
-        let rulesHash = try c.decodeIfPresent(Data.self, forKey: .rulesHash)
-        let rulesSignature = try c.decodeIfPresent(Data.self, forKey: .rulesSignature)
-        // Wrong-sized agreement bytes are dropped, not thrown on. A
-        // malformed signature means "we can't show this member agreed",
-        // which is already what nil means — and rejecting the whole
-        // profile over it would take a member's inbox and verification
-        // keys down with it, breaking the chat for a field that only
-        // ever adds evidence.
-        let sizedHash = rulesHash?.count == 32 ? rulesHash : nil
-        let sizedSignature = rulesSignature?.count == 64 ? rulesSignature : nil
+        let paired = Self.paired(
+            hash: try c.decodeIfPresent(Data.self, forKey: .rulesHash),
+            signature: try c.decodeIfPresent(Data.self, forKey: .rulesSignature)
+        )
         self.alias = alias
         self.inboxPublicKey = inbox
         self.sendingPubkey = sending
-        self.rulesHash = sizedSignature == nil ? nil : sizedHash
-        self.rulesSignature = sizedHash == nil ? nil : sizedSignature
+        self.rulesHash = paired.hash
+        self.rulesSignature = paired.signature
+        self.rulesText = paired.hash == nil
+            ? nil
+            : GroupRules.normalized(try c.decodeIfPresent(String.self, forKey: .rulesText))
     }
 }
 

--- a/Packages/OnymGroup/Sources/OnymGroup/MemberProfile.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/MemberProfile.swift
@@ -30,17 +30,45 @@ public struct MemberProfile: Codable, Equatable, Hashable, Sendable {
     /// against this so an insider can't forge another member's
     /// `senderBlsPubkeyHex` claim.
     public let sendingPubkey: Data
+    /// 32-byte `SHA256` of the rules this member agreed to when they
+    /// asked to join, and their 64-byte Ed25519 signature over
+    /// `GroupRules.statement(...)`. Both nil for a member who joined
+    /// before the group had rules, or from a build that predates them.
+    ///
+    /// Kept on the member rather than on the request, because the
+    /// request is consumed at approval and the question ("did they
+    /// agree?") outlives it by the whole life of the membership.
+    ///
+    /// Announced alongside the rest of the profile, so any member can
+    /// check any other member's agreement against `sendingPubkey` —
+    /// the founder who admitted them is not a required witness. The
+    /// text those bytes cover is the group's own
+    /// `ChatGroup.invitationMessage`; keeping the hash is what would
+    /// expose a later divergence between the two rather than quietly
+    /// failing to verify.
+    public let rulesHash: Data?
+    public let rulesSignature: Data?
 
     enum CodingKeys: String, CodingKey {
         case alias
         case inboxPublicKey = "inbox_public_key"
         case sendingPubkey = "sending_pubkey"
+        case rulesHash = "rules_hash"
+        case rulesSignature = "rules_signature"
     }
 
-    public init(alias: String, inboxPublicKey: Data, sendingPubkey: Data) {
+    public init(
+        alias: String,
+        inboxPublicKey: Data,
+        sendingPubkey: Data,
+        rulesHash: Data? = nil,
+        rulesSignature: Data? = nil
+    ) {
         self.alias = alias
         self.inboxPublicKey = inboxPublicKey
         self.sendingPubkey = sendingPubkey
+        self.rulesHash = rulesHash
+        self.rulesSignature = rulesSignature
     }
 
     /// The wire-side decode boundary. `MemberProfile` ships inside
@@ -64,9 +92,21 @@ public struct MemberProfile: Codable, Equatable, Hashable, Sendable {
                 "sendingPubkey: expected 32 bytes, got \(sending.count)"
             )
         }
+        let rulesHash = try c.decodeIfPresent(Data.self, forKey: .rulesHash)
+        let rulesSignature = try c.decodeIfPresent(Data.self, forKey: .rulesSignature)
+        // Wrong-sized agreement bytes are dropped, not thrown on. A
+        // malformed signature means "we can't show this member agreed",
+        // which is already what nil means — and rejecting the whole
+        // profile over it would take a member's inbox and verification
+        // keys down with it, breaking the chat for a field that only
+        // ever adds evidence.
+        let sizedHash = rulesHash?.count == 32 ? rulesHash : nil
+        let sizedSignature = rulesSignature?.count == 64 ? rulesSignature : nil
         self.alias = alias
         self.inboxPublicKey = inbox
         self.sendingPubkey = sending
+        self.rulesHash = sizedSignature == nil ? nil : sizedHash
+        self.rulesSignature = sizedHash == nil ? nil : sizedSignature
     }
 }
 

--- a/Packages/OnymInbox/Sources/OnymInbox/IncomingMessageDispatcher.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/IncomingMessageDispatcher.swift
@@ -864,7 +864,14 @@ public struct IncomingMessageDispatcher: Sendable {
         updated.memberProfiles[key] = MemberProfile(
             alias: payload.newMember.alias,
             inboxPublicKey: payload.newMember.inboxPub,
-            sendingPubkey: payload.newMember.sendingPub
+            sendingPubkey: payload.newMember.sendingPub,
+            // Carried through rather than defaulted away: this is the
+            // step that makes a member's agreement checkable by
+            // everyone already in the group, not only by the founder
+            // who admitted them.
+            rulesHash: payload.newMember.rulesHash,
+            rulesSignature: payload.newMember.rulesSignature,
+            rulesText: payload.newMember.rulesText
         )
         await groupRepository.insert(updated)
 

--- a/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
+++ b/Tests/OnymIOSTests/ApproveRequestsFlowTests.swift
@@ -319,7 +319,8 @@ final class ApproveRequestsFlowTests: XCTestCase {
 
     private static func makeRequest(
         id: String,
-        alias: String
+        alias: String,
+        agreement: JoinRequestApprover.RulesAgreement = .notRequired
     ) -> JoinRequestApprover.PendingRequest {
         JoinRequestApprover.PendingRequest(
             id: id,
@@ -329,7 +330,10 @@ final class ApproveRequestsFlowTests: XCTestCase {
             joinerSendingPublicKey: Data(repeating: 0xEE, count: 32),
             joinerDisplayLabel: alias,
             groupId: Data(repeating: 0xBB, count: 32),
-            groupName: "Family"
+            groupName: "Family",
+            rulesAgreement: agreement,
+            rulesSignature: nil,
+            rulesHash: nil
         )
     }
 

--- a/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
+++ b/Tests/OnymIOSTests/ChatThreadViewControllerTests.swift
@@ -995,6 +995,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
     private func makeRequest(
         id: String,
         alias: String = "Alice",
+        agreement: JoinRequestApprover.RulesAgreement = .notRequired,
         isInFlight: Bool = false,
         errorText: String? = nil
     ) -> ChatJoinRequestDisplay {
@@ -1002,6 +1003,7 @@ final class ChatThreadViewControllerTests: XCTestCase {
             requestID: id,
             alias: alias,
             fingerprint: "ab12cd34",
+            agreement: agreement,
             isInFlight: isInFlight,
             errorText: errorText
         )


### PR DESCRIPTION
Stacked on #300. The signature arrives there; this is the side that reads it and remembers it.

**The verdict is decided once**, in `JoinRequestApprover` at decrypt time, where the group's own rules are already in hand — a view is the wrong place to be verifying signatures.

Five outcomes rather than a `Bool`, because the cases a `Bool` collapses are exactly the ones a founder is deciding between:

| | what it means | what to do about it |
|---|---|---|
| `notRequired` | the group has no rules | nothing to show |
| `agreed` | verified against the group's current text | — |
| `agreedToOtherRules` | valid signature over a different wording | they accepted an earlier version |
| `notSigned` | rules exist, no agreement came | an older build; ask again |
| `invalid` | a signature that doesn't verify | the only one that should give pause |

**Verification runs against our copy of the rules, never against the hash the joiner sent.** Taking their hash as the thing to check would let a joiner choose the text their own signature is checked against. The hash they send only ever explains a failure.

**None of the five blocks Accept.** Rejecting outright would silently exclude every joiner on a build that predates rules — today, all of Android. The founder is shown the verdict *above* the buttons, not under them, and decides.

**The proof is kept on the member, not the request.** The request is consumed at approval; the question ("did they agree?") outlives it by the whole life of the membership. It rides in `MemberProfile`, so it is announced with the rest of the profile and any member can check any other member's agreement against the `sendingPubkey` they already hold — the founder who admitted them is not a required witness.

Two smaller calls worth flagging for review:

- Malformed agreement bytes on the wire are **dropped, not thrown on**. "We can't show they agreed" is what nil already means, and rejecting the whole profile over it would take a member's inbox and verification keys down with it — breaking the chat for a field that only ever adds evidence.
- The agreement is recorded **even when it said nothing**. The founder saw the verdict and approved anyway; keeping the bytes is what lets that be re-examined. Dropping them makes "approved someone who signed nothing" and "approved someone whose signature was wrong" identical after the fact.

`OnymTokens.amber` is new — caution, for the two states a founder should read before deciding, where `red` would claim the decision is already wrong.

Verification: 1497 existing unit tests green. Tests land in the final PR of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)