### PR TITLE
Boxes that give, and the ones that shouldn't

### DIFF
--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatEmptyStateView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatEmptyStateView.swift
@@ -91,7 +91,7 @@ struct ChatEmptyStateView: View {
     private func benefit(icon: String, title: LocalizedStringKey, detail: LocalizedStringKey) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
-                .font(OnymType.font(size: 16, weight: .semibold))
+                .font(OnymType.fixed(size: 16, weight: .semibold))
                 .foregroundStyle(OnymAccent.blue.color)
                 .frame(width: 24, height: 22)
             VStack(alignment: .leading, spacing: 2) {

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatMembersView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatMembersView.swift
@@ -262,7 +262,7 @@ struct ChatMembersView: View {
                         Text(group.name)
                             .font(OnymType.font(size: 18, weight: .semibold))
                             .foregroundStyle(OnymTokens.text)
-                            .lineLimit(1)
+                            .onymLineLimit(1)
                         Image(systemName: "pencil")
                             .font(OnymType.font(size: 13, weight: .semibold))
                             .foregroundStyle(OnymTokens.text3)
@@ -274,7 +274,7 @@ struct ChatMembersView: View {
                 Text(group.name)
                     .font(OnymType.font(size: 18, weight: .semibold))
                     .foregroundStyle(OnymTokens.text)
-                    .lineLimit(1)
+                    .onymLineLimit(1)
             }
         }
         .padding(.top, 16)

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatThreadView.swift
@@ -363,7 +363,7 @@ public struct ChatThreadView: View {
                     Text(currentGroupName)
                         .font(OnymType.font(size: 16, weight: .semibold))
                         .foregroundStyle(OnymTokens.text)
-                        .lineLimit(1)
+                        .onymLineLimit(1)
                     if currentMemberCount > 1 {
                         Text("\(currentMemberCount) members")
                             .font(OnymType.font(size: 11))

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatsView.swift
@@ -286,7 +286,7 @@ public struct ChatsView: View {
                     .fill(Color.accentColor.opacity(0.10))
                     .frame(width: 96, height: 96)
                 Image(systemName: "lock.shield.fill")
-                    .font(OnymType.font(size: 42))
+                    .font(OnymType.fixed(size: 42))
                     .foregroundStyle(Color.accentColor)
             }
             .padding(.bottom, 20)
@@ -354,7 +354,7 @@ public struct ChatsView: View {
     private func benefitRow(icon: String, title: LocalizedStringKey, detail: LocalizedStringKey) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
-                .font(OnymType.font(size: 16, weight: .semibold))
+                .font(OnymType.fixed(size: 16, weight: .semibold))
                 .foregroundStyle(Color.accentColor)
                 .frame(width: 24, height: 22)
             VStack(alignment: .leading, spacing: 2) {
@@ -583,7 +583,7 @@ private struct PendingChatsRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(row.name?.isEmpty == false ? row.name! : String(localized: "(Unnamed)"))
                     .font(OnymType.font(size: 16, weight: .semibold))
-                    .lineLimit(1)
+                    .onymLineLimit(1)
                     .foregroundStyle(.secondary)
                 HStack(spacing: 6) {
                     Image(systemName: icon)
@@ -592,7 +592,7 @@ private struct PendingChatsRow: View {
                     Text(subtitle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                        .lineLimit(1)
+                        .onymLineLimit(1)
                         .accessibilityIdentifier("chats.pending.subtitle.\(row.id)")
                 }
             }
@@ -668,7 +668,7 @@ private struct ChatsRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(group.name.isEmpty ? "(Unnamed)" : group.name)
                     .font(OnymType.font(size: 16, weight: .semibold))
-                    .lineLimit(1)
+                    .onymLineLimit(1)
                 // The join hint leads, because it is the only line in the
                 // row that needs an action and a badge alone was what
                 // nobody noticed on the toolbar. It no longer *replaces*
@@ -683,7 +683,7 @@ private struct ChatsRow: View {
                         Text(joinRequestSubtitle)
                             .font(.caption)
                             .foregroundStyle(OnymAccent.blue.color)
-                            .lineLimit(1)
+                            .onymLineLimit(1)
                             .layoutPriority(1)
                             .accessibilityIdentifier("chats.row.join_request.\(group.id)")
                         Text("·")
@@ -699,7 +699,7 @@ private struct ChatsRow: View {
                         // Unread rows read a touch stronger than the muted
                         // "no messages / metadata" line.
                         .foregroundStyle(item.unreadCount > 0 ? .primary : .secondary)
-                        .lineLimit(1)
+                        .onymLineLimit(1)
                         .accessibilityIdentifier("chats.row.subtitle.\(group.id)")
                 }
             }

--- a/Packages/OnymDesign/Sources/OnymDesign/SettingsDesign.swift
+++ b/Packages/OnymDesign/Sources/OnymDesign/SettingsDesign.swift
@@ -16,11 +16,20 @@ import OnymDesignTokens
 public struct IconTile: View {
     let symbol: String
     let bg: Color
-    var size: CGFloat = 30
     var weight: Font.Weight = .semibold
 
-    // `size`/`weight` have no external consumer today, so the public
-    // init omits them (they keep their internal defaults).
+    /// The tile grows with the reader's text size, but not all the way.
+    ///
+    /// A tile pinned at 30pt beside 46pt type looks like a bug — the row
+    /// stops reading as one thing. Growing it on the full curve is worse
+    /// the other way: a 2.8× tile is 85pt of decoration crowding out the
+    /// words it decorates. `@ScaledMetric` moves it with the text and
+    /// the cap keeps it a tile.
+    @ScaledMetric(relativeTo: .body) private var scaledSize: CGFloat = 30
+    private var size: CGFloat { min(scaledSize, 46) }
+
+    // `weight` has no external consumer today, so the public init omits
+    // it (it keeps its internal default).
     public init(symbol: String, bg: Color) {
         self.symbol = symbol
         self.bg = bg
@@ -31,8 +40,10 @@ public struct IconTile: View {
             .fill(bg)
             .frame(width: size, height: size)
             .overlay(
+                // Sized off the tile, so the glyph tracks whatever the
+                // tile settled on rather than the reader's setting.
                 Image(systemName: symbol)
-                    .font(OnymType.font(size: size * 0.5, weight: weight))
+                    .font(OnymType.fixed(size: size * 0.5, weight: weight))
                     .foregroundStyle(OnymTokens.onTile)
             )
             .overlay(
@@ -46,10 +57,12 @@ public struct IconTile: View {
 /// code, a star button, etc.) over the same coloured fill.
 public struct SettingsContentTile<Content: View>: View {
     let bg: Color
-    var size: CGFloat = 30
     @ViewBuilder var content: () -> Content
 
-    // `size` has no external consumer today; the public init omits it.
+    /// Tracks `IconTile` — same tile, arbitrary content inside it.
+    @ScaledMetric(relativeTo: .body) private var scaledSize: CGFloat = 30
+    private var size: CGFloat { min(scaledSize, 46) }
+
     public init(bg: Color, @ViewBuilder content: @escaping () -> Content) {
         self.bg = bg
         self.content = content
@@ -153,6 +166,19 @@ public struct LargeTitle: View {
             .font(OnymType.font(size: 34, weight: .bold))
             .foregroundStyle(OnymTokens.text)
             .tracking(-0.75)
+            // At the largest sizes 34pt becomes 96pt and a single word
+            // like "Settings" is wider than the screen, so it breaks
+            // mid-word — "Setting" above a lonely "s". Shrinking a title
+            // that is already enormous costs the reader nothing;
+            // hyphenating their own app's name costs them a moment of
+            // confusion every time they open it.
+            //
+            // The line limit is what makes the scale factor work at all:
+            // given unlimited lines SwiftUI wraps rather than shrinks,
+            // and wrapping is the thing being avoided. Two lines leaves
+            // room for a longer title to breathe before it scales.
+            .lineLimit(2)
+            .minimumScaleFactor(0.55)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 20)
             .padding(.top, 4)
@@ -211,8 +237,8 @@ public struct SwipeToDeleteRow<Content: View>: View {
         ZStack(alignment: .trailing) {
             Button(role: .destructive, action: confirmDelete) {
                 VStack(spacing: 3) {
-                    Image(systemName: "trash.fill").font(OnymType.font(size: 16, weight: .semibold))
-                    Text(deleteLabel).font(OnymType.font(size: 11, weight: .semibold))
+                    Image(systemName: "trash.fill").font(OnymType.fixed(size: 16, weight: .semibold))
+                    Text(deleteLabel).font(OnymType.fixed(size: 11, weight: .semibold))
                 }
                 .foregroundStyle(OnymTokens.onTile)
                 .frame(width: revealWidth)
@@ -378,7 +404,10 @@ public struct Row<Tile: View, Right: View>: View {
                               ? OnymType.mono(size: 16.5)
                               : OnymType.font(size: 16.5))
                         .foregroundStyle(titleColor)
-                        .lineLimit(1)
+                        // A mono title is a key or a URL and truncates
+                        // on purpose. A prose one is a label the reader
+                        // came for, and gives way at accessibility sizes.
+                        .onymLineLimit(1, relaxing: !titleMono)
                     if let subtitle {
                         Text(subtitle)
                             .font(subtitleMono

--- a/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymLineLimit.swift
+++ b/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymLineLimit.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+// MARK: - Line limits that give way
+
+public extension View {
+    /// A line limit that lifts at accessibility text sizes.
+    ///
+    /// `lineLimit(1)` is right for a relay URL or a pubkey: a reader
+    /// comparing one character at a time is better served by a truncated
+    /// line than by sixty characters wrapped across a card, and those
+    /// sites keep the plain modifier deliberately.
+    ///
+    /// It is wrong for a group name or a row subtitle. At the largest
+    /// accessibility size type is 2.82× — a name that fitted on one line
+    /// no longer does, and holding it to one line means the reader who
+    /// most needs to read it sees the least of it.
+    ///
+    /// Below the accessibility sizes this behaves exactly like
+    /// `lineLimit(_:)`, so nothing moves for readers who never changed
+    /// the setting.
+    /// - Parameter relaxing: pass `false` where the same component
+    ///   sometimes shows a key or a URL — the limit then behaves exactly
+    ///   like `lineLimit(_:)`. `Row` uses this: its title relaxes when
+    ///   it is a label and holds when it is mono.
+    func onymLineLimit(_ limit: Int, relaxing: Bool = true) -> some View {
+        modifier(RelaxingLineLimit(limit: limit, relaxing: relaxing))
+    }
+}
+
+private struct RelaxingLineLimit: ViewModifier {
+    @Environment(\.dynamicTypeSize) private var typeSize
+    let limit: Int
+    let relaxing: Bool
+
+    func body(content: Content) -> some View {
+        content.lineLimit(relaxing && typeSize.isAccessibilitySize ? nil : limit)
+    }
+}

--- a/Packages/OnymGroup/Package.resolved
+++ b/Packages/OnymGroup/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "onym-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onymchat/onym-sdk-swift.git",
+      "state" : {
+        "revision" : "b24a3be023f7445777598ce280a84907b32f7452",
+        "version" : "0.0.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Packages/OnymGroup/Sources/OnymGroup/CreateGroupView.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/CreateGroupView.swift
@@ -132,8 +132,13 @@ private struct OnymPrimaryButton: View {
             Text(title)
                 .font(OnymType.font(size: 16, weight: .bold))
                 .tracking(-0.16)
+                .multilineTextAlignment(.center)
+                .padding(.vertical, 14)
                 .frame(maxWidth: .infinity)
-                .frame(height: 52)
+                // 52pt is the design's height, not a ceiling. At the
+                // largest accessibility size this label is 45pt tall and
+                // the button has to grow around it.
+                .frame(minHeight: 52)
                 .foregroundStyle(enabled ? OnymTokens.onAccent : OnymTokens.text3)
                 .background(enabled ? accent : OnymTokens.surface3)
                 .clipShape(RoundedRectangle(cornerRadius: OnymRadius.card))
@@ -153,8 +158,10 @@ private struct OnymQuietButton: View {
         Button(action: action) {
             Text(title)
                 .font(OnymType.font(size: 14.5, weight: .semibold))
+                .multilineTextAlignment(.center)
+                .padding(.vertical, 12)
                 .frame(maxWidth: .infinity)
-                .frame(height: 44)
+                .frame(minHeight: 44)
                 .foregroundStyle(OnymTokens.text2)
         }
         .buttonStyle(.plain)
@@ -476,7 +483,7 @@ private struct CreateGroupStep2View: View {
             ZStack {
                 Circle().fill(OnymTokens.surface3)
                 Image(systemName: "key.fill")
-                    .font(OnymType.font(size: 14, weight: .semibold))
+                    .font(OnymType.fixed(size: 14, weight: .semibold))
                     .foregroundStyle(accentColor)
             }
             .frame(width: 40, height: 40)
@@ -515,7 +522,7 @@ private struct CreateGroupStep2View: View {
                         ZStack {
                             Circle().fill(accentColor.opacity(0.22))
                             Image(systemName: "key.fill")
-                                .font(OnymType.font(size: 12, weight: .semibold))
+                                .font(OnymType.fixed(size: 12, weight: .semibold))
                                 .foregroundStyle(accentColor)
                         }
                         .frame(width: 30, height: 30)
@@ -892,7 +899,7 @@ private struct CreateGroupCreatingView: View {
                     .font(OnymType.font(size: 12))
                     .foregroundStyle(OnymTokens.text2)
             }
-            .lineLimit(1)
+            .onymLineLimit(1)
             .truncationMode(.tail)
 
             Spacer(minLength: 0)
@@ -1066,7 +1073,7 @@ private struct CreateGroupSuccessView: View {
                     Circle().fill(OnymTokens.green)
                         .overlay(Circle().stroke(OnymTokens.bg, lineWidth: 2))
                     Image(systemName: "checkmark")
-                        .font(OnymType.font(size: 12, weight: .bold))
+                        .font(OnymType.fixed(size: 12, weight: .bold))
                         .foregroundStyle(OnymTokens.onAccent)
                 }
                 .frame(width: 28, height: 28)
@@ -1207,7 +1214,7 @@ private struct CreateGroupSuccessView: View {
                     .font(OnymType.font(size: 12))
                     .foregroundStyle(OnymTokens.text2)
             }
-            .lineLimit(1)
+            .onymLineLimit(1)
 
             Spacer(minLength: 0)
 

--- a/Packages/OnymGroup/Sources/OnymGroup/GroupAvatarPickerButton.swift
+++ b/Packages/OnymGroup/Sources/OnymGroup/GroupAvatarPickerButton.swift
@@ -86,7 +86,7 @@ public struct GroupAvatarPickerButton: View {
                     .frame(width: 28, height: 28)
                     .overlay(Circle().stroke(OnymTokens.bg, lineWidth: 2))
                 Image(systemName: "camera.fill")
-                    .font(OnymType.font(size: 12, weight: .semibold))
+                    .font(OnymType.fixed(size: 12, weight: .semibold))
                     .foregroundStyle(OnymTokens.onAccent)
             }
             .offset(x: 4, y: 4)

--- a/Packages/OnymIdentityUI/Sources/OnymIdentityUI/IdentitiesView.swift
+++ b/Packages/OnymIdentityUI/Sources/OnymIdentityUI/IdentitiesView.swift
@@ -31,7 +31,7 @@ struct IdentitiesView: View {
                     HStack(spacing: 10) {
                         Circle().fill(OnymAccent.blue.color).frame(width: 22, height: 22)
                             .overlay(Image(systemName: "plus")
-                                .font(OnymType.font(size: 13, weight: .bold))
+                                .font(OnymType.fixed(size: 13, weight: .bold))
                                 .foregroundStyle(OnymTokens.onAccent))
                         Text("Add Identity")
                             .font(OnymType.font(size: 16, weight: .medium))

--- a/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
+++ b/Packages/OnymModerationUI/Sources/OnymModerationUI/OpenCaseBanner.swift
@@ -31,7 +31,7 @@ public struct OpenCaseBanner: View {
                 HStack(spacing: 10) {
                     Circle().fill(OnymTile.amber).frame(width: 22, height: 22)
                         .overlay(Image(systemName: "exclamationmark")
-                            .font(OnymType.font(size: 12, weight: .bold))
+                            .font(OnymType.fixed(size: 12, weight: .bold))
                             .foregroundStyle(.white))
                     Text(notices.count == 1
                          ? "A moderation case is open against this device."

--- a/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
+++ b/Packages/OnymOnboarding/Sources/OnymOnboarding/OnboardingView.swift
@@ -195,7 +195,7 @@ struct WelcomeStepContent: View {
     private func bullet(symbol: String, text: LocalizedStringKey) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: symbol)
-                .font(OnymType.font(size: 15, weight: .semibold))
+                .font(OnymType.fixed(size: 15, weight: .semibold))
                 .foregroundStyle(.tint)
                 .frame(width: 24)
             Text(text)

--- a/Packages/OnymRecovery/Sources/OnymRecovery/RecoveryPhraseBackupView.swift
+++ b/Packages/OnymRecovery/Sources/OnymRecovery/RecoveryPhraseBackupView.swift
@@ -173,7 +173,7 @@ private struct IntroScreen: View {
                     .frame(width: 72, height: 72)
                     .shadow(color: Color.accentColor.opacity(0.25), radius: 10, x: 0, y: 8)
                 Image(systemName: "key.fill")
-                    .font(OnymType.font(size: 30, weight: .semibold))
+                    .font(OnymType.fixed(size: 30, weight: .semibold))
                     .foregroundStyle(.white)
             }
             Text("Your identity, in 12 words")
@@ -342,7 +342,7 @@ private struct RevealScreen: View {
                                 .fill(Color.primary.opacity(0.08))
                                 .frame(width: 44, height: 44)
                             Image(systemName: "eye.slash")
-                                .font(OnymType.font(size: 18, weight: .semibold))
+                                .font(OnymType.fixed(size: 18, weight: .semibold))
                                 .foregroundStyle(Color.primary)
                         }
                         Text("Tap to reveal")
@@ -445,7 +445,7 @@ private struct VerifyOption: View {
                             .fill(OnymTokens.green)
                             .frame(width: 22, height: 22)
                         Image(systemName: "checkmark")
-                            .font(OnymType.font(size: 12, weight: .bold))
+                            .font(OnymType.fixed(size: 12, weight: .bold))
                             .foregroundStyle(.white)
                     }
                 }
@@ -517,7 +517,7 @@ private struct DoneScreen: View {
                     .frame(width: 96, height: 96)
                     .shadow(color: OnymTokens.green.opacity(0.4), radius: 16, x: 0, y: 12)
                 Image(systemName: "checkmark")
-                    .font(OnymType.font(size: 44, weight: .bold))
+                    .font(OnymType.fixed(size: 44, weight: .bold))
                     .foregroundStyle(.white)
             }
             .padding(.bottom, 24)
@@ -577,7 +577,7 @@ private struct RoundedIcon: View {
                 .fill(background)
                 .frame(width: 30, height: 30)
             Image(systemName: systemImage)
-                .font(OnymType.font(size: 15, weight: .semibold))
+                .font(OnymType.fixed(size: 15, weight: .semibold))
                 .foregroundStyle(.white)
         }
     }

--- a/Packages/OnymSettings/Sources/OnymSettings/DeployContractView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DeployContractView.swift
@@ -179,7 +179,7 @@ struct DeployContractView: View {
                 }
             } label: {
                 Image(systemName: copied == label ? "checkmark" : "doc.on.doc")
-                    .font(OnymType.font(size: 12, weight: .semibold))
+                    .font(OnymType.fixed(size: 12, weight: .semibold))
                     .foregroundStyle(copied == label
                                      ? OnymTerminal.text
                                      : .white)

--- a/Packages/OnymSettings/Sources/OnymSettings/DiscoverySettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/DiscoverySettingsView.swift
@@ -39,7 +39,7 @@ struct DiscoverySettingsView: View {
                         Circle().fill(OnymAccent.blue.color)
                             .frame(width: 30, height: 30)
                             .overlay(Image(systemName: "plus")
-                                .font(OnymType.font(size: 14, weight: .bold))
+                                .font(OnymType.fixed(size: 14, weight: .bold))
                                 .foregroundStyle(OnymTokens.onAccent))
                     }
                     .accessibilityIdentifier("settings.discovery.add")

--- a/Packages/OnymSettings/Sources/OnymSettings/IdentityCarouselCard.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/IdentityCarouselCard.swift
@@ -174,7 +174,7 @@ struct IdentityCarouselCard: View {
                             .font(OnymType.font(size: 20, weight: .bold))
                             .tracking(-0.2)
                             .foregroundStyle(isActive ? OnymAccent.blue.color : OnymTokens.text)
-                            .lineLimit(1)
+                            .onymLineLimit(1)
                         Image(systemName: "pencil")
                             .font(OnymType.font(size: 13, weight: .semibold))
                             .foregroundStyle(OnymTokens.text3)

--- a/Packages/OnymSettings/Sources/OnymSettings/PrivacyEncryptionView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/PrivacyEncryptionView.swift
@@ -175,7 +175,7 @@ struct PrivacyEncryptionView: View {
                 .overlay(RoundedRectangle(cornerRadius: OnymRadius.card, style: .continuous)
                     .stroke(OnymTokens.green.opacity(0.35), lineWidth: 1.5))
                 .overlay(Image(systemName: "lock.shield.fill")
-                    .font(OnymType.font(size: 28))
+                    .font(OnymType.fixed(size: 28))
                     .foregroundStyle(OnymTokens.green))
             VStack(alignment: .leading, spacing: 3) {
                 Text("Everything is encrypted")

--- a/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/RelayerSettingsView.swift
@@ -154,7 +154,7 @@ struct RelayerSettingsView: View {
                         ) {
                             Button { flow.tappedSetPrimary(url: endpoint.url) } label: {
                                 Image(systemName: flow.isPrimary(endpoint) ? "star.fill" : "star")
-                                    .font(OnymType.font(size: 17))
+                                    .font(OnymType.fixed(size: 17))
                                     .foregroundStyle(flow.isPrimary(endpoint) ? OnymTile.amber : OnymTokens.text3)
                                     .frame(width: 30, height: 30)
                             }
@@ -261,7 +261,7 @@ struct RelayerSettingsView: View {
                 Circle().fill(OnymAccent.blue.color)
                     .frame(width: 30, height: 30)
                     .overlay(Image(systemName: "plus")
-                        .font(OnymType.font(size: 14, weight: .bold))
+                        .font(OnymType.fixed(size: 14, weight: .bold))
                         .foregroundStyle(OnymTokens.onAccent))
             } right: {
                 HStack(spacing: 4) {
@@ -313,7 +313,7 @@ struct RelayerSettingsView: View {
                 Circle().fill(OnymAccent.blue.color)
                     .frame(width: 22, height: 22)
                     .overlay(Image(systemName: "plus")
-                        .font(OnymType.font(size: 13, weight: .bold))
+                        .font(OnymType.fixed(size: 13, weight: .bold))
                         .foregroundStyle(OnymTokens.onAccent))
             }
             .accessibilityIdentifier("relayer.add.custom.button")
@@ -332,7 +332,7 @@ struct RelayerSettingsView: View {
                         .fill(.white.opacity(0.08))
                         .frame(width: 44, height: 44)
                     Image(systemName: "chevron.left.forwardslash.chevron.right")
-                        .font(OnymType.font(size: 18))
+                        .font(OnymType.fixed(size: 18))
                         .foregroundStyle(.white)
                 }
                 VStack(alignment: .leading, spacing: 2) {

--- a/Packages/OnymSettings/Sources/OnymSettings/RunYourOwnRelayerView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/RunYourOwnRelayerView.swift
@@ -157,7 +157,7 @@ struct RunYourOwnRelayerView: View {
                 }
             } label: {
                 Image(systemName: copied == label ? "checkmark" : "doc.on.doc")
-                    .font(OnymType.font(size: 12, weight: .semibold))
+                    .font(OnymType.fixed(size: 12, weight: .semibold))
                     .foregroundStyle(copied == label
                                      ? OnymTerminal.text
                                      : .white)

--- a/Packages/OnymSettings/Sources/OnymSettings/SelfHostGuideView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SelfHostGuideView.swift
@@ -132,7 +132,7 @@ struct SelfHostGuideView: View {
                 }
             } label: {
                 Image(systemName: copied == label ? "checkmark" : "doc.on.doc")
-                    .font(OnymType.font(size: 12, weight: .semibold))
+                    .font(OnymType.fixed(size: 12, weight: .semibold))
                     .foregroundStyle(copied == label
                                      ? OnymTerminal.text
                                      : .white)

--- a/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/SettingsView.swift
@@ -459,7 +459,7 @@ public struct SettingsView: View {
             HStack(spacing: 10) {
                 Circle().fill(OnymTile.amber).frame(width: 22, height: 22)
                     .overlay(Image(systemName: "exclamationmark")
-                        .font(OnymType.font(size: 12, weight: .bold))
+                        .font(OnymType.fixed(size: 12, weight: .bold))
                         .foregroundStyle(.white))
                 Text(count == 1
                      ? "1 identity hasn’t been backed up yet."

--- a/Packages/OnymSettings/Sources/OnymSettings/UseExistingContractView.swift
+++ b/Packages/OnymSettings/Sources/OnymSettings/UseExistingContractView.swift
@@ -170,7 +170,7 @@ struct UseExistingContractView: View {
         HStack(alignment: .top, spacing: 10) {
             Circle().fill(OnymTokens.green).frame(width: 22, height: 22)
                 .overlay(Image(systemName: "checkmark")
-                    .font(OnymType.font(size: 11, weight: .bold))
+                    .font(OnymType.fixed(size: 11, weight: .bold))
                     .foregroundStyle(.white))
                 .padding(.top, 1)
             VStack(alignment: .leading, spacing: 2) {

--- a/Sources/OnymIOS/OnboardingSteps.swift
+++ b/Sources/OnymIOS/OnboardingSteps.swift
@@ -1918,7 +1918,7 @@ struct OnboardingDoneContent: View {
                                 Text(verbatim: row.value)
                                     .font(.system(size: 12))
                                     .foregroundStyle(OnymTokens.text2)
-                                    .lineLimit(1)
+                                    .onymLineLimit(1)
                                     .truncationMode(.tail)
                                 // The checkable claim: URL / key
                                 // fingerprint / manifest hash on its


### PR DESCRIPTION
Second of four. Base: #322.

The type scales now, so the layout has to let it. **Rendering the shared components at AX5 found four defects that the counting beforehand had pointed at almost none of.**

My pre-work measurement said "21 fixed heights, 27 line limits". Most of those turned out to be hairlines (`height: 1`), spacers, and `minHeight` on text editors — all already fine. The real breakage was somewhere none of my greps looked.

### 29 SF Symbols scaling inside fixed frames

A 12pt glyph in a 22pt circle, a 44pt one in a 96pt seal. Scaled by 2.82× they overflow their own boxes badly. These are drawings, not words, and take `OnymType.fixed`. The rule is narrow: a glyph the reader needs meaning from belongs in `font`, and its box has to give instead.

### Two buttons pinned around labels that outgrow them

52pt and 44pt heights around labels that reach 45pt and 41pt. They set a minimum now, and pad.

### 13 line limits lifted, 14 deliberately kept

Prose — group names, member names, subtitles — lifts at accessibility sizes via `onymLineLimit`. Keys and URLs keep `lineLimit(1)`: a truncated relay URL is kinder than sixty characters wrapped across a card, and a pubkey is for comparing, not reading. `Row` does both, so its title relaxes when it is a label and holds when it is mono.

### Tiles and title

Icon tiles stayed 30pt beside 46pt text, which reads as a bug rather than a choice. They track the text now, capped — a tile on the full curve would be 85pt of decoration crowding out what it decorates. The glyph is sized off whatever the tile settled on, so the two cannot disagree.

The large title broke mid-word: "Setting" above a lonely "s". Its minimum scale factor needed a line limit to work against — given unlimited lines SwiftUI wraps rather than shrinks, and wrapping was the thing being avoided.

### One limitation worth knowing

The fonts read the UIKit trait collection; the line limits read the SwiftUI environment. On device the system sets both and they agree. A SwiftUI-only `.environment(\.dynamicTypeSize, …)` override moves the second and not the first, so a test or preview has to set both. The app has **zero** previews and overrides dynamic type **nowhere**, so this costs nothing today — it would be the reason to move onto `@ScaledMetric` if that ever changes.

### Not decided here

At accessibility sizes rows keep tile and text side by side, leaving text ~240pt. Apple's pattern stacks the tile above the text at those sizes. That changes how every settings row looks for accessibility users, so it is a design call rather than a mechanical one — happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf
