### PR TITLE
Speak the erase wire the operator actually answers

### DIFF
--- a/Packages/OnymBackup/Sources/OnymBackup/BackupFormat.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupFormat.swift
@@ -63,8 +63,20 @@ enum BackupFormat {
         return formatter
     }()
 
+    /// Reading is wider than writing: RFC 3339 allows fractional
+    /// seconds, and the operator's stamps carry them, so a reader
+    /// pinned to the emitting form would refuse every receipt the
+    /// operator actually signs.
+    static let fractionalTimestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+
     static func date(fromRFC3339 value: String) -> Date? {
         timestampFormatter.date(from: value)
+            ?? fractionalTimestampFormatter.date(from: value)
     }
 
     static func string(fromDate date: Date) -> String {

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupPort.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupPort.swift
@@ -35,10 +35,12 @@ public protocol BackupPort: Sendable {
     /// restore.
     func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws
 
-    /// Request erasure and return the operator's signed receipt.
-    /// An acknowledged-but-incomplete erasure is `erasureUnconfirmed`,
-    /// carrying the receipt — it is not success.
-    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt
+    /// Request erasure and return the operator's signed receipts — one
+    /// per distinct pinned `termsId` in scope (§11), so a single
+    /// snapshot yields exactly one and `all` may yield several. Never
+    /// empty. An acknowledged-but-incomplete erasure is
+    /// `erasureUnconfirmed`, carrying the receipt — it is not success.
+    func eraseSnapshot(scope: ErasureScope) async throws -> [ErasureReceipt]
 
     /// The portable container for migration to another operator or to the
     /// person's own storage. Never gated on payment

--- a/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/BackupRepository.swift
@@ -740,9 +740,9 @@ public actor BackupRepository {
         guard surplus <= erasable.count else { return }
 
         for row in erasable.prefix(surplus) {
-            let receipt: ErasureReceipt
+            let receipts: [ErasureReceipt]
             do {
-                receipt = try await port.eraseSnapshot(scope: .snapshot(row.snapshotReference))
+                receipts = try await port.eraseSnapshot(scope: .snapshot(row.snapshotReference))
             } catch {
                 // Stopped, not thrown. A housekeeping erase that failed
                 // says nothing about whether this snapshot can be
@@ -757,7 +757,7 @@ public actor BackupRepository {
             // durable record that this happened, and a batch written
             // after the last erase is a batch lost by a crash in the
             // middle of the first.
-            record(receipt, scope: .snapshot(row.snapshotReference), in: &state)
+            record(receipts, scope: .snapshot(row.snapshotReference), in: &state)
             try commit(state, expecting: state.componentId)
         }
     }
@@ -909,13 +909,13 @@ public actor BackupRepository {
     /// snapshot it describes: what an erasure did not reach is the part
     /// a person may need to re-read long afterwards.
     @discardableResult
-    public func erase(scope: ErasureScope) async throws -> ErasureReceipt {
-        let receipt = try await port.eraseSnapshot(scope: scope)
+    public func erase(scope: ErasureScope) async throws -> [ErasureReceipt] {
+        let receipts = try await port.eraseSnapshot(scope: scope)
         var state = try stateStore.load()
         let enrolled = state.componentId
-        record(receipt, scope: scope, in: &state)
+        record(receipts, scope: scope, in: &state)
         try commit(state, expecting: enrolled)
-        return receipt
+        return receipts
     }
 
     /// Write down one erasure: keep the receipt, drop the local record of
@@ -927,11 +927,11 @@ public actor BackupRepository {
     /// would have the run's next `commit` write a state with no receipt
     /// in it straight back over the top.
     private func record(
-        _ receipt: ErasureReceipt,
+        _ receipts: [ErasureReceipt],
         scope: ErasureScope,
         in state: inout BackupState
     ) {
-        state.receipts.append(receipt.rawBytes)
+        state.receipts.append(contentsOf: receipts.map(\.rawBytes))
         if case .snapshot(let reference) = scope {
             state.snapshots.removeAll { $0.digest == reference.digest }
         } else {

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient+Transport.swift
@@ -12,9 +12,104 @@ extension URLSessionBackupClient {
 
     static let decoder: JSONDecoder = {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        // Through `BackupFormat`, not `.iso8601`, so every timestamp
+        // the operator sends — `retainedAt` in a listing as much as a
+        // receipt's `acknowledgedAt` — is read by the one reader whose
+        // tolerance this module owns and tests. The operator's clock
+        // stamps fractional seconds, and whether `.iso8601` accepts
+        // those is a fact about the Foundation build, not about this
+        // code; the rolling window must not hang on it.
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+            guard let date = BackupFormat.date(fromRFC3339: value) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container, debugDescription: "not an RFC 3339 timestamp")
+            }
+            return date
+        }
         return decoder
     }()
+
+    /// Split a top-level JSON array into its elements' *own* byte
+    /// ranges, verbatim.
+    ///
+    /// For a response whose elements are kept as evidence — erasure
+    /// receipts — parsing and re-serializing would substitute this
+    /// client's key order, whitespace, and number formatting for the
+    /// operator's, and a signature over the original bytes could never
+    /// be checked against the substitute. So the array structure is the
+    /// only thing read here; each element's bytes pass through
+    /// untouched, and whether they are a well-formed receipt is the
+    /// element decoder's question.
+    ///
+    /// Returns `nil` when `data` is not a complete top-level array —
+    /// truncated, trailing garbage, or not an array at all.
+    static func topLevelJSONArrayElements(in data: Data) -> [Data]? {
+        let space: Set<UInt8> = [0x20, 0x09, 0x0a, 0x0d]
+        var index = data.startIndex
+        func skipWhitespace() {
+            while index < data.endIndex, space.contains(data[index]) { index += 1 }
+        }
+        func element(endingAt end: Data.Index, from start: Data.Index) -> Data {
+            var trimmed = end
+            while trimmed > start, space.contains(data[data.index(before: trimmed)]) {
+                trimmed = data.index(before: trimmed)
+            }
+            return data.subdata(in: start..<trimmed)
+        }
+
+        skipWhitespace()
+        guard index < data.endIndex, data[index] == UInt8(ascii: "[") else { return nil }
+        index += 1
+        skipWhitespace()
+
+        var elements: [Data] = []
+        var closed = false
+        if index < data.endIndex, data[index] == UInt8(ascii: "]") {
+            index += 1
+            closed = true
+        }
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var start = index
+        while !closed, index < data.endIndex {
+            let byte = data[index]
+            if inString {
+                if escaped { escaped = false }
+                else if byte == UInt8(ascii: #"\"#) { escaped = true }
+                else if byte == UInt8(ascii: "\"") { inString = false }
+            } else {
+                switch byte {
+                case UInt8(ascii: "\""): inString = true
+                case UInt8(ascii: "{"), UInt8(ascii: "["): depth += 1
+                case UInt8(ascii: "]") where depth == 0:
+                    guard index > start || !elements.isEmpty else { return nil }
+                    elements.append(element(endingAt: index, from: start))
+                    index += 1
+                    closed = true
+                    continue
+                case UInt8(ascii: "}"), UInt8(ascii: "]"):
+                    depth -= 1
+                    if depth < 0 { return nil }
+                case UInt8(ascii: ",") where depth == 0:
+                    guard index > start else { return nil }
+                    elements.append(element(endingAt: index, from: start))
+                    index += 1
+                    skipWhitespace()
+                    start = index
+                    continue
+                default: break
+                }
+            }
+            index += 1
+        }
+        guard closed else { return nil }
+        skipWhitespace()
+        guard index == data.endIndex else { return nil }
+        return elements
+    }
 
     func decode<Value: Decodable>(_ data: Data) throws -> Value {
         guard let value = try? Self.decoder.decode(Value.self, from: data) else {

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
@@ -285,17 +285,36 @@ public struct URLSessionBackupClient: BackupPort {
         )
         let data = try await post(path: ["v1", "erasures"], body: body)
         // One receipt per distinct pinned `termsId` in scope — an array
-        // even for a single snapshot, and never empty: an erasure that
-        // committed nothing is an error, not a receipt.
-        guard
-            let elements = try? JSONSerialization.jsonObject(with: data) as? [Any],
-            !elements.isEmpty
+        // even for a single snapshot. Split into the operator's own
+        // byte ranges rather than re-serialized: `rawBytes` is what the
+        // repository keeps as the durable record and what a signature
+        // over the receipt would be checked against, and a client
+        // reconstruction — different key order, whitespace, number
+        // formatting — is neither.
+        //
+        // An empty array is refused deliberately. This profile answers
+        // "nothing in scope" with an error (`not_found`,
+        // `receipt_expired`), never with an empty acknowledgement, so
+        // `[]` can only be an operator claiming to have erased while
+        // committing to nothing — and a receipt is the only durable
+        // record, so nothing is not a success.
+        guard let elements = Self.topLevelJSONArrayElements(in: data), !elements.isEmpty
         else {
             throw BackupError.rejected(code: "malformed_receipt", message: nil)
         }
-        return try elements.map {
-            let raw = try JSONSerialization.data(withJSONObject: $0, options: [.sortedKeys])
-            return try ErasureReceipt.decode(raw: raw)
+        return try elements.map { raw in
+            let receipt = try ErasureReceipt.decode(raw: raw)
+            // An echoed scope that is not the one asked about is an
+            // operator answering a different question. Recording it
+            // would drop the local row for the requested digest on the
+            // strength of a receipt that covers something else.
+            guard receipt.scope == scope.wireValue else {
+                throw BackupError.rejected(
+                    code: "scope_mismatch",
+                    message: "the operator answered about a different scope"
+                )
+            }
+            return receipt
         }
     }
 

--- a/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
+++ b/Packages/OnymBackup/Sources/OnymBackup/URLSessionBackupClient.swift
@@ -268,14 +268,35 @@ public struct URLSessionBackupClient: BackupPort {
         )
     }
 
-    public func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+    public func eraseSnapshot(scope: ErasureScope) async throws -> [ErasureReceipt] {
         struct Body: Encodable {
             let version = 1
+            let operationId: String
             let scope: String
         }
-        let body = try Self.encoder.encode(Body(scope: scope.wireValue))
+        // Client-chosen, like every other operation's id (§14.9): a
+        // lost erase response can only be asked about under an id this
+        // side already knows.
+        let body = try Self.encoder.encode(
+            Body(
+                operationId: try BackupComposer.newIdentifier(),
+                scope: scope.wireValue
+            )
+        )
         let data = try await post(path: ["v1", "erasures"], body: body)
-        return try ErasureReceipt.decode(raw: data)
+        // One receipt per distinct pinned `termsId` in scope — an array
+        // even for a single snapshot, and never empty: an erasure that
+        // committed nothing is an error, not a receipt.
+        guard
+            let elements = try? JSONSerialization.jsonObject(with: data) as? [Any],
+            !elements.isEmpty
+        else {
+            throw BackupError.rejected(code: "malformed_receipt", message: nil)
+        }
+        return try elements.map {
+            let raw = try JSONSerialization.data(withJSONObject: $0, options: [.sortedKeys])
+            return try ErasureReceipt.decode(raw: raw)
+        }
     }
 
     public func exportSnapshots(to directory: URL) async throws -> BackupExport {

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -354,7 +354,7 @@ public final class DeviceBackupSettingsFlow {
         stopFailure = nil
         if erasingFirst {
             do {
-                state.lastReceipt = try await repository.erase(scope: .all)
+                state.lastReceipt = try await repository.erase(scope: .all).first
             } catch {
                 // Not stopped, and not erased. Saying so beats reporting
                 // either one as done.
@@ -390,7 +390,7 @@ public final class DeviceBackupSettingsFlow {
     /// may want it later.
     public func erase(scope: ErasureScope) async {
         do {
-            state.lastReceipt = try await repository.erase(scope: scope)
+            state.lastReceipt = try await repository.erase(scope: scope).first
             await loadSnapshots()
         } catch {
             // The previous receipt is left alone. It describes an

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsFlow.swift
@@ -354,7 +354,8 @@ public final class DeviceBackupSettingsFlow {
         stopFailure = nil
         if erasingFirst {
             do {
-                state.lastReceipt = try await repository.erase(scope: .all).first
+                state.lastReceipt = Self.receiptToShow(
+                    try await repository.erase(scope: .all))
             } catch {
                 // Not stopped, and not erased. Saying so beats reporting
                 // either one as done.
@@ -390,7 +391,7 @@ public final class DeviceBackupSettingsFlow {
     /// may want it later.
     public func erase(scope: ErasureScope) async {
         do {
-            state.lastReceipt = try await repository.erase(scope: scope).first
+            state.lastReceipt = Self.receiptToShow(try await repository.erase(scope: scope))
             await loadSnapshots()
         } catch {
             // The previous receipt is left alone. It describes an
@@ -399,6 +400,21 @@ public final class DeviceBackupSettingsFlow {
             // here is not a reason to destroy the record of an earlier
             // success.
             state.status = .failed(message: BackupCopy.describe(error))
+        }
+    }
+
+    /// Which of an erasure's receipts the card shows.
+    ///
+    /// A `scope: "all"` spanning snapshots pinned to different terms is
+    /// several receipts; every one is recorded by the repository, but
+    /// the card shows one. Chosen by the latest `completionCommittedBy`
+    /// — the deadline the person can still hold the operator to — and
+    /// by `receiptId` on a tie, so the choice is a function of the
+    /// receipts' content and never of the order the operator happened
+    /// to list them in.
+    static func receiptToShow(_ receipts: [ErasureReceipt]) -> ErasureReceipt? {
+        receipts.max {
+            ($0.completionCommittedBy, $0.receiptId) < ($1.completionCommittedBy, $1.receiptId)
         }
     }
 }

--- a/Tests/OnymIOSTests/BackupAdapterTests.swift
+++ b/Tests/OnymIOSTests/BackupAdapterTests.swift
@@ -208,14 +208,100 @@ final class BackupAdapterTests: XCTestCase {
         XCTAssertEqual(receipts.map(\.termsId), [termsA, termsB])
     }
 
-    /// An empty receipt array is an operator acknowledging nothing; a
-    /// receipt is the only durable record, so nothing is not a success.
+    /// An empty receipt array is an operator acknowledging nothing —
+    /// this profile answers "nothing in scope" with an error, never an
+    /// empty acknowledgement — and it must be *this* refusal, not an
+    /// unrelated transport failure passing the test by accident.
     func testAnEmptyReceiptArrayIsRefused() async throws {
         respond(200, "[]")
         do {
             _ = try await makeClient().eraseSnapshot(scope: .all)
             XCTFail("an erasure with no receipt was accepted")
-        } catch {}
+        } catch BackupError.rejected(let code, _) {
+            XCTAssertEqual(code, "malformed_receipt")
+        }
+    }
+
+    /// `rawBytes` is the durable record and the bytes a signature would
+    /// be checked against, so each stored receipt must be the
+    /// operator's exact bytes — key order, spacing, escapes and all —
+    /// not a client re-serialization.
+    func testStoredReceiptBytesAreTheOperatorsOwn() async throws {
+        let termsId = "sha256:" + String(repeating: "a", count: 64)
+        // Deliberately hostile to reconstruction: unsorted keys, odd
+        // spacing, an escaped solidus, and a fractional stamp.
+        let first = #"{"receiptId":"r-1", "operator":"onym:key:op","scope":"all",  "acknowledgedAt":"2026-08-22T13:42:25.779692123Z","completionCommittedBy":"2026-08-29T13:42:25+00:00","excludedScope":"copies\/exports","coveredScope":"primary","termsId":"\#(termsId)","receiptVersion":1}"#
+        let second = #"{"receiptVersion":1,"receiptId":"r-2","operator":"onym:key:op","scope":"all","acknowledgedAt":"2026-08-22T13:42:25Z","completionCommittedBy":"2026-08-29T13:42:25Z","coveredScope":"primary","excludedScope":"copies other participants hold","termsId":"\#(termsId)"}"#
+        respond(200, "[ \(first) ,\n\(second) ]")
+
+        let receipts = try await makeClient().eraseSnapshot(scope: .all)
+        XCTAssertEqual(receipts.count, 2)
+        XCTAssertEqual(receipts[0].rawBytes, Data(first.utf8))
+        XCTAssertEqual(receipts[1].rawBytes, Data(second.utf8))
+    }
+
+    /// A receipt whose `scope` is not the one requested is an operator
+    /// answering a different question, and recording it would drop the
+    /// local row for the requested digest on the strength of a receipt
+    /// covering something else.
+    func testAReceiptForADifferentScopeIsRefused() async throws {
+        let termsId = "sha256:" + String(repeating: "a", count: 64)
+        respond(
+            200,
+            #"""
+            [{"receiptVersion":1,"receiptId":"r-1","operator":"onym:key:op",
+              "scope":"sha256:\#(String(repeating: "e", count: 64))",
+              "acknowledgedAt":"2026-08-22T13:42:25Z",
+              "completionCommittedBy":"2026-08-29T13:42:25Z",
+              "coveredScope":"primary and replicas",
+              "excludedScope":"copies other participants hold",
+              "termsId":"\#(termsId)"}]
+            """#
+        )
+        let reference = try SnapshotReference(
+            digest: "sha256:" + String(repeating: "b", count: 64), sealedByteSize: 4)
+        do {
+            _ = try await makeClient().eraseSnapshot(scope: .snapshot(reference))
+            XCTFail("a receipt for a different scope was accepted")
+        } catch BackupError.rejected(let code, _) {
+            XCTAssertEqual(code, "scope_mismatch")
+        }
+    }
+
+    /// The listing feeds the rolling window, and the operator's clock
+    /// stamps fractional seconds — a listing refused for its timestamps
+    /// is `makeRoom` silently never pruning again.
+    func testListedTimestampsWithFractionalSecondsAreAccepted() async throws {
+        let digest = "sha256:" + String(repeating: "d", count: 64)
+        respond(
+            200,
+            #"""
+            [{"snapshotReference":{"referenceVersion":1,
+              "algorithm":"\#(BackupProfile.digestSuite)",
+              "digest":"\#(digest)","sealedByteSize":4},
+              "acceptedTermsId":"sha256:\#(String(repeating: "a", count: 64))",
+              "retainedAt":"2026-08-22T13:42:25.779692123Z",
+              "retainedUntil":null,"supersedes":null,"status":"retained"}]
+            """#
+        )
+        let listed = try await makeClient().listSnapshots()
+        XCTAssertEqual(listed.map(\.snapshotReference.digest), [digest])
+    }
+
+    /// Every stamp shape the operator's clock can emit: bare seconds,
+    /// micro- and nanosecond fractions, and a numeric UTC offset.
+    func testTheTimestampReaderAcceptsTheOperatorsClock() {
+        for stamp in [
+            "2026-08-22T13:42:25Z",
+            "2026-08-22T13:42:25.779Z",
+            "2026-08-22T13:42:25.779692Z",
+            "2026-08-22T13:42:25.779692123Z",
+            "2026-08-22T13:42:25+00:00",
+            "2026-08-22T13:42:25.779692+00:00",
+        ] {
+            XCTAssertNotNil(BackupFormat.date(fromRFC3339: stamp), stamp)
+        }
+        XCTAssertNil(BackupFormat.date(fromRFC3339: "2026-08-22 13:42:25"))
     }
 
     /// Drain an intercepted request's body. `URLProtocol` hands the

--- a/Tests/OnymIOSTests/BackupAdapterTests.swift
+++ b/Tests/OnymIOSTests/BackupAdapterTests.swift
@@ -144,6 +144,98 @@ final class BackupAdapterTests: XCTestCase {
         XCTAssertNotNil(headers["X-Onym-Signature"])
     }
 
+    /// The erase request carries a client-chosen `operationId` — the
+    /// operator refuses the body without one, which silently disabled
+    /// the rolling window: every §11 erase came back 400, `makeRoom`
+    /// swallowed it, and the sixth backup was refused `quota_exceeded`
+    /// instead of evicting the oldest.
+    func testEraseSendsAnOperationIdAndReadsTheReceiptArray() async throws {
+        let seen = SendableBox()
+        // The response shape the operator actually sends: an *array* of
+        // receipts (one per pinned termsId in scope), stamped with
+        // fractional seconds, which RFC 3339 allows and the operator's
+        // clock produces.
+        let termsId = "sha256:" + String(repeating: "a", count: 64)
+        respond(
+            200,
+            #"""
+            [{"receiptVersion":1,"receiptId":"r-1","operator":"onym:key:op",
+              "scope":"sha256:\#(String(repeating: "b", count: 64))",
+              "acknowledgedAt":"2026-08-22T13:42:25.779692Z",
+              "completionCommittedBy":"2026-08-29T13:42:25.779692Z",
+              "coveredScope":"primary and replicas",
+              "excludedScope":"copies other participants hold",
+              "termsId":"\#(termsId)"}]
+            """#
+        ) { seen.value = $0 }
+
+        let reference = try SnapshotReference(
+            digest: "sha256:" + String(repeating: "b", count: 64), sealedByteSize: 4)
+        let receipts = try await makeClient().eraseSnapshot(scope: .snapshot(reference))
+
+        XCTAssertEqual(receipts.count, 1)
+        XCTAssertEqual(receipts[0].receiptId, "r-1")
+        XCTAssertEqual(receipts[0].termsId, termsId)
+
+        let body = Self.body(of: seen.value)
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let operationId = try XCTUnwrap(object["operationId"] as? String)
+        XCTAssertFalse(operationId.isEmpty, "the operator refuses an erase without an id")
+        XCTAssertEqual(object["scope"] as? String, reference.digest)
+    }
+
+    /// A `scope: "all"` spanning snapshots pinned to different terms is
+    /// several receipts, and every one of them is evidence to keep.
+    func testEraseAllKeepsEveryReceipt() async throws {
+        let stamp = "2026-08-22T13:42:25.779692Z"
+        let receipt: (String, String) -> String = { id, terms in
+            #"""
+            {"receiptVersion":1,"receiptId":"\#(id)","operator":"onym:key:op",
+             "scope":"all","acknowledgedAt":"\#(stamp)",
+             "completionCommittedBy":"\#(stamp)",
+             "coveredScope":"primary and replicas",
+             "excludedScope":"copies other participants hold",
+             "termsId":"\#(terms)"}
+            """#
+        }
+        let termsA = "sha256:" + String(repeating: "a", count: 64)
+        let termsB = "sha256:" + String(repeating: "c", count: 64)
+        respond(200, "[\(receipt("r-1", termsA)),\(receipt("r-2", termsB))]")
+
+        let receipts = try await makeClient().eraseSnapshot(scope: .all)
+        XCTAssertEqual(receipts.map(\.receiptId), ["r-1", "r-2"])
+        XCTAssertEqual(receipts.map(\.termsId), [termsA, termsB])
+    }
+
+    /// An empty receipt array is an operator acknowledging nothing; a
+    /// receipt is the only durable record, so nothing is not a success.
+    func testAnEmptyReceiptArrayIsRefused() async throws {
+        respond(200, "[]")
+        do {
+            _ = try await makeClient().eraseSnapshot(scope: .all)
+            XCTFail("an erasure with no receipt was accepted")
+        } catch {}
+    }
+
+    /// Drain an intercepted request's body. `URLProtocol` hands the
+    /// body back as a stream, not `httpBody`.
+    private static func body(of request: URLRequest?) -> Data {
+        guard let request else { return Data() }
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            guard read > 0 else { break }
+            data.append(contentsOf: buffer[0..<read])
+        }
+        return data
+    }
+
     // MARK: - Repository
 
     /// A payment refusal keeps the sealed bytes, and the retry sends the
@@ -1025,14 +1117,14 @@ private actor ScriptedPort: BackupPort {
     /// listed, and a receipt comes back. A stub that only recorded the
     /// call would let a test claim room was made without the list ever
     /// getting shorter.
-    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+    func eraseSnapshot(scope: ErasureScope) async throws -> [ErasureReceipt] {
         erasedScopes.append(scope.wireValue)
         if case .snapshot(let reference) = scope {
             retained.removeAll { $0.snapshotReference.digest == reference.digest }
         } else {
             retained.removeAll()
         }
-        return ErasureReceipt(
+        return [ErasureReceipt(
             receiptId: "receipt-\(erasedScopes.count)",
             operatorKey: "onym:key:" + String(repeating: "1", count: 64),
             scope: scope.wireValue,
@@ -1042,7 +1134,7 @@ private actor ScriptedPort: BackupPort {
             excludedScope: "copies other participants hold",
             termsId: Self.termsId,
             rawBytes: Data(#"{"receiptId":"\#(erasedScopes.count)"}"#.utf8),
-            signature: nil)
+            signature: nil)]
     }
     func exportSnapshots(to directory: URL) async throws -> BackupExport {
         BackupExport(directory: directory, snapshots: [], receipts: [])

--- a/Tests/OnymIOSTests/BackupDisclosureTests.swift
+++ b/Tests/OnymIOSTests/BackupDisclosureTests.swift
@@ -527,7 +527,7 @@ private struct RebindingPort: BackupPort {
     }
     func listSnapshots() async throws -> [RetainedSnapshot] { [] }
     func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws {}
-    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+    func eraseSnapshot(scope: ErasureScope) async throws -> [ErasureReceipt] {
         throw BackupError.operatorUnavailable
     }
     func exportSnapshots(to directory: URL) async throws -> BackupExport {

--- a/Tests/OnymIOSTests/BackupPurchaseRestoreTests.swift
+++ b/Tests/OnymIOSTests/BackupPurchaseRestoreTests.swift
@@ -204,7 +204,7 @@ private struct SilentPort: BackupPort {
     func downloadSnapshot(_ reference: SnapshotReference, to destination: URL) async throws {
         throw BackupError.operatorUnavailable
     }
-    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+    func eraseSnapshot(scope: ErasureScope) async throws -> [ErasureReceipt] {
         throw BackupError.operatorUnavailable
     }
     func exportSnapshots(to directory: URL) async throws -> BackupExport {

--- a/Tests/OnymIOSTests/BackupRestoreTests.swift
+++ b/Tests/OnymIOSTests/BackupRestoreTests.swift
@@ -672,7 +672,7 @@ private struct HoldingPort: BackupPort {
         try? FileManager.default.removeItem(at: destination)
         try FileManager.default.copyItem(at: snapshot.sealedBytesURL, to: destination)
     }
-    func eraseSnapshot(scope: ErasureScope) async throws -> ErasureReceipt {
+    func eraseSnapshot(scope: ErasureScope) async throws -> [ErasureReceipt] {
         throw BackupError.operatorUnavailable
     }
     func exportSnapshots(to directory: URL) async throws -> BackupExport {


### PR DESCRIPTION
## The problem

With five backups retained at an operator declaring `maximumRetainedSnapshots: 5`, the sixth run was refused `quota_exceeded` and Settings showed "1 operator needs attention" — instead of the rolling window erasing the oldest snapshot and the new one landing.

`makeRoom` was doing its job: it listed the operator's snapshots, picked the oldest, and requested a §11 erase. The erase never succeeded, and `makeRoom` deliberately swallows a failed housekeeping erase (a failed erase says nothing about whether the upload can be stored), so nothing surfaced until the operator itself refused the upload.

## Three wire mismatches, all on the erase path

Measured against the deployed operator (`onym-infra/backup/operator`, live at backup.onym.app):

1. **The erase body carried no `operationId`.** The operator requires a client-chosen id — §14.9 reconciliation is keyed on an id the client already knows — and answers 400 without one. Every erase this client ever sent was refused.
2. **The response is an array of receipts; the client decoded a single object.** The operator mints one receipt per distinct pinned `termsId` in scope, so even a single-snapshot erase arrives as a one-element array.
3. **The operator's timestamps carry fractional seconds; the receipt parser refused them.** `acknowledgedAt`/`completionCommittedBy` are stamped `2026-08-22T13:42:25.779692Z` (RFC 3339, `time` crate), and `BackupFormat.date(fromRFC3339:)` was pinned to the fraction-less form.

The unit suite never caught this because `ScriptedPort` fakes the port above the wire; the erase request and response bytes were never exercised against the operator's actual shapes.

## The fix

- `URLSessionBackupClient.eraseSnapshot` sends a client-chosen `operationId` and decodes the receipt array — refusing an empty one, because an erasure that committed nothing is an error, not a receipt.
- `BackupPort.eraseSnapshot` returns `[ErasureReceipt]`; the repository records every receipt's raw bytes (they are the only durable record), and `DeviceBackupSettingsFlow` keeps the first for display.
- `BackupFormat.date(fromRFC3339:)` reads fractional seconds. Reading is wider than writing: emission stays pinned to the fraction-less form the signed bytes use.

## Tests

- `testEraseSendsAnOperationIdAndReadsTheReceiptArray` — pins the request body shape and the array response with fractional stamps, at the transport level through `StubURLProtocol`.
- `testEraseAllKeepsEveryReceipt` — a `scope: "all"` spanning two pinned terms returns both receipts.
- `testAnEmptyReceiptArrayIsRefused`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
