### PR TITLE
A member's standing on the rules, and a proof that leaves the device

### DIFF
--- a/Packages/OnymGroup/Sources/OnymGroup/ChatGroup.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/ChatGroup.swift
@@ -186,7 +186,7 @@ public struct ChatGroup: Identifiable, Equatable, Sendable {
     /// `groupType` themselves.
     public func isAdmin(blsPublicKey: Data) -> Bool {
         guard let storedAdminHex = adminPubkeyHex?.lowercased() else { return false }
-        let candidate = blsPublicKey.map { String(format: "%02x", $0) }.joined().lowercased()
+        let candidate = blsPublicKey.hexString.lowercased()
         return candidate == storedAdminHex
     }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/DataHex.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/DataHex.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Data {
+    /// Lowercase hex. One implementation, because there were four
+    /// hand-rolled `%02x` loops in this package and a fifth was about
+    /// to be written.
+    var hexString: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Packages/OnymGroup/Sources/OnymGroup/GroupRulesProof.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupRulesProof.swift
@@ -45,18 +45,26 @@ public struct GroupRulesProof: Equatable, Sendable {
     public let currentRules: String?
     public let standing: GroupRulesStanding
 
-    public init(
-        group: ChatGroup,
-        member: MemberProfile,
-        blsHex: String
-    ) {
-        let standing = group.rulesStanding(of: member, blsHex: blsHex)
-        self.groupIDHex = group.id
+    /// `nil` when no member is stored under `blsHex` — the same reason
+    /// `rulesStanding(ofMemberWith:)` takes the key alone: a proof
+    /// about a profile that isn't in this group's roster is a document
+    /// nobody should be able to produce by accident.
+    public init?(group: ChatGroup, blsHex: String) {
+        guard let member = group.memberProfiles[blsHex],
+              let standing = group.rulesStanding(ofMemberWith: blsHex)
+        else { return nil }
+        // Re-hexed from the bytes signing actually used, rather than
+        // echoing `group.id`. `bytes(fromHex:)` is lenient, and the
+        // `_readme` tells the reader this field is 32 bytes — a
+        // malformed id would otherwise ship instructions that cannot be
+        // followed.
+        self.groupIDHex = group.groupIDData.hexString
         self.groupName = group.name
         self.memberAlias = member.alias
         self.memberBlsHex = blsHex
         self.standing = standing
-        self.currentRules = GroupRules.normalized(group.invitationMessage)
+        let currentRules = GroupRules.normalized(group.invitationMessage)
+        self.currentRules = currentRules
         // Only carried where they mean something. Shipping a signature
         // that doesn't verify, or one there is no text for, would put
         // bytes in a document called a proof that prove nothing.
@@ -67,17 +75,27 @@ public struct GroupRulesProof: Equatable, Sendable {
         } else {
             self.sendingPublicKey = nil
             self.signature = nil
-            self.rules = nil
+            // The author is the one unproven standing with words worth
+            // carrying: they are the group's rules, and a document
+            // about the person who wrote them that contains none of
+            // them is thin to the point of useless.
+            self.rules = standing == .author ? currentRules : nil
         }
     }
 
     /// A filename someone can find again in a Files app six months
     /// later: the group and the member, not a hash.
     public var suggestedFileName: String {
+        // A fixed locale, not the device's: `lowercased()` under a
+        // Turkish locale maps I to a dotless ı, so the same group would
+        // produce different filenames on two phones. And ASCII only —
+        // diacritic folding leaves CJK and Cyrillic untouched, so
+        // testing for "is a letter" would let them through into a name
+        // that is meant to survive being emailed around.
         let stem = "\(groupName)-\(memberAlias)"
-            .folding(options: .diacriticInsensitive, locale: .current)
-            .lowercased()
-            .map { $0.isLetter || $0.isNumber ? $0 : "-" }
+            .folding(options: .diacriticInsensitive, locale: Locale(identifier: "en_US_POSIX"))
+            .lowercased(with: Locale(identifier: "en_US_POSIX"))
+            .map { $0.isASCII && ($0.isLetter || $0.isNumber) ? $0 : "-" }
             .reduce(into: "") { out, character in
                 // Collapse runs, so "Maple  Garden!" doesn't become
                 // "maple--garden-".
@@ -142,11 +160,13 @@ public struct GroupRulesProof: Equatable, Sendable {
             let text: String
             let sha256: String
             let matchesCurrentRules: Bool
+            let currentText: String?
 
             enum CodingKeys: String, CodingKey {
                 case text
                 case sha256
                 case matchesCurrentRules = "matches_current_rules"
+                case currentText = "current_text"
             }
         }
 
@@ -165,16 +185,26 @@ public struct GroupRulesProof: Equatable, Sendable {
             member: .init(
                 alias: memberAlias,
                 blsPublicKey: memberBlsHex,
-                sendingPublicKey: sendingPublicKey.map(Self.hex),
-                signature: signature.map(Self.hex),
+                sendingPublicKey: sendingPublicKey.map(\.hexString),
+                signature: signature.map(\.hexString),
                 signed: standing.isProven,
                 note: Self.note(for: standing)
             ),
             rules: rules.map { text in
-                .init(
+                // From the standing, not re-derived. `signed` and
+                // `signedEarlierVersion` already *are* this fact, and a
+                // type whose thesis is single-sourced derivation should
+                // not answer the same question twice.
+                let matches = standing != .signedEarlierVersion
+                return .init(
                     text: text,
-                    sha256: Self.hex(GroupRules.hash(text)),
-                    matchesCurrentRules: text == currentRules
+                    sha256: GroupRules.hash(text).hexString,
+                    matchesCurrentRules: matches,
+                    // Only where it differs, and then in full: a reader
+                    // told the wording diverged has nothing to compare
+                    // against otherwise. Identical copies would just be
+                    // the same paragraph twice.
+                    currentText: matches ? nil : currentRules
                 )
             }
         )
@@ -193,7 +223,17 @@ public struct GroupRulesProof: Equatable, Sendable {
         "  2. check member.signature against that message and that key.",
         "The rules text here is the wording this member signed. When",
         "matches_current_rules is false, the group has changed its rules",
-        "since — the signature still covers the text in this file.",
+        "since — the signature still covers the text in this file, and",
+        "current_text carries what the group says now, to compare.",
+        "",
+        "What the signature does NOT cover, and what you must not read",
+        "out of it: alias and bls_public_key. Neither is inside the",
+        "signed message. The alias is a name this member chose and can",
+        "change, and the pairing of that name and that BLS key with this",
+        "signature is an assertion by the app that wrote this file — not",
+        "something the signature proves. What the signature proves is",
+        "that the holder of sending_public_key agreed to these rules for",
+        "this group. Tie that key to a person by some other means.",
     ]
 
     static func note(for standing: GroupRulesStanding) -> String? {
@@ -206,12 +246,12 @@ public struct GroupRulesProof: Equatable, Sendable {
             "This member wrote the rules; founders do not sign their own."
         case .didNotSign:
             "Joined before this group had rules, or from an app version that predates them."
+        case .unknownRules:
+            "A signature is stored for this member, but the wording it covers is not on "
+            + "this device, so nothing here can check it."
         case .doesNotVerify:
             "A signature was stored for this member and it does not verify."
         }
     }
 
-    static func hex(_ data: Data) -> String {
-        data.map { String(format: "%02x", $0) }.joined()
-    }
 }

--- a/Packages/OnymGroup/Sources/OnymGroup/GroupRulesProof.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupRulesProof.swift
@@ -1,0 +1,217 @@
+import Foundation
+import CryptoKit
+
+/// One member's agreement to a group's rules, as a file that can leave
+/// the device and still mean something.
+///
+/// ## What makes it a proof
+///
+/// Not this app's say-so. The document carries the exact inputs to the
+/// check — the rules text, the member's Ed25519 public key, and their
+/// signature — so a reader who trusts none of this can recompute
+/// `GroupRules.statement(...)` and verify it with any Ed25519
+/// implementation. The `_readme` lines say how, in the file itself,
+/// because a proof whose verification procedure lives in a codebase the
+/// reader doesn't have is a screenshot with extra steps.
+///
+/// ## The rules it carries are the signed ones
+///
+/// `rules` is the text stored beside the signature, not whatever the
+/// group says today. Those differ exactly when the founder changed the
+/// wording after this member joined, and the honest export is the one
+/// whose bytes verify — with `matches_current_rules` naming the
+/// divergence rather than hiding it.
+///
+/// ## What it deliberately doesn't carry
+///
+/// No group secret, no member roster, no inbox keys. A proof of
+/// agreement should be showable to an outsider — a moderator, a
+/// landlord, a court — without also handing them the ability to read
+/// the group or find the people in it. The sending public key is
+/// already public by construction (it verifies every message this
+/// member sends) and the signature is meaningless without it.
+public struct GroupRulesProof: Equatable, Sendable {
+    public let groupIDHex: String
+    public let groupName: String
+    public let memberAlias: String
+    public let memberBlsHex: String
+    /// Nil when there is nothing to prove — see `standing`.
+    public let sendingPublicKey: Data?
+    public let signature: Data?
+    /// The text the signature covers, which is the text that was on
+    /// screen when this member agreed.
+    public let rules: String?
+    /// The rules the group holds now, for the reader to compare.
+    public let currentRules: String?
+    public let standing: GroupRulesStanding
+
+    public init(
+        group: ChatGroup,
+        member: MemberProfile,
+        blsHex: String
+    ) {
+        let standing = group.rulesStanding(of: member, blsHex: blsHex)
+        self.groupIDHex = group.id
+        self.groupName = group.name
+        self.memberAlias = member.alias
+        self.memberBlsHex = blsHex
+        self.standing = standing
+        self.currentRules = GroupRules.normalized(group.invitationMessage)
+        // Only carried where they mean something. Shipping a signature
+        // that doesn't verify, or one there is no text for, would put
+        // bytes in a document called a proof that prove nothing.
+        if standing.isProven {
+            self.sendingPublicKey = member.sendingPubkey
+            self.signature = member.rulesSignature
+            self.rules = member.rulesText
+        } else {
+            self.sendingPublicKey = nil
+            self.signature = nil
+            self.rules = nil
+        }
+    }
+
+    /// A filename someone can find again in a Files app six months
+    /// later: the group and the member, not a hash.
+    public var suggestedFileName: String {
+        let stem = "\(groupName)-\(memberAlias)"
+            .folding(options: .diacriticInsensitive, locale: .current)
+            .lowercased()
+            .map { $0.isLetter || $0.isNumber ? $0 : "-" }
+            .reduce(into: "") { out, character in
+                // Collapse runs, so "Maple  Garden!" doesn't become
+                // "maple--garden-".
+                if character == "-", out.last == "-" { return }
+                out.append(character)
+            }
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        let named = stem.isEmpty ? "group-rules" : stem
+        return "onym-rules-proof-\(named).json"
+    }
+
+    /// The file's bytes: pretty-printed, key-ordered JSON, so two
+    /// exports of the same agreement are byte-identical and a diff
+    /// between them means something changed.
+    public func jsonData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(document)
+    }
+
+    // MARK: - Document
+
+    /// The on-disk shape. Separate from the value type above so the
+    /// wire form is written out in one readable place rather than
+    /// assembled by `CodingKeys` scattered across a model.
+    struct Document: Encodable {
+        let readme: [String]
+        let group: Group
+        let member: Member
+        let rules: Rules?
+
+        struct Group: Encodable {
+            let id: String
+            let name: String
+        }
+
+        struct Member: Encodable {
+            let alias: String
+            let blsPublicKey: String
+            let sendingPublicKey: String?
+            let signature: String?
+            let signed: Bool
+            /// Present only when `signed` is false: why there is
+            /// nothing to check, in words rather than a code.
+            let note: String?
+
+            /// snake_case, like every other key in the file — and, more
+            /// to the point, like the names `_readme` tells the reader
+            /// to look for. Instructions that cite a key the document
+            /// doesn't contain are worse than no instructions.
+            enum CodingKeys: String, CodingKey {
+                case alias
+                case blsPublicKey = "bls_public_key"
+                case sendingPublicKey = "sending_public_key"
+                case signature
+                case signed
+                case note
+            }
+        }
+
+        struct Rules: Encodable {
+            let text: String
+            let sha256: String
+            let matchesCurrentRules: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case text
+                case sha256
+                case matchesCurrentRules = "matches_current_rules"
+            }
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case readme = "_readme"
+            case group
+            case member
+            case rules
+        }
+    }
+
+    var document: Document {
+        Document(
+            readme: Self.readme,
+            group: .init(id: groupIDHex, name: groupName),
+            member: .init(
+                alias: memberAlias,
+                blsPublicKey: memberBlsHex,
+                sendingPublicKey: sendingPublicKey.map(Self.hex),
+                signature: signature.map(Self.hex),
+                signed: standing.isProven,
+                note: Self.note(for: standing)
+            ),
+            rules: rules.map { text in
+                .init(
+                    text: text,
+                    sha256: Self.hex(GroupRules.hash(text)),
+                    matchesCurrentRules: text == currentRules
+                )
+            }
+        )
+    }
+
+    /// How to check this without trusting the app that wrote it. Split
+    /// across lines because JSON has no comments and a single 400-column
+    /// string is not something anyone reads.
+    static let readme = [
+        "Proof that this member agreed to this group's rules.",
+        "To verify, with any Ed25519 implementation:",
+        "  1. message = \"onym-group-rules-v1\" (ASCII, 19 bytes)",
+        "             || group.id (32 bytes, hex above)",
+        "             || SHA-256(rules.text as UTF-8) (32 bytes)",
+        "             || member.sending_public_key (32 bytes, hex above)",
+        "  2. check member.signature against that message and that key.",
+        "The rules text here is the wording this member signed. When",
+        "matches_current_rules is false, the group has changed its rules",
+        "since — the signature still covers the text in this file.",
+    ]
+
+    static func note(for standing: GroupRulesStanding) -> String? {
+        switch standing {
+        case .signed, .signedEarlierVersion:
+            nil
+        case .noRules:
+            "This group has no rules, so nothing was asked of anyone."
+        case .author:
+            "This member wrote the rules; founders do not sign their own."
+        case .didNotSign:
+            "Joined before this group had rules, or from an app version that predates them."
+        case .doesNotVerify:
+            "A signature was stored for this member and it does not verify."
+        }
+    }
+
+    static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Packages/OnymGroup/Sources/OnymGroup/GroupRulesStanding.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupRulesStanding.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Where one member stands on a group's rules, decided from what this
+/// device holds about them.
+///
+/// The same question `JoinRequestApprover.RulesAgreement` answers for a
+/// request that hasn't been accepted yet, asked again for a member who
+/// is already in. It is a separate type because the answers differ: a
+/// request cannot have been written by the founder, and a member cannot
+/// be "an older client we could ask to upgrade" — they are in, and what
+/// is left is what the stored bytes do or don't show.
+///
+/// Every case is derived by re-verifying, never by reading a flag: the
+/// signature is checked against the text stored beside it each time
+/// this is asked. A stored boolean would be a claim about a check
+/// somebody once ran.
+public enum GroupRulesStanding: Equatable, Sendable {
+    /// The group asks nothing of anyone.
+    case noRules
+    /// This member wrote the rules. Founders don't sign their own
+    /// terms, and rendering them as "didn't sign" would read as a
+    /// failure rather than as the shape of the thing.
+    case author
+    /// Verified, against the rules the group holds now.
+    case signed
+    /// Verified — but over different words than the group's current
+    /// rules. They agreed to an earlier version, which is a fact about
+    /// the group's history rather than about this member.
+    case signedEarlierVersion
+    /// Nothing to check: they joined before the group had rules, or
+    /// through a build that predates them.
+    case didNotSign
+    /// Bytes that don't verify. Kept distinct from `didNotSign`
+    /// because the two say different things about the same member, and
+    /// only one of them is odd.
+    case doesNotVerify
+
+    /// True only where a signature was actually checked and passed.
+    /// The mark on a row, and the `signed` field in an export, both
+    /// come from here rather than from separate readings.
+    public var isProven: Bool {
+        switch self {
+        case .signed, .signedEarlierVersion: true
+        case .noRules, .author, .didNotSign, .doesNotVerify: false
+        }
+    }
+}
+
+public extension ChatGroup {
+    /// Where `member` stands on this group's rules.
+    ///
+    /// - Parameter blsHex: the member's key in `memberProfiles`, which
+    ///   is also how `adminPubkeyHex` names the founder.
+    func rulesStanding(of member: MemberProfile, blsHex: String) -> GroupRulesStanding {
+        guard let current = GroupRules.normalized(invitationMessage) else { return .noRules }
+        if let admin = adminPubkeyHex?.lowercased(), admin == blsHex.lowercased() {
+            return .author
+        }
+        guard member.rulesSignature != nil, let signedText = member.rulesText else {
+            return .didNotSign
+        }
+        guard member.agreedToRules(groupID: groupIDData) else { return .doesNotVerify }
+        return signedText == current ? .signed : .signedEarlierVersion
+    }
+}

--- a/Packages/OnymGroup/Sources/OnymGroup/GroupRulesStanding.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupRulesStanding.swift
@@ -30,9 +30,25 @@ public enum GroupRulesStanding: Equatable, Sendable {
     /// Nothing to check: they joined before the group had rules, or
     /// through a build that predates them.
     case didNotSign
-    /// Bytes that don't verify. Kept distinct from `didNotSign`
-    /// because the two say different things about the same member, and
-    /// only one of them is odd.
+    /// A stored signature this device cannot check, because it doesn't
+    /// hold the wording the signature covers.
+    ///
+    /// Reachable, and not the same as `didNotSign`: an admitting device
+    /// records the agreement with the rules as they stood, so a founder
+    /// who clears the rules between a request and its approval produces
+    /// exactly this — 64 bytes and nothing to check them against. Left
+    /// in `didNotSign` it exported "joined before this group had
+    /// rules", which is a claim, and a false one.
+    ///
+    /// Named for what is known rather than what it suggests, and
+    /// deliberately the same name and wording as
+    /// `JoinRequestApprover.RulesAgreement.unknownRules`: it is the
+    /// same fact about the same bytes, one seen at approval and one
+    /// seen afterwards.
+    case unknownRules
+    /// Bytes that don't verify against the text stored with them. Kept
+    /// distinct from `didNotSign` because the two say different things
+    /// about the same member, and only one of them is odd.
     case doesNotVerify
 
     /// True only where a signature was actually checked and passed.
@@ -41,25 +57,54 @@ public enum GroupRulesStanding: Equatable, Sendable {
     public var isProven: Bool {
         switch self {
         case .signed, .signedEarlierVersion: true
-        case .noRules, .author, .didNotSign, .doesNotVerify: false
+        case .noRules, .author, .didNotSign, .unknownRules, .doesNotVerify: false
         }
     }
 }
 
 public extension ChatGroup {
-    /// Where `member` stands on this group's rules.
+    /// Where the member stored under `blsHex` stands on this group's
+    /// rules.
     ///
-    /// - Parameter blsHex: the member's key in `memberProfiles`, which
-    ///   is also how `adminPubkeyHex` names the founder.
-    func rulesStanding(of member: MemberProfile, blsHex: String) -> GroupRulesStanding {
-        guard let current = GroupRules.normalized(invitationMessage) else { return .noRules }
+    /// Takes the key rather than the profile, and looks the profile up
+    /// here. Passing both let a caller hand over one member's profile
+    /// under another's key — and since `adminPubkeyHex` is compared
+    /// against that key, the mismatch that mattered was the one that
+    /// returned `.author` for somebody else. The same argument
+    /// `GroupRules.isAgreement` makes for taking the rules text rather
+    /// than a hash: make the wrong pairing unsayable.
+    ///
+    /// `nil` when no member is stored under that key.
+    func rulesStanding(ofMemberWith blsHex: String) -> GroupRulesStanding? {
+        guard let member = memberProfiles[blsHex] else { return nil }
+        return standing(of: member, blsHex: blsHex)
+    }
+
+    /// The stored bytes are read *before* the group's current state,
+    /// because they outlive it.
+    ///
+    /// `invitationMessage` is a `var`. A founder who clears the rules
+    /// would otherwise turn every agreement ever made into "this group
+    /// asks nothing of anyone", and drop the signature, key and text
+    /// from every export — deleting the evidence by editing a text
+    /// field. What somebody signed happened; the group's present
+    /// wording doesn't get a vote on it.
+    private func standing(of member: MemberProfile, blsHex: String) -> GroupRulesStanding {
+        let current = GroupRules.normalized(invitationMessage)
+        if let signature = member.rulesSignature {
+            guard let signedText = member.rulesText else { return .unknownRules }
+            guard GroupRules.isAgreement(
+                signature: signature,
+                rules: signedText,
+                groupID: groupIDData,
+                joinerSendingPublicKey: member.sendingPubkey
+            ) else { return .doesNotVerify }
+            return signedText == current ? .signed : .signedEarlierVersion
+        }
+        guard current != nil else { return .noRules }
         if let admin = adminPubkeyHex?.lowercased(), admin == blsHex.lowercased() {
             return .author
         }
-        guard member.rulesSignature != nil, let signedText = member.rulesText else {
-            return .didNotSign
-        }
-        guard member.agreedToRules(groupID: groupIDData) else { return .doesNotVerify }
-        return signedText == current ? .signed : .signedEarlierVersion
+        return .didNotSign
     }
 }


### PR DESCRIPTION
The agreement has been recorded since #301 and read by nobody: the founder saw a verdict once, at approval, and the bytes then sat on the member profile. This is the model for showing it to everyone and handing it to someone outside the group. Screens are in the PR above; nothing renders this yet.

**`GroupRulesStanding`** answers "where does this member stand" — the same question `JoinRequestApprover.RulesAgreement` answers for a request that hasn't been accepted, asked again for someone already in. A separate type because the answers differ: a request can't have been written by the founder, and a member can't be "an old client we could ask to upgrade". What's left is `author`, `signed`, `signedEarlierVersion`, `didNotSign`, `doesNotVerify`.

`author` earns its case. Founders don't sign their own terms, and rendering the person who wrote the rules as "didn't sign" would read as a failure rather than as the shape of the thing.

Every case is derived by **re-verifying**, never by reading a flag. The signature is checked against the text stored beside it each time the question is asked, because a stored boolean is a claim about a check somebody once ran.

**`GroupRulesProof`** is the export. What makes it a proof is not this app's say-so: it carries the rules text, the member's Ed25519 key and their signature, so a reader who trusts none of this can recompute the statement and check it with any Ed25519 implementation. The `_readme` lines spell out that procedure *inside the file*, because a proof whose verification steps live in a codebase the reader doesn't have is a screenshot with extra steps.

Three deliberate choices:

- The `rules` it carries are the **signed** ones, not whatever the group says today. Those differ exactly when the wording changed after this member joined, and `matches_current_rules` names the divergence rather than hiding it.
- Signature and key are **omitted entirely** unless the standing is proven. Bytes that don't verify, in a document called a proof, invite a reader to assume someone already checked.
- **No group secret, no roster, no inbox keys.** This is meant to be showable to an outsider — a moderator, a committee — without also handing them the ability to read the group or find the people in it.

Verified rather than asserted: an exported file was checked against an independent RFC 8032 implementation, following only the instructions in its own `_readme`. It verifies, and stops verifying when one character of the rules is altered.

Tests land in the last PR of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)