### PR TITLE
The chat thread joins the design system it was drawn from

### DIFF
--- a/Packages/OnymChatsUI/Package.resolved
+++ b/Packages/OnymChatsUI/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "onym-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onymchat/onym-sdk-swift.git",
+      "state" : {
+        "revision" : "b24a3be023f7445777598ce280a84907b32f7452",
+        "version" : "0.0.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/AlbumGridView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/AlbumGridView.swift
@@ -116,7 +116,10 @@ final class AlbumGridView: UIView {
             addSubview(playGlyph)
 
             overflowLabel.translatesAutoresizingMaskIntoConstraints = false
-            overflowLabel.font = .systemFont(ofSize: 22, weight: .semibold)
+            // Fixed: this sits centred on a photo tile in a grid of fixed
+            // cells. Growing it 2.8× would spill out of the tile. The
+            // count is announced instead — see accessibilityLabel below.
+            overflowLabel.font = OnymType.uiFixed(size: 22, weight: .semibold)
             overflowLabel.textColor = .white
             overflowLabel.textAlignment = .center
             overflowLabel.backgroundColor = OnymTokens.scrimUI.withAlphaComponent(0.45)
@@ -150,6 +153,13 @@ final class AlbumGridView: UIView {
             playGlyph.isHidden = !item.isVideo
             overflowLabel.isHidden = overflowCount <= 0
             overflowLabel.text = overflowCount > 0 ? "+\(overflowCount)" : nil
+            // The plate cannot grow with the reader's setting without
+            // spilling out of its tile, so the count is spoken instead
+            // of only drawn.
+            overflowLabel.isAccessibilityElement = overflowCount > 0
+            overflowLabel.accessibilityLabel = overflowCount > 0
+                ? "\(overflowCount) more"
+                : nil
             imageView.image = Blurhash.decode(poster.blurhash, size: CGSize(width: 24, height: 24))
             guard let imageLoader else { return }
             let sha = poster.sha256

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatBubbleCell.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatBubbleCell.swift
@@ -363,7 +363,10 @@ final class ChatBubbleCell: UITableViewCell {
         }
         bodyView.setBody(
             message.body,
-            font: .preferredFont(forTextStyle: .body),
+            // uiBody, not uiFont(17): the cell measures this text to
+            // size itself, so the font's leading has to be the leading
+            // TextKit will actually lay out.
+            font: OnymType.uiBody(),
             color: bodyColor
         )
         applyNameHeader(sender)
@@ -940,7 +943,9 @@ final class ChatBubbleCell: UITableViewCell {
         attachmentImageView.addSubview(playOverlay)
 
         durationLabel.translatesAutoresizingMaskIntoConstraints = false
-        durationLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        // Fixed: a duration plate sitting on a video thumbnail, whose
+        // size the thumbnail dictates.
+        durationLabel.font = OnymType.uiFixed(size: 11, weight: .semibold)
         durationLabel.textColor = .white
         durationLabel.textAlignment = .center
         durationLabel.backgroundColor = OnymTokens.scrimUI.withAlphaComponent(0.55)
@@ -1038,8 +1043,7 @@ final class ChatBubbleCell: UITableViewCell {
         quoteBar.layer.cornerCurve = .continuous
         quoteContainer.addSubview(quoteBar)
 
-        let nameBase = UIFont.systemFont(ofSize: 12, weight: .semibold)
-        quoteNameLabel.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: nameBase)
+        quoteNameLabel.font = OnymType.uiFont(size: 12, weight: .semibold)
         quoteNameLabel.adjustsFontForContentSizeCategory = true
         quoteNameLabel.numberOfLines = 1
         quoteNameLabel.lineBreakMode = .byTruncatingTail
@@ -1047,8 +1051,7 @@ final class ChatBubbleCell: UITableViewCell {
         quoteNameLabel.accessibilityIdentifier = "chat.bubble.quote.name"
         quoteContainer.addSubview(quoteNameLabel)
 
-        let snippetBase = UIFont.systemFont(ofSize: 13, weight: .regular)
-        quoteSnippetLabel.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: snippetBase)
+        quoteSnippetLabel.font = OnymType.uiFont(size: 13)
         quoteSnippetLabel.adjustsFontForContentSizeCategory = true
         quoteSnippetLabel.numberOfLines = 1
         quoteSnippetLabel.lineBreakMode = .byTruncatingTail
@@ -1082,8 +1085,7 @@ final class ChatBubbleCell: UITableViewCell {
         contentView.addSubview(statusImageView2)
 
         failureLabel.translatesAutoresizingMaskIntoConstraints = false
-        let base = UIFont.systemFont(ofSize: 12, weight: .regular)
-        failureLabel.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: base)
+        failureLabel.font = OnymType.uiFont(size: 12)
         failureLabel.adjustsFontForContentSizeCategory = true
         failureLabel.numberOfLines = 0
         failureLabel.textAlignment = .right
@@ -1096,8 +1098,7 @@ final class ChatBubbleCell: UITableViewCell {
     private func buildNameLabel() {
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
         // Scaled so it tracks Dynamic Type — `systemFont` alone wouldn't.
-        let base = UIFont.systemFont(ofSize: 12, weight: .semibold)
-        nameLabel.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: base)
+        nameLabel.font = OnymType.uiFont(size: 12, weight: .semibold)
         nameLabel.adjustsFontForContentSizeCategory = true
         nameLabel.numberOfLines = 1
         nameLabel.lineBreakMode = .byTruncatingTail

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatInputPanelView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatInputPanelView.swift
@@ -154,7 +154,7 @@ final class ChatInputPanelView: UIView {
         topDivider.translatesAutoresizingMaskIntoConstraints = false
         addSubview(topDivider)
 
-        textView.font = .preferredFont(forTextStyle: .body)
+        textView.font = OnymType.uiBody()
         textView.adjustsFontForContentSizeCategory = true
         textView.textColor = UIColor(OnymTokens.text)
         // Mid-grey pill on the near-black background (matches the attach /
@@ -270,13 +270,15 @@ final class ChatInputPanelView: UIView {
         recordingOverlay.addSubview(recordingDot)
 
         recordingTimeLabel.translatesAutoresizingMaskIntoConstraints = false
-        recordingTimeLabel.font = .monospacedDigitSystemFont(ofSize: 15, weight: .regular)
+        recordingTimeLabel.font = OnymType.uiMonoDigit(size: 15)
+        recordingTimeLabel.adjustsFontForContentSizeCategory = true
         recordingTimeLabel.textColor = UIColor(OnymTokens.text)
         recordingTimeLabel.text = "0:00"
         recordingOverlay.addSubview(recordingTimeLabel)
 
         recordingHintLabel.translatesAutoresizingMaskIntoConstraints = false
-        recordingHintLabel.font = .preferredFont(forTextStyle: .subheadline)
+        recordingHintLabel.font = OnymType.uiFont(size: 15)
+        recordingHintLabel.adjustsFontForContentSizeCategory = true
         recordingHintLabel.textColor = UIColor(OnymTokens.text3)
         recordingHintLabel.text = "‹ slide to cancel"
         recordingHintLabel.textAlignment = .center
@@ -307,8 +309,7 @@ final class ChatInputPanelView: UIView {
         replyBannerBar.layer.cornerCurve = .continuous
         replyBanner.addSubview(replyBannerBar)
 
-        let titleBase = UIFont.systemFont(ofSize: 12, weight: .semibold)
-        replyBannerTitle.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: titleBase)
+        replyBannerTitle.font = OnymType.uiFont(size: 12, weight: .semibold)
         replyBannerTitle.adjustsFontForContentSizeCategory = true
         replyBannerTitle.numberOfLines = 1
         replyBannerTitle.lineBreakMode = .byTruncatingTail
@@ -316,8 +317,7 @@ final class ChatInputPanelView: UIView {
         replyBannerTitle.accessibilityIdentifier = "chat.input.reply_banner.title"
         replyBanner.addSubview(replyBannerTitle)
 
-        let snippetBase = UIFont.systemFont(ofSize: 13, weight: .regular)
-        replyBannerSnippet.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: snippetBase)
+        replyBannerSnippet.font = OnymType.uiFont(size: 13)
         replyBannerSnippet.adjustsFontForContentSizeCategory = true
         replyBannerSnippet.numberOfLines = 1
         replyBannerSnippet.lineBreakMode = .byTruncatingTail

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatJoinRequestCell.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatJoinRequestCell.swift
@@ -76,21 +76,21 @@ final class ChatJoinRequestCell: UITableViewCell {
         card.layer.borderColor = UIColor(OnymTokens.hairline).cgColor
         contentView.addSubview(card)
 
-        titleLabel.font = .preferredFont(forTextStyle: .subheadline)
+        titleLabel.font = OnymType.uiFont(size: 15)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.textColor = UIColor(OnymTokens.text)
         titleLabel.numberOfLines = 0
 
-        fingerprintLabel.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        fingerprintLabel.font = OnymType.uiMono(size: 12)
         fingerprintLabel.adjustsFontForContentSizeCategory = true
         fingerprintLabel.textColor = UIColor(OnymTokens.text3)
         fingerprintLabel.numberOfLines = 1
 
-        agreementLabel.font = .preferredFont(forTextStyle: .caption1)
+        agreementLabel.font = OnymType.uiFont(size: 12)
         agreementLabel.adjustsFontForContentSizeCategory = true
         agreementLabel.numberOfLines = 0
 
-        errorLabel.font = .preferredFont(forTextStyle: .caption1)
+        errorLabel.font = OnymType.uiFont(size: 12)
         errorLabel.adjustsFontForContentSizeCategory = true
         errorLabel.textColor = UIColor(OnymTokens.red)
         errorLabel.numberOfLines = 0
@@ -98,7 +98,7 @@ final class ChatJoinRequestCell: UITableViewCell {
         // The on-chain admit is a PLONK proof plus a relayer round-trip
         // plus a Stellar confirmation — several seconds of apparent
         // nothing. Say so rather than letting it read as a hung tap.
-        hintLabel.font = .preferredFont(forTextStyle: .caption2)
+        hintLabel.font = OnymType.uiFont(size: 11)
         hintLabel.adjustsFontForContentSizeCategory = true
         hintLabel.textColor = UIColor(OnymTokens.text2)
         hintLabel.numberOfLines = 0
@@ -168,7 +168,7 @@ final class ChatJoinRequestCell: UITableViewCell {
             : UIColor(OnymTokens.text)
         config.titleTextAttributesTransformer = .init { incoming in
             var out = incoming
-            out.font = .preferredFont(forTextStyle: .subheadline)
+            out.font = OnymType.uiFont(size: 15)
             return out
         }
         return config

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatSystemNoticeCell.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatSystemNoticeCell.swift
@@ -32,7 +32,7 @@ final class ChatSystemNoticeCell: UITableViewCell {
         contentView.addSubview(pill)
 
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .preferredFont(forTextStyle: .footnote)
+        label.font = OnymType.uiFont(size: 13)
         label.adjustsFontForContentSizeCategory = true
         label.textColor = UIColor(OnymTokens.text2)
         label.textAlignment = .center

--- a/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatVoiceMessageView.swift
+++ b/Packages/OnymChatsUI/Sources/OnymChatsUI/ChatVoiceMessageView.swift
@@ -57,12 +57,15 @@ final class ChatVoiceMessageView: UIView {
         addSubview(waveform)
 
         durationLabel.translatesAutoresizingMaskIntoConstraints = false
-        durationLabel.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
+        durationLabel.font = OnymType.uiMonoDigit(size: 12)
+        durationLabel.adjustsFontForContentSizeCategory = true
         durationLabel.setContentHuggingPriority(.required, for: .horizontal)
         addSubview(durationLabel)
 
         NSLayoutConstraint.activate([
-            heightAnchor.constraint(equalToConstant: Self.contentHeight),
+            // The row holds a duration that scales, so 40pt is a floor
+            // rather than a height.
+            heightAnchor.constraint(greaterThanOrEqualToConstant: Self.contentHeight),
 
             playButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
             playButton.centerYAnchor.constraint(equalTo: centerYAnchor),

--- a/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymType.swift
+++ b/Packages/OnymDesignTokens/Sources/OnymDesignTokens/OnymType.swift
@@ -66,6 +66,80 @@ public enum OnymType {
         .system(size: size, weight: weight)
     }
 
+    // MARK: UIKit
+
+    /// The text face, for the UIKit half of the app.
+    ///
+    /// The chat thread draws its cells in UIKit, so without these the
+    /// most-used screen in the app would be the one place an adopter's
+    /// typeface never reached.
+    ///
+    /// Pair with `adjustsFontForContentSizeCategory = true`. Unlike the
+    /// SwiftUI side this goes through `UIFontMetrics.scaledFont`, which
+    /// is what that flag tracks — a label given a font this package had
+    /// already multiplied would size correctly once and then never
+    /// follow the reader again.
+    ///
+    /// The cost is that `scaledFont` rounds to whole points. Every size
+    /// UIKit asks for here is already whole, so nothing rounds today;
+    /// a half-point size passed to this would quietly become a whole one.
+    public static func uiFont(size: CGFloat, weight: UIFont.Weight = .regular) -> UIFont {
+        scaled(.systemFont(ofSize: size, weight: weight))
+    }
+
+    /// The mono face for UIKit — fingerprints, keys.
+    public static func uiMono(size: CGFloat, weight: UIFont.Weight = .regular) -> UIFont {
+        scaled(.monospacedSystemFont(ofSize: size, weight: weight))
+    }
+
+    /// Proportional face with fixed-width digits — timers and durations,
+    /// where a counting number should not shuffle the layout each tick.
+    public static func uiMonoDigit(size: CGFloat, weight: UIFont.Weight = .regular) -> UIFont {
+        scaled(.monospacedDigitSystemFont(ofSize: size, weight: weight))
+    }
+
+    /// The body face for a UIKit text *container* — a `UITextView`
+    /// whose layout maths reads `font.lineHeight` back out.
+    ///
+    /// The three candidates all report the same metrics — 17pt,
+    /// `lineHeight` 20.287, `ceil` 21:
+    ///
+    /// - `preferredFont(forTextStyle: .body)`
+    /// - `systemFont(ofSize: 17)`
+    /// - `UIFontMetrics.scaledFont(for: systemFont(ofSize: 17))`
+    ///
+    /// They do not lay out the same. The composer sizes itself to
+    /// `ceil(font.lineHeight) * 3` and agrees with its own contents when
+    /// given the text-style font; given the metrics-derived one it
+    /// stands two points taller than three lines of its own text.
+    ///
+    /// Why the layout differs when the reported metrics match is not
+    /// established — only that it does, repeatably, and that a test
+    /// caught it. That is the honest extent of what is known here.
+    ///
+    /// Use this where the app measures text rather than merely draws
+    /// it. Adopters swapping the typeface should return their own face
+    /// here too, keeping its natural leading.
+    public static func uiBody() -> UIFont {
+        .preferredFont(forTextStyle: .body)
+    }
+
+    /// UIKit's `fixed`: a size that does not answer to the setting,
+    /// for labels pinned inside artwork — a duration badge sitting on a
+    /// video thumbnail, an overflow count on a photo tile.
+    public static func uiFixed(size: CGFloat, weight: UIFont.Weight = .regular) -> UIFont {
+        .systemFont(ofSize: size, weight: weight)
+    }
+
+    private static func scaled(_ font: UIFont) -> UIFont {
+        // `compatibleWith:` for the same reason `scale()` needs it —
+        // `scaledFont(for:)` alone ignores `UITraitCollection.current`
+        // and hands back the unscaled font at every setting. Measured:
+        // 12pt in, 12pt out, at the largest accessibility size.
+        UIFontMetrics(forTextStyle: .body)
+            .scaledFont(for: font, compatibleWith: .current)
+    }
+
     /// The reader's text-size setting, as a multiplier.
     ///
     /// Keyed to `.body`, so the whole app moves on one curve rather than


### PR DESCRIPTION
Third of four. Base: #323.

**The premise of this PR was wrong and the audit corrected it.** Counting `UILabel` occurrences had suggested eighteen labels needed Dynamic Type turned on. Checking each one found twelve already scaled and only eight did not — the chat layer was in better shape than the count implied.

### What the count missed entirely

**None of the twenty font assignments went through the token layer.** Every one reached for `UIFont` directly, so the most-read screen in the app was the one place an adopter's typeface would never arrive. Nineteen route through `OnymType` now; the twentieth inherits from a sibling.

`OnymType` grows a UIKit half to make that possible: `uiFont`, `uiMono`, `uiMonoDigit`, `uiFixed`, `uiBody`.

### The same trap, a second time

These go through `UIFontMetrics.scaledFont` rather than the ratio the SwiftUI side uses, because that is what `adjustsFontForContentSizeCategory` tracks. And they pass `compatibleWith: .current`, for the same reason `scale()` has to:

> `scaledFont(for:)` alone ignores the current trait collection. **Measured: 12pt in, 12pt out, at the largest accessibility size.**

That is the second time this trap has appeared in this API, in the second of the two places it could. Both are now covered by tests in #325.

### Eight fixed, two deliberately not

A duration plate on a video thumbnail and an overflow count on a photo tile cannot grow 2.8× without leaving the artwork they sit on. The grid cannot give, so **the count is spoken instead of only drawn** — the overflow label carries an accessibility label now, which it did not before.

The voice message row pinned itself to 40pt around a duration that scales. Forty is a floor now.

### A correction worth reading

The composer sizes itself to `ceil(font.lineHeight) * 3`, and giving it a metrics-derived font in place of the text-style one left it two points taller than three lines of its own text. A test caught it. `OnymType.uiBody` exists for the places where the app *measures* text rather than merely drawing it.

My first explanation for this was wrong, and I want it on the record rather than quietly fixed: the two fonts do **not** carry different leading. They report identical metrics — 17pt, `lineHeight` 20.287, `ceil` 21 — and lay out differently anyway. Why is not established. What is known is that the arithmetic agrees with one of them and not the other, and which one. The doc comment and the test say exactly that and no more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf
