### PR TITLE
Tests for the bytes both sides must agree on, and the silences between

### DIFF
--- a/Packages/OnymFoundation/Tests/OnymFoundationTests/InboxTagTests.swift
+++ b/Packages/OnymFoundation/Tests/OnymFoundationTests/InboxTagTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XCTest
+@testable import OnymFoundation
+
+/// Golden vector for the one formula behind every inbox route. Seven
+/// call sites (senders, subscribers, the identity repository, push
+/// registration) derive tags through `InboxTag.derive`; this pin is
+/// what stands between them and a silent formula edit that would
+/// re-route every inbox at once. The hex was computed by an
+/// independent oracle (Python hashlib over
+/// `SHA256("sep-inbox-v1" || key)[..8]`) — regenerate it there, never
+/// by re-running the Swift under test.
+final class InboxTagTests: XCTestCase {
+    func testDeriveMatchesThePinnedVector() {
+        let key = Data(0..<32) // 000102…1f
+        XCTAssertEqual(InboxTag.derive(from: key), "fdee1b12aa915aa3")
+    }
+
+    func testDeriveOfEmptyKeyIsStillDomainSeparated() {
+        // SHA256("sep-inbox-v1") — the prefix alone. Pinned so the
+        // domain-separation string itself cannot drift unnoticed.
+        XCTAssertEqual(InboxTag.derive(from: Data()), "064cb2d524b4d3fe")
+    }
+}

--- a/Packages/OnymPush/Sources/OnymPush/StubPushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/StubPushBackendClient.swift
@@ -23,6 +23,10 @@ public actor StubPushBackendClient: PushBackendClient {
     public var registrationKeyAnswer: Data
     public var registerAnswer: Result<PushRegisterResponse, Error>
     public var unregisterAnswer: Result<Void, Error>
+    /// Awaited inside `register` before the request is recorded — a
+    /// test can hold a register "in flight" (e.g. behind a gate it
+    /// controls) while it interleaves a disable, then let it land.
+    public var onRegister: (@Sendable () async -> Void)?
 
     public init(
         registrationKeyAnswer: Data = StubPushBackendClient.defaultRegistrationKey,
@@ -40,6 +44,9 @@ public actor StubPushBackendClient: PushBackendClient {
     }
 
     public func register(_ request: PushRegisterRequest) async throws -> PushRegisterResponse {
+        if let onRegister {
+            await onRegister()
+        }
         registered.append(request)
         return try registerAnswer.get()
     }
@@ -61,7 +68,7 @@ public actor StubPushBackendClient: PushBackendClient {
         registrationKeyAnswer = key
     }
 
-    public func setUnregisterAnswer(_ answer: Result<Void, Error>) {
-        unregisterAnswer = answer
+    public func setOnRegister(_ hook: (@Sendable () async -> Void)?) {
+        onRegister = hook
     }
 }

--- a/Packages/OnymPush/Sources/OnymPush/StubPushBackendClient.swift
+++ b/Packages/OnymPush/Sources/OnymPush/StubPushBackendClient.swift
@@ -53,6 +53,10 @@ public actor StubPushBackendClient: PushBackendClient {
         registerAnswer = answer
     }
 
+    public func setUnregisterAnswer(_ answer: Result<Void, Error>) {
+        unregisterAnswer = answer
+    }
+
     public func setRegistrationKeyAnswer(_ key: Data) {
         registrationKeyAnswer = key
     }

--- a/Tests/OnymIOSTests/NotificationsSettingsFlowTests.swift
+++ b/Tests/OnymIOSTests/NotificationsSettingsFlowTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import OnymSettings
+
+/// The Notifications screen's state machine: the toggle must never
+/// claim more than what actually happened — authorization denied snaps
+/// back, overlapping flips don't double-run, and "on" is distinguished
+/// from "accepted by the backend".
+@MainActor
+final class NotificationsSettingsFlowTests: XCTestCase {
+    func testDeniedAuthorizationSnapsBackAndSaysWhy() async {
+        let flow = NotificationsSettingsFlow(
+            isEnabled: false,
+            enable: { false },
+            disable: {}
+        )
+
+        await flow.setEnabled(true)
+
+        XCTAssertFalse(flow.isEnabled)
+        XCTAssertTrue(flow.authorizationDenied)
+        XCTAssertFalse(flow.isWorking)
+    }
+
+    func testGrantedAuthorizationEnables() async {
+        let flow = NotificationsSettingsFlow(
+            isEnabled: false,
+            enable: { true },
+            disable: {}
+        )
+
+        await flow.setEnabled(true)
+
+        XCTAssertTrue(flow.isEnabled)
+        XCTAssertFalse(flow.authorizationDenied)
+    }
+
+    /// A flip while the previous flip is still working is dropped —
+    /// two overlapping enables would prompt twice and register twice.
+    func testReentrantSetEnabledIsDropped() async {
+        let enableCalls = Counter()
+        let gate = AsyncGate()
+        let flow = NotificationsSettingsFlow(
+            isEnabled: false,
+            enable: {
+                await enableCalls.increment()
+                await gate.wait()
+                return true
+            },
+            disable: {}
+        )
+
+        let first = Task { await flow.setEnabled(true) }
+        // Let the first flip reach the suspension inside enable().
+        await Task.yield()
+        while await enableCalls.value == 0 { await Task.yield() }
+        XCTAssertTrue(flow.isWorking)
+
+        // Second flip while working: rejected without a second call.
+        await flow.setEnabled(true)
+
+        await gate.open()
+        await first.value
+
+        let calls = await enableCalls.value
+        XCTAssertEqual(calls, 1)
+        XCTAssertTrue(flow.isEnabled)
+    }
+
+    /// Turning off clears a stale denial note — it described a
+    /// previous attempt, and the switch now honestly reads off.
+    func testDisableClearsTheDenialNote() async {
+        let denyFirst = Flag(true)
+        let flow = NotificationsSettingsFlow(
+            isEnabled: false,
+            enable: {
+                defer { denyFirst.value = false }
+                return !denyFirst.value
+            },
+            disable: {}
+        )
+        await flow.setEnabled(true) // denied → note shows
+        XCTAssertTrue(flow.authorizationDenied)
+
+        await flow.setEnabled(true) // granted this time
+        await flow.setEnabled(false) // an explicit off makes it stale
+        XCTAssertFalse(flow.isEnabled)
+        XCTAssertFalse(flow.authorizationDenied)
+    }
+
+    /// "On" is not "registered": the pending note tracks the injected
+    /// probe on init, after each flip, and on explicit refresh.
+    func testRegistrationPendingFollowsTheProbe() async {
+        let pending = Flag(true)
+        let flow = NotificationsSettingsFlow(
+            isEnabled: true,
+            enable: { true },
+            disable: {},
+            isRegistrationPending: { pending.value }
+        )
+        XCTAssertTrue(flow.registrationPending)
+
+        pending.value = false
+        flow.refreshRegistrationState()
+        XCTAssertFalse(flow.registrationPending)
+
+        pending.value = true
+        await flow.setEnabled(false)
+        XCTAssertTrue(flow.registrationPending)
+    }
+}
+
+// MARK: - Small test actors
+
+private actor Counter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}
+
+private actor AsyncGate {
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        opened = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+}
+
+/// A mutable box the @MainActor tests flip between reads.
+@MainActor
+private final class Flag {
+    var value: Bool
+    init(_ value: Bool) { self.value = value }
+}

--- a/Tests/OnymIOSTests/NotificationsSettingsFlowTests.swift
+++ b/Tests/OnymIOSTests/NotificationsSettingsFlowTests.swift
@@ -107,6 +107,32 @@ final class NotificationsSettingsFlowTests: XCTestCase {
         await flow.setEnabled(false)
         XCTAssertTrue(flow.registrationPending)
     }
+
+    /// The coordinator can disable underneath a still-mounted screen
+    /// (authorization revoked in system Settings, app foregrounded
+    /// back onto this view): the refresh re-reads the persisted opt-in
+    /// through the injected closure instead of trusting the
+    /// presentation-time snapshot.
+    func testRefreshResyncsIsEnabledFromTheStore() async {
+        let stored = Flag(true)
+        let flow = NotificationsSettingsFlow(
+            isEnabled: true,
+            enable: { true },
+            disable: {},
+            readIsEnabled: { stored.value }
+        )
+        XCTAssertTrue(flow.isEnabled)
+
+        // The coordinator disabled off-screen.
+        stored.value = false
+        flow.refreshRegistrationState()
+        XCTAssertFalse(flow.isEnabled)
+
+        // And a re-enable elsewhere reads back too.
+        stored.value = true
+        flow.refreshRegistrationState()
+        XCTAssertTrue(flow.isEnabled)
+    }
 }
 
 // MARK: - Small test actors

--- a/Tests/OnymIOSTests/NotificationsSettingsFlowTests.swift
+++ b/Tests/OnymIOSTests/NotificationsSettingsFlowTests.swift
@@ -38,7 +38,7 @@ final class NotificationsSettingsFlowTests: XCTestCase {
     /// two overlapping enables would prompt twice and register twice.
     func testReentrantSetEnabledIsDropped() async {
         let enableCalls = Counter()
-        let gate = AsyncGate()
+        let gate = OneShotGate()
         let flow = NotificationsSettingsFlow(
             isEnabled: false,
             enable: {
@@ -58,7 +58,7 @@ final class NotificationsSettingsFlowTests: XCTestCase {
         // Second flip while working: rejected without a second call.
         await flow.setEnabled(true)
 
-        await gate.open()
+        gate.open()
         await first.value
 
         let calls = await enableCalls.value
@@ -140,22 +140,6 @@ final class NotificationsSettingsFlowTests: XCTestCase {
 private actor Counter {
     private(set) var value = 0
     func increment() { value += 1 }
-}
-
-private actor AsyncGate {
-    private var opened = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func wait() async {
-        if opened { return }
-        await withCheckedContinuation { waiters.append($0) }
-    }
-
-    func open() {
-        opened = true
-        for waiter in waiters { waiter.resume() }
-        waiters.removeAll()
-    }
 }
 
 /// A mutable box the @MainActor tests flip between reads.

--- a/Tests/OnymIOSTests/PushBackendClientTests.swift
+++ b/Tests/OnymIOSTests/PushBackendClientTests.swift
@@ -48,9 +48,9 @@ final class PushBackendClientTests: XCTestCase {
 
     /// Records the request URL and (streamed) body, answering `payload`
     /// with `status`. The handler runs on the URL loading system's
-    /// thread; `Recorder` carries the value back safely.
+    /// thread; `RecorderBox` carries the value back safely.
     private func recordRequests(
-        into recorded: Recorder<RecordedWire>,
+        into recorded: RecorderBox<RecordedWire>,
         status: Int = 200,
         payload: Data = Data()
     ) {
@@ -86,7 +86,7 @@ final class PushBackendClientTests: XCTestCase {
     }
 
     func testRegisterSendsCamelCaseBase64Body() async throws {
-        let recorded = Recorder<RecordedWire>()
+        let recorded = RecorderBox<RecordedWire>()
         recordRequests(
             into: recorded,
             payload: Data(#"{"expiresAt":"2026-10-21T12:00:00Z"}"#.utf8)
@@ -118,7 +118,7 @@ final class PushBackendClientTests: XCTestCase {
     }
 
     func testRegisterSendsPresentDeviceTokenAsBase64() async throws {
-        let recorded = Recorder<RecordedWire>()
+        let recorded = RecorderBox<RecordedWire>()
         recordRequests(
             into: recorded,
             payload: Data(#"{"expiresAt":"2026-10-21T12:00:00Z"}"#.utf8)
@@ -136,7 +136,7 @@ final class PushBackendClientTests: XCTestCase {
     /// base64 body shape minus subscriptions, and an empty 200 counts
     /// as success — there is nothing to decode.
     func testUnregisterSendsBodyAndAcceptsEmptyOK() async throws {
-        let recorded = Recorder<RecordedWire>()
+        let recorded = RecorderBox<RecordedWire>()
         recordRequests(into: recorded)
 
         try await makeClient().unregister(
@@ -194,7 +194,7 @@ final class PushBackendClientTests: XCTestCase {
     /// strategy does not — the dual-formatter decode is the client's
     /// sole reason both shapes work, so the fractional one is pinned.
     func testFractionalSecondsExpiryDecodes() async throws {
-        let recorded = Recorder<RecordedWire>()
+        let recorded = RecorderBox<RecordedWire>()
         recordRequests(
             into: recorded,
             payload: Data(#"{"expiresAt":"2026-10-21T12:00:00.250Z"}"#.utf8)

--- a/Tests/OnymIOSTests/PushBackendClientTests.swift
+++ b/Tests/OnymIOSTests/PushBackendClientTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import OnymPush
+
+/// Wire tests for `URLSessionPushBackendClient` against the push
+/// backend's shapes: camelCase + base64 `Data` request bodies, the
+/// `{error, message}` refusal envelope kept verbatim, and the
+/// https-only guard that no build relaxes.
+final class PushBackendClientTests: XCTestCase {
+    private let baseURL = URL(string: "https://push.example")!
+    private var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        session = StubURLProtocol.makeSession()
+    }
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        session = nil
+        super.tearDown()
+    }
+
+    private func makeClient(baseURL: URL? = nil) -> URLSessionPushBackendClient {
+        URLSessionPushBackendClient(baseURL: baseURL ?? self.baseURL, session: session)
+    }
+
+    private func makeRegisterRequest() throws -> PushRegisterRequest {
+        PushRegisterRequest(
+            deviceToken: nil,
+            userKey: "onym:key:aabb",
+            timestamp: ISO8601DateFormatter.push.date(from: "2026-08-22T12:00:00Z")!,
+            signature: Data([0x01]),
+            tokenEnvelope: PushTokenEnvelope(
+                ephemeralPublicKey: Data(repeating: 1, count: 32),
+                nonce: Data(repeating: 2, count: 12),
+                ciphertext: Data([0x03]),
+                authenticationTag: Data(repeating: 4, count: 16)
+            ),
+            subscriptions: [PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])]
+        )
+    }
+
+    func testInsecureBaseURLIsRefusedBeforeAnyRequest() async throws {
+        let client = makeClient(baseURL: URL(string: "http://push.example")!)
+        do {
+            _ = try await client.registrationKey()
+            XCTFail("http must be refused")
+        } catch let PushClientError.insecureBaseURL(url) {
+            XCTAssertEqual(url, "http://push.example")
+        }
+    }
+
+    func testRegisterSendsCamelCaseBase64Body() async throws {
+        let recorded = NSMutableDictionary()
+        StubURLProtocol.set(handler: { request in
+            recorded["url"] = request.url?.absoluteString
+            recorded["body"] = request.httpBody ?? request.httpBodyStream.map { stream in
+                stream.open()
+                defer { stream.close() }
+                var data = Data()
+                var buffer = [UInt8](repeating: 0, count: 4096)
+                while stream.hasBytesAvailable {
+                    let read = stream.read(&buffer, maxLength: buffer.count)
+                    guard read > 0 else { break }
+                    data.append(buffer, count: read)
+                }
+                return data
+            }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (Data(#"{"expiresAt":"2026-10-21T12:00:00Z"}"#.utf8), response)
+        })
+
+        let response = try await makeClient().register(makeRegisterRequest())
+        XCTAssertEqual(recorded["url"] as? String, "https://push.example/v1/register")
+        let body = try JSONSerialization.jsonObject(
+            with: recorded["body"] as? Data ?? Data()
+        ) as? [String: Any]
+        XCTAssertEqual(body?["userKey"] as? String, "onym:key:aabb")
+        XCTAssertEqual(body?["timestamp"] as? String, "2026-08-22T12:00:00Z")
+        let envelope = body?["tokenEnvelope"] as? [String: Any]
+        XCTAssertEqual(
+            envelope?["ephemeralPublicKey"] as? String,
+            Data(repeating: 1, count: 32).base64EncodedString()
+        )
+        let subscriptions = body?["subscriptions"] as? [[String: Any]]
+        XCTAssertEqual(subscriptions?.first?["tag"] as? String, "a1b2c3d4e5f60718")
+        XCTAssertEqual(
+            response.expiresAt,
+            ISO8601DateFormatter.push.date(from: "2026-10-21T12:00:00Z")
+        )
+    }
+
+    func testRefusalEnvelopeSurfacesVerbatim() async throws {
+        StubURLProtocol.set(handler: { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil
+            )!
+            return (
+                Data(#"{"error":"signature_invalid","message":"session signature already used"}"#.utf8),
+                response
+            )
+        })
+        do {
+            _ = try await makeClient().register(makeRegisterRequest())
+            XCTFail("401 must throw")
+        } catch let PushClientError.rejected(rejection) {
+            XCTAssertEqual(rejection.statusCode, 401)
+            XCTAssertEqual(rejection.rawCode, "signature_invalid")
+            XCTAssertEqual(rejection.message, "session signature already used")
+        }
+    }
+
+    func testRegistrationKeyDecodesBase64() async throws {
+        let key = Data(repeating: 7, count: 32)
+        StubURLProtocol.set(handler: { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://push.example/v1/registration-key")
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (Data(#"{"publicKey":"\#(key.base64EncodedString())"}"#.utf8), response)
+        })
+        let fetched = try await makeClient().registrationKey()
+        XCTAssertEqual(fetched, key)
+    }
+}

--- a/Tests/OnymIOSTests/PushBackendClientTests.swift
+++ b/Tests/OnymIOSTests/PushBackendClientTests.swift
@@ -24,9 +24,9 @@ final class PushBackendClientTests: XCTestCase {
         URLSessionPushBackendClient(baseURL: baseURL ?? self.baseURL, session: session)
     }
 
-    private func makeRegisterRequest() throws -> PushRegisterRequest {
+    private func makeRegisterRequest(deviceToken: Data? = nil) throws -> PushRegisterRequest {
         PushRegisterRequest(
-            deviceToken: nil,
+            deviceToken: deviceToken,
             userKey: "onym:key:aabb",
             timestamp: ISO8601DateFormatter.push.date(from: "2026-08-22T12:00:00Z")!,
             signature: Data([0x01]),
@@ -40,18 +40,13 @@ final class PushBackendClientTests: XCTestCase {
         )
     }
 
-    func testInsecureBaseURLIsRefusedBeforeAnyRequest() async throws {
-        let client = makeClient(baseURL: URL(string: "http://push.example")!)
-        do {
-            _ = try await client.registrationKey()
-            XCTFail("http must be refused")
-        } catch let PushClientError.insecureBaseURL(url) {
-            XCTAssertEqual(url, "http://push.example")
-        }
-    }
-
-    func testRegisterSendsCamelCaseBase64Body() async throws {
-        let recorded = NSMutableDictionary()
+    /// Records the request URL and (streamed) body, answering `payload`
+    /// with `status`.
+    private func recordRequests(
+        into recorded: NSMutableDictionary,
+        status: Int = 200,
+        payload: Data = Data()
+    ) {
         StubURLProtocol.set(handler: { request in
             recorded["url"] = request.url?.absoluteString
             recorded["body"] = request.httpBody ?? request.httpBodyStream.map { stream in
@@ -67,10 +62,28 @@ final class PushBackendClientTests: XCTestCase {
                 return data
             }
             let response = HTTPURLResponse(
-                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil
             )!
-            return (Data(#"{"expiresAt":"2026-10-21T12:00:00Z"}"#.utf8), response)
+            return (payload, response)
         })
+    }
+
+    func testInsecureBaseURLIsRefusedBeforeAnyRequest() async throws {
+        let client = makeClient(baseURL: URL(string: "http://push.example")!)
+        do {
+            _ = try await client.registrationKey()
+            XCTFail("http must be refused")
+        } catch let PushClientError.insecureBaseURL(url) {
+            XCTAssertEqual(url, "http://push.example")
+        }
+    }
+
+    func testRegisterSendsCamelCaseBase64Body() async throws {
+        let recorded = NSMutableDictionary()
+        recordRequests(
+            into: recorded,
+            payload: Data(#"{"expiresAt":"2026-10-21T12:00:00Z"}"#.utf8)
+        )
 
         let response = try await makeClient().register(makeRegisterRequest())
         XCTAssertEqual(recorded["url"] as? String, "https://push.example/v1/register")
@@ -79,6 +92,11 @@ final class PushBackendClientTests: XCTestCase {
         ) as? [String: Any]
         XCTAssertEqual(body?["userKey"] as? String, "onym:key:aabb")
         XCTAssertEqual(body?["timestamp"] as? String, "2026-08-22T12:00:00Z")
+        // A nil attestation token omits the key entirely — that
+        // missing-key form is the backend's contract (serde reads an
+        // absent `Option` as `None`), pinned here so a "helpful"
+        // null-encoding change fails a test, not production.
+        XCTAssertNil(body?["deviceToken"])
         let envelope = body?["tokenEnvelope"] as? [String: Any]
         XCTAssertEqual(
             envelope?["ephemeralPublicKey"] as? String,
@@ -89,6 +107,59 @@ final class PushBackendClientTests: XCTestCase {
         XCTAssertEqual(
             response.expiresAt,
             ISO8601DateFormatter.push.date(from: "2026-10-21T12:00:00Z")
+        )
+    }
+
+    func testRegisterSendsPresentDeviceTokenAsBase64() async throws {
+        let recorded = NSMutableDictionary()
+        recordRequests(
+            into: recorded,
+            payload: Data(#"{"expiresAt":"2026-10-21T12:00:00Z"}"#.utf8)
+        )
+        let attestation = Data("device-token".utf8)
+
+        _ = try await makeClient().register(makeRegisterRequest(deviceToken: attestation))
+        let body = try JSONSerialization.jsonObject(
+            with: recorded["body"] as? Data ?? Data()
+        ) as? [String: Any]
+        XCTAssertEqual(body?["deviceToken"] as? String, attestation.base64EncodedString())
+    }
+
+    /// The unregister wire: `POST /v1/unregister`, the same camelCase
+    /// base64 body shape minus subscriptions, and an empty 200 counts
+    /// as success — there is nothing to decode.
+    func testUnregisterSendsBodyAndAcceptsEmptyOK() async throws {
+        let recorded = NSMutableDictionary()
+        recordRequests(into: recorded)
+
+        try await makeClient().unregister(
+            PushUnregisterRequest(
+                deviceToken: nil,
+                userKey: "onym:key:aabb",
+                timestamp: ISO8601DateFormatter.push.date(from: "2026-08-22T12:00:00Z")!,
+                signature: Data([0x02]),
+                tokenEnvelope: PushTokenEnvelope(
+                    ephemeralPublicKey: Data(repeating: 1, count: 32),
+                    nonce: Data(repeating: 2, count: 12),
+                    ciphertext: Data([0x03]),
+                    authenticationTag: Data(repeating: 4, count: 16)
+                )
+            )
+        )
+
+        XCTAssertEqual(recorded["url"] as? String, "https://push.example/v1/unregister")
+        let body = try JSONSerialization.jsonObject(
+            with: recorded["body"] as? Data ?? Data()
+        ) as? [String: Any]
+        XCTAssertEqual(body?["userKey"] as? String, "onym:key:aabb")
+        XCTAssertEqual(body?["timestamp"] as? String, "2026-08-22T12:00:00Z")
+        XCTAssertNil(body?["deviceToken"])
+        XCTAssertEqual(body?["signature"] as? String, Data([0x02]).base64EncodedString())
+        XCTAssertNil(body?["subscriptions"])
+        let envelope = body?["tokenEnvelope"] as? [String: Any]
+        XCTAssertEqual(
+            envelope?["nonce"] as? String,
+            Data(repeating: 2, count: 12).base64EncodedString()
         )
     }
 

--- a/Tests/OnymIOSTests/PushBackendClientTests.swift
+++ b/Tests/OnymIOSTests/PushBackendClientTests.swift
@@ -170,6 +170,53 @@ final class PushBackendClientTests: XCTestCase {
         )
     }
 
+    /// A refusal whose body is not the `{error, message}` envelope (a
+    /// proxy's HTML, an empty body) still surfaces typed: the
+    /// synthetic `http_<status>` code, not a decode error.
+    func testNonEnvelopeRefusalFallsBackToSyntheticCode() async throws {
+        StubURLProtocol.set(handler: { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 503, httpVersion: nil, headerFields: nil
+            )!
+            return (Data("<html>upstream unavailable</html>".utf8), response)
+        })
+        do {
+            _ = try await makeClient().register(makeRegisterRequest())
+            XCTFail("503 must throw")
+        } catch let PushClientError.rejected(rejection) {
+            XCTAssertEqual(rejection.statusCode, 503)
+            XCTAssertEqual(rejection.rawCode, "http_503")
+            XCTAssertEqual(rejection.code, .unknown("http_503"))
+        }
+    }
+
+    /// RFC 3339 permits fractional seconds and Foundation's `.iso8601`
+    /// strategy does not — the dual-formatter decode is the client's
+    /// sole reason both shapes work, so the fractional one is pinned.
+    func testFractionalSecondsExpiryDecodes() async throws {
+        let recorded = Recorder<RecordedWire>()
+        recordRequests(
+            into: recorded,
+            payload: Data(#"{"expiresAt":"2026-10-21T12:00:00.250Z"}"#.utf8)
+        )
+        let response = try await makeClient().register(makeRegisterRequest())
+        let whole = ISO8601DateFormatter.push.date(from: "2026-10-21T12:00:00Z")!
+        XCTAssertEqual(response.expiresAt.timeIntervalSince(whole), 0.25, accuracy: 0.001)
+    }
+
+    /// The other half of the transport guard: an https scheme with an
+    /// *empty* host (`https:///`) is refused before any request, same
+    /// as a non-https scheme.
+    func testEmptyHostHTTPSBaseURLIsRefused() async throws {
+        let client = makeClient(baseURL: URL(string: "https:///push")!)
+        do {
+            _ = try await client.registrationKey()
+            XCTFail("an empty host must be refused")
+        } catch let PushClientError.insecureBaseURL(url) {
+            XCTAssertEqual(url, "https:///push")
+        }
+    }
+
     func testRefusalEnvelopeSurfacesVerbatim() async throws {
         StubURLProtocol.set(handler: { request in
             let response = HTTPURLResponse(

--- a/Tests/OnymIOSTests/PushBackendClientTests.swift
+++ b/Tests/OnymIOSTests/PushBackendClientTests.swift
@@ -24,7 +24,7 @@ final class PushBackendClientTests: XCTestCase {
         URLSessionPushBackendClient(baseURL: baseURL ?? self.baseURL, session: session)
     }
 
-    private func makeRegisterRequest(deviceToken: Data? = nil) throws -> PushRegisterRequest {
+    private func makeRegisterRequest(deviceToken: Data? = nil) -> PushRegisterRequest {
         PushRegisterRequest(
             deviceToken: deviceToken,
             userKey: "onym:key:aabb",

--- a/Tests/OnymIOSTests/PushBackendClientTests.swift
+++ b/Tests/OnymIOSTests/PushBackendClientTests.swift
@@ -40,16 +40,22 @@ final class PushBackendClientTests: XCTestCase {
         )
     }
 
+    /// What the URLProtocol handler saw of one request.
+    struct RecordedWire {
+        let url: String?
+        let body: Data?
+    }
+
     /// Records the request URL and (streamed) body, answering `payload`
-    /// with `status`.
+    /// with `status`. The handler runs on the URL loading system's
+    /// thread; `Recorder` carries the value back safely.
     private func recordRequests(
-        into recorded: NSMutableDictionary,
+        into recorded: Recorder<RecordedWire>,
         status: Int = 200,
         payload: Data = Data()
     ) {
         StubURLProtocol.set(handler: { request in
-            recorded["url"] = request.url?.absoluteString
-            recorded["body"] = request.httpBody ?? request.httpBodyStream.map { stream in
+            let body = request.httpBody ?? request.httpBodyStream.map { stream in
                 stream.open()
                 defer { stream.close() }
                 var data = Data()
@@ -61,6 +67,7 @@ final class PushBackendClientTests: XCTestCase {
                 }
                 return data
             }
+            recorded.record(RecordedWire(url: request.url?.absoluteString, body: body))
             let response = HTTPURLResponse(
                 url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil
             )!
@@ -79,16 +86,16 @@ final class PushBackendClientTests: XCTestCase {
     }
 
     func testRegisterSendsCamelCaseBase64Body() async throws {
-        let recorded = NSMutableDictionary()
+        let recorded = Recorder<RecordedWire>()
         recordRequests(
             into: recorded,
             payload: Data(#"{"expiresAt":"2026-10-21T12:00:00Z"}"#.utf8)
         )
 
         let response = try await makeClient().register(makeRegisterRequest())
-        XCTAssertEqual(recorded["url"] as? String, "https://push.example/v1/register")
+        XCTAssertEqual(recorded.value?.url, "https://push.example/v1/register")
         let body = try JSONSerialization.jsonObject(
-            with: recorded["body"] as? Data ?? Data()
+            with: recorded.value?.body ?? Data()
         ) as? [String: Any]
         XCTAssertEqual(body?["userKey"] as? String, "onym:key:aabb")
         XCTAssertEqual(body?["timestamp"] as? String, "2026-08-22T12:00:00Z")
@@ -111,7 +118,7 @@ final class PushBackendClientTests: XCTestCase {
     }
 
     func testRegisterSendsPresentDeviceTokenAsBase64() async throws {
-        let recorded = NSMutableDictionary()
+        let recorded = Recorder<RecordedWire>()
         recordRequests(
             into: recorded,
             payload: Data(#"{"expiresAt":"2026-10-21T12:00:00Z"}"#.utf8)
@@ -120,7 +127,7 @@ final class PushBackendClientTests: XCTestCase {
 
         _ = try await makeClient().register(makeRegisterRequest(deviceToken: attestation))
         let body = try JSONSerialization.jsonObject(
-            with: recorded["body"] as? Data ?? Data()
+            with: recorded.value?.body ?? Data()
         ) as? [String: Any]
         XCTAssertEqual(body?["deviceToken"] as? String, attestation.base64EncodedString())
     }
@@ -129,7 +136,7 @@ final class PushBackendClientTests: XCTestCase {
     /// base64 body shape minus subscriptions, and an empty 200 counts
     /// as success — there is nothing to decode.
     func testUnregisterSendsBodyAndAcceptsEmptyOK() async throws {
-        let recorded = NSMutableDictionary()
+        let recorded = Recorder<RecordedWire>()
         recordRequests(into: recorded)
 
         try await makeClient().unregister(
@@ -147,9 +154,9 @@ final class PushBackendClientTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(recorded["url"] as? String, "https://push.example/v1/unregister")
+        XCTAssertEqual(recorded.value?.url, "https://push.example/v1/unregister")
         let body = try JSONSerialization.jsonObject(
-            with: recorded["body"] as? Data ?? Data()
+            with: recorded.value?.body ?? Data()
         ) as? [String: Any]
         XCTAssertEqual(body?["userKey"] as? String, "onym:key:aabb")
         XCTAssertEqual(body?["timestamp"] as? String, "2026-08-22T12:00:00Z")

--- a/Tests/OnymIOSTests/PushCoordinatorTests.swift
+++ b/Tests/OnymIOSTests/PushCoordinatorTests.swift
@@ -13,6 +13,12 @@ import OnymTransportNostr
 final class PushCoordinatorTests: XCTestCase {
     private var defaultsSuite: String!
     private var keychain: IdentityKeychainStore!
+    /// The scene-lifetime `run()` task, hoisted so tearDown can await
+    /// its actual completion: `cancel()` alone is asynchronous, and a
+    /// still-winding-down task group would race the keychain wipe and
+    /// defaults-domain removal below — cross-test bleed dressed as a
+    /// flake.
+    private var scene: Task<Void, Never>?
 
     override func setUp() {
         super.setUp()
@@ -20,12 +26,14 @@ final class PushCoordinatorTests: XCTestCase {
         keychain = IdentityKeychainStore(testNamespace: defaultsSuite)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
+        scene?.cancel()
+        _ = await scene?.value
+        scene = nil
         UserDefaults(suiteName: defaultsSuite)?
             .removePersistentDomain(forName: defaultsSuite)
         try? keychain?.wipeAll()
         keychain = nil
-        super.tearDown()
     }
 
     private func makePreferences(enabled: Bool) -> PushPreferenceStore {
@@ -62,9 +70,9 @@ final class PushCoordinatorTests: XCTestCase {
         let coordinator = makeCoordinator(preferences: preferences, denied: { true })
 
         // run() then observes streams for the scene's life; poll the
-        // observable effect and cancel.
-        let scene = Task { await coordinator.run() }
-        defer { scene.cancel() }
+        // observable effect. tearDown cancels the task and awaits its
+        // completion before wiping shared state.
+        scene = Task { await coordinator.run() }
 
         let deadline = Date().addingTimeInterval(2)
         while Date() < deadline, preferences.isEnabled {

--- a/Tests/OnymIOSTests/PushCoordinatorTests.swift
+++ b/Tests/OnymIOSTests/PushCoordinatorTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import OnymIOS
+import OnymIdentity
+import OnymPush
+import OnymTransportNostr
+
+/// The privacy-load-bearing gate: notification authorization revoked
+/// in system Settings while the in-app preference says on means the
+/// toggle is a lie and the server still holds a registration — both
+/// the cold launch and the foreground hook must run the full disable
+/// path. The authorization probe is injected, so these tests drive it
+/// directly.
+final class PushCoordinatorTests: XCTestCase {
+    private var defaultsSuite: String!
+    private var keychain: IdentityKeychainStore!
+
+    override func setUp() {
+        super.setUp()
+        defaultsSuite = "push-coordinator-tests-\(UUID().uuidString)"
+        keychain = IdentityKeychainStore(testNamespace: defaultsSuite)
+    }
+
+    override func tearDown() {
+        UserDefaults(suiteName: defaultsSuite)?
+            .removePersistentDomain(forName: defaultsSuite)
+        try? keychain?.wipeAll()
+        keychain = nil
+        super.tearDown()
+    }
+
+    private func makePreferences(enabled: Bool) -> PushPreferenceStore {
+        let suite = defaultsSuite!
+        let store = PushPreferenceStore(defaults: { UserDefaults(suiteName: suite)! })
+        store.setEnabled(enabled)
+        return store
+    }
+
+    private func makeCoordinator(
+        preferences: PushPreferenceStore,
+        denied: @escaping @Sendable () async -> Bool
+    ) -> PushCoordinator {
+        PushCoordinator(
+            identityRepository: IdentityRepository(
+                keychain: keychain,
+                selectionStore: .inMemory()
+            ),
+            relaysRepository: NostrRelaysRepository(
+                store: InMemoryNostrRelaysSelectionStore(initial: .empty)
+            ),
+            client: StubPushBackendClient(),
+            preferences: preferences,
+            notificationAuthorizationDenied: denied
+        )
+    }
+
+    /// Cold launch: `.onChange(of: scenePhase)` never fires for the
+    /// initial `.active`, so `run()` itself must reconcile with system
+    /// Settings — enabled + denied means the full disable path, before
+    /// any APNs registration.
+    func testRunDisablesWhenAuthorizationWasRevoked() async throws {
+        let preferences = makePreferences(enabled: true)
+        let coordinator = makeCoordinator(preferences: preferences, denied: { true })
+
+        // run() then observes streams for the scene's life; poll the
+        // observable effect and cancel.
+        let scene = Task { await coordinator.run() }
+        defer { scene.cancel() }
+
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline, preferences.isEnabled {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTAssertFalse(preferences.isEnabled)
+    }
+
+    func testForegroundDisablesWhenAuthorizationWasRevoked() async {
+        let preferences = makePreferences(enabled: true)
+        let coordinator = makeCoordinator(preferences: preferences, denied: { true })
+
+        await coordinator.appForegrounded()
+
+        XCTAssertFalse(preferences.isEnabled)
+        XCTAssertFalse(coordinator.registrationPending)
+    }
+
+    /// Authorization intact: the gate must NOT disable — the opt-in
+    /// survives the foreground reconciliation untouched.
+    func testForegroundKeepsAGrantedAuthorizationEnabled() async {
+        let preferences = makePreferences(enabled: true)
+        let coordinator = makeCoordinator(preferences: preferences, denied: { false })
+
+        await coordinator.appForegrounded()
+
+        XCTAssertTrue(preferences.isEnabled)
+    }
+
+    /// Denied but already off: nothing to reconcile, nothing flips.
+    func testForegroundWithPushOffIgnoresTheDenial() async {
+        let preferences = makePreferences(enabled: false)
+        let coordinator = makeCoordinator(preferences: preferences, denied: { true })
+
+        await coordinator.appForegrounded()
+
+        XCTAssertFalse(preferences.isEnabled)
+    }
+}

--- a/Tests/OnymIOSTests/PushCoordinatorTests.swift
+++ b/Tests/OnymIOSTests/PushCoordinatorTests.swift
@@ -111,4 +111,42 @@ final class PushCoordinatorTests: XCTestCase {
 
         XCTAssertFalse(preferences.isEnabled)
     }
+
+    // MARK: - Relay caps (backend alignment)
+
+    /// The backend refuses registrations over its caps (4 relays per
+    /// tag, 8 hosts / 4 URLs-per-host per device); the client
+    /// truncates first so a big relay list degrades to the four
+    /// highest-priority relays instead of a refused register.
+    func testCappedRelaysKeepsShortListsVerbatim() {
+        XCTAssertEqual(PushCoordinator.cappedRelays([]), [])
+        let two = ["wss://a.example", "wss://b.example"]
+        XCTAssertEqual(PushCoordinator.cappedRelays(two), two)
+    }
+
+    /// Deterministic priority: the default relay first (the backend
+    /// exempts it from capacity caps), then configured order.
+    func testCappedRelaysPrefersTheDefaultRelayThenConfiguredOrder() {
+        let configured = [
+            "wss://a.example", "wss://b.example", "wss://c.example",
+            "wss://d.example", PushCoordinator.defaultRelayURL, "wss://e.example",
+        ]
+        XCTAssertEqual(
+            PushCoordinator.cappedRelays(configured),
+            [
+                PushCoordinator.defaultRelayURL,
+                "wss://a.example", "wss://b.example", "wss://c.example",
+            ]
+        )
+    }
+
+    /// A duplicate URL must not burn one of the four slots.
+    func testCappedRelaysDeduplicates() {
+        XCTAssertEqual(
+            PushCoordinator.cappedRelays(
+                ["wss://a.example", "wss://a.example", "wss://b.example"]
+            ),
+            ["wss://a.example", "wss://b.example"]
+        )
+    }
 }

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -436,6 +436,36 @@ final class PushRegistrationInteractorTests: XCTestCase {
         XCTAssertEqual(preferences.lastRegisteredToken, Data([0x0c, 0x0d]))
     }
 
+    /// Backend alignment: the process-wide rate limiter answers HTTP
+    /// 429 with code "capacity", and the backend claims the single-use
+    /// signature only after every other check passes — so a capacity
+    /// refusal leaves the request resubmittable and the client must
+    /// treat it as fully retryable: nothing recorded, nothing cleared,
+    /// the next trigger simply tries again.
+    func testCapacityRefusalIsFullyRetryable() async throws {
+        let client = StubPushBackendClient(
+            registerAnswer: .failure(PushClientError.rejected(
+                PushRejection(statusCode: 429, rawCode: "capacity", message: "over the window")
+            ))
+        )
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await waitUntil { await client.registered.count == 1 }
+        // Refused: no fingerprint, no token, nothing to unlearn.
+        XCTAssertNil(preferences.lastRegistrationFingerprint)
+        XCTAssertNil(preferences.lastRegisteredToken)
+        XCTAssertTrue(preferences.pendingUnregisterTokens.isEmpty)
+
+        // The window passed: the next opportunity registers cleanly.
+        await client.setRegisterAnswer(.success(PushRegisterResponse(expiresAt: .distantFuture)))
+        await interactor.appForegrounded()
+        try await waitUntil { await client.registered.count == 2 }
+        XCTAssertNotNil(preferences.lastRegistrationFingerprint)
+    }
+
     /// The dropped-token scenario from review: a rotation whose drain
     /// failed (old token still owed) followed by a disable (new token
     /// now owed too) is *two* debts — the old single-slot store kept

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -319,6 +319,30 @@ final class PushRegistrationInteractorTests: XCTestCase {
         XCTAssertEqual(registered.count, 1)
     }
 
+    /// A *degenerate* window — `expiresAt` at (or behind) the moment
+    /// of registration — must not make "already registered"
+    /// unsatisfiable either: below the one-hour floor the grant is
+    /// ignored entirely and the fixed interval alone paces, so a
+    /// foreground stays quiet instead of re-registering (and spending
+    /// a signature) every single time.
+    func testDegenerateExpiryWindowDoesNotChurn() async throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let client = StubPushBackendClient(
+            registerAnswer: .success(PushRegisterResponse(expiresAt: now))
+        )
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences, clock: { now })
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await waitUntil { await client.registered.count == 1 }
+        await interactor.appForegrounded()
+        try await settle()
+
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 1)
+    }
+
     /// The fixed interval alone forces a refresh: with `expiresAt`
     /// far away, an unchanged registration still re-registers once the
     /// interval has elapsed, so the backend's 60-day sweep never reaps

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -36,14 +36,16 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
     private func makeInteractor(
         client: StubPushBackendClient,
-        preferences: PushPreferenceStore
+        preferences: PushPreferenceStore,
+        clock: @escaping @Sendable () -> Date = Date.init
     ) -> PushRegistrationInteractor {
         PushRegistrationInteractor(
             client: client,
             signer: StubSigner(),
             attestation: NoAttestation(),
             preferences: preferences,
-            debounce: .milliseconds(20)
+            debounce: .milliseconds(20),
+            clock: clock
         )
     }
 
@@ -158,5 +160,104 @@ final class PushRegistrationInteractorTests: XCTestCase {
         let unregistered = await client.unregistered
         XCTAssertEqual(unregistered.count, 1)
         XCTAssertNil(preferences.lastRegistrationFingerprint)
+        // The successful unregister leaves nothing pending and no
+        // stale token to fall back to.
+        XCTAssertNil(preferences.pendingUnregisterToken)
+        XCTAssertNil(preferences.lastRegisteredToken)
+    }
+
+    /// One offline opt-out must not leave the device registered on the
+    /// server: the intent persists past the failure and drains at the
+    /// next reconcile opportunity.
+    func testOfflineDisablePersistsPendingUnregisterAndDrainsOnForeground() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        await interactor.updateToken(Data([0x0a, 0x0b]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await settle()
+
+        await client.setUnregisterAnswer(.failure(PushClientError.invalidResponse))
+        preferences.setEnabled(false)
+        await interactor.pushDisabled()
+
+        // The attempt happened, failed, and the intent survived it.
+        let afterFailure = await client.unregistered
+        XCTAssertEqual(afterFailure.count, 1)
+        XCTAssertEqual(preferences.pendingUnregisterToken, Data([0x0a, 0x0b]))
+
+        // Next foreground: the pending unregister drains first, and
+        // with the preference off nothing re-registers.
+        await client.setUnregisterAnswer(.success(()))
+        await interactor.appForegrounded()
+        try await settle()
+
+        let drained = await client.unregistered
+        XCTAssertEqual(drained.count, 2)
+        XCTAssertNil(preferences.pendingUnregisterToken)
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 1)
+    }
+
+    /// Disabling in a launch where APNs has not (re)delivered the
+    /// token falls back to the last successfully registered one — the
+    /// register recorded it for exactly this moment.
+    func testDisableWithoutLiveTokenFallsBackToTheRecordedOne() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: true)
+        let first = makeInteractor(client: client, preferences: preferences)
+
+        await first.updateToken(Data([0x0a, 0x0b]))
+        await first.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await settle()
+        XCTAssertEqual(preferences.lastRegisteredToken, Data([0x0a, 0x0b]))
+
+        // A fresh interactor — same persisted state, no APNs token yet.
+        let second = makeInteractor(client: client, preferences: preferences)
+        preferences.setEnabled(false)
+        await second.pushDisabled()
+
+        let unregistered = await client.unregistered
+        XCTAssertEqual(unregistered.count, 1)
+        XCTAssertNil(preferences.pendingUnregisterToken)
+    }
+
+    func testRegisterRecordsExpiry() async throws {
+        let expires = Date(timeIntervalSince1970: 1_800_000_000)
+        let client = StubPushBackendClient(
+            registerAnswer: .success(PushRegisterResponse(expiresAt: expires))
+        )
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await settle()
+
+        XCTAssertEqual(preferences.registrationExpiresAt, expires)
+    }
+
+    /// The backend's own expiry drives the refresh: an unchanged
+    /// registration re-registers once `now` is within seven days of
+    /// `expiresAt`, even though the fixed interval has not elapsed.
+    func testNearExpiryReRegistersDespiteUnchangedInputs() async throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let client = StubPushBackendClient(
+            registerAnswer: .success(
+                PushRegisterResponse(expiresAt: now.addingTimeInterval(3 * 24 * 3600))
+            )
+        )
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences, clock: { now })
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await settle()
+        await interactor.appForegrounded()
+        try await settle()
+
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 2)
     }
 }

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -181,7 +181,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
         XCTAssertNil(preferences.lastRegistrationFingerprint)
         // The successful unregister leaves nothing pending and no
         // stale token to fall back to.
-        XCTAssertNil(preferences.pendingUnregisterToken)
+        XCTAssertTrue(preferences.pendingUnregisterTokens.isEmpty)
         XCTAssertNil(preferences.lastRegisteredToken)
 
         preferences.setEnabled(false)
@@ -206,14 +206,14 @@ final class PushRegistrationInteractorTests: XCTestCase {
         // The attempt happened, failed, and the intent survived it.
         let afterFailure = await client.unregistered
         XCTAssertEqual(afterFailure.count, 1)
-        XCTAssertEqual(preferences.pendingUnregisterToken, Data([0x0a, 0x0b]))
+        XCTAssertEqual(preferences.pendingUnregisterTokens, [Data([0x0a, 0x0b])])
 
         // Next foreground: the pending unregister drains first, and
         // with the preference off nothing re-registers.
         await client.setUnregisterAnswer(.success(()))
         await interactor.appForegrounded()
         try await waitUntil { await client.unregistered.count == 2 }
-        XCTAssertNil(preferences.pendingUnregisterToken)
+        XCTAssertTrue(preferences.pendingUnregisterTokens.isEmpty)
         let registered = await client.registered
         XCTAssertEqual(registered.count, 1)
     }
@@ -238,7 +238,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         let unregistered = await client.unregistered
         XCTAssertEqual(unregistered.count, 1)
-        XCTAssertNil(preferences.pendingUnregisterToken)
+        XCTAssertTrue(preferences.pendingUnregisterTokens.isEmpty)
     }
 
     func testRegisterRecordsExpiry() async throws {
@@ -393,8 +393,45 @@ final class PushRegistrationInteractorTests: XCTestCase {
         try await waitUntil { await client.registered.count == 2 }
         try await waitUntil { await client.unregistered.count == 1 }
 
-        XCTAssertNil(preferences.pendingUnregisterToken)
+        XCTAssertTrue(preferences.pendingUnregisterTokens.isEmpty)
         XCTAssertEqual(preferences.lastRegisteredToken, Data([0x0c, 0x0d]))
+    }
+
+    /// The dropped-token scenario from review: a rotation whose drain
+    /// failed (old token still owed) followed by a disable (new token
+    /// now owed too) is *two* debts — the old single-slot store kept
+    /// only the newer one and the old token stayed wake-able until the
+    /// backend's 60-day sweep. Both must survive and both must drain.
+    func testRotationDebtAndDisableDebtBothDrain() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        await interactor.updateToken(Data([0x0a]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await waitUntil { await client.registered.count == 1 }
+
+        // Rotation with the unregister path down: A's debt persists
+        // past the failed drain while B registers.
+        await client.setUnregisterAnswer(.failure(PushClientError.invalidResponse))
+        await interactor.updateToken(Data([0x0b]))
+        try await waitUntil { await client.registered.count == 2 }
+        XCTAssertEqual(preferences.pendingUnregisterTokens, [Data([0x0a])])
+
+        // Disable while A is still owed: B joins the set instead of
+        // overwriting A.
+        preferences.setEnabled(false)
+        await interactor.pushDisabled()
+        XCTAssertEqual(
+            Set(preferences.pendingUnregisterTokens),
+            Set([Data([0x0a]), Data([0x0b])])
+        )
+
+        // Network back: one opportunity drains both debts.
+        await client.setUnregisterAnswer(.success(()))
+        await interactor.appForegrounded()
+        try await waitUntil { preferences.pendingUnregisterTokens.isEmpty }
+        XCTAssertNil(preferences.lastRegisteredToken)
     }
 
     /// Swallowed reconcile errors are observable through the test-only
@@ -453,7 +490,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
         await interactor.pushDisabled()
         let beforeLanding = await client.unregistered
         XCTAssertTrue(beforeLanding.isEmpty)
-        XCTAssertEqual(preferences.pendingUnregisterToken, Data([0x0a, 0x0b]))
+        XCTAssertEqual(preferences.pendingUnregisterTokens, [Data([0x0a, 0x0b])])
 
         // Let the register land — after the unregister intent.
         await client.setOnRegister(nil)
@@ -463,7 +500,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
         // Nothing recorded as registered, nothing left pending: the
         // register that landed late was superseded and torn down.
         XCTAssertNil(preferences.lastRegistrationFingerprint)
-        XCTAssertNil(preferences.pendingUnregisterToken)
+        XCTAssertTrue(preferences.pendingUnregisterTokens.isEmpty)
         let registered = await client.registered
         XCTAssertEqual(registered.count, 1)
     }

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -510,8 +510,8 @@ final class PushRegistrationInteractorTests: XCTestCase {
         let preferences = makePreferences(enabled: true)
         let interactor = makeInteractor(client: client, preferences: preferences)
 
-        let gate = TestGate()
-        let inFlight = TestGate()
+        let gate = OneShotGate()
+        let inFlight = OneShotGate()
         await client.setOnRegister {
             inFlight.open()
             await gate.wait()
@@ -571,31 +571,3 @@ private final class FailureBox: @unchecked Sendable {
     }
 }
 
-/// A reusable one-shot gate for holding an async call open.
-private final class TestGate: @unchecked Sendable {
-    private let lock = NSLock()
-    private var opened = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func wait() async {
-        await withCheckedContinuation { continuation in
-            lock.lock()
-            if opened {
-                lock.unlock()
-                continuation.resume()
-                return
-            }
-            waiters.append(continuation)
-            lock.unlock()
-        }
-    }
-
-    func open() {
-        lock.lock()
-        opened = true
-        let resumed = waiters
-        waiters = []
-        lock.unlock()
-        for waiter in resumed { waiter.resume() }
-    }
-}

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -37,6 +37,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
     private func makeInteractor(
         client: StubPushBackendClient,
         preferences: PushPreferenceStore,
+        refreshInterval: TimeInterval = 7 * 24 * 3600,
         clock: @escaping @Sendable () -> Date = Date.init
     ) -> PushRegistrationInteractor {
         PushRegistrationInteractor(
@@ -45,6 +46,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
             attestation: NoAttestation(),
             preferences: preferences,
             debounce: .milliseconds(20),
+            refreshInterval: refreshInterval,
             clock: clock
         )
     }
@@ -56,9 +58,28 @@ final class PushRegistrationInteractorTests: XCTestCase {
         return store
     }
 
-    /// Debounce is 20ms; give reconciliation room to run.
+    /// Deadline-polls instead of sleeping a fixed interval: the
+    /// debounce is 20ms, so the expected state usually lands within a
+    /// poll or two, and a genuinely stuck condition fails loudly.
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @escaping () async -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("condition never became true within \(timeout)", file: file, line: line)
+    }
+
+    /// For asserting that nothing happens: enough time for the 20ms
+    /// debounce plus a would-be call to land, kept short because it is
+    /// pure waiting — a positive expectation should use `waitUntil`.
     private func settle() async throws {
-        try await Task.sleep(for: .milliseconds(300))
+        try await Task.sleep(for: .milliseconds(200))
     }
 
     func testRegistersOnceTokenAndSubscriptionsAreKnown() async throws {
@@ -68,10 +89,9 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await interactor.updateToken(Data([0x01, 0x02]))
         await interactor.updateSubscriptions(subs)
-        try await settle()
+        try await waitUntil { await client.registered.count == 1 }
 
         let registered = await client.registered
-        XCTAssertEqual(registered.count, 1)
         XCTAssertEqual(registered.first?.subscriptions, subs)
         // The attestation stub has no token; the request must say so
         // rather than fabricate one.
@@ -97,7 +117,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await interactor.updateToken(Data([0x01]))
         await interactor.updateSubscriptions(subs)
-        try await settle()
+        try await waitUntil { await client.registered.count == 1 }
         // Same inputs again — the fingerprint matches, nothing is sent.
         await interactor.updateSubscriptions(subs)
         await interactor.appForegrounded()
@@ -113,15 +133,14 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await interactor.updateToken(Data([0x01]))
         await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
-        try await settle()
+        try await waitUntil { await client.registered.count == 1 }
         await interactor.updateSubscriptions([
             PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"]),
             PushSubscription(tag: "00ff00ff00ff00ff", relays: ["wss://nostr.onym.app"]),
         ])
-        try await settle()
+        try await waitUntil { await client.registered.count == 2 }
 
         let registered = await client.registered
-        XCTAssertEqual(registered.count, 2)
         XCTAssertEqual(registered.last?.subscriptions.count, 2)
     }
 
@@ -134,15 +153,12 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await interactor.updateToken(Data([0x01]))
         await interactor.updateSubscriptions(subs)
-        try await settle()
+        try await waitUntil { await client.registered.count == 1 }
         // The failure recorded no fingerprint, so the next opportunity
         // tries again — this time succeeding.
         await client.setRegisterAnswer(.success(PushRegisterResponse(expiresAt: .distantFuture)))
         await interactor.appForegrounded()
-        try await settle()
-
-        let registered = await client.registered
-        XCTAssertEqual(registered.count, 2)
+        try await waitUntil { await client.registered.count == 2 }
     }
 
     func testDisableUnregistersWithTheKnownToken() async throws {
@@ -152,9 +168,12 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await interactor.updateToken(Data([0x0a, 0x0b]))
         await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
-        try await settle()
+        try await waitUntil { await client.registered.count == 1 }
+        XCTAssertNotNil(preferences.lastRegistrationFingerprint)
 
-        preferences.setEnabled(false)
+        // Deliberately NOT `setEnabled(false)` first: that call clears
+        // the fingerprint itself, which would make the assertion below
+        // pass vacuously. `pushDisabled()` must clear it on its own.
         await interactor.pushDisabled()
 
         let unregistered = await client.unregistered
@@ -164,6 +183,8 @@ final class PushRegistrationInteractorTests: XCTestCase {
         // stale token to fall back to.
         XCTAssertNil(preferences.pendingUnregisterToken)
         XCTAssertNil(preferences.lastRegisteredToken)
+
+        preferences.setEnabled(false)
     }
 
     /// One offline opt-out must not leave the device registered on the
@@ -176,7 +197,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await interactor.updateToken(Data([0x0a, 0x0b]))
         await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
-        try await settle()
+        try await waitUntil { await client.registered.count == 1 }
 
         await client.setUnregisterAnswer(.failure(PushClientError.invalidResponse))
         preferences.setEnabled(false)
@@ -191,10 +212,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
         // with the preference off nothing re-registers.
         await client.setUnregisterAnswer(.success(()))
         await interactor.appForegrounded()
-        try await settle()
-
-        let drained = await client.unregistered
-        XCTAssertEqual(drained.count, 2)
+        try await waitUntil { await client.unregistered.count == 2 }
         XCTAssertNil(preferences.pendingUnregisterToken)
         let registered = await client.registered
         XCTAssertEqual(registered.count, 1)
@@ -210,7 +228,7 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await first.updateToken(Data([0x0a, 0x0b]))
         await first.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
-        try await settle()
+        try await waitUntil { await client.registered.count == 1 }
         XCTAssertEqual(preferences.lastRegisteredToken, Data([0x0a, 0x0b]))
 
         // A fresh interactor — same persisted state, no APNs token yet.
@@ -233,15 +251,55 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await interactor.updateToken(Data([0x01]))
         await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
-        try await settle()
-
-        XCTAssertEqual(preferences.registrationExpiresAt, expires)
+        try await waitUntil { preferences.registrationExpiresAt == expires }
     }
 
     /// The backend's own expiry drives the refresh: an unchanged
-    /// registration re-registers once `now` is within seven days of
-    /// `expiresAt`, even though the fixed interval has not elapsed.
+    /// registration re-registers once `now` is inside the expiry
+    /// margin, even though the fixed interval has not elapsed (it is
+    /// set far away here to isolate the expiry path).
     func testNearExpiryReRegistersDespiteUnchangedInputs() async throws {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let clock = ClockBox(start)
+        // A 10-day window: the margin is min(7d, window/2) = 5 days.
+        let client = StubPushBackendClient(
+            registerAnswer: .success(
+                PushRegisterResponse(expiresAt: start.addingTimeInterval(10 * 24 * 3600))
+            )
+        )
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(
+            client: client,
+            preferences: preferences,
+            refreshInterval: 365 * 24 * 3600,
+            clock: { clock.now }
+        )
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await waitUntil { await client.registered.count == 1 }
+
+        // Four days in — still a day outside the margin: quiet.
+        clock.now = start.addingTimeInterval(4 * 24 * 3600)
+        await interactor.appForegrounded()
+        try await settle()
+        var registered = await client.registered
+        XCTAssertEqual(registered.count, 1)
+
+        // Six days in — inside the 5-day margin: re-register.
+        clock.now = start.addingTimeInterval(6 * 24 * 3600)
+        await interactor.appForegrounded()
+        try await waitUntil { await client.registered.count == 2 }
+        registered = await client.registered
+        XCTAssertEqual(registered.count, 2)
+    }
+
+    /// A backend window shorter than twice the fixed margin must not
+    /// make "already registered" unsatisfiable — the margin derives
+    /// from the window, so a fresh registration under a 3-day window
+    /// stays quiet instead of re-registering (and spending a
+    /// signature) at every foreground.
+    func testShortExpiryWindowDoesNotChurn() async throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let client = StubPushBackendClient(
             registerAnswer: .success(
@@ -253,11 +311,215 @@ final class PushRegistrationInteractorTests: XCTestCase {
 
         await interactor.updateToken(Data([0x01]))
         await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
-        try await settle()
+        try await waitUntil { await client.registered.count == 1 }
         await interactor.appForegrounded()
         try await settle()
 
         let registered = await client.registered
-        XCTAssertEqual(registered.count, 2)
+        XCTAssertEqual(registered.count, 1)
+    }
+
+    /// The fixed interval alone forces a refresh: with `expiresAt`
+    /// far away, an unchanged registration still re-registers once the
+    /// interval has elapsed, so the backend's 60-day sweep never reaps
+    /// a live device.
+    func testElapsedRefreshIntervalReRegisters() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences, refreshInterval: 0)
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await waitUntil { await client.registered.count == 1 }
+        await interactor.appForegrounded()
+        try await waitUntil { await client.registered.count == 2 }
+    }
+
+    /// An empty subscription list is meaningful: it registers (clears
+    /// every tag at the backend) rather than being treated as "nothing
+    /// to say", and the device stays registered.
+    func testEmptySubscriptionsRegistersWithNoTags() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await waitUntil { await client.registered.count == 1 }
+
+        await interactor.updateSubscriptions([])
+        try await waitUntil { await client.registered.count == 2 }
+
+        let registered = await client.registered
+        XCTAssertEqual(registered.last?.subscriptions, [])
+        XCTAssertNotNil(preferences.lastRegisteredToken)
+        XCTAssertNotNil(preferences.lastRegistrationFingerprint)
+        let unregistered = await client.unregistered
+        XCTAssertTrue(unregistered.isEmpty)
+    }
+
+    /// `pushEnabled()` is itself a reconcile trigger: with inputs
+    /// already known but no registration recorded (the preference was
+    /// off when they arrived), flipping it on registers.
+    func testPushEnabledTriggersReconcile() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: false)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await settle()
+        let before = await client.registered
+        XCTAssertTrue(before.isEmpty)
+
+        preferences.setEnabled(true)
+        await interactor.pushEnabled()
+        try await waitUntil { await client.registered.count == 1 }
+    }
+
+    /// APNs rotated the token: the backend keys registrations by token
+    /// hash, so the old row must be unregistered rather than left
+    /// wake-able until the 60-day sweep.
+    func testTokenRotationUnregistersThePreviousToken() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        await interactor.updateToken(Data([0x0a, 0x0b]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await waitUntil { await client.registered.count == 1 }
+
+        await interactor.updateToken(Data([0x0c, 0x0d]))
+        try await waitUntil { await client.registered.count == 2 }
+        try await waitUntil { await client.unregistered.count == 1 }
+
+        XCTAssertNil(preferences.pendingUnregisterToken)
+        XCTAssertEqual(preferences.lastRegisteredToken, Data([0x0c, 0x0d]))
+    }
+
+    /// Swallowed reconcile errors are observable through the test-only
+    /// hook: a degenerate (all-zero) registration key makes the seal
+    /// refuse, no register reaches the backend, and the failure is
+    /// reported rather than silently vanishing.
+    func testReconcileFailureHookSeesTheSwallowedError() async throws {
+        let client = StubPushBackendClient(
+            registrationKeyAnswer: Data(repeating: 0, count: 32)
+        )
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        let failures = FailureBox()
+        await interactor.setOnReconcileFailure { failures.append($0) }
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await waitUntil { !failures.errors.isEmpty }
+
+        let registered = await client.registered
+        XCTAssertTrue(registered.isEmpty)
+        XCTAssertEqual(
+            failures.errors.first as? PushTokenEnvelope.SealError,
+            .invalidServerKey
+        )
+    }
+
+    /// The reentrancy hole the second review found: a disable landing
+    /// while a register is suspended mid-flight must win. The register
+    /// still reaches the backend (it was already in transit), but it
+    /// is never recorded as live, and the pending unregister both
+    /// survives it and drains after it — the backend ends the episode
+    /// forgotten, not registered behind the user's back.
+    func testDisableDuringInFlightRegisterEndsUnregistered() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        let gate = TestGate()
+        let inFlight = TestGate()
+        await client.setOnRegister {
+            inFlight.open()
+            await gate.wait()
+        }
+
+        await interactor.updateToken(Data([0x0a, 0x0b]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        // Hold until the register is suspended inside the client.
+        await inFlight.wait()
+
+        // The disable interleaves: it must not spend a second
+        // signature concurrently — it queues behind the in-flight
+        // pass and returns.
+        preferences.setEnabled(false)
+        await interactor.pushDisabled()
+        let beforeLanding = await client.unregistered
+        XCTAssertTrue(beforeLanding.isEmpty)
+        XCTAssertEqual(preferences.pendingUnregisterToken, Data([0x0a, 0x0b]))
+
+        // Let the register land — after the unregister intent.
+        await client.setOnRegister(nil)
+        gate.open()
+        try await waitUntil { await client.unregistered.count == 1 }
+
+        // Nothing recorded as registered, nothing left pending: the
+        // register that landed late was superseded and torn down.
+        XCTAssertNil(preferences.lastRegistrationFingerprint)
+        XCTAssertNil(preferences.pendingUnregisterToken)
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 1)
+    }
+}
+
+/// A mutable now the test can advance; the interactor's clock closure
+/// reads it. Locked because the closure is `@Sendable`.
+private final class ClockBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var date: Date
+    init(_ date: Date) { self.date = date }
+    var now: Date {
+        get { lock.lock(); defer { lock.unlock() }; return date }
+        set { lock.lock(); defer { lock.unlock() }; date = newValue }
+    }
+}
+
+/// Collects errors from the `@Sendable` failure hook.
+private final class FailureBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [Error] = []
+    func append(_ error: Error) {
+        lock.lock(); defer { lock.unlock() }
+        stored.append(error)
+    }
+    var errors: [Error] {
+        lock.lock(); defer { lock.unlock() }
+        return stored
+    }
+}
+
+/// A reusable one-shot gate for holding an async call open.
+private final class TestGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if opened {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            waiters.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    func open() {
+        lock.lock()
+        opened = true
+        let resumed = waiters
+        waiters = []
+        lock.unlock()
+        for waiter in resumed { waiter.resume() }
     }
 }

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -1,0 +1,162 @@
+import CryptoKit
+import XCTest
+@testable import OnymPush
+
+/// Reconciliation behavior: the interactor should call the backend
+/// exactly when something it registered would change, and stay silent
+/// otherwise — silence is a privacy property here, not a nicety.
+final class PushRegistrationInteractorTests: XCTestCase {
+    private var defaultsSuite: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaultsSuite = "push-tests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuite)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: defaultsSuite)
+        super.tearDown()
+    }
+
+    private struct StubSigner: PushSigner {
+        let key = Curve25519.Signing.PrivateKey()
+        func userKeyID() async throws -> String {
+            "onym:key:" + key.publicKey.rawRepresentation.map { String(format: "%02x", $0) }.joined()
+        }
+        func sign(_ message: Data) async throws -> Data {
+            try key.signature(for: message)
+        }
+    }
+
+    private struct NoAttestation: PushDeviceAttestationProvider {
+        func currentToken() async -> Data? { nil }
+    }
+
+    private func makeInteractor(
+        client: StubPushBackendClient,
+        preferences: PushPreferenceStore
+    ) -> PushRegistrationInteractor {
+        PushRegistrationInteractor(
+            client: client,
+            signer: StubSigner(),
+            attestation: NoAttestation(),
+            preferences: preferences,
+            debounce: .milliseconds(20)
+        )
+    }
+
+    private func makePreferences(enabled: Bool) -> PushPreferenceStore {
+        let suite = defaultsSuite!
+        let store = PushPreferenceStore(defaults: { UserDefaults(suiteName: suite)! })
+        store.setEnabled(enabled)
+        return store
+    }
+
+    /// Debounce is 20ms; give reconciliation room to run.
+    private func settle() async throws {
+        try await Task.sleep(for: .milliseconds(300))
+    }
+
+    func testRegistersOnceTokenAndSubscriptionsAreKnown() async throws {
+        let client = StubPushBackendClient()
+        let interactor = makeInteractor(client: client, preferences: makePreferences(enabled: true))
+        let subs = [PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])]
+
+        await interactor.updateToken(Data([0x01, 0x02]))
+        await interactor.updateSubscriptions(subs)
+        try await settle()
+
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 1)
+        XCTAssertEqual(registered.first?.subscriptions, subs)
+        // The attestation stub has no token; the request must say so
+        // rather than fabricate one.
+        XCTAssertNil(registered.first?.deviceToken)
+    }
+
+    func testDisabledPreferenceMeansNoCallAtAll() async throws {
+        let client = StubPushBackendClient()
+        let interactor = makeInteractor(client: client, preferences: makePreferences(enabled: false))
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://r.example"])])
+        try await settle()
+
+        let registered = await client.registered
+        XCTAssertTrue(registered.isEmpty)
+    }
+
+    func testUnchangedStateIsNotReRegistered() async throws {
+        let client = StubPushBackendClient()
+        let interactor = makeInteractor(client: client, preferences: makePreferences(enabled: true))
+        let subs = [PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])]
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions(subs)
+        try await settle()
+        // Same inputs again — the fingerprint matches, nothing is sent.
+        await interactor.updateSubscriptions(subs)
+        await interactor.appForegrounded()
+        try await settle()
+
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 1)
+    }
+
+    func testChangedSubscriptionsReRegister() async throws {
+        let client = StubPushBackendClient()
+        let interactor = makeInteractor(client: client, preferences: makePreferences(enabled: true))
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await settle()
+        await interactor.updateSubscriptions([
+            PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"]),
+            PushSubscription(tag: "00ff00ff00ff00ff", relays: ["wss://nostr.onym.app"]),
+        ])
+        try await settle()
+
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 2)
+        XCTAssertEqual(registered.last?.subscriptions.count, 2)
+    }
+
+    func testFailedRegistrationIsRetriedOnNextTrigger() async throws {
+        let client = StubPushBackendClient(
+            registerAnswer: .failure(PushClientError.invalidResponse)
+        )
+        let interactor = makeInteractor(client: client, preferences: makePreferences(enabled: true))
+        let subs = [PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])]
+
+        await interactor.updateToken(Data([0x01]))
+        await interactor.updateSubscriptions(subs)
+        try await settle()
+        // The failure recorded no fingerprint, so the next opportunity
+        // tries again — this time succeeding.
+        await client.setRegisterAnswer(.success(PushRegisterResponse(expiresAt: .distantFuture)))
+        await interactor.appForegrounded()
+        try await settle()
+
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 2)
+    }
+
+    func testDisableUnregistersWithTheKnownToken() async throws {
+        let client = StubPushBackendClient()
+        let preferences = makePreferences(enabled: true)
+        let interactor = makeInteractor(client: client, preferences: preferences)
+
+        await interactor.updateToken(Data([0x0a, 0x0b]))
+        await interactor.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
+        try await settle()
+
+        preferences.setEnabled(false)
+        await interactor.pushDisabled()
+
+        let unregistered = await client.unregistered
+        XCTAssertEqual(unregistered.count, 1)
+        XCTAssertNil(preferences.lastRegistrationFingerprint)
+    }
+}

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -185,7 +185,12 @@ final class PushRegistrationInteractorTests: XCTestCase {
         XCTAssertTrue(preferences.pendingUnregisterTokens.isEmpty)
         XCTAssertNil(preferences.lastRegisteredToken)
 
-        preferences.setEnabled(false)
+        // And no register follows: with the preference still on (the
+        // artificial state above), a follow-up reconcile pass would
+        // happily re-register — the disable must not queue one.
+        try await settle()
+        let registered = await client.registered
+        XCTAssertEqual(registered.count, 1)
     }
 
     /// One offline opt-out must not leave the device registered on the

--- a/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationInteractorTests.swift
@@ -37,12 +37,13 @@ final class PushRegistrationInteractorTests: XCTestCase {
     private func makeInteractor(
         client: StubPushBackendClient,
         preferences: PushPreferenceStore,
+        signer: StubSigner = StubSigner(),
         refreshInterval: TimeInterval = 7 * 24 * 3600,
         clock: @escaping @Sendable () -> Date = Date.init
     ) -> PushRegistrationInteractor {
         PushRegistrationInteractor(
             client: client,
-            signer: StubSigner(),
+            signer: signer,
             attestation: NoAttestation(),
             preferences: preferences,
             debounce: .milliseconds(20),
@@ -224,7 +225,12 @@ final class PushRegistrationInteractorTests: XCTestCase {
     func testDisableWithoutLiveTokenFallsBackToTheRecordedOne() async throws {
         let client = StubPushBackendClient()
         let preferences = makePreferences(enabled: true)
-        let first = makeInteractor(client: client, preferences: preferences)
+        // One signer for both interactors: a relaunch keeps the same
+        // signing identity, and a per-interactor random key would let
+        // this test pass even if the fallback token were wrongly
+        // derived from signer state rather than from the store.
+        let signer = StubSigner()
+        let first = makeInteractor(client: client, preferences: preferences, signer: signer)
 
         await first.updateToken(Data([0x0a, 0x0b]))
         await first.updateSubscriptions([PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://nostr.onym.app"])])
@@ -232,13 +238,17 @@ final class PushRegistrationInteractorTests: XCTestCase {
         XCTAssertEqual(preferences.lastRegisteredToken, Data([0x0a, 0x0b]))
 
         // A fresh interactor — same persisted state, no APNs token yet.
-        let second = makeInteractor(client: client, preferences: preferences)
+        let second = makeInteractor(client: client, preferences: preferences, signer: signer)
         preferences.setEnabled(false)
         await second.pushDisabled()
 
         let unregistered = await client.unregistered
         XCTAssertEqual(unregistered.count, 1)
         XCTAssertTrue(preferences.pendingUnregisterTokens.isEmpty)
+        // Same signer, so the unregister names the same userKey the
+        // register did — the relaunch scenario as it actually is.
+        let registered = await client.registered
+        XCTAssertEqual(unregistered.first?.userKey, registered.first?.userKey)
     }
 
     func testRegisterRecordsExpiry() async throws {

--- a/Tests/OnymIOSTests/PushRegistrationPayloadTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationPayloadTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import OnymPush
+
+/// The signed session payload MUST match `payload.rs` in the push
+/// backend byte-for-byte — these are the same properties and fixtures
+/// pinned on the Rust side, so drift on either end fails a build
+/// before it refuses every real signature in production.
+final class PushRegistrationPayloadTests: XCTestCase {
+    private let userKey = "onym:key:aabb"
+    private let deviceToken = Data("device-token".utf8)
+    private let timestamp = ISO8601DateFormatter.push.date(from: "2026-08-22T12:00:00Z")!
+    private let apnsToken = Data([0x0a, 0x0b, 0x0c, 0x0d, 0xee, 0xff])
+    private let subscriptions = [
+        PushSubscription(
+            tag: "a1b2c3d4e5f60718",
+            relays: ["wss://nostr.onym.app", "wss://relay.example.com"]
+        ),
+        PushSubscription(tag: "00ff00ff00ff00ff", relays: ["wss://nostr.onym.app"]),
+    ]
+
+    func testFieldsAreLengthPrefixedBigEndian() {
+        let payload = SignedPushSessionPayload.unregister(
+            deviceToken: Data("ab".utf8),
+            userKey: "k",
+            timestamp: timestamp,
+            apnsToken: Data([0x01])
+        )
+        let context = SignedPushSessionPayload.unregisterContext
+        // context + token(2) + userKey(1) + timestamp(20) + apnsToken(1)
+        // + empty digest, each with a 4-byte prefix.
+        XCTAssertEqual(payload.count, 4 * 6 + context.count + 2 + 1 + 20 + 1)
+        XCTAssertEqual(Array(payload.prefix(4)), [0, 0, 0, UInt8(context.count)])
+    }
+
+    func testRegisterAndUnregisterAreDomainSeparated() {
+        let register = SignedPushSessionPayload.register(
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: apnsToken,
+            subscriptions: []
+        )
+        let unregister = SignedPushSessionPayload.unregister(
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: apnsToken
+        )
+        XCTAssertNotEqual(register, unregister)
+    }
+
+    /// The digest covers the wire order — reordering the subscription
+    /// list is a different signature, because the backend recomputes
+    /// from exactly what was transmitted.
+    func testDigestIsOrderSensitiveAndInjective() {
+        let reversed = [subscriptions[1], subscriptions[0]]
+        XCTAssertNotEqual(
+            SignedPushSessionPayload.digest(of: subscriptions),
+            SignedPushSessionPayload.digest(of: reversed)
+        )
+        // Length prefixes: no two different field splits collide.
+        XCTAssertNotEqual(
+            SignedPushSessionPayload.digest(of: [PushSubscription(tag: "ab", relays: ["c"])]),
+            SignedPushSessionPayload.digest(of: [PushSubscription(tag: "a", relays: ["bc"])])
+        )
+    }
+
+    /// An absent device token and an empty one encode identically —
+    /// intentional, matching the moderation payload's contract.
+    func testAbsentAndEmptyDeviceTokenAgree() {
+        XCTAssertEqual(
+            SignedPushSessionPayload.register(
+                deviceToken: nil, userKey: userKey, timestamp: timestamp,
+                apnsToken: apnsToken, subscriptions: []
+            ),
+            SignedPushSessionPayload.register(
+                deviceToken: Data(), userKey: userKey, timestamp: timestamp,
+                apnsToken: apnsToken, subscriptions: []
+            )
+        )
+    }
+
+    // ─── Cross-implementation fixtures ───────────────────────────────
+    //
+    // These hex strings are what THIS implementation produced over the
+    // inputs above; the backend's `payload.rs` pins the same strings.
+    // Regenerate from Swift — never by hand — if the format changes,
+    // and update both sides in the same change.
+
+    func testRegisterFixtureMatchesTheBackend() {
+        let expected = "000000156f6e796d2d707573682d72656769737465722d76310000000c646576696365"
+            + "2d746f6b656e0000000d6f6e796d3a6b65793a6161626200000014323032362d30382d"
+            + "32325431323a30303a30305a000000060a0b0c0deeff000000203ae773f8c0e9d68"
+            + "10aadf1564c3c63821a019269b84d50ddccb902878399fc48"
+        let payload = SignedPushSessionPayload.register(
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: apnsToken,
+            subscriptions: subscriptions
+        )
+        XCTAssertEqual(hex(payload), expected)
+    }
+
+    func testRegisterWithoutTokenFixtureMatchesTheBackend() {
+        let expected = "000000156f6e796d2d707573682d72656769737465722d7631000000000000000d6f6e"
+            + "796d3a6b65793a6161626200000014323032362d30382d32325431323a30303a30305a"
+            + "000000060a0b0c0deeff000000203ae773f8c0e9d6810aadf1564c3c63821a019269b8"
+            + "4d50ddccb902878399fc48"
+        let payload = SignedPushSessionPayload.register(
+            deviceToken: nil,
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: apnsToken,
+            subscriptions: subscriptions
+        )
+        XCTAssertEqual(hex(payload), expected)
+    }
+
+    func testUnregisterFixtureMatchesTheBackend() {
+        let expected = "000000176f6e796d2d707573682d756e72656769737465722d76310000000c64657669"
+            + "63652d746f6b656e0000000d6f6e796d3a6b65793a6161626200000014323032362d30"
+            + "382d32325431323a30303a30305a000000060a0b0c0deeff00000000"
+        let payload = SignedPushSessionPayload.unregister(
+            deviceToken: deviceToken,
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: apnsToken
+        )
+        XCTAssertEqual(hex(payload), expected)
+    }
+
+    func testSubscriptionsDigestFixtureMatchesTheBackend() {
+        XCTAssertEqual(
+            hex(SignedPushSessionPayload.digest(of: subscriptions)),
+            "3ae773f8c0e9d6810aadf1564c3c63821a019269b84d50ddccb902878399fc48"
+        )
+    }
+
+    private func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/OnymIOSTests/PushRegistrationPayloadTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationPayloadTests.swift
@@ -90,8 +90,8 @@ final class PushRegistrationPayloadTests: XCTestCase {
     func testRegisterFixtureMatchesTheBackend() {
         let expected = "000000156f6e796d2d707573682d72656769737465722d76310000000c646576696365"
             + "2d746f6b656e0000000d6f6e796d3a6b65793a6161626200000014323032362d30382d"
-            + "32325431323a30303a30305a000000060a0b0c0deeff000000203ae773f8c0e9d68"
-            + "10aadf1564c3c63821a019269b84d50ddccb902878399fc48"
+            + "32325431323a30303a30305a000000060a0b0c0deeff00000020058ea2fe4226d7fb35"
+            + "a804975feb9961e1800113e70fd39a7dd61647cbdd92b5"
         let payload = SignedPushSessionPayload.register(
             deviceToken: deviceToken,
             userKey: userKey,
@@ -105,8 +105,8 @@ final class PushRegistrationPayloadTests: XCTestCase {
     func testRegisterWithoutTokenFixtureMatchesTheBackend() {
         let expected = "000000156f6e796d2d707573682d72656769737465722d7631000000000000000d6f6e"
             + "796d3a6b65793a6161626200000014323032362d30382d32325431323a30303a30305a"
-            + "000000060a0b0c0deeff000000203ae773f8c0e9d6810aadf1564c3c63821a019269b8"
-            + "4d50ddccb902878399fc48"
+            + "000000060a0b0c0deeff00000020058ea2fe4226d7fb35a804975feb9961e1800113e7"
+            + "0fd39a7dd61647cbdd92b5"
         let payload = SignedPushSessionPayload.register(
             deviceToken: nil,
             userKey: userKey,
@@ -133,7 +133,28 @@ final class PushRegistrationPayloadTests: XCTestCase {
     func testSubscriptionsDigestFixtureMatchesTheBackend() {
         XCTAssertEqual(
             hex(SignedPushSessionPayload.digest(of: subscriptions)),
-            "3ae773f8c0e9d6810aadf1564c3c63821a019269b84d50ddccb902878399fc48"
+            "058ea2fe4226d7fb35a804975feb9961e1800113e70fd39a7dd61647cbdd92b5"
+        )
+    }
+
+    /// The digest binds grouping, not just flattened pairs: an entry
+    /// with an empty relay list still contributes bytes (tag plus a
+    /// zero relay count), so `{tag, relays: []}` differs from omitting
+    /// the entry — and an empty subscription list digests to
+    /// SHA-256 of nothing, both pinned against the backend.
+    func testEmptyRelayListsStillShapeTheDigest() {
+        let bareEntry = [PushSubscription(tag: "a1b2c3d4e5f60718", relays: [])]
+        XCTAssertEqual(
+            hex(SignedPushSessionPayload.digest(of: bareEntry)),
+            "03a2f27940d35cb25a941ba710b844a82cf4aabf50aa0c893785cf8726aab8b8"
+        )
+        XCTAssertEqual(
+            hex(SignedPushSessionPayload.digest(of: [])),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+        XCTAssertNotEqual(
+            SignedPushSessionPayload.digest(of: bareEntry),
+            SignedPushSessionPayload.digest(of: [])
         )
     }
 

--- a/Tests/OnymIOSTests/PushRegistrationPayloadTests.swift
+++ b/Tests/OnymIOSTests/PushRegistrationPayloadTests.swift
@@ -65,6 +65,25 @@ final class PushRegistrationPayloadTests: XCTestCase {
         )
     }
 
+    /// The digest binds grouping, not just the flattened (tag, relay)
+    /// pairs: the per-entry relay count makes one entry carrying two
+    /// relays digest differently from the same tag split across two
+    /// entries. This exact collision existed before the count was
+    /// added — pinned here so it cannot come back.
+    func testDigestIsGroupingSensitive() {
+        let grouped = [
+            PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://r1.example", "wss://r2.example"]),
+        ]
+        let split = [
+            PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://r1.example"]),
+            PushSubscription(tag: "a1b2c3d4e5f60718", relays: ["wss://r2.example"]),
+        ]
+        XCTAssertNotEqual(
+            SignedPushSessionPayload.digest(of: grouped),
+            SignedPushSessionPayload.digest(of: split)
+        )
+    }
+
     /// An absent device token and an empty one encode identically —
     /// intentional, matching the moderation payload's contract.
     func testAbsentAndEmptyDeviceTokenAgree() {
@@ -115,6 +134,17 @@ final class PushRegistrationPayloadTests: XCTestCase {
             subscriptions: subscriptions
         )
         XCTAssertEqual(hex(payload), expected)
+        // The empty-Data spelling is fixture-pinned too, not just
+        // proven equal to nil elsewhere: both spellings must produce
+        // these exact backend-verified bytes.
+        let emptyToken = SignedPushSessionPayload.register(
+            deviceToken: Data(),
+            userKey: userKey,
+            timestamp: timestamp,
+            apnsToken: apnsToken,
+            subscriptions: subscriptions
+        )
+        XCTAssertEqual(hex(emptyToken), expected)
     }
 
     func testUnregisterFixtureMatchesTheBackend() {

--- a/Tests/OnymIOSTests/PushTokenEnvelopeTests.swift
+++ b/Tests/OnymIOSTests/PushTokenEnvelopeTests.swift
@@ -1,0 +1,80 @@
+import CryptoKit
+import XCTest
+@testable import OnymPush
+
+/// The envelope's parameters (X25519 → HKDF-SHA256 with the
+/// `onym-push-token-v1` salt → AES-256-GCM) must match the backend's
+/// `open_token_envelope`. The Rust side pins an envelope THIS
+/// implementation sealed; here the scheme is proven self-consistent
+/// and its constants are pinned.
+final class PushTokenEnvelopeTests: XCTestCase {
+    func testSealedEnvelopeDecryptsWithTheServerKey() throws {
+        let serverKey = Curve25519.KeyAgreement.PrivateKey()
+        let token = Data([0x0a, 0x0b, 0x0c, 0x0d, 0xee, 0xff])
+
+        let envelope = try PushTokenEnvelope.seal(
+            apnsToken: token,
+            serverPublicKey: serverKey.publicKey.rawRepresentation
+        )
+        XCTAssertEqual(envelope.ephemeralPublicKey.count, 32)
+        XCTAssertEqual(envelope.nonce.count, 12)
+        XCTAssertEqual(envelope.authenticationTag.count, 16)
+
+        XCTAssertEqual(try open(envelope, with: serverKey), token)
+    }
+
+    func testEnvelopeIsNotDecryptableWithAnotherKey() throws {
+        let serverKey = Curve25519.KeyAgreement.PrivateKey()
+        let otherKey = Curve25519.KeyAgreement.PrivateKey()
+        let envelope = try PushTokenEnvelope.seal(
+            apnsToken: Data([0x01]),
+            serverPublicKey: serverKey.publicKey.rawRepresentation
+        )
+        XCTAssertThrowsError(try open(envelope, with: otherKey))
+    }
+
+    func testSealRefusesAMalformedServerKey() {
+        XCTAssertThrowsError(
+            try PushTokenEnvelope.seal(apnsToken: Data([0x01]), serverPublicKey: Data([0x02]))
+        )
+    }
+
+    func testFreshRandomnessPerSeal() throws {
+        let serverKey = Curve25519.KeyAgreement.PrivateKey()
+        let first = try PushTokenEnvelope.seal(
+            apnsToken: Data([0x01]),
+            serverPublicKey: serverKey.publicKey.rawRepresentation
+        )
+        let second = try PushTokenEnvelope.seal(
+            apnsToken: Data([0x01]),
+            serverPublicKey: serverKey.publicKey.rawRepresentation
+        )
+        XCTAssertNotEqual(first.ephemeralPublicKey, second.ephemeralPublicKey)
+        XCTAssertNotEqual(first.nonce, second.nonce)
+    }
+
+    /// The scheme spelled out independently of the implementation
+    /// under test — the salt and info strings are the contract with
+    /// the backend, so a drive-by "cleanup" of either fails here.
+    private func open(
+        _ envelope: PushTokenEnvelope,
+        with serverKey: Curve25519.KeyAgreement.PrivateKey
+    ) throws -> Data {
+        let ephemeral = try Curve25519.KeyAgreement.PublicKey(
+            rawRepresentation: envelope.ephemeralPublicKey
+        )
+        let shared = try serverKey.sharedSecretFromKeyAgreement(with: ephemeral)
+        let key = shared.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data("onym-push-token-v1".utf8),
+            sharedInfo: Data("aes-256-gcm".utf8),
+            outputByteCount: 32
+        )
+        let box = try AES.GCM.SealedBox(
+            nonce: AES.GCM.Nonce(data: envelope.nonce),
+            ciphertext: envelope.ciphertext,
+            tag: envelope.authenticationTag
+        )
+        return try AES.GCM.open(box, using: key)
+    }
+}

--- a/Tests/OnymIOSTests/PushTokenEnvelopeTests.swift
+++ b/Tests/OnymIOSTests/PushTokenEnvelopeTests.swift
@@ -36,6 +36,35 @@ final class PushTokenEnvelopeTests: XCTestCase {
     func testSealRefusesAMalformedServerKey() {
         XCTAssertThrowsError(
             try PushTokenEnvelope.seal(apnsToken: Data([0x01]), serverPublicKey: Data([0x02]))
+        ) { error in
+            XCTAssertEqual(error as? PushTokenEnvelope.SealError, .invalidServerKey)
+        }
+    }
+
+    /// 32 zero bytes decodes as a key but names a low-order point
+    /// whose agreement CryptoKit rejects — the seal must surface that
+    /// as the same "not a server key" error, not an opaque CryptoKit
+    /// throw (this was the silent failure mode of the stub's old
+    /// all-zero default).
+    func testSealRefusesADegenerateServerKey() {
+        XCTAssertThrowsError(
+            try PushTokenEnvelope.seal(
+                apnsToken: Data([0x01]),
+                serverPublicKey: Data(repeating: 0, count: 32)
+            )
+        ) { error in
+            XCTAssertEqual(error as? PushTokenEnvelope.SealError, .invalidServerKey)
+        }
+    }
+
+    /// The stub's pinned default key must itself be sealable — the
+    /// property the deterministic default exists to guarantee.
+    func testStubDefaultKeyIsSealable() {
+        XCTAssertNoThrow(
+            try PushTokenEnvelope.seal(
+                apnsToken: Data([0x01]),
+                serverPublicKey: StubPushBackendClient.defaultRegistrationKey
+            )
         )
     }
 

--- a/Tests/OnymIOSTests/Support/OneShotGate.swift
+++ b/Tests/OnymIOSTests/Support/OneShotGate.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// A reusable one-shot gate for holding an async call open until the
+/// test decides to let it through. Open is sticky: waiters that arrive
+/// after `open()` pass immediately. Lock-backed rather than an actor
+/// so `open()` can be called from synchronous test code, and one type
+/// rather than the two identical private copies the push tests grew.
+final class OneShotGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if opened {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            waiters.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    func open() {
+        lock.lock()
+        opened = true
+        let resumed = waiters
+        waiters = []
+        lock.unlock()
+        for waiter in resumed { waiter.resume() }
+    }
+}

--- a/Tests/OnymIOSTests/Support/Recorder.swift
+++ b/Tests/OnymIOSTests/Support/Recorder.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A lock-backed box for a value recorded inside a `@Sendable` handler
+/// on some other thread (a URLProtocol callback, a failure hook) and
+/// read back from the test thread. The awaits in a test usually give a
+/// happens-after in practice, but under Swift 5 mode nothing checks —
+/// this box makes the crossing explicit, safe, and typed where an
+/// `NSMutableDictionary` is none of the three.
+final class Recorder<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Value?
+
+    func record(_ value: Value) {
+        lock.lock()
+        defer { lock.unlock() }
+        stored = value
+    }
+
+    var value: Value? {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+}

--- a/Tests/OnymIOSTests/Support/RecorderBox.swift
+++ b/Tests/OnymIOSTests/Support/RecorderBox.swift
@@ -6,7 +6,7 @@ import Foundation
 /// happens-after in practice, but under Swift 5 mode nothing checks —
 /// this box makes the crossing explicit, safe, and typed where an
 /// `NSMutableDictionary` is none of the three.
-final class Recorder<Value>: @unchecked Sendable {
+final class RecorderBox<Value>: @unchecked Sendable {
     private let lock = NSLock()
     private var stored: Value?
 


### PR DESCRIPTION
Final iOS PR of the push stack, on top of #312. 58 tests across the six push classes in OnymIOSTests, plus 2 InboxTag golden vectors in OnymFoundationTests — all passing on the iPhone 17 simulator.

- **`PushRegistrationPayloadTests`** — layout, domain separation, digest order-sensitivity/injectivity, absent-vs-empty token agreement, and the **cross-implementation fixtures**: hex produced by running this Swift implementation over pinned inputs. The backend's `payload.rs` (onymchat/onym-push#3) pins the identical strings, so byte drift on either side fails a build before it refuses every real signature in production.
- **`PushTokenEnvelopeTests`** — round-trip with the scheme (X25519 → HKDF `onym-push-token-v1` → AES-256-GCM) spelled out independently of the implementation under test, wrong-key refusal, malformed-key refusal, fresh randomness per seal.
- **`PushBackendClientTests`** — StubURLProtocol wire tests: camelCase/base64/RFC-3339 bodies, `{error, message}` refusals surfaced verbatim plus the `http_<status>` fallback for non-envelope bodies, fractional-seconds expiry decode, https-only guard including the empty-host case, registration-key decode.
- **`PushRegistrationInteractorTests`** — reconciliation where the assertion is as often "no call was made" as "one was": disabled ⇒ silence, unchanged fingerprint ⇒ silence, changed subscriptions ⇒ one replace-all call, failure ⇒ retried on next trigger, a 429 `capacity` refusal fully retryable, disable ⇒ unregister with the known token and no register queued after it, the set-of-pending-unregisters draining every debt (rotation + disable), degenerate expiry windows not churning, and the disable-vs-in-flight-register race ending unregistered.
- **`PushCoordinatorTests`** — the privacy-load-bearing authorization gate (cold-launch revoke ⇒ full disable, foreground revoke ⇒ full disable, granted ⇒ untouched, already-off ⇒ no-op) and the deterministic relay-cap truncation against the backend's per-request caps.
- **`NotificationsSettingsFlowTests`** — denied-authorization snapback, reentrant flips dropped, stale denial notes cleared, `registrationPending` following the probe, off-screen disable resync.
- **`InboxTagTests`** (OnymFoundationTests) — golden vector for the hoisted formula behind all seven inbox-tag call sites, plus a pin on the `sep-inbox-v1` domain-separation prefix itself.
- Shared test support: a lock-backed `RecorderBox` for values crossing from `@Sendable` handlers, and one `OneShotGate` replacing the two identical private gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf
