### PR TITLE
Stay quiet while the user is already looking at the thread

### DIFF
--- a/Sources/OnymIOS/PushAppDelegate.swift
+++ b/Sources/OnymIOS/PushAppDelegate.swift
@@ -61,8 +61,8 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        // Foreground presentation goes through this delegate; set
-        // before anything can arrive.
+        // Foreground presentation is decided by this delegate; set
+        // before anything can arrive so the decision is never missed.
         UNUserNotificationCenter.current().delegate = self
         return true
     }
@@ -87,14 +87,23 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
         // Quiet by design; the reconciler retries on later inputs.
     }
 
-    /// A push arriving while the app is foregrounded still shows its
-    /// (content-free) banner — without this, foreground arrivals are
-    /// silently swallowed and the toggle looks broken exactly when the
-    /// user is watching.
+    /// A push arriving while the app is foregrounded is suppressed.
+    /// The alert APNs carries is fixed and content-free — "New
+    /// message", no group or thread key (`apns.rs` in the push
+    /// backend) — so nothing here can tell which conversation it
+    /// belongs to, and it would banner over the very thread the user
+    /// is reading. It does not need to: foregrounded means the
+    /// repositories hold live relay connections, so the message is
+    /// already landing in the UI on its own. The banner would only ever
+    /// repeat what the user can see.
+    ///
+    /// Returning empty means the notification is dropped rather than
+    /// deferred to Notification Center, which is the point: it carries
+    /// nothing worth catching up on later.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        [.banner, .sound]
+        []
     }
 }


### PR DESCRIPTION
A push arriving while the app is foregrounded now presents nothing.

The alert APNs carries is fixed and content-free — `{"alert": {"title": "Onym", "body": "New message"}}`, no group or thread key (see `apns.rs` in the push backend, and the earlier decision to reject group-hash topics). So `willPresent` cannot tell which conversation the push belongs to, and it would banner over the very thread the user is reading.

It does not need to. Foregrounded means the repositories hold live relay connections, so the message is already landing in the UI on its own — the banner could only ever repeat what the user can see. Returning an empty option set drops the notification rather than deferring it to Notification Center, which is the point: it carries nothing worth catching up on later.

The behaviour this replaces was justified in its own comment as keeping the toggle from *looking* broken while the user watches. That is a diagnosability argument, and it was being paid for in interruptions. If the toggle needs to be verifiable, a status line in push settings is the place for it — noted as a follow-up, not done here.

No test changes: nothing currently exercises `PushAppDelegate`, and the presentation options are a one-line policy the delegate hands to UIKit.

Verified with a simulator build (iPhone 17): `** BUILD SUCCEEDED **`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf