### PR TITLE
Group rules, read on the way in and signed on the way out

### DIFF
--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/JoinConfirmView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/JoinConfirmView.swift
@@ -42,8 +42,15 @@ public struct JoinConfirmView: View {
             ScrollView {
                 VStack(spacing: 18) {
                     header
+                    // Same field, two names: since the rename, a
+                    // group's invitation message *is* its rules, so an
+                    // offer whose text became the rules card must not
+                    // also draw it as a greeting. Only a message that
+                    // says something different earns its own card.
                     if let message = confirmation.invitationMessage,
-                       !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                       !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                       message.trimmingCharacters(in: .whitespacesAndNewlines)
+                           != confirmation.rules {
                         invitationCard(message)
                     }
                     if let rules = confirmation.rules {

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/JoinConfirmView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/JoinConfirmView.swift
@@ -33,6 +33,9 @@ public struct JoinConfirmView: View {
 
     @State private var label: String = ""
     @State private var isSending = false
+    /// Unticked until the person ticks it. Only ever gates Send for a
+    /// group that has rules — see `canSend`.
+    @State private var agreedToRules = false
 
     public var body: some View {
         NavigationStack {
@@ -42,6 +45,9 @@ public struct JoinConfirmView: View {
                     if let message = confirmation.invitationMessage,
                        !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         invitationCard(message)
+                    }
+                    if let rules = confirmation.rules {
+                        rulesCard(rules)
                     }
                     nameField
                     disclosure
@@ -106,6 +112,48 @@ public struct JoinConfirmView: View {
             .accessibilityIdentifier("join_confirm.invitation_message")
     }
 
+    /// The rules, and the tick that turns reading them into agreeing.
+    ///
+    /// Send signs this exact text, so it is shown in full rather than
+    /// truncated behind a "more": a signature over words that were
+    /// folded away is not much of an agreement. The text is
+    /// founder-supplied and untrusted, hence rendered plain — no
+    /// markdown, no links to follow.
+    private func rulesCard(_ rules: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Group rules")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(OnymTokens.text3)
+            Text(rules)
+                .font(.system(size: 14))
+                .foregroundStyle(OnymTokens.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+                .accessibilityIdentifier("join_confirm.rules_text")
+            Divider().overlay(OnymTokens.hairline)
+            Toggle(isOn: $agreedToRules) {
+                Text("I agree to these rules")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(OnymTokens.text)
+            }
+            .tint(OnymAccent.blue.color)
+            .accessibilityIdentifier("join_confirm.agree_toggle")
+            // Said plainly, because it is the part that outlives the
+            // tap: the founder keeps this, and can show it.
+            Text("Your agreement is signed with this identity\u{2019}s key and sent with your request.")
+                .font(.system(size: 11))
+                .foregroundStyle(OnymTokens.text2)
+        }
+        .padding(14)
+        .background(OnymTokens.surface2)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(OnymTokens.hairline, lineWidth: 1)
+        )
+        .accessibilityIdentifier("join_confirm.rules")
+    }
+
     /// Pre-filled, never blank: the identity's own name is the answer
     /// almost every time, so joining is Send and nothing else. The field
     /// is here for the times it isn't — a name you'd rather this room
@@ -148,6 +196,17 @@ public struct JoinConfirmView: View {
                     .font(.system(size: 12))
                     .foregroundStyle(OnymTokens.text2)
             }
+            if confirmation.rules != nil {
+                Label {
+                    Text("Your signed agreement to the rules goes with it.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(OnymTokens.text2)
+                } icon: {
+                    Image(systemName: "signature")
+                        .font(.system(size: 12))
+                        .foregroundStyle(OnymTokens.text2)
+                }
+            }
             row("group", value: shortHex(confirmation.groupIDHex))
             row("invite key", value: shortHex(hex(confirmation.introPublicKey)))
         }
@@ -165,7 +224,9 @@ public struct JoinConfirmView: View {
         } label: {
             Text(isSending
                  ? String(localized: "Sending\u{2026}")
-                 : String(localized: "Send join request"))
+                 : confirmation.rules == nil
+                    ? String(localized: "Send join request")
+                    : String(localized: "Agree and send request"))
                 .font(.system(size: 15, weight: .semibold))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
@@ -180,8 +241,16 @@ public struct JoinConfirmView: View {
     /// A name is required: an empty one reaches the founder as a blank
     /// row they are asked to admit. It is pre-filled from the identity,
     /// so this only bites if someone deliberately clears it.
+    ///
+    /// The rules tick is required only when there are rules. A group
+    /// that asks nothing of its joiners keeps that one-tap join: there
+    /// is nothing to affirm, and a tick standing for nothing is
+    /// friction that teaches people to tick without reading.
     private var canSend: Bool {
-        !isSending && !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        guard !isSending,
+              !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return false }
+        return confirmation.rules == nil || agreedToRules
     }
 
     /// `LocalizedStringKey`, not `String`: passing a `String` picks

--- a/Packages/OnymGroup/Sources/OnymGroup/ChatGroup.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/ChatGroup.swift
@@ -132,6 +132,25 @@ public struct ChatGroup: Identifiable, Equatable, Sendable {
         self.invitationMessage = invitationMessage
     }
 
+    /// The group's rules if a link can carry them, else nil.
+    ///
+    /// Groups created before the cap existed can hold a message longer
+    /// than an invite link accepts — the field was documented as "any
+    /// length" — and `IntroCapability` rejects those, which turned
+    /// "Share invite" into a permanent failure for exactly those
+    /// groups. Losing the rules from the link is bad; losing the
+    /// ability to invite anyone is worse.
+    ///
+    /// Omitted rather than truncated, because truncation is the one
+    /// option that produces a wrong answer instead of a missing one:
+    /// joiners would sign an abridged text and every one of those
+    /// signatures would then fail against the founder's full copy,
+    /// reaching them as signatures that don't check out.
+    public var linkableRules: String? {
+        guard let rules = GroupRules.normalized(invitationMessage) else { return nil }
+        return GroupRules.fits(rules) ? rules : nil
+    }
+
     /// Group ID as the raw 32-byte payload (parsed back from `id`).
     /// Used directly when building chain payloads + invitations.
     public var groupIDData: Data {

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupFlow.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupFlow.swift
@@ -35,12 +35,31 @@ public final class CreateGroupFlow {
     // MARK: - Form state
 
     public var name: String
-    /// Optional free-text invitation the creator writes — a greeting,
-    /// group policy, or articles of association. Travels in the sealed
-    /// invite payloads (never the QR/link, never on-chain) so invitees
-    /// read it before accepting and it persists as the group's intro.
-    /// Any length; empty means "no invitation".
-    var invitationMessage: String = ""
+    /// The group's rules: what everyone joining agrees to. Travels in
+    /// the sealed invite payloads *and*, since joiners must be able to
+    /// read them before agreeing, in the invite link itself — which is
+    /// where the length cap comes from. Persists as the group's intro,
+    /// and is the text a joiner's signature covers. Empty means the
+    /// group asks nothing, and no agreement is collected.
+    ///
+    /// Clamped rather than validated at submit: a founder who has
+    /// typed past the limit is told by the counter, and letting them
+    /// keep typing into a field that will refuse to mint a link at the
+    /// end is the worse failure. See `GroupRules.maxLength`.
+    var invitationMessage: String = "" {
+        didSet {
+            if invitationMessage.count > GroupRules.maxLength {
+                invitationMessage = String(
+                    invitationMessage.prefix(GroupRules.maxLength)
+                )
+            }
+        }
+    }
+
+    /// How much room is left in the rules, for the field's counter.
+    public var rulesRemaining: Int {
+        GroupRules.maxLength - invitationMessage.count
+    }
     /// Always `.tyranny` in PR-C — the picker disables the others.
     public var governance: OnymUIGovernance = .tyranny
     public internal(set) var invitees: [OnymInvitee] = []

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupFlow.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupFlow.swift
@@ -42,23 +42,46 @@ public final class CreateGroupFlow {
     /// and is the text a joiner's signature covers. Empty means the
     /// group asks nothing, and no agreement is collected.
     ///
-    /// Clamped rather than validated at submit: a founder who has
-    /// typed past the limit is told by the counter, and letting them
-    /// keep typing into a field that will refuse to mint a link at the
-    /// end is the worse failure. See `GroupRules.maxLength`.
-    var invitationMessage: String = "" {
-        didSet {
-            if invitationMessage.count > GroupRules.maxLength {
-                invitationMessage = String(
-                    invitationMessage.prefix(GroupRules.maxLength)
-                )
-            }
+    /// Clamped rather than validated at submit: a founder who has typed
+    /// past the limit is told by the counter, and letting them keep
+    /// typing into a field that will refuse to mint a link at the end
+    /// is the worse failure.
+    ///
+    /// The clamp lives in the view's `onChange`, where the name field's
+    /// does — a plain stored property here, rather than one carrying a
+    /// `didSet` whose interaction with `@Observable`'s accessor
+    /// synthesis would have to be reasoned about before trusting
+    /// `rulesRemaining` to update live.
+    var invitationMessage: String = ""
+
+    /// The same text clamped to what an invite can carry, in both units
+    /// that bound it.
+    ///
+    /// Bytes are the cap that decides whether a link is valid, and
+    /// characters are what the counter shows; a scalar can cost up to
+    /// four bytes, so trimming proceeds one character at a time rather
+    /// than slicing bytes and risking a cut mid-scalar.
+    public static func clampedRules(_ text: String) -> String {
+        var clamped = text.count > GroupRules.maxLength
+            ? String(text.prefix(GroupRules.maxLength))
+            : text
+        while clamped.utf8.count > GroupRules.maxBytes {
+            clamped.removeLast()
         }
+        return clamped
     }
 
     /// How much room is left in the rules, for the field's counter.
+    ///
+    /// Whichever cap is closer: Latin text runs out of characters
+    /// first, and scripts that cost more per character run out of bytes
+    /// first. Showing the larger of the two would keep counting down
+    /// while typing had already stopped having any effect.
     public var rulesRemaining: Int {
-        GroupRules.maxLength - invitationMessage.count
+        min(
+            GroupRules.maxLength - invitationMessage.count,
+            GroupRules.maxBytes - invitationMessage.utf8.count
+        )
     }
     /// Always `.tyranny` in PR-C — the picker disables the others.
     public var governance: OnymUIGovernance = .tyranny

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupInteractor.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupInteractor.swift
@@ -743,7 +743,12 @@ public struct CreateGroupInteractor: Sendable {
                     ownerIdentityID: ownerIdentityID,
                     groupId: groupID,
                     groupName: groupName,
-                    label: IntroKeyEntry.fingerprint(of: inboxKey)
+                    label: IntroKeyEntry.fingerprint(of: inboxKey),
+                    // The offer carries the rules too, but a create-time
+                    // invitee can also be reached by the link this
+                    // capability encodes — and the two must ask them to
+                    // agree to the same words.
+                    rules: invitationMessage
                 )
             } catch {
                 throw CreateGroupError.invitationSendFailed(

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupInteractor.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupInteractor.swift
@@ -748,7 +748,15 @@ public struct CreateGroupInteractor: Sendable {
                     // invitee can also be reached by the link this
                     // capability encodes — and the two must ask them to
                     // agree to the same words.
-                    rules: invitationMessage
+                    //
+                    // Dropped from the link if it won't fit, for the
+                    // reason `ChatGroup.linkableRules` gives: a group
+                    // that can't mint an invite at all is the worse
+                    // failure, and truncating would have joiners sign
+                    // an abridged text that then fails to verify.
+                    rules: GroupRules.normalized(invitationMessage).flatMap {
+                        GroupRules.fits($0) ? $0 : nil
+                    }
                 )
             } catch {
                 throw CreateGroupError.invitationSendFailed(

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupView.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupView.swift
@@ -262,6 +262,12 @@ private struct CreateGroupStep1View: View {
         .lineLimit(3...12)
         .textInputAutocapitalization(.sentences)
         .accessibilityIdentifier("create_group.step1.invitation_field")
+        // Clamped here, the way the name field above is, so a paste
+        // that overshoots is cut as it lands rather than at submit.
+        .onChange(of: flow.invitationMessage) { _, new in
+            let clamped = CreateGroupFlow.clampedRules(new)
+            if clamped != new { flow.invitationMessage = clamped }
+        }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
         .background(OnymTokens.surface2)
@@ -282,7 +288,7 @@ private struct CreateGroupStep1View: View {
             if flow.rulesRemaining <= 100 {
                 Text("\(flow.rulesRemaining)")
                     .monospacedDigit()
-                    .foregroundStyle(flow.rulesRemaining == 0 ? OnymTokens.amber : OnymTokens.text3)
+                    .foregroundStyle(flow.rulesRemaining <= 0 ? OnymTokens.amber : OnymTokens.text3)
                     .accessibilityLabel("\(flow.rulesRemaining) characters left")
             }
         }

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupView.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupView.swift
@@ -175,7 +175,7 @@ private struct CreateGroupStep1View: View {
                     avatar
                     nameField
                     nameFootnote
-                    OnymSectionLabel(text: "Invitation message")
+                    OnymSectionLabel(text: "Group rules")
                     invitationField
                     invitationFootnote
                     OnymSectionLabel(text: "Group type")
@@ -252,7 +252,7 @@ private struct CreateGroupStep1View: View {
         TextField(
             "",
             text: $flow.invitationMessage,
-            prompt: Text("Add a greeting, group rules, or policy…")
+            prompt: Text("What everyone here agrees to. Optional.")
                 .foregroundColor(OnymTokens.text3),
             axis: .vertical
         )
@@ -272,12 +272,24 @@ private struct CreateGroupStep1View: View {
     }
 
     private var invitationFootnote: some View {
-        Text("Shown to people before they accept your invite. Optional.")
-            .font(.system(size: 11.5))
-            .foregroundStyle(OnymTokens.text3)
-            .padding(.horizontal, 4)
-            .padding(.top, 6)
-            .frame(maxWidth: .infinity, alignment: .leading)
+        HStack(alignment: .top, spacing: 8) {
+            Text("Anyone joining reads these and signs that they agree, so you can show later what they agreed to.")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            // Only once it starts to matter. A counter sitting at 500
+            // on an empty field reads as a demand for 500 characters;
+            // what a founder needs is warning that the room is running
+            // out, and the cap is the QR code's, so running out is real.
+            if flow.rulesRemaining <= 100 {
+                Text("\(flow.rulesRemaining)")
+                    .monospacedDigit()
+                    .foregroundStyle(flow.rulesRemaining == 0 ? OnymTokens.amber : OnymTokens.text3)
+                    .accessibilityLabel("\(flow.rulesRemaining) characters left")
+            }
+        }
+        .font(.system(size: 11.5))
+        .foregroundStyle(OnymTokens.text3)
+        .padding(.horizontal, 4)
+        .padding(.top, 6)
     }
 
     /// Founder is the only group type today, so the picker is replaced by

--- a/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
@@ -44,11 +44,15 @@ public actor InviteIntroducer {
     ///     is sensitive (deeplink transits cleartext channels).
     ///   - label: nil for the shared link; the invitee's fingerprint
     ///     for a create-time offer, so the invite list can name it.
+    ///   - rules: the group's rules, carried in the link so whoever
+    ///     opens it can read them before agreeing. Public, like
+    ///     `groupName`, and capped — see `GroupRules.maxLength`.
     public func mint(
         ownerIdentityID: IdentityID,
         groupId: Data,
         groupName: String? = nil,
-        label: String? = nil
+        label: String? = nil,
+        rules: String? = nil
     ) async throws -> IntroCapability {
         guard groupId.count == 32 else {
             throw IntroducerError.invalidGroupID(actualSize: groupId.count)
@@ -73,7 +77,8 @@ public actor InviteIntroducer {
         return try IntroCapability(
             introPublicKey: pubBytes,
             groupId: groupId,
-            groupName: groupName
+            groupName: groupName,
+            rules: rules
         )
     }
 
@@ -82,7 +87,8 @@ public actor InviteIntroducer {
     public func currentOrMint(
         ownerIdentityID: IdentityID,
         groupId: Data,
-        groupName: String? = nil
+        groupName: String? = nil,
+        rules: String? = nil
     ) async throws -> IntroCapability {
         // Ahead of the store read so the throw is the same whichever
         // branch would have run.
@@ -99,16 +105,23 @@ public actor InviteIntroducer {
                 $0.groupId == groupId && $0.label == nil && !$0.isLegacy
             }
             if let live {
+                // The rules come from the caller's current group, not
+                // from whenever this key was minted: the link is a
+                // pointer to the group, and a live key handed out with
+                // stale rules would have joiners signing text the
+                // founder had already replaced.
                 return try IntroCapability(
                     introPublicKey: live.introPublicKey,
                     groupId: groupId,
-                    groupName: groupName
+                    groupName: groupName,
+                    rules: rules
                 )
             }
             return try await self.mint(
                 ownerIdentityID: ownerIdentityID,
                 groupId: groupId,
-                groupName: groupName
+                groupName: groupName,
+                rules: rules
             )
         }
     }

--- a/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/InviteIntroducer.swift
@@ -174,7 +174,8 @@ public actor InviteIntroducer {
     public func rotate(
         ownerIdentityID: IdentityID,
         groupId: Data,
-        groupName: String? = nil
+        groupName: String? = nil,
+        rules: String? = nil
     ) async throws -> IntroCapability {
         guard groupId.count == 32 else {
             throw IntroducerError.invalidGroupID(actualSize: groupId.count)
@@ -192,7 +193,12 @@ public actor InviteIntroducer {
             let fresh = try await self.mint(
                 ownerIdentityID: ownerIdentityID,
                 groupId: groupId,
-                groupName: groupName
+                groupName: groupName,
+                // A rotated link is the same invitation to the same
+                // group. Minting it without rules would hand every
+                // joiner on it the one-tap join and land them on the
+                // founder's screen as having declined to agree.
+                rules: rules
             )
 
             for pub in superseded where pub != fresh.introPublicKey {

--- a/Packages/OnymGroup/Sources/OnymGroup/ShareInviteFlow.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/ShareInviteFlow.swift
@@ -93,7 +93,10 @@ public final class ShareInviteFlow: Identifiable {
             let cap = try await introducer.currentOrMint(
                 ownerIdentityID: activeID,
                 groupId: group.groupIDData,
-                groupName: group.name
+                groupName: group.name,
+                // Straight from the group, so a link shared today
+                // carries what this group asks of joiners today.
+                rules: group.invitationMessage
             )
             currentIntroPub = cap.introPublicKey
             state = .ready(link: cap.toAppLink(), groupName: group.name)

--- a/Packages/OnymGroup/Sources/OnymGroup/ShareInviteFlow.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/ShareInviteFlow.swift
@@ -96,7 +96,7 @@ public final class ShareInviteFlow: Identifiable {
                 groupName: group.name,
                 // Straight from the group, so a link shared today
                 // carries what this group asks of joiners today.
-                rules: group.invitationMessage
+                rules: group.linkableRules
             )
             currentIntroPub = cap.introPublicKey
             state = .ready(link: cap.toAppLink(), groupName: group.name)
@@ -131,7 +131,8 @@ public final class ShareInviteFlow: Identifiable {
             let cap = try await introducer.rotate(
                 ownerIdentityID: activeID,
                 groupId: group.groupIDData,
-                groupName: group.name
+                groupName: group.name,
+                rules: group.linkableRules
             )
             currentIntroPub = cap.introPublicKey
             state = .ready(link: cap.toAppLink(), groupName: group.name)

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingChatStore.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingChatStore.swift
@@ -16,7 +16,9 @@ public protocol PendingChatStore: Sendable {
     /// while a join request is still in flight.
     func setStatus(id: String, status: PendingChat.Status) async
     /// Take the reply channel and the descriptive fields from a newer
-    /// offer for a row that already exists, leaving its status alone.
+    /// offer for a row that already exists, leaving its status and its
+    /// `joinerLabel` alone — the offer describes the invitation, not the
+    /// name this device chose to ask under.
     ///
     /// A re-invite mints a *fresh* intro key and "Generate new link"
     /// revokes the old one (`IntroKeyStore.revoke`), so a row that kept
@@ -85,7 +87,13 @@ public actor InMemoryPendingChatStore: PendingChatStore {
             inviterAlias: inviterAlias,
             invitationMessage: invitationMessage,
             receivedAt: existing.receivedAt,
-            status: existing.status
+            status: existing.status,
+            // Carried, the way the SwiftData store carries it: the name
+            // this device asked under is not the offer's to replace,
+            // and the confirmation screen now refreshes a row it has
+            // just labelled — dropping it here made the next "Ask
+            // again" arrive from a stranger.
+            joinerLabel: existing.joinerLabel
         )
     }
 

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingChatsFlow.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingChatsFlow.swift
@@ -114,7 +114,13 @@ public final class PendingChatsFlow {
     private let groupRepository: GroupRepository
     /// Seals + sends a `JoinRequestPayload` for the given capability —
     /// the same `JoinRequestSender` the deeplink path uses.
-    private let submitJoin: @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome
+    ///
+    /// The third argument is the rules text that was on screen when the
+    /// person agreed, which is what their signature ends up covering.
+    /// It travels from the screen rather than being read back off the
+    /// capability, so a request can never claim agreement to words
+    /// nobody was shown.
+    private let submitJoin: @Sendable (IntroCapability, String, String?) async -> JoinRequestSender.Outcome
     /// The joiner's display label, read lazily at accept time so an
     /// identity rename is picked up without re-wiring.
     ///
@@ -147,7 +153,7 @@ public final class PendingChatsFlow {
         repository: PendingChatRepository,
         verificationStore: PendingVerificationStore,
         groupRepository: GroupRepository,
-        submitJoin: @escaping @Sendable (IntroCapability, String) async -> JoinRequestSender.Outcome,
+        submitJoin: @escaping @Sendable (IntroCapability, String, String?) async -> JoinRequestSender.Outcome,
         displayLabel: @escaping @Sendable () async -> String,
         retryVerification: @escaping @Sendable (String) async -> Void,
         currentIdentityID: @escaping @Sendable () async -> IdentityID?
@@ -270,6 +276,11 @@ public final class PendingChatsFlow {
         /// holds its private half is who this discloses to, and that is
         /// worth showing rather than describing.
         public let introPublicKey: Data
+        /// The group's rules, when it has any. Shown on the screen and
+        /// signed by Send — the same string for both, because a
+        /// signature over anything other than what was read is not an
+        /// agreement.
+        public let rules: String?
         /// Pre-filled into the name field: the identity's own alias, or
         /// the name a previous attempt on this row used.
         public let suggestedLabel: String
@@ -305,6 +316,11 @@ public final class PendingChatsFlow {
         } else {
             suggested = await displayLabel()
         }
+        // The link's own copy wins over a stored offer's. Both should
+        // say the same thing, and when they don't, the rules the person
+        // is about to read have to be the ones that came with the
+        // invitation they actually opened.
+        let rules = capability.rules ?? existing?.invitationMessage
         return .confirm(
             JoinConfirmation(
                 rowID: rowID,
@@ -313,6 +329,7 @@ public final class PendingChatsFlow {
                 inviterAlias: existing?.inviterAlias ?? "",
                 invitationMessage: existing?.invitationMessage,
                 introPublicKey: capability.introPublicKey,
+                rules: rules,
                 suggestedLabel: suggested,
                 origin: .link(capability)
             )
@@ -340,6 +357,9 @@ public final class PendingChatsFlow {
             inviterAlias: chat.inviterAlias,
             invitationMessage: chat.invitationMessage,
             introPublicKey: chat.introPublicKey,
+            // A pushed invitation carries its rules on the stored offer
+            // — there is no capability to read them from.
+            rules: chat.invitationMessage,
             suggestedLabel: suggested,
             origin: .offer(rowID: chat.id)
         )
@@ -386,7 +406,10 @@ public final class PendingChatsFlow {
                 // shows the group, not a person who never said their
                 // name.
                 inviterAlias: "",
-                invitationMessage: nil,
+                // The link's rules, kept on the row: "Ask again" has to
+                // re-sign the same text, and the row is the only place
+                // it survives once the capability is gone.
+                invitationMessage: capability.rules,
                 receivedAt: Date(),
                 status: .offered,
                 joinerLabel: trimmed
@@ -466,6 +489,10 @@ public final class PendingChatsFlow {
     ///
     /// `label` is always supplied by a caller a person reached: there is
     /// no path from an inbound link or event to here.
+    ///
+    /// The rules signed are the row's own — the same text the screen
+    /// showed, kept there for exactly this reason, so a re-send months
+    /// later still says what the first one said.
     private func send(_ chat: PendingChat, label: String) {
         let id = chat.id
         guard !sendingIDs.contains(id) else { return }
@@ -485,8 +512,9 @@ public final class PendingChatsFlow {
         rebuild()
         let submitJoin = self.submitJoin
         let repository = self.repository
+        let rules = chat.invitationMessage
         Task { @MainActor [weak self] in
-            let outcome = await submitJoin(capability, label)
+            let outcome = await submitJoin(capability, label, rules)
             switch outcome {
             case .sent:
                 await repository.markRequested(id: id)

--- a/Packages/OnymInbox/Sources/OnymInbox/PendingChatsFlow.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/PendingChatsFlow.swift
@@ -320,7 +320,7 @@ public final class PendingChatsFlow {
         // say the same thing, and when they don't, the rules the person
         // is about to read have to be the ones that came with the
         // invitation they actually opened.
-        let rules = capability.rules ?? existing?.invitationMessage
+        let rules = GroupRules.normalized(capability.rules ?? existing?.invitationMessage)
         return .confirm(
             JoinConfirmation(
                 rowID: rowID,
@@ -359,7 +359,13 @@ public final class PendingChatsFlow {
             introPublicKey: chat.introPublicKey,
             // A pushed invitation carries its rules on the stored offer
             // — there is no capability to read them from.
-            rules: chat.invitationMessage,
+            //
+            // Normalized here rather than trusted: a group whose rules
+            // are whitespace has none, and passing `"   "` through
+            // would draw an empty rules card, demand a tick for it, and
+            // then send no signature at all, because the sender
+            // normalizes before signing.
+            rules: GroupRules.normalized(chat.invitationMessage),
             suggestedLabel: suggested,
             origin: .offer(rowID: chat.id)
         )
@@ -391,7 +397,7 @@ public final class PendingChatsFlow {
             // on underneath.
             guard chat.status == .offered else { return .waiting(rowID: rowID) }
             await repository.attachJoinerLabel(id: rowID, label: trimmed)
-            send(chat, label: trimmed)
+            send(chat, label: trimmed, rules: confirmation.rules)
             return .waiting(rowID: rowID)
         case .link(let capability):
             guard let owner = await currentIdentityID() else {
@@ -406,17 +412,19 @@ public final class PendingChatsFlow {
                 // shows the group, not a person who never said their
                 // name.
                 inviterAlias: "",
-                // The link's rules, kept on the row: "Ask again" has to
-                // re-sign the same text, and the row is the only place
-                // it survives once the capability is gone.
-                invitationMessage: capability.rules,
+                // The rules the screen showed, kept on the row: "Ask
+                // again" has to re-sign the same text, and the row is
+                // the only place it survives once the capability is
+                // gone. The screen's copy, not the capability's, so the
+                // two can't drift.
+                invitationMessage: confirmation.rules,
                 receivedAt: Date(),
                 status: .offered,
                 joinerLabel: trimmed
             )
             switch await repository.record(chat) {
             case .inserted:
-                send(chat, label: trimmed)
+                send(chat, label: trimmed, rules: confirmation.rules)
                 return .waiting(rowID: chat.id)
             case .alreadyPresent:
                 // A pushed offer for this group arrived first and is
@@ -424,7 +432,25 @@ public final class PendingChatsFlow {
                 await repository.attachJoinerLabel(id: chat.id, label: trimmed)
                 let existing = await repository.currentChats().first { $0.id == chat.id }
                 if let existing, existing.status == .offered {
-                    send(existing, label: trimmed)
+                    // The stored offer's text may differ from the
+                    // link's, and the screen resolved the link's ahead
+                    // of it. So the row is brought up to what was
+                    // actually read before anything is signed —
+                    // otherwise this send, and every "Ask again" after
+                    // it, would attest to words nobody saw.
+                    let shown = PendingChat(
+                        groupID: existing.groupID,
+                        ownerIdentityID: existing.ownerIdentityID,
+                        introPublicKey: existing.introPublicKey,
+                        groupName: existing.groupName,
+                        inviterAlias: existing.inviterAlias,
+                        invitationMessage: confirmation.rules,
+                        receivedAt: existing.receivedAt,
+                        status: existing.status,
+                        joinerLabel: trimmed
+                    )
+                    await repository.refreshOffer(shown)
+                    send(shown, label: trimmed, rules: confirmation.rules)
                 }
                 return .waiting(rowID: chat.id)
             case .failed, .notRecorded:
@@ -468,7 +494,7 @@ public final class PendingChatsFlow {
             // one after this repeats it rather than re-deriving it from
             // an identity that may since have been renamed.
             if let label = chat.joinerLabel {
-                send(chat, label: label)
+                send(chat, label: label, rules: GroupRules.normalized(chat.invitationMessage))
                 return
             }
             let repository = self.repository
@@ -476,7 +502,11 @@ public final class PendingChatsFlow {
             Task { @MainActor [weak self] in
                 let label = await displayLabel()
                 await repository.attachJoinerLabel(id: id, label: label)
-                self?.send(chat, label: label)
+                self?.send(
+                    chat,
+                    label: label,
+                    rules: GroupRules.normalized(chat.invitationMessage)
+                )
             }
         case .offered, .chainSettling:
             break
@@ -490,10 +520,13 @@ public final class PendingChatsFlow {
     /// `label` is always supplied by a caller a person reached: there is
     /// no path from an inbound link or event to here.
     ///
-    /// The rules signed are the row's own — the same text the screen
-    /// showed, kept there for exactly this reason, so a re-send months
-    /// later still says what the first one said.
-    private func send(_ chat: PendingChat, label: String) {
+    /// `rules` is passed rather than read off `chat`, because the two
+    /// can disagree and only one of them is the agreement: the screen
+    /// resolves a link's rules ahead of a stored offer's, so a row
+    /// whose text differs would otherwise be signed instead of the
+    /// words that were on screen. A re-send passes the row's own copy,
+    /// which is the same text, kept for exactly that.
+    private func send(_ chat: PendingChat, label: String, rules: String?) {
         let id = chat.id
         guard !sendingIDs.contains(id) else { return }
         let capability: IntroCapability
@@ -512,7 +545,6 @@ public final class PendingChatsFlow {
         rebuild()
         let submitJoin = self.submitJoin
         let repository = self.repository
-        let rules = chat.invitationMessage
         Task { @MainActor [weak self] in
             let outcome = await submitJoin(capability, label, rules)
             switch outcome {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7615,6 +7615,198 @@
           }
         }
       }
+    },
+    "Group rules": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group rules"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Правила группы"
+          }
+        }
+      }
+    },
+    "I agree to these rules": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I agree to these rules"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Я согласен с этими правилами"
+          }
+        }
+      }
+    },
+    "Your agreement is signed with this identity’s key and sent with your request.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your agreement is signed with this identity’s key and sent with your request."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваше согласие подписывается ключом этой личности и отправляется вместе с запросом."
+          }
+        }
+      }
+    },
+    "Agree and send request": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agree and send request"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Согласиться и отправить запрос"
+          }
+        }
+      }
+    },
+    "Your signed agreement to the rules goes with it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your signed agreement to the rules goes with it."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вместе с ним отправляется ваше подписанное согласие с правилами."
+          }
+        }
+      }
+    },
+    "What everyone here agrees to. Optional.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What everyone here agrees to. Optional."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "То, с чем соглашаются все участники. Необязательно."
+          }
+        }
+      }
+    },
+    "Anyone joining reads these and signs that they agree, so you can show later what they agreed to.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anyone joining reads these and signs that they agree, so you can show later what they agreed to."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каждый, кто вступает, читает их и подписывает согласие — потом вы сможете показать, с чем именно он согласился."
+          }
+        }
+      }
+    },
+    "%lld characters left": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld characters left"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Осталось символов: %lld"
+          }
+        }
+      }
+    },
+    "Signed the group rules": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signed the group rules"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подписал правила группы"
+          }
+        }
+      }
+    },
+    "Signed a different version of the rules": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signed a different version of the rules"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подписал другую версию правил"
+          }
+        }
+      }
+    },
+    "Didn’t sign the group rules": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Didn’t sign the group rules"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не подписал правила группы"
+          }
+        }
+      }
+    },
+    "Their signature on the rules doesn’t check out": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Their signature on the rules doesn’t check out"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Его подпись под правилами не проходит проверку"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7643,7 +7643,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Я согласен с этими правилами"
+            "value": "Я принимаю эти правила"
           }
         }
       }
@@ -7760,22 +7760,6 @@
         }
       }
     },
-    "Signed a different version of the rules": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signed a different version of the rules"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Подписал другую версию правил"
-          }
-        }
-      }
-    },
     "Didn’t sign the group rules": {
       "localizations": {
         "en": {
@@ -7804,6 +7788,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Его подпись под правилами не проходит проверку"
+          }
+        }
+      }
+    },
+    "Signed rules this device doesn’t have — can’t be checked": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signed rules this device doesn’t have — can’t be checked"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подписал правила, которых нет на этом устройстве — проверить нельзя"
           }
         }
       }

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -785,16 +785,15 @@ struct OnymIOSApp: App {
             repository: pendingChatRepository,
             verificationStore: pendingVerificationStore,
             groupRepository: groupRepository,
-            submitJoin: { cap, label in
+            submitJoin: { cap, label, rules in
                 await pendingChatsSender.send(
                     capability: cap,
                     joinerDisplayLabel: label,
-                    // Nothing collects an agreement yet: the screen
-                    // that shows rules and the flow that carries the
-                    // answer land with the joiner UI. Spelled out
-                    // rather than defaulted, so this reads as a stage
-                    // the stack is at and not as a caller that forgot.
-                    agreedRules: nil
+                    // The rules the screen showed, carried by the flow
+                    // rather than re-read from the capability: the
+                    // signature has to cover what a person actually
+                    // read.
+                    agreedRules: rules
                 )
             },
             displayLabel: { [repository] in

--- a/Tests/OnymIOSTests/ChatGroupTests.swift
+++ b/Tests/OnymIOSTests/ChatGroupTests.swift
@@ -23,7 +23,47 @@ final class ChatGroupTests: XCTestCase {
         XCTAssertEqual(group.groupIDData, Data([0xAB, 0xCD]))
     }
 
-    private func makeGroup(id: String) -> ChatGroup {
+    // MARK: - linkableRules
+
+    func test_linkableRules_areTheCanonicalTextAJoinerWillSign() {
+        let group = makeGroup(id: "abcd", invitationMessage: "  Be kind.\n")
+        XCTAssertEqual(
+            group.linkableRules, "Be kind.",
+            "the link carries the same form the signature covers"
+        )
+    }
+
+    func test_linkableRules_areNilForAGroupThatAsksNothing() {
+        XCTAssertNil(makeGroup(id: "abcd", invitationMessage: nil).linkableRules)
+        XCTAssertNil(
+            makeGroup(id: "abcd", invitationMessage: "   ").linkableRules,
+            "blank rules are no rules, not an empty thing to agree to"
+        )
+    }
+
+    func test_linkableRules_omitTextTooLongForALink_ratherThanBlockingTheShare() {
+        // The field was documented as "any length" before the cap, so a
+        // group created by an earlier build can hold more than an
+        // invite accepts. Omitted rather than truncated: an abridged
+        // text is the one option that produces a wrong answer instead
+        // of a missing one, since joiners would sign it and every
+        // signature would then fail against the founder's full copy.
+        let long = String(repeating: "a", count: GroupRules.maxBytes + 1)
+        let group = makeGroup(id: "abcd", invitationMessage: long)
+
+        XCTAssertNil(group.linkableRules)
+        XCTAssertNoThrow(
+            try IntroCapability(
+                introPublicKey: Data(repeating: 0x44, count: 32),
+                groupId: Data(repeating: 0x11, count: 32),
+                groupName: group.name,
+                rules: group.linkableRules
+            ),
+            "a legacy group must still be shareable"
+        )
+    }
+
+    private func makeGroup(id: String, invitationMessage: String? = nil) -> ChatGroup {
         ChatGroup(
             id: id,
             ownerIdentityID: IdentityID(),
@@ -39,7 +79,8 @@ final class ChatGroupTests: XCTestCase {
             groupType: .tyranny,
             adminPubkeyHex: nil,
             adminEd25519PubkeyHex: nil,
-            isPublishedOnChain: false
+            isPublishedOnChain: false,
+            invitationMessage: invitationMessage
         )
     }
 }

--- a/Tests/OnymIOSTests/CreateGroupFlowTests.swift
+++ b/Tests/OnymIOSTests/CreateGroupFlowTests.swift
@@ -372,6 +372,52 @@ final class CreateGroupFlowTests: XCTestCase {
         XCTAssertNil(flow.error)
     }
 
+    // MARK: - Group rules
+
+    /// One `Character`, 25 UTF-8 bytes — the shape that makes a
+    /// character cap and a byte cap disagree.
+    private let family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}"
+
+    func test_clampedRules_stopsAtTheCharacterCap() {
+        let typed = String(repeating: "a", count: GroupRules.maxLength + 50)
+        XCTAssertEqual(
+            CreateGroupFlow.clampedRules(typed).count, GroupRules.maxLength
+        )
+    }
+
+    func test_clampedRules_stopsAtTheByteCap_withoutCuttingAScalar() {
+        // 200 characters is well inside the character cap and five
+        // thousand bytes outside the byte one, which is the cap that
+        // decides whether a link is valid. Trimmed a character at a
+        // time, so what is left is still the text that was typed.
+        let clamped = CreateGroupFlow.clampedRules(String(repeating: family, count: 200))
+
+        XCTAssertEqual(
+            clamped,
+            String(repeating: family, count: GroupRules.maxBytes / family.utf8.count)
+        )
+        XCTAssertLessThanOrEqual(clamped.utf8.count, GroupRules.maxBytes)
+    }
+
+    func test_clampedRules_leavesTextThatFitsAlone() {
+        XCTAssertEqual(CreateGroupFlow.clampedRules("Be kind."), "Be kind.")
+        XCTAssertEqual(CreateGroupFlow.clampedRules(""), "")
+    }
+
+    func test_rulesRemaining_countsDownWhicheverCapIsCloser() async throws {
+        let flow = await makeFlow()
+
+        // Latin text runs out of characters first.
+        flow.invitationMessage = String(repeating: "a", count: 100)
+        XCTAssertEqual(flow.rulesRemaining, GroupRules.maxLength - 100)
+
+        // Fifty family emoji: 450 characters still to spare, and 250
+        // bytes. Showing the larger would keep counting down while
+        // typing had already stopped having any effect.
+        flow.invitationMessage = String(repeating: family, count: 50)
+        XCTAssertEqual(flow.rulesRemaining, GroupRules.maxBytes - 50 * 25)
+    }
+
     // MARK: - Helpers
 
     private func makeFlow() async -> CreateGroupFlow {

--- a/Tests/OnymIOSTests/InviteIntroducerTests.swift
+++ b/Tests/OnymIOSTests/InviteIntroducerTests.swift
@@ -286,6 +286,27 @@ final class InviteIntroducerTests: XCTestCase {
         XCTAssertEqual(rotated.introPublicKey, resolved.introPublicKey)
     }
 
+    func test_rotate_carriesTheRulesOntoTheFreshLink() async throws {
+        // "Generate new link" is the same invitation to the same group.
+        // A rotated link minted without rules hands every joiner on it
+        // the one-tap join and lands them on the founder's screen as
+        // having declined to agree.
+        let store = InMemoryIntroKeyStore()
+        let introducer = InviteIntroducer(store: store)
+
+        _ = try await introducer.currentOrMint(
+            ownerIdentityID: alice, groupId: sampleGroupId, rules: "Be kind."
+        )
+        let rotated = try await introducer.rotate(
+            ownerIdentityID: alice,
+            groupId: sampleGroupId,
+            groupName: "Family",
+            rules: "Be kind."
+        )
+
+        XCTAssertEqual(rotated.rules, "Be kind.")
+    }
+
     func test_rotate_leavesOtherGroupsAlone() async throws {
         let store = InMemoryIntroKeyStore()
         let introducer = InviteIntroducer(store: store)

--- a/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
+++ b/Tests/OnymIOSTests/PendingChatRepositoryTests.swift
@@ -307,7 +307,8 @@ final class PendingChatRepositoryTests: XCTestCase {
                 inviterAlias: inviterAlias,
                 invitationMessage: invitationMessage,
                 receivedAt: existing.receivedAt,
-                status: existing.status
+                status: existing.status,
+                joinerLabel: existing.joinerLabel
             )
         }
 

--- a/Tests/OnymIOSTests/PendingChatStoreTests.swift
+++ b/Tests/OnymIOSTests/PendingChatStoreTests.swift
@@ -222,6 +222,7 @@ final class PendingChatStoreTests: XCTestCase {
         let afterStatus = await store.list().first { $0.id == old.id }
         XCTAssertEqual(afterStatus?.status, .failed(.transport), file: file, line: line)
 
+        await store.setJoinerLabel(id: new.id, label: "Bobby")
         await store.refreshOffer(
             id: new.id,
             introPublicKey: Data(repeating: 0x99, count: 32),
@@ -232,6 +233,11 @@ final class PendingChatStoreTests: XCTestCase {
         let refreshed = await store.list().first { $0.id == new.id }
         XCTAssertEqual(refreshed?.introPublicKey, Data(repeating: 0x99, count: 32), file: file, line: line)
         XCTAssertEqual(refreshed?.groupName, "renamed", file: file, line: line)
+        // A newer offer describes the invitation, not the name this
+        // device asked under. The confirmation screen refreshes a row it
+        // has just labelled, so a conformer that dropped the label here
+        // would make the next "Ask again" arrive from a stranger.
+        XCTAssertEqual(refreshed?.joinerLabel, "Bobby", file: file, line: line)
         // A row that isn't there absorbs the write rather than creating one.
         await store.setStatus(id: "nobody:home", status: .requested)
         let afterGhost = await store.list()

--- a/Tests/OnymIOSTests/PendingChatsFlowTests.swift
+++ b/Tests/OnymIOSTests/PendingChatsFlowTests.swift
@@ -587,8 +587,8 @@ final class PendingChatsFlowTests: XCTestCase {
                 repository: repository,
                 verificationStore: verifications,
                 groupRepository: groups,
-                submitJoin: { capability, label in
-                    await sender.send(capability: capability, label: label)
+                submitJoin: { capability, label, rules in
+                    await sender.send(capability: capability, label: label, rules: rules)
                 },
                 displayLabel: { "Bob" },
                 retryVerification: { hex in await retries.record(hex) },
@@ -713,6 +713,9 @@ private actor SpyJoinSender {
     struct Call: Sendable {
         let capability: IntroCapability
         let label: String
+        /// The rules text the send signed, so a test can assert that a
+        /// request agreed to what the screen displayed.
+        let rules: String?
     }
 
     private(set) var calls: [Call] = []
@@ -730,8 +733,12 @@ private actor SpyJoinSender {
         gate = nil
     }
 
-    func send(capability: IntroCapability, label: String) async -> JoinRequestSender.Outcome {
-        calls.append(Call(capability: capability, label: label))
+    func send(
+        capability: IntroCapability,
+        label: String,
+        rules: String?
+    ) async -> JoinRequestSender.Outcome {
+        calls.append(Call(capability: capability, label: label, rules: rules))
         if held {
             await withCheckedContinuation { continuation in
                 if held { gate = continuation } else { continuation.resume() }

--- a/Tests/OnymIOSTests/PendingChatsFlowTests.swift
+++ b/Tests/OnymIOSTests/PendingChatsFlowTests.swift
@@ -536,6 +536,77 @@ final class PendingChatsFlowTests: XCTestCase {
         XCTAssertEqual(harness.flow.rows.count, 1, "one waiting room, not two")
     }
 
+    // MARK: - What gets signed
+
+    func test_theRulesSigned_areTheOnesTheScreenShowed() async throws {
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        guard case .confirm(let confirmation) =
+                await harness.flow.prepareJoin(capability: harness.capability(rules: "Be kind."))
+        else { return XCTFail("expected a confirmation") }
+        XCTAssertEqual(confirmation.rules, "Be kind.")
+
+        await harness.flow.confirmJoin(confirmation, label: "Bobby")
+
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+        let calls = await harness.sender.calls
+        XCTAssertEqual(calls.first?.rules, "Be kind.")
+        // Kept on the row, because "Ask again" months later has to
+        // re-sign the same words and the capability is gone by then.
+        let stored = await harness.repository.currentChats()
+        XCTAssertEqual(stored.first?.invitationMessage, "Be kind.")
+    }
+
+    func test_aLinkOnAnUnansweredOffer_signsTheTextThatWasRead_andKeepsIt() async throws {
+        // The screen resolves a link's rules ahead of a stored offer's,
+        // so a row whose words differ must be brought up to what was
+        // actually read — otherwise this send, and every "Ask again"
+        // after it, attests to text nobody saw.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        await harness.repository.record(harness.makeChat(invitationMessage: "an older draft"))
+        try await waitFor { harness.flow.rows.first?.state == .offered }
+
+        guard case .confirm(let confirmation) = await harness.flow.prepareJoin(
+            capability: harness.capability(rules: "the rules as shown")
+        ) else { return XCTFail("an unanswered offer must still be confirmable") }
+        XCTAssertEqual(confirmation.rules, "the rules as shown")
+        await harness.flow.confirmJoin(confirmation, label: "Bobby")
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+        try await waitFor { harness.flow.rows.first?.state == .waiting }
+
+        harness.flow.retry(harness.makeChat().id)
+
+        try await waitForAsync { await harness.sender.calls.count == 2 }
+        let calls = await harness.sender.calls
+        XCTAssertEqual(calls.map(\.rules), ["the rules as shown", "the rules as shown"])
+        XCTAssertEqual(
+            calls.map(\.label), ["Bobby", "Bobby"],
+            "re-asking introduces the same person the first ask did"
+        )
+    }
+
+    func test_rulesThatAreOnlyWhitespace_askNothingAndSignNothing() async throws {
+        // `"   "` is non-nil, and left alone it drew an empty rules
+        // card and a mandatory tick — then signed nothing, because the
+        // sender normalizes before signing.
+        let harness = await Harness.make(owner: owner)
+        await harness.flow.start()
+        let chat = harness.makeChat(invitationMessage: "   ")
+        await harness.repository.record(chat)
+        try await waitFor { harness.flow.rows.first?.state == .offered }
+
+        guard let confirmation = await harness.flow.prepareAccept(rowID: chat.id)
+        else { return XCTFail("expected a confirmation") }
+        XCTAssertNil(confirmation.rules)
+
+        await harness.flow.confirmJoin(confirmation, label: "Bobby")
+
+        try await waitForAsync { await harness.sender.calls.count == 1 }
+        let calls = await harness.sender.calls
+        XCTAssertNil(calls.first?.rules)
+    }
+
     func test_aLinkIntoAChatYouAreIn_opensItWithoutDisclosingAnything() async throws {
         let harness = await Harness.make(owner: owner)
         let capability = harness.capability()
@@ -616,22 +687,26 @@ final class PendingChatsFlowTests: XCTestCase {
             await flow.confirmJoin(confirmation, label: label)
         }
 
-        func capability() -> IntroCapability {
+        func capability(rules: String? = nil) -> IntroCapability {
             try! IntroCapability(
                 introPublicKey: Data(repeating: 0x44, count: 32),
                 groupId: Data(repeating: 0x11, count: 32),
-                groupName: "Maple Garden"
+                groupName: "Maple Garden",
+                rules: rules
             )
         }
 
-        func makeChat(introPublicKey: Data = Data(repeating: 0x44, count: 32)) -> PendingChat {
+        func makeChat(
+            introPublicKey: Data = Data(repeating: 0x44, count: 32),
+            invitationMessage: String? = "come in"
+        ) -> PendingChat {
             PendingChat(
                 groupID: Data(repeating: 0x11, count: 32),
                 ownerIdentityID: owner ?? IdentityID(),
                 introPublicKey: introPublicKey,
                 groupName: "Maple Garden",
                 inviterAlias: "Alice",
-                invitationMessage: "come in",
+                invitationMessage: invitationMessage,
                 receivedAt: Date(),
                 status: .offered
             )


### PR DESCRIPTION
Stacked on #301. The screens, and the rename.

The field's own placeholder already read *"Add a greeting, group rules, or policy…"*. This makes it the rules, gives joiners something to agree to, and carries the agreement back.

**The founder's side.** "Invitation message" → "Group rules", and the footnote now says what that costs the person reading it: anyone joining reads these and signs that they agree. The field is clamped to 500 characters rather than validated at submit — the cap is the invite QR code's, and letting someone type past it into a field that will refuse to mint a link at the end is the worse failure. The counter appears at the last hundred characters and not before: one sitting at 500 on an empty field reads as a demand for 500 characters.

**The link.** `ShareInviteFlow` and the create-time invitee mint both pass the group's *current* rules — including down the `currentOrMint` path that reuses a live intro key. The link is a pointer to the group, and a reused key handed out with rules from whenever it was minted would have joiners signing text the founder had already replaced.

**The joiner's side.** The confirmation screen grows a rules card: the full text, never truncated behind a "more", because Send signs this exact string and a signature over folded-away words is not much of an agreement. The tick under it turns reading into agreeing, and it gates Send — **but only for a group that has rules**.

That last point is the one design call worth arguing with. A group that asks nothing keeps the one-tap join the pre-filled name bought; a tick standing for nothing is friction that teaches people to tick without reading. With rules, the button says what it does: *"Agree and send request"*.

**The rules signed are the ones the screen showed**, threaded through as a value rather than re-read from the capability at send time. A link's copy wins over a stored offer's when both exist, since the person read the invitation they actually opened. And the text is kept on the pending row, because "Ask again" months later has to re-sign the same words — the capability is long gone by then.

Twelve strings, en and ru.

Verification: 1497 existing unit tests green; the whole stack builds. Tests for the feature land in the PR after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)