### PR TITLE
A package that can ask to be woken, and nothing else

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,11 +229,13 @@ jobs:
             -resultBundlePath /tmp/onym-foundation.xcresult
 
       - name: xcodebuild build (OnymPush package)
-        # OnymPush has no package test target (its suites live in
-        # OnymIOSTests, run above) but nothing else compiles the
-        # package on its own, so a signature-payload typo could land
-        # green. Build it standalone here — same `always()` rationale
-        # as the package test steps.
+        # OnymPush's suites live in OnymIOSTests (run above), which
+        # already compiles the package — as a dependency of the app
+        # target. This standalone build proves something the app build
+        # cannot: the package needs no app scaffolding, so an
+        # accidental reference to app-side types fails here instead of
+        # landing green. Same `always()` rationale as the package test
+        # steps.
         if: always()
         working-directory: Packages/OnymPush
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,21 @@ jobs:
             -derivedDataPath /tmp/onym-foundation-tests \
             -resultBundlePath /tmp/onym-foundation.xcresult
 
+      - name: xcodebuild build (OnymPush package)
+        # OnymPush has no package test target (its suites live in
+        # OnymIOSTests, run above) but nothing else compiles the
+        # package on its own, so a signature-payload typo could land
+        # green. Build it standalone here — same `always()` rationale
+        # as the package test steps.
+        if: always()
+        working-directory: Packages/OnymPush
+        run: |
+          rm -rf /tmp/onym-push-build
+          xcodebuild build \
+            -scheme OnymPush \
+            -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }},OS=latest" \
+            -derivedDataPath /tmp/onym-push-build
+
       - name: Upload unit test xcresult
         # `always()` so `report-to-issue` can parse green runs too —
         # not just failures.

--- a/Packages/OnymPush/Package.swift
+++ b/Packages/OnymPush/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OnymPush",
+    platforms: [.iOS("18.0")],
+    products: [
+        .library(name: "OnymPush", targets: ["OnymPush"]),
+    ],
+    targets: [
+        .target(name: "OnymPush"),
+    ]
+)

--- a/Packages/OnymPush/Sources/OnymPush/PushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushBackendClient.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// A register call as the client presents it. Every field the
+/// signature covers is transmitted (the APNs token inside the
+/// envelope), so the backend can reconstruct the signed bytes and
+/// actually verify — see `SignedPushSessionPayload`.
+public struct PushRegisterRequest: Codable, Sendable, Equatable {
+    /// Fresh `DCDevice` token, or nil when attestation is unavailable
+    /// (simulator, enterprise build). The client never fabricates one.
+    public let deviceToken: Data?
+    public let userKey: String
+    public let timestamp: Date
+    /// User-key signature over `SignedPushSessionPayload.register`.
+    public let signature: Data
+    public let tokenEnvelope: PushTokenEnvelope
+    public let subscriptions: [PushSubscription]
+
+    public init(
+        deviceToken: Data?,
+        userKey: String,
+        timestamp: Date,
+        signature: Data,
+        tokenEnvelope: PushTokenEnvelope,
+        subscriptions: [PushSubscription]
+    ) {
+        self.deviceToken = deviceToken
+        self.userKey = userKey
+        self.timestamp = timestamp
+        self.signature = signature
+        self.tokenEnvelope = tokenEnvelope
+        self.subscriptions = subscriptions
+    }
+}
+
+public struct PushRegisterResponse: Codable, Sendable, Equatable {
+    /// When this registration lapses unless refreshed — the client
+    /// re-registers well before this while push stays enabled.
+    public let expiresAt: Date
+
+    public init(expiresAt: Date) {
+        self.expiresAt = expiresAt
+    }
+}
+
+public struct PushUnregisterRequest: Codable, Sendable, Equatable {
+    public let deviceToken: Data?
+    public let userKey: String
+    public let timestamp: Date
+    /// User-key signature over `SignedPushSessionPayload.unregister`.
+    public let signature: Data
+    public let tokenEnvelope: PushTokenEnvelope
+
+    public init(
+        deviceToken: Data?,
+        userKey: String,
+        timestamp: Date,
+        signature: Data,
+        tokenEnvelope: PushTokenEnvelope
+    ) {
+        self.deviceToken = deviceToken
+        self.userKey = userKey
+        self.timestamp = timestamp
+        self.signature = signature
+        self.tokenEnvelope = tokenEnvelope
+    }
+}
+
+/// The push backend's refusal, kept verbatim: the service's error
+/// vocabulary (`signature_invalid`, `relay_invalid`, `capacity`) is
+/// what the caller branches on.
+public struct PushRejection: Error, Sendable, Equatable {
+    public let statusCode: Int
+    public let rawCode: String
+    public let message: String
+
+    public init(statusCode: Int, rawCode: String, message: String) {
+        self.statusCode = statusCode
+        self.rawCode = rawCode
+        self.message = message
+    }
+}
+
+public enum PushClientError: Error {
+    /// The base URL is not https — never relaxed, in any build.
+    case insecureBaseURL(String)
+    case invalidResponse
+    case malformedResponse(String)
+    case rejected(PushRejection)
+}
+
+/// The interface vendor's push backend — the relay watcher that turns
+/// inbox-tagged events into content-free wakes. Production builds ship
+/// `URLSessionPushBackendClient` against the deployed service; tests
+/// use `StubPushBackendClient`.
+public protocol PushBackendClient: Sendable {
+    /// The X25519 key APNs tokens are encrypted to. Fetched before
+    /// each register call so server-side rotation needs no release.
+    func registrationKey() async throws -> Data
+
+    /// Replace-all upsert of this device's subscription set. Session
+    /// signatures are single-use server-side; a replay is refused 401.
+    func register(_ request: PushRegisterRequest) async throws -> PushRegisterResponse
+
+    /// Idempotent delete of this device's registration.
+    func unregister(_ request: PushUnregisterRequest) async throws
+}

--- a/Packages/OnymPush/Sources/OnymPush/PushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushBackendClient.swift
@@ -73,6 +73,11 @@ public struct PushRejection: Error, Sendable, Equatable {
     public let rawCode: String
     public let message: String
 
+    /// The typed reading of `rawCode`, for callers that branch —
+    /// `.unknown` retains verbatim what a newer backend said, so no
+    /// vocabulary growth is ever silently collapsed.
+    public var code: PushErrorCode { PushErrorCode(rawCode: rawCode) }
+
     public init(statusCode: Int, rawCode: String, message: String) {
         self.statusCode = statusCode
         self.rawCode = rawCode
@@ -80,7 +85,31 @@ public struct PushRejection: Error, Sendable, Equatable {
     }
 }
 
-public enum PushClientError: Error {
+/// Stable error vocabulary emitted by the push backend — the shape of
+/// the moderation package's `AuthorityErrorCode`, with an explicit
+/// `unknown` arm because `rawCode` must survive codes this build has
+/// never heard of.
+public enum PushErrorCode: Sendable, Equatable {
+    case signatureInvalid
+    case relayInvalid
+    case capacity
+    case badRequest
+    case internalError
+    case unknown(String)
+
+    public init(rawCode: String) {
+        switch rawCode {
+        case "signature_invalid": self = .signatureInvalid
+        case "relay_invalid": self = .relayInvalid
+        case "capacity": self = .capacity
+        case "bad_request": self = .badRequest
+        case "internal_error": self = .internalError
+        default: self = .unknown(rawCode)
+        }
+    }
+}
+
+public enum PushClientError: Error, Sendable, Equatable {
     /// The base URL is not https — never relaxed, in any build.
     case insecureBaseURL(String)
     case invalidResponse

--- a/Packages/OnymPush/Sources/OnymPush/PushPreferenceStore.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushPreferenceStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The user's push opt-in, and the fingerprint of the last
+/// registration the backend accepted.
+///
+/// Push is **off by default**: enabling it hands a third party (the
+/// push backend, and Apple) the inbox-tag ↔ device linkage the rest of
+/// the app avoids creating, so that trade is the user's to make in
+/// Settings, never a default.
+public struct PushPreferenceStore: Sendable {
+    private static let enabledKey = "push.enabled"
+    private static let fingerprintKey = "push.lastRegistrationFingerprint"
+    private static let registeredAtKey = "push.lastRegisteredAt"
+
+    private let defaults: @Sendable () -> UserDefaults
+
+    public init(defaults: @escaping @Sendable () -> UserDefaults = { .standard }) {
+        self.defaults = defaults
+    }
+
+    public var isEnabled: Bool {
+        defaults().bool(forKey: Self.enabledKey)
+    }
+
+    public func setEnabled(_ enabled: Bool) {
+        defaults().set(enabled, forKey: Self.enabledKey)
+        if !enabled {
+            clearRegistration()
+        }
+    }
+
+    /// Hash of (token, subscriptions) the backend last accepted, so
+    /// reconciliation can tell "nothing changed" from "re-register".
+    public var lastRegistrationFingerprint: String? {
+        defaults().string(forKey: Self.fingerprintKey)
+    }
+
+    public var lastRegisteredAt: Date? {
+        defaults().object(forKey: Self.registeredAtKey) as? Date
+    }
+
+    public func recordRegistration(fingerprint: String, at date: Date) {
+        defaults().set(fingerprint, forKey: Self.fingerprintKey)
+        defaults().set(date, forKey: Self.registeredAtKey)
+    }
+
+    public func clearRegistration() {
+        defaults().removeObject(forKey: Self.fingerprintKey)
+        defaults().removeObject(forKey: Self.registeredAtKey)
+    }
+}

--- a/Packages/OnymPush/Sources/OnymPush/PushPreferenceStore.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushPreferenceStore.swift
@@ -7,6 +7,18 @@ import Foundation
 /// push backend, and Apple) the inbox-tag ↔ device linkage the rest of
 /// the app avoids creating, so that trade is the user's to make in
 /// Settings, never a default.
+///
+/// Raw APNs tokens sit here in plaintext `UserDefaults`, deliberately.
+/// An APNs token is not a secret in the keychain sense: it is a
+/// routing handle that only the operator's APNs auth key can turn
+/// into a delivered push, and Apple rotates it on restore or
+/// reinstall — a copy lifted from an unencrypted backup lets an
+/// attacker do nothing on their own. That is a different posture from
+/// `UserDefaultsCaseSubmissionStore` (encrypted at rest because a
+/// statement is the user's own words), and a different adversary from
+/// the one `PushTokenEnvelope` defends against (passive capture in
+/// the operator's infrastructure, where the token would otherwise sit
+/// beside the APNs key that makes it potent).
 public struct PushPreferenceStore: Sendable {
     private static let enabledKey = "push.enabled"
     private static let fingerprintKey = "push.lastRegistrationFingerprint"

--- a/Packages/OnymPush/Sources/OnymPush/PushPreferenceStore.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushPreferenceStore.swift
@@ -13,7 +13,7 @@ public struct PushPreferenceStore: Sendable {
     private static let registeredAtKey = "push.lastRegisteredAt"
     private static let expiresAtKey = "push.registrationExpiresAt"
     private static let lastRegisteredTokenKey = "push.lastRegisteredToken"
-    private static let pendingUnregisterTokenKey = "push.pendingUnregisterToken"
+    private static let pendingUnregisterTokensKey = "push.pendingUnregisterTokens"
 
     private let defaults: @Sendable () -> UserDefaults
 
@@ -62,20 +62,34 @@ public struct PushPreferenceStore: Sendable {
         defaults().removeObject(forKey: Self.lastRegisteredTokenKey)
     }
 
-    /// An unregister the backend has not yet acknowledged: set before
-    /// the attempt, cleared only on success, retried at every
-    /// reconcile opportunity — so one offline opt-out cannot leave the
-    /// device registered forever.
-    public var pendingUnregisterToken: Data? {
-        defaults().data(forKey: Self.pendingUnregisterTokenKey)
+    /// Every unregister the backend has not yet acknowledged: each
+    /// token is added before the attempt, removed only on success, and
+    /// retried at every reconcile opportunity — so one offline opt-out
+    /// cannot leave the device registered forever. A *set*, not a
+    /// slot: a rotation whose drain failed (old token still pending)
+    /// followed by a disable (new token now pending too) owes the
+    /// backend two unregisters, and a single slot would silently drop
+    /// one, leaving that token wake-able until the 60-day sweep.
+    /// Persisted as an array; membership is deduplicated on add.
+    public var pendingUnregisterTokens: [Data] {
+        defaults().array(forKey: Self.pendingUnregisterTokensKey) as? [Data] ?? []
     }
 
-    public func setPendingUnregister(token: Data) {
-        defaults().set(token, forKey: Self.pendingUnregisterTokenKey)
+    public func addPendingUnregister(token: Data) {
+        var tokens = pendingUnregisterTokens
+        guard !tokens.contains(token) else { return }
+        tokens.append(token)
+        defaults().set(tokens, forKey: Self.pendingUnregisterTokensKey)
     }
 
-    public func clearPendingUnregister() {
-        defaults().removeObject(forKey: Self.pendingUnregisterTokenKey)
+    public func removePendingUnregister(token: Data) {
+        var tokens = pendingUnregisterTokens
+        tokens.removeAll { $0 == token }
+        if tokens.isEmpty {
+            defaults().removeObject(forKey: Self.pendingUnregisterTokensKey)
+        } else {
+            defaults().set(tokens, forKey: Self.pendingUnregisterTokensKey)
+        }
     }
 
     public func recordRegistration(

--- a/Packages/OnymPush/Sources/OnymPush/PushPreferenceStore.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushPreferenceStore.swift
@@ -11,6 +11,9 @@ public struct PushPreferenceStore: Sendable {
     private static let enabledKey = "push.enabled"
     private static let fingerprintKey = "push.lastRegistrationFingerprint"
     private static let registeredAtKey = "push.lastRegisteredAt"
+    private static let expiresAtKey = "push.registrationExpiresAt"
+    private static let lastRegisteredTokenKey = "push.lastRegisteredToken"
+    private static let pendingUnregisterTokenKey = "push.pendingUnregisterToken"
 
     private let defaults: @Sendable () -> UserDefaults
 
@@ -39,13 +42,57 @@ public struct PushPreferenceStore: Sendable {
         defaults().object(forKey: Self.registeredAtKey) as? Date
     }
 
-    public func recordRegistration(fingerprint: String, at date: Date) {
+    /// When the backend said the accepted registration lapses — drives
+    /// the refresh alongside the fixed interval.
+    public var registrationExpiresAt: Date? {
+        defaults().object(forKey: Self.expiresAtKey) as? Date
+    }
+
+    /// The APNs token the backend last accepted, kept so an unregister
+    /// after relaunch (or before APNs re-delivers) still has a token
+    /// to name. Deliberately NOT dropped by `clearRegistration()` —
+    /// disabling clears the registration record first and unregisters
+    /// after, and the unregister is what needs this. Cleared once an
+    /// unregister actually succeeds.
+    public var lastRegisteredToken: Data? {
+        defaults().data(forKey: Self.lastRegisteredTokenKey)
+    }
+
+    public func clearLastRegisteredToken() {
+        defaults().removeObject(forKey: Self.lastRegisteredTokenKey)
+    }
+
+    /// An unregister the backend has not yet acknowledged: set before
+    /// the attempt, cleared only on success, retried at every
+    /// reconcile opportunity — so one offline opt-out cannot leave the
+    /// device registered forever.
+    public var pendingUnregisterToken: Data? {
+        defaults().data(forKey: Self.pendingUnregisterTokenKey)
+    }
+
+    public func setPendingUnregister(token: Data) {
+        defaults().set(token, forKey: Self.pendingUnregisterTokenKey)
+    }
+
+    public func clearPendingUnregister() {
+        defaults().removeObject(forKey: Self.pendingUnregisterTokenKey)
+    }
+
+    public func recordRegistration(
+        fingerprint: String,
+        token: Data,
+        at date: Date,
+        expiresAt: Date
+    ) {
         defaults().set(fingerprint, forKey: Self.fingerprintKey)
+        defaults().set(token, forKey: Self.lastRegisteredTokenKey)
         defaults().set(date, forKey: Self.registeredAtKey)
+        defaults().set(expiresAt, forKey: Self.expiresAtKey)
     }
 
     public func clearRegistration() {
         defaults().removeObject(forKey: Self.fingerprintKey)
         defaults().removeObject(forKey: Self.registeredAtKey)
+        defaults().removeObject(forKey: Self.expiresAtKey)
     }
 }

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -1,0 +1,171 @@
+import CryptoKit
+import Foundation
+
+/// Reconciles what this device wants the push backend to know with
+/// what the backend was last told. The inputs — the APNs token, the
+/// identity-derived subscription set, the relay list, the opt-in —
+/// all change independently; every change lands here, is debounced,
+/// and becomes at most one replace-all `register` call (or an
+/// `unregister` when push is turned off).
+///
+/// The transport repositories own their lifecycles; this interactor
+/// only *observes* identity and relay state and talks to the push
+/// backend. It never drives transports.
+public actor PushRegistrationInteractor {
+    private let client: PushBackendClient
+    private let signer: PushSigner
+    private let attestation: PushDeviceAttestationProvider
+    private let preferences: PushPreferenceStore
+    private let debounce: Duration
+    /// Re-register even when nothing changed, so the backend's
+    /// stale-registration sweep (60 days) never reaps a live device.
+    private let refreshInterval: TimeInterval
+
+    private var apnsToken: Data?
+    private var subscriptions: [PushSubscription]?
+    private var pendingReconcile: Task<Void, Never>?
+
+    public init(
+        client: PushBackendClient,
+        signer: PushSigner,
+        attestation: PushDeviceAttestationProvider,
+        preferences: PushPreferenceStore = PushPreferenceStore(),
+        debounce: Duration = .seconds(2),
+        refreshInterval: TimeInterval = 7 * 24 * 3600
+    ) {
+        self.client = client
+        self.signer = signer
+        self.attestation = attestation
+        self.preferences = preferences
+        self.debounce = debounce
+        self.refreshInterval = refreshInterval
+    }
+
+    // MARK: - Inputs
+
+    /// APNs delivered (or rotated) the device token.
+    public func updateToken(_ token: Data) {
+        apnsToken = token
+        scheduleReconcile()
+    }
+
+    /// The desired subscription set changed: an identity was added or
+    /// removed, or the relay list changed. An empty array is
+    /// meaningful — it clears every tag at the backend while keeping
+    /// the device registered.
+    public func updateSubscriptions(_ desired: [PushSubscription]) {
+        subscriptions = desired
+        scheduleReconcile()
+    }
+
+    /// The user turned push on (authorization already granted and
+    /// `registerForRemoteNotifications` called by the UI layer).
+    public func pushEnabled() {
+        scheduleReconcile()
+    }
+
+    /// The user turned push off. Best-effort unregister with the last
+    /// known token; the backend's stale sweep is the backstop when
+    /// this races a token we never learned.
+    public func pushDisabled() async {
+        pendingReconcile?.cancel()
+        pendingReconcile = nil
+        preferences.clearRegistration()
+        guard let token = apnsToken else { return }
+        try? await unregister(token: token)
+    }
+
+    /// An opportunity moment (app foregrounded): re-run reconciliation
+    /// so the periodic refresh happens without a dedicated timer.
+    public func appForegrounded() {
+        scheduleReconcile()
+    }
+
+    // MARK: - Reconciliation
+
+    private func scheduleReconcile() {
+        pendingReconcile?.cancel()
+        let delay = debounce
+        pendingReconcile = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            await self?.reconcile()
+        }
+    }
+
+    private func reconcile() async {
+        guard preferences.isEnabled,
+              let token = apnsToken,
+              let subscriptions else { return }
+
+        let fingerprint = Self.fingerprint(token: token, subscriptions: subscriptions)
+        if fingerprint == preferences.lastRegistrationFingerprint,
+           let registeredAt = preferences.lastRegisteredAt,
+           Date().timeIntervalSince(registeredAt) < refreshInterval {
+            return
+        }
+
+        do {
+            let serverKey = try await client.registrationKey()
+            let envelope = try PushTokenEnvelope.seal(apnsToken: token, serverPublicKey: serverKey)
+            let userKey = try await signer.userKeyID()
+            let deviceToken = await attestation.currentToken()
+            let timestamp = Date()
+            let payload = SignedPushSessionPayload.register(
+                deviceToken: deviceToken,
+                userKey: userKey,
+                timestamp: timestamp,
+                apnsToken: token,
+                subscriptions: subscriptions
+            )
+            let signature = try await signer.sign(payload)
+            _ = try await client.register(
+                PushRegisterRequest(
+                    deviceToken: deviceToken,
+                    userKey: userKey,
+                    timestamp: timestamp,
+                    signature: signature,
+                    tokenEnvelope: envelope,
+                    subscriptions: subscriptions
+                )
+            )
+            preferences.recordRegistration(fingerprint: fingerprint, at: timestamp)
+        } catch {
+            // Deliberately quiet: registration is retried on the next
+            // input change or foreground, and per the no-activity-log
+            // stance nothing user-linked is recorded about the failure.
+        }
+    }
+
+    private func unregister(token: Data) async throws {
+        let serverKey = try await client.registrationKey()
+        let envelope = try PushTokenEnvelope.seal(apnsToken: token, serverPublicKey: serverKey)
+        let userKey = try await signer.userKeyID()
+        let deviceToken = await attestation.currentToken()
+        let timestamp = Date()
+        let payload = SignedPushSessionPayload.unregister(
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: token
+        )
+        let signature = try await signer.sign(payload)
+        try await client.unregister(
+            PushUnregisterRequest(
+                deviceToken: deviceToken,
+                userKey: userKey,
+                timestamp: timestamp,
+                signature: signature,
+                tokenEnvelope: envelope
+            )
+        )
+    }
+
+    /// What "already registered" means: same token, same subscription
+    /// set, in the digest form the signature itself uses.
+    static func fingerprint(token: Data, subscriptions: [PushSubscription]) -> String {
+        var input = Data(SHA256.hash(data: token))
+        input.append(SignedPushSessionPayload.digest(of: subscriptions))
+        return Data(SHA256.hash(data: input)).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -30,7 +30,16 @@ public actor PushRegistrationInteractor {
 
     private var apnsToken: Data?
     private var subscriptions: [PushSubscription]?
-    private var pendingReconcile: Task<Void, Never>?
+    /// The *sleeping* debounce only — never the pass itself. Inputs
+    /// (and `pushDisabled`) cancel this handle to coalesce or drop a
+    /// pass that has not started; the pass body runs in a separate
+    /// unstructured Task that nothing here ever cancels, so an input
+    /// arriving mid-pass can never abort in-flight HTTP (wasting a
+    /// single-use signature the backend may already have spent) and a
+    /// disable can never delegate its drain to a Task it just
+    /// cancelled — where every URLSession call would throw
+    /// `URLError.cancelled` immediately and be swallowed.
+    private var pendingDebounce: Task<Void, Never>?
     /// Reconciliation must never overlap itself — nor the opt-out
     /// drain, which takes the same slot: two interleaved passes would
     /// spend two single-use session signatures on the same state, and
@@ -101,8 +110,12 @@ public actor PushRegistrationInteractor {
     /// last successfully registered token when APNs has not delivered
     /// one this launch.
     public func pushDisabled() async {
-        pendingReconcile?.cancel()
-        pendingReconcile = nil
+        // Cancels only a debounce still sleeping. A pass already
+        // running keeps its Task: it holds the single pass slot, so
+        // the `claimPass()` below fails and the drain is queued — and
+        // the holder drains it from a Task no one cancelled.
+        pendingDebounce?.cancel()
+        pendingDebounce = nil
         let token = apnsToken ?? preferences.lastRegisteredToken
         preferences.clearRegistration()
         guard let token else { return }
@@ -127,12 +140,18 @@ public actor PushRegistrationInteractor {
     // MARK: - Reconciliation
 
     private func scheduleReconcile() {
-        pendingReconcile?.cancel()
+        pendingDebounce?.cancel()
         let delay = debounce
-        pendingReconcile = Task { [weak self] in
+        pendingDebounce = Task { [weak self] in
             try? await Task.sleep(for: delay)
             guard !Task.isCancelled else { return }
-            await self?.reconcile()
+            // The pass runs in its own unstructured Task so that a
+            // later input cancelling the *next* debounce — or a
+            // disable cancelling this one a beat too late — never
+            // propagates cancellation into a pass whose HTTP is
+            // already in flight. Overlap is impossible regardless:
+            // `claimPass()` serializes passes on the actor.
+            Task { await self?.reconcile() }
         }
     }
 

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -210,9 +210,7 @@ public actor PushRegistrationInteractor {
            let registeredAt = preferences.lastRegisteredAt,
            now.timeIntervalSince(registeredAt) < refreshInterval,
            let expiresAt = preferences.registrationExpiresAt,
-           now < expiresAt.addingTimeInterval(
-               -Self.expiryMargin(registeredAt: registeredAt, expiresAt: expiresAt)
-           ) {
+           !Self.refreshDueByExpiry(now: now, registeredAt: registeredAt, expiresAt: expiresAt) {
             return
         }
 
@@ -281,12 +279,26 @@ public actor PushRegistrationInteractor {
         }
     }
 
-    /// How close to `expiresAt` counts as "expiring": at most
-    /// `maxExpiryMargin`, but never more than half the window the
-    /// backend granted, so a short window still leaves a usable
-    /// "already registered" period.
-    static func expiryMargin(registeredAt: Date, expiresAt: Date) -> TimeInterval {
-        min(maxExpiryMargin, max(0, expiresAt.timeIntervalSince(registeredAt)) / 2)
+    /// A granted window shorter than this (including `expiresAt` at or
+    /// behind `registeredAt`) is degenerate: any margin would make the
+    /// "already registered" skip unsatisfiable, so every foreground
+    /// would re-register and spend a signature.
+    static let minimumExpiryWindow: TimeInterval = 3600
+
+    /// Whether the backend-granted window says it is time to
+    /// re-register. Normally: within `maxExpiryMargin` of `expiresAt`,
+    /// but never more than half the granted window, so a short window
+    /// still leaves a usable "already registered" period. A window
+    /// below `minimumExpiryWindow` is ignored entirely and the fixed
+    /// `refreshInterval` alone paces re-registration — the simplest
+    /// rule that keeps the refresh bounded from both sides: a sane
+    /// grant is honored with margin, a degenerate one cannot turn
+    /// every foreground into a register.
+    static func refreshDueByExpiry(now: Date, registeredAt: Date, expiresAt: Date) -> Bool {
+        let window = expiresAt.timeIntervalSince(registeredAt)
+        guard window >= Self.minimumExpiryWindow else { return false }
+        let margin = min(maxExpiryMargin, window / 2)
+        return now >= expiresAt.addingTimeInterval(-margin)
     }
 
     /// Drains every pending unregister, not a single slot: a rotation

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -21,8 +21,11 @@ public actor PushRegistrationInteractor {
     /// stale-registration sweep (60 days) never reaps a live device.
     private let refreshInterval: TimeInterval
     /// Also re-register when the backend's own `expiresAt` is this
-    /// close, whichever comes first.
-    private let expiryMargin: TimeInterval = 7 * 24 * 3600
+    /// close, whichever comes first. Capped at half the window the
+    /// backend actually granted: a margin as long as the whole window
+    /// would make "far enough from expiry" unsatisfiable and turn
+    /// every foreground into a register (and a spent signature).
+    private static let maxExpiryMargin: TimeInterval = 7 * 24 * 3600
     private let clock: @Sendable () -> Date
 
     private var apnsToken: Data?
@@ -55,9 +58,22 @@ public actor PushRegistrationInteractor {
         self.clock = clock
     }
 
+    /// Test-only observability for errors reconciliation deliberately
+    /// swallows (registration is retried, and per the no-activity-log
+    /// stance nothing is recorded about the failure). `nil` in
+    /// production.
+    private var onReconcileFailure: (@Sendable (Error) -> Void)?
+
+    public func setOnReconcileFailure(_ hook: (@Sendable (Error) -> Void)?) {
+        onReconcileFailure = hook
+    }
+
     // MARK: - Inputs
 
-    /// APNs delivered (or rotated) the device token.
+    /// APNs delivered (or rotated) the device token. On rotation the
+    /// previous token is queued for unregister (see `reconcilePass`):
+    /// the backend keys registrations by token hash, so the old row
+    /// would otherwise stay wake-able until the 60-day sweep.
     public func updateToken(_ token: Data) {
         apnsToken = token
         scheduleReconcile()
@@ -159,13 +175,27 @@ public actor PushRegistrationInteractor {
               let token = apnsToken,
               let subscriptions else { return }
 
+        // APNs rotated the token: the backend keys registrations by
+        // token hash, so the replaced row would stay wake-able until
+        // the 60-day sweep. Queue the old token through the existing
+        // pending-unregister path (persisted, retried) and try to
+        // drain it now, before its replacement registers.
+        if let previous = preferences.lastRegisteredToken,
+           previous != token,
+           preferences.pendingUnregisterToken == nil {
+            preferences.setPendingUnregister(token: previous)
+            await drainPendingUnregister()
+        }
+
         let fingerprint = Self.fingerprint(token: token, subscriptions: subscriptions)
         let now = clock()
         if fingerprint == preferences.lastRegistrationFingerprint,
            let registeredAt = preferences.lastRegisteredAt,
            now.timeIntervalSince(registeredAt) < refreshInterval,
            let expiresAt = preferences.registrationExpiresAt,
-           now < expiresAt.addingTimeInterval(-expiryMargin) {
+           now < expiresAt.addingTimeInterval(
+               -Self.expiryMargin(registeredAt: registeredAt, expiresAt: expiresAt)
+           ) {
             return
         }
 
@@ -199,6 +229,17 @@ public actor PushRegistrationInteractor {
                     subscriptions: subscriptions
                 )
             )
+            // Re-read the opt-in *after* the awaits: a disable that
+            // landed while the register was in flight already cleared
+            // the record and must win. Recording here would leave prefs
+            // claiming "registered" while disabled — and the register
+            // that just reached the backend must be torn down, so the
+            // token goes onto the pending-unregister path instead (the
+            // follow-up pass the disable queued drains it).
+            guard preferences.isEnabled else {
+                preferences.setPendingUnregister(token: token)
+                return
+            }
             preferences.recordRegistration(
                 fingerprint: fingerprint,
                 token: token,
@@ -218,7 +259,16 @@ public actor PushRegistrationInteractor {
             // Deliberately quiet: registration is retried on the next
             // input change or foreground, and per the no-activity-log
             // stance nothing user-linked is recorded about the failure.
+            onReconcileFailure?(error)
         }
+    }
+
+    /// How close to `expiresAt` counts as "expiring": at most
+    /// `maxExpiryMargin`, but never more than half the window the
+    /// backend granted, so a short window still leaves a usable
+    /// "already registered" period.
+    static func expiryMargin(registeredAt: Date, expiresAt: Date) -> TimeInterval {
+        min(maxExpiryMargin, max(0, expiresAt.timeIntervalSince(registeredAt)) / 2)
     }
 
     private func drainPendingUnregister() async {
@@ -231,6 +281,7 @@ public actor PushRegistrationInteractor {
             }
         } catch {
             // Stays pending; retried at the next reconcile opportunity.
+            onReconcileFailure?(error)
         }
     }
 

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -119,7 +119,7 @@ public actor PushRegistrationInteractor {
         let token = apnsToken ?? preferences.lastRegisteredToken
         preferences.clearRegistration()
         guard let token else { return }
-        preferences.setPendingUnregister(token: token)
+        preferences.addPendingUnregister(token: token)
         // The drain takes the same single pass slot reconciliation
         // uses: running alongside a pass would spend a second
         // single-use signature, and that pass's register could land
@@ -197,12 +197,10 @@ public actor PushRegistrationInteractor {
         // APNs rotated the token: the backend keys registrations by
         // token hash, so the replaced row would stay wake-able until
         // the 60-day sweep. Queue the old token through the existing
-        // pending-unregister path (persisted, retried) and try to
-        // drain it now, before its replacement registers.
-        if let previous = preferences.lastRegisteredToken,
-           previous != token,
-           preferences.pendingUnregisterToken == nil {
-            preferences.setPendingUnregister(token: previous)
+        // pending-unregister path (persisted, retried, deduplicated)
+        // and try to drain it now, before its replacement registers.
+        if let previous = preferences.lastRegisteredToken, previous != token {
+            preferences.addPendingUnregister(token: previous)
             await drainPendingUnregister()
         }
 
@@ -222,7 +220,7 @@ public actor PushRegistrationInteractor {
         // unhonored *now* is superseded by the registration about to
         // replace it, but one the user asks for *during* the attempt
         // is the newer instruction and must survive it.
-        let supersededUnregister = preferences.pendingUnregisterToken
+        let unregisterWasPending = preferences.pendingUnregisterTokens.contains(token)
 
         do {
             let serverKey = try await client.registrationKey()
@@ -256,7 +254,7 @@ public actor PushRegistrationInteractor {
             // token goes onto the pending-unregister path instead (the
             // follow-up pass the disable queued drains it).
             guard preferences.isEnabled else {
-                preferences.setPendingUnregister(token: token)
+                preferences.addPendingUnregister(token: token)
                 return
             }
             preferences.recordRegistration(
@@ -267,12 +265,13 @@ public actor PushRegistrationInteractor {
             )
             // A registration for this token retires an unregister that
             // was already pending for it (replace-all upsert): draining
-            // it later would tear down the live registration. An
-            // opt-out that arrived mid-attempt is left alone — the
-            // follow-up pass drains it.
-            if supersededUnregister == token,
-               preferences.pendingUnregisterToken == token {
-                preferences.clearPendingUnregister()
+            // it later would tear down the live registration. Only
+            // *this* token's entry is removed — unregisters pending
+            // for other tokens (a failed rotation's debt) are untouched
+            // — and an opt-out that arrived mid-attempt is left alone:
+            // the follow-up pass drains it.
+            if unregisterWasPending {
+                preferences.removePendingUnregister(token: token)
             }
         } catch {
             // Deliberately quiet: registration is retried on the next
@@ -290,17 +289,23 @@ public actor PushRegistrationInteractor {
         min(maxExpiryMargin, max(0, expiresAt.timeIntervalSince(registeredAt)) / 2)
     }
 
+    /// Drains every pending unregister, not a single slot: a rotation
+    /// whose drain failed and a subsequent disable each owe the
+    /// backend a distinct unregister, and both debts must survive.
     private func drainPendingUnregister() async {
-        guard let pending = preferences.pendingUnregisterToken else { return }
-        do {
-            try await unregister(token: pending)
-            preferences.clearPendingUnregister()
-            if preferences.lastRegisteredToken == pending {
-                preferences.clearLastRegisteredToken()
+        for pending in preferences.pendingUnregisterTokens {
+            do {
+                try await unregister(token: pending)
+                preferences.removePendingUnregister(token: pending)
+                if preferences.lastRegisteredToken == pending {
+                    preferences.clearLastRegisteredToken()
+                }
+            } catch {
+                // Stays pending; retried at the next reconcile
+                // opportunity. The remaining tokens are still tried —
+                // they are independent debts.
+                onReconcileFailure?(error)
             }
-        } catch {
-            // Stays pending; retried at the next reconcile opportunity.
-            onReconcileFailure?(error)
         }
     }
 

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -73,6 +73,12 @@ public actor PushRegistrationInteractor {
     /// production.
     private var onReconcileFailure: (@Sendable (Error) -> Void)?
 
+    /// Intended for tests only — but it is public production API, and
+    /// nothing here can stop a caller from wiring the hook to a
+    /// persistent sink and building exactly the failure/activity log
+    /// this package declines to keep. The app target must never set
+    /// it; a production caller reaching for it should treat this
+    /// caveat as the review gate.
     public func setOnReconcileFailure(_ hook: (@Sendable (Error) -> Void)?) {
         onReconcileFailure = hook
     }

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -20,10 +20,20 @@ public actor PushRegistrationInteractor {
     /// Re-register even when nothing changed, so the backend's
     /// stale-registration sweep (60 days) never reaps a live device.
     private let refreshInterval: TimeInterval
+    /// Also re-register when the backend's own `expiresAt` is this
+    /// close, whichever comes first.
+    private let expiryMargin: TimeInterval = 7 * 24 * 3600
+    private let clock: @Sendable () -> Date
 
     private var apnsToken: Data?
     private var subscriptions: [PushSubscription]?
     private var pendingReconcile: Task<Void, Never>?
+    /// Reconciliation must never overlap itself: two interleaved
+    /// passes would spend two single-use session signatures on the
+    /// same state. One pass runs; passes requested meanwhile coalesce
+    /// into exactly one follow-up.
+    private var reconcileInFlight = false
+    private var reconcileQueuedWhileInFlight = false
 
     public init(
         client: PushBackendClient,
@@ -31,7 +41,8 @@ public actor PushRegistrationInteractor {
         attestation: PushDeviceAttestationProvider,
         preferences: PushPreferenceStore = PushPreferenceStore(),
         debounce: Duration = .seconds(2),
-        refreshInterval: TimeInterval = 7 * 24 * 3600
+        refreshInterval: TimeInterval = 7 * 24 * 3600,
+        clock: @escaping @Sendable () -> Date = Date.init
     ) {
         self.client = client
         self.signer = signer
@@ -39,6 +50,7 @@ public actor PushRegistrationInteractor {
         self.preferences = preferences
         self.debounce = debounce
         self.refreshInterval = refreshInterval
+        self.clock = clock
     }
 
     // MARK: - Inputs
@@ -64,15 +76,20 @@ public actor PushRegistrationInteractor {
         scheduleReconcile()
     }
 
-    /// The user turned push off. Best-effort unregister with the last
-    /// known token; the backend's stale sweep is the backstop when
-    /// this races a token we never learned.
+    /// The user turned push off. The intent to unregister is persisted
+    /// *before* the attempt and cleared only on success, so an offline
+    /// opt-out is retried at every reconcile opportunity rather than
+    /// leaving the device registered on the server. Falls back to the
+    /// last successfully registered token when APNs has not delivered
+    /// one this launch.
     public func pushDisabled() async {
         pendingReconcile?.cancel()
         pendingReconcile = nil
+        let token = apnsToken ?? preferences.lastRegisteredToken
         preferences.clearRegistration()
-        guard let token = apnsToken else { return }
-        try? await unregister(token: token)
+        guard let token else { return }
+        preferences.setPendingUnregister(token: token)
+        await drainPendingUnregister()
     }
 
     /// An opportunity moment (app foregrounded): re-run reconciliation
@@ -94,14 +111,34 @@ public actor PushRegistrationInteractor {
     }
 
     private func reconcile() async {
+        if reconcileInFlight {
+            reconcileQueuedWhileInFlight = true
+            return
+        }
+        reconcileInFlight = true
+        defer { reconcileInFlight = false }
+        repeat {
+            reconcileQueuedWhileInFlight = false
+            await reconcilePass()
+        } while reconcileQueuedWhileInFlight
+    }
+
+    private func reconcilePass() async {
+        // A pending unregister is the user's last unhonored
+        // instruction — it drains first, whatever the current opt-in.
+        await drainPendingUnregister()
+
         guard preferences.isEnabled,
               let token = apnsToken,
               let subscriptions else { return }
 
         let fingerprint = Self.fingerprint(token: token, subscriptions: subscriptions)
+        let now = clock()
         if fingerprint == preferences.lastRegistrationFingerprint,
            let registeredAt = preferences.lastRegisteredAt,
-           Date().timeIntervalSince(registeredAt) < refreshInterval {
+           now.timeIntervalSince(registeredAt) < refreshInterval,
+           let expiresAt = preferences.registrationExpiresAt,
+           now < expiresAt.addingTimeInterval(-expiryMargin) {
             return
         }
 
@@ -110,7 +147,7 @@ public actor PushRegistrationInteractor {
             let envelope = try PushTokenEnvelope.seal(apnsToken: token, serverPublicKey: serverKey)
             let userKey = try await signer.userKeyID()
             let deviceToken = await attestation.currentToken()
-            let timestamp = Date()
+            let timestamp = clock()
             let payload = SignedPushSessionPayload.register(
                 deviceToken: deviceToken,
                 userKey: userKey,
@@ -119,7 +156,7 @@ public actor PushRegistrationInteractor {
                 subscriptions: subscriptions
             )
             let signature = try await signer.sign(payload)
-            _ = try await client.register(
+            let response = try await client.register(
                 PushRegisterRequest(
                     deviceToken: deviceToken,
                     userKey: userKey,
@@ -129,11 +166,35 @@ public actor PushRegistrationInteractor {
                     subscriptions: subscriptions
                 )
             )
-            preferences.recordRegistration(fingerprint: fingerprint, at: timestamp)
+            preferences.recordRegistration(
+                fingerprint: fingerprint,
+                token: token,
+                at: timestamp,
+                expiresAt: response.expiresAt
+            )
+            // A registration for this token supersedes any unregister
+            // still pending for it (replace-all upsert): draining it
+            // later would tear down the live registration.
+            if preferences.pendingUnregisterToken == token {
+                preferences.clearPendingUnregister()
+            }
         } catch {
             // Deliberately quiet: registration is retried on the next
             // input change or foreground, and per the no-activity-log
             // stance nothing user-linked is recorded about the failure.
+        }
+    }
+
+    private func drainPendingUnregister() async {
+        guard let pending = preferences.pendingUnregisterToken else { return }
+        do {
+            try await unregister(token: pending)
+            preferences.clearPendingUnregister()
+            if preferences.lastRegisteredToken == pending {
+                preferences.clearLastRegisteredToken()
+            }
+        } catch {
+            // Stays pending; retried at the next reconcile opportunity.
         }
     }
 
@@ -142,7 +203,7 @@ public actor PushRegistrationInteractor {
         let envelope = try PushTokenEnvelope.seal(apnsToken: token, serverPublicKey: serverKey)
         let userKey = try await signer.userKeyID()
         let deviceToken = await attestation.currentToken()
-        let timestamp = Date()
+        let timestamp = clock()
         let payload = SignedPushSessionPayload.unregister(
             deviceToken: deviceToken,
             userKey: userKey,

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -28,9 +28,11 @@ public actor PushRegistrationInteractor {
     private var apnsToken: Data?
     private var subscriptions: [PushSubscription]?
     private var pendingReconcile: Task<Void, Never>?
-    /// Reconciliation must never overlap itself: two interleaved
-    /// passes would spend two single-use session signatures on the
-    /// same state. One pass runs; passes requested meanwhile coalesce
+    /// Reconciliation must never overlap itself — nor the opt-out
+    /// drain, which takes the same slot: two interleaved passes would
+    /// spend two single-use session signatures on the same state, and
+    /// a register still in flight could land *after* an opt-out's
+    /// unregister. One pass runs; passes requested meanwhile coalesce
     /// into exactly one follow-up.
     private var reconcileInFlight = false
     private var reconcileQueuedWhileInFlight = false
@@ -89,7 +91,15 @@ public actor PushRegistrationInteractor {
         preferences.clearRegistration()
         guard let token else { return }
         preferences.setPendingUnregister(token: token)
+        // The drain takes the same single pass slot reconciliation
+        // uses: running alongside a pass would spend a second
+        // single-use signature, and that pass's register could land
+        // *after* this unregister and leave the device registered. A
+        // pass holding the slot drains this before it releases it.
+        guard claimPass() else { return }
+        defer { reconcileInFlight = false }
         await drainPendingUnregister()
+        await runQueuedPasses()
     }
 
     /// An opportunity moment (app foregrounded): re-run reconciliation
@@ -111,16 +121,33 @@ public actor PushRegistrationInteractor {
     }
 
     private func reconcile() async {
+        guard claimPass() else { return }
+        defer { reconcileInFlight = false }
+        await reconcilePass()
+        await runQueuedPasses()
+    }
+
+    /// Claims the single pass slot. When a pass already holds it, this
+    /// records that another is wanted — the holder runs it before
+    /// releasing — and yields.
+    private func claimPass() -> Bool {
         if reconcileInFlight {
             reconcileQueuedWhileInFlight = true
-            return
+            return false
         }
         reconcileInFlight = true
-        defer { reconcileInFlight = false }
-        repeat {
+        return true
+    }
+
+    /// Whatever was requested during a pass collapses into exactly one
+    /// follow-up, which re-checks the fingerprint. No suspension point
+    /// separates the last check here from releasing the slot, so a
+    /// request can never be queued and then stranded.
+    private func runQueuedPasses() async {
+        while reconcileQueuedWhileInFlight {
             reconcileQueuedWhileInFlight = false
             await reconcilePass()
-        } while reconcileQueuedWhileInFlight
+        }
     }
 
     private func reconcilePass() async {
@@ -141,6 +168,12 @@ public actor PushRegistrationInteractor {
            now < expiresAt.addingTimeInterval(-expiryMargin) {
             return
         }
+
+        // Read before the attempt, deliberately: an unregister still
+        // unhonored *now* is superseded by the registration about to
+        // replace it, but one the user asks for *during* the attempt
+        // is the newer instruction and must survive it.
+        let supersededUnregister = preferences.pendingUnregisterToken
 
         do {
             let serverKey = try await client.registrationKey()
@@ -172,10 +205,13 @@ public actor PushRegistrationInteractor {
                 at: timestamp,
                 expiresAt: response.expiresAt
             )
-            // A registration for this token supersedes any unregister
-            // still pending for it (replace-all upsert): draining it
-            // later would tear down the live registration.
-            if preferences.pendingUnregisterToken == token {
+            // A registration for this token retires an unregister that
+            // was already pending for it (replace-all upsert): draining
+            // it later would tear down the live registration. An
+            // opt-out that arrived mid-attempt is left alone — the
+            // follow-up pass drains it.
+            if supersededUnregister == token,
+               preferences.pendingUnregisterToken == token {
                 preferences.clearPendingUnregister()
             }
         } catch {

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationPayload.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationPayload.swift
@@ -1,0 +1,126 @@
+import CryptoKit
+import Foundation
+
+/// One inbox tag and the relays the push backend should watch for it.
+/// The tag is the identity's public routing handle (first 8 bytes hex
+/// of `SHA256("sep-inbox-v1" || inboxPublicKey)`) — already visible to
+/// every relay, which is the point: registering it tells the backend
+/// nothing a relay operator doesn't know, except that this device
+/// wants to be woken for it.
+public struct PushSubscription: Codable, Sendable, Equatable {
+    public let tag: String
+    public let relays: [String]
+
+    public init(tag: String, relays: [String]) {
+        self.tag = tag
+        self.relays = relays
+    }
+}
+
+/// Shared construction for the session payloads the user key signs.
+///
+/// These MUST match `payload.rs` in the push backend
+/// (`onym-push/apple/src/payload.rs`) byte-for-byte, or every
+/// signature check fails. Every field is length-prefixed and the
+/// payload is domain-separated by context, so no two field layouts can
+/// collide and a register signature can never be replayed as an
+/// unregister.
+///
+/// The signature covers the raw APNs token even though it travels
+/// encrypted (see `PushTokenEnvelope`), binding the envelope's content
+/// to the session — and it covers the subscription list **exactly as
+/// transmitted**, in wire order, with no normalization.
+///
+/// The user key authenticates the session only. The backend verifies
+/// it and discards it; nothing derived from it is stored.
+public enum SignedPushSessionPayload {
+    public static let registerContext = "onym-push-register-v1"
+    public static let unregisterContext = "onym-push-unregister-v1"
+
+    /// The bytes the user key signs for `POST /v1/register`.
+    public static func register(
+        deviceToken: Data?,
+        userKey: String,
+        timestamp: Date,
+        apnsToken: Data,
+        subscriptions: [PushSubscription]
+    ) -> Data {
+        bytes(
+            context: registerContext,
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: apnsToken,
+            subscriptionsDigest: digest(of: subscriptions)
+        )
+    }
+
+    /// The bytes the user key signs for `POST /v1/unregister`. The
+    /// trailing digest slot is empty — same layout, different context.
+    public static func unregister(
+        deviceToken: Data?,
+        userKey: String,
+        timestamp: Date,
+        apnsToken: Data
+    ) -> Data {
+        bytes(
+            context: unregisterContext,
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: apnsToken,
+            subscriptionsDigest: Data()
+        )
+    }
+
+    /// SHA-256 over each `(tag, relay)` pair in transmitted order,
+    /// each field length-prefixed. Mirrors `subscriptions_digest`.
+    static func digest(of subscriptions: [PushSubscription]) -> Data {
+        var encoded = Data()
+        for subscription in subscriptions {
+            for relay in subscription.relays {
+                append(&encoded, Data(subscription.tag.utf8))
+                append(&encoded, Data(relay.utf8))
+            }
+        }
+        return Data(SHA256.hash(data: encoded))
+    }
+
+    private static func bytes(
+        context: String,
+        deviceToken: Data?,
+        userKey: String,
+        timestamp: Date,
+        apnsToken: Data,
+        subscriptionsDigest: Data
+    ) -> Data {
+        var payload = Data()
+        append(&payload, Data(context.utf8))
+        append(&payload, deviceToken ?? Data())
+        append(&payload, Data(userKey.utf8))
+        append(&payload, Data(ISO8601DateFormatter.push.string(from: timestamp).utf8))
+        append(&payload, apnsToken)
+        append(&payload, subscriptionsDigest)
+        return payload
+    }
+
+    /// Big-endian 32-bit length prefix, so concatenation is injective.
+    private static func append(_ payload: inout Data, _ field: Data) {
+        var length = UInt32(field.count).bigEndian
+        withUnsafeBytes(of: &length) { payload.append(contentsOf: $0) }
+        payload.append(field)
+    }
+}
+
+extension ISO8601DateFormatter {
+    /// One formatter configuration for signed payloads — the stable
+    /// subset (no fractional seconds), pinned so the signed bytes
+    /// can't shift with a caller's formatter settings. Matches the
+    /// moderation package's formatter.
+    static let push: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
+}

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationPayload.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationPayload.swift
@@ -29,7 +29,8 @@ public struct PushSubscription: Codable, Sendable, Equatable {
 /// The signature covers the raw APNs token even though it travels
 /// encrypted (see `PushTokenEnvelope`), binding the envelope's content
 /// to the session — and it covers the subscription list **exactly as
-/// transmitted**, in wire order, with no normalization.
+/// transmitted**: wire order, grouping, and relay counts, with no
+/// normalization, so no two distinct transmitted lists share bytes.
 ///
 /// The user key authenticates the session only. The backend verifies
 /// it and discards it; nothing derived from it is stored.
@@ -73,13 +74,23 @@ public enum SignedPushSessionPayload {
         )
     }
 
-    /// SHA-256 over each `(tag, relay)` pair in transmitted order,
-    /// each field length-prefixed. Mirrors `subscriptions_digest`.
+    /// SHA-256 over the subscription list exactly as transmitted,
+    /// grouping included: for each subscription in wire order,
+    /// `len32(tag) || tag || be32(relays.count)` followed by
+    /// `len32(relay) || relay` for each relay. Mirrors
+    /// `subscriptions_digest` in the backend's `payload.rs`.
+    ///
+    /// The bare big-endian relay count binds the *shape* of the list,
+    /// not just its flattened pairs: the same tag→relay pairs split
+    /// into different entries digest differently, and an entry with an
+    /// empty relay list still contributes bytes rather than vanishing.
     static func digest(of subscriptions: [PushSubscription]) -> Data {
         var encoded = Data()
         for subscription in subscriptions {
+            append(&encoded, Data(subscription.tag.utf8))
+            var count = UInt32(subscription.relays.count).bigEndian
+            withUnsafeBytes(of: &count) { encoded.append(contentsOf: $0) }
             for relay in subscription.relays {
-                append(&encoded, Data(subscription.tag.utf8))
                 append(&encoded, Data(relay.utf8))
             }
         }

--- a/Packages/OnymPush/Sources/OnymPush/PushSigner.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushSigner.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Identity seam: how push registrations get user signatures without
+/// this package depending on OnymIdentity. The app target adapts
+/// `IdentityRepository` behind this — the private key never crosses
+/// the boundary, only detached signatures do. Same shape as
+/// `ModerationSigner`.
+///
+/// The signature authenticates the call; the backend verifies the key
+/// and discards it. Which identity signs is therefore immaterial to
+/// the backend — any currently-persisted identity's key will do.
+public protocol PushSigner: Sendable {
+    /// The signing identity's key reference: `onym:key:<hex>`.
+    func userKeyID() async throws -> String
+    /// Ed25519 detached signature over `message` with that key.
+    func sign(_ message: Data) async throws -> Data
+}
+
+/// Attestation seam, mirroring the moderation package's provider: a
+/// fresh `DCDevice` token per call, or nil where attestation does not
+/// exist (simulator, enterprise build). The client never fabricates
+/// one.
+public protocol PushDeviceAttestationProvider: Sendable {
+    func currentToken() async -> Data?
+}

--- a/Packages/OnymPush/Sources/OnymPush/PushTokenEnvelope.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushTokenEnvelope.swift
@@ -1,0 +1,58 @@
+import CryptoKit
+import Foundation
+
+/// The APNs token, encrypted to the push backend's static X25519 key
+/// (`x25519-aes-256-gcm-v1`, the invitation scheme's shape with its
+/// own HKDF salt) so the raw token never sits readable in a proxy
+/// buffer or request body at rest. The Rust counterpart is
+/// `open_token_envelope` in `onym-push/apple/src/crypto.rs`.
+public struct PushTokenEnvelope: Codable, Sendable, Equatable {
+    public let ephemeralPublicKey: Data
+    public let nonce: Data
+    public let ciphertext: Data
+    public let authenticationTag: Data
+
+    /// Distinct from the invitation scheme's salt on purpose: a
+    /// captured invitation ciphertext and a captured registration
+    /// envelope must never be interchangeable inputs.
+    private static let hkdfSalt = Data("onym-push-token-v1".utf8)
+    private static let hkdfInfo = Data("aes-256-gcm".utf8)
+
+    public init(ephemeralPublicKey: Data, nonce: Data, ciphertext: Data, authenticationTag: Data) {
+        self.ephemeralPublicKey = ephemeralPublicKey
+        self.nonce = nonce
+        self.ciphertext = ciphertext
+        self.authenticationTag = authenticationTag
+    }
+
+    public enum SealError: Error, Equatable {
+        /// The fetched registration key is not a 32-byte X25519 key.
+        case invalidServerKey
+    }
+
+    /// Seal `apnsToken` to the backend's registration key (fetched
+    /// from `GET /v1/registration-key` before each register call, so
+    /// server-side key rotation needs no client release).
+    public static func seal(apnsToken: Data, serverPublicKey: Data) throws -> PushTokenEnvelope {
+        guard let serverKey = try? Curve25519.KeyAgreement.PublicKey(
+            rawRepresentation: serverPublicKey
+        ) else {
+            throw SealError.invalidServerKey
+        }
+        let ephemeral = Curve25519.KeyAgreement.PrivateKey()
+        let shared = try ephemeral.sharedSecretFromKeyAgreement(with: serverKey)
+        let key = shared.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: hkdfSalt,
+            sharedInfo: hkdfInfo,
+            outputByteCount: 32
+        )
+        let sealed = try AES.GCM.seal(apnsToken, using: key)
+        return PushTokenEnvelope(
+            ephemeralPublicKey: ephemeral.publicKey.rawRepresentation,
+            nonce: Data(sealed.nonce),
+            ciphertext: sealed.ciphertext,
+            authenticationTag: sealed.tag
+        )
+    }
+}

--- a/Packages/OnymPush/Sources/OnymPush/PushTokenEnvelope.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushTokenEnvelope.swift
@@ -7,6 +7,16 @@ import Foundation
 /// buffer or request body at rest. The Rust counterpart is
 /// `open_token_envelope` in `onym-push/apple/src/crypto.rs`.
 public struct PushTokenEnvelope: Codable, Sendable, Equatable {
+    /// The sealing scheme this envelope implements. Deliberately NOT a
+    /// wire field: the backend's `TokenEnvelope` decoder rejects
+    /// unknown keys (`deny_unknown_fields`), so adding one requires a
+    /// lockstep backend change — and on the wire the scheme is already
+    /// identified by the HKDF salt's domain separation (a ciphertext
+    /// sealed under any other scheme simply fails to open). If a
+    /// second scheme ever ships, versioning moves to the wire in a
+    /// coordinated change on both sides.
+    public static let scheme = "x25519-aes-256-gcm-v1"
+
     public let ephemeralPublicKey: Data
     public let nonce: Data
     public let ciphertext: Data

--- a/Packages/OnymPush/Sources/OnymPush/PushTokenEnvelope.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushTokenEnvelope.swift
@@ -36,7 +36,9 @@ public struct PushTokenEnvelope: Codable, Sendable, Equatable {
     }
 
     public enum SealError: Error, Equatable {
-        /// The fetched registration key is not a 32-byte X25519 key.
+        /// The fetched registration key is not a usable X25519 key —
+        /// wrong length, or a point (e.g. all-zero / low-order) whose
+        /// key agreement CryptoKit rejects.
         case invalidServerKey
     }
 
@@ -50,7 +52,12 @@ public struct PushTokenEnvelope: Codable, Sendable, Equatable {
             throw SealError.invalidServerKey
         }
         let ephemeral = Curve25519.KeyAgreement.PrivateKey()
-        let shared = try ephemeral.sharedSecretFromKeyAgreement(with: serverKey)
+        // Decoding accepts any 32 bytes; the agreement is where a
+        // degenerate point (all-zero, low-order) actually fails. Both
+        // are the same defect from the caller's view: not a server key.
+        guard let shared = try? ephemeral.sharedSecretFromKeyAgreement(with: serverKey) else {
+            throw SealError.invalidServerKey
+        }
         let key = shared.hkdfDerivedSymmetricKey(
             using: SHA256.self,
             salt: hkdfSalt,

--- a/Packages/OnymPush/Sources/OnymPush/StubPushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/StubPushBackendClient.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// In-memory stand-in for tests and previews: records what was sent,
+/// answers what it was told to.
+public actor StubPushBackendClient: PushBackendClient {
+    public private(set) var registered: [PushRegisterRequest] = []
+    public private(set) var unregistered: [PushUnregisterRequest] = []
+
+    /// 32 zero bytes decodes as a valid X25519 public key; tests that
+    /// care set a real one.
+    public var registrationKeyAnswer: Data
+    public var registerAnswer: Result<PushRegisterResponse, Error>
+    public var unregisterAnswer: Result<Void, Error>
+
+    public init(
+        registrationKeyAnswer: Data = Data(repeating: 0, count: 32),
+        registerAnswer: Result<PushRegisterResponse, Error> =
+            .success(PushRegisterResponse(expiresAt: .distantFuture)),
+        unregisterAnswer: Result<Void, Error> = .success(())
+    ) {
+        self.registrationKeyAnswer = registrationKeyAnswer
+        self.registerAnswer = registerAnswer
+        self.unregisterAnswer = unregisterAnswer
+    }
+
+    public func registrationKey() async throws -> Data {
+        registrationKeyAnswer
+    }
+
+    public func register(_ request: PushRegisterRequest) async throws -> PushRegisterResponse {
+        registered.append(request)
+        return try registerAnswer.get()
+    }
+
+    public func unregister(_ request: PushUnregisterRequest) async throws {
+        unregistered.append(request)
+        try unregisterAnswer.get()
+    }
+
+    public func setRegisterAnswer(_ answer: Result<PushRegisterResponse, Error>) {
+        registerAnswer = answer
+    }
+
+    public func setRegistrationKeyAnswer(_ key: Data) {
+        registrationKeyAnswer = key
+    }
+}

--- a/Packages/OnymPush/Sources/OnymPush/StubPushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/StubPushBackendClient.swift
@@ -1,19 +1,31 @@
+import CryptoKit
 import Foundation
 
 /// In-memory stand-in for tests and previews: records what was sent,
 /// answers what it was told to.
 public actor StubPushBackendClient: PushBackendClient {
+    /// A pinned, deterministic, *valid* X25519 public key (derived
+    /// from the fixed private scalar 0x11…11). All-zero bytes would
+    /// decode but name a low-order point whose agreement CryptoKit
+    /// rejects — sealing to it throws, and every default-stub register
+    /// would silently vanish. Deterministic rather than fresh so
+    /// fixtures and failures reproduce byte-for-byte.
+    public static let defaultRegistrationKey: Data = {
+        let scalar = Data(repeating: 0x11, count: 32)
+        // swiftlint:disable:next force_try
+        return try! Curve25519.KeyAgreement.PrivateKey(rawRepresentation: scalar)
+            .publicKey.rawRepresentation
+    }()
+
     public private(set) var registered: [PushRegisterRequest] = []
     public private(set) var unregistered: [PushUnregisterRequest] = []
 
-    /// 32 zero bytes decodes as a valid X25519 public key; tests that
-    /// care set a real one.
     public var registrationKeyAnswer: Data
     public var registerAnswer: Result<PushRegisterResponse, Error>
     public var unregisterAnswer: Result<Void, Error>
 
     public init(
-        registrationKeyAnswer: Data = Data(repeating: 0, count: 32),
+        registrationKeyAnswer: Data = StubPushBackendClient.defaultRegistrationKey,
         registerAnswer: Result<PushRegisterResponse, Error> =
             .success(PushRegisterResponse(expiresAt: .distantFuture)),
         unregisterAnswer: Result<Void, Error> = .success(())
@@ -43,5 +55,9 @@ public actor StubPushBackendClient: PushBackendClient {
 
     public func setRegistrationKeyAnswer(_ key: Data) {
         registrationKeyAnswer = key
+    }
+
+    public func setUnregisterAnswer(_ answer: Result<Void, Error>) {
+        unregisterAnswer = answer
     }
 }

--- a/Packages/OnymPush/Sources/OnymPush/URLSessionPushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/URLSessionPushBackendClient.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// HTTP client for the deployed push backend (`onym-push/apple`). One
+/// base URL, one GET and two POSTs, JSON both ways.
+///
+/// Wire notes, pinned against `apple/src` of the reference:
+/// - Request/response keys are camelCase; `Data` fields travel as
+///   base64 strings and timestamps as RFC 3339 UTC seconds.
+/// - Errors arrive as `{ "error": <code>, "message": <text> }` and
+///   surface as `PushClientError.rejected` with the code verbatim.
+/// - Session signatures are single-use server-side.
+public struct URLSessionPushBackendClient: PushBackendClient {
+    /// The deployed push backend for this interface.
+    public static let defaultBaseURL = URL(string: "https://push.onym.app")!
+
+    private let baseURL: URL
+    private let session: URLSession
+
+    /// Ephemeral and cookie-less: session state that outlives a
+    /// request is linkable surface this codebase avoids everywhere.
+    public static let defaultSession: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieAcceptPolicy = .never
+        return URLSession(configuration: configuration)
+    }()
+
+    public init(
+        baseURL: URL = URLSessionPushBackendClient.defaultBaseURL,
+        session: URLSession = URLSessionPushBackendClient.defaultSession
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func registrationKey() async throws -> Data {
+        struct KeyResponse: Decodable {
+            let publicKey: Data
+        }
+        let data = try await send(path: ["v1", "registration-key"], body: nil)
+        let response: KeyResponse = try decode(data)
+        return response.publicKey
+    }
+
+    public func register(_ request: PushRegisterRequest) async throws -> PushRegisterResponse {
+        let body = try Self.encoder().encode(request)
+        let data = try await send(path: ["v1", "register"], body: body)
+        return try decode(data)
+    }
+
+    public func unregister(_ request: PushUnregisterRequest) async throws {
+        let body = try Self.encoder().encode(request)
+        _ = try await send(path: ["v1", "unregister"], body: body)
+    }
+
+    // MARK: - Transport
+
+    private func send(path: [String], body: Data?) async throws -> Data {
+        // https only, every build — matching the enforcement client. A
+        // local reference deployment is reached through an https
+        // proxy/tunnel, never by relaxing transport security here.
+        let host = baseURL.host?.lowercased() ?? ""
+        guard !host.isEmpty, baseURL.scheme?.lowercased() == "https" else {
+            throw PushClientError.insecureBaseURL(baseURL.absoluteString)
+        }
+        let url = path.reduce(baseURL) { partial, component in
+            partial.appending(path: component)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = body == nil ? "GET" : "POST"
+        request.timeoutInterval = 15
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if body != nil {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw PushClientError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw PushClientError.rejected(Self.rejection(http.statusCode, data))
+        }
+        return data
+    }
+
+    private static func rejection(_ statusCode: Int, _ data: Data) -> PushRejection {
+        struct Envelope: Decodable {
+            let error: String
+            let message: String
+        }
+        if let envelope = try? JSONDecoder().decode(Envelope.self, from: data) {
+            return PushRejection(
+                statusCode: statusCode,
+                rawCode: envelope.error,
+                message: envelope.message
+            )
+        }
+        return PushRejection(
+            statusCode: statusCode,
+            rawCode: "http_\(statusCode)",
+            message: "the push backend rejected the request (HTTP \(statusCode))"
+        )
+    }
+
+    private func decode<Value: Decodable>(_ data: Data) throws -> Value {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            return try decoder.decode(Value.self, from: data)
+        } catch {
+            throw PushClientError.malformedResponse("push backend response: \(error)")
+        }
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}

--- a/Packages/OnymPush/Sources/OnymPush/URLSessionPushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/URLSessionPushBackendClient.swift
@@ -104,9 +104,36 @@ public struct URLSessionPushBackendClient: PushBackendClient {
         )
     }
 
+    /// RFC 3339 permits fractional seconds; Foundation's built-in
+    /// `.iso8601` strategy accepts only the whole-second form, so both
+    /// shapes are tried — same rationale as the moderation package's
+    /// `ModerationJSON.decoder()` (built once, replicated here rather
+    /// than imported to keep this package dependency-free).
+    private static let fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let wholeSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
     private func decode<Value: Decodable>(_ data: Data) throws -> Value {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+            if let date = Self.wholeSeconds.date(from: value) ?? Self.fractional.date(from: value) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "expected an RFC 3339 timestamp"
+            )
+        }
         do {
             return try decoder.decode(Value.self, from: data)
         } catch {

--- a/Packages/OnymPush/Sources/OnymPush/URLSessionPushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/URLSessionPushBackendClient.swift
@@ -8,6 +8,11 @@ import Foundation
 ///   base64 strings and timestamps as RFC 3339 UTC seconds.
 /// - Errors arrive as `{ "error": <code>, "message": <text> }` and
 ///   surface as `PushClientError.rejected` with the code verbatim.
+/// - A `nil` `deviceToken` omits the JSON key entirely (synthesized
+///   Codable). That missing-key form IS the contract: the backend's
+///   field is `Option<String>` (serde reads an absent key as `None`;
+///   `deny_unknown_fields` guards only the token envelope struct) and
+///   its API tests exercise bodies with no `deviceToken` key.
 /// - Session signatures are single-use server-side.
 public struct URLSessionPushBackendClient: PushBackendClient {
     /// The deployed push backend for this interface.
@@ -126,7 +131,7 @@ public struct URLSessionPushBackendClient: PushBackendClient {
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let value = try container.decode(String.self)
-            if let date = Self.wholeSeconds.date(from: value) ?? Self.fractional.date(from: value) {
+            if let date = Self.fractional.date(from: value) ?? Self.wholeSeconds.date(from: value) {
                 return date
             }
             throw DecodingError.dataCorruptedError(

--- a/project.yml
+++ b/project.yml
@@ -242,6 +242,7 @@ targets:
       - package: OnymModerationUI
       - package: OnymDiscovery
       - package: OnymOnboarding
+      - package: OnymPush
 
   OnymIOSUITests:
     type: bundle.ui-testing

--- a/project.yml
+++ b/project.yml
@@ -39,8 +39,9 @@ packages:
   OnymModerationUI: {path: Packages/OnymModerationUI}
   OnymDiscovery: {path: Packages/OnymDiscovery}
   OnymOnboarding: {path: Packages/OnymOnboarding}
-  # No target dependency yet (that lands with the app wiring): listed
-  # so the package resolves with the project and CI compiles it.
+  # OnymIOSTests links this (its suites live there); CI additionally
+  # builds the package standalone to prove it compiles without any app
+  # scaffolding — see release.yml's "xcodebuild build (OnymPush)" step.
   OnymPush: {path: Packages/OnymPush}
 
 targets:

--- a/project.yml
+++ b/project.yml
@@ -39,6 +39,9 @@ packages:
   OnymModerationUI: {path: Packages/OnymModerationUI}
   OnymDiscovery: {path: Packages/OnymDiscovery}
   OnymOnboarding: {path: Packages/OnymOnboarding}
+  # No target dependency yet (that lands with the app wiring): listed
+  # so the package resolves with the project and CI compiles it.
+  OnymPush: {path: Packages/OnymPush}
 
 targets:
   OnymIOS:


### PR DESCRIPTION
First of three iOS PRs for push notifications, pairing with backend PRs onymchat/onym-push#1–#2. New `Packages/OnymPush`, no app wiring yet — it builds standalone.

## Design recap

The backend is a relay watcher: this device registers its inbox tags (already relay-visible routing handles), the relays to watch, and an encrypted APNs token; the backend wakes it with a content-free "New message" alert when a matching kind-34113 event appears. No group concept anywhere; senders never contact the backend.

## Contents

- `PushRegistrationPayload.swift` — the signed session bytes, mirrored byte-for-byte by `onym-push/apple/src/payload.rs` (length-prefixed, domain-separated; the subscriptions digest covers the wire order exactly, no normalization on either side). Cross-language fixtures are generated from this side in the tests PR.
- `PushTokenEnvelope.swift` — CryptoKit X25519 + HKDF (salt `onym-push-token-v1`) + AES-GCM, so the raw token never sits readable in transit buffers or the backend's request path.
- `PushBackendClient.swift` / `URLSessionPushBackendClient.swift` — the enforcement client's shape: `https://push.onym.app`, ephemeral cookie-less session, https-only in every build, `{error, message}` rejections kept verbatim. Plus an actor stub for tests.
- `PushRegistrationInteractor.swift` — replace-all reconciliation behind `PushSigner`/`PushDeviceAttestationProvider` seams (the `ModerationSigner` pattern): debounced, fingerprinted so unchanged state makes no call, with a 7-day refresh so the backend's 60-day stale sweep never reaps a live device. Registration failures are deliberately quiet per the no-activity-logging stance.
- `PushPreferenceStore.swift` — opt-in, **default OFF**: the tag↔device linkage is the user's trade to make in Settings, never a default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf