### PR TITLE
Type that answers to the person reading it

### DIFF
--- a/Packages/OnymDesignTokens/README.md
+++ b/Packages/OnymDesignTokens/README.md
@@ -18,15 +18,25 @@ touching a line of app code.
 | `OnymTerminal` | The pinned-dark console block: surface, deep, phosphor text, ink, two overlays |
 | `OnymTint` | Pastel fills and the deep inks that read on them — hero tiles, the amber notice, governance badges |
 | `OnymRadius` | 10 corner steps — `card` `field` `panel` `hero` `inset` `control` `badge` `tile` `chip` `pill` — plus `shape(_:)` |
-| `OnymType` | `font(size:weight:)` and `mono(size:weight:)` — the text and mono faces |
+| `OnymType` | `font(size:weight:)`, `mono(size:weight:)`, `fixed(size:weight:)`, `scale(_:)` — the text and mono faces, and the reader's size setting |
 | `Color.dynamic(light:dark:)` | Helper for declaring a color that follows the system trait collection |
 
 Radius steps are named for what they wrap, not what they measure. An
 adopter setting `inset` to 16 should not need to know it used to be 12.
 
 `OnymType` carries no size scale on purpose — sizes still arrive from
-the call site. Swapping the typeface is two function bodies; imposing a
-scale on 465 call sites is a design decision, not a packaging one.
+the call site. Swapping the typeface is three function bodies; imposing
+a scale on 470 call sites is a design decision, not a packaging one.
+
+`font` and `mono` honour Dynamic Type; `fixed` deliberately does not,
+and is for SF Symbols used as artwork inside boxes drawn at a set size.
+If you replace the bodies, keep the scaling — dropping it turns Dynamic
+Type off for the whole app.
+
+One trap worth inheriting the answer to: the scaling is applied as a
+**ratio**, not by passing the size to `UIFontMetrics.scaledFont(for:)`.
+That method rounds to whole points *at the default text size* — 11.5pt
+comes back 12pt — and the app spends around sixty half-point sizes.
 
 Anything else — `OnymMark`, `OnymGovIcon`, the `Settings*` components,
 `OnymAccent.forSender(blsPubkeyHex:)` — lives in `OnymDesign` and is

--- a/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymType.swift
+++ b/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymType.swift
@@ -1,15 +1,16 @@
 import SwiftUI
+import UIKit
 
 // MARK: - Typography
 
 /// The typeface layer. Two families — text and mono — and nothing else.
 ///
-/// There is deliberately no size scale here. The app currently spends
-/// 31 distinct sizes, which is not a scale but an accretion, and
-/// collapsing it is a design decision rather than a packaging one.
-/// What this type does is put every font call behind a swappable
-/// family, so an adopter shipping their own typeface changes two
-/// functions instead of 465 call sites.
+/// There is deliberately no size scale here. The app spends 31 distinct
+/// sizes, which is not a scale but an accretion, and collapsing it is a
+/// design decision rather than a packaging one. What this type does is
+/// put every font call behind a swappable family, so an adopter
+/// shipping their own typeface changes three functions instead of 470
+/// call sites.
 ///
 /// ## For adopters
 ///
@@ -17,30 +18,74 @@ import SwiftUI
 ///
 /// ```swift
 /// public static func font(size: CGFloat, weight: Font.Weight = .regular) -> Font {
-///     .custom("Inter", size: size).weight(weight)
+///     .custom("Inter", size: scaled(size)).weight(weight)
 /// }
 /// ```
 ///
 /// Sizes arrive in points from the call site. If your face runs small,
 /// scale inside the function rather than asking the app to pass
-/// different numbers.
+/// different numbers. Keep the `scaled(_:)` call — dropping it turns
+/// Dynamic Type off for the whole app.
 ///
 /// ## Dynamic Type
 ///
-/// These return fixed-size fonts, matching the behaviour of the
-/// `.system(size:)` calls they replaced — this package changed the
-/// seam, not the sizing policy. Honouring Dynamic Type means routing
-/// through `Font.custom(_:size:relativeTo:)` here *and* auditing the
-/// layouts that assume fixed metrics, which is its own piece of work.
+/// `font` and `mono` grow and shrink with the reader's text-size
+/// setting. `fixed` does not, and is for glyphs that are drawings
+/// rather than words.
+///
+/// The scaling is applied as a **ratio**, not by handing the size to
+/// `UIFontMetrics.scaledFont(for:)`. That method rounds to whole points
+/// — 11.5pt becomes 12pt, 13.5pt becomes 14pt — and it does so *at the
+/// default text size*, where nothing should move at all. The app spends
+/// around sixty half-point sizes, so taking the obvious route would
+/// have shipped a visible change to every reader who never touched the
+/// setting, in the name of helping the ones who did.
 public enum OnymType {
     /// The text face. Everything that is not a key, hash, or relay URL.
     public static func font(size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .system(size: size, weight: weight)
+        .system(size: scaled(size), weight: weight)
     }
 
     /// The mono face — relay URLs, pubkeys, recovery words, anything a
     /// person may need to compare character by character.
     public static func mono(size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .system(size: size, weight: weight, design: .monospaced)
+        .system(size: scaled(size), weight: weight, design: .monospaced)
+    }
+
+    /// A size that does not answer to the text-size setting.
+    ///
+    /// For SF Symbols used as artwork rather than type — the 44pt mark
+    /// on an onboarding screen, the glyph centred in a 30pt tile. These
+    /// sit inside boxes drawn at fixed sizes, and a symbol growing to
+    /// 2.8× inside a 30pt square does not help anybody read anything.
+    ///
+    /// Reach for this only when the glyph is decoration. If it carries
+    /// meaning a reader needs, it belongs in `font` and its box needs to
+    /// give.
+    public static func fixed(size: CGFloat, weight: Font.Weight = .regular) -> Font {
+        .system(size: size, weight: weight)
+    }
+
+    /// The reader's text-size setting, as a multiplier.
+    ///
+    /// Keyed to `.body`, so the whole app moves on one curve rather than
+    /// each size drifting against its own text style. At the default
+    /// setting this is exactly 1 and every size is untouched; at the
+    /// largest accessibility size it is about 2.82.
+    ///
+    /// The trait collection has to be passed in. `scaledValue(for:)`
+    /// without one does *not* consult `UITraitCollection.current` — it
+    /// answers 1.0 at every setting, which looks like working code and
+    /// would have quietly given every reader the default size forever.
+    /// `.current` is the right default because SwiftUI sets it while
+    /// evaluating a view body, which is the only place these are called
+    /// from.
+    public static func scale(_ traits: UITraitCollection = .current) -> CGFloat {
+        UIFontMetrics(forTextStyle: .body)
+            .scaledValue(for: 100, compatibleWith: traits) / 100
+    }
+
+    private static func scaled(_ size: CGFloat) -> CGFloat {
+        size * scale()
     }
 }


### PR DESCRIPTION
First of four. Makes `OnymType.font` and `OnymType.mono` grow and shrink with the reader's text-size setting.

Because #317 put every font call behind these two functions, that is **two function bodies rather than 470 call sites** — the reason the token seam was worth building.

`OnymType.fixed` joins them, for SF Symbols that are drawings rather than words. Nothing uses it yet; the layout PR decides what does.

### Two implementations that compile, read plausibly, and are wrong

Both were found by spiking rather than reasoning, and either could have shipped.

**1. `UIFontMetrics.scaledFont(for:)` rounds to whole points — at the default setting.**

```
scaledFont: 11.5pt -> 12.0pt at default
scaledFont: 12.5pt -> 13.0pt at default
scaledFont: 13.5pt -> 14.0pt at default
```

The app spends ~60 half-point sizes. That route ships a visible change to every reader who never touched the setting, in the name of helping the ones who did. Taking the metric as a **ratio** and applying it here keeps 13.5pt at exactly 13.5pt and grows it to 38.0pt at AX5.

**2. `scaledValue(for:)` with no trait collection silently returns 1.0 at every setting.**

It does not consult `UITraitCollection.current`. Passed `.current` explicitly it tracks properly, and SwiftUI does set `.current` while evaluating a view body — verified against a hosted view, ×2.82 at AX5. The version without it looks like working Dynamic Type support and delivers none.

### Nothing moves on screen yet

The type scales; the boxes it sits in do not. That is #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf
