### PR TITLE
Tests for the two traps, and one that could not be written honestly

### DIFF
--- a/Packages/OnymDesign/Tests/OnymDesignTests/LayoutGrowthTests.swift
+++ b/Packages/OnymDesign/Tests/OnymDesignTests/LayoutGrowthTests.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import OnymDesign
+
+/// Whether the shared components actually grow when the reader asks
+/// them to.
+///
+/// This began as a throwaway harness for looking at the layout pass, and
+/// earned a place by finding four defects that counting call sites had
+/// pointed at none of: glyphs overflowing fixed boxes, buttons pinned
+/// around labels that outgrew them, tiles stranded at 30pt beside 46pt
+/// text, and a title breaking mid-word into "Setting" over a lonely "s".
+///
+/// On device the system sets both the UIKit trait collection — which the
+/// fonts read — and the SwiftUI environment, which the line limits read.
+/// A test has to set both, or the two disagree and it measures a state
+/// no reader is ever in.
+@MainActor
+final class LayoutGrowthTests: XCTestCase {
+
+    private struct Sample: View {
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                LargeTitle("Settings")
+                SectionLabel("TRANSPORT")
+                Card {
+                    Row(title: "Relayers",
+                        subtitle: "wss://relay.onym.app",
+                        subtitleMono: true) {
+                        IconTile(symbol: "antenna.radiowaves.left.and.right",
+                                 bg: OnymTile.indigo)
+                    }
+                    Row(title: "Notifications and alerts",
+                        subtitle: "Wake this device when a message arrives",
+                        last: true) {
+                        IconTile(symbol: "bell.fill", bg: OnymTile.red)
+                    }
+                }
+                Footnote("Published by the onym-relayer project. Tap to add.")
+            }
+            .padding(.vertical, 12)
+            .background(OnymTokens.surface)
+        }
+    }
+
+    /// Renders `content` as the system would at `category`, and returns
+    /// the size it settled on.
+    private func renderedSize<V: View>(
+        at category: UIContentSizeCategory,
+        width: CGFloat = 390,
+        @ViewBuilder _ content: @escaping () -> V
+    ) -> CGSize {
+        var size = CGSize.zero
+        UITraitCollection(preferredContentSizeCategory: category).performAsCurrent {
+            let renderer = ImageRenderer(
+                content: content()
+                    .environment(\.dynamicTypeSize, Self.typeSize(for: category))
+                    .frame(width: width)
+            )
+            size = renderer.uiImage?.size ?? .zero
+        }
+        return size
+    }
+
+    private static func typeSize(for category: UIContentSizeCategory) -> DynamicTypeSize {
+        category == .accessibilityExtraExtraExtraLarge ? .accessibility5 : .large
+    }
+
+    func testTheSettingsScreenGrowsForTheReader() {
+        let base = renderedSize(at: .large) { Sample() }
+        let big = renderedSize(at: .accessibilityExtraExtraExtraLarge) { Sample() }
+
+        XCTAssertGreaterThan(base.height, 0, "nothing rendered")
+        XCTAssertGreaterThan(
+            big.height, base.height * 1.8,
+            "the screen barely grew — something is still pinning the layout"
+        )
+        // Width is fixed by the frame; if it exceeds it, something is
+        // pushing out sideways rather than wrapping.
+        XCTAssertEqual(big.width, base.width, accuracy: 1,
+                       "content escaped its width instead of wrapping")
+    }
+
+    func testIconTileGrowsButStaysATile() {
+        let base = renderedSize(at: .large, width: 100) {
+            IconTile(symbol: "bell.fill", bg: OnymTile.red)
+        }
+        let big = renderedSize(at: .accessibilityExtraExtraExtraLarge, width: 100) {
+            IconTile(symbol: "bell.fill", bg: OnymTile.red)
+        }
+        XCTAssertGreaterThan(big.height, base.height,
+                             "a tile stranded at 30pt beside 46pt text reads as a bug")
+        XCTAssertLessThanOrEqual(
+            big.height, 47,
+            "the cap is what keeps this a tile rather than 85pt of decoration"
+        )
+    }
+
+    // Not covered here: that `LargeTitle` shrinks a long single word
+    // rather than breaking it mid-word into "Setting" over a lonely "s".
+    //
+    // It was tried. Because `minimumScaleFactor` shrinks the wrapped
+    // case too, a one-line title and a two-line one land close enough in
+    // height that any threshold separating them is a number picked to
+    // make the test pass rather than a property being asserted. The
+    // behaviour is real and was confirmed by looking at the render; a
+    // brittle test that agrees with it today is worth less than this
+    // note. Snapshot testing would settle it properly, and the repo has
+    // no snapshot harness to hang it on.
+}

--- a/Packages/OnymDesignTokens/Tests/OnymDesignTokensTests/DynamicTypeTests.swift
+++ b/Packages/OnymDesignTokens/Tests/OnymDesignTokensTests/DynamicTypeTests.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import OnymDesignTokens
+
+/// Guards on the type scaling.
+///
+/// Two of these exist because the obvious implementation is wrong in a
+/// way that compiles, reads plausibly, and ships. Neither would be
+/// caught by a human looking at the screen at the default text size,
+/// which is the setting almost every reviewer has.
+final class DynamicTypeTests: XCTestCase {
+
+    private func at(_ category: UIContentSizeCategory, _ body: () -> Void) {
+        UITraitCollection(preferredContentSizeCategory: category).performAsCurrent(body)
+    }
+
+    // MARK: The half-point trap
+
+    func testDefaultSettingLeavesEverySizeExactlyWhereItIs() {
+        // `UIFontMetrics.scaledFont(for:)` rounds to whole points, and
+        // does it at the *default* setting: 11.5pt comes back 12pt. The
+        // app spends around sixty half-point sizes, so taking that route
+        // changes text for every reader who never touched the setting.
+        //
+        // If this fails, someone has swapped the ratio for scaledFont.
+        at(.large) {
+            for size in [9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5] as [CGFloat] {
+                XCTAssertEqual(
+                    OnymType.scale() * size, size, accuracy: 0.001,
+                    "\(size)pt moved at the default setting — is scale() rounding?"
+                )
+            }
+        }
+    }
+
+    func testHalfPointsSurviveScaling() {
+        at(.accessibilityExtraExtraExtraLarge) {
+            let scaled = OnymType.scale() * 13.5
+            XCTAssertNotEqual(scaled, scaled.rounded(), accuracy: 0.0001,
+                              "a scaled half-point size should not land on a whole point")
+        }
+    }
+
+    // MARK: The silent-1.0 trap
+
+    func testScaleActuallyReadsTheSetting() {
+        // `scaledValue(for:)` with no trait collection does not consult
+        // UITraitCollection.current — it answers 1.0 at every setting.
+        // That version of this code looks like working Dynamic Type
+        // support and delivers none of it.
+        var ratios: [CGFloat] = []
+        for category: UIContentSizeCategory in [
+            .extraSmall, .large, .extraExtraExtraLarge,
+            .accessibilityExtraExtraExtraLarge,
+        ] {
+            at(category) { ratios.append(OnymType.scale()) }
+        }
+        XCTAssertEqual(ratios, ratios.sorted(), "ratio should rise with the setting")
+        XCTAssertLessThan(ratios.first!, 1.0, "extraSmall should shrink")
+        XCTAssertGreaterThan(ratios.last!, 2.0,
+                             "scale() is not reading the setting at all")
+    }
+
+    func testScaleIsExactlyOneAtTheDefault() {
+        at(.large) { XCTAssertEqual(OnymType.scale(), 1.0, accuracy: 0.0001) }
+    }
+
+    // MARK: fixed
+    //
+    // SwiftUI publishes no way to read a `Font`'s resolved size, so
+    // these measure what it actually draws rather than asserting
+    // against a number that cannot be obtained.
+
+    /// Height of one line rendered with `font`, built inside the trait
+    /// so the token reads the right setting.
+    @MainActor
+    private func drawnHeight(at category: UIContentSizeCategory,
+                             _ font: @escaping () -> Font) -> CGFloat {
+        var height: CGFloat = 0
+        UITraitCollection(preferredContentSizeCategory: category).performAsCurrent {
+            let renderer = ImageRenderer(content: Text("Hg").font(font()).fixedSize())
+            height = renderer.uiImage?.size.height ?? 0
+        }
+        return height
+    }
+
+    @MainActor
+    func testFixedIgnoresTheSetting() {
+        let base = drawnHeight(at: .large) { OnymType.fixed(size: 30) }
+        let big = drawnHeight(at: .accessibilityExtraExtraExtraLarge) { OnymType.fixed(size: 30) }
+        XCTAssertGreaterThan(base, 0, "nothing was drawn")
+        XCTAssertEqual(base, big, accuracy: 0.5,
+                       "fixed() must not move — it is for artwork, not words")
+    }
+
+    @MainActor
+    func testFontDoesAnswerTheSetting() {
+        let base = drawnHeight(at: .large) { OnymType.font(size: 30) }
+        let big = drawnHeight(at: .accessibilityExtraExtraExtraLarge) { OnymType.font(size: 30) }
+        XCTAssertGreaterThan(base, 0, "nothing was drawn")
+        XCTAssertGreaterThan(big, base * 1.5, "font() did not grow with the setting")
+    }
+
+    // MARK: UIKit half
+
+    func testUIKitFacesReadTheSetting() {
+        // Asserted rather than assumed: `scaledValue(for:)` ignores
+        // `.current`, so it is a fair question whether `scaledFont(for:)`
+        // does too. If this fails, uiFont needs `compatibleWith:` the
+        // same way `scale()` does — and every UIKit label in the chat
+        // thread is stuck at the default size.
+        var sizes: [CGFloat] = []
+        for category: UIContentSizeCategory in [.large, .accessibilityExtraExtraExtraLarge] {
+            at(category) { sizes.append(OnymType.uiFont(size: 12).pointSize) }
+        }
+        XCTAssertEqual(sizes[0], 12, accuracy: 0.001, "12pt should be 12pt at the default")
+        XCTAssertGreaterThan(sizes[1], 24, "uiFont is not reading the setting")
+    }
+
+    func testUIKitMonoStaysMono() {
+        let mono = OnymType.uiMono(size: 12)
+        XCTAssertNotEqual(mono.fontName, UIFont.systemFont(ofSize: 12).fontName,
+                          "a fingerprint that stops being monospaced stops lining up")
+    }
+
+    func testUIKitFixedDoesNotScale() {
+        at(.accessibilityExtraExtraExtraLarge) {
+            XCTAssertEqual(OnymType.uiFixed(size: 22).pointSize, 22, accuracy: 0.001)
+        }
+    }
+
+    func testUIBodyIsTheTextStyleFont() {
+        // What `uiBody` must remain, stated as narrowly as it is known.
+        //
+        // The composer sizes itself to `ceil(font.lineHeight) * 3` and
+        // agrees with its own contents when given this font. Given
+        // `scaledFont(for: systemFont(17))` — which reports an identical
+        // lineHeight, 20.287 — it stands two points taller than three
+        // lines of its own text.
+        //
+        // Why the layout differs when the metrics match is not
+        // established here, so this asserts only the thing that was
+        // actually measured: the identity of the font. The behaviour it
+        // protects is guarded where it lives, by
+        // `ChatInputPanelViewTests.test_textGrows_capsAtMaxLineCount` —
+        // which is the test that caught the swap in the first place.
+        at(.large) {
+            XCTAssertEqual(OnymType.uiBody(), UIFont.preferredFont(forTextStyle: .body))
+        }
+    }
+}


### PR DESCRIPTION
Last of four. Base: #324.

Twenty-four tests across the two packages, guarding things that would otherwise fail silently at a setting no reviewer has switched on.

### Two exist because the obvious implementation is wrong

Both compile, both read plausibly, and neither is visible at the default text size:

- **`UIFontMetrics.scaledFont` rounds to whole points at the default setting.** 11.5pt comes back 12pt. Sixty half-point sizes would shift for readers who never touched anything.
- **`scaledValue` with no trait collection answers 1.0 at every setting.** It looks exactly like working Dynamic Type support and delivers none.

Both now fail loudly if someone reaches for the simpler-looking call.

### Layout tests

These began as a throwaway harness for looking at the render, and earned a place by finding four defects that counting call sites had pointed at none of. They assert the settings screen grows with the reader, a tile grows without becoming 85pt of decoration, and nothing escapes its width instead of wrapping.

### One test is deliberately absent

That `LargeTitle` shrinks a long word rather than breaking it mid-word is real, and was confirmed by looking at the render. It could not be asserted honestly: `minimumScaleFactor` shrinks the wrapped case too, so a one-line title and a two-line one land close enough in height that any threshold between them is a number chosen to make the test pass. The absence is written down where the test would be. A brittle test that agrees with the truth today is worth less than a note saying why there isn't one — snapshot testing would settle it, and the repo has no harness to hang that on.

### Two things removed rather than kept green

- A contract test resolved a SwiftUI `Font`'s point size through a helper that **always returned nil**, so it compared `-1` to `-1` and passed without measuring anything.
- A test asserting `uiBody` lays out to the height its own metrics promise turned out to assert something **false** — the promise holds in the composer's configuration, not in a bare text view. What survives asserts only the font's identity and points at the composer's own test for the behaviour, which is where it was caught to begin with.

CI already runs both package suites from the token stack, so these are picked up without further wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z1YSTEHK4oxHTE9zabVyf
