### PR TITLE
Tests for the standing, the proof, and what both devices can see

### DIFF
--- a/Tests/OnymIOSTests/GroupRulesStandingTests.swift
+++ b/Tests/OnymIOSTests/GroupRulesStandingTests.swift
@@ -1,0 +1,527 @@
+import XCTest
+import CryptoKit
+@testable import OnymIOS
+@testable import OnymGroup
+import OnymIdentity
+
+/// Where a member stands, and what an export of that standing may say.
+///
+/// The cases that matter are the ones where a mark would overstate:
+/// bytes that don't verify, and bytes that verify over words the group
+/// has since replaced. A screen that called either of those "signed"
+/// would be making a claim this device cannot support.
+final class GroupRulesStandingTests: XCTestCase {
+
+    private let groupID = Data(repeating: 0x1a, count: 32)
+    private let rules = "Be kind. No links."
+    private let adminHex = String(repeating: "ff", count: 48)
+
+    // MARK: - Standing
+
+    func test_aGroupWithNoRules_hasNoStandingToReport() {
+        XCTAssertEqual(standing(of: unsigned(), rules: nil), .noRules)
+    }
+
+    func test_blankRules_areNoRules() {
+        // Whitespace is not a thing anyone can be held to.
+        XCTAssertEqual(standing(of: unsigned(), rules: "   \n "), .noRules)
+    }
+
+    func test_theFounder_wroteThemRatherThanFailingToSign() {
+        // Rendering the author as "didn't sign" would read as a failure
+        // rather than as the shape of the thing.
+        XCTAssertEqual(
+            standing(of: unsigned(alias: "Alice"), key: adminHex, rules: rules),
+            .author
+        )
+    }
+
+    func test_theFounderIsMatchedCaseInsensitively() {
+        // `adminPubkeyHex` and the `memberProfiles` key are both hex
+        // strings from different sources; a case difference must not
+        // demote the founder to "didn't sign".
+        XCTAssertEqual(
+            standing(
+                of: unsigned(alias: "Alice"),
+                key: adminHex,
+                rules: rules,
+                adminHex: adminHex.uppercased()
+            ),
+            .author
+        )
+    }
+
+    func test_aVerifiedSignatureOverTheCurrentRules_isSigned() {
+        XCTAssertEqual(standing(of: signer().profile, rules: rules), .signed)
+    }
+
+    func test_aMemberWithNothingStored_didNotSign() {
+        XCTAssertEqual(standing(of: unsigned(), key: "dd", rules: rules), .didNotSign)
+    }
+
+    func test_rulesChangedSinceTheySigned_saysSoRatherThanFailing() {
+        // The signature is still good; it covers different words. That
+        // is a fact about the group's history, not about the member.
+        let verdict = standing(of: signer().profile, rules: "Be kind. No links. And no photos.")
+        XCTAssertEqual(verdict, .signedEarlierVersion)
+        XCTAssertEqual(verdict?.isProven, true, "an earlier version still checks out")
+    }
+
+    func test_bytesThatDoNotVerify_areNotAMissingSignature() {
+        // Distinct from `didNotSign`: only one of the two is odd.
+        let key = Curve25519.Signing.PrivateKey()
+        let profile = MemberProfile(
+            alias: "Mallory",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: key.publicKey.rawRepresentation,
+            rulesHash: GroupRules.hash(rules),
+            rulesSignature: Data(repeating: 0x00, count: 64),
+            rulesText: rules
+        )
+        let verdict = standing(of: profile, key: "mm", rules: rules)
+        XCTAssertEqual(verdict, .doesNotVerify)
+        XCTAssertEqual(verdict?.isProven, false)
+    }
+
+    func test_aSignatureLiftedFromAnotherMember_doesNotVerifyHere() {
+        // The signer is named inside the signed bytes, so re-attributing
+        // one member's agreement to another fails.
+        let real = signer()
+        let impostor = MemberProfile(
+            alias: "Mallory",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: Curve25519.Signing.PrivateKey().publicKey.rawRepresentation,
+            rulesHash: GroupRules.hash(rules),
+            rulesSignature: real.profile.rulesSignature,
+            rulesText: rules
+        )
+        XCTAssertEqual(standing(of: impostor, key: "mm", rules: rules), .doesNotVerify)
+    }
+
+    // MARK: - Export
+
+    func test_theExportCarriesWhatAnOutsiderNeedsToCheckIt() throws {
+        let signed = signer()
+        let group = makeGroup(rules: rules, members: ["cc": signed.profile])
+        let proof = try XCTUnwrap(GroupRulesProof(group: group, blsHex: "cc"))
+        let json = try object(from: proof)
+
+        XCTAssertEqual((json["group"] as? [String: Any])?["id"] as? String, group.id)
+        let member = try XCTUnwrap(json["member"] as? [String: Any])
+        XCTAssertEqual(member["signed"] as? Bool, true)
+        XCTAssertEqual(
+            member["sending_public_key"] as? String,
+            hex(signed.key.publicKey.rawRepresentation)
+        )
+        XCTAssertEqual(member["signature"] as? String, hex(signed.profile.rulesSignature!))
+        let carried = try XCTUnwrap(json["rules"] as? [String: Any])
+        XCTAssertEqual(carried["text"] as? String, rules)
+        XCTAssertEqual(carried["sha256"] as? String, hex(GroupRules.hash(rules)))
+        XCTAssertEqual(carried["matches_current_rules"] as? Bool, true)
+    }
+
+    func test_theExportedBytesActuallyVerify() throws {
+        try assertExportVerifiesItself(groupRules: rules)
+    }
+
+    func test_theExportVerifiesEvenAfterTheGroupChangedItsRules() throws {
+        // The case the export exists to get right, and the one the
+        // string comparison below can't prove: shipping today's wording
+        // beside an old signature would produce a document that fails
+        // its own instructions. Checking it cryptographically is the
+        // only way to know it doesn't.
+        try assertExportVerifiesItself(groupRules: "Be kind. No links. And no photos.")
+    }
+
+    /// Verifies a proof the way its `_readme` tells a stranger to:
+    /// rebuild the statement out of the document's own fields, and
+    /// check the signature it carries.
+    private func assertExportVerifiesItself(
+        groupRules: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let signed = signer()
+        let proof = try XCTUnwrap(GroupRulesProof(
+            group: makeGroup(rules: groupRules, members: ["cc": signed.profile]),
+            blsHex: "cc"
+        ))
+        let json = try object(from: proof)
+        let member = try XCTUnwrap(json["member"] as? [String: Any])
+        let carried = try XCTUnwrap(json["rules"] as? [String: Any])
+        let groupID = try XCTUnwrap(Data(
+            hexString: try XCTUnwrap((json["group"] as? [String: Any])?["id"] as? String)
+        ))
+        let keyBytes = try XCTUnwrap(Data(
+            hexString: try XCTUnwrap(member["sending_public_key"] as? String)
+        ))
+        let signature = try XCTUnwrap(Data(
+            hexString: try XCTUnwrap(member["signature"] as? String)
+        ))
+        // The byte counts the readme instructs the reader to assume.
+        XCTAssertEqual(groupID.count, 32, "readme says group.id is 32 bytes", file: file, line: line)
+        XCTAssertEqual(keyBytes.count, 32, file: file, line: line)
+        XCTAssertEqual(signature.count, 64, file: file, line: line)
+
+        var statement = Data("onym-group-rules-v1".utf8)
+        statement.append(groupID)
+        statement.append(Data(SHA256.hash(data: Data(
+            (try XCTUnwrap(carried["text"] as? String)).utf8
+        ))))
+        statement.append(keyBytes)
+
+        let key = try Curve25519.Signing.PublicKey(rawRepresentation: keyBytes)
+        XCTAssertTrue(
+            key.isValidSignature(signature, for: statement),
+            "the document must verify by its own instructions", file: file, line: line
+        )
+    }
+
+    func test_theExportCarriesTheSignedWordingNotTodays() throws {
+        // The bytes verify against what was agreed to. Exporting the
+        // group's current text beside the old signature would produce a
+        // document that fails its own instructions.
+        let signed = signer()
+        let group = makeGroup(
+            rules: "Be kind. No links. And no photos.",
+            members: ["cc": signed.profile]
+        )
+        let json = try object(from: try XCTUnwrap(
+            GroupRulesProof(group: group, blsHex: "cc")
+        ))
+        let carried = try XCTUnwrap(json["rules"] as? [String: Any])
+        XCTAssertEqual(carried["text"] as? String, rules, "the wording they signed")
+        XCTAssertEqual(carried["matches_current_rules"] as? Bool, false, "and the divergence is named")
+    }
+
+    func test_anUnprovenStanding_shipsNoBytesToMistakeForProof() throws {
+        // A signature in a document called a proof, which does not
+        // verify, is worse than no signature: it invites a reader to
+        // assume someone already checked.
+        let key = Curve25519.Signing.PrivateKey()
+        let profile = MemberProfile(
+            alias: "Mallory",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: key.publicKey.rawRepresentation,
+            rulesHash: GroupRules.hash(rules),
+            rulesSignature: Data(repeating: 0x00, count: 64),
+            rulesText: rules
+        )
+        let json = try object(from: try XCTUnwrap(GroupRulesProof(
+            group: makeGroup(rules: rules, members: ["mm": profile]), blsHex: "mm"
+        )))
+        let member = try XCTUnwrap(json["member"] as? [String: Any])
+        XCTAssertEqual(member["signed"] as? Bool, false)
+        XCTAssertNil(member["signature"])
+        XCTAssertNil(member["sending_public_key"])
+        XCTAssertNil(json["rules"])
+        XCTAssertNotNil(member["note"], "and it says why, in words")
+    }
+
+    func test_theReadmeNamesKeysTheDocumentActuallyHas() throws {
+        // Instructions citing a key that isn't in the file are worse
+        // than no instructions.
+        let json = try object(from: try XCTUnwrap(GroupRulesProof(
+            group: makeGroup(rules: rules, members: ["cc": signer().profile]), blsHex: "cc"
+        )))
+        let readme = try XCTUnwrap(json["_readme"] as? [String]).joined(separator: "\n")
+        let member = try XCTUnwrap(json["member"] as? [String: Any])
+        for cited in ["sending_public_key", "signature"] {
+            XCTAssertTrue(readme.contains(cited), "_readme cites \(cited)")
+            XCTAssertNotNil(member[cited], "and the document has it")
+        }
+        XCTAssertTrue(readme.contains("onym-group-rules-v1"))
+    }
+
+    func test_theExportIsStableBetweenRuns() throws {
+        // Sorted keys and no timestamp, so a diff between two exports
+        // of the same agreement means something changed.
+        let proof = try XCTUnwrap(GroupRulesProof(
+            group: makeGroup(rules: rules, members: ["cc": signer().profile]), blsHex: "cc"
+        ))
+        XCTAssertEqual(try proof.jsonData(), try proof.jsonData())
+    }
+
+    func test_theFileNameSaysWhoAndWhichGroup() throws {
+        // A realistic roster key: 96 hex characters, as a BLS pubkey
+        // renders. The suffix is its first twelve.
+        let key = String(repeating: "ab12", count: 24)
+        let proof = try XCTUnwrap(GroupRulesProof(
+            group: makeGroup(
+                rules: rules, name: "Maple  Garden!", members: [key: signer().profile]
+            ),
+            blsHex: key
+        ))
+        XCTAssertEqual(
+            proof.suggestedFileName,
+            "onym-rules-proof-maple-garden-bob-ab12ab12ab12.json"
+        )
+    }
+
+    func test_namesThatReduceToNothing_stillGiveEachMemberTheirOwnFile() throws {
+        // Cyrillic and CJK survive neither diacritic folding nor the
+        // ASCII filter, so the readable stem collapses entirely and
+        // every member of such a group fell back to one filename. The
+        // export is deliberately left in place for the share sheet, so
+        // a collision means a lazily-reading extension can hand out the
+        // second member's agreement under the first one's name.
+        let group = makeGroup(
+            rules: rules,
+            name: "Дом на Тверской",
+            members: [
+                "aa11bb22cc33": unsigned(alias: "Борис"),
+                "dd44ee55ff66": unsigned(alias: "Анна"),
+            ]
+        )
+        let boris = try XCTUnwrap(GroupRulesProof(group: group, blsHex: "aa11bb22cc33"))
+        let anna = try XCTUnwrap(GroupRulesProof(group: group, blsHex: "dd44ee55ff66"))
+
+        XCTAssertNotEqual(boris.suggestedFileName, anna.suggestedFileName)
+        XCTAssertEqual(boris.suggestedFileName, "onym-rules-proof-group-rules-aa11bb22cc33.json")
+        XCTAssertTrue(boris.suggestedFileName.allSatisfy(\.isASCII))
+    }
+
+    func test_aStoredSignatureWithNoTextIsNotAMissingOne() {
+        // Reachable: the admitting device records the agreement with
+        // the rules as they stood, so a founder clearing them between a
+        // request and its approval leaves bytes with nothing to check
+        // them against. Reported as `didNotSign` it exported "joined
+        // before this group had rules" — a claim, and a false one.
+        let profile = MemberProfile(
+            alias: "Bob",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: Data(repeating: 0xEE, count: 32),
+            rulesHash: GroupRules.hash(rules),
+            rulesSignature: Data(repeating: 0x55, count: 64),
+            rulesText: nil
+        )
+        XCTAssertEqual(standing(of: profile, rules: rules), .unknownRules)
+    }
+
+    func test_clearingTheRulesDoesNotDeleteWhatPeopleSigned() {
+        // `invitationMessage` is a `var`. Reading group state before
+        // the stored bytes turned every agreement ever made into "this
+        // group asks nothing of anyone" — evidence deleted by editing a
+        // text field.
+        let verdict = standing(of: signer().profile, rules: nil)
+        XCTAssertEqual(verdict, .signedEarlierVersion)
+        XCTAssertEqual(verdict?.isProven, true)
+    }
+
+    func test_aProfileUnderAKeyThatIsNotInTheRoster_hasNoStandingAndNoProof() {
+        // The mismatch the key-only API exists to make unsayable: the
+        // admin's hex paired with somebody else's profile used to
+        // return `.author`.
+        let group = makeGroup(rules: rules, members: ["cc": signer().profile])
+        XCTAssertNil(group.rulesStanding(ofMemberWith: adminHex))
+        XCTAssertNil(GroupRulesProof(group: group, blsHex: adminHex))
+    }
+
+    // MARK: - Exports for the standings that aren't proofs
+
+    func test_theAuthorsExportCarriesTheirWordsAndClaimsNoSignature() throws {
+        // The one export every group with rules has. It must not
+        // pretend to be a signature, and it must not be empty either:
+        // the rules are this member's own words.
+        let group = makeGroup(rules: rules, members: [adminHex: unsigned(alias: "Alice")])
+        let json = try object(from: try XCTUnwrap(
+            GroupRulesProof(group: group, blsHex: adminHex)
+        ))
+        let member = try XCTUnwrap(json["member"] as? [String: Any])
+        XCTAssertEqual(member["signed"] as? Bool, false)
+        XCTAssertNil(member["signature"])
+        XCTAssertEqual(
+            (json["rules"] as? [String: Any])?["text"] as? String, rules,
+            "a document about the person who wrote the rules must contain them"
+        )
+        XCTAssertEqual(
+            member["note"] as? String,
+            "This member wrote the rules; founders do not sign their own."
+        )
+    }
+
+    func test_aGroupWithNoRules_exportsThatRatherThanAnAccusation() throws {
+        let group = makeGroup(rules: nil, members: ["dd": unsigned()])
+        let json = try object(from: try XCTUnwrap(
+            GroupRulesProof(group: group, blsHex: "dd")
+        ))
+        let member = try XCTUnwrap(json["member"] as? [String: Any])
+        XCTAssertEqual(member["signed"] as? Bool, false)
+        XCTAssertNil(json["rules"])
+        XCTAssertEqual(
+            member["note"] as? String,
+            "This group has no rules, so nothing was asked of anyone."
+        )
+    }
+
+    func test_theDivergedWordingShipsBothVersions() throws {
+        // A reader told the wording changed needs the other wording to
+        // compare against; `matches_current_rules` alone is a claim
+        // they can't check.
+        let today = "Be kind. No links. And no photos."
+        let group = makeGroup(rules: today, members: ["cc": signer().profile])
+        let json = try object(from: try XCTUnwrap(
+            GroupRulesProof(group: group, blsHex: "cc")
+        ))
+        let carried = try XCTUnwrap(json["rules"] as? [String: Any])
+        XCTAssertEqual(carried["text"] as? String, rules, "what they signed")
+        XCTAssertEqual(carried["current_text"] as? String, today, "and what the group says now")
+    }
+
+    func test_matchingRules_shipNoRedundantCopy() throws {
+        let group = makeGroup(rules: rules, members: ["cc": signer().profile])
+        let json = try object(from: try XCTUnwrap(
+            GroupRulesProof(group: group, blsHex: "cc")
+        ))
+        XCTAssertNil(
+            (json["rules"] as? [String: Any])?["current_text"],
+            "identical copies would be the same paragraph twice"
+        )
+    }
+
+    func test_theReadmeSaysWhatTheSignatureDoesNotCover() throws {
+        // Without this a reader concludes "the member with this BLS key
+        // agreed" — a pairing this app asserts, not one the signature
+        // carries.
+        let group = makeGroup(rules: rules, members: ["cc": signer().profile])
+        let json = try object(from: try XCTUnwrap(
+            GroupRulesProof(group: group, blsHex: "cc")
+        ))
+        let readme = try XCTUnwrap(json["_readme"] as? [String]).joined(separator: "\n")
+        XCTAssertTrue(readme.contains("does NOT cover"))
+        for outside in ["alias", "bls_public_key"] {
+            XCTAssertTrue(readme.contains(outside), "readme must name \(outside) as outside")
+        }
+    }
+
+    func test_theFileNameIsTheSameOnEveryDevice() throws {
+        // `lowercased()` under a Turkish locale maps I to a dotless ı,
+        // and diacritic folding leaves CJK alone — either would make
+        // one group's proof arrive under two names.
+        let key = String(repeating: "ab12", count: 24)
+        let group = makeGroup(
+            rules: rules, name: "İstanbul 名簿", members: [key: signer().profile]
+        )
+        let name = try XCTUnwrap(GroupRulesProof(group: group, blsHex: key)).suggestedFileName
+        XCTAssertEqual(name, "onym-rules-proof-istanbul-bob-ab12ab12ab12.json")
+        XCTAssertTrue(name.allSatisfy(\.isASCII))
+    }
+
+    func test_aHostileRosterKeyCannotReachOutsideTheExportDirectory() throws {
+        // Roster keys are arbitrary JSON object keys — nothing checks
+        // their shape on decode — and this one reaches a filesystem
+        // path. Measured before the fix: three levels of `..` put the
+        // write in the app container, outside `tmp` entirely. The row
+        // is reachable, too: a group with rules gives `.didNotSign` a
+        // chevron, so opening it is all it takes.
+        let key = "../../../Documents/pwned"
+        let group = makeGroup(rules: rules, members: [key: unsigned()])
+        let name = try XCTUnwrap(
+            GroupRulesProof(group: group, blsHex: key)
+        ).suggestedFileName
+
+        XCTAssertFalse(name.contains(".."), "no parent traversal survives into the name")
+        XCTAssertFalse(name.contains("/"), "and no separator does either")
+        XCTAssertTrue(name.allSatisfy(\.isASCII))
+        // The property that matters, stated the way the bug was found:
+        // the composed URL stays inside the directory it was given.
+        let directory = FileManager.default.temporaryDirectory
+        let written = directory.appendingPathComponent(name).standardizedFileURL
+        XCTAssertTrue(
+            written.path.hasPrefix(directory.standardizedFileURL.path),
+            "the export must not be writable outside the directory chosen for it"
+        )
+    }
+
+    func test_aKeyTooShortToDistinguishMembers_isHashedRatherThanTruncated() throws {
+        // Scrubbing a hostile or malformed key can leave a couple of
+        // characters, or none — and a suffix that short puts back the
+        // collision it exists to prevent. Two such members must still
+        // get their own file.
+        let group = makeGroup(
+            rules: rules,
+            name: "Maple Garden",
+            members: ["../a": unsigned(alias: "Bo"), "../b": unsigned(alias: "Bo")]
+        )
+        let first = try XCTUnwrap(GroupRulesProof(group: group, blsHex: "../a"))
+        let second = try XCTUnwrap(GroupRulesProof(group: group, blsHex: "../b"))
+
+        XCTAssertNotEqual(first.suggestedFileName, second.suggestedFileName)
+        for name in [first.suggestedFileName, second.suggestedFileName] {
+            XCTAssertFalse(name.contains(".."))
+            XCTAssertTrue(name.allSatisfy(\.isASCII))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func signer() -> (key: Curve25519.Signing.PrivateKey, profile: MemberProfile) {
+        let key = Curve25519.Signing.PrivateKey()
+        let signature = try! key.signature(for: GroupRules.statement(
+            groupID: groupID,
+            rulesHash: GroupRules.hash(rules),
+            joinerSendingPublicKey: key.publicKey.rawRepresentation
+        ))
+        return (key, MemberProfile(
+            alias: "Bob",
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: key.publicKey.rawRepresentation,
+            rulesHash: GroupRules.hash(rules),
+            rulesSignature: signature,
+            rulesText: rules
+        ))
+    }
+
+    private func makeGroup(
+        rules: String?,
+        name: String = "Maple Garden",
+        adminHex: String? = nil,
+        members: [String: MemberProfile] = [:]
+    ) -> ChatGroup {
+        ChatGroup(
+            id: groupID.hexString,
+            ownerIdentityID: IdentityID(),
+            name: name,
+            groupSecret: Data(repeating: 0x01, count: 32),
+            createdAt: Date(),
+            members: [],
+            memberProfiles: members,
+            epoch: 0,
+            salt: Data(repeating: 0x02, count: 32),
+            commitment: nil,
+            tier: .small,
+            groupType: .tyranny,
+            adminPubkeyHex: adminHex ?? self.adminHex,
+            adminEd25519PubkeyHex: nil,
+            isPublishedOnChain: false,
+            invitationMessage: rules
+        )
+    }
+
+    /// The standing of the one member in a group built around them.
+    private func standing(
+        of member: MemberProfile,
+        key: String = "cc",
+        rules: String?,
+        adminHex: String? = nil
+    ) -> GroupRulesStanding? {
+        makeGroup(rules: rules, adminHex: adminHex, members: [key: member])
+            .rulesStanding(ofMemberWith: key)
+    }
+
+    private func unsigned(alias: String = "Dana") -> MemberProfile {
+        MemberProfile(
+            alias: alias,
+            inboxPublicKey: Data(repeating: 0xAA, count: 32),
+            sendingPubkey: Data(repeating: 0xEE, count: 32)
+        )
+    }
+
+    private func object(from proof: GroupRulesProof) throws -> [String: Any] {
+        try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try proof.jsonData()) as? [String: Any]
+        )
+    }
+
+    private func hex(_ data: Data) -> String { data.hexString }
+}

--- a/Tests/OnymIOSTests/GroupRulesVectorTests.swift
+++ b/Tests/OnymIOSTests/GroupRulesVectorTests.swift
@@ -211,21 +211,3 @@ final class GroupRulesVectorTests: XCTestCase {
     }
 
 }
-
-private extension Data {
-    /// Test-only, so the golden signature can be written as the hex a
-    /// reader can compare against another implementation's output.
-    init?(hexString: String) {
-        var bytes: [UInt8] = []
-        var index = hexString.startIndex
-        while index < hexString.endIndex {
-            let next = hexString.index(index, offsetBy: 2, limitedBy: hexString.endIndex)
-            guard let next, let byte = UInt8(hexString[index..<next], radix: 16) else {
-                return nil
-            }
-            bytes.append(byte)
-            index = next
-        }
-        self.init(bytes)
-    }
-}

--- a/Tests/OnymIOSTests/GroupStateRefreshTests.swift
+++ b/Tests/OnymIOSTests/GroupStateRefreshTests.swift
@@ -228,6 +228,55 @@ final class GroupStateVerifierTests: XCTestCase {
         XCTAssertEqual(sends, 0, "a non-admin device must not answer refresh requests")
     }
 
+    func test_handleRefreshRequest_theReplyCarriesTheGroupsRules() async throws {
+        // A joiner whose first invitation deferred with
+        // `.staleNeedsRefresh` materializes from this payload. Without
+        // the rules they land in a group that appears to ask nothing of
+        // anyone — every member unmarked, and their own agreement,
+        // shipped in `memberProfiles` right beside it, meaningless.
+        let verifier = makeVerifier()
+        let rules = "Be kind. No links."
+        let requesterBls = Data(repeating: 0x02, count: 48)
+        let requesterBlsHex = requesterBls.map { String(format: "%02x", $0) }.joined()
+        // The requester's inbox key is this device's own, so the reply
+        // — sealed to the requester — can be opened and read. The
+        // verifier only checks cryptographic shape here, not that the
+        // two parties are distinct.
+        let active = await identity.currentIdentity()
+        let me = try XCTUnwrap(active)
+        let group = seedTyrannyGroup(
+            adminPubkeyHex: await myBlsHex(),
+            memberProfiles: [requesterBlsHex: MemberProfile(
+                alias: "Member",
+                inboxPublicKey: me.inboxPublicKey,
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
+            )],
+            invitationMessage: rules
+        )
+        _ = await groups.insert(group)
+
+        let request = try GroupStateRefreshRequest(
+            groupID: Data(repeating: 0x42, count: 32),
+            requesterInboxPublicKey: me.inboxPublicKey,
+            requesterBlsPublicKey: requesterBls
+        )
+        await verifier.handleRefreshRequest(
+            request, ownerIdentityID: owner, requesterEd25519: Data(repeating: 0xEE, count: 32)
+        )
+
+        let payload = await transport.lastPayload()
+        let sealed = try XCTUnwrap(payload, "the admin must answer a member's refresh request")
+        // The keychain identity, not this suite's synthetic `owner` —
+        // the envelope is sealed to the former's inbox key.
+        let selected = await identity.currentSelectedID()
+        let plaintext = try await identity.decryptInvitation(
+            envelopeBytes: sealed,
+            asIdentity: try XCTUnwrap(selected)
+        )
+        let invite = try JSONDecoder().decode(GroupInvitationPayload.self, from: plaintext)
+        XCTAssertEqual(invite.invitationMessage, rules)
+    }
+
     /// Full loop: a pending verification is cleared once the fresh
     /// snapshot materializes the group.
     func test_resolve_clearsPendingWhenGroupMaterializes() async throws {
@@ -326,7 +375,8 @@ final class GroupStateVerifierTests: XCTestCase {
 
     private func seedTyrannyGroup(
         adminPubkeyHex: String,
-        memberProfiles: [String: MemberProfile]
+        memberProfiles: [String: MemberProfile],
+        invitationMessage: String? = nil
     ) -> ChatGroup {
         ChatGroup(
             id: String(repeating: "42", count: 32),
@@ -343,7 +393,8 @@ final class GroupStateVerifierTests: XCTestCase {
             groupType: .tyranny,
             adminPubkeyHex: adminPubkeyHex,
             adminEd25519PubkeyHex: String(repeating: "ee", count: 32),
-            isPublishedOnChain: true
+            isPublishedOnChain: true,
+            invitationMessage: invitationMessage
         )
     }
 
@@ -364,10 +415,14 @@ final class GroupStateVerifierTests: XCTestCase {
 
 private actor VerifierRecordingInboxTransport: InboxTransport {
     private(set) var sends: Int = 0
+    /// Kept so a test can open the reply and read what it carried, not
+    /// only count that one went out.
+    private(set) var payloads: [Data] = []
     func connect(to endpoints: [TransportEndpoint]) async {}
     func disconnect() async {}
     func send(_ payload: Data, to inbox: TransportInboxID) async throws -> PublishReceipt {
         sends += 1
+        payloads.append(payload)
         return PublishReceipt(messageID: "spy-\(sends)", acceptedBy: 1)
     }
     nonisolated func subscribe(inbox: TransportInboxID) -> AsyncStream<InboundInbox> {
@@ -375,4 +430,5 @@ private actor VerifierRecordingInboxTransport: InboxTransport {
     }
     func unsubscribe(inbox: TransportInboxID) async {}
     func sendCount() -> Int { sends }
+    func lastPayload() -> Data? { payloads.last }
 }

--- a/Tests/OnymIOSTests/HexTestSupport.swift
+++ b/Tests/OnymIOSTests/HexTestSupport.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Hex → `Data`, for tests.
+///
+/// There were three private copies of this in the target
+/// (`MediaCommitmentFixtureTests`, `GroupRulesVectorTests`,
+/// `GroupRulesStandingTests`) and each one was a place the next fixture
+/// would grow a fourth.
+///
+/// Deliberately *not* `ChatGroup.bytes(fromHex:)`. These tests check
+/// documents and fixtures produced by the code under test, and reading
+/// them back with that same code would let a shared bug agree with
+/// itself. This is a second implementation on purpose, and it is
+/// strict where the production one is lenient: an odd length or a
+/// non-hex character is nil rather than a silently shorter `Data`.
+extension Data {
+    init?(hexString: String) {
+        guard hexString.count % 2 == 0 else { return nil }
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(hexString.count / 2)
+        var index = hexString.startIndex
+        while index < hexString.endIndex {
+            let next = hexString.index(index, offsetBy: 2)
+            guard let byte = UInt8(hexString[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        self.init(bytes)
+    }
+}

--- a/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
+++ b/Tests/OnymIOSTests/IncomingMessageDispatcherTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CryptoKit
 @testable import OnymIOS
 import OnymChain
 import OnymIdentity
@@ -1136,7 +1137,9 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         memberProfiles: [String: MemberProfile],
         adminEd25519PubkeyHex: String? = nil,
         groupType: SEPGroupType = .anarchy,
-        avatarJPEG: Data? = nil
+        avatarJPEG: Data? = nil,
+        invitationMessage: String? = nil,
+        owner: IdentityID? = nil
     ) async {
         // Default to .anarchy so the existing dispatcher tests skip
         // PR 13b's Tyranny-only on-chain commitment verification.
@@ -1144,7 +1147,7 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         // in via the parameter and seed `chainState` accordingly.
         let group = ChatGroup(
             id: groupID.map { String(format: "%02x", $0) }.joined(),
-            ownerIdentityID: owner,
+            ownerIdentityID: owner ?? self.owner,
             name: "Family",
             groupSecret: Data(repeating: 0x55, count: 32),
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
@@ -1158,9 +1161,400 @@ final class IncomingMessageDispatcherTests: XCTestCase {
             adminPubkeyHex: nil,
             adminEd25519PubkeyHex: adminEd25519PubkeyHex,
             isPublishedOnChain: true,
-            avatarJPEG: avatarJPEG
+            avatarJPEG: avatarJPEG,
+            invitationMessage: invitationMessage
         )
         _ = await groups.insert(group)
+    }
+
+    // MARK: - Group rules
+
+    func test_announcement_carriesTheJoinersAgreementToEveryMember() async throws {
+        // The claim the whole feature rests on: an agreement is
+        // checkable by any member, not only the founder who admitted
+        // them. Everyone but that founder learns it from here.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let rules = "Be kind. No links."
+        let joinerKey = Curve25519.Signing.PrivateKey()
+        let joinerSendingPub = joinerKey.publicKey.rawRepresentation
+        let signature = try joinerKey.signature(for: GroupRules.statement(
+            groupID: groupID,
+            rulesHash: GroupRules.hash(rules),
+            joinerSendingPublicKey: joinerSendingPub
+        ))
+        let creator = MemberProfile(
+            alias: "Alice",
+            inboxPublicKey: Data(repeating: 0x10, count: 32),
+            sendingPubkey: Data(repeating: 0xEE, count: 32)
+        )
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: ["aa".repeated(48): creator],
+            invitationMessage: rules
+        )
+
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: "bb".repeated(48),
+            joinerInboxByte: 0x33,
+            joinerAlias: "Bob",
+            adminAlias: "Alice",
+            joinerSendingPub: joinerSendingPub,
+            rulesHash: GroupRules.hash(rules),
+            rulesSignature: signature,
+            rulesText: rules
+        ))
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(plaintext),
+                senderEd25519PublicKey: Data(repeating: 0xEE, count: 32)
+            ),
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+
+        await dispatcher.dispatch(
+            messageID: "msg-rules",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        let updated = try XCTUnwrap(after.first { $0.groupIDData == groupID })
+        let joiner = try XCTUnwrap(updated.memberProfiles["bb".repeated(48)])
+        XCTAssertEqual(joiner.rulesText, rules,
+                       "the wording has to travel with the bytes it covers")
+        XCTAssertTrue(
+            joiner.agreedToRules(groupID: groupID),
+            "and an existing member must be able to check it themselves"
+        )
+        XCTAssertEqual(updated.rulesStanding(ofMemberWith: "bb".repeated(48)), .signed)
+    }
+
+    func test_announcement_fromAnOlderBuild_carriesNoAgreementAndSaysSo() async throws {
+        let groupID = Data(repeating: 0xAB, count: 32)
+        // Left as the fixture's `.anarchy`: Tyranny announcements go
+        // through on-chain commitment verification this suite doesn't
+        // seed. So this asserts what the announcement *carried* —
+        // nothing — and leaves what a group type makes of that to the
+        // standing tests either side of it.
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: ["aa".repeated(48): MemberProfile(
+                alias: "Alice",
+                inboxPublicKey: Data(repeating: 0x10, count: 32),
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
+            )],
+            invitationMessage: "Be kind. No links."
+        )
+        let plaintext = try Self.encode(announcement: try Self.makeAnnouncement(
+            groupID: groupID,
+            joinerBlsHex: "bb".repeated(48),
+            joinerInboxByte: 0x33,
+            joinerAlias: "Bob",
+            adminAlias: "Alice"
+        ))
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(plaintext),
+                senderEd25519PublicKey: Data(repeating: 0xEE, count: 32)
+            ),
+            identities: StubIdentities(summaries: []),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-legacy",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        let updated = try XCTUnwrap(after.first { $0.groupIDData == groupID })
+        let joiner = try XCTUnwrap(updated.memberProfiles["bb".repeated(48)])
+        XCTAssertNil(joiner.rulesSignature)
+        XCTAssertNil(joiner.rulesText)
+    }
+
+    func test_aMemberWhoSignedNothing_inAGroupThatCollectsAgreements_didNotSign() async throws {
+        // The other half of the pair: where agreements *are* collected,
+        // an empty record means what it says.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: ["bb".repeated(48): MemberProfile(
+                alias: "Bob",
+                inboxPublicKey: Data(repeating: 0x33, count: 32),
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
+            )],
+            groupType: .tyranny,
+            invitationMessage: "Be kind. No links."
+        )
+        let all = await groups.currentGroups()
+        let group = try XCTUnwrap(all.first { $0.groupIDData == groupID })
+        XCTAssertEqual(group.rulesStanding(ofMemberWith: "bb".repeated(48)), .didNotSign)
+    }
+
+    func test_aGroupTypeWithNoJoinApproval_marksNobodyAsHavingDeclined() async throws {
+        // Anarchy and one-on-one have no join request and no admin, so
+        // `.author` — keyed on `adminPubkeyHex`, nil for both — would
+        // have marked every member, including whoever wrote the rules,
+        // as having refused to sign them. Unreachable today, since
+        // `.tyranny` is the only type `CreateGroupFlow` produces, and
+        // pinned so it stays right when the others ship.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: ["aa".repeated(48): MemberProfile(
+                alias: "Alice",
+                inboxPublicKey: Data(repeating: 0x10, count: 32),
+                sendingPubkey: Data(repeating: 0xEE, count: 32)
+            )],
+            groupType: .anarchy,
+            invitationMessage: "Be kind. No links."
+        )
+        let all = await groups.currentGroups()
+        let group = try XCTUnwrap(all.first { $0.groupIDData == groupID })
+        XCTAssertEqual(group.rulesStanding(ofMemberWith: "aa".repeated(48)), .notCollected)
+    }
+
+    func test_aLaterInvitationWithoutTheSelfRow_doesNotEraseTheStoredAgreement() async throws {
+        // The path re-runs on every relay replay, and an admin on a
+        // build that predates the self row sends none. Copying the wire
+        // straight over put the joiner back to "didn't sign" — the
+        // defect this work exists to fix, reached by version skew.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let rules = "Be kind. No links."
+        let selfKey = Curve25519.Signing.PrivateKey()
+        let selfBlsHex = "cc".repeated(48)
+        let signature = try selfKey.signature(for: GroupRules.statement(
+            groupID: groupID,
+            rulesHash: GroupRules.hash(rules),
+            joinerSendingPublicKey: selfKey.publicKey.rawRepresentation
+        ))
+        // Already on the device, with the agreement recorded.
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [selfBlsHex: MemberProfile(
+                alias: "Me",
+                inboxPublicKey: Data(repeating: 0x10, count: 32),
+                sendingPubkey: selfKey.publicKey.rawRepresentation,
+                rulesHash: GroupRules.hash(rules),
+                rulesSignature: signature,
+                rulesText: rules
+            )],
+            invitationMessage: rules
+        )
+
+        // A second invitation for the same group, from an admin whose
+        // build knows nothing about self rows.
+        let invitation = GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),
+            name: "Family",
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: nil,
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.anarchy.rawValue,
+            adminPubkeyHex: nil,
+            memberProfiles: nil,
+            invitationMessage: rules
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed(try JSONEncoder().encode(invitation)),
+                senderEd25519PublicKey: Data(repeating: 0xEE, count: 32)
+            ),
+            identities: StubIdentities(summaries: [
+                IdentitySummary(
+                    id: owner,
+                    name: "Me",
+                    blsPublicKey: Data(selfBlsHex.hexBytes),
+                    inboxPublicKey: Data(repeating: 0x10, count: 32),
+                    sendingPublicKey: selfKey.publicKey.rawRepresentation
+                )
+            ]),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-replay",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
+
+        let after = await groups.currentGroups()
+        let updated = try XCTUnwrap(after.first { $0.groupIDData == groupID })
+        XCTAssertEqual(
+            updated.rulesStanding(ofMemberWith: selfBlsHex), .signed,
+            "an invitation that says nothing about our agreement must not delete it"
+        )
+    }
+
+    func test_aReApprovalWithNoText_doesNotDowngradeAVerifiedAgreement() async throws {
+        // Re-approving an old pending request after a rules edit sends
+        // the signature with no text (`JoinRequestApprover.textCovering`).
+        // Preferring the wire because it "has 64 bytes in it" turned an
+        // agreement that verifies into one that can't be checked.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let rules = "Be kind. No links."
+        let selfKey = Curve25519.Signing.PrivateKey()
+        let selfBlsHex = "cc".repeated(48)
+        let signature = try selfKey.signature(for: GroupRules.statement(
+            groupID: groupID,
+            rulesHash: GroupRules.hash(rules),
+            joinerSendingPublicKey: selfKey.publicKey.rawRepresentation
+        ))
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [selfBlsHex: MemberProfile(
+                alias: "Me",
+                inboxPublicKey: Data(repeating: 0x10, count: 32),
+                sendingPubkey: selfKey.publicKey.rawRepresentation,
+                rulesHash: GroupRules.hash(rules),
+                rulesSignature: signature,
+                rulesText: rules
+            )],
+            invitationMessage: rules
+        )
+
+        // The wire's row: same signature, no wording to check it against.
+        let wireRow = MemberProfile(
+            alias: "Me",
+            inboxPublicKey: Data(repeating: 0x10, count: 32),
+            sendingPubkey: selfKey.publicKey.rawRepresentation,
+            rulesHash: GroupRules.hash(rules),
+            rulesSignature: signature,
+            rulesText: nil
+        )
+        await dispatchInvitation(
+            groupID: groupID,
+            rules: rules,
+            profiles: [selfBlsHex: wireRow],
+            selfBlsHex: selfBlsHex,
+            selfSendingPub: selfKey.publicKey.rawRepresentation
+        )
+
+        let after = await groups.currentGroups()
+        let updated = try XCTUnwrap(after.first { $0.groupIDData == groupID })
+        XCTAssertEqual(
+            updated.rulesStanding(ofMemberWith: selfBlsHex), .signed,
+            "a record that proves something outranks one that doesn't"
+        )
+    }
+
+    func test_theStoredFloorIsReadFromThisIdentitysRow() async throws {
+        // Two identities on one device hold two rows for one group.
+        // Looking the floor up by group alone read the other identity's
+        // row and stamped its agreement onto this profile.
+        let groupID = Data(repeating: 0xAB, count: 32)
+        let rules = "Be kind. No links."
+        let selfBlsHex = "cc".repeated(48)
+        let otherKey = Curve25519.Signing.PrivateKey()
+        let otherOwner = IdentityID()
+        let otherSignature = try otherKey.signature(for: GroupRules.statement(
+            groupID: groupID,
+            rulesHash: GroupRules.hash(rules),
+            joinerSendingPublicKey: otherKey.publicKey.rawRepresentation
+        ))
+        // The *other* identity's row for the same group, with an
+        // agreement. Ours has none.
+        await groups.setCurrentIdentity(otherOwner)
+        await seedGroup(
+            groupID: groupID,
+            memberProfiles: [selfBlsHex: MemberProfile(
+                alias: "Someone else",
+                inboxPublicKey: Data(repeating: 0x10, count: 32),
+                sendingPubkey: otherKey.publicKey.rawRepresentation,
+                rulesHash: GroupRules.hash(rules),
+                rulesSignature: otherSignature,
+                rulesText: rules
+            )],
+            invitationMessage: rules,
+            owner: otherOwner
+        )
+        await groups.setCurrentIdentity(owner)
+
+        await dispatchInvitation(
+            groupID: groupID,
+            rules: rules,
+            profiles: nil,
+            selfBlsHex: selfBlsHex,
+            selfSendingPub: Data(repeating: 0xEE, count: 32)
+        )
+
+        let after = await groups.currentGroups()
+        let mine = try XCTUnwrap(
+            after.first { $0.groupIDData == groupID && $0.ownerIdentityID == owner }
+        )
+        XCTAssertNil(
+            mine.memberProfiles[selfBlsHex]?.rulesSignature,
+            "another identity's agreement must not become ours"
+        )
+    }
+
+    /// Dispatches a `GroupInvitationPayload` as though it arrived
+    /// sealed, with this suite's `owner` as the recipient.
+    private func dispatchInvitation(
+        groupID: Data,
+        rules: String?,
+        profiles: [String: MemberProfile]?,
+        selfBlsHex: String,
+        selfSendingPub: Data
+    ) async {
+        let invitation = GroupInvitationPayload(
+            version: 1,
+            groupID: groupID,
+            groupSecret: Data(repeating: 0x55, count: 32),
+            name: "Family",
+            members: [],
+            epoch: 0,
+            salt: Data(repeating: 0x66, count: 32),
+            commitment: nil,
+            tierRaw: SEPTier.small.rawValue,
+            groupTypeRaw: SEPGroupType.anarchy.rawValue,
+            adminPubkeyHex: nil,
+            memberProfiles: profiles,
+            invitationMessage: rules
+        )
+        let dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter: FakeInvitationEnvelopeDecrypter(
+                mode: .fixed((try? JSONEncoder().encode(invitation)) ?? Data()),
+                senderEd25519PublicKey: Data(repeating: 0xEE, count: 32)
+            ),
+            identities: StubIdentities(summaries: [
+                IdentitySummary(
+                    id: owner,
+                    name: "Me",
+                    blsPublicKey: Data(selfBlsHex.hexBytes),
+                    inboxPublicKey: Data(repeating: 0x10, count: 32),
+                    sendingPublicKey: selfSendingPub
+                )
+            ]),
+            groupRepository: groups,
+            invitationsRepository: invitations,
+            chainState: chainState,
+            messageRepository: MessageRepository(store: SwiftDataMessageStore.inMemory())
+        )
+        await dispatcher.dispatch(
+            messageID: "msg-\(UUID().uuidString)",
+            ownerIdentityID: owner,
+            payload: Data("envelope".utf8),
+            receivedAt: Date()
+        )
     }
 
     private static func makeAnnouncement(
@@ -1168,14 +1562,21 @@ final class IncomingMessageDispatcherTests: XCTestCase {
         joinerBlsHex: String,
         joinerInboxByte: UInt8,
         joinerAlias: String,
-        adminAlias: String
+        adminAlias: String,
+        joinerSendingPub: Data = Data(repeating: 0xEE, count: 32),
+        rulesHash: Data? = nil,
+        rulesSignature: Data? = nil,
+        rulesText: String? = nil
     ) throws -> MemberAnnouncementPayload {
         let blsPub = Data(joinerBlsHex.hexBytes)
         let member = try MemberAnnouncementPayload.AnnouncedMember(
             blsPub: blsPub,
             inboxPub: Data(repeating: joinerInboxByte, count: 32),
             alias: joinerAlias,
-            sendingPub: Data(repeating: 0xEE, count: 32)
+            sendingPub: joinerSendingPub,
+            rulesHash: rulesHash,
+            rulesSignature: rulesSignature,
+            rulesText: rulesText
         )
         return try MemberAnnouncementPayload(
             version: 1,

--- a/Tests/OnymIOSTests/JoinRequestApproverTests.swift
+++ b/Tests/OnymIOSTests/JoinRequestApproverTests.swift
@@ -200,6 +200,140 @@ final class JoinRequestApproverTests: XCTestCase {
         XCTAssertEqual(profile.inboxPublicKey, env.joinerInboxPub)
     }
 
+    // MARK: - Group rules
+
+    /// The rules the fixture's joiner signs.
+    private static let fixtureRules = "Be kind. No links."
+
+    func test_approve_keepsTheAgreementOnTheLocalMemberRecord() async throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let env = try await seedEnvironment(
+            groupRules: Self.fixtureRules, joinerSigningKey: key
+        )
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .sent)
+
+        let all = await groups.currentGroups()
+        let group = try XCTUnwrap(all.first { $0.groupIDData == env.groupID })
+        let joinerHex = env.joinerBlsPub.map { String(format: "%02x", $0) }.joined()
+        let profile = try XCTUnwrap(group.memberProfiles[joinerHex])
+        XCTAssertNotNil(profile.rulesSignature)
+        XCTAssertEqual(profile.rulesText, Self.fixtureRules,
+                       "the text the verdict was reached against, kept with the bytes")
+        XCTAssertTrue(profile.agreedToRules(groupID: env.groupID))
+        XCTAssertEqual(group.rulesStanding(ofMemberWith: joinerHex), .signed)
+    }
+
+    func test_approve_shipsTheJoinersOwnRowInTheInvitation() async throws {
+        // The joiner keeps no copy of the signature they sent, so this
+        // is the only way their own device can ever show it. Without
+        // it they land marked as never having signed the rules they had
+        // just agreed to.
+        let key = Curve25519.Signing.PrivateKey()
+        let env = try await seedEnvironment(
+            groupRules: Self.fixtureRules, joinerSigningKey: key
+        )
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .sent)
+
+        let sends = await transport.sends
+        let sealed = try XCTUnwrap(
+            sends.first { $0.inbox == env.expectedJoinerTag }?.payload
+        )
+        let invite = try await decodeInvitation(sealed)
+        let joinerHex = env.joinerBlsPub.map { String(format: "%02x", $0) }.joined()
+        let row = try XCTUnwrap(
+            invite.memberProfiles?[joinerHex],
+            "the invitation must carry the joiner's own row"
+        )
+        XCTAssertNotNil(row.rulesSignature)
+        XCTAssertEqual(row.rulesText, Self.fixtureRules)
+        XCTAssertTrue(
+            row.agreedToRules(groupID: env.groupID),
+            "and it must be the agreement, not just its shape"
+        )
+        XCTAssertEqual(invite.invitationMessage, Self.fixtureRules,
+                       "along with the rules themselves")
+    }
+
+    func test_approve_recordsAnAgreementItCouldNotVerify() async throws {
+        // The founder saw the verdict and admitted them anyway. Keeping
+        // the bytes is what lets that decision be re-read later; the
+        // standing stays honest about them.
+        let env = try await seedEnvironment(
+            groupRules: Self.fixtureRules,
+            joinerSigningKey: nil
+        )
+        await env.approver.pumpOnce()
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .sent)
+
+        let all = await groups.currentGroups()
+        let group = try XCTUnwrap(all.first { $0.groupIDData == env.groupID })
+        let joinerHex = env.joinerBlsPub.map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(group.rulesStanding(ofMemberWith: joinerHex), .didNotSign)
+    }
+
+    func test_approve_afterTheRulesChanged_doesNotAccuseTheJoiner() async throws {
+        // A founder editing the rules between request and approval used
+        // to ship the joiner a row pairing their signature with the new
+        // wording — resolving, on their own first look at the group, to
+        // "their signature doesn't check out". It isn't true: the
+        // signature is fine and this device no longer holds what it
+        // covers.
+        let key = Curve25519.Signing.PrivateKey()
+        let env = try await seedEnvironment(
+            groupRules: Self.fixtureRules, joinerSigningKey: key
+        )
+        await env.approver.pumpOnce()
+
+        // The edit, after the request was signed and before it is acted on.
+        let before = await groups.currentGroups()
+        var edited = try XCTUnwrap(before.first { $0.groupIDData == env.groupID })
+        edited.invitationMessage = "Be kind. No links. And no photos."
+        _ = await groups.insert(edited)
+
+        let outcome = await env.approver.approve(requestId: env.requestID)
+        XCTAssertEqual(outcome, .sent)
+
+        let joinerHex = env.joinerBlsPub.map { String(format: "%02x", $0) }.joined()
+        let after = await groups.currentGroups()
+        let group = try XCTUnwrap(after.first { $0.groupIDData == env.groupID })
+        let profile = try XCTUnwrap(group.memberProfiles[joinerHex])
+        XCTAssertNotNil(profile.rulesSignature, "the evidence is kept")
+        XCTAssertNil(profile.rulesText, "but not paired with words it doesn't cover")
+        XCTAssertEqual(
+            group.rulesStanding(ofMemberWith: joinerHex), .unknownRules,
+            "can't be checked — not an accusation"
+        )
+
+        // And the same restraint in what the joiner is sent.
+        let sends = await transport.sends
+        let sealed = try XCTUnwrap(
+            sends.first { $0.inbox == env.expectedJoinerTag }?.payload
+        )
+        let invite = try await decodeInvitation(sealed)
+        let row = try XCTUnwrap(invite.memberProfiles?[joinerHex])
+        XCTAssertNotNil(row.rulesSignature)
+        XCTAssertNil(row.rulesText)
+    }
+
+    /// Opens an invitation the approver sealed to the joiner.
+    ///
+    /// The fixture collapses joiner and admin into one identity, so the
+    /// active identity is also the recipient — `decryptInvitation` is
+    /// the supported way in, rather than pulling the key out by hand.
+    private func decodeInvitation(_ sealed: Data) async throws -> GroupInvitationPayload {
+        let ownerID = try await XCTUnwrapAsync(await identity.currentSelectedID())
+        let plaintext = try await identity.decryptInvitation(
+            envelopeBytes: sealed,
+            asIdentity: ownerID
+        )
+        return try JSONDecoder().decode(GroupInvitationPayload.self, from: plaintext)
+    }
+
     // MARK: - PR 5: broadcastJoin fanout
 
     func test_approve_fanoutTargetsExistingMembersExcludingAdminAndJoiner() async throws {
@@ -660,7 +794,9 @@ final class JoinRequestApproverTests: XCTestCase {
     private func seedEnvironment(
         insertGroup: Bool = true,
         extraMemberProfiles: [String: MemberProfile] = [:],
-        omitJoinerLeafHash: Bool = false
+        omitJoinerLeafHash: Bool = false,
+        groupRules: String? = nil,
+        joinerSigningKey: Curve25519.Signing.PrivateKey? = nil
     ) async throws -> Env {
         let active = try await identity.bootstrap()
         let ownerID = try await XCTUnwrapAsync(await identity.currentSelectedID())
@@ -697,13 +833,29 @@ final class JoinRequestApproverTests: XCTestCase {
         let joinerBlsPub = Data(repeating: 0xCC, count: 48)
         let joinerLeafHash = Data(repeating: 0xDD, count: 32)
         let joinerAlias = "Joiner Bob"
+        // A real agreement when the group has rules, so the approver's
+        // handling of it can be asserted rather than assumed.
+        let joinerSendingPub = joinerSigningKey?.publicKey.rawRepresentation
+            ?? Data(repeating: 0xEE, count: 32)
+        var rulesHash: Data?
+        var rulesSignature: Data?
+        if let groupRules, let joinerSigningKey {
+            rulesHash = GroupRules.hash(groupRules)
+            rulesSignature = try joinerSigningKey.signature(for: GroupRules.statement(
+                groupID: groupID,
+                rulesHash: GroupRules.hash(groupRules),
+                joinerSendingPublicKey: joinerSendingPub
+            ))
+        }
         let joinPayload = try JoinRequestPayload(
             joinerInboxPublicKey: joinerInboxPub,
             joinerBlsPublicKey: joinerBlsPub,
             joinerLeafHash: omitJoinerLeafHash ? nil : joinerLeafHash,
-            joinerSendingPublicKey: Data(repeating: 0xEE, count: 32),
+            joinerSendingPublicKey: joinerSendingPub,
             joinerDisplayLabel: joinerAlias,
-            groupId: groupID
+            groupId: groupID,
+            rulesHash: rulesHash,
+            rulesSignature: rulesSignature
         )
         let joinPayloadBytes = try JSONEncoder().encode(joinPayload)
         let sealed = try await identity.sealInvitation(
@@ -753,7 +905,8 @@ final class JoinRequestApproverTests: XCTestCase {
                 groupType: .tyranny,
                 adminPubkeyHex: adminBlsHex,
                 adminEd25519PubkeyHex: nil,
-                isPublishedOnChain: true
+                isPublishedOnChain: true,
+                invitationMessage: groupRules
             )
             _ = await groups.insert(group)
         }

--- a/Tests/OnymIOSTests/MediaCommitmentFixtureTests.swift
+++ b/Tests/OnymIOSTests/MediaCommitmentFixtureTests.swift
@@ -104,19 +104,3 @@ final class MediaCommitmentFixtureTests: XCTestCase {
         XCTAssertTrue(try fixture().preimage.contains(#"image\/jpeg"#))
     }
 }
-
-private extension Data {
-    init?(hexString: String) {
-        guard hexString.count % 2 == 0 else { return nil }
-        var bytes = [UInt8]()
-        bytes.reserveCapacity(hexString.count / 2)
-        var index = hexString.startIndex
-        while index < hexString.endIndex {
-            let next = hexString.index(index, offsetBy: 2)
-            guard let byte = UInt8(hexString[index..<next], radix: 16) else { return nil }
-            bytes.append(byte)
-            index = next
-        }
-        self.init(bytes)
-    }
-}

--- a/Tests/OnymIOSUITests/GroupRulesProofUITests.swift
+++ b/Tests/OnymIOSUITests/GroupRulesProofUITests.swift
@@ -1,0 +1,169 @@
+import XCTest
+
+/// The rules, end to end: written at creation, read and signed on the
+/// way in, and shown afterwards to everyone in the group.
+///
+/// The last part is why this is a UI test and not three unit tests. The
+/// claim behind the feature is that a member's agreement is visible and
+/// checkable by *any* member — not only by the founder who admitted
+/// them — and that only holds if the signature survives the invitation
+/// payload and the announcement. Nothing below the UI exercises that
+/// whole path, so it is asserted here, from both devices.
+final class GroupRulesProofUITests: XCTestCase {
+
+    private let baseArgs = [
+        "--ui-testing", "--mock-biometric", "--ui-loopback",
+        "-AppleLanguages", "(en)", "-AppleLocale", "en_US",
+    ]
+    private let rules = "Be kind. No links. Ask before adding anyone."
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_rulesAreSignedOnTheWayInAndShownToBothMembersAfter() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--reset-keychain"] + baseArgs
+        app.launch()
+
+        TwoIdentityFlow.addIdentity(app, name: "Alice")
+        TwoIdentityFlow.addIdentity(app, name: "Bob")
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
+
+        let create = CreateGroupScreen(app: app)
+        create.open()
+        create.typeName("Founders")
+        create.typeInvitation(rules)
+        create.tapNext()
+        create.tapCreate()
+        XCTAssertTrue(create.waitForSuccess(), "group creation never succeeded")
+        create.tapShareInvite()
+        let share = ShareInviteScreen(app: app)
+        XCTAssertTrue(share.waitReady(), "share-invite screen never appeared")
+        guard let link = share.readInviteLink(), !link.isEmpty else {
+            return XCTFail("invite link was not exposed")
+        }
+        share.done()
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
+        app.terminate()
+
+        // ───────── Bob reads the rules and agrees ─────────
+        app.launchArguments = baseArgs + ["--open-url", link]
+        app.launch()
+
+        let confirm = JoinConfirmScreen(app: app)
+        XCTAssertTrue(confirm.waitReady(), "join confirmation never appeared")
+        XCTAssertTrue(
+            app.staticTexts[rules].waitForExistence(timeout: 5),
+            "the rules must be on screen before anyone is asked to agree to them"
+        )
+        // The gate. A group with rules costs one more tap than one
+        // without, and this is that tap.
+        XCTAssertFalse(
+            app.buttons["join_confirm.send"].isEnabled,
+            "Send must stay closed until the rules are agreed to"
+        )
+        // SwiftUI hangs the identifier on the container rather than the
+        // switch; there is exactly one switch on this screen.
+        let agree = app.switches.firstMatch
+        XCTAssertTrue(agree.waitForExistence(timeout: 5), "agree toggle missing")
+        agree.tap()
+        XCTAssertTrue(app.buttons["join_confirm.send"].isEnabled, "agreeing must open Send")
+        confirm.send()
+
+        let pending = PendingChatScreen(app: app)
+        XCTAssertTrue(pending.waitReady(), "pending chat never appeared")
+        pending.back()
+
+        // ───────── The founder admits them ─────────
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.openChat(app)
+        let thread = ChatThreadScreen(app: app)
+        XCTAssertTrue(thread.waitReady(), "Alice's thread never opened")
+        JoinRequestRow(app: app).acceptFirst()
+        XCTAssertTrue(
+            JoinRequestRow(app: app).waitForJoinedNotice(alias: "Bob"),
+            "join approval never produced a joined notice"
+        )
+
+        try assertMembersScreenShowsStandings(app, from: "Alice")
+
+        // ───────── And Bob sees the same, on his own device ─────────
+        thread.back()
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
+        TwoIdentityFlow.openChat(app)
+        XCTAssertTrue(thread.waitReady(), "Bob's thread never opened")
+        try assertMembersScreenShowsStandings(app, from: "Bob")
+    }
+
+    /// The rules, and both members' standings, as rendered for whoever
+    /// is currently signed in. Identical from either side — that is the
+    /// assertion.
+    private func assertMembersScreenShowsStandings(
+        _ app: XCUIApplication,
+        from viewer: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        app.buttons["chat.info"].tap()
+        XCTAssertTrue(
+            app.staticTexts["GROUP RULES"].waitForExistence(timeout: 15),
+            "\(viewer) never saw the group rules section", file: file, line: line
+        )
+        XCTAssertTrue(
+            app.staticTexts[rules].exists,
+            "\(viewer) saw the section without the rules in it", file: file, line: line
+        )
+        XCTAssertTrue(
+            app.staticTexts["Signed the group rules"].waitForExistence(timeout: 10),
+            "\(viewer) could not see that Bob signed", file: file, line: line
+        )
+        XCTAssertTrue(
+            app.staticTexts["Wrote the group rules"].exists,
+            "\(viewer) saw the founder marked as something other than the author",
+            file: file, line: line
+        )
+
+        // And the proof behind the mark, with the wording it covers.
+        // `XCTUnwrap`, not `?.tap()`: a silent no-op here surfaced as
+        // "could not open Bob's proof", pointing at the sheet rather
+        // than at the row that was never there.
+        let bobRow = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'members.row.'")
+        ).allElementsBoundByIndex.first { $0.label.contains("Bob") }
+        try XCTUnwrap(bobRow, "\(viewer) saw no row for Bob").tap()
+        XCTAssertTrue(
+            app.staticTexts["WHAT THEY SIGNED"].waitForExistence(timeout: 5),
+            "\(viewer) could not open Bob's proof", file: file, line: line
+        )
+        XCTAssertTrue(
+            app.buttons["rules_proof.export"].exists,
+            "\(viewer) had no way to export it", file: file, line: line
+        )
+        XCTAssertTrue(
+            app.staticTexts["member"].exists,
+            "\(viewer) saw a proof identified only by a self-asserted alias",
+            file: file, line: line
+        )
+        app.buttons["rules_proof.done"].tap()
+
+        // The other sheet on this screen. Both present through one
+        // `sheet(item:)` over an enum now, because two `.sheet`
+        // modifiers on one view leave SwiftUI honouring whichever it
+        // likes — and this is the one that would have gone quiet, since
+        // only the admin reaches it.
+        let shareInvite = app.buttons["members.share_invite_button"]
+        if shareInvite.waitForExistence(timeout: 2) {
+            shareInvite.tap()
+            let share = ShareInviteScreen(app: app)
+            XCTAssertTrue(
+                share.waitReady(),
+                "\(viewer) is this group's admin and the share-invite sheet never presented",
+                file: file, line: line
+            )
+            share.done()
+        }
+        app.navigationBars.buttons.element(boundBy: 0).tap()
+    }
+}

--- a/Tests/OnymIOSUITests/MultiIdentityChatUITests.swift
+++ b/Tests/OnymIOSUITests/MultiIdentityChatUITests.swift
@@ -47,11 +47,11 @@ final class MultiIdentityChatUITests: XCTestCase {
         app.launchArguments = ["--reset-keychain"] + baseArgs
         app.launch()
 
-        addIdentity(app, name: "Alice")
-        addIdentity(app, name: "Bob")
+        TwoIdentityFlow.addIdentity(app, name: "Alice")
+        TwoIdentityFlow.addIdentity(app, name: "Bob")
 
         // Identity 1 (Alice) creates a Founder group.
-        switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
         let create = CreateGroupScreen(app: app)
         create.open()
         create.typeName("Founders")
@@ -70,7 +70,7 @@ final class MultiIdentityChatUITests: XCTestCase {
         share.done()
 
         // Leave Bob active so session 2 boots as the joiner.
-        switchIdentity(app, to: "Bob")
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
         app.terminate()
 
         // ───────── Session 2: join → approve → chat ─────────
@@ -101,8 +101,8 @@ final class MultiIdentityChatUITests: XCTestCase {
         // Identity 1 (Alice) approves the join request — from inside the
         // group's chat thread, which is the whole point of the surface:
         // there is no separate "Join requests" screen to find.
-        switchIdentity(app, to: "Alice")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.openChat(app)
         let thread = ChatThreadScreen(app: app)
         XCTAssertTrue(thread.waitReady(), "Alice's chat thread never opened")
         let joinRequest = JoinRequestRow(app: app)
@@ -112,8 +112,8 @@ final class MultiIdentityChatUITests: XCTestCase {
         thread.back()
 
         // ───────── Bob → Alice: message received + read ─────────
-        switchIdentity(app, to: "Bob")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(thread.waitReady(), "Bob's chat thread never opened")
         thread.send("Hello from Bob")
         XCTAssertTrue(thread.waitForMessage("Hello from Bob"),
@@ -121,36 +121,36 @@ final class MultiIdentityChatUITests: XCTestCase {
         thread.back()
 
         // Alice asserts she received it; viewing ships a read receipt.
-        switchIdentity(app, to: "Alice")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(thread.waitReady(), "Alice's chat thread never opened")
         XCTAssertTrue(thread.waitForMessage("Hello from Bob"),
                       "Alice never received Bob's message")
         thread.back()
 
         // Bob asserts his message was read.
-        switchIdentity(app, to: "Bob")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(thread.waitForStatus("Read"),
                       "Bob's message never flipped to Read after Alice opened the thread")
         thread.back()
 
         // ───────── Alice → Bob: same, other direction ─────────
-        switchIdentity(app, to: "Alice")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.openChat(app)
         thread.send("Hello from Alice")
         XCTAssertTrue(thread.waitForMessage("Hello from Alice"),
                       "Alice's own outgoing message never rendered")
         thread.back()
 
-        switchIdentity(app, to: "Bob")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(thread.waitForMessage("Hello from Alice"),
                       "Bob never received Alice's message")
         thread.back()
 
-        switchIdentity(app, to: "Alice")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(thread.waitForStatus("Read"),
                       "Alice's message never flipped to Read after Bob opened the thread")
         thread.back()
@@ -159,8 +159,8 @@ final class MultiIdentityChatUITests: XCTestCase {
         // Under `--ui-loopback` the attach button sends a generated test
         // image (the system photo picker can't be driven from XCUITest);
         // the blob round-trips through the in-memory Blossom fake.
-        switchIdentity(app, to: "Bob")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(thread.waitReady(), "Bob's chat thread never opened")
         // Two-step: attach stages the image in the preview strip, then
         // Send confirms.
@@ -182,8 +182,8 @@ final class MultiIdentityChatUITests: XCTestCase {
                       "swiping down never dismissed the full-screen image viewer")
         thread.back()
 
-        switchIdentity(app, to: "Alice")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(app.images["chat.bubble.image"].waitForExistence(timeout: 25),
                       "Alice never received + rendered the image")
         thread.back()
@@ -194,8 +194,8 @@ final class MultiIdentityChatUITests: XCTestCase {
         // driven from XCUITest); the audio blob round-trips through the
         // in-memory Blossom fake. The bubble exposes the player button as
         // `chat.bubble.voice.play`.
-        switchIdentity(app, to: "Alice")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(thread.waitReady(), "Alice's chat thread never opened")
         // The mic button is shown when the composer is empty.
         app.buttons["chat.input.mic"].tap()
@@ -203,8 +203,8 @@ final class MultiIdentityChatUITests: XCTestCase {
                       "Alice's sent voice bubble never rendered")
         thread.back()
 
-        switchIdentity(app, to: "Bob")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(app.buttons["chat.bubble.voice.play"].waitForExistence(timeout: 25),
                       "Bob never received + rendered the voice message")
         thread.back()
@@ -212,8 +212,8 @@ final class MultiIdentityChatUITests: XCTestCase {
         // ───────── Album: two images → one grid message ─────────
         // Stage two images in the preview strip, then Send once → a
         // single album bubble rendered as a grid.
-        switchIdentity(app, to: "Bob")
-        openChat(app)
+        TwoIdentityFlow.switchIdentity(app, to: "Bob")
+        TwoIdentityFlow.openChat(app)
         XCTAssertTrue(thread.waitReady(), "Bob's chat thread never opened for album")
         app.buttons["chat.input.attach"].tap()
         app.buttons["chat.input.attach"].tap()
@@ -230,7 +230,7 @@ final class MultiIdentityChatUITests: XCTestCase {
         // ───────── Search: find a message + open its chat ─────────
         // As Alice, search her messages for Bob's text, tap the result,
         // and assert it opens the chat thread scrolled to that message.
-        switchIdentity(app, to: "Alice")
+        TwoIdentityFlow.switchIdentity(app, to: "Alice")
         let search = SearchScreen(app: app)
         search.tapSearchTab()
         search.search(for: "Hello from Bob")
@@ -248,31 +248,6 @@ final class MultiIdentityChatUITests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func addIdentity(_ app: XCUIApplication, name: String) {
-        let settings = SettingsScreen(app: app)
-        settings.addIdentityViaCarousel(name: name)
-        // On create the carousel jumps to the new identity's QR page, so
-        // its alias appears as a static text.
-        let alias = app.staticTexts.matching(
-            NSPredicate(format: "label CONTAINS %@", name)
-        ).firstMatch
-        XCTAssertTrue(alias.waitForExistence(timeout: 8),
-                      "newly-added identity '\(name)' never appeared in the carousel")
-    }
-
-    /// Switch the active identity via the Chats toolbar picker, matching
-    /// the menu row by its visible name (we don't know the UUIDs here).
-    private func switchIdentity(_ app: XCUIApplication, to name: String) {
-        let chats = ChatsScreen(app: app)
-        chats.tapChatsTab()
-        chats.tapPicker()
-        let item = app.buttons.matching(NSPredicate(format: "label CONTAINS %@", name)).firstMatch
-        XCTAssertTrue(item.waitForExistence(timeout: 5),
-                      "identity '\(name)' never appeared in the picker menu")
-        item.tap()
-        _ = chats.navTitle(name).waitForExistence(timeout: 5)
-    }
-
     /// Poll until `element` no longer exists, or the timeout elapses.
     private func waitForDisappearance(of element: XCUIElement, timeout: TimeInterval) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
@@ -283,13 +258,4 @@ final class MultiIdentityChatUITests: XCTestCase {
         return !element.exists
     }
 
-    /// Open the single group's thread from the Chats list.
-    private func openChat(_ app: XCUIApplication) {
-        let row = app.buttons.matching(
-            NSPredicate(format: "identifier BEGINSWITH 'chats.row.'")
-        ).firstMatch
-        XCTAssertTrue(row.waitForExistence(timeout: 25),
-                      "chat row never appeared in the list")
-        row.tap()
-    }
 }

--- a/Tests/OnymIOSUITests/PageObjects/TwoIdentityFlow.swift
+++ b/Tests/OnymIOSUITests/PageObjects/TwoIdentityFlow.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+/// The two-identity dance every multi-party UI test opens with.
+///
+/// This existed verbatim in `MultiIdentityChatUITests`, `SearchUITests`
+/// and `GroupRulesProofUITests` before it was extracted — three copies
+/// of the same waits, which is three places to fix when the picker or
+/// the carousel moves.
+enum TwoIdentityFlow {
+
+    /// Create an identity from the settings carousel and wait for it to
+    /// land. The carousel jumps to the new identity's QR page on
+    /// create, so its alias surfaces as a static text.
+    static func addIdentity(
+        _ app: XCUIApplication,
+        name: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        SettingsScreen(app: app).addIdentityViaCarousel(name: name)
+        let alias = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", name)
+        ).firstMatch
+        XCTAssertTrue(
+            alias.waitForExistence(timeout: 8),
+            "newly-added identity '\(name)' never appeared in the carousel",
+            file: file, line: line
+        )
+    }
+
+    /// Switch the active identity via the Chats toolbar picker, matched
+    /// by visible name — the UUIDs aren't known here.
+    static func switchIdentity(
+        _ app: XCUIApplication,
+        to name: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let chats = ChatsScreen(app: app)
+        chats.tapChatsTab()
+        chats.tapPicker()
+        let item = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS %@", name)
+        ).firstMatch
+        XCTAssertTrue(
+            item.waitForExistence(timeout: 5),
+            "identity '\(name)' never appeared in the picker menu",
+            file: file, line: line
+        )
+        item.tap()
+        _ = chats.navTitle(name).waitForExistence(timeout: 5)
+    }
+
+    /// Open the first chat in the list.
+    static func openChat(
+        _ app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let row = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'chats.row.'")
+        ).firstMatch
+        XCTAssertTrue(
+            row.waitForExistence(timeout: 25),
+            "chat row never appeared in the list", file: file, line: line
+        )
+        row.tap()
+    }
+}


### PR DESCRIPTION
Stacked on the screens PR.

**`GroupRulesStandingTests`** covers the standings where a mark would overstate: bytes that don't verify, a signature lifted from another member, and a signature that is good over words the group has since replaced — which stays *proven*, because it is, and says so separately. Plus the founder matched case-insensitively, since `adminPubkeyHex` and the profile key are hex from two sources and a case difference must not demote the author to "didn't sign".

For the export, the load-bearing test **rebuilds the statement from the document's own fields and verifies it**. That is the file's whole claim; asserting anything less would only test the writer against itself. Alongside it: the wording carried is the signed one rather than today's, an unproven standing ships no signature at all, the `_readme` only cites keys the document actually has, two exports of one agreement are byte-identical, and names that reduce to nothing still produce a findable filename.

**`GroupRulesProofUITests`** is a UI test because the claim is cross-device: an agreement is checkable by *any* member, not only the founder who admitted them, and that holds only if the signature survives the invitation payload. Nothing below the UI crosses two devices. It asserts the gate on the way in — Send closed until the rules are agreed to, open after — then the same two standings from Alice's device and from Bob's.

That second half is what failed before the fix in the PR below, which is why it's worth its ~2 minutes of runtime.

1579 unit tests green; the UI test green end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)