### PR TITLE
The app can now ask to be woken, if and only if the user says so

### DIFF
--- a/OnymIOS.entitlements
+++ b/OnymIOS.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:onym.app</string>

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatReceiptSender.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatReceiptSender.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import OnymFoundation
 import OnymTransport
 import OnymIdentity
 
@@ -69,12 +70,8 @@ public struct ChatReceiptSender: ChatReceiptSending {
         return (try? await inboxTransport.send(sealed, to: tag)) != nil
     }
 
-    /// Same derivation as `SendMessageInteractor` / `IntroInboxPump`.
     static func inboxTag(from inboxPublicKey: Data) -> String {
-        var hasher = SHA256()
-        hasher.update(data: Data("sep-inbox-v1".utf8))
-        hasher.update(data: inboxPublicKey)
-        return hasher.finalize().prefix(8).map { String(format: "%02x", $0) }.joined()
+        InboxTag.derive(from: inboxPublicKey)
     }
 }
 

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatReceiptSender.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/ChatReceiptSender.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import OnymFoundation
 import OnymTransport

--- a/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
+++ b/Packages/OnymChatsCore/Sources/OnymChatsCore/SendMessageInteractor.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CryptoKit
 import OSLog
+import OnymFoundation
 import OnymTransport
 import OnymIdentity
 import OnymTransportBlossom
@@ -1199,16 +1200,8 @@ public actor SendMessageInteractor {
         }
     }
 
-    /// Same derivation as `IdentityRepository.inboxTag(from:)` —
-    /// duplicated here because the repo's helper is private and we
-    /// only need the formula, not the keychain lookup. Matches
-    /// `CreateGroupInteractor.inboxTag(from:)`.
     private static func inboxTag(from inboxPublicKey: Data) -> String {
-        var hasher = SHA256()
-        hasher.update(data: Data("sep-inbox-v1".utf8))
-        hasher.update(data: inboxPublicKey)
-        let hash = hasher.finalize()
-        return hash.prefix(8).map { String(format: "%02x", $0) }.joined()
+        InboxTag.derive(from: inboxPublicKey)
     }
 }
 

--- a/Packages/OnymFoundation/Sources/OnymFoundation/InboxTag.swift
+++ b/Packages/OnymFoundation/Sources/OnymFoundation/InboxTag.swift
@@ -1,0 +1,19 @@
+import CryptoKit
+import Foundation
+
+/// The inbox routing tag: first 8 bytes, lowercase hex, of
+/// `SHA256("sep-inbox-v1" || inboxPublicKey)`.
+///
+/// This is the one formula behind every `inboxTag(from:)` helper —
+/// hoisted here so senders, subscribers, the identity repository, and
+/// the push registration all derive the same tag from the same bytes.
+/// A pure function of the public key: the tag is a *public* routing
+/// handle, already visible to every relay carrying the inbox.
+public enum InboxTag {
+    public static func derive(from inboxPublicKey: Data) -> String {
+        var hasher = SHA256()
+        hasher.update(data: Data("sep-inbox-v1".utf8))
+        hasher.update(data: inboxPublicKey)
+        return hasher.finalize().prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupInteractor.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupInteractor.swift
@@ -858,15 +858,8 @@ public struct CreateGroupInteractor: Sendable {
 
     // MARK: - Helpers
 
-    /// Same derivation as `IdentityRepository.inboxTag(from:)` —
-    /// duplicated here because the repo's helper is private and we
-    /// only need the formula, not the keychain lookup.
     private static func inboxTag(from inboxPublicKey: Data) -> String {
-        var hasher = SHA256()
-        hasher.update(data: Data("sep-inbox-v1".utf8))
-        hasher.update(data: inboxPublicKey)
-        let hash = hasher.finalize()
-        return hash.prefix(8).map { String(format: "%02x", $0) }.joined()
+        InboxTag.derive(from: inboxPublicKey)
     }
 
     private static func randomBytes(_ count: Int) throws -> Data {

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroInboxPump.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroInboxPump.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import OnymFoundation
 import OnymTransport
 
 /// Sender-side pump for intro inbox subscriptions. Mirrors
@@ -54,15 +55,8 @@ public struct IntroInboxPump: Sendable {
         await subs.applyEmpty()
     }
 
-    /// Mirror of `IdentityRepository.inboxTag(from:)` /
-    /// `InboxFanoutInteractor.inboxTag(from:)`. Pure function of
-    /// the pubkey; safe to recompute.
     public static func inboxTag(from publicKey: Data) -> String {
-        var hasher = SHA256()
-        hasher.update(data: Data("sep-inbox-v1".utf8))
-        hasher.update(data: publicKey)
-        let digest = hasher.finalize()
-        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        InboxTag.derive(from: publicKey)
     }
 }
 

--- a/Packages/OnymGroup/Sources/OnymGroup/IntroInboxPump.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/IntroInboxPump.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import OnymFoundation
 import OnymTransport

--- a/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
+++ b/Packages/OnymIdentity/Sources/OnymIdentity/IdentityRepository.swift
@@ -947,11 +947,7 @@ public actor IdentityRepository: InvitationEnvelopeDecrypting, InvitationEnvelop
     }
 
     private static func inboxTag(from inboxPublicKey: Data) -> String {
-        var hasher = SHA256()
-        hasher.update(data: Data("sep-inbox-v1".utf8))
-        hasher.update(data: inboxPublicKey)
-        let hash = hasher.finalize()
-        return hash.prefix(8).map { String(format: "%02x", $0) }.joined()
+        InboxTag.derive(from: inboxPublicKey)
     }
 
     // MARK: - Naming helpers

--- a/Packages/OnymInbox/Sources/OnymInbox/InboxFanoutInteractor.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/InboxFanoutInteractor.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import OnymFoundation
 import OnymTransport
 import OnymIdentity
 
@@ -88,15 +89,8 @@ public struct InboxFanoutInteractor: Sendable {
         return out
     }
 
-    /// Mirror of `IdentityRepository.inboxTag(from:)`. Pure function of
-    /// the inbox pubkey; safe to recompute here without going back
-    /// through the actor.
     private static func inboxTag(from inboxPublicKey: Data) -> String {
-        var hasher = SHA256()
-        hasher.update(data: Data("sep-inbox-v1".utf8))
-        hasher.update(data: inboxPublicKey)
-        let digest = hasher.finalize()
-        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        InboxTag.derive(from: inboxPublicKey)
     }
 }
 

--- a/Packages/OnymInbox/Sources/OnymInbox/InboxFanoutInteractor.swift
+++ b/Packages/OnymInbox/Sources/OnymInbox/InboxFanoutInteractor.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import OnymFoundation
 import OnymTransport

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -17,7 +17,12 @@ import Foundation
 /// user's personas live on one device. The backend's contract is
 /// replace-all per device token — per-identity registration is
 /// structurally incompatible with it — so this correlation is
-/// documented (here and in Settings) rather than papered over.
+/// documented (here and in Settings) rather than papered over. The
+/// signature itself adds nothing to it: the app signs with a
+/// device-local key created for push alone (the app target's
+/// `DevicePushSigner`), so the `userKey` the backend sees is linked to
+/// no identity and never rotates with persona switches — successive
+/// refreshes cannot be used to link persona keys.
 public actor PushRegistrationInteractor {
     private let client: PushBackendClient
     private let signer: PushSigner

--- a/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushRegistrationInteractor.swift
@@ -11,6 +11,13 @@ import Foundation
 /// The transport repositories own their lifecycles; this interactor
 /// only *observes* identity and relay state and talks to the push
 /// backend. It never drives transports.
+///
+/// A named trade: one registration carries every identity's inbox tag
+/// under one signature, so the push backend can tell that all of this
+/// user's personas live on one device. The backend's contract is
+/// replace-all per device token — per-identity registration is
+/// structurally incompatible with it — so this correlation is
+/// documented (here and in Settings) rather than papered over.
 public actor PushRegistrationInteractor {
     private let client: PushBackendClient
     private let signer: PushSigner

--- a/Packages/OnymPush/Sources/OnymPush/PushSigner.swift
+++ b/Packages/OnymPush/Sources/OnymPush/PushSigner.swift
@@ -1,14 +1,16 @@
 import Foundation
 
-/// Identity seam: how push registrations get user signatures without
-/// this package depending on OnymIdentity. The app target adapts
-/// `IdentityRepository` behind this — the private key never crosses
-/// the boundary, only detached signatures do. Same shape as
-/// `ModerationSigner`.
+/// Signing seam: how push registrations get session signatures
+/// without this package choosing the key. The private key never
+/// crosses the boundary — only the key reference and detached
+/// signatures do. Same shape as `ModerationSigner`.
 ///
 /// The signature authenticates the call; the backend verifies the key
-/// and discards it. Which identity signs is therefore immaterial to
-/// the backend — any currently-persisted identity's key will do.
+/// and discards it, so *any* Ed25519 key will do. The app deliberately
+/// supplies a device-local key created for push alone (its
+/// `DevicePushSigner`), never an identity's key: an identity-keyed
+/// signature would hand the backend persona linkage the payload
+/// otherwise avoids.
 public protocol PushSigner: Sendable {
     /// The signing identity's key reference: `onym:key:<hex>`.
     func userKeyID() async throws -> String

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsFlow.swift
@@ -16,23 +16,35 @@ public final class NotificationsSettingsFlow {
     /// denied — the switch snaps back and the UI points at system
     /// Settings.
     public private(set) var authorizationDenied = false
+    /// On, but the backend has not yet accepted a registration —
+    /// authorization is granted while the APNs token and register call
+    /// are still in flight. The view shows "activating" instead of
+    /// claiming the wake path works before it does.
+    public private(set) var registrationPending = false
 
     private let enable: () async -> Bool
     private let disable: () async -> Void
+    private let isRegistrationPending: () -> Bool
 
     /// - Parameters:
     ///   - isEnabled: the persisted opt-in at presentation time.
     ///   - enable: requests authorization, registers with APNs and the
     ///     push backend. Returns false when authorization was denied.
     ///   - disable: unregisters everywhere and clears the opt-in.
+    ///   - isRegistrationPending: whether the opt-in is on with no
+    ///     accepted registration yet — re-read on view appearance and
+    ///     after each toggle, since registration completes off-screen.
     public init(
         isEnabled: Bool,
         enable: @escaping () async -> Bool,
-        disable: @escaping () async -> Void
+        disable: @escaping () async -> Void,
+        isRegistrationPending: @escaping () -> Bool = { false }
     ) {
         self.isEnabled = isEnabled
         self.enable = enable
         self.disable = disable
+        self.isRegistrationPending = isRegistrationPending
+        registrationPending = isRegistrationPending()
     }
 
     public func setEnabled(_ wanted: Bool) async {
@@ -47,6 +59,16 @@ public final class NotificationsSettingsFlow {
         } else {
             await disable()
             isEnabled = false
+            // The denial note described a previous attempt; an
+            // explicit off makes it stale.
+            authorizationDenied = false
         }
+        refreshRegistrationState()
+    }
+
+    /// Registration completes off-screen (APNs token delivery, then
+    /// the backend call), so the view re-reads on appearance.
+    public func refreshRegistrationState() {
+        registrationPending = isRegistrationPending()
     }
 }

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsFlow.swift
@@ -26,6 +26,7 @@ public final class NotificationsSettingsFlow {
     private let disable: () async -> Void
     private let isRegistrationPending: () -> Bool
     private let readIsEnabled: (() -> Bool)?
+    private let reconcileWithSystem: (() async -> Void)?
 
     /// - Parameters:
     ///   - isEnabled: the persisted opt-in at presentation time.
@@ -40,18 +41,25 @@ public final class NotificationsSettingsFlow {
     ///     revoked in system Settings, app foregrounded back onto this
     ///     view), so the toggle re-reads rather than trusting its
     ///     presentation-time snapshot.
+    ///   - reconcileWithSystem: the push stack's foreground
+    ///     reconciliation — the step that notices a revoked
+    ///     authorization and disables. Awaited before the re-read on
+    ///     foreground so this screen reads settled state instead of
+    ///     racing the root-level hook that runs the same check.
     public init(
         isEnabled: Bool,
         enable: @escaping () async -> Bool,
         disable: @escaping () async -> Void,
         isRegistrationPending: @escaping () -> Bool = { false },
-        readIsEnabled: (() -> Bool)? = nil
+        readIsEnabled: (() -> Bool)? = nil,
+        reconcileWithSystem: (() async -> Void)? = nil
     ) {
         self.isEnabled = isEnabled
         self.enable = enable
         self.disable = disable
         self.isRegistrationPending = isRegistrationPending
         self.readIsEnabled = readIsEnabled
+        self.reconcileWithSystem = reconcileWithSystem
         registrationPending = isRegistrationPending()
     }
 
@@ -82,5 +90,18 @@ public final class NotificationsSettingsFlow {
             isEnabled = readIsEnabled()
         }
         registrationPending = isRegistrationPending()
+    }
+
+    /// Foreground is when a revoke made in system Settings becomes
+    /// knowable, and `.onAppear` does not fire for a screen that stayed
+    /// mounted across the trip out and back — which is exactly the trip
+    /// the denial note above sends the user on. Reconciling here rather
+    /// than only re-reading is deliberate: the root-level foreground
+    /// hook runs the same check on its own detached task, so a bare
+    /// re-read could win the race and show the pre-revoke answer with
+    /// nothing left to correct it.
+    public func appForegrounded() async {
+        await reconcileWithSystem?()
+        refreshRegistrationState()
     }
 }

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsFlow.swift
@@ -25,6 +25,7 @@ public final class NotificationsSettingsFlow {
     private let enable: () async -> Bool
     private let disable: () async -> Void
     private let isRegistrationPending: () -> Bool
+    private let readIsEnabled: (() -> Bool)?
 
     /// - Parameters:
     ///   - isEnabled: the persisted opt-in at presentation time.
@@ -34,16 +35,23 @@ public final class NotificationsSettingsFlow {
     ///   - isRegistrationPending: whether the opt-in is on with no
     ///     accepted registration yet — re-read on view appearance and
     ///     after each toggle, since registration completes off-screen.
+    ///   - readIsEnabled: the persisted opt-in *now*. The coordinator
+    ///     can disable underneath a still-mounted screen (authorization
+    ///     revoked in system Settings, app foregrounded back onto this
+    ///     view), so the toggle re-reads rather than trusting its
+    ///     presentation-time snapshot.
     public init(
         isEnabled: Bool,
         enable: @escaping () async -> Bool,
         disable: @escaping () async -> Void,
-        isRegistrationPending: @escaping () -> Bool = { false }
+        isRegistrationPending: @escaping () -> Bool = { false },
+        readIsEnabled: (() -> Bool)? = nil
     ) {
         self.isEnabled = isEnabled
         self.enable = enable
         self.disable = disable
         self.isRegistrationPending = isRegistrationPending
+        self.readIsEnabled = readIsEnabled
         registrationPending = isRegistrationPending()
     }
 
@@ -67,8 +75,12 @@ public final class NotificationsSettingsFlow {
     }
 
     /// Registration completes off-screen (APNs token delivery, then
-    /// the backend call), so the view re-reads on appearance.
+    /// the backend call) and the coordinator can disable off-screen
+    /// too, so the view re-reads both on appearance.
     public func refreshRegistrationState() {
+        if let readIsEnabled {
+            isEnabled = readIsEnabled()
+        }
         registrationPending = isRegistrationPending()
     }
 }

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsFlow.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsFlow.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Observation
+
+/// State for the Notifications screen. Deliberately closure-injected —
+/// OnymSettings knows nothing about the push stack; the app hands in
+/// "what enabling and disabling actually do" (authorization prompt,
+/// APNs registration, backend calls) and this flow only sequences and
+/// renders them. Views observe state; they never drive registration
+/// themselves.
+@MainActor
+@Observable
+public final class NotificationsSettingsFlow {
+    public private(set) var isEnabled: Bool
+    public private(set) var isWorking = false
+    /// The user flipped the toggle on but the system authorization was
+    /// denied — the switch snaps back and the UI points at system
+    /// Settings.
+    public private(set) var authorizationDenied = false
+
+    private let enable: () async -> Bool
+    private let disable: () async -> Void
+
+    /// - Parameters:
+    ///   - isEnabled: the persisted opt-in at presentation time.
+    ///   - enable: requests authorization, registers with APNs and the
+    ///     push backend. Returns false when authorization was denied.
+    ///   - disable: unregisters everywhere and clears the opt-in.
+    public init(
+        isEnabled: Bool,
+        enable: @escaping () async -> Bool,
+        disable: @escaping () async -> Void
+    ) {
+        self.isEnabled = isEnabled
+        self.enable = enable
+        self.disable = disable
+    }
+
+    public func setEnabled(_ wanted: Bool) async {
+        guard wanted != isEnabled, !isWorking else { return }
+        isWorking = true
+        defer { isWorking = false }
+        if wanted {
+            authorizationDenied = false
+            let granted = await enable()
+            isEnabled = granted
+            authorizationDenied = !granted
+        } else {
+            await disable()
+            isEnabled = false
+        }
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
@@ -40,8 +40,14 @@ public struct NotificationsSettingsView: View {
                     )
                 }
 
+                if flow.registrationPending {
+                    SettingsFootnote(
+                        "Activating\u{2026} the push server has not confirmed this device yet. This finishes on its own; check back if alerts don\u{2019}t arrive."
+                    )
+                }
+
                 SettingsFootnote(
-                    "How it works: an Onym-run push server watches your configured Nostr relays for your inbox codes and asks Apple to wake this device, a few seconds delayed at random. It never sees message content, senders, or groups — it holds only your inbox codes and an encrypted push token, and forgets both when you turn this off. The alert itself always reads \u{201C}New message\u{201D}; nothing about the conversation passes through Apple."
+                    "How it works: an Onym-run push server watches your configured Nostr relays for your inbox codes and asks Apple to wake this device, a few seconds delayed at random. It never sees message content, senders, or groups — it holds only your inbox codes and an encrypted push token, and asks the server to forget both when you turn this off (retried until the server confirms). All of your identities\u{2019} inbox codes are registered together, so the push server can tell they belong to one device. The alert itself always reads \u{201C}New message\u{201D}; nothing about the conversation passes through Apple."
                 )
             }
             .padding(.horizontal)
@@ -50,6 +56,11 @@ public struct NotificationsSettingsView: View {
         .background(Color(.systemGroupedBackground))
         .navigationTitle("Notifications")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            // Registration completes off-screen; re-read so a finished
+            // (or still-pending) activation renders truthfully.
+            flow.refreshRegistrationState()
+        }
         .onChange(of: switchState) { _, wanted in
             guard wanted != flow.isEnabled else { return }
             Task {

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
@@ -48,7 +48,7 @@ public struct NotificationsSettingsView: View {
                 }
 
                 SettingsFootnote(
-                    "How it works: an Onym-run push server watches your configured Nostr relays for your inbox codes and asks Apple to wake this device, a few seconds delayed at random. It never sees message content, senders, or groups — it holds only your inbox codes and an encrypted push token, and asks the server to forget both when you turn this off (retried until the server confirms). All of your identities\u{2019} inbox codes are registered together, so the push server can tell they belong to one device. The alert itself always reads \u{201C}New message\u{201D}; nothing about the conversation passes through Apple."
+                    "How it works: an Onym-run push server watches your configured Nostr relays for your inbox codes and asks Apple to wake this device, a few seconds delayed at random. It never sees message content, senders, or groups. What this device sends it: your inbox codes, an encrypted push token, a signing key created on this device just for push and linked to none of your identities, and a device-attestation token from Apple. Turning this off tells the server to forget this device (retried until it confirms). All of your identities\u{2019} inbox codes are registered together, so the push server can tell they belong to one device. The alert itself always reads \u{201C}New message\u{201D}; nothing about the conversation passes through Apple."
                 )
             }
             .padding(.horizontal)

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
@@ -42,7 +42,7 @@ public struct NotificationsSettingsView: View {
 
                 if flow.registrationPending {
                     SettingsFootnote(
-                        "Activating\u{2026} the push server has not confirmed this device yet. This finishes on its own; check back if alerts don\u{2019}t arrive."
+                        "Activating\u{2026} the push server has not confirmed this device yet. Onym retries when you return to the app; check back if alerts don\u{2019}t arrive."
                     )
                 }
 
@@ -57,9 +57,13 @@ public struct NotificationsSettingsView: View {
         .navigationTitle("Notifications")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            // Registration completes off-screen; re-read so a finished
-            // (or still-pending) activation renders truthfully.
+            // Registration completes off-screen, and the coordinator
+            // can disable off-screen (authorization revoked in system
+            // Settings); re-read so both render truthfully. The
+            // onChange guard keeps this resync from re-driving the
+            // flow.
             flow.refreshRegistrationState()
+            switchState = flow.isEnabled
         }
         .onChange(of: switchState) { _, wanted in
             guard wanted != flow.isEnabled else { return }

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
@@ -1,0 +1,61 @@
+import OnymDesign
+import SwiftUI
+
+/// Settings → Notifications: one switch, off by default, and an honest
+/// statement of the trade. Enabling push hands two parties something
+/// the rest of the app avoids creating — Onym's push server learns
+/// which inbox codes this device wants wakes for, and Apple carries a
+/// content-free alert — so the copy says exactly that instead of
+/// "enable notifications to stay connected".
+public struct NotificationsSettingsView: View {
+    @State private var flow: NotificationsSettingsFlow
+    @State private var switchState: Bool
+
+    public init(flow: NotificationsSettingsFlow) {
+        _flow = State(initialValue: flow)
+        _switchState = State(initialValue: flow.isEnabled)
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                SettingsCard {
+                    Toggle(isOn: $switchState) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Message Notifications")
+                                .font(.body)
+                            Text("Content-free alerts when a message arrives")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 6)
+                    .disabled(flow.isWorking)
+                    .accessibilityIdentifier("settings.notifications_toggle")
+                }
+
+                if flow.authorizationDenied {
+                    SettingsFootnote(
+                        "Notifications are blocked for Onym in system Settings. Allow them there, then turn this on again."
+                    )
+                }
+
+                SettingsFootnote(
+                    "How it works: an Onym-run push server watches your configured Nostr relays for your inbox codes and asks Apple to wake this device, a few seconds delayed at random. It never sees message content, senders, or groups — it holds only your inbox codes and an encrypted push token, and forgets both when you turn this off. The alert itself always reads \u{201C}New message\u{201D}; nothing about the conversation passes through Apple."
+                )
+            }
+            .padding(.horizontal)
+            .padding(.top, 8)
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("Notifications")
+        .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: switchState) { _, wanted in
+            guard wanted != flow.isEnabled else { return }
+            Task {
+                await flow.setEnabled(wanted)
+                switchState = flow.isEnabled
+            }
+        }
+    }
+}

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// content-free alert — so the copy says exactly that instead of
 /// "enable notifications to stay connected".
 public struct NotificationsSettingsView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @State private var flow: NotificationsSettingsFlow
     @State private var switchState: Bool
 
@@ -64,6 +65,17 @@ public struct NotificationsSettingsView: View {
             // flow.
             flow.refreshRegistrationState()
             switchState = flow.isEnabled
+        }
+        .onChange(of: scenePhase) { _, phase in
+            // The footnote above sends the user to system Settings to
+            // allow or block notifications; they come back to this
+            // screen still mounted, so `.onAppear` never fires and only
+            // this catches the revoke.
+            guard phase == .active else { return }
+            Task {
+                await flow.appForegrounded()
+                switchState = flow.isEnabled
+            }
         }
         .onChange(of: switchState) { _, wanted in
             guard wanted != flow.isEnabled else { return }

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -65,6 +65,10 @@ public struct SettingsView: View {
     /// could never be reached from a standing start. The section shows
     /// when EITHER is wired.
     let makeBackupOperatorSettingsFlow: (@MainActor () -> BackupOperatorSettingsFlow)?
+    /// Settings → Notifications. Optional so the section hides when
+    /// the app runs without the push stack wired — same pattern as
+    /// moderation and discovery.
+    let makeNotificationsSettingsFlow: (@MainActor () -> NotificationsSettingsFlow)?
 
     public init(
         makeBackupFlow: @escaping @MainActor () -> RecoveryPhraseBackupFlow,
@@ -80,7 +84,8 @@ public struct SettingsView: View {
         makeDiscoverySettingsFlow: (@MainActor () -> DiscoverySettingsFlow)? = nil,
         onRestartOnboarding: (@MainActor () -> Void)? = nil,
         makeDeviceBackupView: (@MainActor () -> DeviceBackupVendorsView)? = nil,
-        makeBackupOperatorSettingsFlow: (@MainActor () -> BackupOperatorSettingsFlow)? = nil
+        makeBackupOperatorSettingsFlow: (@MainActor () -> BackupOperatorSettingsFlow)? = nil,
+        makeNotificationsSettingsFlow: (@MainActor () -> NotificationsSettingsFlow)? = nil
     ) {
         self.makeBackupFlow = makeBackupFlow
         self.makeRelayerSettingsFlow = makeRelayerSettingsFlow
@@ -96,6 +101,7 @@ public struct SettingsView: View {
         self.onRestartOnboarding = onRestartOnboarding
         self.makeDeviceBackupView = makeDeviceBackupView
         self.makeBackupOperatorSettingsFlow = makeBackupOperatorSettingsFlow
+        self.makeNotificationsSettingsFlow = makeNotificationsSettingsFlow
     }
 
     @State private var showRecoveryPhrase = false
@@ -233,6 +239,31 @@ public struct SettingsView: View {
                     .accessibilityIdentifier("settings.blossom_relays_row")
                 }
                 SettingsFootnote("Nostr relays and Blossom servers carry your messages and media. Replace them with your own instances for maximum privacy.")
+
+                // Hidden until the app wires the push stack, like the
+                // other optional sections.
+                if let makeNotificationsSettingsFlow {
+                    SettingsSectionLabel("NOTIFICATIONS")
+                    SettingsCard {
+                        NavigationLink {
+                            NotificationsSettingsView(flow: makeNotificationsSettingsFlow())
+                        } label: {
+                            SettingsRow(
+                                title: "Notifications",
+                                subtitle: "Content-free wakes, off by default",
+                                last: true
+                            ) {
+                                SettingsIconTile(
+                                    symbol: "bell.badge.fill",
+                                    bg: SettingsTile.indigo
+                                )
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("settings.notifications_row")
+                    }
+                    SettingsFootnote("Off means no third party ever learns this device wants waking. On hands Onym's push server your inbox codes and Apple a content-free alert — never message content.")
+                }
 
                 // Absent until the app supplies it, like every other
                 // optional section here — a build without backup wired

--- a/Sources/OnymIOS/AppDependencies.swift
+++ b/Sources/OnymIOS/AppDependencies.swift
@@ -130,6 +130,14 @@ struct AppDependencies {
     /// point: this is the surface that exists BEFORE any consent, and
     /// the one that makes the other appear.
     let makeBackupOperatorSettingsFlow: (@MainActor () -> BackupOperatorSettingsFlow)?
+    /// Settings → Notifications. Optional so builds without the push
+    /// stack (UI-test harness) show no row — same pattern as the
+    /// moderation and discovery factories.
+    let makeNotificationsSettingsFlow: (@MainActor () -> NotificationsSettingsFlow)?
+    /// The push registration coordinator: runs from a root-level
+    /// `.task`, re-reconciles on foreground. Nil alongside the factory
+    /// above.
+    let pushCoordinator: PushCoordinator?
     /// Raised by the backup picker's consent apply step so the root
     /// view re-resolves the Device Backup screen immediately. Without
     /// it a consent given from a Settings sheet — where the tab never

--- a/Sources/OnymIOS/DevicePushSigner.swift
+++ b/Sources/OnymIOS/DevicePushSigner.swift
@@ -1,0 +1,106 @@
+import CryptoKit
+import Foundation
+import OnymPush
+import Security
+
+/// Signs push registrations with a key that belongs to the *device*,
+/// not to any identity: a random Ed25519 key generated on first use
+/// and kept in the Keychain, used for push and nothing else.
+///
+/// Why not sign with the current identity's key (the moderation
+/// signer's shape): registrations refresh every 7 days, and whichever
+/// persona is current would sign the refresh — successive registers
+/// for the same device token signed by different persona keys would
+/// let the push backend link those persona keys to each other. The
+/// backend verifies the key and discards it, so *any* key
+/// authenticates the session; a per-install random key carries zero
+/// identity linkage and never rotates with persona switches. It also
+/// keeps the register payload's `userKey` field free of identity
+/// material, so Settings can state honestly what leaves the device.
+///
+/// Keychain posture matches `KeychainIntroKeyStore`:
+/// `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — one cached
+/// unlock per device, no iCloud Keychain sync, no encrypted-backup
+/// transfer. Losing the key (reinstall, restore) is harmless: the
+/// next launch mints a fresh one and the next register simply
+/// authenticates with that.
+struct DevicePushSigner: PushSigner {
+    /// Keychain service — one fixed item per device.
+    static let serviceDefault = "app.onym.ios.push_signing_key"
+    static let account = "ed25519"
+
+    private let service: String
+
+    init(testNamespace: String? = nil) {
+        if let testNamespace, !testNamespace.isEmpty {
+            service = "\(Self.serviceDefault).\(testNamespace)"
+        } else {
+            service = Self.serviceDefault
+        }
+    }
+
+    func userKeyID() async throws -> String {
+        let key = try loadOrCreateKey()
+        let hex = key.publicKey.rawRepresentation
+            .map { String(format: "%02x", $0) }.joined()
+        return "onym:key:\(hex)"
+    }
+
+    func sign(_ message: Data) async throws -> Data {
+        try loadOrCreateKey().signature(for: message)
+    }
+
+    /// Test helper — drop the key so the next use mints a fresh one.
+    func wipe() {
+        SecItemDelete(query() as CFDictionary)
+    }
+
+    // MARK: - Keychain
+
+    private func loadOrCreateKey() throws -> Curve25519.Signing.PrivateKey {
+        if let existing = try loadKey() { return existing }
+        let fresh = Curve25519.Signing.PrivateKey()
+        var add = query()
+        add[kSecValueData as String] = fresh.rawRepresentation
+        add[kSecAttrAccessible as String] =
+            kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(add as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            // Two callers raced first use. Whoever won, both must sign
+            // with the stored key — a register and its follow-up
+            // signed by different keys is exactly the churn this type
+            // exists to avoid.
+            if let stored = try loadKey() { return stored }
+        }
+        guard status == errSecSuccess else {
+            throw DevicePushSignerError.keychain(status)
+        }
+        return fresh
+    }
+
+    private func loadKey() throws -> Curve25519.Signing.PrivateKey? {
+        var q = query()
+        q[kSecReturnData as String] = true
+        q[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        let status = SecItemCopyMatching(q as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else {
+            return nil
+        }
+        // A corrupted blob throws rather than silently minting a new
+        // key over a store error.
+        return try Curve25519.Signing.PrivateKey(rawRepresentation: data)
+    }
+
+    private func query() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: Self.account,
+        ]
+    }
+}
+
+enum DevicePushSignerError: Error {
+    case keychain(OSStatus)
+}

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1551,7 +1551,8 @@ struct OnymIOSApp: App {
                 NotificationsSettingsFlow(
                     isEnabled: pushCoordinator.isEnabled,
                     enable: { await pushCoordinator.enable() },
-                    disable: { await pushCoordinator.disable() }
+                    disable: { await pushCoordinator.disable() },
+                    isRegistrationPending: { pushCoordinator.registrationPending }
                 )
             },
             pushCoordinator: pushCoordinator,

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1553,7 +1553,8 @@ struct OnymIOSApp: App {
                     enable: { await pushCoordinator.enable() },
                     disable: { await pushCoordinator.disable() },
                     isRegistrationPending: { pushCoordinator.registrationPending },
-                    readIsEnabled: { pushCoordinator.isEnabled }
+                    readIsEnabled: { pushCoordinator.isEnabled },
+                    reconcileWithSystem: { await pushCoordinator.appForegrounded() }
                 )
             },
             pushCoordinator: pushCoordinator,

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -1552,7 +1552,8 @@ struct OnymIOSApp: App {
                     isEnabled: pushCoordinator.isEnabled,
                     enable: { await pushCoordinator.enable() },
                     disable: { await pushCoordinator.disable() },
-                    isRegistrationPending: { pushCoordinator.registrationPending }
+                    isRegistrationPending: { pushCoordinator.registrationPending },
+                    readIsEnabled: { pushCoordinator.isEnabled }
                 )
             },
             pushCoordinator: pushCoordinator,

--- a/Sources/OnymIOS/OnymIOSApp.swift
+++ b/Sources/OnymIOS/OnymIOSApp.swift
@@ -22,6 +22,10 @@ import OnymBilling
 
 @main
 struct OnymIOSApp: App {
+    /// APNs device tokens arrive only through `UIApplicationDelegate`;
+    /// the delegate does nothing but relay them (`PushAppDelegate`).
+    @UIApplicationDelegateAdaptor(PushAppDelegate.self) private var pushAppDelegate
+
     private let dependencies: AppDependencies
     private let identityRepository: IdentityRepository
     /// Held so the replay observer outlives `init`.
@@ -1383,6 +1387,14 @@ struct OnymIOSApp: App {
             onboardingRestartController = nil
         }
 
+        // Push notifications. Opt-in lives in PushPreferenceStore
+        // (default off); until the user enables it in Settings the
+        // coordinator's streams run but nothing leaves the device.
+        let pushCoordinator = PushCoordinator(
+            identityRepository: repository,
+            relaysRepository: nostrRelaysRepository
+        )
+
         self.dependencies = AppDependencies(
             makeRecoveryPhraseBackupFlow: { @MainActor in
                 RecoveryPhraseBackupFlow(
@@ -1535,6 +1547,14 @@ struct OnymIOSApp: App {
                 ).makeDeviceBackupView()
             },
             makeBackupOperatorSettingsFlow: makeBackupOperatorSettingsFlow,
+            makeNotificationsSettingsFlow: {
+                NotificationsSettingsFlow(
+                    isEnabled: pushCoordinator.isEnabled,
+                    enable: { await pushCoordinator.enable() },
+                    disable: { await pushCoordinator.disable() }
+                )
+            },
+            pushCoordinator: pushCoordinator,
             backupConsentSignal: backupConsentSignal,
             makeOnboardingFlow: makeOnboardingFlow,
             presentOnboardingAtLaunch: shouldOnboard,
@@ -1852,6 +1872,13 @@ struct OnymIOSApp: App {
                         dispatcher: dispatcher
                     )
                     await fanout.run()
+                }
+                .task {
+                    // Push registration reconciler: consumes the APNs
+                    // token stream, the identity list, and the relay
+                    // configuration. Sends nothing anywhere until the
+                    // user enables notifications in Settings.
+                    await dependencies.pushCoordinator?.run()
                 }
                 .task {
                     // Level-2 deeplink intro pump. Subscribes to one

--- a/Sources/OnymIOS/PushAppDelegate.swift
+++ b/Sources/OnymIOS/PushAppDelegate.swift
@@ -1,24 +1,59 @@
 import UIKit
+import UserNotifications
 
 /// The one thing an app delegate is still required for: APNs delivers
 /// the device token through `UIApplicationDelegate` callbacks, not a
 /// modern async API. This delegate does nothing else — the token is
-/// relayed into a stream `PushCoordinator` consumes, and failures are
+/// relayed into streams `PushCoordinator` consumes, and failures are
 /// silent (registration is retried on the next foreground; per the
 /// no-activity-logging stance nothing is recorded).
-final class PushAppDelegate: NSObject, UIApplicationDelegate {
-    private static let pipe = AsyncStream.makeStream(of: Data.self)
+final class PushAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    /// Multicast with replay: every subscriber gets its own stream, a
+    /// new subscriber immediately receives the latest token when APNs
+    /// already delivered one, and no continuation is ever finished —
+    /// the streams are process-lifetime by design, so a subscriber
+    /// arriving after the token (or a second subscriber, ever) can't
+    /// silently see nothing.
+    private static let lock = NSLock()
+    // nonisolated(unsafe): every touch is under `lock`.
+    private nonisolated(unsafe) static var latestToken: Data?
+    private nonisolated(unsafe) static var continuations: [AsyncStream<Data>.Continuation] = []
 
-    /// Every token APNs hands this process, in order. The token can
-    /// rotate on restore or reinstall, so this is a stream, not a
-    /// one-shot.
-    static var deviceTokens: AsyncStream<Data> { pipe.stream }
+    /// Every token APNs hands this process, in order, starting with
+    /// the most recent one if it already arrived. The token can rotate
+    /// on restore or reinstall, so this is a stream, not a one-shot.
+    static var deviceTokens: AsyncStream<Data> {
+        AsyncStream { continuation in
+            lock.lock()
+            defer { lock.unlock() }
+            continuations.append(continuation)
+            if let latestToken {
+                continuation.yield(latestToken)
+            }
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        // Foreground presentation goes through this delegate; set
+        // before anything can arrive.
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
 
     func application(
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        Self.pipe.continuation.yield(deviceToken)
+        Self.lock.lock()
+        Self.latestToken = deviceToken
+        let subscribers = Self.continuations
+        Self.lock.unlock()
+        for continuation in subscribers {
+            continuation.yield(deviceToken)
+        }
     }
 
     func application(
@@ -26,5 +61,16 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate {
         didFailToRegisterForRemoteNotificationsWithError error: Error
     ) {
         // Quiet by design; the reconciler retries on later inputs.
+    }
+
+    /// A push arriving while the app is foregrounded still shows its
+    /// (content-free) banner — without this, foreground arrivals are
+    /// silently swallowed and the toggle looks broken exactly when the
+    /// user is watching.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.banner, .sound]
     }
 }

--- a/Sources/OnymIOS/PushAppDelegate.swift
+++ b/Sources/OnymIOS/PushAppDelegate.swift
@@ -28,15 +28,22 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
             let id = UUID()
             lock.lock()
             continuations[id] = continuation
-            let replay = latestToken
+            // The replay is yielded *inside* the lock, deliberately: a
+            // token APNs delivers between unlock and a late replay
+            // would be yielded first and the older replay would land
+            // second — and the consumer's last-write-wins `updateToken`
+            // would then register a stale token. Delivery holds the
+            // same lock, so ordering is settled here. Yielding to an
+            // AsyncStream continuation is non-blocking, so holding the
+            // lock across it is safe.
+            if let replay = latestToken {
+                continuation.yield(replay)
+            }
             lock.unlock()
             continuation.onTermination = { _ in
                 lock.lock()
                 defer { lock.unlock() }
                 continuations.removeValue(forKey: id)
-            }
-            if let replay {
-                continuation.yield(replay)
             }
         }
     }

--- a/Sources/OnymIOS/PushAppDelegate.swift
+++ b/Sources/OnymIOS/PushAppDelegate.swift
@@ -10,27 +10,44 @@ import UserNotifications
 final class PushAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     /// Multicast with replay: every subscriber gets its own stream, a
     /// new subscriber immediately receives the latest token when APNs
-    /// already delivered one, and no continuation is ever finished —
-    /// the streams are process-lifetime by design, so a subscriber
-    /// arriving after the token (or a second subscriber, ever) can't
-    /// silently see nothing.
-    private static let lock = NSLock()
+    /// already delivered one, and a consumer that goes away is removed
+    /// on termination (the house pattern — see
+    /// `NostrRelaysRepository.snapshots`) so a cancelled subscriber
+    /// does not leak its continuation for the process's life.
+    private nonisolated static let lock = NSLock()
     // nonisolated(unsafe): every touch is under `lock`.
     private nonisolated(unsafe) static var latestToken: Data?
-    private nonisolated(unsafe) static var continuations: [AsyncStream<Data>.Continuation] = []
+    private nonisolated(unsafe) static var continuations:
+        [UUID: AsyncStream<Data>.Continuation] = [:]
 
     /// Every token APNs hands this process, in order, starting with
     /// the most recent one if it already arrived. The token can rotate
     /// on restore or reinstall, so this is a stream, not a one-shot.
-    static var deviceTokens: AsyncStream<Data> {
+    nonisolated static var deviceTokens: AsyncStream<Data> {
         AsyncStream { continuation in
+            let id = UUID()
             lock.lock()
-            defer { lock.unlock() }
-            continuations.append(continuation)
-            if let latestToken {
-                continuation.yield(latestToken)
+            continuations[id] = continuation
+            let replay = latestToken
+            lock.unlock()
+            continuation.onTermination = { _ in
+                lock.lock()
+                defer { lock.unlock() }
+                continuations.removeValue(forKey: id)
+            }
+            if let replay {
+                continuation.yield(replay)
             }
         }
+    }
+
+    /// Disabling push drops the replayed token: nothing left in the
+    /// app should want it, and a stale secret should not outlive its
+    /// use. APNs re-delivers on the next `registerForRemoteNotifications`.
+    nonisolated static func clearLatestToken() {
+        lock.lock()
+        defer { lock.unlock() }
+        latestToken = nil
     }
 
     func application(
@@ -49,7 +66,7 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
     ) {
         Self.lock.lock()
         Self.latestToken = deviceToken
-        let subscribers = Self.continuations
+        let subscribers = Array(Self.continuations.values)
         Self.lock.unlock()
         for continuation in subscribers {
             continuation.yield(deviceToken)

--- a/Sources/OnymIOS/PushAppDelegate.swift
+++ b/Sources/OnymIOS/PushAppDelegate.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+/// The one thing an app delegate is still required for: APNs delivers
+/// the device token through `UIApplicationDelegate` callbacks, not a
+/// modern async API. This delegate does nothing else — the token is
+/// relayed into a stream `PushCoordinator` consumes, and failures are
+/// silent (registration is retried on the next foreground; per the
+/// no-activity-logging stance nothing is recorded).
+final class PushAppDelegate: NSObject, UIApplicationDelegate {
+    private static let pipe = AsyncStream.makeStream(of: Data.self)
+
+    /// Every token APNs hands this process, in order. The token can
+    /// rotate on restore or reinstall, so this is a stream, not a
+    /// one-shot.
+    static var deviceTokens: AsyncStream<Data> { pipe.stream }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Self.pipe.continuation.yield(deviceToken)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        // Quiet by design; the reconciler retries on later inputs.
+    }
+}

--- a/Sources/OnymIOS/PushCoordinator.swift
+++ b/Sources/OnymIOS/PushCoordinator.swift
@@ -35,7 +35,12 @@ actor PushCoordinator {
     private let identityRepository: IdentityRepository
     private let relaysRepository: NostrRelaysRepository
 
-    private var latestTags: [String] = []
+    /// nil until the first identity read completes — an actually-empty
+    /// identity list (loaded, count 0) becomes `[]`, which is
+    /// meaningful and clears the backend's tag set. The distinction
+    /// keeps a slow keychain read from causing an empty-set register
+    /// followed immediately by a re-register.
+    private var latestTags: [String]?
     private var latestRelays: [String] = []
 
     init(
@@ -57,6 +62,14 @@ actor PushCoordinator {
 
     nonisolated var isEnabled: Bool {
         preferences.isEnabled
+    }
+
+    /// Enabled but not yet accepted by the backend: authorization was
+    /// granted, but no registration fingerprint has been recorded —
+    /// Settings shows this as "activating" rather than claiming the
+    /// wake path works before it does.
+    nonisolated var registrationPending: Bool {
+        preferences.isEnabled && preferences.lastRegistrationFingerprint == nil
     }
 
     /// Runs for the scene's life from a `RootView`-level `.task`.
@@ -98,8 +111,19 @@ actor PushCoordinator {
     }
 
     /// Foreground hook, same shape as the moderation gate's: gives the
-    /// interactor its periodic-refresh opportunity without a timer.
+    /// interactor its periodic-refresh opportunity without a timer —
+    /// and reconciles with system Settings first: if the user revoked
+    /// notification authorization there while the in-app preference
+    /// says on, the toggle is a lie and the server still holds a
+    /// registration, so this runs the full disable path.
     func appForegrounded() async {
+        if preferences.isEnabled {
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            if settings.authorizationStatus == .denied {
+                await disable()
+                return
+            }
+        }
         await interactor.appForegrounded()
     }
 
@@ -135,7 +159,7 @@ actor PushCoordinator {
     /// empty identity list clears the backend's tag set (the device
     /// row survives, so re-adding an identity needs no re-consent).
     private func pushDesiredSubscriptions() async {
-        guard !latestRelays.isEmpty else { return }
+        guard let latestTags, !latestRelays.isEmpty else { return }
         let subscriptions = latestTags.map {
             PushSubscription(tag: $0, relays: latestRelays)
         }

--- a/Sources/OnymIOS/PushCoordinator.swift
+++ b/Sources/OnymIOS/PushCoordinator.swift
@@ -40,7 +40,12 @@ actor PushCoordinator {
     /// keeps a slow keychain read from causing an empty-set register
     /// followed immediately by a re-register.
     private var latestTags: [String]?
-    private var latestRelays: [String] = []
+    /// Same nil-until-loaded shape as `latestTags`: nil means the
+    /// relay configuration has not been read yet, `[]` is meaningful —
+    /// the user removed every relay, so nothing is watchable and the
+    /// backend's subscription set must be cleared (see
+    /// `pushDesiredSubscriptions`).
+    private var latestRelays: [String]?
 
     init(
         identityRepository: IdentityRepository,
@@ -179,12 +184,19 @@ actor PushCoordinator {
 
     /// Every identity's tag, watched on every configured relay. An
     /// empty identity list clears the backend's tag set (the device
-    /// row survives, so re-adding an identity needs no re-consent).
+    /// row survives, so re-adding an identity needs no re-consent) —
+    /// and an empty *relay* list resolves to the same empty
+    /// subscription set: with no relay to watch, no tag is watchable,
+    /// and the backend refuses entries with zero relays. The two empty
+    /// cases are therefore symmetric on the wire; what they share is
+    /// "stop watching everything, keep the device registered". Only a
+    /// not-yet-loaded input (nil) is withheld, so a slow first read
+    /// can't cause a clearing register followed by a re-register.
     private func pushDesiredSubscriptions() async {
-        guard let latestTags, !latestRelays.isEmpty else { return }
-        let subscriptions = latestTags.map {
-            PushSubscription(tag: $0, relays: latestRelays)
-        }
+        guard let latestTags, let latestRelays else { return }
+        let subscriptions = latestRelays.isEmpty
+            ? []
+            : latestTags.map { PushSubscription(tag: $0, relays: latestRelays) }
         await interactor.updateSubscriptions(subscriptions)
     }
 

--- a/Sources/OnymIOS/PushCoordinator.swift
+++ b/Sources/OnymIOS/PushCoordinator.swift
@@ -1,0 +1,148 @@
+import Foundation
+import OnymFoundation
+import OnymIdentity
+import OnymModeration
+import OnymPush
+import OnymTransportNostr
+import UIKit
+import UserNotifications
+
+/// The moderation signer already has exactly the shape the push seam
+/// needs (`userKeyID` + detached `sign`), so it serves both. The push
+/// backend verifies the key and discards it — which identity signs is
+/// immaterial there.
+extension IdentityModerationSigner: PushSigner {}
+
+/// Push's attestation seam over the same `DCDevice` provider the
+/// moderation stack uses: a fresh token per call, nil where the
+/// platform has none (simulator, enterprise build).
+struct DCDevicePushAttestation: PushDeviceAttestationProvider {
+    private let provider = DCDeviceAttestationProvider()
+
+    func currentToken() async -> Data? {
+        try? await provider.generateToken()
+    }
+}
+
+/// Owns the push stack's app-side lifecycle: feeds the reconciling
+/// interactor from the APNs token stream, the identity list, and the
+/// relay configuration, and gives Settings its enable/disable
+/// behavior. Observation only — transports and repositories are never
+/// driven from here.
+actor PushCoordinator {
+    private let interactor: PushRegistrationInteractor
+    private let preferences: PushPreferenceStore
+    private let identityRepository: IdentityRepository
+    private let relaysRepository: NostrRelaysRepository
+
+    private var latestTags: [String] = []
+    private var latestRelays: [String] = []
+
+    init(
+        identityRepository: IdentityRepository,
+        relaysRepository: NostrRelaysRepository,
+        client: PushBackendClient = URLSessionPushBackendClient(),
+        preferences: PushPreferenceStore = PushPreferenceStore()
+    ) {
+        self.identityRepository = identityRepository
+        self.relaysRepository = relaysRepository
+        self.preferences = preferences
+        self.interactor = PushRegistrationInteractor(
+            client: client,
+            signer: IdentityModerationSigner(repository: identityRepository),
+            attestation: DCDevicePushAttestation(),
+            preferences: preferences
+        )
+    }
+
+    nonisolated var isEnabled: Bool {
+        preferences.isEnabled
+    }
+
+    /// Runs for the scene's life from a `RootView`-level `.task`.
+    func run() async {
+        if preferences.isEnabled {
+            // A fresh launch with push already enabled re-requests the
+            // token — it can have rotated while the app was gone.
+            await registerWithAPNs()
+        }
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { [interactor] in
+                for await token in PushAppDelegate.deviceTokens {
+                    await interactor.updateToken(token)
+                }
+            }
+            group.addTask { await self.observeIdentities() }
+            group.addTask { await self.observeRelays() }
+        }
+    }
+
+    /// Settings turned push on. Returns false when the system
+    /// authorization was denied (the opt-in is then NOT recorded).
+    func enable() async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        let granted =
+            (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+        guard granted else { return false }
+        preferences.setEnabled(true)
+        await registerWithAPNs()
+        await interactor.pushEnabled()
+        return true
+    }
+
+    /// Settings turned push off: the backend forgets this device.
+    func disable() async {
+        preferences.setEnabled(false)
+        await MainActor.run { UIApplication.shared.unregisterForRemoteNotifications() }
+        await interactor.pushDisabled()
+    }
+
+    /// Foreground hook, same shape as the moderation gate's: gives the
+    /// interactor its periodic-refresh opportunity without a timer.
+    func appForegrounded() async {
+        await interactor.appForegrounded()
+    }
+
+    // MARK: - Inputs
+
+    private func observeIdentities() async {
+        if let summaries = try? await identityRepository.currentIdentities() {
+            await apply(tags: summaries.map { InboxTag.derive(from: $0.inboxPublicKey) })
+        }
+        for await summaries in identityRepository.identitiesStream {
+            await apply(tags: summaries.map { InboxTag.derive(from: $0.inboxPublicKey) })
+        }
+    }
+
+    private func observeRelays() async {
+        await apply(relays: relaysRepository.currentEndpoints().map(\.url.absoluteString))
+        for await snapshot in relaysRepository.snapshots {
+            await apply(relays: snapshot.endpoints.map(\.url.absoluteString))
+        }
+    }
+
+    private func apply(tags: [String]) async {
+        latestTags = tags
+        await pushDesiredSubscriptions()
+    }
+
+    private func apply(relays: [String]) async {
+        latestRelays = relays
+        await pushDesiredSubscriptions()
+    }
+
+    /// Every identity's tag, watched on every configured relay. An
+    /// empty identity list clears the backend's tag set (the device
+    /// row survives, so re-adding an identity needs no re-consent).
+    private func pushDesiredSubscriptions() async {
+        guard !latestRelays.isEmpty else { return }
+        let subscriptions = latestTags.map {
+            PushSubscription(tag: $0, relays: latestRelays)
+        }
+        await interactor.updateSubscriptions(subscriptions)
+    }
+
+    private func registerWithAPNs() async {
+        await MainActor.run { UIApplication.shared.registerForRemoteNotifications() }
+    }
+}

--- a/Sources/OnymIOS/PushCoordinator.swift
+++ b/Sources/OnymIOS/PushCoordinator.swift
@@ -34,6 +34,11 @@ actor PushCoordinator {
     private let preferences: PushPreferenceStore
     private let identityRepository: IdentityRepository
     private let relaysRepository: NostrRelaysRepository
+    /// Whether the system's notification authorization has been
+    /// revoked. Injected so the privacy-load-bearing "revoked while
+    /// enabled ⇒ full disable" gate is unit-testable; production reads
+    /// `UNUserNotificationCenter`.
+    private let notificationAuthorizationDenied: @Sendable () async -> Bool
 
     /// nil until the first identity read completes — an actually-empty
     /// identity list (loaded, count 0) becomes `[]`, which is
@@ -47,11 +52,16 @@ actor PushCoordinator {
         identityRepository: IdentityRepository,
         relaysRepository: NostrRelaysRepository,
         client: PushBackendClient = URLSessionPushBackendClient(),
-        preferences: PushPreferenceStore = PushPreferenceStore()
+        preferences: PushPreferenceStore = PushPreferenceStore(),
+        notificationAuthorizationDenied: @escaping @Sendable () async -> Bool = {
+            await UNUserNotificationCenter.current()
+                .notificationSettings().authorizationStatus == .denied
+        }
     ) {
         self.identityRepository = identityRepository
         self.relaysRepository = relaysRepository
         self.preferences = preferences
+        self.notificationAuthorizationDenied = notificationAuthorizationDenied
         self.interactor = PushRegistrationInteractor(
             client: client,
             signer: IdentityModerationSigner(repository: identityRepository),
@@ -75,9 +85,20 @@ actor PushCoordinator {
     /// Runs for the scene's life from a `RootView`-level `.task`.
     func run() async {
         if preferences.isEnabled {
-            // A fresh launch with push already enabled re-requests the
-            // token — it can have rotated while the app was gone.
-            await registerWithAPNs()
+            // Cold launch reconciles with system Settings BEFORE
+            // touching APNs: SwiftUI never fires `.onChange(of:
+            // scenePhase)` for the initial `.active`, so without this
+            // check here an authorization revoked while the app was
+            // gone would leave the server registration alive until
+            // some later foreground.
+            if await notificationAuthorizationDenied() {
+                await disable()
+            } else {
+                // A fresh launch with push already enabled re-requests
+                // the token — it can have rotated while the app was
+                // gone.
+                await registerWithAPNs()
+            }
         }
         await withTaskGroup(of: Void.self) { group in
             group.addTask { [interactor] in
@@ -108,6 +129,10 @@ actor PushCoordinator {
         preferences.setEnabled(false)
         await MainActor.run { UIApplication.shared.unregisterForRemoteNotifications() }
         await interactor.pushDisabled()
+        // Nothing left in the app should want the token; drop the
+        // replayed copy rather than holding a secret longer than
+        // needed. APNs re-delivers on the next enable.
+        PushAppDelegate.clearLatestToken()
     }
 
     /// Foreground hook, same shape as the moderation gate's: gives the
@@ -117,12 +142,9 @@ actor PushCoordinator {
     /// says on, the toggle is a lie and the server still holds a
     /// registration, so this runs the full disable path.
     func appForegrounded() async {
-        if preferences.isEnabled {
-            let settings = await UNUserNotificationCenter.current().notificationSettings()
-            if settings.authorizationStatus == .denied {
-                await disable()
-                return
-            }
+        if preferences.isEnabled, await notificationAuthorizationDenied() {
+            await disable()
+            return
         }
         await interactor.appForegrounded()
     }

--- a/Sources/OnymIOS/PushCoordinator.swift
+++ b/Sources/OnymIOS/PushCoordinator.swift
@@ -7,12 +7,6 @@ import OnymTransportNostr
 import UIKit
 import UserNotifications
 
-/// The moderation signer already has exactly the shape the push seam
-/// needs (`userKeyID` + detached `sign`), so it serves both. The push
-/// backend verifies the key and discards it — which identity signs is
-/// immaterial there.
-extension IdentityModerationSigner: PushSigner {}
-
 /// Push's attestation seam over the same `DCDevice` provider the
 /// moderation stack uses: a fresh token per call, nil where the
 /// platform has none (simulator, enterprise build).
@@ -52,6 +46,12 @@ actor PushCoordinator {
         identityRepository: IdentityRepository,
         relaysRepository: NostrRelaysRepository,
         client: PushBackendClient = URLSessionPushBackendClient(),
+        // The device-local push key, never an identity's key: push
+        // registrations refresh on their own schedule, and an
+        // identity-keyed signature would let the backend link the
+        // persona keys that sign successive refreshes for one device
+        // token. See `DevicePushSigner`.
+        signer: PushSigner = DevicePushSigner(),
         preferences: PushPreferenceStore = PushPreferenceStore(),
         notificationAuthorizationDenied: @escaping @Sendable () async -> Bool = {
             await UNUserNotificationCenter.current()
@@ -64,7 +64,7 @@ actor PushCoordinator {
         self.notificationAuthorizationDenied = notificationAuthorizationDenied
         self.interactor = PushRegistrationInteractor(
             client: client,
-            signer: IdentityModerationSigner(repository: identityRepository),
+            signer: signer,
             attestation: DCDevicePushAttestation(),
             preferences: preferences
         )

--- a/Sources/OnymIOS/PushCoordinator.swift
+++ b/Sources/OnymIOS/PushCoordinator.swift
@@ -194,10 +194,58 @@ actor PushCoordinator {
     /// can't cause a clearing register followed by a re-register.
     private func pushDesiredSubscriptions() async {
         guard let latestTags, let latestRelays else { return }
-        let subscriptions = latestRelays.isEmpty
+        let relays = Self.cappedRelays(latestRelays)
+        let subscriptions = relays.isEmpty
             ? []
-            : latestTags.map { PushSubscription(tag: $0, relays: latestRelays) }
+            : latestTags.map { PushSubscription(tag: $0, relays: relays) }
         await interactor.updateSubscriptions(subscriptions)
+    }
+
+    // MARK: - Backend relay caps
+
+    /// The deployed backend's per-request caps
+    /// (onym-push `apple/README.md`, `apple/src/config.rs` defaults):
+    /// at most 4 relays per tag, 8 distinct relay hosts per device,
+    /// and 4 URLs per host per device. Every tag shares this one relay
+    /// list, so capping the list once satisfies the per-tag cap —
+    /// and because 4 URLs can span at most 4 hosts with at most 4 on
+    /// any one, it satisfies both host caps too; they are still
+    /// enforced here explicitly so a future cap change fails safe.
+    private static let maxRelaysPerTag = 4
+    private static let maxRelayHosts = 8
+    private static let maxRelaysPerHost = 4
+
+    /// The one relay the backend exempts from its capacity caps.
+    static let defaultRelayURL = "wss://nostr.onym.app"
+
+    /// Truncates the configured relay list to what the backend will
+    /// accept, deterministically: the default relay first (the backend
+    /// exempts it from capacity caps, so it is the never-wasted slot),
+    /// then the user's configured relays in their configured order,
+    /// deduplicated, dropped once any cap is reached. Truncation is
+    /// silent by design — recording "which relays we didn't register"
+    /// would be an activity log this app declines to keep, and a
+    /// refused register would silence pushes entirely, which is worse
+    /// than watching the user's four highest-priority relays.
+    static func cappedRelays(_ configured: [String]) -> [String] {
+        var ordered = configured
+        if let index = ordered.firstIndex(of: defaultRelayURL), index != 0 {
+            ordered.remove(at: index)
+            ordered.insert(defaultRelayURL, at: 0)
+        }
+        var result: [String] = []
+        var urlsPerHost: [String: Int] = [:]
+        for relay in ordered {
+            guard result.count < maxRelaysPerTag else { break }
+            guard !result.contains(relay) else { continue }
+            let host = URL(string: relay)?.host?.lowercased() ?? relay
+            let count = urlsPerHost[host] ?? 0
+            if count == 0, urlsPerHost.count >= maxRelayHosts { continue }
+            guard count < maxRelaysPerHost else { continue }
+            urlsPerHost[host] = count + 1
+            result.append(relay)
+        }
+        return result
     }
 
     private func registerWithAPNs() async {

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -171,6 +171,9 @@ struct RootView: View {
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
                 dependencies.moderationGateFlow.appForegrounded()
+                if let pushCoordinator = dependencies.pushCoordinator {
+                    Task { await pushCoordinator.appForegrounded() }
+                }
             }
         }
         // Settings → Restart Onboarding: present a fresh walk
@@ -357,7 +360,8 @@ struct RootView: View {
                             { restart.requestRestart() }
                         },
                         makeDeviceBackupView: deviceBackupView.map { view in { view } },
-                        makeBackupOperatorSettingsFlow: dependencies.makeBackupOperatorSettingsFlow
+                        makeBackupOperatorSettingsFlow: dependencies.makeBackupOperatorSettingsFlow,
+                        makeNotificationsSettingsFlow: dependencies.makeNotificationsSettingsFlow
                     )
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/project.yml
+++ b/project.yml
@@ -183,6 +183,9 @@ targets:
           - applinks:onym.app
         # Push notifications. `development` is the source-entitlements
         # value; automatic signing flips it to `production` on export.
+        # CAVEAT: only *automatic* signing rewrites it — a manually
+        # signed archive ships this development entitlement verbatim,
+        # and the app silently talks to APNs' sandbox in production.
         # Pushes are content-free alerts, so no UIBackgroundModes.
         aps-environment: development
     settings:

--- a/project.yml
+++ b/project.yml
@@ -76,6 +76,7 @@ targets:
       - package: OnymModerationUI
       - package: OnymDiscovery
       - package: OnymOnboarding
+      - package: OnymPush
     # Hand-written Info.plist via xcodegen's `info:` block. We tried
     # the GENERATE_INFOPLIST_FILE + INFOPLIST_KEY_* approach first but
     # `INFOPLIST_KEY_UILaunchScreen_BackgroundColor` / `_ImageName` are
@@ -180,6 +181,10 @@ targets:
         # over once Apple's CDN has fetched + validated the file.
         com.apple.developer.associated-domains:
           - applinks:onym.app
+        # Push notifications. `development` is the source-entitlements
+        # value; automatic signing flips it to `production` on export.
+        # Pushes are content-free alerts, so no UIBackgroundModes.
+        aps-environment: development
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.onym.ios

--- a/project.yml
+++ b/project.yml
@@ -182,10 +182,11 @@ targets:
         com.apple.developer.associated-domains:
           - applinks:onym.app
         # Push notifications. `development` is the source-entitlements
-        # value; automatic signing flips it to `production` on export.
-        # CAVEAT: only *automatic* signing rewrites it — a manually
-        # signed archive ships this development entitlement verbatim,
-        # and the app silently talks to APNs' sandbox in production.
+        # value; automatic signing flips it to `production` on export —
+        # and this target signs automatically (CODE_SIGN_STYLE:
+        # Automatic, below), so the caveat about manually signed
+        # archives shipping the sandbox entitlement is inert here; it
+        # would matter only if signing ever moved to Manual.
         # Pushes are content-free alerts, so no UIBackgroundModes.
         aps-environment: development
     settings:


### PR DESCRIPTION
Second iOS PR, on top of #311. The OnymPush package gets wired into the app; nothing leaves the device until the user flips the Settings toggle.

- **`PushAppDelegate`** — the app's first `UIApplicationDelegate`, existing solely because APNs tokens only arrive through delegate callbacks. It relays them into a replaying multicast `AsyncStream` (replay yielded under the delivery lock, so a stale token can never land after a fresher one) and does nothing else.
- **`PushCoordinator`** — observes `identitiesStream` (tags via the hoisted `InboxTag`), `NostrRelaysRepository.snapshots` (relay set, nil-until-loaded so an empty list is a meaningful "stop watching everything"), and the token stream, feeding the package's reconciling interactor. Relay lists are truncated client-side against the deployed backend's caps (4 per tag, 8 hosts, 4 per host), default relay first. Attestation adapts the same `DCDevice` provider moderation uses. Foreground re-reconciliation hooks the existing `scenePhase` block beside the moderation gate.
- **`DevicePushSigner`** — push registrations are signed by a device-local Ed25519 key minted on first use and kept in the Keychain, used for push and nothing else. The backend verifies and discards the key, so any key authenticates; a per-install random key carries zero identity linkage and never rotates with persona switches — identity keys stay out of the push payload entirely.
- **Settings → Notifications** — optional-factory pattern like moderation/discovery, so harness builds show no row. Toggle default OFF; enabling runs system authorization → APNs registration → backend register, and a denial snaps the switch back and points at system Settings. The copy states the actual trade (transport-honesty style): what leaves the device is inbox codes, an encrypted push token, a per-device signing key linked to no identity, and a device-attestation token; Apple carries a content-free "New message"; nobody sees content, senders, or groups. `NotificationsSettingsFlow` is closure-injected, keeping OnymSettings free of any OnymPush dependency.
- **`InboxTag` hoist** — the same eight-byte SHA-256 formula existed in six private copies (IdentityRepository, SendMessageInteractor, InboxFanoutInteractor, IntroInboxPump, CreateGroupInteractor, ChatReceiptSender); all now delegate to one `OnymFoundation.InboxTag.derive(from:)`. Push registration is the seventh caller and did not want to be the seventh copy.
- **project.yml** — OnymPush package (app + unit-test targets), `aps-environment: development` in the generated entitlements (inert caveat under automatic signing). No `UIBackgroundModes`: pushes are plain alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf
