### PR TITLE
A package that holds only the colors, so another may hold different ones

### DIFF
--- a/Packages/OnymDesign/Package.swift
+++ b/Packages/OnymDesign/Package.swift
@@ -7,7 +7,16 @@ let package = Package(
     products: [
         .library(name: "OnymDesign", targets: ["OnymDesign"])
     ],
+    dependencies: [
+        // The swappable token layer. Adopters who want a differently
+        // styled build repoint this one dependency at their own module
+        // named `OnymDesignTokens` — see that package's README.
+        .package(path: "../OnymDesignTokens")
+    ],
     targets: [
-        .target(name: "OnymDesign")
+        .target(
+            name: "OnymDesign",
+            dependencies: [.product(name: "OnymDesignTokens", package: "OnymDesignTokens")]
+        )
     ]
 )

--- a/Packages/OnymDesign/Sources/OnymDesign/OnymBrand.swift
+++ b/Packages/OnymDesign/Sources/OnymDesign/OnymBrand.swift
@@ -1,97 +1,11 @@
 import SwiftUI
 import UIKit
 
-// MARK: - Tokens
+@_exported import OnymDesignTokens
 
-/// Theme-adaptive design tokens for the Create Group flow. Each color
-/// resolves to its light or dark variant via the system trait
-/// collection — no per-view `@Environment(\.colorScheme)` plumbing
-/// required, the `UIColor` dynamic provider does the work.
-///
-/// Mirrors the Claude Designed reference's `THEMES.dark` + `THEMES.light`
-/// from `app.jsx`. Pinned RGB values came directly from that source.
-public enum OnymTokens {
-    public static let bg              = Color.dynamic(light: hex(0xFFFFFF),  dark: hex(0x000000))
-    public static let surface         = Color.dynamic(light: hex(0xF5F5F7),  dark: hex(0x0E0E10))
-    public static let surface2        = Color.dynamic(light: hex(0xFFFFFF),  dark: hex(0x17171A))
-    public static let surface3        = Color.dynamic(light: hex(0xEBEBEF),  dark: hex(0x1F1F23))
-    public static let text            = Color.dynamic(light: hex(0x0A0A0C),  dark: hex(0xF2F2F4))
-    public static let text2           = Color.dynamic(light: hex(0x0A0A0C, 0.62), dark: hex(0xF2F2F4, 0.62))
-    public static let text3           = Color.dynamic(light: hex(0x0A0A0C, 0.42), dark: hex(0xF2F2F4, 0.40))
-    public static let hairline        = Color.dynamic(light: .black.opacity(0.06), dark: .white.opacity(0.07))
-    public static let hairlineStrong  = Color.dynamic(light: .black.opacity(0.12), dark: .white.opacity(0.12))
-    public static let green           = Color.dynamic(light: hex(0x1FA84A),  dark: hex(0x34C759))
-    public static let red             = Color.dynamic(light: hex(0xE5392E),  dark: hex(0xFF453A))
-    /// Caution, not failure: something a person should read before
-    /// deciding, where `red` would say the decision is already wrong.
-    ///
-    /// The light value is darker than the system orange it started as.
-    /// `#FF9500` on `surface2` is ~2.1:1, which fails WCAG AA for the
-    /// caption-sized text this is used on — and it is used on the lines
-    /// a founder is most expected to actually read. `#B25E00` clears
-    /// 4.5:1. The dark variant already did.
-    public static let amber           = Color.dynamic(light: hex(0xB25E00),  dark: hex(0xFF9F0A))
+// MARK: - Sender → accent
 
-    /// Reads on accent fills (button labels, governance card check
-    /// glyphs, success seal). Light → white text on saturated accent;
-    /// dark → black text. The same `OnymTokens.onAccent` keeps the
-    /// view code theme-agnostic.
-    public static let onAccent        = Color.dynamic(light: .white,         dark: .black)
-
-    /// Hex literal helper. Optional alpha multiplies sRGB opacity in
-    /// place — saves the per-call `.opacity(...)` modifier when
-    /// declaring text2 / text3 style tokens.
-    private static func hex(_ rgb: UInt32, _ alpha: Double = 1) -> Color {
-        Color(
-            red:   Double((rgb >> 16) & 0xFF) / 255,
-            green: Double((rgb >> 8)  & 0xFF) / 255,
-            blue:  Double(rgb         & 0xFF) / 255,
-            opacity: alpha
-        )
-    }
-}
-
-extension Color {
-    /// Build a SwiftUI `Color` that swaps between `light` and `dark`
-    /// based on the system trait collection. Backed by `UIColor`'s
-    /// dynamic provider so it reacts to user dark-mode toggles
-    /// without re-rendering or re-evaluating the calling view.
-    public static func dynamic(light: Color, dark: Color) -> Color {
-        Color(UIColor { traits in
-            traits.userInterfaceStyle == .dark ? UIColor(dark) : UIColor(light)
-        })
-    }
-}
-
-// MARK: - Accent palette
-
-public enum OnymAccent: String, CaseIterable, Identifiable, Sendable {
-    case orange, blue, green, purple, pink, yellow
-
-    public var id: String { rawValue }
-
-    /// Per-theme variants from the design. Light variants are
-    /// slightly desaturated for legibility on white surfaces; dark
-    /// variants are the brighter saturated set that pops on black.
-    public var color: Color {
-        switch self {
-        case .orange: Color.dynamic(light: rgb(0xE85F2A), dark: rgb(0xFF7A45))
-        case .blue:   Color.dynamic(light: rgb(0x1F86E0), dark: rgb(0x3FA8FF))
-        case .green:  Color.dynamic(light: rgb(0x1FA84A), dark: rgb(0x3DD66E))
-        case .purple: Color.dynamic(light: rgb(0x8B4DEB), dark: rgb(0xB278FF))
-        case .pink:   Color.dynamic(light: rgb(0xE03253), dark: rgb(0xFF4D6D))
-        case .yellow: Color.dynamic(light: rgb(0xD9A400), dark: rgb(0xFFC93C))
-        }
-    }
-
-    private func rgb(_ hex: UInt32) -> Color {
-        Color(
-            red:   Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8)  & 0xFF) / 255,
-            blue:  Double(hex         & 0xFF) / 255
-        )
-    }
-
+extension OnymAccent {
     /// Deterministic accent for a chat sender, keyed off their BLS
     /// pubkey hex.
     ///
@@ -102,6 +16,10 @@ public enum OnymAccent: String, CaseIterable, Identifiable, Sendable {
     /// a pure function of the hex bytes (FNV-1a, not the per-process-
     /// seeded `Hashable`), so the same person resolves to the same color
     /// on every device, in every group, across launches.
+    ///
+    /// Lives here rather than in `OnymDesignTokens` because it is
+    /// mapping policy, not a token value — adopters swapping the token
+    /// module inherit this behaviour unchanged.
     public static func forSender(blsPubkeyHex: String) -> OnymAccent {
         var hash: UInt64 = 0xcbf2_9ce4_8422_2325  // FNV-1a offset basis
         for byte in blsPubkeyHex.utf8 {

--- a/Packages/OnymDesignTokens/Package.swift
+++ b/Packages/OnymDesignTokens/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OnymDesignTokens",
+    platforms: [.iOS("18.0")],
+    products: [
+        .library(name: "OnymDesignTokens", targets: ["OnymDesignTokens"])
+    ],
+    targets: [
+        .target(name: "OnymDesignTokens")
+    ]
+)

--- a/Packages/OnymDesignTokens/README.md
+++ b/Packages/OnymDesignTokens/README.md
@@ -1,0 +1,70 @@
+# OnymDesignTokens
+
+The swappable look of the Onym app. This package holds token *values*
+only — colors today, radii and type in the next step. It has no
+dependencies, defines no components, and knows nothing about the app.
+
+Everything visual in `OnymDesign` and the eight UI packages reads from
+here, so replacing this one module restyles the whole app without
+touching a line of app code.
+
+## What is in the contract
+
+| Symbol | What it is |
+| --- | --- |
+| `OnymTokens` | 13 theme-adaptive colors: surfaces, text ramp, hairlines, semantic green/red/amber, `onAccent` |
+| `OnymAccent` | The 6-case identity accent palette, `.color` per case |
+| `Color.dynamic(light:dark:)` | Helper for declaring a color that follows the system trait collection |
+
+Anything else — `OnymMark`, `OnymGovIcon`, the `Settings*` components,
+`OnymAccent.forSender(blsPubkeyHex:)` — lives in `OnymDesign` and is
+**not** yours to reimplement. Sender-to-accent mapping in particular is
+policy, not a token: adopters inherit it unchanged.
+
+## How to ship a differently styled build
+
+1. Copy this directory to your own package, keeping the module name
+   `OnymDesignTokens` and the product name `OnymDesignTokens`. The name
+   is load-bearing — it is what the rest of the graph imports.
+2. Change the values. Keep every symbol in the table above, with the
+   same names and types.
+3. Repoint the dependency in `Packages/OnymDesign/Package.swift` at your
+   copy:
+
+   ```swift
+   dependencies: [
+       .package(path: "../AcmeOnymTokens")   // instead of ../OnymDesignTokens
+   ]
+   ```
+
+   or, if you consume Onym as a git dependency, use SwiftPM's
+   `--replace-scm-with-local` / a `.package(name:path:)` override.
+4. Build. That is the whole swap.
+
+### The completeness guarantee
+
+There is no protocol to conform to and no registration call, because
+none is needed: the app refers to these tokens by name from 758 call
+sites. A replacement module that omits `text3`, or types it as
+`UIColor` instead of `Color`, fails to compile. You cannot ship a
+half-finished theme by accident.
+
+### What this seam does *not* give you
+
+Swapping is a **build-time** choice, not a runtime one. There is no
+in-app theme picker and no way to change tokens without recompiling.
+That is the deliberate trade for compile-time completeness and zero
+indirection on every color read. Light and dark still switch live at
+runtime, as before — that is inside each token, not across modules.
+
+## Keeping in step with the design system
+
+Values here mirror the `Onym Design System` project on claude.ai.
+Two divergences are intentional and should survive any resync:
+
+- **`amber` light variant is `#B25E00`,** not the system orange
+  `#FF9500`. The original fails WCAG AA (~2.1:1) at the caption size it
+  is used on, and it is used on lines a founder is most expected to
+  read.
+- **`text3` dark is 0.40 alpha** against light's 0.42 — the darker
+  ground needs slightly less fade to hold the same apparent contrast.

--- a/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymAccent.swift
+++ b/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymAccent.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+// MARK: - Accent palette
+
+/// The identity accent palette. One accent belongs to each chat sender
+/// and is used consistently across their bubbles and avatar.
+///
+/// The *case set* is part of the contract, not a token: `OnymDesign`
+/// maps a sender's pubkey onto `allCases`, so adopters recolor the
+/// cases but should not add or remove them — changing the count
+/// reshuffles every existing sender's color.
+public enum OnymAccent: String, CaseIterable, Identifiable, Sendable {
+    case orange, blue, green, purple, pink, yellow
+
+    public var id: String { rawValue }
+
+    /// Per-theme variants from the design. Light variants are
+    /// slightly desaturated for legibility on white surfaces; dark
+    /// variants are the brighter saturated set that pops on black.
+    public var color: Color {
+        switch self {
+        case .orange: Color.dynamic(light: rgb(0xE85F2A), dark: rgb(0xFF7A45))
+        case .blue:   Color.dynamic(light: rgb(0x1F86E0), dark: rgb(0x3FA8FF))
+        case .green:  Color.dynamic(light: rgb(0x1FA84A), dark: rgb(0x3DD66E))
+        case .purple: Color.dynamic(light: rgb(0x8B4DEB), dark: rgb(0xB278FF))
+        case .pink:   Color.dynamic(light: rgb(0xE03253), dark: rgb(0xFF4D6D))
+        case .yellow: Color.dynamic(light: rgb(0xD9A400), dark: rgb(0xFFC93C))
+        }
+    }
+
+    private func rgb(_ hex: UInt32) -> Color {
+        Color(
+            red:   Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8)  & 0xFF) / 255,
+            blue:  Double(hex         & 0xFF) / 255
+        )
+    }
+}

--- a/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymTokens.swift
+++ b/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymTokens.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Tokens
+
+/// Theme-adaptive design tokens for the whole app. Each color resolves
+/// to its light or dark variant via the system trait collection — no
+/// per-view `@Environment(\.colorScheme)` plumbing required, the
+/// `UIColor` dynamic provider does the work.
+///
+/// Values mirror the `Onym Design System` reference. Pinned RGB values
+/// came directly from that source.
+///
+/// This type is the *substitution surface* for adopters — see this
+/// package's README. Every member here is called by name from the app
+/// and the UI packages, so a replacement `OnymDesignTokens` module must
+/// declare all of them or the app will not compile.
+public enum OnymTokens {
+    public static let bg              = Color.dynamic(light: hex(0xFFFFFF),  dark: hex(0x000000))
+    public static let surface         = Color.dynamic(light: hex(0xF5F5F7),  dark: hex(0x0E0E10))
+    public static let surface2        = Color.dynamic(light: hex(0xFFFFFF),  dark: hex(0x17171A))
+    public static let surface3        = Color.dynamic(light: hex(0xEBEBEF),  dark: hex(0x1F1F23))
+    public static let text            = Color.dynamic(light: hex(0x0A0A0C),  dark: hex(0xF2F2F4))
+    public static let text2           = Color.dynamic(light: hex(0x0A0A0C, 0.62), dark: hex(0xF2F2F4, 0.62))
+    public static let text3           = Color.dynamic(light: hex(0x0A0A0C, 0.42), dark: hex(0xF2F2F4, 0.40))
+    public static let hairline        = Color.dynamic(light: .black.opacity(0.06), dark: .white.opacity(0.07))
+    public static let hairlineStrong  = Color.dynamic(light: .black.opacity(0.12), dark: .white.opacity(0.12))
+    public static let green           = Color.dynamic(light: hex(0x1FA84A),  dark: hex(0x34C759))
+    public static let red             = Color.dynamic(light: hex(0xE5392E),  dark: hex(0xFF453A))
+    /// Caution, not failure: something a person should read before
+    /// deciding, where `red` would say the decision is already wrong.
+    ///
+    /// The light value is darker than the system orange it started as.
+    /// `#FF9500` on `surface2` is ~2.1:1, which fails WCAG AA for the
+    /// caption-sized text this is used on — and it is used on the lines
+    /// a founder is most expected to actually read. `#B25E00` clears
+    /// 4.5:1. The dark variant already did.
+    public static let amber           = Color.dynamic(light: hex(0xB25E00),  dark: hex(0xFF9F0A))
+
+    /// Reads on accent fills (button labels, governance card check
+    /// glyphs, success seal). Light → white text on saturated accent;
+    /// dark → black text. The same `OnymTokens.onAccent` keeps the
+    /// view code theme-agnostic.
+    public static let onAccent        = Color.dynamic(light: .white,         dark: .black)
+
+    /// Hex literal helper. Optional alpha multiplies sRGB opacity in
+    /// place — saves the per-call `.opacity(...)` modifier when
+    /// declaring text2 / text3 style tokens.
+    private static func hex(_ rgb: UInt32, _ alpha: Double = 1) -> Color {
+        Color(
+            red:   Double((rgb >> 16) & 0xFF) / 255,
+            green: Double((rgb >> 8)  & 0xFF) / 255,
+            blue:  Double(rgb         & 0xFF) / 255,
+            opacity: alpha
+        )
+    }
+}
+
+extension Color {
+    /// Build a SwiftUI `Color` that swaps between `light` and `dark`
+    /// based on the system trait collection. Backed by `UIColor`'s
+    /// dynamic provider so it reacts to user dark-mode toggles
+    /// without re-rendering or re-evaluating the calling view.
+    public static func dynamic(light: Color, dark: Color) -> Color {
+        Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark ? UIColor(dark) : UIColor(light)
+        })
+    }
+}


### PR DESCRIPTION
First of five. Extracts the token layer so an adopter can ship Onym in their own colors.

`OnymTokens`, `OnymAccent` and `Color.dynamic` move out of `OnymBrand.swift` into a new zero-dependency `OnymDesignTokens` package. `OnymDesign` depends on it and re-exports it, so **all 758 call sites across the eight UI packages and the app compile untouched**. Nothing visible changes.

What it buys is a seam. An adopter copies the package, keeps the module name, changes the values, repoints one dependency. Nothing else in the graph knows.

The completeness check is the compiler: a replacement that forgets a token has no protocol to fail to conform to, only 758 call sites that no longer resolve.

`forSender` stays behind in `OnymDesign` — mapping a pubkey onto the palette is policy, not a value, and adopters should inherit it rather than reimplement it.

The seam is a **build-time** choice, not a runtime one; that trade is documented in the package README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf