### PR TITLE
The app and the drawing agree on what to call things

### DIFF
--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupEnrolmentView.swift
@@ -113,8 +113,8 @@ public struct BackupEnrolmentView: View {
                     symbol: "clock.arrow.circlepath",
                     identifier: "backup.enrolment.schedule")
 
-                SettingsSectionLabel("WHAT THE OPERATOR PROMISES")
-                SettingsCard {
+                SectionLabel("WHAT THE OPERATOR PROMISES")
+                Card {
                     ForEach(Array(disclosure.items.enumerated()), id: \.element.id) { index, item in
                         VStack(alignment: .leading, spacing: 4) {
                             // `verbatim` throughout: these are the
@@ -140,7 +140,7 @@ public struct BackupEnrolmentView: View {
                     }
                 }
 
-                SettingsFootnote(
+                Footnote(
                     "These terms are pinned to every backup you make under them. If the operator publishes different terms later, backups stop until you have seen them.")
 
             }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/BackupRestoreView.swift
@@ -14,7 +14,7 @@ public struct BackupRestoreView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                SettingsFootnote(
+                Footnote(
                     "Restoring adds this backup's messages and groups to what is already on this phone. Nothing is deleted, and your identity is not touched.")
 
                 switch flow.state {
@@ -108,7 +108,7 @@ public struct BackupRestoreView: View {
     @ViewBuilder
     private var unreachableNote: some View {
         if !flow.unreachableOperators.isEmpty {
-            SettingsFootnote(
+            Footnote(
                 verbatim: "Could not reach \(flow.unreachableOperators.joined(separator: ", ")). Anything held there is not in this list.")
                 .accessibilityIdentifier("backup.restore.unreachable")
         }
@@ -116,13 +116,13 @@ public struct BackupRestoreView: View {
 
     private func list(_ snapshots: [RestorableSnapshot]) -> some View {
         Group {
-            SettingsSectionLabel("BACKUPS")
-            SettingsCard {
+            SectionLabel("BACKUPS")
+            Card {
                 ForEach(Array(snapshots.enumerated()), id: \.element.id) { index, row in
                     Button {
                         confirming = row
                     } label: {
-                        SettingsRow(
+                        Row(
                             // Per operator, not per list. These rows come
                             // from independent operators now: the newest
                             // row overall might be one operator's copy
@@ -138,7 +138,7 @@ public struct BackupRestoreView: View {
                             subtitle: Self.subtitle(for: row),
                             last: index == snapshots.count - 1
                         ) {
-                            SettingsIconTile(symbol: "shippingbox", bg: OnymTile.blue)
+                            IconTile(symbol: "shippingbox", bg: OnymTile.blue)
                         }
                     }
                     .buttonStyle(.plain)
@@ -146,7 +146,7 @@ public struct BackupRestoreView: View {
                         "backup.restore.snapshot.\(row.snapshot.snapshotReference.digestHex)")
                 }
             }
-            SettingsFootnote(
+            Footnote(
                 "Sizes are rounded into buckets, so they do not tell you how much history a backup holds.")
         }
     }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupSettingsView.swift
@@ -26,9 +26,9 @@ public struct DeviceBackupSettingsView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                SettingsSectionLabel("STATUS")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("STATUS")
+                Card {
+                    Row(
                         title: statusTitle,
                         subtitle: statusSubtitle,
                         // A failure message renders here, and one line
@@ -36,28 +36,28 @@ public struct DeviceBackupSettingsView: View {
                         subtitleLineLimit: 3,
                         last: true
                     ) {
-                        SettingsIconTile(symbol: statusSymbol, bg: OnymTile.blue)
+                        IconTile(symbol: statusSymbol, bg: OnymTile.blue)
                     }
                     .accessibilityIdentifier("backup.status_row")
                 }
-                SettingsFootnote(verbatim: statusFootnote)
+                Footnote(verbatim: statusFootnote)
 
                 if flow.attachmentsWithheld {
-                    SettingsFootnote(
+                    Footnote(
                         "You set this operator up with attachments included, but another operator you back up to was not. One backup is made for all of them, so attachments are currently left out of every one — including this operator's.")
                         .accessibilityIdentifier("backup.attachments_withheld")
                 }
 
                 if flow.needsEnrolment {
                     if let enrolment = makeEnrolment() {
-                        SettingsCard {
+                        Card {
                             NavigationLink { enrolment } label: {
-                                SettingsRow(
+                                Row(
                                     title: enrolmentRowTitle,
                                     subtitle: "Read what it does before turning it on",
                                     last: true
                                 ) {
-                                    SettingsIconTile(symbol: "externaldrive.badge.plus",
+                                    IconTile(symbol: "externaldrive.badge.plus",
                                                      bg: OnymTile.green)
                                 }
                             }
@@ -67,23 +67,23 @@ public struct DeviceBackupSettingsView: View {
                     }
                 }
                 if !flow.needsEnrolment {
-                    SettingsCard {
+                    Card {
                         Button {
                             Task { await flow.backUpNow() }
                         } label: {
-                            SettingsRow(
+                            Row(
                                 title: "Back Up Now",
                                 subtitle: "Uploads your whole history to this operator",
                                 last: true
                             ) {
-                                SettingsIconTile(symbol: "arrow.up.circle", bg: OnymTile.blue)
+                                IconTile(symbol: "arrow.up.circle", bg: OnymTile.blue)
                             }
                         }
                         .buttonStyle(.plain)
                         .disabled(flow.state.status == .running)
                         .accessibilityIdentifier("backup.back_up_now_row")
                     }
-                    SettingsFootnote(
+                    Footnote(
                         "Each backup uploads everything, not just what changed — there is no incremental upload yet.")
 
                     snapshotsSection
@@ -144,26 +144,26 @@ public struct DeviceBackupSettingsView: View {
     @ViewBuilder
     private var stopSection: some View {
         if flow.canStopBackingUp {
-            SettingsCard {
+            Card {
                 Button(role: .destructive) {
                     confirmingStop = true
                 } label: {
-                    SettingsRow(
+                    Row(
                         title: "Stop Backing Up Here",
                         subtitle: "Ends this operator's copy and stops paying for it",
                         last: true
                     ) {
-                        SettingsIconTile(symbol: "xmark.bin", bg: OnymTile.red)
+                        IconTile(symbol: "xmark.bin", bg: OnymTile.red)
                     }
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("backup.stop_row")
             }
             if let failure = flow.stopFailure {
-                SettingsFootnote(verbatim: failure)
+                Footnote(verbatim: failure)
                     .accessibilityIdentifier("backup.stop_failed")
             } else {
-                SettingsFootnote(
+                Footnote(
                     "Your other operators are not affected. Erasing asks this operator to destroy what it holds and keeps its signed receipt; stopping without erasing leaves what it has until its own retention period ends.")
             }
         }
@@ -171,35 +171,35 @@ public struct DeviceBackupSettingsView: View {
 
     private var snapshotsSection: some View {
         Group {
-            SettingsSectionLabel("SNAPSHOTS")
-            SettingsCard {
+            SectionLabel("SNAPSHOTS")
+            Card {
                 if flow.state.snapshots.isEmpty {
-                    SettingsRow(
+                    Row(
                         title: "None yet",
                         subtitle: "Nothing has been accepted by the operator",
                         last: true
                     ) {
-                        SettingsIconTile(symbol: "tray", bg: OnymTile.gray)
+                        IconTile(symbol: "tray", bg: OnymTile.gray)
                     }
                 } else {
                     ForEach(Array(flow.state.snapshots.enumerated()), id: \.element.snapshotReference) {
                         index, snapshot in
                         // The digest lives in the subtitle rather than
-                        // the title: `SettingsRow` takes a localization
+                        // the title: `Row` takes a localization
                         // key for its title, and runtime data must never
                         // be looked up as one.
-                        SettingsRow(
+                        Row(
                             title: "Snapshot",
                             subtitle: Self.subtitle(for: snapshot),
                             last: index == flow.state.snapshots.count - 1
                         ) {
-                            SettingsIconTile(symbol: "shippingbox", bg: OnymTile.gray)
+                            IconTile(symbol: "shippingbox", bg: OnymTile.gray)
                         }
                         .accessibilityIdentifier("backup.snapshot.\(snapshot.snapshotReference.digestHex)")
                     }
                 }
             }
-            SettingsFootnote(
+            Footnote(
                 "Sizes are rounded into buckets before upload, so what the operator sees does not measure your history.")
         }
     }

--- a/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
+++ b/Packages/OnymBackupUI/Sources/OnymBackupUI/DeviceBackupVendorsView.swift
@@ -31,33 +31,33 @@ public struct DeviceBackupVendorsView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                SettingsSectionLabel("STATUS")
-                SettingsCard {
-                    SettingsRow(title: statusTitle, subtitle: statusSubtitle, last: true) {
-                        SettingsIconTile(symbol: statusSymbol, bg: OnymTile.blue)
+                SectionLabel("STATUS")
+                Card {
+                    Row(title: statusTitle, subtitle: statusSubtitle, last: true) {
+                        IconTile(symbol: statusSymbol, bg: OnymTile.blue)
                     }
                     .accessibilityIdentifier("backup.status_row")
                 }
-                SettingsFootnote(verbatim: statusFootnote)
+                Footnote(verbatim: statusFootnote)
 
                 if flow.enrolledCount > 0 {
-                    SettingsCard {
+                    Card {
                         Button {
                             Task { await flow.backUpAllNow() }
                         } label: {
-                            SettingsRow(
+                            Row(
                                 title: flow.enrolledCount > 1 ? "Back Up To All" : "Back Up Now",
                                 subtitle: backUpSubtitle,
                                 last: true
                             ) {
-                                SettingsIconTile(symbol: "arrow.up.circle", bg: OnymTile.blue)
+                                IconTile(symbol: "arrow.up.circle", bg: OnymTile.blue)
                             }
                         }
                         .buttonStyle(.plain)
                         .disabled(flow.isRunning)
                         .accessibilityIdentifier("backup.back_up_now_row")
                     }
-                    SettingsFootnote(
+                    Footnote(
                         "Each backup uploads everything, not just what changed — there is no incremental upload yet.")
                 }
 
@@ -72,14 +72,14 @@ public struct DeviceBackupVendorsView: View {
                 // Hiding restore until someone agrees to *store* a
                 // backup asks them to take on a new obligation before
                 // they may read what they already have.
-                SettingsCard {
+                Card {
                     NavigationLink { makeRestore() } label: {
-                        SettingsRow(
+                        Row(
                             title: "Restore From Backup",
                             subtitle: "Adds messages and chats — nothing is deleted",
                             last: true
                         ) {
-                            SettingsIconTile(symbol: "arrow.down.circle", bg: OnymTile.green)
+                            IconTile(symbol: "arrow.down.circle", bg: OnymTile.green)
                         }
                     }
                     .buttonStyle(.plain)
@@ -122,23 +122,23 @@ public struct DeviceBackupVendorsView: View {
     @ViewBuilder
     private var restorePurchases: some View {
         if flow.canRestorePurchases {
-            SettingsCard {
+            Card {
                 Button {
                     Task { await flow.restorePurchases() }
                 } label: {
-                    SettingsRow(
+                    Row(
                         title: "Restore Purchases",
                         subtitle: purchaseRestoreSubtitle,
                         last: true
                     ) {
-                        SettingsIconTile(symbol: "arrow.clockwise.circle", bg: OnymTile.gray)
+                        IconTile(symbol: "arrow.clockwise.circle", bg: OnymTile.gray)
                     }
                 }
                 .buttonStyle(.plain)
                 .disabled(flow.purchaseRestore == .running)
                 .accessibilityIdentifier("backup.restore_purchases_row")
             }
-            SettingsFootnote(
+            Footnote(
                 "If you paid for storage on another phone, this brings that purchase to this one. You are not charged again.")
         }
     }
@@ -194,8 +194,8 @@ public struct DeviceBackupVendorsView: View {
     /// problem.
     private var operators: some View {
         Group {
-            SettingsSectionLabel("OPERATORS")
-            SettingsCard {
+            SectionLabel("OPERATORS")
+            Card {
                 ForEach(Array(flow.vendors.enumerated()), id: \.element.id) { index, vendor in
                     NavigationLink {
                         DeviceBackupSettingsView(
@@ -203,7 +203,7 @@ public struct DeviceBackupVendorsView: View {
                             makeEnrolment: { makeEnrolment(vendor.id) }
                         )
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Operator",
                             subtitle: Self.subtitle(for: vendor),
                             // Two lines, because the thing worth reading
@@ -213,7 +213,7 @@ public struct DeviceBackupVendorsView: View {
                             subtitleLineLimit: 2,
                             last: index == flow.vendors.count - 1
                         ) {
-                            SettingsIconTile(
+                            IconTile(
                                 symbol: Self.symbol(for: vendor.flow.state.status),
                                 bg: Self.tint(for: vendor.flow.state.status))
                         }
@@ -222,13 +222,13 @@ public struct DeviceBackupVendorsView: View {
                     .accessibilityIdentifier("backup.operator_row.\(vendor.id)")
                 }
             }
-            SettingsFootnote(
+            Footnote(
                 "Every operator you set up keeps its own separate copy, sealed with its own key and paid for separately. One of them shutting down or losing your data does not take the others with it — and each one extends the life of this history for everyone in it, under its own jurisdiction.")
         }
     }
 
     /// The operator's name, then what it is actually doing. The name is
-    /// runtime data, so it lives in the subtitle: `SettingsRow` takes a
+    /// runtime data, so it lives in the subtitle: `Row` takes a
     /// localization key for its title, and looking up user-facing data
     /// as one would be a bug waiting for a translator.
     /// The note comes from the operator's own flow rather than from the

--- a/Packages/OnymDesign/Sources/OnymDesign/SettingsDesign.swift
+++ b/Packages/OnymDesign/Sources/OnymDesign/SettingsDesign.swift
@@ -13,7 +13,7 @@ import OnymDesignTokens
 // OnymDesignTokens — it was a token family sitting in a component file.
 
 /// Square-rounded coloured tile. SF symbol over the fill colour.
-public struct SettingsIconTile: View {
+public struct IconTile: View {
     let symbol: String
     let bg: Color
     var size: CGFloat = 30
@@ -68,9 +68,9 @@ public struct SettingsContentTile<Content: View>: View {
 }
 
 /// Section label above a card. All-caps, mid-grey, small letterspacing.
-public struct SettingsSectionLabel<Trailing: View>: View {
+public struct SectionLabel<Trailing: View>: View {
     let text: LocalizedStringKey
-    /// Runtime data rather than UI copy — see `SettingsRow.verbatimTitle`.
+    /// Runtime data rather than UI copy — see `Row.verbatimTitle`.
     var verbatimText: String? = nil
     @ViewBuilder var trailing: () -> Trailing
 
@@ -101,7 +101,7 @@ public struct SettingsSectionLabel<Trailing: View>: View {
     }
 }
 
-extension SettingsSectionLabel where Trailing == EmptyView {
+extension SectionLabel where Trailing == EmptyView {
     public init(_ text: LocalizedStringKey) {
         self.init(text, trailing: { EmptyView() })
     }
@@ -114,9 +114,9 @@ extension SettingsSectionLabel where Trailing == EmptyView {
 
 /// Footnote text beneath a card — italic-equivalent grey copy used as
 /// section explanations.
-public struct SettingsFootnote: View {
+public struct Footnote: View {
     let text: LocalizedStringKey
-    /// Runtime data rather than UI copy — see `SettingsRow.verbatimTitle`.
+    /// Runtime data rather than UI copy — see `Row.verbatimTitle`.
     var verbatimText: String? = nil
     public init(_ text: LocalizedStringKey) { self.text = text }
     /// Footnote from runtime data (e.g. an already-localized error
@@ -138,9 +138,9 @@ public struct SettingsFootnote: View {
 
 /// Settings large title. Renders the same 34pt bold heading the design
 /// shows beneath the nav bar on each top-level screen.
-public struct SettingsLargeTitle: View {
+public struct LargeTitle: View {
     let text: LocalizedStringKey
-    /// Runtime data rather than UI copy — see `SettingsRow.verbatimTitle`.
+    /// Runtime data rather than UI copy — see `Row.verbatimTitle`.
     var verbatimText: String? = nil
     public init(_ text: LocalizedStringKey) { self.text = text }
     /// Title from runtime data (e.g. an authority's published name).
@@ -162,7 +162,7 @@ public struct SettingsLargeTitle: View {
 
 /// White rounded card surface used for grouped rows. 14pt corner
 /// radius, full-bleed inside the page's 16pt horizontal padding.
-public struct SettingsCard<Content: View>: View {
+public struct Card<Content: View>: View {
     @ViewBuilder var content: () -> Content
     public init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content
@@ -273,7 +273,7 @@ public struct SettingsRowDivider: View {
 /// Button. The chevron renders whenever `hasChevron` is true,
 /// independent of `onTap`, because the wrapping `NavigationLink`
 /// itself owns the tap.
-public struct SettingsRow<Tile: View, Right: View>: View {
+public struct Row<Tile: View, Right: View>: View {
     let title: LocalizedStringKey
     /// Set instead of `title` when the text is runtime data (a name
     /// fetched from the network, an identifier) rather than UI copy.
@@ -408,7 +408,7 @@ public struct SettingsRow<Tile: View, Right: View>: View {
     }
 }
 
-extension SettingsRow where Right == EmptyView {
+extension Row where Right == EmptyView {
     public init(
         title: LocalizedStringKey,
         titleColor: Color = OnymTokens.text,
@@ -437,7 +437,7 @@ extension SettingsRow where Right == EmptyView {
     }
 
     /// Tile-only row whose title is runtime data — see the
-    /// `titleText:` initializer on `SettingsRow`.
+    /// `titleText:` initializer on `Row`.
     public init(
         titleText: String,
         titleColor: Color = OnymTokens.text,
@@ -468,7 +468,7 @@ extension SettingsRow where Right == EmptyView {
 }
 
 /// Small uppercase chip used for TESTNET / PUBLIC etc. on relayer rows.
-public struct SettingsChip: View {
+public struct Chip: View {
     let text: String
     let fg: Color
     let bg: Color
@@ -491,7 +491,7 @@ public struct SettingsChip: View {
 }
 
 /// Pill button used for the in-card Copy/Share split actions.
-public struct SettingsTextButton: View {
+public struct TextButton: View {
     let title: LocalizedStringKey
     let systemImage: String
     var foreground: Color = OnymTokens.text
@@ -523,7 +523,7 @@ public struct SettingsTextButton: View {
 
 /// Primary CTA used for Continue / Build & Deploy / Verify etc. Same
 /// dimensions as the design's `PrimaryButton`.
-public struct SettingsPrimaryButton<Label: View>: View {
+public struct PrimaryButton<Label: View>: View {
     var disabled: Bool = false
     let action: () -> Void
     @ViewBuilder var label: () -> Label
@@ -553,7 +553,7 @@ public struct SettingsPrimaryButton<Label: View>: View {
     }
 }
 
-extension SettingsPrimaryButton where Label == Text {
+extension PrimaryButton where Label == Text {
     public init(_ text: LocalizedStringKey, disabled: Bool = false, action: @escaping () -> Void) {
         self.disabled = disabled
         self.action = action
@@ -563,7 +563,7 @@ extension SettingsPrimaryButton where Label == Text {
 
 /// Step indicator for multi-step flows (backup, onboarding). Active
 /// dot expands into a 22pt capsule; visited dots stay filled at 6pt.
-public struct SettingsStepIndicator: View {
+public struct StepIndicator: View {
     let step: Int
     var count: Int = 3
 

--- a/Packages/OnymIdentityUI/Sources/OnymIdentityUI/IdentitiesView.swift
+++ b/Packages/OnymIdentityUI/Sources/OnymIdentityUI/IdentitiesView.swift
@@ -11,7 +11,7 @@ struct IdentitiesView: View {
     @Bindable var flow: IdentitiesFlow
     @State private var showAddSheet = false
     /// Per-row height, scaled with Dynamic Type via `UIFontMetrics`.
-    /// 64 is the baseline at default size (matches `SettingsRow`'s
+    /// 64 is the baseline at default size (matches `Row`'s
     /// padding + dual-line label); AX1+/XL settings scale it up
     /// automatically so the inner List frame grows in step.
     @ScaledMetric private var rowHeight: CGFloat = 64
@@ -19,10 +19,10 @@ struct IdentitiesView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Identities")
-                SettingsFootnote("Tap an identity to open it. Each identity has its own keys, chats, and recovery phrase.")
+                LargeTitle("Identities")
+                Footnote("Tap an identity to open it. Each identity has its own keys, chats, and recovery phrase.")
 
-                SettingsSectionLabel("YOUR IDENTITIES")
+                SectionLabel("YOUR IDENTITIES")
                 identitiesList
 
                 Button {
@@ -48,7 +48,7 @@ struct IdentitiesView: View {
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("identities.add_button")
 
-                SettingsFootnote("Only the active identity’s chats are visible. Switch between identities to see different inboxes.")
+                Footnote("Only the active identity’s chats are visible. Switch between identities to see different inboxes.")
             }
             .padding(.bottom, 32)
         }
@@ -74,8 +74,8 @@ struct IdentitiesView: View {
     // MARK: - Identities list
 
     /// SwiftUI `.swipeActions` is a List-only modifier — applying it to a
-    /// `VStack`/`SettingsCard` row is silently inert. We want both the
-    /// SettingsCard look (rounded card, custom hairlines) and native
+    /// `VStack`/`Card` row is silently inert. We want both the
+    /// Card look (rounded card, custom hairlines) and native
     /// swipe-to-Remove, so the rows live inside a `List` with system
     /// chrome suppressed: `.listStyle(.plain)`, transparent
     /// `scrollContentBackground`, hidden separators (we draw our own),
@@ -96,7 +96,7 @@ struct IdentitiesView: View {
                     NavigationLink {
                         IdentityDetailView(flow: flow, summary: summary)
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: LocalizedStringKey(summary.name),
                             subtitle: "BLS \(flow.blsPrefix(of: summary))…",
                             subtitleMono: true,
@@ -165,8 +165,8 @@ private struct AddIdentitySheet: View {
                         .padding(.top, 16)
                         .padding(.bottom, 24)
 
-                    SettingsSectionLabel("NAME")
-                    SettingsCard {
+                    SectionLabel("NAME")
+                    Card {
                         TextField("Identity name", text: $flow.pendingName)
                             .textInputAutocapitalization(.words)
                             .autocorrectionDisabled()
@@ -175,10 +175,10 @@ private struct AddIdentitySheet: View {
                             .padding(.vertical, 12)
                             .accessibilityIdentifier("add_identity.name_field")
                     }
-                    SettingsFootnote("Defaults to “Identity N” if left blank.")
+                    Footnote("Defaults to “Identity N” if left blank.")
 
-                    SettingsSectionLabel("RESTORE FROM RECOVERY PHRASE")
-                    SettingsCard {
+                    SectionLabel("RESTORE FROM RECOVERY PHRASE")
+                    Card {
                         TextEditor(text: $flow.pendingMnemonic)
                             .frame(minHeight: 96)
                             .font(OnymType.mono(size: 15))
@@ -190,7 +190,7 @@ private struct AddIdentitySheet: View {
                             .padding(.vertical, 8)
                             .accessibilityIdentifier("add_identity.mnemonic_field")
                     }
-                    SettingsFootnote("Leave blank to mint a fresh BIP-39 identity. Paste a 12 or 24-word phrase to restore.")
+                    Footnote("Leave blank to mint a fresh BIP-39 identity. Paste a 12 or 24-word phrase to restore.")
 
                     if let error = flow.addError {
                         Text(error)
@@ -246,7 +246,7 @@ public struct RemoveIdentitySheet: View {
                         .padding(.horizontal, 20)
                         .padding(.top, 16)
 
-                    SettingsCard {
+                    Card {
                         TextField("Type \"\(summary.name)\" to confirm",
                                   text: $flow.pendingRemovalConfirmText)
                             .autocorrectionDisabled()

--- a/Packages/OnymIdentityUI/Sources/OnymIdentityUI/IdentityDetailView.swift
+++ b/Packages/OnymIdentityUI/Sources/OnymIdentityUI/IdentityDetailView.swift
@@ -31,16 +31,16 @@ struct IdentityDetailView: View {
                 hero
 
                 inviteCard
-                SettingsFootnote("Anyone with this code can start a chat with you. The chat itself is end-to-end encrypted.")
+                Footnote("Anyone with this code can start a chat with you. The chat itself is end-to-end encrypted.")
 
-                SettingsSectionLabel("STATE")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("STATE")
+                Card {
+                    Row(
                         title: "Set as active",
                         hasChevron: !isActive,
                         onTap: isActive ? nil : { flow.select(summary.id) }
                     ) {
-                        SettingsIconTile(symbol: "checkmark.circle.fill", bg: OnymTile.green)
+                        IconTile(symbol: "checkmark.circle.fill", bg: OnymTile.green)
                     } right: {
                         if isActive {
                             Text("Active")
@@ -50,21 +50,21 @@ struct IdentityDetailView: View {
                     }
 
                     Button { showShare = true } label: {
-                        SettingsRow(
+                        Row(
                             title: "Share invite key",
                             subtitle: "QR code or link",
                             last: true
                         ) {
-                            SettingsIconTile(symbol: "square.and.arrow.up", bg: OnymTile.indigo)
+                            IconTile(symbol: "square.and.arrow.up", bg: OnymTile.indigo)
                         }
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("identity.share_row.\(summary.id)")
                 }
 
-                SettingsSectionLabel("ADVANCED")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("ADVANCED")
+                Card {
+                    Row(
                         title: "Copy public key",
                         subtitle: "BLS \(flow.blsPrefix(of: summary))…",
                         subtitleMono: true,
@@ -74,20 +74,20 @@ struct IdentityDetailView: View {
                                 .map { String(format: "%02x", $0) }.joined()
                         }
                     ) {
-                        SettingsIconTile(symbol: "doc.on.doc.fill", bg: OnymTile.gray)
+                        IconTile(symbol: "doc.on.doc.fill", bg: OnymTile.gray)
                     }
-                    SettingsRow(
+                    Row(
                         title: "Delete identity",
                         titleColor: OnymTokens.red,
                         hasChevron: false,
                         last: true,
                         onTap: { flow.startRemoval(of: summary) }
                     ) {
-                        SettingsIconTile(symbol: "trash.fill", bg: OnymTile.red)
+                        IconTile(symbol: "trash.fill", bg: OnymTile.red)
                     }
                 }
 
-                SettingsFootnote("Deleting an identity removes its keys from this device. If you’ve backed up the recovery phrase, you can restore it later.")
+                Footnote("Deleting an identity removes its keys from this device. If you’ve backed up the recovery phrase, you can restore it later.")
             }
             .padding(.bottom, 32)
         }
@@ -145,8 +145,8 @@ struct IdentityDetailView: View {
 
     private var inviteCard: some View {
         Group {
-            SettingsSectionLabel("INVITE KEY")
-            SettingsCard {
+            SectionLabel("INVITE KEY")
+            Card {
                 VStack(spacing: 14) {
                     SettingsQRCode(
                         value: settingsInviteURL(blsPublicKey: summary.inboxPublicKey),
@@ -181,7 +181,7 @@ struct IdentityDetailView: View {
                 SettingsRowDivider(inset: 16)
 
                 HStack(spacing: 0) {
-                    SettingsTextButton(
+                    TextButton(
                         title: "Copy link",
                         systemImage: "doc.on.doc",
                         foreground: OnymAccent.blue.color

--- a/Packages/OnymIdentityUI/Sources/OnymIdentityUI/ShareKeyView.swift
+++ b/Packages/OnymIdentityUI/Sources/OnymIdentityUI/ShareKeyView.swift
@@ -93,7 +93,7 @@ public struct ShareKeyView: View {
                 .padding(.horizontal, 16)
                 .padding(.top, 14)
 
-                SettingsFootnote("Anyone who scans this code with Onym can start a private, end-to-end encrypted chat with \(identity.name). The invite key contains your inbox X25519 public key only — no contact info.")
+                Footnote("Anyone who scans this code with Onym can start a private, end-to-end encrypted chat with \(identity.name). The invite key contains your inbox X25519 public key only — no contact info.")
             }
             .padding(.bottom, 24)
         }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/BannedView.swift
@@ -77,7 +77,7 @@ public struct BannedView: View {
                 // verdict details can be long, but a banned user must not
                 // have to discover the appeal action by scrolling.
                 if let builder = caseFlowBuilder {
-                    SettingsPrimaryButton(action: { caseSheet = .appeal }) {
+                    PrimaryButton(action: { caseSheet = .appeal }) {
                         Text("Review case and appeal")
                     }
                     .accessibilityIdentifier("moderation.banned.appeal")
@@ -91,15 +91,15 @@ public struct BannedView: View {
                         }
                     }
                 } else if let appealURL = state.appealURL {
-                    SettingsPrimaryButton(action: { openURL(appealURL) }) {
+                    PrimaryButton(action: { openURL(appealURL) }) {
                         Text("Appeal this ban")
                     }
                     .accessibilityIdentifier("moderation.banned.appeal")
                     .padding(.horizontal, 16)
                 }
 
-                SettingsSectionLabel("VERDICT")
-                SettingsCard {
+                SectionLabel("VERDICT")
+                Card {
                     VStack(alignment: .leading, spacing: 8) {
                         detailRow("Reference", state.verdictRef, monospaced: true)
                         if let verdict = state.verdict {
@@ -115,7 +115,7 @@ public struct BannedView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(16)
                 }
-                SettingsFootnote("The ban covers this device on this app only. The Onym protocol itself remains open.")
+                Footnote("The ban covers this device on this app only. The Onym protocol itself remains open.")
 
                 VStack(spacing: 10) {
                     // In-app appeal is primary — the flow retains the
@@ -199,7 +199,7 @@ public struct BannedView: View {
                 .padding(.top, 16)
 
                 if !hasNewHolderPath {
-                    SettingsFootnote("If you're this device's new owner, contact the authority above — device bans survive a change of hands, and the authority runs an expedited procedure for it.")
+                    Footnote("If you're this device's new owner, contact the authority above — device bans survive a change of hands, and the authority runs an expedited procedure for it.")
                 }
             }
             .padding(.bottom, 32)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/DeviceRecoveryView.swift
@@ -81,7 +81,7 @@ public struct DeviceRecoveryView: View {
                 .foregroundStyle(OnymTokens.text2)
                 .lineSpacing(3)
 
-            SettingsCard {
+            Card {
                 VStack(alignment: .leading, spacing: 12) {
                     TextField(String(localized: "Contact — email or phone", comment: "Recovery claim contact field"), text: $contact)
                         .textInputAutocapitalization(.never)
@@ -99,7 +99,7 @@ public struct DeviceRecoveryView: View {
                 .padding(16)
             }
 
-            SettingsPrimaryButton(action: submit) {
+            PrimaryButton(action: submit) {
                 if case .filing = flow.phase {
                     ProgressView().tint(OnymTokens.onAccent)
                 } else {
@@ -121,7 +121,7 @@ public struct DeviceRecoveryView: View {
             Text(claimId)
                 .font(OnymType.mono(size: 12))
                 .foregroundStyle(OnymTokens.text3)
-            SettingsPrimaryButton(action: check) {
+            PrimaryButton(action: check) {
                 if isChecking {
                     ProgressView().tint(OnymTokens.onAccent)
                 } else {
@@ -169,7 +169,7 @@ public struct DeviceRecoveryView: View {
                 title: String(localized: "A moderation record still bans this device"),
                 detail: String(localized: "The grant stays valid, but nothing moves while a ban stands. Resolve the case with the authority, then check again.")
             )
-            SettingsCard {
+            Card {
                 VStack(alignment: .leading, spacing: 10) {
                     Text(contact)
                         .font(OnymType.font(size: 13))
@@ -189,7 +189,7 @@ public struct DeviceRecoveryView: View {
                 }
                 .padding(16)
             }
-            SettingsPrimaryButton(action: check) {
+            PrimaryButton(action: check) {
                 Text("Check again", comment: "Recovery mark-in-force re-check button")
             }
         }

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/GateCheckRequiredView.swift
@@ -65,7 +65,7 @@ public struct GateCheckRequiredView: View {
                 .lineSpacing(3)
                 .padding(.horizontal, 32)
             if canRetry {
-                SettingsPrimaryButton(action: retry) {
+                PrimaryButton(action: retry) {
                     if isRetrying {
                         ProgressView().tint(OnymTokens.onAccent)
                     } else {
@@ -86,7 +86,7 @@ public struct GateCheckRequiredView: View {
                     .accessibilityIdentifier("moderation.gate_required.retry_result")
             }
             if reason == .reidentificationRequired, let makeDeviceRecoveryFlow {
-                SettingsPrimaryButton(action: {
+                PrimaryButton(action: {
                     Task { @MainActor in
                         activeSheet = .deviceRecovery(await makeDeviceRecoveryFlow())
                     }
@@ -221,7 +221,7 @@ private struct RecoveryAppealView: View {
                         .font(OnymType.font(size: 14))
                         .foregroundStyle(OnymTokens.text2)
                 } else {
-                    SettingsCard {
+                    Card {
                         VStack(spacing: 0) {
                             ForEach(caseIDs, id: \.self) { caseID in
                                 Button { openCase(caseID) } label: {

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationCaseView.swift
@@ -26,7 +26,7 @@ public struct ModerationCaseView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    SettingsLargeTitle("Moderation case")
+                    LargeTitle("Moderation case")
 
                     statusSection
                     // Receipts render OUTSIDE the composer gates: a
@@ -81,8 +81,8 @@ public struct ModerationCaseView: View {
 
     private var statusSection: some View {
         Group {
-            SettingsSectionLabel("STATUS")
-            SettingsCard {
+            SectionLabel("STATUS")
+            Card {
                 VStack(alignment: .leading, spacing: 8) {
                     if let status = flow.state.status {
                         row("Case", status.caseId, monospaced: true)
@@ -126,7 +126,7 @@ public struct ModerationCaseView: View {
                 .padding(16)
             }
             if let fetchedAt = flow.state.snapshotFetchedAt {
-                SettingsFootnote("Shown as of \(fetchedAt.formatted(date: .abbreviated, time: .shortened)) — the authority couldn't be reached for a newer status.")
+                Footnote("Shown as of \(fetchedAt.formatted(date: .abbreviated, time: .shortened)) — the authority couldn't be reached for a newer status.")
             }
             if let message = flow.state.statusErrorMessage {
                 errorText(message, id: "moderation.case.status_error")
@@ -158,8 +158,8 @@ public struct ModerationCaseView: View {
 
     private var receiptsSection: some View {
         Group {
-            SettingsSectionLabel("FILED")
-            SettingsCard {
+            SectionLabel("FILED")
+            Card {
                 VStack(alignment: .leading, spacing: 10) {
                     if let receipt = flow.state.responseReceipt {
                         Label(
@@ -189,8 +189,8 @@ public struct ModerationCaseView: View {
 
     private func eventsSection(_ events: [CaseEvent]) -> some View {
         Group {
-            SettingsSectionLabel("HISTORY")
-            SettingsCard {
+            SectionLabel("HISTORY")
+            Card {
                 VStack(alignment: .leading, spacing: 6) {
                     ForEach(Array(events.enumerated()), id: \.offset) { _, event in
                         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -213,8 +213,8 @@ public struct ModerationCaseView: View {
 
     private var responseSection: some View {
         Group {
-            SettingsSectionLabel("YOUR RESPONSE")
-            SettingsCard {
+            SectionLabel("YOUR RESPONSE")
+            Card {
                 VStack(alignment: .leading, spacing: 10) {
                     if flow.state.responseReceipt != nil {
                         Text("You can file additional statements while the case is open; they attach to the same case.")
@@ -237,7 +237,7 @@ public struct ModerationCaseView: View {
                     if let message = flow.state.responseErrorMessage {
                         inlineError(message, id: "moderation.case.response_error")
                     }
-                    SettingsPrimaryButton(action: {
+                    PrimaryButton(action: {
                         let statement = responseText
                         Task {
                             await flow.submitResponse(statement)
@@ -255,7 +255,7 @@ public struct ModerationCaseView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
             }
-            SettingsFootnote("Your statement is signed with your identity key and disclosed to your authority in full. Not responding doesn't concede the case; it proceeds on the record.")
+            Footnote("Your statement is signed with your identity key and disclosed to your authority in full. Not responding doesn't concede the case; it proceeds on the record.")
         }
     }
 
@@ -263,8 +263,8 @@ public struct ModerationCaseView: View {
 
     private var appealSection: some View {
         Group {
-            SettingsSectionLabel("APPEAL")
-            SettingsCard {
+            SectionLabel("APPEAL")
+            Card {
                 VStack(alignment: .leading, spacing: 10) {
                     TextEditor(text: $appealText)
                         .frame(minHeight: 80)
@@ -282,7 +282,7 @@ public struct ModerationCaseView: View {
                     if let message = flow.state.appealErrorMessage {
                         inlineError(message, id: "moderation.case.appeal_error")
                     }
-                    SettingsPrimaryButton(action: {
+                    PrimaryButton(action: {
                         let statement = appealText
                         Task {
                             await flow.submitAppeal(kind: .appeal, statement: statement)
@@ -300,7 +300,7 @@ public struct ModerationCaseView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
             }
-            SettingsFootnote("Filing an appeal does not suspend the ban unless the consented terms say so.")
+            Footnote("Filing an appeal does not suspend the ban unless the consented terms say so.")
         }
     }
 
@@ -308,8 +308,8 @@ public struct ModerationCaseView: View {
 
     private var newHolderSection: some View {
         Group {
-            SettingsSectionLabel("DEVICE CHANGED HANDS?")
-            SettingsCard {
+            SectionLabel("DEVICE CHANGED HANDS?")
+            Card {
                 VStack(alignment: .leading, spacing: 10) {
                     Text("If you acquired this device after the ban, you can file a new-holder claim. A human reviews it on an expedited basis — a device is not a person.")
                         .font(OnymType.font(size: 13))

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationConsentView.swift
@@ -111,7 +111,7 @@ public struct ModerationConsentContent: View {
 
     @ViewBuilder
     private var picker: some View {
-        SettingsLargeTitle(pickerTitle)
+        LargeTitle(pickerTitle)
         Text(pickerBlurb)
             .font(OnymType.font(size: 14))
             .foregroundStyle(OnymTokens.text2)
@@ -123,7 +123,7 @@ public struct ModerationConsentContent: View {
 
         switch flow.state.fetchStatus {
         case .failed(let message):
-            SettingsCard {
+            Card {
                 VStack(spacing: 10) {
                     Text(message)
                         .font(OnymType.font(size: 14))
@@ -135,13 +135,13 @@ public struct ModerationConsentContent: View {
                 .padding(16)
             }
         case .fetching, .idle:
-            SettingsCard {
+            Card {
                 ProgressView()
                     .frame(maxWidth: .infinity)
                     .padding(16)
             }
         case .success where flow.state.authorities.isEmpty:
-            SettingsCard {
+            Card {
                 Text("No authorities are published yet.")
                     .font(OnymType.font(size: 14))
                     .foregroundStyle(OnymTokens.text3)
@@ -149,10 +149,10 @@ public struct ModerationConsentContent: View {
                     .padding(16)
             }
         case .success:
-            SettingsCard {
+            Card {
                 ForEach(Array(flow.state.authorities.enumerated()), id: \.element.componentId) { idx, listing in
                     Button { flow.selectedAuthority(listing) } label: {
-                        SettingsRow(
+                        Row(
                             titleText: listing.name,
                             subtitle: rowSubtitle(for: listing),
                             // The re-consent marker is prepended to the
@@ -161,7 +161,7 @@ public struct ModerationConsentContent: View {
                             subtitleLineLimit: 2,
                             last: idx == flow.state.authorities.count - 1
                         ) {
-                            SettingsIconTile(symbol: "checkmark.shield", bg: OnymTile.indigo)
+                            IconTile(symbol: "checkmark.shield", bg: OnymTile.indigo)
                         }
                     }
                     .buttonStyle(.plain)
@@ -171,7 +171,7 @@ public struct ModerationConsentContent: View {
         }
 
         if let error = flow.state.errorMessage {
-            SettingsFootnote(verbatim: error)
+            Footnote(verbatim: error)
         }
     }
 
@@ -183,8 +183,8 @@ public struct ModerationConsentContent: View {
         if case .reconsent(.termsChanged) = flow.mode,
            let pinned = flow.state.pinnedManifestHash,
            let published = flow.state.publishedManifestHash {
-            SettingsSectionLabel("WHAT CHANGED")
-            SettingsCard {
+            SectionLabel("WHAT CHANGED")
+            Card {
                 VStack(alignment: .leading, spacing: 10) {
                     hashRow("Terms you signed", pinned)
                     hashRow("Published now", published)
@@ -246,7 +246,7 @@ public struct ModerationConsentContent: View {
     @ViewBuilder
     private var review: some View {
         if let reviewing = flow.state.reviewingManifest?.signedManifest {
-            SettingsLargeTitle(verbatim: flow.state.selectedListing?.name ?? String(localized: "Terms"))
+            LargeTitle(verbatim: flow.state.selectedListing?.name ?? String(localized: "Terms"))
 
             Text("These are the exact terms you're consenting to. A case can only ever reach you under a violation class listed here, with these windows and this appeal path.")
                 .font(OnymType.font(size: 14))
@@ -261,8 +261,8 @@ public struct ModerationConsentContent: View {
 
             proceduralCard(reviewing)
 
-            SettingsSectionLabel("WHAT YOU'RE SIGNING")
-            SettingsCard {
+            SectionLabel("WHAT YOU'RE SIGNING")
+            Card {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Manifest hash")
                         .font(OnymType.font(size: 13, weight: .semibold))
@@ -275,14 +275,14 @@ public struct ModerationConsentContent: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
             }
-            SettingsFootnote("Your consent binds to this hash of these exact terms. The authority cannot edit them under your mandate — changed terms bind only new consents.")
+            Footnote("Your consent binds to this hash of these exact terms. The authority cannot edit them under your mandate — changed terms bind only new consents.")
 
             if let error = flow.state.errorMessage {
-                SettingsFootnote(verbatim: error)
+                Footnote(verbatim: error)
             }
 
             VStack(spacing: 10) {
-                SettingsPrimaryButton(action: { flow.tappedAgree() }) {
+                PrimaryButton(action: { flow.tappedAgree() }) {
                     if flow.state.step == .signing {
                         ProgressView().tint(OnymTokens.onAccent)
                     } else {
@@ -322,8 +322,8 @@ public struct ModerationConsentContent: View {
     /// One violation class with all five mandatory terms visible.
     private func classCard(_ violationClass: ViolationClass) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            SettingsSectionLabel(verbatim: violationClass.classId.replacingOccurrences(of: "-", with: " ").uppercased())
-            SettingsCard {
+            SectionLabel(verbatim: violationClass.classId.replacingOccurrences(of: "-", with: " ").uppercased())
+            Card {
                 VStack(alignment: .leading, spacing: 8) {
                     termRow("Response window", violationClass.responseWindow.display)
                     termRow("Decision deadline", violationClass.decisionDeadline.display)
@@ -352,8 +352,8 @@ public struct ModerationConsentContent: View {
     /// terms shared by all classes.
     private func proceduralCard(_ reviewing: SignedManifest) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            SettingsSectionLabel("PROCEDURE")
-            SettingsCard {
+            SectionLabel("PROCEDURE")
+            Card {
                 VStack(alignment: .leading, spacing: 8) {
                     if let appellate = reviewing.manifest.appellate {
                         termRow("Appeals heard by", appellate)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/ModerationSettingsView.swift
@@ -26,7 +26,7 @@ public struct ModerationSettingsView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Moderation")
+                LargeTitle("Moderation")
 
                 if !flow.state.openCases.isEmpty {
                     OpenCaseBanner(notices: flow.state.openCases, makeCaseFlow: makeCaseFlow)
@@ -40,8 +40,8 @@ public struct ModerationSettingsView: View {
                 }
 
                 if !flow.pendingRegistrations.isEmpty {
-                    SettingsSectionLabel("PENDING REGISTRATION")
-                    SettingsCard {
+                    SectionLabel("PENDING REGISTRATION")
+                    Card {
                         ForEach(
                             Array(flow.pendingRegistrations.enumerated()),
                             id: \.element.historyRowID
@@ -49,12 +49,12 @@ public struct ModerationSettingsView: View {
                             Button {
                                 Task { await flow.retryRegistration(record) }
                             } label: {
-                                SettingsRow(
+                                Row(
                                     titleText: record.authorityName,
                                     subtitle: pendingRegistrationSubtitle(record),
                                     last: idx == flow.pendingRegistrations.count - 1
                                 ) {
-                                    SettingsIconTile(
+                                    IconTile(
                                         symbol: "clock.arrow.circlepath",
                                         bg: OnymTile.indigo
                                     )
@@ -66,29 +66,29 @@ public struct ModerationSettingsView: View {
                         }
                     }
                     if let message = flow.state.registrationErrorMessage {
-                        SettingsFootnote(verbatim: message)
+                        Footnote(verbatim: message)
                     } else {
-                        SettingsFootnote(
+                        Footnote(
                             "These signed mandates are not active. Tap one to retry delivery of the exact persisted artifact; no new consent is created."
                         )
                     }
                 }
 
                 if !flow.previousMandates.isEmpty {
-                    SettingsSectionLabel("PREVIOUS MANDATES")
-                    SettingsCard {
+                    SectionLabel("PREVIOUS MANDATES")
+                    Card {
                         ForEach(Array(flow.previousMandates.enumerated()), id: \.element.historyRowID) { idx, record in
-                            SettingsRow(
+                            Row(
                                 titleText: record.authorityName,
                                 subtitle: "Consented \(record.mandate.acceptedAt.formatted(date: .abbreviated, time: .omitted)) · \(String(record.mandate.manifestHash.prefix(16)))…",
                                 hasChevron: false,
                                 last: idx == flow.previousMandates.count - 1
                             ) {
-                                SettingsIconTile(symbol: "doc.text", bg: OnymTile.gray)
+                                IconTile(symbol: "doc.text", bg: OnymTile.gray)
                             }
                         }
                     }
-                    SettingsFootnote("Old mandates stay bound to the exact terms they consented to. Switching authorities never rewrites them.")
+                    Footnote("Old mandates stay bound to the exact terms they consented to. Switching authorities never rewrites them.")
                 }
             }
             .padding(.bottom, 32)
@@ -107,8 +107,8 @@ public struct ModerationSettingsView: View {
 
     private func activeCard(_ record: MandateRecord) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            SettingsSectionLabel("CURRENT AUTHORITY")
-            SettingsCard {
+            SectionLabel("CURRENT AUTHORITY")
+            Card {
                 VStack(alignment: .leading, spacing: 8) {
                     row("Authority", record.authorityName)
                     row("Component", record.mandate.authority, monospaced: true)
@@ -128,32 +128,32 @@ public struct ModerationSettingsView: View {
                 SettingsRowDivider()
 
                 Button { showSwitchConsent = true } label: {
-                    SettingsRow(
+                    Row(
                         title: "Switch authority",
                         subtitle: "Signs a fresh mandate under the new authority's terms",
                         last: true
                     ) {
-                        SettingsIconTile(symbol: "arrow.triangle.2.circlepath", bg: OnymTile.indigo)
+                        IconTile(symbol: "arrow.triangle.2.circlepath", bg: OnymTile.indigo)
                     }
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("moderation.settings.switch")
             }
-            SettingsFootnote("Your consent is the authority's entire jurisdiction: it can only decide cases against you under the classes and terms you signed, and its verdicts must be reasoned, expiring, and appealable.")
+            Footnote("Your consent is the authority's entire jurisdiction: it can only decide cases against you under the classes and terms you signed, and its verdicts must be reasoned, expiring, and appealable.")
         }
     }
 
     private var noMandateCard: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SettingsSectionLabel("CURRENT AUTHORITY")
-            SettingsCard {
+            SectionLabel("CURRENT AUTHORITY")
+            Card {
                 Button { showSwitchConsent = true } label: {
-                    SettingsRow(
+                    Row(
                         title: "Choose a moderation authority",
                         subtitle: "No mandate signed on this device yet",
                         last: true
                     ) {
-                        SettingsIconTile(symbol: "checkmark.shield", bg: OnymTile.indigo)
+                        IconTile(symbol: "checkmark.shield", bg: OnymTile.indigo)
                     }
                 }
                 .buttonStyle(.plain)

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
@@ -84,10 +84,10 @@ public struct CaseNoticeDetailView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Moderation case")
+                LargeTitle("Moderation case")
 
-                SettingsSectionLabel("NOTICE")
-                SettingsCard {
+                SectionLabel("NOTICE")
+                Card {
                     VStack(alignment: .leading, spacing: 8) {
                         row("Case", notice.caseId, monospaced: true)
                         row("Authority", notice.authority)
@@ -99,11 +99,11 @@ public struct CaseNoticeDetailView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(16)
                 }
-                SettingsFootnote("If the authority doesn't decide by the deadline, the case is dismissed automatically — silence never bans anyone. Not responding doesn't concede the case; it proceeds on the record.")
+                Footnote("If the authority doesn't decide by the deadline, the case is dismissed automatically — silence never bans anyone. Not responding doesn't concede the case; it proceeds on the record.")
 
-                SettingsSectionLabel("RESPONSE")
+                SectionLabel("RESPONSE")
                 if let makeCaseFlow {
-                    SettingsCard {
+                    Card {
                         NavigationLink {
                             ModerationCaseView(flow: makeCaseFlow(notice))
                         } label: {
@@ -129,7 +129,7 @@ public struct CaseNoticeDetailView: View {
                         .accessibilityIdentifier("moderation.case_detail.open_case")
                     }
                 } else {
-                    SettingsCard {
+                    Card {
                         Text("Responding from this surface isn't wired up. Use the authority's contact channel to respond before the deadline.")
                             .font(OnymType.font(size: 14))
                             .foregroundStyle(OnymTokens.text2)

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStepScaffold.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingStepScaffold.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// builder slot.
 ///
 /// Deliberately styled with plain SwiftUI — this package does not
-/// depend on OnymDesign. PR 3 supplies `SettingsStepIndicator` (made
+/// depend on OnymDesign. PR 3 supplies `StepIndicator` (made
 /// public there) through the `indicator` slot and can restyle the
 /// buttons via the content it injects; the scaffold's own chrome stays
 /// system-styled.

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -297,7 +297,7 @@ struct PlaceholderStepContent: View {
 }
 
 /// Fallback step indicator: plain dots. The app replaces it with
-/// `SettingsStepIndicator` via the `stepIndicator` slot.
+/// `StepIndicator` via the `stepIndicator` slot.
 struct DefaultStepIndicator: View {
     let index: Int
     let count: Int

--- a/Packages/OnymSettings/Sources/OnymSettings/AboutView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/AboutView.swift
@@ -23,39 +23,39 @@ struct AboutView: View {
             VStack(alignment: .leading, spacing: 0) {
                 hero
 
-                SettingsSectionLabel("VERSION")
-                SettingsCard {
-                    SettingsRow(title: "Version", hasChevron: false, inset: 16) {
+                SectionLabel("VERSION")
+                Card {
+                    Row(title: "Version", hasChevron: false, inset: 16) {
                         EmptyView()
                     } right: {
                         Text(version).foregroundStyle(OnymTokens.text2)
                     }
-                    SettingsRow(title: "Build", hasChevron: false, inset: 16) {
+                    Row(title: "Build", hasChevron: false, inset: 16) {
                         EmptyView()
                     } right: {
                         Text(build)
                             .font(OnymType.mono(size: 13.5))
                             .foregroundStyle(OnymTokens.text2)
                     }
-                    SettingsRow(
+                    Row(
                         title: "Check for updates",
                         last: true,
                         onTap: { open(Self.sourceURL.absoluteString + "/releases") }
                     ) {
-                        SettingsIconTile(symbol: "arrow.up.circle.fill", bg: OnymTile.blue)
+                        IconTile(symbol: "arrow.up.circle.fill", bg: OnymTile.blue)
                     }
                 }
 
-                SettingsSectionLabel("RESOURCES")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("RESOURCES")
+                Card {
+                    Row(
                         title: "Source code",
                         subtitle: "github.com/onymchat/onym-ios",
                         subtitleMono: true,
                         hasChevron: false,
                         onTap: { open(Self.sourceURL.absoluteString) }
                     ) {
-                        SettingsIconTile(symbol: "chevron.left.forwardslash.chevron.right",
+                        IconTile(symbol: "chevron.left.forwardslash.chevron.right",
                                          bg: OnymTokens.text)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
@@ -63,81 +63,81 @@ struct AboutView: View {
                     }
                     .accessibilityIdentifier("about.source_row")
 
-                    SettingsRow(
+                    Row(
                         title: "Documentation",
                         subtitle: "docs.onym.app",
                         hasChevron: false,
                         onTap: { open(Self.docsURL.absoluteString) }
                     ) {
-                        SettingsIconTile(symbol: "doc.text.fill", bg: OnymTile.indigo)
+                        IconTile(symbol: "doc.text.fill", bg: OnymTile.indigo)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
 
-                    SettingsRow(
+                    Row(
                         title: "Whitepaper",
                         subtitle: "The Onym protocol",
                         hasChevron: false,
                         onTap: { open("https://onym.app/whitepaper") }
                     ) {
-                        SettingsIconTile(symbol: "sparkles", bg: OnymTile.green)
+                        IconTile(symbol: "sparkles", bg: OnymTile.green)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
 
-                    SettingsRow(
+                    Row(
                         title: "Changelog",
                         subtitle: "What’s new",
                         last: true,
                         onTap: { open(Self.sourceURL.absoluteString + "/releases") }
                     ) {
-                        SettingsIconTile(symbol: "list.star", bg: OnymTile.purple)
+                        IconTile(symbol: "list.star", bg: OnymTile.purple)
                     }
                 }
 
-                SettingsSectionLabel("HELP")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("HELP")
+                Card {
+                    Row(
                         title: "FAQ",
                         hasChevron: false,
                         onTap: { open(Self.docsURL.absoluteString + "/faq") }
                     ) {
-                        SettingsIconTile(symbol: "questionmark.circle.fill",
+                        IconTile(symbol: "questionmark.circle.fill",
                                          bg: OnymTile.blue)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
-                    SettingsRow(
+                    Row(
                         title: "Community chat",
                         subtitle: "Join the dev group on Onym",
                         hasChevron: false,
                         onTap: { open("https://onym.app/community") }
                     ) {
-                        SettingsIconTile(symbol: "bubble.left.fill", bg: OnymTile.green)
+                        IconTile(symbol: "bubble.left.fill", bg: OnymTile.green)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
-                    SettingsRow(
+                    Row(
                         title: "Contact support",
                         subtitle: "hello@onym.app",
                         hasChevron: false,
                         last: true,
                         onTap: { open(Self.supportURL.absoluteString) }
                     ) {
-                        SettingsIconTile(symbol: "envelope.fill", bg: OnymTile.orange)
+                        IconTile(symbol: "envelope.fill", bg: OnymTile.orange)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
                 }
 
-                SettingsSectionLabel("LEGAL")
-                SettingsCard {
-                    SettingsRow(title: "Privacy policy",
+                SectionLabel("LEGAL")
+                Card {
+                    Row(title: "Privacy policy",
                                 hasChevron: false, inset: 16,
                                 onTap: { open("https://onym.app/privacy") }) {
                         EmptyView()
@@ -145,7 +145,7 @@ struct AboutView: View {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
-                    SettingsRow(title: "Terms of service",
+                    Row(title: "Terms of service",
                                 hasChevron: false, inset: 16,
                                 onTap: { open("https://onym.app/terms") }) {
                         EmptyView()
@@ -153,7 +153,7 @@ struct AboutView: View {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
-                    SettingsRow(title: "Open source licenses",
+                    Row(title: "Open source licenses",
                                 inset: 16, last: true,
                                 onTap: { open(Self.sourceURL.absoluteString + "/blob/main/LICENSE") }) {
                         EmptyView()

--- a/Packages/OnymSettings/Sources/OnymSettings/AddDiscoveryProviderView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/AddDiscoveryProviderView.swift
@@ -46,7 +46,7 @@ struct AddDiscoveryProviderView: View {
 
     @ViewBuilder
     private var urlEntry: some View {
-        SettingsLargeTitle("Add Discovery Provider")
+        LargeTitle("Add Discovery Provider")
         Text("Paste the provider's manifest URL. Its manifest and catalogs are signed — you'll review the operator key fingerprint before this app trusts anything it publishes.")
             .font(OnymType.font(size: 14))
             .foregroundStyle(OnymTokens.text2)
@@ -54,7 +54,7 @@ struct AddDiscoveryProviderView: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 16)
 
-        SettingsCard {
+        Card {
             TextField("https://discovery.example.com/manifest.json",
                       text: $flow.addDraft)
                 .textInputAutocapitalization(.never)
@@ -66,10 +66,10 @@ struct AddDiscoveryProviderView: View {
         }
 
         if let error = flow.addError {
-            SettingsFootnote(verbatim: error)
+            Footnote(verbatim: error)
         }
 
-        SettingsPrimaryButton(action: { flow.tappedFetchProvider() }) {
+        PrimaryButton(action: { flow.tappedFetchProvider() }) {
             if case .fetching = flow.addPhase {
                 ProgressView().tint(OnymTokens.onAccent)
             } else {
@@ -91,7 +91,7 @@ struct AddDiscoveryProviderView: View {
 
     @ViewBuilder
     private func confirm(_ preview: DiscoveryProviderPreview) -> some View {
-        SettingsLargeTitle("Confirm Operator Key")
+        LargeTitle("Confirm Operator Key")
 
         Text("This fingerprint identifies the provider's operator key. Verify it out-of-band — the provider's website, documentation, or the operator directly — before confirming. It's pinned on confirm: a later manifest signed by any other key will be rejected.")
             .font(OnymType.font(size: 14))
@@ -100,8 +100,8 @@ struct AddDiscoveryProviderView: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 12)
 
-        SettingsSectionLabel("OPERATOR KEY FINGERPRINT")
-        SettingsCard {
+        SectionLabel("OPERATOR KEY FINGERPRINT")
+        Card {
             Text(verbatim: preview.operatorKeyFingerprint)
                 .font(OnymType.mono(size: 28, weight: .semibold))
                 .foregroundStyle(OnymTokens.text)
@@ -110,10 +110,10 @@ struct AddDiscoveryProviderView: View {
                 .padding(.vertical, 20)
                 .accessibilityIdentifier("settings.discovery.add.fingerprint")
         }
-        SettingsFootnote("First 16 characters of the operator's Ed25519 public key.")
+        Footnote("First 16 characters of the operator's Ed25519 public key.")
 
-        SettingsSectionLabel("PROVIDER")
-        SettingsCard {
+        SectionLabel("PROVIDER")
+        Card {
             summaryRow("Provider", preview.providerId)
             summaryRow("Manifest URL", preview.manifestURL.absoluteString)
             summaryRow(
@@ -124,7 +124,7 @@ struct AddDiscoveryProviderView: View {
         }
 
         VStack(spacing: 10) {
-            SettingsPrimaryButton("Pin Key & Add Provider") {
+            PrimaryButton("Pin Key & Add Provider") {
                 flow.tappedConfirmAdd()
             }
             .accessibilityIdentifier("settings.discovery.add.confirm")

--- a/Packages/OnymSettings/Sources/OnymSettings/AnchorsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/AnchorsView.swift
@@ -24,18 +24,18 @@ struct AnchorsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Anchors")
-                SettingsFootnote("Pick the active network and the contract version used to anchor on-chain group state. The active network applies to new chats; existing chats keep the contract they were created with.")
+                LargeTitle("Anchors")
+                Footnote("Pick the active network and the contract version used to anchor on-chain group state. The active network applies to new chats; existing chats keep the contract they were created with.")
 
-                SettingsSectionLabel("ACTIVE NETWORK")
-                SettingsCard {
+                SectionLabel("ACTIVE NETWORK")
+                Card {
                     networkRow(.testnet, last: false)
                     networkRow(.public, last: true)
                 }
 
                 if flow.hasAnyContracts(network: activeNetwork) {
-                    SettingsSectionLabel("CONTRACT VERSIONS · \(activeNetwork.displayName.uppercased())")
-                    SettingsCard {
+                    SectionLabel("CONTRACT VERSIONS · \(activeNetwork.displayName.uppercased())")
+                    Card {
                         let types = GovernanceType.allCases
                         ForEach(Array(types.enumerated()), id: \.element.self) { idx, type in
                             govRow(type, last: idx == types.count - 1)
@@ -63,7 +63,7 @@ struct AnchorsView: View {
         Button {
             useMainnet = (network == .public)
         } label: {
-            SettingsRow(
+            Row(
                 title: LocalizedStringKey(network.displayName),
                 subtitle: hasContracts ? networkSubtitle(network) : "No contracts yet",
                 hasChevron: false,
@@ -111,7 +111,7 @@ struct AnchorsView: View {
             NavigationLink {
                 AnchorsVersionView(flow: flow, key: key)
             } label: {
-                SettingsRow(
+                Row(
                     title: LocalizedStringKey(type.displayName),
                     subtitle: "\(binding.release) " + (isExplicit ? "(selected)" : "(latest)"),
                     inset: 56,
@@ -123,7 +123,7 @@ struct AnchorsView: View {
             .buttonStyle(.plain)
             .accessibilityIdentifier("anchors.type.\(type.rawValue)")
         } else {
-            SettingsRow(
+            Row(
                 title: LocalizedStringKey(type.displayName),
                 subtitle: "No contract",
                 hasChevron: false,
@@ -150,8 +150,8 @@ struct AnchorsNetworkView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsSectionLabel("GOVERNANCE TYPES")
-                SettingsCard {
+                SectionLabel("GOVERNANCE TYPES")
+                Card {
                     let types = GovernanceType.allCases
                     ForEach(Array(types.enumerated()), id: \.element.self) { idx, type in
                         govRow(type, last: idx == types.count - 1)
@@ -175,7 +175,7 @@ struct AnchorsNetworkView: View {
             NavigationLink {
                 AnchorsVersionView(flow: flow, key: key)
             } label: {
-                SettingsRow(
+                Row(
                     title: LocalizedStringKey(type.displayName),
                     subtitle: "\(binding.release) " + (isExplicit ? "(selected)" : "(latest)"),
                     inset: 56,
@@ -187,7 +187,7 @@ struct AnchorsNetworkView: View {
             .buttonStyle(.plain)
             .accessibilityIdentifier("anchors.type.\(type.rawValue)")
         } else {
-            SettingsRow(
+            Row(
                 title: LocalizedStringKey(type.displayName),
                 subtitle: "No contract",
                 hasChevron: false,
@@ -253,8 +253,8 @@ struct AnchorsVersionView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsSectionLabel("CONTRACT VERSION")
-                SettingsCard {
+                SectionLabel("CONTRACT VERSION")
+                Card {
                     let releases = flow.availableReleases(for: key)
                     let selectedTag = flow.binding(for: key)?.release
                     let latestTag = releases.first?.release
@@ -267,21 +267,21 @@ struct AnchorsVersionView: View {
                         )
                     }
                 }
-                SettingsFootnote("Tap a version to view the contract, source code, and audit report.")
+                Footnote("Tap a version to view the contract, source code, and audit report.")
 
-                SettingsSectionLabel("CUSTOM")
-                SettingsCard {
+                SectionLabel("CUSTOM")
+                Card {
                     NavigationLink {
                         DeployContractView(key: key)
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Deploy from source",
                             subtitle: "Build & publish your own contract"
                         ) {
                             // Fixed dark slate (not adaptive OnymTokens.text,
                             // which goes near-white in dark mode and hid the
                             // white glyph). Matches the deploy guide's hero.
-                            SettingsIconTile(symbol: "chevron.left.forwardslash.chevron.right",
+                            IconTile(symbol: "chevron.left.forwardslash.chevron.right",
                                              bg: OnymTerminal.surface)
                         }
                     }
@@ -291,24 +291,24 @@ struct AnchorsVersionView: View {
                     NavigationLink {
                         UseExistingContractView(key: key)
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Use existing address",
                             subtitle: "Point to a deployed contract",
                             last: true
                         ) {
-                            SettingsIconTile(symbol: "shippingbox.fill",
+                            IconTile(symbol: "shippingbox.fill",
                                              bg: OnymTile.indigo)
                         }
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("anchors.use_existing")
                 }
-                SettingsFootnote("Onym only ships audited (or pending-audit) contracts. If you’ve forked or deployed your own, point new chats at it here. Existing chats keep the contract they were created with.")
+                Footnote("Onym only ships audited (or pending-audit) contracts. If you’ve forked or deployed your own, point new chats at it here. Existing chats keep the contract they were created with.")
 
                 if flow.hasExplicitSelection(for: key) {
-                    SettingsSectionLabel("RESET")
-                    SettingsCard {
-                        SettingsRow(
+                    SectionLabel("RESET")
+                    Card {
+                        Row(
                             title: "Reset to default (latest)",
                             titleColor: OnymAccent.blue.color,
                             hasChevron: false,
@@ -337,7 +337,7 @@ struct AnchorsVersionView: View {
         NavigationLink {
             ContractDetailView(flow: flow, key: key, release: release)
         } label: {
-            SettingsRow(
+            Row(
                 title: LocalizedStringKey(release.release),
                 titleMono: true,
                 subtitle: release.publishedAt.formatted(date: .abbreviated, time: .omitted),

--- a/Packages/OnymSettings/Sources/OnymSettings/BackupOperatorSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BackupOperatorSettingsView.swift
@@ -27,7 +27,7 @@ struct BackupOperatorSettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Backup Operators")
+                LargeTitle("Backup Operators")
 
                 if flow.catalogEntries.isEmpty {
                     emptyCard
@@ -42,7 +42,7 @@ struct BackupOperatorSettingsView: View {
                     )
                 }
 
-                SettingsFootnote("A backup operator stores sealed copies of this phone's history. The copy is sealed here, before it leaves — the operator keeps bytes it cannot read, and only your recovery phrase can open them. You can back up to more than one operator, and each one holds its own copy under its own terms.")
+                Footnote("A backup operator stores sealed copies of this phone's history. The copy is sealed here, before it leaves — the operator keeps bytes it cannot read, and only your recovery phrase can open them. You can back up to more than one operator, and each one holds its own copy under its own terms.")
             }
             .padding(.bottom, 32)
         }
@@ -68,7 +68,7 @@ struct BackupOperatorSettingsView: View {
     /// backup operator. Say why nothing is on offer rather than
     /// leaving a screen that looks like it is still loading.
     private var emptyCard: some View {
-        SettingsCard {
+        Card {
             Text("No backup operators are listed by the discovery providers you trust. Add a provider that lists one, and it will appear here.")
                 .font(OnymType.font(size: 14))
                 .foregroundStyle(OnymTokens.text3)

--- a/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/BlossomRelaySettingsView.swift
@@ -22,9 +22,9 @@ struct BlossomRelaySettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Blossom Relays")
+                LargeTitle("Blossom Relays")
 
-                SettingsSectionLabel(
+                SectionLabel(
                     "CONFIGURED · \(flow.state.snapshot.endpoints.count)"
                 )
                 configuredCard
@@ -38,28 +38,28 @@ struct BlossomRelaySettingsView: View {
                     onSelect: { consentEntry = $0 }
                 )
 
-                SettingsSectionLabel("ADD CUSTOM URL")
+                SectionLabel("ADD CUSTOM URL")
                 customURLCard
-                SettingsFootnote(
+                Footnote(
                     "Blossom servers store your media blobs (images, video, voice). Use Onym's, a private deployment, or any Blossom server you trust. URLs must use the https:// (or http://) scheme."
                 )
 
                 resetCard
-                SettingsFootnote(
+                Footnote(
                     "Uploads and downloads use the active server. Changes apply to the next upload or download."
                 )
 
-                SettingsSectionLabel("SELF-HOST")
-                SettingsCard {
+                SectionLabel("SELF-HOST")
+                Card {
                     NavigationLink {
                         SelfHostGuideView.blossom
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Run your own server",
                             subtitle: "Deploy a Blossom server with Docker",
                             last: true
                         ) {
-                            SettingsIconTile(symbol: "server.rack",
+                            IconTile(symbol: "server.rack",
                                              bg: OnymTerminal.surface)
                         }
                     }
@@ -93,7 +93,7 @@ struct BlossomRelaySettingsView: View {
     private var configuredCard: some View {
         let endpoints = flow.state.snapshot.endpoints
         if endpoints.isEmpty {
-            SettingsCard {
+            Card {
                 Text("No servers configured. Media can't be sent or received.")
                     .font(OnymType.font(size: 14))
                     .foregroundStyle(OnymTokens.text3)
@@ -102,7 +102,7 @@ struct BlossomRelaySettingsView: View {
                     .accessibilityIdentifier("blossom.configured.empty")
             }
         } else {
-            // Clipped rounded stack (not SettingsCard) so each row can
+            // Clipped rounded stack (not Card) so each row can
             // swipe left to reveal a Delete action masked to the card's
             // corners. Rows carry the card surface so the reveal stays
             // hidden until slid.
@@ -114,7 +114,7 @@ struct BlossomRelaySettingsView: View {
                     ) {
                         VStack(spacing: 0) {
                             HStack(spacing: 12) {
-                                SettingsIconTile(
+                                IconTile(
                                     symbol: "photo.on.rectangle.angled",
                                     bg: OnymTile.indigo
                                 )
@@ -201,7 +201,7 @@ struct BlossomRelaySettingsView: View {
     // MARK: - Custom URL add
 
     private var customURLCard: some View {
-        SettingsCard {
+        Card {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
                     TextField(
@@ -253,12 +253,12 @@ struct BlossomRelaySettingsView: View {
     // MARK: - Reset
 
     private var resetCard: some View {
-        SettingsCard {
+        Card {
             Button {
                 flow.tappedResetToDefault()
             } label: {
                 HStack {
-                    SettingsIconTile(
+                    IconTile(
                         symbol: "arrow.counterclockwise",
                         bg: OnymTile.gray
                     )

--- a/Packages/OnymSettings/Sources/OnymSettings/ContractDetailView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/ContractDetailView.swift
@@ -41,9 +41,9 @@ struct ContractDetailView: View {
             VStack(alignment: .leading, spacing: 0) {
                 hero
 
-                SettingsSectionLabel("ON-CHAIN")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("ON-CHAIN")
+                Card {
+                    Row(
                         title: "Stellar Expert",
                         subtitle: explorerSubtitle,
                         subtitleMono: true,
@@ -59,27 +59,27 @@ struct ContractDetailView: View {
                     }
                     .accessibilityIdentifier("contract_detail.stellar_expert")
 
-                    SettingsRow(
+                    Row(
                         title: "Copy contract address",
                         hasChevron: false,
                         last: true,
                         onTap: entry.map { e in { UIPasteboard.general.string = e.id } }
                     ) {
-                        SettingsIconTile(symbol: "doc.on.doc.fill", bg: OnymTile.gray)
+                        IconTile(symbol: "doc.on.doc.fill", bg: OnymTile.gray)
                     }
                     .accessibilityIdentifier("contract_detail.copy_address")
                 }
 
-                SettingsSectionLabel("SOURCE")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("SOURCE")
+                Card {
+                    Row(
                         title: "View source on GitHub",
                         subtitle: "onymchat/onym-contracts @ \(release.release)",
                         subtitleMono: true,
                         hasChevron: false,
                         onTap: { open(Self.contractsRepoURL.absoluteString + "/releases/tag/\(release.release)") }
                     ) {
-                        SettingsIconTile(symbol: "chevron.left.forwardslash.chevron.right",
+                        IconTile(symbol: "chevron.left.forwardslash.chevron.right",
                                          bg: OnymTokens.text)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
@@ -87,21 +87,21 @@ struct ContractDetailView: View {
                     }
                     .accessibilityIdentifier("contract_detail.github")
 
-                    SettingsRow(
+                    Row(
                         title: "Audit report",
                         subtitle: auditLabel,
                         hasChevron: false,
                         last: true
                     ) {
-                        SettingsIconTile(symbol: "exclamationmark.circle.fill",
+                        IconTile(symbol: "exclamationmark.circle.fill",
                                          bg: OnymTile.amber)
                     }
                     .accessibilityIdentifier("contract_detail.audit")
                 }
 
-                SettingsFootnote("This is the contract that anchors \(key.type.displayName.lowercased()) groups created on \(key.network.displayName.lowercased()). Existing chats keep the contract they were created with — picking a different version only affects new chats.")
+                Footnote("This is the contract that anchors \(key.type.displayName.lowercased()) groups created on \(key.network.displayName.lowercased()). Existing chats keep the contract they were created with — picking a different version only affects new chats.")
 
-                SettingsPrimaryButton(
+                PrimaryButton(
                     isCurrentSelection ? "Currently selected" : "Use this version",
                     disabled: isCurrentSelection
                 ) {

--- a/Packages/OnymSettings/Sources/OnymSettings/DeployContractView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DeployContractView.swift
@@ -75,7 +75,7 @@ struct DeployContractView: View {
                     }
                 }
 
-                SettingsFootnote("Deployment runs on your computer, not on the phone — the app can't build wasm or submit a deploy transaction directly.")
+                Footnote("Deployment runs on your computer, not on the phone — the app can't build wasm or submit a deploy transaction directly.")
             }
             .padding(.bottom, 24)
         }

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogSection.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoveryCatalogSection.swift
@@ -52,20 +52,20 @@ public struct DiscoveryCatalogSection: View {
     public var body: some View {
         if !entries.isEmpty {
             if let label {
-                SettingsSectionLabel(label)
+                SectionLabel(label)
             }
-            SettingsCard {
+            Card {
                 ForEach(Array(entries.enumerated()), id: \.element.id) { idx, entry in
                     row(entry, last: idx == entries.count - 1)
                 }
             }
-            SettingsFootnote("Published by the discovery providers you trust. Tapping an entry shows the operator's manifest and terms — nothing is added without your explicit acceptance.")
+            Footnote("Published by the discovery providers you trust. Tapping an entry shows the operator's manifest and terms — nothing is added without your explicit acceptance.")
         }
     }
 
     private func row(_ entry: AttributedCatalogEntry, last: Bool) -> some View {
         let record = activeConsent(entry)
-        return SettingsRow(
+        return Row(
             titleText: ModuleConsentFlow.shortComponentId(entry.entry.componentId),
             subtitle: subtitle(for: entry),
             subtitleLineLimit: 2,
@@ -74,7 +74,7 @@ public struct DiscoveryCatalogSection: View {
             last: last,
             onTap: { onSelect(entry) }
         ) {
-            SettingsIconTile(symbol: tileSymbol, bg: OnymTile.purple)
+            IconTile(symbol: tileSymbol, bg: OnymTile.purple)
         } right: {
             HStack(spacing: 4) {
                 if let status = entry.entry.status {
@@ -93,7 +93,7 @@ public struct DiscoveryCatalogSection: View {
     /// text — the field exists precisely so a warned entry never
     /// renders indistinguishable from a clean one.
     private func statusChip(_ status: EntryStatus) -> some View {
-        SettingsChip(
+        Chip(
             text: (status.state == "warning"
                 ? String(localized: "WARNING")
                 : String(localized: "UNDER REVIEW")).uppercased(),
@@ -114,13 +114,13 @@ public struct DiscoveryCatalogSection: View {
     @ViewBuilder
     private func consentChip(for entry: AttributedCatalogEntry, record: PinnedConsentRecord?) -> some View {
         if let record, record.manifestHash == entry.entry.manifest.digest {
-            SettingsChip(text: String(localized: "CONSENTED").uppercased(),
+            Chip(text: String(localized: "CONSENTED").uppercased(),
                          fg: OnymTokens.green, bg: OnymTokens.green.opacity(0.15))
         } else if record != nil {
-            SettingsChip(text: String(localized: "TERMS CHANGED").uppercased(),
+            Chip(text: String(localized: "TERMS CHANGED").uppercased(),
                          fg: OnymTile.amber, bg: OnymTile.amber.opacity(0.15))
         } else {
-            SettingsChip(text: String(localized: "REVIEW").uppercased(),
+            Chip(text: String(localized: "REVIEW").uppercased(),
                          fg: OnymTile.gray, bg: OnymTile.gray.opacity(0.15))
         }
     }

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoverySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoverySettingsView.swift
@@ -21,15 +21,15 @@ struct DiscoverySettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Discovery")
+                LargeTitle("Discovery")
 
-                SettingsSectionLabel("PROVIDERS · \(flow.state.sources.count)")
+                SectionLabel("PROVIDERS · \(flow.state.sources.count)")
                 sourcesCard
-                SettingsFootnote("Providers publish signed catalogs of relays and services this app can adopt. Every catalog is verified against the operator key you pinned when you added the provider.")
+                Footnote("Providers publish signed catalogs of relays and services this app can adopt. Every catalog is verified against the operator key you pinned when you added the provider.")
 
-                SettingsSectionLabel("ADD")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("ADD")
+                Card {
+                    Row(
                         title: "Add Discovery Provider",
                         subtitle: "Fetch a provider manifest by URL",
                         hasChevron: false,
@@ -44,7 +44,7 @@ struct DiscoverySettingsView: View {
                     }
                     .accessibilityIdentifier("settings.discovery.add")
                 }
-                SettingsFootnote("You'll see the provider's operator key fingerprint before anything is trusted. Verify it out-of-band — the fingerprint is pinned on first use.")
+                Footnote("You'll see the provider's operator key fingerprint before anything is trusted. Verify it out-of-band — the fingerprint is pinned on first use.")
             }
             .padding(.bottom, 32)
         }
@@ -85,7 +85,7 @@ struct DiscoverySettingsView: View {
     private var sourcesCard: some View {
         let sources = flow.state.sources
         if sources.isEmpty {
-            SettingsCard {
+            Card {
                 Text("No discovery providers configured. Add one below.")
                     .font(OnymType.font(size: 14))
                     .foregroundStyle(OnymTokens.text3)
@@ -94,7 +94,7 @@ struct DiscoverySettingsView: View {
                     .accessibilityIdentifier("settings.discovery.empty")
             }
         } else {
-            // Clipped rounded stack (not SettingsCard) so each row can
+            // Clipped rounded stack (not Card) so each row can
             // swipe left to reveal a Delete action masked to the card's
             // corners — same construction as the relayer / nostr lists.
             VStack(spacing: 0) {
@@ -121,7 +121,7 @@ struct DiscoverySettingsView: View {
     private func sourceRow(_ status: DiscoverySourceStatus, last: Bool) -> some View {
         VStack(spacing: 0) {
             HStack(alignment: .top, spacing: 12) {
-                SettingsIconTile(symbol: "antenna.radiowaves.left.and.right", bg: OnymTile.purple)
+                IconTile(symbol: "antenna.radiowaves.left.and.right", bg: OnymTile.purple)
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 6) {
                         Text(verbatim: status.source.userLabel)
@@ -206,19 +206,19 @@ struct DiscoverySettingsView: View {
     @ViewBuilder
     private func statusChip(for status: DiscoverySourceStatus) -> some View {
         if status.lastError != nil, status.lastErrorIsIntegrity {
-            SettingsChip(text: String(localized: "INTEGRITY").uppercased(),
+            Chip(text: String(localized: "INTEGRITY").uppercased(),
                          fg: OnymTokens.red, bg: OnymTokens.red.opacity(0.15))
         } else if status.lastError != nil {
-            SettingsChip(text: String(localized: "FAILED").uppercased(),
+            Chip(text: String(localized: "FAILED").uppercased(),
                          fg: OnymTile.amber, bg: OnymTile.amber.opacity(0.15))
         } else if flow.state.fetchStatus == .fetching {
-            SettingsChip(text: String(localized: "FETCHING").uppercased(),
+            Chip(text: String(localized: "FETCHING").uppercased(),
                          fg: OnymTile.gray, bg: OnymTile.gray.opacity(0.15))
         } else if status.source.pinnedOperatorKeyHex == nil {
-            SettingsChip(text: String(localized: "UNCONFIRMED").uppercased(),
+            Chip(text: String(localized: "UNCONFIRMED").uppercased(),
                          fg: OnymTile.gray, bg: OnymTile.gray.opacity(0.15))
         } else {
-            SettingsChip(text: String(localized: "OK").uppercased(),
+            Chip(text: String(localized: "OK").uppercased(),
                          fg: OnymTokens.green, bg: OnymTokens.green.opacity(0.15))
         }
     }

--- a/Packages/OnymSettings/Sources/OnymSettings/IdentityCarouselCard.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/IdentityCarouselCard.swift
@@ -369,7 +369,7 @@ struct RenameIdentitySheet: View {
                         .padding(.horizontal, 20)
                         .padding(.top, 16)
 
-                    SettingsCard {
+                    Card {
                         TextField("Identity name", text: $text)
                             .textInputAutocapitalization(.words)
                             .autocorrectionDisabled()
@@ -452,7 +452,7 @@ struct RestoreIdentitySheet: View {
                         .padding(.horizontal, 20)
                         .padding(.top, 16)
 
-                    SettingsCard {
+                    Card {
                         TextField("word word word …", text: $phrase, axis: .vertical)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
@@ -463,7 +463,7 @@ struct RestoreIdentitySheet: View {
                             .accessibilityIdentifier("restore_identity.phrase_field")
                     }
 
-                    SettingsCard {
+                    Card {
                         TextField("Name (optional)", text: $name)
                             .textInputAutocapitalization(.words)
                             .autocorrectionDisabled()

--- a/Packages/OnymSettings/Sources/OnymSettings/ModuleConsentView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/ModuleConsentView.swift
@@ -56,7 +56,7 @@ public struct ModuleConsentView: View {
     @ViewBuilder
     private var loading: some View {
         if let error = flow.errorMessage {
-            SettingsCard {
+            Card {
                 VStack(spacing: 10) {
                     Text(verbatim: error)
                         .font(OnymType.font(size: 14))
@@ -88,7 +88,7 @@ public struct ModuleConsentView: View {
     /// — retrying could never succeed, so offering the button would be
     /// a lie. Cancel in the toolbar remains the way out.
     private var failed: some View {
-        SettingsCard {
+        Card {
             VStack(spacing: 10) {
                 Image(systemName: "xmark.octagon")
                     .font(OnymType.font(size: 28))
@@ -112,7 +112,7 @@ public struct ModuleConsentView: View {
         if let reviewed = flow.reviewed {
             let manifest = reviewed.signedManifest
 
-            SettingsLargeTitle(verbatim: flow.displayName)
+            LargeTitle(verbatim: flow.displayName)
 
             attributionBanner
 
@@ -123,8 +123,8 @@ public struct ModuleConsentView: View {
                 statusBanner(status)
             }
 
-            SettingsSectionLabel("SERVICE")
-            SettingsCard {
+            SectionLabel("SERVICE")
+            Card {
                 VStack(alignment: .leading, spacing: 8) {
                     termRow("Seat", manifest.seat)
                     termRow("Component", manifest.componentId)
@@ -142,18 +142,18 @@ public struct ModuleConsentView: View {
             }
 
             if let termsURL = flow.termsURL {
-                SettingsSectionLabel("TERMS")
-                SettingsCard {
+                SectionLabel("TERMS")
+                Card {
                     NavigationLink {
                         MarkdownDocumentView(title: String(localized: "Terms"), url: termsURL)
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Linked terms",
                             subtitle: termsURL.absoluteString,
                             subtitleMono: true,
                             last: true
                         ) {
-                            SettingsIconTile(symbol: "doc.text", bg: OnymTile.gray)
+                            IconTile(symbol: "doc.text", bg: OnymTile.gray)
                         }
                     }
                     .buttonStyle(.plain)
@@ -161,8 +161,8 @@ public struct ModuleConsentView: View {
                 }
             }
 
-            SettingsSectionLabel("WHAT YOU'RE ACCEPTING")
-            SettingsCard {
+            SectionLabel("WHAT YOU'RE ACCEPTING")
+            Card {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Manifest hash")
                         .font(OnymType.font(size: 13, weight: .semibold))
@@ -175,14 +175,14 @@ public struct ModuleConsentView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
             }
-            SettingsFootnote("Your acceptance pins this hash of these exact bytes and adds the service's endpoint to your configuration. Nothing is signed and nothing leaves this device — you can remove the endpoint at any time.")
+            Footnote("Your acceptance pins this hash of these exact bytes and adds the service's endpoint to your configuration. Nothing is signed and nothing leaves this device — you can remove the endpoint at any time.")
 
             if let error = flow.errorMessage {
-                SettingsFootnote(verbatim: error)
+                Footnote(verbatim: error)
             }
 
             VStack(spacing: 10) {
-                SettingsPrimaryButton(action: { flow.tappedAccept() }) {
+                PrimaryButton(action: { flow.tappedAccept() }) {
                     if flow.step == .applying {
                         ProgressView().tint(OnymTokens.onAccent)
                     } else {
@@ -199,7 +199,7 @@ public struct ModuleConsentView: View {
                 // Paid-only manifest (no entitled offer to select):
                 // Accept stays disabled, and the screen says why
                 // instead of leaving a dead button.
-                SettingsFootnote("None of this service's offers can be selected yet — purchasing is not yet available in this app, so this service can't be added.")
+                Footnote("None of this service's offers can be selected yet — purchasing is not yet available in this app, so this service can't be added.")
             }
         }
     }
@@ -210,7 +210,7 @@ public struct ModuleConsentView: View {
     private func statusBanner(_ status: EntryStatus) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
-                SettingsChip(
+                Chip(
                     text: (status.state == "warning"
                         ? String(localized: "WARNING")
                         : String(localized: "UNDER REVIEW")).uppercased(),
@@ -280,8 +280,8 @@ public struct ModuleConsentView: View {
 
     @ViewBuilder
     private func offersSection(_ manifest: SignedServiceManifest) -> some View {
-        SettingsSectionLabel("OFFERS")
-        SettingsCard {
+        SectionLabel("OFFERS")
+        Card {
             ForEach(Array(manifest.offers.enumerated()), id: \.element.offerId) { idx, offer in
                 offerRow(
                     offer,
@@ -291,7 +291,7 @@ public struct ModuleConsentView: View {
             }
         }
         if manifest.offers.contains(where: { !flow.entitledOfferIds.contains($0.offerId) }) {
-            SettingsFootnote("Paid offers can't be selected yet — purchasing is not yet available in this app.")
+            Footnote("Paid offers can't be selected yet — purchasing is not yet available in this app.")
         }
     }
 

--- a/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NostrRelaySettingsView.swift
@@ -23,9 +23,9 @@ struct NostrRelaySettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Nostr Relays")
+                LargeTitle("Nostr Relays")
 
-                SettingsSectionLabel(
+                SectionLabel(
                     "CONFIGURED · \(flow.state.snapshot.endpoints.count)"
                 )
                 configuredCard
@@ -39,28 +39,28 @@ struct NostrRelaySettingsView: View {
                     onSelect: { consentEntry = $0 }
                 )
 
-                SettingsSectionLabel("ADD CUSTOM URL")
+                SectionLabel("ADD CUSTOM URL")
                 customURLCard
-                SettingsFootnote(
+                Footnote(
                     "Use a private deployment, localhost, or any Nostr relay you trust. URLs must use the wss:// (or ws://) scheme."
                 )
 
                 resetCard
-                SettingsFootnote(
+                Footnote(
                     "Changes apply on the next app launch. The inbox transport reads relays once at boot."
                 )
 
-                SettingsSectionLabel("SELF-HOST")
-                SettingsCard {
+                SectionLabel("SELF-HOST")
+                Card {
                     NavigationLink {
                         SelfHostGuideView.nostr
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Run your own relay",
                             subtitle: "Deploy a Nostr relay with Docker",
                             last: true
                         ) {
-                            SettingsIconTile(symbol: "server.rack",
+                            IconTile(symbol: "server.rack",
                                              bg: OnymTerminal.surface)
                         }
                     }
@@ -94,7 +94,7 @@ struct NostrRelaySettingsView: View {
     private var configuredCard: some View {
         let endpoints = flow.state.snapshot.endpoints
         if endpoints.isEmpty {
-            SettingsCard {
+            Card {
                 Text("No relays configured. Inbox transport is offline.")
                     .font(OnymType.font(size: 14))
                     .foregroundStyle(OnymTokens.text3)
@@ -103,7 +103,7 @@ struct NostrRelaySettingsView: View {
                     .accessibilityIdentifier("nostr.configured.empty")
             }
         } else {
-            // Clipped rounded stack (not SettingsCard) so each row can
+            // Clipped rounded stack (not Card) so each row can
             // swipe left to reveal a Delete action masked to the card's
             // corners. Rows carry the card surface so the reveal stays
             // hidden until slid.
@@ -115,7 +115,7 @@ struct NostrRelaySettingsView: View {
                     ) {
                         VStack(spacing: 0) {
                             HStack(spacing: 12) {
-                                SettingsIconTile(
+                                IconTile(
                                     symbol: "antenna.radiowaves.left.and.right",
                                     bg: OnymTile.indigo
                                 )
@@ -164,7 +164,7 @@ struct NostrRelaySettingsView: View {
     // MARK: - Custom URL add
 
     private var customURLCard: some View {
-        SettingsCard {
+        Card {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
                     TextField(
@@ -216,12 +216,12 @@ struct NostrRelaySettingsView: View {
     // MARK: - Reset
 
     private var resetCard: some View {
-        SettingsCard {
+        Card {
             Button {
                 flow.tappedResetToDefault()
             } label: {
                 HStack {
-                    SettingsIconTile(
+                    IconTile(
                         symbol: "arrow.counterclockwise",
                         bg: OnymTile.gray
                     )

--- a/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/NotificationsSettingsView.swift
@@ -20,7 +20,7 @@ public struct NotificationsSettingsView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                SettingsCard {
+                Card {
                     Toggle(isOn: $switchState) {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Message Notifications")
@@ -36,18 +36,18 @@ public struct NotificationsSettingsView: View {
                 }
 
                 if flow.authorizationDenied {
-                    SettingsFootnote(
+                    Footnote(
                         "Notifications are blocked for Onym in system Settings. Allow them there, then turn this on again."
                     )
                 }
 
                 if flow.registrationPending {
-                    SettingsFootnote(
+                    Footnote(
                         "Activating\u{2026} the push server has not confirmed this device yet. Onym retries when you return to the app; check back if alerts don\u{2019}t arrive."
                     )
                 }
 
-                SettingsFootnote(
+                Footnote(
                     "How it works: an Onym-run push server watches your configured Nostr relays for your inbox codes and asks Apple to wake this device, a few seconds delayed at random. It never sees message content, senders, or groups. What this device sends it: your inbox codes, an encrypted push token, a signing key created on this device just for push and linked to none of your identities, and a device-attestation token from Apple. Turning this off tells the server to forget this device (retried until it confirms). All of your identities\u{2019} inbox codes are registered together, so the push server can tell they belong to one device. The alert itself always reads \u{201C}New message\u{201D}; nothing about the conversation passes through Apple."
                 )
             }

--- a/Packages/OnymSettings/Sources/OnymSettings/OfferBadge.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/OfferBadge.swift
@@ -9,7 +9,7 @@ struct OfferBadge: View {
     let offer: ServiceOffer
 
     var body: some View {
-        SettingsChip(
+        Chip(
             text: Self.modelDisplayName(offer.model).uppercased(),
             fg: offer.isFree ? OnymTokens.green : OnymTile.gray,
             bg: (offer.isFree ? OnymTokens.green : OnymTile.gray).opacity(0.15)
@@ -42,10 +42,10 @@ struct OfferDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle(verbatim: offer.offerId)
+                LargeTitle(verbatim: offer.offerId)
 
-                SettingsSectionLabel("OFFER")
-                SettingsCard {
+                SectionLabel("OFFER")
+                Card {
                     VStack(alignment: .leading, spacing: 8) {
                         detailRow("Offer ID", offer.offerId)
                         detailRow("Model", OfferBadge.modelDisplayName(offer.model))
@@ -58,8 +58,8 @@ struct OfferDetailView: View {
                 }
 
                 if let service = serviceSummary {
-                    SettingsSectionLabel("SERVICE TERMS")
-                    SettingsCard {
+                    SectionLabel("SERVICE TERMS")
+                    Card {
                         Text(verbatim: service)
                             .font(OnymType.mono(size: 12))
                             .foregroundStyle(OnymTokens.text2)
@@ -67,11 +67,11 @@ struct OfferDetailView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(16)
                     }
-                    SettingsFootnote("Published by the operator as part of the signed manifest. This app doesn't interpret it — it's shown exactly as offered.")
+                    Footnote("Published by the operator as part of the signed manifest. This app doesn't interpret it — it's shown exactly as offered.")
                 }
 
                 if !isEntitled {
-                    SettingsFootnote("Purchasing is not yet available in this app. Paid offers become selectable once in-app purchases land.")
+                    Footnote("Purchasing is not yet available in this app. Paid offers become selectable once in-app purchases land.")
                 }
             }
             .padding(.bottom, 32)

--- a/Packages/OnymSettings/Sources/OnymSettings/PrivacyEncryptionView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/PrivacyEncryptionView.swift
@@ -28,44 +28,44 @@ struct PrivacyEncryptionView: View {
             VStack(alignment: .leading, spacing: 0) {
                 heroCard.padding(.top, 8)
 
-                SettingsSectionLabel("HOW IT WORKS")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("HOW IT WORKS")
+                Card {
+                    Row(
                         title: "End-to-end encryption",
                         subtitle: "MLS · forward secrecy",
                         hasChevron: false
                     ) {
-                        SettingsIconTile(symbol: "key.fill", bg: OnymTile.purple)
+                        IconTile(symbol: "key.fill", bg: OnymTile.purple)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
-                    SettingsRow(
+                    Row(
                         title: "Anonymous on-chain",
                         subtitle: "No phone, no email, no IP",
                         hasChevron: false
                     ) {
-                        SettingsIconTile(symbol: "sparkles", bg: OnymTile.indigo)
+                        IconTile(symbol: "sparkles", bg: OnymTile.indigo)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
-                    SettingsRow(
+                    Row(
                         title: "Verifiable by anyone",
                         subtitle: "Group state anchored on Stellar",
                         hasChevron: false,
                         last: true
                     ) {
-                        SettingsIconTile(symbol: "shield.fill", bg: OnymTile.green)
+                        IconTile(symbol: "shield.fill", bg: OnymTile.green)
                     } right: {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
                 }
 
-                SettingsSectionLabel("YOUR KEYS")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("YOUR KEYS")
+                Card {
+                    Row(
                         title: "Active identity",
                         subtitle: activeName,
                         hasChevron: false
@@ -76,19 +76,19 @@ struct PrivacyEncryptionView: View {
                             .foregroundStyle(OnymTokens.green)
                             .font(OnymType.font(size: 13.5))
                     }
-                    SettingsRow(title: "BIP-39 wordlist", hasChevron: false) {
-                        SettingsIconTile(symbol: "checkmark", bg: OnymTile.gray)
+                    Row(title: "BIP-39 wordlist", hasChevron: false) {
+                        IconTile(symbol: "checkmark", bg: OnymTile.gray)
                     } right: {
                         Text("English").foregroundStyle(OnymTokens.text2).font(OnymType.font(size: 14))
                     }
-                    SettingsRow(title: "Identity key", hasChevron: false) {
+                    Row(title: "Identity key", hasChevron: false) {
                         SettingsContentTile(bg: OnymTile.indigo) {
                             Text("npub").font(OnymType.font(size: 9, weight: .bold)).foregroundStyle(.white)
                         }
                     } right: {
                         Text("Nostr (npub)").foregroundStyle(OnymTokens.text2).font(OnymType.font(size: 14))
                     }
-                    SettingsRow(title: "Signature scheme", hasChevron: false, last: true) {
+                    Row(title: "Signature scheme", hasChevron: false, last: true) {
                         SettingsContentTile(bg: OnymTile.gray) {
                             Text("BLS").font(OnymType.font(size: 9.5, weight: .bold)).foregroundStyle(.white)
                         }
@@ -96,23 +96,23 @@ struct PrivacyEncryptionView: View {
                         Text("BLS12-381").foregroundStyle(OnymTokens.text2).font(OnymType.font(size: 14))
                     }
                 }
-                SettingsFootnote("Your recovery phrase generates a master seed. Onym derives a Nostr keypair (your public identity, shown as npub1…), a Stellar keypair (for anchoring), and a BLS key (for group signatures).")
+                Footnote("Your recovery phrase generates a master seed. Onym derives a Nostr keypair (your public identity, shown as npub1…), a Stellar keypair (for anchoring), and a BLS key (for group signatures).")
 
-                SettingsSectionLabel("APP LOCK")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("APP LOCK")
+                Card {
+                    Row(
                         title: "Require Face ID",
                         subtitle: "Unlock Onym with biometrics",
                         hasChevron: false
                     ) {
-                        SettingsIconTile(symbol: "faceid", bg: OnymTile.gray)
+                        IconTile(symbol: "faceid", bg: OnymTile.gray)
                     } right: {
                         Toggle("", isOn: $appLock)
                             .labelsHidden()
                             .tint(OnymTokens.green)
                             .accessibilityIdentifier("privacy.app_lock")
                     }
-                    SettingsRow(
+                    Row(
                         title: "Auto-lock",
                         inset: 16,
                         last: true,
@@ -129,15 +129,15 @@ struct PrivacyEncryptionView: View {
                     }
                 }
 
-                SettingsSectionLabel("METADATA")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("METADATA")
+                Card {
+                    Row(
                         title: "Send read receipts",
                         subtitle: "Show others when you’ve read their messages",
                         hasChevron: false,
                         last: true
                     ) {
-                        SettingsIconTile(symbol: "checkmark.circle.fill", bg: OnymTile.blue)
+                        IconTile(symbol: "checkmark.circle.fill", bg: OnymTile.blue)
                     } right: {
                         Toggle("", isOn: $readReceipts)
                             .labelsHidden()
@@ -145,7 +145,7 @@ struct PrivacyEncryptionView: View {
                             .accessibilityIdentifier("privacy.read_receipts")
                     }
                 }
-                SettingsFootnote("Read receipts are end-to-end encrypted, but they reveal you’re online. Turn off for stricter privacy.")
+                Footnote("Read receipts are end-to-end encrypted, but they reveal you’re online. Turn off for stricter privacy.")
                 // The DATA section (Clear local message cache) moved to the
                 // Settings home, above About, where it does real work.
             }

--- a/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsView.swift
@@ -24,16 +24,16 @@ struct RelayerSettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsLargeTitle("Relayer")
+                LargeTitle("Relayer")
 
                 strategyToggle
 
-                SettingsSectionLabel("CONFIGURED · \(flow.state.snapshot.configuration.endpoints.count)")
+                SectionLabel("CONFIGURED · \(flow.state.snapshot.configuration.endpoints.count)")
                 configuredCard
 
-                SettingsSectionLabel("ADD FROM PUBLISHED LIST")
+                SectionLabel("ADD FROM PUBLISHED LIST")
                 publishedCard
-                SettingsFootnote("Published by the onym-relayer project. Tap to add.")
+                Footnote("Published by the onym-relayer project. Tap to add.")
 
                 DiscoveryCatalogSection(
                     entries: flow.catalogEntries,
@@ -44,9 +44,9 @@ struct RelayerSettingsView: View {
                     onSelect: { consentEntry = $0 }
                 )
 
-                SettingsSectionLabel("ADD CUSTOM URL")
+                SectionLabel("ADD CUSTOM URL")
                 customURLCard
-                SettingsFootnote("Use a private deployment, localhost, or any relayer not in the published list.")
+                Footnote("Use a private deployment, localhost, or any relayer not in the published list.")
 
                 runYourOwnCTA
             }
@@ -126,7 +126,7 @@ struct RelayerSettingsView: View {
     private var configuredCard: some View {
         let endpoints = flow.state.snapshot.configuration.endpoints
         if endpoints.isEmpty {
-            SettingsCard {
+            Card {
                 Text("No relayers configured. Add one below.")
                     .font(OnymType.font(size: 14))
                     .foregroundStyle(OnymTokens.text3)
@@ -134,7 +134,7 @@ struct RelayerSettingsView: View {
                     .padding(.horizontal, 16).padding(.vertical, 14)
             }
         } else {
-            // Custom rounded/clipped stack (not SettingsCard) so each
+            // Custom rounded/clipped stack (not Card) so each
             // row can swipe left to reveal a Delete action masked to the
             // card's corners. Rows carry the card's surface color so the
             // reveal stays hidden until slid.
@@ -144,7 +144,7 @@ struct RelayerSettingsView: View {
                         accessibilityID: "relayer.configured.\(endpoint.url.absoluteString)",
                         onDelete: { flow.tappedRemove(url: endpoint.url) }
                     ) {
-                        SettingsRow(
+                        Row(
                             title: LocalizedStringKey(endpoint.name),
                             subtitle: endpoint.url.absoluteString,
                             subtitleMono: true,
@@ -163,7 +163,7 @@ struct RelayerSettingsView: View {
                         } right: {
                             HStack(spacing: 4) {
                                 ForEach(endpoint.networks, id: \.self) { net in
-                                    SettingsChip(
+                                    Chip(
                                         text: net.uppercased(),
                                         fg: chipColor(for: net),
                                         bg: chipColor(for: net).opacity(0.15)
@@ -195,7 +195,7 @@ struct RelayerSettingsView: View {
     private var publishedCard: some View {
         let snapshot = flow.state.snapshot
         let unconfigured = flow.unconfiguredKnownList
-        SettingsCard {
+        Card {
             switch snapshot.fetchStatus {
             case .idle:
                 fetchingRow
@@ -249,7 +249,7 @@ struct RelayerSettingsView: View {
     @ViewBuilder
     private func knownList(_ unconfigured: [RelayerEndpoint]) -> some View {
         ForEach(Array(unconfigured.enumerated()), id: \.element.url) { idx, endpoint in
-            SettingsRow(
+            Row(
                 title: LocalizedStringKey(endpoint.name),
                 subtitle: endpoint.url.absoluteString,
                 subtitleMono: true,
@@ -266,7 +266,7 @@ struct RelayerSettingsView: View {
             } right: {
                 HStack(spacing: 4) {
                     ForEach(endpoint.networks, id: \.self) { net in
-                        SettingsChip(
+                        Chip(
                             text: net.uppercased(),
                             fg: chipColor(for: net),
                             bg: chipColor(for: net).opacity(0.15)
@@ -281,7 +281,7 @@ struct RelayerSettingsView: View {
     // MARK: - Custom URL
 
     private var customURLCard: some View {
-        SettingsCard {
+        Card {
             TextField("https://relayer.example.com",
                       text: Binding(
                         get: { flow.state.customDraft },
@@ -303,7 +303,7 @@ struct RelayerSettingsView: View {
 
             SettingsRowDivider(inset: 16)
 
-            SettingsRow(
+            Row(
                 title: "Add Custom URL",
                 hasChevron: false,
                 inset: 0,

--- a/Packages/OnymSettings/Sources/OnymSettings/RunYourOwnRelayerView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/RunYourOwnRelayerView.swift
@@ -54,7 +54,7 @@ struct RunYourOwnRelayerView: View {
                     }
                 }
 
-                SettingsFootnote("Need help? Open an issue on [GitHub](https://github.com/onymchat/onym-ios/issues).")
+                Footnote("Need help? Open an issue on [GitHub](https://github.com/onymchat/onym-ios/issues).")
             }
             .padding(.bottom, 24)
         }

--- a/Packages/OnymSettings/Sources/OnymSettings/SelfHostGuideView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SelfHostGuideView.swift
@@ -43,7 +43,7 @@ struct SelfHostGuideView: View {
                             .padding(.leading, 30)
                     }
                 }
-                SettingsFootnote(footnote)
+                Footnote(footnote)
             }
             .padding(.bottom, 24)
         }

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -147,36 +147,36 @@ public struct SettingsView: View {
                 // action), and the informational Privacy screen is gone.
 
                 if let makeDiscoverySettingsFlow {
-                    SettingsSectionLabel("DISCOVERY")
-                    SettingsCard {
+                    SectionLabel("DISCOVERY")
+                    Card {
                         NavigationLink {
                             DiscoverySettingsView(flow: makeDiscoverySettingsFlow())
                         } label: {
-                            SettingsRow(
+                            Row(
                                 title: "Discovery Providers",
                                 subtitle: "Catalogs of relays and services",
                                 last: true
                             ) {
-                                SettingsIconTile(symbol: "sparkle.magnifyingglass",
+                                IconTile(symbol: "sparkle.magnifyingglass",
                                                  bg: OnymTile.purple)
                             }
                         }
                         .buttonStyle(.plain)
                         .accessibilityIdentifier("settings.discovery_row")
                     }
-                    SettingsFootnote("Discovery providers publish signed catalogs of services you can adopt. You choose which providers to trust — each one's key is pinned when you add it.")
+                    Footnote("Discovery providers publish signed catalogs of services you can adopt. You choose which providers to trust — each one's key is pinned when you add it.")
                 }
 
-                SettingsSectionLabel("ANCHORS")
-                SettingsCard {
+                SectionLabel("ANCHORS")
+                Card {
                     NavigationLink {
                         AnchorsView(flow: makeAnchorsPickerFlow())
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Anchors",
                             subtitle: useMainnet ? "Stellar · Mainnet" : "Stellar · Testnet"
                         ) {
-                            SettingsIconTile(symbol: "link", bg: OnymTile.orange)
+                            IconTile(symbol: "link", bg: OnymTile.orange)
                         }
                     }
                     .buttonStyle(.plain)
@@ -189,30 +189,30 @@ public struct SettingsView: View {
                     NavigationLink {
                         RelayerSettingsView(flow: makeRelayerSettingsFlow())
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Relayer",
                             subtitle: "Stellar Soroban",
                             last: true
                         ) {
-                            SettingsIconTile(symbol: "antenna.radiowaves.left.and.right",
+                            IconTile(symbol: "antenna.radiowaves.left.and.right",
                                              bg: OnymTile.indigo)
                         }
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("settings.relayer_row")
                 }
-                SettingsFootnote("Anchors and the relayer default to Onym-run instances. Replace them with your own deployments for maximum privacy.")
+                Footnote("Anchors and the relayer default to Onym-run instances. Replace them with your own deployments for maximum privacy.")
 
-                SettingsSectionLabel("TRANSPORT")
-                SettingsCard {
+                SectionLabel("TRANSPORT")
+                Card {
                     NavigationLink {
                         NostrRelaySettingsView(flow: makeNostrRelaySettingsFlow())
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Nostr Relays",
                             subtitle: "Inbox + invitation transport"
                         ) {
-                            SettingsIconTile(
+                            IconTile(
                                 symbol: "antenna.radiowaves.left.and.right.circle.fill",
                                 bg: OnymTile.indigo
                             )
@@ -224,12 +224,12 @@ public struct SettingsView: View {
                     NavigationLink {
                         BlossomRelaySettingsView(flow: makeBlossomRelaySettingsFlow())
                     } label: {
-                        SettingsRow(
+                        Row(
                             title: "Blossom Relays",
                             subtitle: "Media storage servers",
                             last: true
                         ) {
-                            SettingsIconTile(
+                            IconTile(
                                 symbol: "photo.on.rectangle.angled",
                                 bg: OnymTile.indigo
                             )
@@ -238,22 +238,22 @@ public struct SettingsView: View {
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("settings.blossom_relays_row")
                 }
-                SettingsFootnote("Nostr relays and Blossom servers carry your messages and media. Replace them with your own instances for maximum privacy.")
+                Footnote("Nostr relays and Blossom servers carry your messages and media. Replace them with your own instances for maximum privacy.")
 
                 // Hidden until the app wires the push stack, like the
                 // other optional sections.
                 if let makeNotificationsSettingsFlow {
-                    SettingsSectionLabel("NOTIFICATIONS")
-                    SettingsCard {
+                    SectionLabel("NOTIFICATIONS")
+                    Card {
                         NavigationLink {
                             NotificationsSettingsView(flow: makeNotificationsSettingsFlow())
                         } label: {
-                            SettingsRow(
+                            Row(
                                 title: "Notifications",
                                 subtitle: "Content-free wakes, off by default",
                                 last: true
                             ) {
-                                SettingsIconTile(
+                                IconTile(
                                     symbol: "bell.badge.fill",
                                     bg: OnymTile.indigo
                                 )
@@ -262,7 +262,7 @@ public struct SettingsView: View {
                         .buttonStyle(.plain)
                         .accessibilityIdentifier("settings.notifications_row")
                     }
-                    SettingsFootnote("Off means no third party ever learns this device wants waking. On hands Onym's push server your inbox codes and Apple a content-free alert — never message content.")
+                    Footnote("Off means no third party ever learns this device wants waking. On hands Onym's push server your inbox codes and Apple a content-free alert — never message content.")
                 }
 
                 // Absent until the app supplies it, like every other
@@ -276,13 +276,13 @@ public struct SettingsView: View {
                 // in: no consent, therefore no section, therefore
                 // nowhere to consent.
                 if makeDeviceBackupView != nil || makeBackupOperatorSettingsFlow != nil {
-                    SettingsSectionLabel("BACKUP")
-                    SettingsCard {
+                    SectionLabel("BACKUP")
+                    Card {
                         if let makeDeviceBackupView {
                             NavigationLink {
                                 makeDeviceBackupView()
                             } label: {
-                                SettingsRow(
+                                Row(
                                     title: "Device Backup",
                                     subtitle: "Sealed copies of this phone's history",
                                     // Last only when the picker row is
@@ -290,7 +290,7 @@ public struct SettingsView: View {
                                     // divider under its final row.
                                     last: makeBackupOperatorSettingsFlow == nil
                                 ) {
-                                    SettingsIconTile(
+                                    IconTile(
                                         symbol: "externaldrive.badge.timemachine",
                                         bg: OnymTile.blue)
                                 }
@@ -302,7 +302,7 @@ public struct SettingsView: View {
                             NavigationLink {
                                 BackupOperatorSettingsView(flow: makeBackupOperatorSettingsFlow())
                             } label: {
-                                SettingsRow(
+                                Row(
                                     title: "Backup Operators",
                                     // Names the second copy on purpose:
                                     // consenting to another operator
@@ -313,7 +313,7 @@ public struct SettingsView: View {
                                     subtitle: "Find an operator to hold a copy",
                                     last: true
                                 ) {
-                                    SettingsIconTile(
+                                    IconTile(
                                         symbol: "externaldrive.badge.plus",
                                         bg: OnymTile.blue)
                                 }
@@ -322,7 +322,7 @@ public struct SettingsView: View {
                             .accessibilityIdentifier("settings.backup_operators_row")
                         }
                     }
-                    SettingsFootnote("A backup is sealed on this phone before it leaves. The operator keeps bytes it cannot read, and only your recovery phrase can open them.")
+                    Footnote("A backup is sealed on this phone before it leaves. The operator keeps bytes it cannot read, and only your recovery phrase can open them.")
                 }
 
                 // The section gates on the two original factories; the
@@ -330,8 +330,8 @@ public struct SettingsView: View {
                 // must not make the whole MODERATION entry vanish for
                 // callers that don't supply it.
                 if let makeModerationSettingsFlow, let makeModerationConsentFlow {
-                    SettingsSectionLabel("MODERATION")
-                    SettingsCard {
+                    SectionLabel("MODERATION")
+                    Card {
                         NavigationLink {
                             ModerationSettingsView(
                                 flow: makeModerationSettingsFlow(),
@@ -339,49 +339,49 @@ public struct SettingsView: View {
                                 makeCaseFlow: makeModerationCaseFlow
                             )
                         } label: {
-                            SettingsRow(
+                            Row(
                                 title: "Moderation",
                                 subtitle: "Your consented authority and its terms",
                                 last: true
                             ) {
-                                SettingsIconTile(symbol: "checkmark.shield", bg: OnymTile.green)
+                                IconTile(symbol: "checkmark.shield", bg: OnymTile.green)
                             }
                         }
                         .buttonStyle(.plain)
                         .accessibilityIdentifier("settings.moderation_row")
                     }
-                    SettingsFootnote("The moderation authority handles reports of prohibited content under terms you consented to. You can switch to a different authority at any time.")
+                    Footnote("The moderation authority handles reports of prohibited content under terms you consented to. You can switch to a different authority at any time.")
                 }
 
                 if onRestartOnboarding != nil {
-                    SettingsSectionLabel("SETUP")
-                    SettingsCard {
+                    SectionLabel("SETUP")
+                    Card {
                         Button { showRestartOnboardingConfirm = true } label: {
-                            SettingsRow(
+                            Row(
                                 title: "Restart Onboarding",
                                 subtitle: "Review your service choices again",
                                 hasChevron: false,
                                 last: true
                             ) {
-                                SettingsIconTile(symbol: "arrow.counterclockwise.circle.fill",
+                                IconTile(symbol: "arrow.counterclockwise.circle.fill",
                                                  bg: OnymTile.blue)
                             }
                         }
                         .buttonStyle(.plain)
                         .accessibilityIdentifier("settings.restart_onboarding_row")
                     }
-                    SettingsFootnote("Runs the first-launch setup again: message transport, file storage, notary, and moderation. Your identity, chats, and messages are kept, and your current choices stay until you change them.")
+                    Footnote("Runs the first-launch setup again: message transport, file storage, notary, and moderation. Your identity, chats, and messages are kept, and your current choices stay until you change them.")
                 }
 
-                SettingsSectionLabel("DATA")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("DATA")
+                Card {
+                    Row(
                         title: "Send read receipts",
                         subtitle: "You'll only see others' read status if this is on",
                         subtitleLineLimit: nil,
                         hasChevron: false
                     ) {
-                        SettingsIconTile(
+                        IconTile(
                             symbol: sendReadReceipts ? "checkmark.message.fill" : "message",
                             bg: sendReadReceipts ? OnymTile.indigo : OnymTile.gray
                         )
@@ -393,20 +393,20 @@ public struct SettingsView: View {
                     }
 
                     Button { showClearConfirm1 = true } label: {
-                        SettingsRow(
+                        Row(
                             title: "Clear Local Message Cache",
                             titleColor: OnymTokens.red,
                             subtitle: "Delete every message on this device. Your chats stay.",
                             hasChevron: false,
                             last: true
                         ) {
-                            SettingsIconTile(symbol: "trash.fill", bg: OnymTile.red)
+                            IconTile(symbol: "trash.fill", bg: OnymTile.red)
                         }
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("settings.clear_messages_row")
                 }
-                SettingsFootnote("Onym keeps no copy of your messages on any server — this device is the only place they live. Cleared messages can’t be downloaded again: relays hold them only briefly and may already have dropped them.")
+                Footnote("Onym keeps no copy of your messages on any server — this device is the only place they live. Cleared messages can’t be downloaded again: relays hold them only briefly and may already have dropped them.")
 
                 watermark
             }

--- a/Packages/OnymSettings/Sources/OnymSettings/UseExistingContractView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/UseExistingContractView.swift
@@ -34,8 +34,8 @@ struct UseExistingContractView: View {
             VStack(alignment: .leading, spacing: 0) {
                 heroCard
 
-                SettingsSectionLabel("STELLAR CONTRACT ADDRESS")
-                SettingsCard {
+                SectionLabel("STELLAR CONTRACT ADDRESS")
+                Card {
                     VStack(alignment: .leading, spacing: 4) {
                         TextEditor(text: $addr)
                             .font(OnymType.mono(size: 14))
@@ -53,7 +53,7 @@ struct UseExistingContractView: View {
 
                         if !addr.isEmpty {
                             HStack(spacing: 8) {
-                                SettingsChip(
+                                Chip(
                                     text: looksValid ? "Valid format" : "\(addr.count)/56 chars",
                                     fg: looksValid ? OnymTokens.green : OnymTokens.red,
                                     bg: looksValid
@@ -69,8 +69,8 @@ struct UseExistingContractView: View {
                     .padding(.horizontal, 16).padding(.vertical, 12)
                 }
 
-                SettingsSectionLabel("LABEL")
-                SettingsCard {
+                SectionLabel("LABEL")
+                Card {
                     TextField("My fork v0.0.5", text: $label)
                         .font(OnymType.font(size: 16))
                         .padding(.horizontal, 16).padding(.vertical, 12)
@@ -79,9 +79,9 @@ struct UseExistingContractView: View {
                             if v.count > 30 { label = String(v.prefix(30)) }
                         }
                 }
-                SettingsFootnote("Shown alongside the contract address in chats and on the Anchors list.")
+                Footnote("Shown alongside the contract address in chats and on the Anchors list.")
 
-                SettingsPrimaryButton(
+                PrimaryButton(
                     disabled: !looksValid,
                     action: {
                         if verdict == .ok { dismiss() } else { verify() }
@@ -102,9 +102,9 @@ struct UseExistingContractView: View {
                         .padding(.top, 12)
                 }
 
-                SettingsSectionLabel("HOW TO FIND IT")
-                SettingsCard {
-                    SettingsRow(
+                SectionLabel("HOW TO FIND IT")
+                Card {
+                    Row(
                         title: "Browse on Stellar Expert",
                         subtitle: "stellar.expert",
                         hasChevron: false,
@@ -121,7 +121,7 @@ struct UseExistingContractView: View {
                         Image(systemName: "arrow.up.right.square")
                             .foregroundStyle(OnymTokens.text3)
                     }
-                    SettingsRow(
+                    Row(
                         title: "Soroban CLI",
                         subtitle: "soroban contract id …",
                         subtitleMono: true,
@@ -129,7 +129,7 @@ struct UseExistingContractView: View {
                         last: true,
                         onTap: { open("https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup") }
                     ) {
-                        SettingsIconTile(symbol: "terminal.fill", bg: OnymTile.gray)
+                        IconTile(symbol: "terminal.fill", bg: OnymTile.gray)
                     }
                 }
             }

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -334,7 +334,7 @@ private struct OnboardingRestoreSheet: View {
                     .foregroundStyle(OnymTokens.text2)
                     .lineSpacing(2)
 
-                SettingsCard {
+                Card {
                     TextField("word word word …", text: $phrase, axis: .vertical)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
@@ -359,7 +359,7 @@ private struct OnboardingRestoreSheet: View {
 
                 Spacer(minLength: 0)
 
-                SettingsPrimaryButton(isRestoring ? "Restoring…" : "Restore identity") {
+                PrimaryButton(isRestoring ? "Restoring…" : "Restore identity") {
                     Task { await submit() }
                 }
                 .disabled(!canRestore || isRestoring)
@@ -622,7 +622,7 @@ struct OnboardingServicesContent: View {
                         .font(.system(size: 17, weight: .semibold))
                         .foregroundStyle(OnymTokens.text)
                     if !usingCustom {
-                        SettingsChip(
+                        Chip(
                             text: String(localized: "Selected"),
                             fg: OnymTokens.onAccent,
                             bg: OnymAccent.blue.color
@@ -668,7 +668,7 @@ struct OnboardingServicesContent: View {
                             .font(.system(size: 17, weight: .semibold))
                             .foregroundStyle(OnymTokens.text)
                         if usingCustom {
-                            SettingsChip(
+                            Chip(
                                 text: String(localized: "Selected"),
                                 fg: OnymTokens.onAccent,
                                 bg: OnymAccent.blue.color
@@ -1013,7 +1013,7 @@ struct OnboardingDiscoveryContent: View {
             .accessibilityIdentifier("onboarding.services.directory.source")
 
             if status.source.pinnedOperatorKeyHex == nil {
-                SettingsPrimaryButton("Verify & Confirm") {
+                PrimaryButton("Verify & Confirm") {
                     flow.tappedConfirmSource(providerId: status.source.providerId)
                 }
                 .padding(.top, 12)
@@ -1122,7 +1122,7 @@ struct OnboardingDiscoveryContent: View {
                     in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .padding(.top, 8)
 
-        SettingsPrimaryButton("Pin Key & Confirm") {
+        PrimaryButton("Pin Key & Confirm") {
             flow.tappedConfirmAdd()
         }
         .padding(.top, 12)
@@ -1617,7 +1617,7 @@ struct OnboardingNotaryContent: View {
                                 Spacer(minLength: 4)
                                 HStack(spacing: 4) {
                                     ForEach(endpoint.networks, id: \.self) { net in
-                                        SettingsChip(
+                                        Chip(
                                             text: net.uppercased(),
                                             fg: net == "public" ? OnymTokens.red : OnymTokens.green,
                                             bg: (net == "public" ? OnymTokens.red : OnymTokens.green).opacity(0.15)
@@ -1792,7 +1792,7 @@ struct OnboardingRecoveryContent: View {
                         in: RoundedRectangle(cornerRadius: 14, style: .continuous))
             .accessibilityIdentifier("onboarding.recoveryPhrase.status")
 
-            SettingsPrimaryButton(sawPhrase || backedUp ? "View it again" : "Reveal my recovery phrase") {
+            PrimaryButton(sawPhrase || backedUp ? "View it again" : "Reveal my recovery phrase") {
                 flow = makeBackupFlow()
                 showBackup = true
             }

--- a/Sources/OnymIOS/RootView.swift
+++ b/Sources/OnymIOS/RootView.swift
@@ -230,7 +230,7 @@ struct RootView: View {
                         { step in make(flow, step) }
                     },
                     stepIndicator: { index, count in
-                        AnyView(SettingsStepIndicator(step: index, count: count))
+                        AnyView(StepIndicator(step: index, count: count))
                     }
                 )
                 .interactiveDismissDisabled(true)


### PR DESCRIPTION
Fourth of five. Base: #318.

Eleven components existed on both sides under two names. The design system said `Card`, `Row`, `Chip`, `Footnote`, `LargeTitle`, `IconTile`, `SectionLabel`, `StepIndicator`, `PrimaryButton`, `TextButton`; the app said the same words with `Settings` in front — a prefix that stopped being true the moment these atoms started rendering chat, identity, moderation and recovery screens.

**474 references** now use the shared word. This makes the design project's "maps 1:1 to the `OnymDesign` SwiftUI package" claim true for the components that exist on both sides.

Three keep their prefix because there is nothing on the other side to agree with: `SettingsContentTile`, `SettingsRowDivider`, `SettingsQRCode`.

### On bare `Row`

The one name worth checking. Four types in the repo already declare a nested `Row` — in `PendingChatsFlow`, the backup client, the intro request log, and `ChatsView` — and a nested name shadows a top-level one inside its own scope. None of those four files render a design-system row, so nothing is shadowed today. It is the kind of thing that will be true right up until it isn't, so it is called out here rather than discovered later.

### Still not aligned

Eleven design-system components have no `OnymDesign` counterpart at all — `Screen`, `ScreenContent`, `NavBar`, `TabDock`, `GlassButton`, `ChatBubble`, `ChatComposer`, `TextField`, `Toggle`, `Badge`, `ListItem`. They exist in the app, open-coded in feature packages. Promoting them restructures `OnymChatsUI` and is deliberately not in this stack.

Note that `TextField` and `Toggle` will collide with SwiftUI's own types if promoted unprefixed — worth deciding before that work starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf
