### PR TITLE
Tests for the palette a stranger might replace, and the floors it must clear

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,35 @@ jobs:
             -derivedDataPath /tmp/onym-foundation-tests \
             -resultBundlePath /tmp/onym-foundation.xcresult
 
+      - name: xcodebuild test (OnymDesignTokens package)
+        # The token contract and the contrast floors. These gate the
+        # palette against a resync from the design system quietly
+        # reintroducing a colour that fails WCAG AA — which is exactly
+        # how the amber token went wrong once already. Same `always()`
+        # rationale as the other package test steps.
+        if: always()
+        working-directory: Packages/OnymDesignTokens
+        run: |
+          rm -rf /tmp/onym-designtokens-tests /tmp/onym-designtokens.xcresult
+          xcodebuild test \
+            -scheme OnymDesignTokens \
+            -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }},OS=latest" \
+            -derivedDataPath /tmp/onym-designtokens-tests \
+            -resultBundlePath /tmp/onym-designtokens.xcresult
+
+      - name: xcodebuild test (OnymDesign package)
+        # Sender-to-accent mapping: determinism across launches and
+        # devices, and sensitivity to every byte of the pubkey.
+        if: always()
+        working-directory: Packages/OnymDesign
+        run: |
+          rm -rf /tmp/onym-design-tests /tmp/onym-design.xcresult
+          xcodebuild test \
+            -scheme OnymDesign \
+            -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }},OS=latest" \
+            -derivedDataPath /tmp/onym-design-tests \
+            -resultBundlePath /tmp/onym-design.xcresult
+
       - name: xcodebuild build (OnymPush package)
         # OnymPush's suites live in OnymIOSTests (run above), which
         # already compiles the package — as a dependency of the app
@@ -275,6 +304,22 @@ jobs:
         with:
           name: foundation-tests-xcresult
           path: /tmp/onym-foundation.xcresult
+          retention-days: 7
+
+      - name: Upload OnymDesignTokens test xcresult
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: designtokens-tests-xcresult
+          path: /tmp/onym-designtokens.xcresult
+          retention-days: 7
+
+      - name: Upload OnymDesign test xcresult
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: design-tests-xcresult
+          path: /tmp/onym-design.xcresult
           retention-days: 7
 
   ui-tests:
@@ -779,6 +824,20 @@ jobs:
           path: /tmp/foundation-xcresult
         continue-on-error: true
 
+      - name: Download designtokens-tests xcresult
+        uses: actions/download-artifact@v4
+        with:
+          name: designtokens-tests-xcresult
+          path: /tmp/designtokens-xcresult
+        continue-on-error: true
+
+      - name: Download design-tests xcresult
+        uses: actions/download-artifact@v4
+        with:
+          name: design-tests-xcresult
+          path: /tmp/design-xcresult
+        continue-on-error: true
+
       - name: Download ui-tests xcresult
         uses: actions/download-artifact@v4
         with:
@@ -798,6 +857,8 @@ jobs:
             --bundle "/tmp/unit-xcresult"       --target OnymIOSTests \
             --bundle "/tmp/discovery-xcresult"  --target OnymDiscoveryTests \
             --bundle "/tmp/foundation-xcresult" --target OnymFoundationTests \
+            --bundle "/tmp/designtokens-xcresult" --target OnymDesignTokensTests \
+            --bundle "/tmp/design-xcresult"     --target OnymDesignTests \
             --bundle "/tmp/ui-xcresult"         --target OnymIOSUITests \
             --results /tmp/results.json \
             --comment-md /tmp/failure_comment.md

--- a/Packages/OnymDesign/Package.swift
+++ b/Packages/OnymDesign/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
         .target(
             name: "OnymDesign",
             dependencies: [.product(name: "OnymDesignTokens", package: "OnymDesignTokens")]
+        ),
+        .testTarget(
+            name: "OnymDesignTests",
+            dependencies: ["OnymDesign"]
         )
     ]
 )

--- a/Packages/OnymDesign/Tests/OnymDesignTests/SenderAccentTests.swift
+++ b/Packages/OnymDesign/Tests/OnymDesignTests/SenderAccentTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import OnymDesign
+
+/// `forSender` is the one piece of colour *policy* in the design layer:
+/// it turns an identity into an accent. It stays in OnymDesign rather
+/// than the token package precisely so adopters inherit it, which makes
+/// its guarantees worth pinning.
+final class SenderAccentTests: XCTestCase {
+
+    private let alice = "8f14e45fceea167a5a36dedd4bea2543"
+    private let bob   = "c9f0f895fb98ab9159f51fd0297e236d"
+
+    func testSameKeyAlwaysResolvesToTheSameAccent() {
+        // Colour has to survive a relaunch and agree across devices, so
+        // the mapping cannot lean on Hashable's per-process seed.
+        let first = OnymAccent.forSender(blsPubkeyHex: alice)
+        for _ in 0..<50 {
+            XCTAssertEqual(OnymAccent.forSender(blsPubkeyHex: alice), first)
+        }
+    }
+
+    func testEveryByteOfTheKeyFeedsTheMapping() {
+        // Two members can both call themselves Alice; the colour has to
+        // come from the pubkey, all of it. If a suffix were ignored,
+        // keys sharing a prefix would always share a colour — and an
+        // impostor could shop for one that matches their target.
+        //
+        // Six colours means two arbitrary keys collide about one time
+        // in six, so this asks the sharper question: does changing a
+        // single character anywhere in the key ever move the colour?
+        for position in 0..<alice.count {
+            var moved = false
+            for digit in "0123456789abcdef" {
+                var chars = Array(alice)
+                if chars[position] == digit { continue }
+                chars[position] = digit
+                if OnymAccent.forSender(blsPubkeyHex: String(chars))
+                    != OnymAccent.forSender(blsPubkeyHex: alice) {
+                    moved = true
+                    break
+                }
+            }
+            XCTAssertTrue(moved, "character \(position) never affects the accent")
+        }
+    }
+
+    func testTwoDistinctKeysCanDiffer() {
+        // Not a guarantee about any particular pair — with six colours,
+        // collisions are expected and fine. This only pins that the
+        // mapping is not constant.
+        XCTAssertGreaterThan(
+            Set([alice, bob, "deadbeef", "0011223344556677"]
+                .map { OnymAccent.forSender(blsPubkeyHex: $0) }).count,
+            1
+        )
+    }
+
+    func testEveryAccentIsReachable() {
+        // A mapping that can only ever produce three of six colours
+        // would make groups look monotonous and would not be obvious
+        // from any single conversation.
+        var seen = Set<OnymAccent>()
+        for i in 0..<2000 {
+            seen.insert(OnymAccent.forSender(blsPubkeyHex: String(format: "%064x", i)))
+        }
+        XCTAssertEqual(seen.count, OnymAccent.allCases.count,
+                       "unreachable accents: \(Set(OnymAccent.allCases).subtracting(seen))")
+    }
+
+    func testDistributionIsNotBadlySkewed() {
+        // FNV-1a over hex bytes should spread roughly evenly. A wildly
+        // uneven split would mean most people share one colour.
+        var tally: [OnymAccent: Int] = [:]
+        let n = 6000
+        for i in 0..<n {
+            tally[OnymAccent.forSender(blsPubkeyHex: String(format: "%064x", i)), default: 0] += 1
+        }
+        let expected = n / OnymAccent.allCases.count
+        for (accent, count) in tally {
+            XCTAssertLessThan(
+                abs(count - expected), expected / 2,
+                "\(accent.rawValue) got \(count) of \(n), expected near \(expected)"
+            )
+        }
+    }
+
+    func testEmptyKeyDoesNotTrap() {
+        // Defensive: a member with no key yet still has to render.
+        XCTAssertNoThrow(OnymAccent.forSender(blsPubkeyHex: ""))
+    }
+}

--- a/Packages/OnymDesignTokens/Package.swift
+++ b/Packages/OnymDesignTokens/Package.swift
@@ -8,6 +8,10 @@ let package = Package(
         .library(name: "OnymDesignTokens", targets: ["OnymDesignTokens"])
     ],
     targets: [
-        .target(name: "OnymDesignTokens")
+        .target(name: "OnymDesignTokens"),
+        .testTarget(
+            name: "OnymDesignTokensTests",
+            dependencies: ["OnymDesignTokens"]
+        )
     ]
 )

--- a/Packages/OnymDesignTokens/README.md
+++ b/Packages/OnymDesignTokens/README.md
@@ -57,6 +57,23 @@ adopter-controlled, just through a different door.
    `--replace-scm-with-local` / a `.package(name:path:)` override.
 4. Build. That is the whole swap.
 
+### Checking your copy before you wire it in
+
+`OnymDesignTokensTests` exercises the whole contract and can be run
+against a replacement module directly:
+
+```
+cd YourTokensPackage
+xcodebuild test -scheme OnymDesignTokens \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+It checks that every token resolves in both appearances, that the
+surface ramp does not collapse, that no two accents come out the same
+colour, that the radius scale stays ordered, and that the palette clears
+its contrast floors. That last one is the point: a theme that fails it
+is not a theme, it is an accessibility regression.
+
 ### The completeness guarantee
 
 There is no protocol to conform to and no registration call, because
@@ -76,11 +93,30 @@ runtime, as before — that is inside each token, not across modules.
 ## Keeping in step with the design system
 
 Values here mirror the `Onym Design System` project on claude.ai.
-Two divergences are intentional and should survive any resync:
+These divergences are intentional and should survive any resync — the
+contrast tests will fail if a resync undoes one:
 
 - **`amber` light variant is `#B25E00`,** not the system orange
   `#FF9500`. The original fails WCAG AA (~2.1:1) at the caption size it
   is used on, and it is used on lines a founder is most expected to
   read.
+- **`OnymTint.orangeInk` is `#BE4300`,** not `#D14A00`. The original
+  measured 4.00:1 on its own pastel and 3.85:1 on the 16% tint — the
+  same failure as amber, found by the contrast suite rather than by
+  hand.
 - **`text3` dark is 0.40 alpha** against light's 0.42 — the darker
   ground needs slightly less fade to hold the same apparent contrast.
+- **The radius scale has ten steps, not the design system's five.** The
+  app was already spending fifteen distinct corners and `inset` (12) is
+  its single most common; the system had no word for it.
+
+### One known shortfall
+
+White glyphs on four of the nine `OnymTile` hues sit below WCAG
+1.4.11's 3:1 for non-text contrast — amber 2.20, teal 2.48, orange
+2.60, green 2.69. This is Apple's Settings palette drawn the way
+Settings draws it, and every tile sits beside a `Row` whose title
+carries the same meaning in text, so nothing is knowable only from the
+tile. `testOnTileStaysLegibleOnEveryTile` holds a regression floor
+rather than claiming conformance. If a tile ever becomes the only cue
+for something, raise that floor and darken the palette to meet it.

--- a/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymTint.swift
+++ b/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymTint.swift
@@ -37,7 +37,11 @@ public enum OnymTint {
     // Orange — the contract-detail tile, the anarchy badge.
     public static let orangeSoft  = hex(0xFEF0E0)
     public static let orangeSoft2 = hex(0xFFE0C0)
-    public static let orangeInk   = hex(0xD14A00)
+    /// Darker than the `#D14A00` this started as. That value measured
+    /// 4.00:1 on `orangeSoft` and 3.85:1 on the 16%-alpha orange tint,
+    /// failing WCAG AA on both — the same failure the `amber` token had
+    /// and for the same reason. `#BE4300` clears 4.5:1 on each.
+    public static let orangeInk   = hex(0xBE4300)
 
     // Amber — the notice banner: fill, hairline, and the text on it.
     public static let amberSoft   = hex(0xFFF6E5)

--- a/Packages/OnymDesignTokens/Tests/OnymDesignTokensTests/ContrastTests.swift
+++ b/Packages/OnymDesignTokens/Tests/OnymDesignTokensTests/ContrastTests.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import OnymDesignTokens
+
+/// Contrast floors the palette has to clear.
+///
+/// These exist because the amber token was once the system orange, and
+/// `#FF9500` on `surface2` measures about 2.1:1 — it failed WCAG AA at
+/// the caption size it is used on, which is the size a founder is most
+/// expected to actually read. It was fixed by hand. A resync from the
+/// design system, or an adopter copying this package and "restoring"
+/// the system colour, would put it straight back.
+///
+/// A theme that cannot clear these is not a theme, it is an
+/// accessibility regression, and it should fail here rather than in
+/// review.
+final class ContrastTests: XCTestCase {
+
+    /// WCAG AA for normal-size body text.
+    private let aa: CGFloat = 4.5
+    /// WCAG AA for large text (18pt+, or 14pt+ bold).
+    private let aaLarge: CGFloat = 3.0
+
+    private func assertContrast(
+        _ fg: Color, on bg: Color, _ style: UIUserInterfaceStyle,
+        atLeast floor: CGFloat, _ label: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        let ratio = Resolved.contrast(fg, on: bg, style)
+        XCTAssertGreaterThanOrEqual(
+            ratio, floor,
+            String(format: "%@ in %@ is %.2f:1, needs %.1f:1",
+                   label, style == .light ? "light" : "dark", ratio, floor),
+            file: file, line: line
+        )
+    }
+
+    func testPrimaryTextClearsAAOnEverySurface() {
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            for (name, surface) in [("bg", OnymTokens.bg),
+                                    ("surface", OnymTokens.surface),
+                                    ("surface2", OnymTokens.surface2),
+                                    ("surface3", OnymTokens.surface3)] {
+                assertContrast(OnymTokens.text, on: surface, style,
+                               atLeast: aa, "text on \(name)")
+            }
+        }
+    }
+
+    func testAmberClearsAAOnCardSurface() {
+        // The whole reason this token diverges from the design system.
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            assertContrast(OnymTokens.amber, on: OnymTokens.surface2, style,
+                           atLeast: aa, "amber on surface2")
+        }
+    }
+
+    func testSemanticColorsClearAAOnCardSurface() {
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            assertContrast(OnymTokens.red, on: OnymTokens.surface2, style,
+                           atLeast: aaLarge, "red on surface2")
+            assertContrast(OnymTokens.green, on: OnymTokens.surface2, style,
+                           atLeast: aaLarge, "green on surface2")
+        }
+    }
+
+    /// White glyphs on the icon tiles, measured.
+    ///
+    /// Four of the nine sit below WCAG 1.4.11's 3:1 for non-text
+    /// contrast — amber at 2.20, teal at 2.48, orange at 2.60, green at
+    /// 2.69. They are Apple's Settings palette, drawn the way Settings
+    /// draws it, and 1.4.11 does not bind here: the glyph is decorative
+    /// and every tile sits beside a `Row` whose title carries the same
+    /// meaning in text. Nothing is only knowable from the tile.
+    ///
+    /// So this is a regression guard rather than a conformance claim.
+    /// The floor catches a theme that pushes a tile to genuinely
+    /// illegible; it does not pretend the current palette clears AA.
+    /// If the glyph ever becomes the only cue for something, this test
+    /// should be raised to `aaLarge` and the palette darkened to meet it.
+    func testOnTileStaysLegibleOnEveryTile() {
+        let floor: CGFloat = 2.1
+        for (name, tile) in [("purple", OnymTile.purple), ("blue", OnymTile.blue),
+                             ("indigo", OnymTile.indigo), ("orange", OnymTile.orange),
+                             ("green", OnymTile.green), ("gray", OnymTile.gray),
+                             ("red", OnymTile.red), ("teal", OnymTile.teal),
+                             ("amber", OnymTile.amber)] {
+            assertContrast(OnymTokens.onTile, on: tile, .light,
+                           atLeast: floor, "onTile on \(name) tile")
+        }
+    }
+
+    /// The tiles that *do* clear 3:1 must not quietly fall below it.
+    func testStrongTilesKeepNonTextContrast() {
+        for (name, tile) in [("purple", OnymTile.purple), ("indigo", OnymTile.indigo),
+                             ("red", OnymTile.red), ("gray", OnymTile.gray),
+                             ("blue", OnymTile.blue)] {
+            assertContrast(OnymTokens.onTile, on: tile, .light,
+                           atLeast: aaLarge, "onTile on \(name) tile")
+        }
+    }
+
+    func testConsoleTextReadsOnConsoleSurface() {
+        assertContrast(OnymTerminal.text, on: OnymTerminal.surfaceDeep, .light,
+                       atLeast: aa, "console text on console surface")
+        assertContrast(OnymTerminal.ink, on: OnymTerminal.text, .light,
+                       atLeast: aa, "console ink on phosphor")
+    }
+
+    func testTintInksReadOnTheirFills() {
+        assertContrast(OnymTint.amberInk, on: OnymTint.amberSoft, .light,
+                       atLeast: aa, "amber ink on amber fill")
+        assertContrast(OnymTint.greenInkDeep, on: OnymTint.greenSoft, .light,
+                       atLeast: aa, "green ink on green fill")
+        assertContrast(OnymTint.orangeInk, on: OnymTint.orangeSoft, .light,
+                       atLeast: aa, "orange ink on orange fill")
+        assertContrast(OnymTint.indigoInk, on: OnymTint.indigoSoft, .light,
+                       atLeast: aa, "indigo ink on indigo fill")
+    }
+}

--- a/Packages/OnymDesignTokens/Tests/OnymDesignTokensTests/TokenContract.swift
+++ b/Packages/OnymDesignTokens/Tests/OnymDesignTokensTests/TokenContract.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import OnymDesignTokens
+
+/// Shared helpers for reading a token's resolved value in a given
+/// appearance, and for the contrast maths the accessibility tests use.
+enum Resolved {
+    static func rgb(_ color: Color, _ style: UIUserInterfaceStyle) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        let ui = UIColor(color).resolvedColor(with: UITraitCollection(userInterfaceStyle: style))
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        ui.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return (r, g, b, a)
+    }
+
+    /// WCAG 2.1 relative luminance.
+    static func luminance(_ color: Color, _ style: UIUserInterfaceStyle) -> CGFloat {
+        let c = rgb(color, style)
+        func lin(_ v: CGFloat) -> CGFloat {
+            v <= 0.03928 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * lin(c.r) + 0.7152 * lin(c.g) + 0.0722 * lin(c.b)
+    }
+
+    /// WCAG contrast ratio between two opaque tokens.
+    static func contrast(_ a: Color, on b: Color, _ style: UIUserInterfaceStyle) -> CGFloat {
+        let la = luminance(a, style), lb = luminance(b, style)
+        let hi = max(la, lb), lo = min(la, lb)
+        return (hi + 0.05) / (lo + 0.05)
+    }
+}
+
+/// The completeness check an adopter runs against their own token
+/// module before wiring it in.
+///
+/// The compiler is the real guarantee — 758 call sites will not resolve
+/// against an incomplete module. This suite exists so the failure is
+/// one readable line rather than several hundred compiler errors, and
+/// so a token that is quietly deleted is caught by something other than
+/// a screen going blank.
+final class TokenContractTests: XCTestCase {
+
+    /// Every colour token, by the name the app calls it.
+    private static let colors: [(String, Color)] = [
+        ("bg", OnymTokens.bg),
+        ("surface", OnymTokens.surface),
+        ("surface2", OnymTokens.surface2),
+        ("surface3", OnymTokens.surface3),
+        ("text", OnymTokens.text),
+        ("text2", OnymTokens.text2),
+        ("text3", OnymTokens.text3),
+        ("hairline", OnymTokens.hairline),
+        ("hairlineStrong", OnymTokens.hairlineStrong),
+        ("green", OnymTokens.green),
+        ("red", OnymTokens.red),
+        ("amber", OnymTokens.amber),
+        ("onAccent", OnymTokens.onAccent),
+        ("onTile", OnymTokens.onTile),
+        ("lightbox", OnymTokens.lightbox),
+        ("scrim", OnymTokens.scrim),
+    ]
+
+    private static let tiles: [(String, Color)] = [
+        ("purple", OnymTile.purple), ("blue", OnymTile.blue),
+        ("indigo", OnymTile.indigo), ("orange", OnymTile.orange),
+        ("green", OnymTile.green), ("gray", OnymTile.gray),
+        ("red", OnymTile.red), ("teal", OnymTile.teal),
+        ("amber", OnymTile.amber),
+    ]
+
+    private static let radii: [(String, CGFloat)] = [
+        ("card", OnymRadius.card), ("field", OnymRadius.field),
+        ("panel", OnymRadius.panel), ("hero", OnymRadius.hero),
+        ("inset", OnymRadius.inset), ("control", OnymRadius.control),
+        ("badge", OnymRadius.badge), ("tile", OnymRadius.tile),
+        ("chip", OnymRadius.chip), ("pill", OnymRadius.pill),
+    ]
+
+    func testEveryColorTokenResolvesInBothAppearances() {
+        for (name, color) in Self.colors {
+            for style in [UIUserInterfaceStyle.light, .dark] {
+                let c = Resolved.rgb(color, style)
+                XCTAssertGreaterThan(
+                    c.a, 0,
+                    "OnymTokens.\(name) is fully transparent in \(style == .light ? "light" : "dark")"
+                )
+            }
+        }
+    }
+
+    func testTokenCountsAreStable() {
+        // A replacement module that drops a token fails to compile long
+        // before it reaches here. These guard the other direction: a
+        // token quietly removed from *this* module, where the call sites
+        // that used it were removed in the same change.
+        XCTAssertEqual(Self.colors.count, 16, "colour token count changed")
+        XCTAssertEqual(Self.tiles.count, 9, "OnymTile lost or gained a hue")
+        XCTAssertEqual(Self.radii.count, 10, "OnymRadius lost or gained a step")
+        XCTAssertEqual(OnymAccent.allCases.count, 6, "OnymAccent case count changed")
+    }
+
+    func testSurfacesAreDistinct() {
+        // surface / surface2 / surface3 stack on each other. If two
+        // collapse to the same value, cards stop reading as cards.
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            let ls = [OnymTokens.surface, OnymTokens.surface2, OnymTokens.surface3]
+                .map { Resolved.luminance($0, style) }
+            XCTAssertNotEqual(ls[0], ls[1], accuracy: 0, "surface and surface2 collapsed")
+            XCTAssertNotEqual(ls[1], ls[2], accuracy: 0, "surface2 and surface3 collapsed")
+        }
+    }
+
+    func testAccentsAreDistinctFromEachOther() {
+        // forSender spreads people across these six. Two that resolve
+        // alike would silently merge two identities' colours.
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            var seen: [String] = []
+            for accent in OnymAccent.allCases {
+                let c = Resolved.rgb(accent.color, style)
+                let key = String(format: "%.3f,%.3f,%.3f", c.r, c.g, c.b)
+                XCTAssertFalse(seen.contains(key), "\(accent.rawValue) duplicates another accent")
+                seen.append(key)
+            }
+        }
+    }
+
+    func testRadiusScaleIsOrdered() {
+        XCTAssertLessThan(OnymRadius.chip, OnymRadius.tile)
+        XCTAssertLessThan(OnymRadius.tile, OnymRadius.badge)
+        XCTAssertLessThan(OnymRadius.badge, OnymRadius.control)
+        XCTAssertLessThan(OnymRadius.control, OnymRadius.inset)
+        XCTAssertLessThan(OnymRadius.inset, OnymRadius.card)
+        XCTAssertLessThan(OnymRadius.card, OnymRadius.panel)
+        XCTAssertLessThan(OnymRadius.panel, OnymRadius.hero)
+        XCTAssertEqual(OnymRadius.card, OnymRadius.field,
+                       "field shares the card curve by design; change both or neither")
+        XCTAssertEqual(OnymRadius.pill, .infinity)
+    }
+
+    func testPillResolvesToACapsule() {
+        // Callers pass `pill` through `shape(_:)` and expect fully
+        // rounded ends, not a rectangle with an enormous radius.
+        let pill = OnymRadius.shape(OnymRadius.pill)
+        let box = CGRect(x: 0, y: 0, width: 200, height: 40)
+        XCTAssertEqual(pill.path(in: box).boundingRect.height, box.height, accuracy: 0.5)
+        XCTAssertEqual(
+            pill.path(in: box).boundingRect.width, box.width, accuracy: 0.5,
+            "pill should fill its frame; a RoundedRectangle at .infinity would not"
+        )
+    }
+
+    func testTypeTokensProduceDistinctFaces() {
+        // If mono stops being mono, a pubkey stops lining up.
+        XCTAssertNotEqual(OnymType.font(size: 14), OnymType.mono(size: 14))
+        XCTAssertNotEqual(OnymType.font(size: 14), OnymType.font(size: 14, weight: .bold))
+    }
+}


### PR DESCRIPTION
Last of five. Base: #319.

Twenty tests across the two packages, plus the adopter documentation.

The **contract suite** is what an adopter runs against their own copy before wiring it in: every token resolves in both appearances, the surface ramp does not collapse, no two accents come out the same colour, the radius scale stays ordered, `pill` really is a capsule. The compiler already refuses an incomplete module; this makes the refusal one readable line instead of several hundred.

### The contrast suite found two things

**`OnymTint.orangeInk` measured 4.00:1** on its own pastel and 3.85:1 on the 16% tint — failing WCAG AA on both, the same way `amber` did once and for the same reason. It is `#BE4300` now, which clears 4.5:1 on each. A small visible change on the contract-detail and anchors screens.

**White glyphs on four of the nine icon tiles sit below 3:1** — amber 2.20, teal 2.48, orange 2.60, green 2.69. That is Apple's Settings palette drawn the way Settings draws it, and every tile sits beside a `Row` whose title says the same thing in words, so nothing is knowable only from the tile. `testOnTileStaysLegibleOnEveryTile` holds a **regression floor and says plainly it is not a conformance claim**. If a glyph ever becomes the only cue for something, the floor goes up and the palette comes down to meet it. Flagging explicitly in case you want that decided differently.

### A test of mine that was wrong before the code was

It asserted two particular pubkeys resolve to different accents — which, with six colours, is a coin that lands wrong one time in six. It caught a coincidence, not a property. The question worth asking is whether *every byte* of the key feeds the mapping, so an impostor cannot shop for a prefix that lands on their target's colour. It asks that now.

### CI

Both suites run the way the other package suites do, and `report-to-issue` parses their results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf
